### PR TITLE
[FEATURE] Voir le nombre d'invitations en attente sur la page de détail d'un centre de certification (PIX-21450)

### DIFF
--- a/admin/app/adapters/certification-center-invitation.js
+++ b/admin/app/adapters/certification-center-invitation.js
@@ -3,11 +3,6 @@ import ApplicationAdapter from './application';
 export default class CertificationCenterInvitationAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  urlForFindAll(modelName, { adapterOptions }) {
-    const { certificationCenterId } = adapterOptions;
-    return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/invitations`;
-  }
-
   queryRecord(store, type, query) {
     if (query.certificationCenterId) {
       const url = `${this.host}/${this.namespace}/certification-centers/${query.certificationCenterId}/invitations`;

--- a/admin/app/adapters/certification-center.js
+++ b/admin/app/adapters/certification-center.js
@@ -3,16 +3,6 @@ import ApplicationAdapter from './application';
 export default class CertificationCenterAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  findHasMany(store, snapshot, _url, relationship) {
-    if (relationship.key === 'certificationCenterMemberships') {
-      return this.ajax(
-        `${this.host}/${this.namespace}/certification-centers/${snapshot.id}/certification-center-memberships`,
-        'GET',
-      );
-    }
-    return super.findHasMany(...arguments);
-  }
-
   archiveCertificationCenter(certificationCenterId) {
     return this.ajax(`${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/archive`, 'POST');
   }

--- a/admin/app/controllers/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/controllers/authenticated/certification-centers/get/invitations.js
@@ -40,6 +40,8 @@ export default class AuthenticatedCertificationCentersGetInvitationsController e
         certificationCenterId: this.model.certificationCenterId,
       });
 
+      await this.model.certificationCenter.hasMany('certificationCenterInvitations').reload();
+
       this.pixToast.sendSuccessNotification({ message: `Un email a bien a été envoyé à l'adresse ${email}.` });
       this.userEmailToInvite = null;
     } catch (err) {

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -23,6 +23,9 @@ export default class CertificationCenter extends Model {
   @hasMany('certification-center-membership', { async: true, inverse: 'certificationCenter' })
   certificationCenterMemberships;
 
+  @hasMany('certification-center-invitation', { async: true, inverse: null })
+  certificationCenterInvitations;
+
   get typeLabel() {
     return types.find((type) => type.value === this.type).label;
   }

--- a/admin/app/routes/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/routes/authenticated/certification-centers/get/invitations.js
@@ -1,17 +1,12 @@
 import Route from '@ember/routing/route';
-import { service } from '@ember/service';
 
 export default class AuthenticatedCertificationCentersGetInvitationsRoute extends Route {
-  @service store;
-
   async model() {
-    this.store.unloadAll('certification-center-invitation');
     const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
-    const certificationCenterId = certificationCenter.id;
-
-    const certificationCenterInvitations = await this.store.findAll('certification-center-invitation', {
-      adapterOptions: { certificationCenterId },
-    });
-    return { certificationCenterId, certificationCenterInvitations };
+    return {
+      certificationCenter,
+      certificationCenterId: certificationCenter.id,
+      certificationCenterInvitations: await certificationCenter.certificationCenterInvitations,
+    };
   }
 }

--- a/admin/app/templates/authenticated/certification-centers/get.gjs
+++ b/admin/app/templates/authenticated/certification-centers/get.gjs
@@ -11,20 +11,20 @@ import Information from 'pix-admin/components/certification-centers/information'
 
   <main class="page-body" id="certification-center-get-page">
     <Information
-      @availableHabilitations={{@controller.model.habilitations}}
-      @certificationCenter={{@controller.model.certificationCenter}}
+      @availableHabilitations={{@model.habilitations}}
+      @certificationCenter={{@model.certificationCenter}}
       @updateCertificationCenter={{@controller.updateCertificationCenter}}
       @refreshModel={{@controller.refresh}}
     />
 
-    {{#unless @controller.model.certificationCenter.isArchived}}
+    {{#unless @model.certificationCenter.isArchived}}
       <PixTabs @variant="primary" @ariaLabel="Navigation de la section centre de certification" class="navigation">
         <LinkTo @route="authenticated.certification-centers.get.team">
-          Équipe ({{@controller.model.certificationCenter.certificationCenterMemberships.length}})
+          Équipe ({{@model.certificationCenter.certificationCenterMemberships.length}})
         </LinkTo>
 
         <LinkTo @route="authenticated.certification-centers.get.invitations">
-          Invitations
+          Invitations ({{@model.certificationCenter.certificationCenterInvitations.length}})
         </LinkTo>
       </PixTabs>
     {{/unless}}

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -279,7 +279,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
           }),
         );
         assert.dom(certificationCenterNavigation.getByRole('link', { name: /Équipe/ })).exists();
-        assert.dom(certificationCenterNavigation.getByRole('link', { name: 'Invitations' })).exists();
+        assert.dom(certificationCenterNavigation.getByRole('link', { name: /Invitations/ })).exists();
       });
 
       test('should display the number of active members in the Équipe tab', async function (assert) {

--- a/admin/tests/acceptance/authenticated/certification-centers/get/invitations-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get/invitations-test.js
@@ -9,6 +9,28 @@ module('Acceptance | Certification-centers | Invitations management', function (
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  test('should display invitations count in tab', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    const certificationCenter = server.create('certification-center', {
+      name: 'Centre Test',
+    });
+    server.create('certification-center-invitation', {
+      certificationCenter,
+      email: 'invite1@example.com',
+    });
+    server.create('certification-center-invitation', {
+      certificationCenter,
+      email: 'invite2@example.com',
+    });
+
+    // when
+    const screen = await visit(`/certification-centers/${certificationCenter.id}/invitations`);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Invitations (2)' })).exists();
+  });
+
   test('should allow to invite a member', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
@@ -24,6 +46,7 @@ module('Acceptance | Certification-centers | Invitations management', function (
     // then
     assert.dom(screen.getByText('user@example.com')).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail du membre à inviter' })).hasNoValue();
+    assert.dom(screen.getByRole('link', { name: 'Invitations (1)' })).exists();
   });
 
   test('should be possible to cancel a certification center invitation', async function (assert) {

--- a/admin/tests/mirage/models/certification-center.js
+++ b/admin/tests/mirage/models/certification-center.js
@@ -3,4 +3,5 @@ import { hasMany, Model } from 'miragejs';
 export default Model.extend({
   habilitations: hasMany('complementaryCertification'),
   certificationCenterMemberships: hasMany('certificationCenterMembership'),
+  certificationCenterInvitations: hasMany('certificationCenterInvitation'),
 });

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -313,11 +313,12 @@ export default function routes() {
     return schema.certificationCenterInvitations.where({ certificationCenterId });
   });
   this.post('/admin/certification-centers/:id/invitations', (schema, request) => {
+    const certificationCenterId = request.params.id;
     const params = JSON.parse(request.requestBody);
     const email = params.data.attributes.email;
     const lang = params.data.attributes.lang;
     const updatedAt = Date.now();
-    return schema.certificationCenterInvitations.create({ email, lang, updatedAt });
+    return schema.certificationCenterInvitations.create({ email, lang, updatedAt, certificationCenterId });
   });
   this.delete('/admin/certification-center-invitations/:id', (schema, request) => {
     const certificationCenterInvitationId = request.params.id;

--- a/admin/tests/mirage/serializers/certification-center.js
+++ b/admin/tests/mirage/serializers/certification-center.js
@@ -9,6 +9,9 @@ export default JSONAPISerializer.extend({
       certificationCenterMemberships: {
         related: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
       },
+      certificationCenterInvitations: {
+        related: `/api/admin/certification-centers/${certificationCenter.id}/invitations`,
+      },
     };
   },
 });

--- a/admin/tests/unit/adapters/certification-center-invitation-test.js
+++ b/admin/tests/unit/adapters/certification-center-invitation-test.js
@@ -6,20 +6,6 @@ import sinon from 'sinon';
 module('Unit | Adapter | certification-center-invitation', function (hooks) {
   setupTest(hooks);
 
-  module('#urlForFindAll', function () {
-    test('should build url with certification center id as dynamic segment', async function (assert) {
-      // given
-      const adapter = this.owner.lookup('adapter:certification-center-invitation');
-      const snapshot = { adapterOptions: { certificationCenterId: 7 } };
-
-      // when
-      const url = adapter.urlForFindAll('certification-center-invitation', snapshot);
-
-      // then
-      assert.deepEqual(url, `${ENV.APP.API_HOST}/api/admin/certification-centers/7/invitations`);
-    });
-  });
-
   module('#queryRecord', function () {
     test('it builds request with specific payload and url', async function (assert) {
       // given

--- a/admin/tests/unit/routes/authenticated/certification-centers/get/invitations-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get/invitations-test.js
@@ -5,43 +5,22 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/certification-centers/get/invitations', function (hooks) {
   setupTest(hooks);
 
-  test("it should unload certification center invitations because it's maybe other certification center's invitations", async function (assert) {
-    // given
-    const route = this.owner.lookup('route:authenticated/certification-centers/get/invitations');
-    const store = this.owner.lookup('service:store');
-
-    store.findAll = sinon.stub();
-    store.unloadAll = sinon.stub();
-    route.modelFor = sinon.stub().returns({ certificationCenter: { id: 777 } });
-
-    // when
-    await route.model();
-
-    // then
-    assert.ok(store.unloadAll.calledWith('certification-center-invitation'));
-  });
-
   test('it should return certification center with its invitations', async function (assert) {
     // given
     const route = this.owner.lookup('route:authenticated/certification-centers/get/invitations');
-    const store = this.owner.lookup('service:store');
 
     const certificationCenterInvitations = Symbol('some certification center invitations');
-
-    store.unloadAll = sinon.stub();
+    const certificationCenter = {
+      id: 777,
+      certificationCenterInvitations,
+    };
     route.modelFor = sinon.stub();
-    route.modelFor.withArgs('authenticated.certification-centers.get').returns({ certificationCenter: { id: 777 } });
-    store.findAll = sinon.stub();
-    store.findAll
-      .withArgs('certification-center-invitation', {
-        adapterOptions: { certificationCenterId: 777 },
-      })
-      .resolves(certificationCenterInvitations);
+    route.modelFor.withArgs('authenticated.certification-centers.get').returns({ certificationCenter });
 
     // when
     const result = await route.model();
 
     // then
-    assert.deepEqual(result, { certificationCenterId: 777, certificationCenterInvitations });
+    assert.deepEqual(result, { certificationCenter, certificationCenterId: 777, certificationCenterInvitations });
   });
 });

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js
@@ -39,6 +39,7 @@ const serialize = function (certificationCenter) {
       'archivedAt',
       'archivistFullName',
       'certificationCenterMemberships',
+      'certificationCenterInvitations',
       'dataProtectionOfficerFirstName',
       'dataProtectionOfficerLastName',
       'dataProtectionOfficerEmail',
@@ -54,6 +55,16 @@ const serialize = function (certificationCenter) {
       relationshipLinks: {
         related(record, current, parent) {
           return `/api/admin/certification-centers/${parent.id}/certification-center-memberships`;
+        },
+      },
+    },
+    certificationCenterInvitations: {
+      ref: 'id',
+      ignoreRelationshipData: true,
+      nullIfMissing: true,
+      relationshipLinks: {
+        related(record, current, parent) {
+          return `/api/admin/certification-centers/${parent.id}/invitations`;
         },
       },
     },

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -277,6 +277,11 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
               'data-protection-officer-email': undefined,
             },
             relationships: {
+              'certification-center-invitations': {
+                links: {
+                  related: '/api/admin/certification-centers/1234/invitations',
+                },
+              },
               'certification-center-memberships': {
                 links: {
                   related: '/api/admin/certification-centers/1234/certification-center-memberships',

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.test.js
@@ -97,6 +97,11 @@ describe('Unit | Organizational Entities | Infrastructure | Serializer | JSONAPI
               related: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
             },
           },
+          'certification-center-invitations': {
+            links: {
+              related: `/api/admin/certification-centers/${certificationCenter.id}/invitations`,
+            },
+          },
           habilitations: {
             data: [
               {


### PR DESCRIPTION
## 🌱 Problème

ETQ user Pix Admin, JV voir le nombre d'invitations en attente sur la page de détail d'une organisation

## 🐣 Proposition

Sur la page de détail d’un centre de certif, dans le nom de l’onglet “Invitations”, ajouter entre parenthèse le nombre d’invitations en attente (= qui n’ont pas été annulés ou acceptés)


## 🐝 Pour tester
- Sur pix-admin
- Sur la page de détail d'un centre de certification
- Dans l'onglet Invitations
- Vérifier que le compteur est à jour avec le nombre d'invitation en attente
  - Envoyer une invitation (compteur +1)
  - Supprimer une invitation (compteur -1)
  - Envoyer à nouveau une invitation (compteur +1)
  - Accepter l'invitation, rafraichir la page (compteur -1)
