### PR TITLE
[TECH] Améliorer les performances du test InMemoryKeyValueStorage

### DIFF
--- a/api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js
+++ b/api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js
@@ -39,14 +39,8 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
   });
 
   describe('#save', function () {
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers();
     });
 
     it('should resolve with the generated key', async function () {
@@ -137,6 +131,7 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
 
     it('should not change the time to live', async function () {
       // given
+      const clock = sinon.useFakeTimers();
       const keyWithTtl = await inMemoryKeyValueStorage.save({
         value: {},
         expirationDelaySeconds: 1,
@@ -144,10 +139,10 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
       const keyWithoutTtl = await inMemoryKeyValueStorage.save({ value: {} });
 
       // when
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await clock.tickAsync(500);
       await inMemoryKeyValueStorage.update(keyWithTtl, {});
       await inMemoryKeyValueStorage.update(keyWithoutTtl, {});
-      await new Promise((resolve) => setTimeout(resolve, 600));
+      await clock.tickAsync(600);
 
       // then
       expect(await inMemoryKeyValueStorage.get(keyWithTtl)).to.be.undefined;
@@ -175,13 +170,14 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
   describe('#expire', function () {
     it('should add an expiration time to the list', async function () {
       // given
+      const clock = sinon.useFakeTimers();
       const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
 
       // when
       const key = 'key:lpush';
       await inMemoryKeyValueStorage.lpush(key, 'value');
       await inMemoryKeyValueStorage.expire({ key, expirationDelaySeconds: 1 });
-      await new Promise((resolve) => setTimeout(resolve, 1200));
+      await clock.tickAsync(1200);
       const list = inMemoryKeyValueStorage.lrange(key);
 
       // then


### PR DESCRIPTION
## 🌱 Problème

Certains tests unitaires de `api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js` est trop long.

<img width="646" height="749" alt="image" src="https://github.com/user-attachments/assets/c8025c7c-e13f-4836-a36c-0a1a6520599f" />


## 🐣 Proposition

Utiliser `sinon.useFakeTimers()` au lieu de faire des "wait" dans le code.

<img width="670" height="747" alt="image" src="https://github.com/user-attachments/assets/ae8cf035-5f3f-4d1a-a85c-6c13130feea9" />


## 🌷 Remarques

N/A

## 🐝 Pour tester

Lancer le test de `api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js`
