### PR TITLE
[TECH] Ajouter le feature toggle isFetchingModulesFromLearningContentEnabled (PIX-22266)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -122,4 +122,11 @@ export default {
     defaultValue: [],
     tags: ['team-acces', 'iam', 'backend'],
   },
+  isFetchingModulesFromLearningContentEnabled: {
+    type: 'boolean',
+    description: 'Enable getting modules from learning content schema',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: false },
+    tags: ['team-devcomp', 'pix-api', 'backend'],
+  },
 };


### PR DESCRIPTION
## 🌱 Problème

Nous avons besoin d'un feature toggle pour pouvoir continuer à récupérer les modules au format .json, en attendant de pouvoir les éditer dans pix editor.

## 🐣 Proposition

Ajouter ce feature toggle

## 🌷 Remarques
RAS

## 🐝 Pour tester
- En local, exécuter la commande `npm run toggles -- --key=isFetchingModulesFromLearningContentEnabled --value=true`
- Vérifier, avec la commande `npm run toggles --list` que le feature toggle est bien passé à `true`.
