### PR TITLE
[FEATURE] Donner accès aux autres rôles à la liste des réseaux (PIX-22120)

### DIFF
--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -38,11 +38,9 @@ export default class Sidebar extends Component {
           {{t "components.layout.sidebar.organizations"}}
         </PixNavigationButton>
 
-        {{#if this.currentUser.adminMember.isSuperAdmin}}
-          <PixNavigationButton class="sidebar__link" @route="authenticated.networks" @icon="accountTree">
-            {{t "components.layout.sidebar.networks"}}
-          </PixNavigationButton>
-        {{/if}}
+        <PixNavigationButton class="sidebar__link" @route="authenticated.networks" @icon="accountTree">
+          {{t "components.layout.sidebar.networks"}}
+        </PixNavigationButton>
 
         <PixNavigationButton class="sidebar__link" @route="authenticated.users" @icon="infoUser">
           {{t "components.layout.sidebar.users"}}

--- a/admin/app/components/networks/head-information.gjs
+++ b/admin/app/components/networks/head-information.gjs
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -6,6 +7,8 @@ import NetworkEditForm from './edit-form';
 import NetworkTitleView from './title-view';
 
 export default class NetworkHeadInformation extends Component {
+  @service accessControl;
+
   @tracked isEditMode = false;
 
   @action
@@ -18,7 +21,11 @@ export default class NetworkHeadInformation extends Component {
       {{#if this.isEditMode}}
         <NetworkEditForm @network={{@network}} @hideForm={{this.toggleEditMode}} />
       {{else}}
-        <NetworkTitleView @network={{@network}} @onEdit={{this.toggleEditMode}} />
+        <NetworkTitleView
+          @network={{@network}}
+          @onEdit={{this.toggleEditMode}}
+          @canEdit={{this.accessControl.hasAccessToNetworkActionsScope}}
+        />
       {{/if}}
     </div>
   </template>

--- a/admin/app/components/networks/title-view.gjs
+++ b/admin/app/components/networks/title-view.gjs
@@ -7,18 +7,20 @@ import CopyButton from 'pix-admin/components/ui/copy-button';
   <div class="network__title-section">
     <div class="network__name-row">
       <h1 class="network__name">{{@network.name}}</h1>
-      <PixTooltip @id="edit-network-tooltip" @position="top" @isInline={{true}}>
-        <:triggerElement>
-          <PixIconButton
-            @iconName="edit"
-            @ariaLabel={{t "common.actions.edit"}}
-            @size="small"
-            @triggerAction={{@onEdit}}
-            aria-describedby="edit-network-tooltip"
-          />
-        </:triggerElement>
-        <:tooltip>{{t "components.networks.editing.actions.edit-tooltip"}}</:tooltip>
-      </PixTooltip>
+      {{#if @canEdit}}
+        <PixTooltip @id="edit-network-tooltip" @position="top" @isInline={{true}}>
+          <:triggerElement>
+            <PixIconButton
+              @iconName="edit"
+              @ariaLabel={{t "common.actions.edit"}}
+              @size="small"
+              @triggerAction={{@onEdit}}
+              aria-describedby="edit-network-tooltip"
+            />
+          </:triggerElement>
+          <:tooltip>{{t "components.networks.editing.actions.edit-tooltip"}}</:tooltip>
+        </PixTooltip>
+      {{/if}}
     </div>
     <div class="network__id">
       <p>ID : <span>{{@network.id}}</span></p>

--- a/admin/app/helpers/get-service.js
+++ b/admin/app/helpers/get-service.js
@@ -1,0 +1,15 @@
+import { getOwner } from '@ember/application';
+import Helper from '@ember/component/helper';
+
+export default class GetService extends Helper {
+  #owner;
+
+  constructor() {
+    super(...arguments);
+    this.#owner = getOwner(this);
+  }
+
+  compute([service]) {
+    return this.#owner.lookup(service);
+  }
+}

--- a/admin/app/routes/authenticated/networks/get.js
+++ b/admin/app/routes/authenticated/networks/get.js
@@ -4,11 +4,6 @@ import { service } from '@ember/service';
 export default class GetRoute extends Route {
   @service store;
   @service router;
-  @service accessControl;
-
-  beforeModel() {
-    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
-  }
 
   async model(params) {
     try {

--- a/admin/app/routes/authenticated/networks/list.js
+++ b/admin/app/routes/authenticated/networks/list.js
@@ -5,7 +5,6 @@ const DEFAULT_PAGE_NUMBER = 1;
 const DEFAULT_PAGE_SIZE = 10;
 
 export default class ListRoute extends Route {
-  @service accessControl;
   @service store;
 
   queryParams = {
@@ -13,10 +12,6 @@ export default class ListRoute extends Route {
     pageSize: { refreshModel: true },
     name: { refreshModel: true },
   };
-
-  beforeModel() {
-    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
-  }
 
   model(params) {
     return this.store.query('network', {

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -87,4 +87,8 @@ export default class AccessControlService extends Service {
   get hasAccessToNetworkFeature() {
     return Boolean(this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier);
   }
+
+  get hasAccessToNetworkActionsScope() {
+    return Boolean(this.currentUser.adminMember.isSuperAdmin);
+  }
 }

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -2,15 +2,20 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { t } from 'ember-intl';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import ListItems from 'pix-admin/components/networks/list-items';
+import getService from 'pix-admin/helpers/get-service';
 
 <template>
   {{pageTitle (t "pages.networks.list.page-title")}}
   <header>
     <h1>{{t "pages.networks.list.title"}}</h1>
     <div class="page-actions">
-      <PixButtonLink @route="authenticated.networks.new" @variant="secondary" @iconBefore="add">
-        {{t "pages.networks.list.new-button"}}
-      </PixButtonLink>
+      {{#let (getService "service:access-control") as |accessControl|}}
+        {{#if accessControl.hasAccessToNetworkActionsScope}}
+          <PixButtonLink @route="authenticated.networks.new" @variant="secondary" @iconBefore="add">
+            {{t "pages.networks.list.new-button"}}
+          </PixButtonLink>
+        {{/if}}
+      {{/let}}
     </div>
   </header>
 

--- a/admin/tests/acceptance/authenticated/networks/get-test.js
+++ b/admin/tests/acceptance/authenticated/networks/get-test.js
@@ -48,28 +48,26 @@ module('Acceptance | Networks | Get', function (hooks) {
     });
   });
 
-  module('when user does not have super admin role', function () {
-    test('it should redirect to the organizations page', async function (assert) {
+  module('when user has metier role', function (hooks) {
+    hooks.beforeEach(async () => {
+      await authenticateAdminMemberWithRole({ isMetier: true })(server);
+    });
+
+    test('it can access the network detail page', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ isSuperAdmin: false })(server);
-
       const NETWORK_ID = 1;
-      const HEAD_ORGANIZATION_ID = 555;
-
       server.create('network', {
         id: NETWORK_ID,
         name: 'My Network',
-        headOrganization: {
-          name: 'Head organization',
-          id: HEAD_ORGANIZATION_ID,
-        },
+        headOrganization: { name: 'Head organization', id: 555 },
       });
 
       // when
-      await visit('/networks/1');
+      const screen = await visit(`/networks/${NETWORK_ID}`);
 
       // then
-      assert.strictEqual(currentURL(), '/organizations/list');
+      assert.strictEqual(currentURL(), `/networks/${NETWORK_ID}`);
+      assert.dom(screen.getByRole('heading', { name: 'My Network' })).exists();
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/networks/list-test.js
+++ b/admin/tests/acceptance/authenticated/networks/list-test.js
@@ -126,16 +126,45 @@ module('Acceptance | Networks | List', function (hooks) {
       });
     });
 
-    module('when user does not have super admin role', function () {
-      test('it should redirect to the organizations page', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isSuperAdmin: false })(server);
+    module('when user has metier role', function (hooks) {
+      hooks.beforeEach(async function () {
+        await authenticateAdminMemberWithRole({ isMetier: true })(server);
+      });
 
+      test('it can access the networks list', async function (assert) {
         // when
         await visit('/networks/list');
 
         // then
-        assert.strictEqual(currentURL(), '/organizations/list');
+        assert.strictEqual(currentURL(), '/networks/list');
+      });
+    });
+
+    module('when user has certif role', function (hooks) {
+      hooks.beforeEach(async function () {
+        await authenticateAdminMemberWithRole({ isCertif: true })(server);
+      });
+
+      test('it can access the networks list', async function (assert) {
+        // when
+        await visit('/networks/list');
+
+        // then
+        assert.strictEqual(currentURL(), '/networks/list');
+      });
+    });
+
+    module('when user has support role', function (hooks) {
+      hooks.beforeEach(async function () {
+        await authenticateAdminMemberWithRole({ isSupport: true })(server);
+      });
+
+      test('it can access the networks list', async function (assert) {
+        // when
+        await visit('/networks/list');
+
+        // then
+        assert.strictEqual(currentURL(), '/networks/list');
       });
     });
   });

--- a/admin/tests/integration/components/layout/sidebar_test.gjs
+++ b/admin/tests/integration/components/layout/sidebar_test.gjs
@@ -74,7 +74,7 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
     });
 
     module('When the user is not a super admin', function () {
-      test('should not display Networks menu', async function (assert) {
+      test('should display Networks menu', async function (assert) {
         // given
         currentUser.adminMember = { isSuperAdmin: false };
 
@@ -82,7 +82,7 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
         const screen = await render(<template><Sidebar /></template>);
 
         // then
-        assert.dom(screen.queryByRole('link', { name: t('components.layout.sidebar.networks') })).doesNotExist();
+        assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.networks') })).exists();
       });
     });
   });

--- a/admin/tests/integration/components/networks/head-information-test.gjs
+++ b/admin/tests/integration/components/networks/head-information-test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
+import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import HeadInformation from 'pix-admin/components/networks/head-information';
@@ -13,6 +14,10 @@ module('Integration | Component | Networks | head-information', function (hooks)
   module('display', function () {
     test('it should display network informations', async function (assert) {
       // given
+      class AccessControlStub extends Service {
+        hasAccessToNetworkActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
       const network = EmberObject.create({ id: 1, name: 'My network' });
 
       // when
@@ -23,10 +28,44 @@ module('Integration | Component | Networks | head-information', function (hooks)
       assert.dom(screen.getByText((_, element) => element.textContent === 'ID : 1')).exists();
       assert.dom(screen.getByRole('button', { name: t('components.networks.copy-id') })).exists();
     });
+
+    test('it should hide the edit button when user does not have network actions scope', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToNetworkActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+      const network = EmberObject.create({ id: 1, name: 'My network' });
+
+      // when
+      const screen = await render(<template><HeadInformation @network={{network}} /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: t('common.actions.edit') })).doesNotExist();
+    });
+
+    test('it should show the edit button when user has network actions scope', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToNetworkActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+      const network = EmberObject.create({ id: 1, name: 'My network' });
+
+      // when
+      const screen = await render(<template><HeadInformation @network={{network}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('common.actions.edit') })).exists();
+    });
   });
 
   test('clicking the edit button shows the edit form', async function (assert) {
     // given
+    class AccessControlStub extends Service {
+      hasAccessToNetworkActionsScope = true;
+    }
+    this.owner.register('service:access-control', AccessControlStub);
     const network = EmberObject.create({ id: 1, name: 'Mon réseau' });
     const screen = await render(<template><HeadInformation @network={{network}} /></template>);
 
@@ -40,6 +79,10 @@ module('Integration | Component | Networks | head-information', function (hooks)
 
   test('clicking the cancel button hides the form and shows the title view', async function (assert) {
     // given
+    class AccessControlStub extends Service {
+      hasAccessToNetworkActionsScope = true;
+    }
+    this.owner.register('service:access-control', AccessControlStub);
     const network = EmberObject.create({ id: 1, name: 'Mon réseau' });
     const screen = await render(<template><HeadInformation @network={{network}} /></template>);
     await click(screen.getByRole('button', { name: t('common.actions.edit') }));

--- a/admin/tests/integration/components/networks/title-view-test.gjs
+++ b/admin/tests/integration/components/networks/title-view-test.gjs
@@ -11,13 +11,15 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | networks/title-view', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it displays the network name, id and edit button', async function (assert) {
+  test('it displays the network name, id and edit button when @canEdit is true', async function (assert) {
     // given
     const network = EmberObject.create({ id: 42, name: 'Mon réseau' });
     const noop = sinon.stub();
 
     // when
-    const screen = await render(<template><NetworkTitleView @network={{network}} @onEdit={{noop}} /></template>);
+    const screen = await render(
+      <template><NetworkTitleView @network={{network}} @onEdit={{noop}} @canEdit={{true}} /></template>,
+    );
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Mon réseau' })).exists();
@@ -26,13 +28,30 @@ module('Integration | Component | networks/title-view', function (hooks) {
     assert.dom(screen.getByRole('button', { name: t('common.actions.edit') })).exists();
   });
 
+  test('it hides the edit button when @canEdit is false', async function (assert) {
+    // given
+    const network = EmberObject.create({ id: 42, name: 'Mon réseau' });
+    const noop = sinon.stub();
+
+    // when
+    const screen = await render(
+      <template><NetworkTitleView @network={{network}} @onEdit={{noop}} @canEdit={{false}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Mon réseau' })).exists();
+    assert.dom(screen.queryByRole('button', { name: t('common.actions.edit') })).doesNotExist();
+  });
+
   test('clicking the edit button calls @onEdit', async function (assert) {
     // given
     const network = EmberObject.create({ id: 1, name: 'Mon réseau' });
     const onEdit = sinon.stub();
 
     // when
-    const screen = await render(<template><NetworkTitleView @network={{network}} @onEdit={{onEdit}} /></template>);
+    const screen = await render(
+      <template><NetworkTitleView @network={{network}} @onEdit={{onEdit}} @canEdit={{true}} /></template>,
+    );
     await click(screen.getByRole('button', { name: t('common.actions.edit') }));
 
     // then

--- a/admin/tests/integration/templates/authenticated/networks/list-test.gjs
+++ b/admin/tests/integration/templates/authenticated/networks/list-test.gjs
@@ -1,0 +1,47 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
+import NetworkList from 'pix-admin/templates/authenticated/networks/list';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Template | networks | list', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const networks = [];
+  const controller = {
+    name: null,
+    triggerFiltering: sinon.stub(),
+    onResetFilter: sinon.stub(),
+  };
+
+  test('it displays the "Nouveau réseau" button when user has network actions scope', async function (assert) {
+    // given
+    class AccessControlStub extends Service {
+      hasAccessToNetworkActionsScope = true;
+    }
+    this.owner.register('service:access-control', AccessControlStub);
+
+    // when
+    const screen = await render(<template><NetworkList @controller={{controller}} @model={{networks}} /></template>);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: t('pages.networks.list.new-button') })).exists();
+  });
+
+  test('it does not display the "Nouveau réseau" button when user does not have network actions scope', async function (assert) {
+    // given
+    class AccessControlStub extends Service {
+      hasAccessToNetworkActionsScope = false;
+    }
+    this.owner.register('service:access-control', AccessControlStub);
+
+    // when
+    const screen = await render(<template><NetworkList @controller={{controller}} @model={{networks}} /></template>);
+
+    // then
+    assert.dom(screen.queryByRole('link', { name: t('pages.networks.list.new-button') })).doesNotExist();
+  });
+});

--- a/admin/tests/unit/routes/networks/list-test.js
+++ b/admin/tests/unit/routes/networks/list-test.js
@@ -1,26 +1,11 @@
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 module('Unit | Route | authenticated/networks/list', function (hooks) {
   setupTest(hooks);
 
-  module('#beforeModel', function () {
-    test('it should check if current user is "SUPER_ADMIN"', function (assert) {
-      // given
-      const route = this.owner.lookup('route:authenticated/networks/list');
-      const restrictAccessToStub = sinon.stub().returns();
-      class AccessControlStub extends Service {
-        restrictAccessTo = restrictAccessToStub;
-      }
-      this.owner.register('service:access-control', AccessControlStub);
-
-      // when
-      route.beforeModel();
-
-      // then
-      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin'], 'authenticated'));
-    });
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:authenticated/networks/list');
+    assert.ok(route);
   });
 });

--- a/api/src/organizational-entities/application/network/network.admin.route.js
+++ b/api/src/organizational-entities/application/network/network.admin.route.js
@@ -14,10 +14,12 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
-                request,
-                h,
-              ),
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
@@ -40,7 +42,7 @@ const register = async function (server) {
         },
         handler: networkAdminController.findAllFilteredNetworks,
         notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès Superadmin**\n" +
+          '- **Cette route est accessible à tous les membres admin authentifiés**\n' +
             '- Renvoie les réseaux, filtrés par nom si le paramètre filter[name] est fourni.',
         ],
         tags: ['api', 'organizational-entities', 'network'],
@@ -53,10 +55,12 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
-                request,
-                h,
-              ),
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
@@ -68,8 +72,8 @@ const register = async function (server) {
         handler: (request, h) => networkAdminController.getNetworkDetails(request, h),
         tags: ['api', 'organizational-entities', 'network'],
         notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès super admin**\n" +
-            "- Elle permet de récupérer les informations d'un réseau",
+          '- **Cette route est accessible à tous les membres admin authentifiés**\n' +
+            '- Renvoie les réseaux, filtrés par nom si le paramètre filter[name] est fourni.',
         ],
       },
     },

--- a/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
@@ -27,6 +27,25 @@ describe('Unit | Application | Admin | Route | Network', function () {
         sinon.assert.notCalled(networkAdminController.findAllFilteredNetworks);
       });
     });
+
+    it('should restrict access with the four admin roles for reading', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(networkAdminController, 'findAllFilteredNetworks').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      await httpTestServer.request('GET', '/api/admin/networks', {});
+
+      // then
+      sinon.assert.calledWithExactly(securityPreHandlers.hasAtLeastOneAccessOf, [
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+        securityPreHandlers.checkAdminMemberHasRoleCertif,
+        securityPreHandlers.checkAdminMemberHasRoleSupport,
+      ]);
+    });
   });
 
   describe('GET /api/admin/networks/{networkId}', function () {
@@ -65,6 +84,25 @@ describe('Unit | Application | Admin | Route | Network', function () {
         expect(response.statusCode).to.equal(403);
         sinon.assert.notCalled(networkAdminController.getNetworkDetails);
       });
+    });
+
+    it('should restrict access with the four admin roles for reading', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(networkAdminController, 'getNetworkDetails').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      await httpTestServer.request('GET', '/api/admin/networks/1', {});
+
+      // then
+      sinon.assert.calledWithExactly(securityPreHandlers.hasAtLeastOneAccessOf, [
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+        securityPreHandlers.checkAdminMemberHasRoleCertif,
+        securityPreHandlers.checkAdminMemberHasRoleSupport,
+      ]);
     });
   });
 


### PR DESCRIPTION
## 🌱 Problème

Dans Pix Admin, la liste des réseaux n'est pour l'instant visible que pour le Super Admin.

## 🐣 Proposition

Rendre la liste des réseaux et les pages de déþail ds réseaux, visibles aux autres roles

## 🌷 Remarques

- Les actions sur les réseaux (créer un réseau et renommer un réseau) restent pour le moment limitées au rôle Super Admin


## 🐝 Pour tester
Sur Pix Admin tester avec tous les rôles:
- SUPER ADMIN: peut voir la liste des réseaux, le détail des réseaux, créer un réseau, renommer un réseau
- METIER: peut voir la liste des réseaux, le détail des réseaux. NE PEUT PAS faire d'actions sur les réseaux
- SUPPORT: npeut voir la liste des réseaux, le détail des réseaux. NE PEUT PAS faire d'actions sur les réseaux
- CERTIF: peut voir la liste des réseaux, le détail des réseaux. NE PEUT PAS faire d'actions sur les réseaux
