### PR TITLE
[TECH] Ajouter la table Modules (PIX-22531)

### DIFF
--- a/api/db/migrations/20260424092823_add-modules-table.js
+++ b/api/db/migrations/20260424092823_add-modules-table.js
@@ -1,0 +1,38 @@
+const SCHEMA_NAME = 'learningcontent';
+const TABLE_NAME = 'modules';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.withSchema(SCHEMA_NAME).createTable(TABLE_NAME, function (table) {
+    table.uuid('id').primary().notNullable().defaultTo(knex.fn.uuid());
+    table.string('shortId', 8).unique().notNullable().comment('used for permanent url');
+    table.string('slug', 100).notNullable().comment('used for user-friendly url');
+    table.string('title').notNullable();
+    table.boolean('isBeta').notNullable().defaultTo(true).comment('draft status of the module');
+    table.string('visibility').notNullable().comment('controls visibility in trainings configuration');
+    table.text('image').notNullable().comment('url');
+    table.text('description').notNullable().comment('may contain html content');
+    table.integer('duration').notNullable().comment('duration of the module in minutes');
+    table.string('level').notNullable();
+    table.string('tabletSupport').notNullable().comment('convenientness level of module reading on small screens');
+    table
+      .specificType('objectives', 'text[]')
+      .notNullable()
+      .comment('objectives of the module. May contain html content');
+    table.jsonb('sections').notNullable().comment('main content of the module');
+    table.jsonb('glossary').defaultTo([]).notNullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.withSchema(SCHEMA_NAME).dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌱 Problème

On veut stocker les modules de la release dans la base de donnée de l'api.

## 🐣 Proposition

Ajouter une table Modules.

## 🌷 Remarques

RAS

## 🐝 Pour tester

- Checkout la branche en local
- lancer un `npm run db:migrate`
- constater la présence de la table modules
- faire un `npm run db:rollback:latest`
- constater la disparition de la table 👻 
