### PR TITLE
[BUGFIX] Sélectionner uniquement les orgas actives d'un centre de certif (PIX-22543).

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/find-divisions-by-certification-center.js
+++ b/api/src/certification/enrolment/domain/usecases/find-divisions-by-certification-center.js
@@ -1,10 +1,17 @@
-const findDivisionsByCertificationCenter = async function ({
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
+export async function findDivisionsByCertificationCenter({
   certificationCenterId,
-  organizationRepository,
+  centerRepository,
   divisionRepository,
 }) {
-  const organizationId = await organizationRepository.getIdByCertificationCenterId(certificationCenterId);
-  return divisionRepository.findByOrganizationIdForCurrentSchoolYear({ organizationId });
-};
+  const activeOrganizationId = await centerRepository.findActiveScoOrganizationId({
+    certificationCenterId,
+  });
 
-export { findDivisionsByCertificationCenter };
+  if (!activeOrganizationId) {
+    throw new NotFoundError('No organization found for this certification center');
+  }
+
+  return divisionRepository.findByOrganizationIdForCurrentSchoolYear({ organizationId: activeOrganizationId });
+}

--- a/api/src/certification/enrolment/domain/usecases/find-students-for-enrolment.js
+++ b/api/src/certification/enrolment/domain/usecases/find-students-for-enrolment.js
@@ -1,4 +1,3 @@
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { StudentForEnrolment } from '../read-models/StudentForEnrolment.js';
 
 const findStudentsForEnrolment = async function ({
@@ -6,30 +5,26 @@ const findStudentsForEnrolment = async function ({
   sessionId,
   page,
   filter,
-  organizationRepository,
+  centerRepository,
   organizationLearnerRepository,
   certificationCandidateRepository,
 }) {
-  try {
-    const organizationId = await organizationRepository.getIdByCertificationCenterId(certificationCenterId);
-    const paginatedStudents = await organizationLearnerRepository.findByOrganizationIdAndUpdatedAtOrderByDivision({
-      page,
-      filter,
-      organizationId,
-    });
-    const certificationCandidates = await certificationCandidateRepository.findBySessionId(sessionId);
-    return {
-      data: _buildStudentsForEnrolment({ students: paginatedStudents.data, certificationCandidates }),
-      pagination: paginatedStudents.pagination,
-    };
-  } catch (error) {
-    // This should not happen but still might (due to missing data in database)
-    // in that case, handle error gracefully.
-    // The error will be handled properly in the future.
-    if (error instanceof NotFoundError) return _emptyResponse(page);
+  const organizationId = await centerRepository.findActiveScoOrganizationId({ certificationCenterId });
 
-    throw error;
+  if (!organizationId) {
+    return _emptyResponse(page);
   }
+
+  const paginatedStudents = await organizationLearnerRepository.findByOrganizationIdAndUpdatedAtOrderByDivision({
+    page,
+    filter,
+    organizationId,
+  });
+  const certificationCandidates = await certificationCandidateRepository.findBySessionId(sessionId);
+  return {
+    data: _buildStudentsForEnrolment({ students: paginatedStudents.data, certificationCandidates }),
+    pagination: paginatedStudents.pagination,
+  };
 };
 
 export { findStudentsForEnrolment };

--- a/api/src/certification/enrolment/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/center-repository.js
@@ -65,6 +65,28 @@ export async function getById({ id }) {
 }
 
 /**
+ * @function
+ * @param {object} params
+ * @param {number} params.certificationCenterId
+ * @returns {Promise<number|null>}
+ */
+export async function findActiveScoOrganizationId({ certificationCenterId }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const [activeOrganizationId] = await knexConn('organizations')
+    .pluck('organizations.id')
+    .innerJoin('certification-centers', 'certification-centers.externalId', 'organizations.externalId')
+    .where({
+      'certification-centers.id': certificationCenterId,
+      'certification-centers.type': CERTIFICATION_CENTER_TYPES.SCO,
+      'organizations.type': Organization.types.SCO,
+      'organizations.archivedAt': null,
+    });
+
+  return activeOrganizationId || null;
+}
+
+/**
  * @typedef {object} CenterDTO
  * @property {number} id
  * @property {string} name

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -3,6 +3,7 @@ import lodash from 'lodash';
 
 import { PIX_ADMIN } from '../../authorization/domain/constants.js';
 import * as checkUserIsCandidateUseCase from '../../certification/enrolment/application/usecases/check-user-is-candidate.js';
+import * as centerRepository from '../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import { Organization } from '../../organizational-entities/domain/models/Organization.js';
 import * as checkCampaignBelongsToCombinedCourseUsecase from '../../prescription/campaign/application/usecases/checkCampaignBelongsToCombinedCourse.js';
@@ -442,7 +443,7 @@ async function checkCertificationCenterIsNotScoManagingStudents(
   dependencies = {
     checkOrganizationIsScoAndManagingStudentUsecase,
     checkUserIsMemberOfCertificationCenterUsecase,
-    organizationRepository,
+    centerRepository,
   },
 ) {
   if (_noCredentials(request)) {
@@ -452,14 +453,10 @@ async function checkCertificationCenterIsNotScoManagingStudents(
   const certificationCenterId =
     request?.params?.certificationCenterId || request?.payload?.data?.attributes?.certificationCenterId;
 
-  let organizationId;
+  const organizationId = await dependencies.centerRepository.findActiveScoOrganizationId({ certificationCenterId });
 
-  try {
-    organizationId = await dependencies.organizationRepository.getIdByCertificationCenterId(certificationCenterId);
-  } catch (error) {
-    if (_noOrganizationFound(error)) {
-      return h.response(true);
-    }
+  if (!organizationId) {
+    return h.response(true);
   }
 
   const isOrganizationScoManagingStudent = await dependencies.checkOrganizationIsScoAndManagingStudentUsecase.execute({
@@ -938,10 +935,6 @@ async function checkCampaignBelongsToCombinedCourse(
 
   await dependencies.checkCampaignBelongsToCombinedCourseUsecase.execute({ campaignId });
   return h.response(true);
-}
-
-function _noOrganizationFound(error) {
-  return error instanceof NotFoundError;
 }
 
 export const securityPreHandlers = {

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -49,25 +49,6 @@ const get = async function (id) {
   return _toDomain({ ...organizationDB, tags });
 };
 
-const getIdByCertificationCenterId = async function (certificationCenterId) {
-  const knexConn = DomainTransaction.getConnection();
-
-  const organizationIds = await knexConn
-    .pluck('organizations.id')
-    .from(ORGANIZATIONS_TABLE_NAME)
-    .innerJoin('certification-centers', function () {
-      this.on('certification-centers.externalId', 'organizations.externalId').andOn(
-        'certification-centers.type',
-        'organizations.type',
-      );
-    })
-    .where('certification-centers.id', certificationCenterId);
-
-  if (organizationIds.length !== 1)
-    throw new NotFoundError(`Not found organization for certification center id ${certificationCenterId}`);
-  return organizationIds[0];
-};
-
 const findActiveScoOrganizationsByExternalId = async function (externalId) {
   const knexConn = DomainTransaction.getConnection();
   const organizationsDB = await knexConn(ORGANIZATIONS_TABLE_NAME)
@@ -102,9 +83,4 @@ const getOrganizationsWithPlacesManagementFeatureEnabled = async function () {
   return organizations.map((organization) => _toDomain(organization));
 };
 
-export {
-  findActiveScoOrganizationsByExternalId,
-  get,
-  getIdByCertificationCenterId,
-  getOrganizationsWithPlacesManagementFeatureEnabled,
-};
+export { findActiveScoOrganizationsByExternalId, get, getOrganizationsWithPlacesManagementFeatureEnabled };

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/center-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/center-repository_test.js
@@ -146,4 +146,106 @@ describe('Integration | Certification |  Center | Repository | center-repository
       expect(result).to.deepEqualInstance(expectedCenter);
     });
   });
+
+  describe('#findActiveScoOrganizationId', function () {
+    context('when the certification center has an active linked organization', function () {
+      it('should return the linked organization id', async function () {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+          type: CertificationCenter.types.SCO,
+          externalId: 'EXTERNALABC',
+        });
+
+        databaseBuilder.factory.buildOrganization({
+          type: CertificationCenter.types.SCO,
+          externalId: certificationCenter.externalId,
+          archivedAt: new Date(),
+          archivedBy: databaseBuilder.factory.buildUser().id,
+        });
+
+        const activeOrganization = databaseBuilder.factory.buildOrganization({
+          type: CertificationCenter.types.SCO,
+          externalId: certificationCenter.externalId,
+          archivedAt: null,
+          archivedBy: null,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await centerRepository.findActiveScoOrganizationId({
+          certificationCenterId: certificationCenter.id,
+        });
+
+        // then
+        expect(result).to.equal(activeOrganization.id);
+      });
+    });
+
+    context('when the certification center has no active linked organization', function () {
+      it('should return null', async function () {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+          type: CertificationCenter.types.SCO,
+          externalId: 'EXTERNALABC',
+        });
+
+        databaseBuilder.factory.buildOrganization({
+          type: CertificationCenter.types.SCO,
+          externalId: certificationCenter.externalId,
+          archivedAt: new Date(),
+          archivedBy: databaseBuilder.factory.buildUser().id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await centerRepository.findActiveScoOrganizationId({
+          certificationCenterId: certificationCenter.id,
+        });
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+
+    context('when the certification center does not exist', function () {
+      it('should return null', async function () {
+        // when
+        const result = await centerRepository.findActiveScoOrganizationId({
+          certificationCenterId: 9999,
+        });
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+
+    context('when only a non-SCO organization shares the certification center externalId', function () {
+      it('should return null', async function () {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+          type: CertificationCenter.types.SCO,
+          externalId: 'EXTERNALABC',
+        });
+
+        databaseBuilder.factory.buildOrganization({
+          type: types.SUP,
+          externalId: certificationCenter.externalId,
+          archivedAt: null,
+          archivedBy: null,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await centerRepository.findActiveScoOrganizationId({
+          certificationCenterId: certificationCenter.id,
+        });
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+  });
 });

--- a/api/tests/certification/enrolment/unit/domain/usecases/find-divisions-by-certification-center_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/find-divisions-by-certification-center_test.js
@@ -1,17 +1,19 @@
 import sinon from 'sinon';
 
 import { findDivisionsByCertificationCenter } from '../../../../../../src/certification/enrolment/domain/usecases/find-divisions-by-certification-center.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | find-divisions-by-certification-center', function () {
   let organization;
-  let organizationRepository;
+  let centerRepository;
   let divisionRepository;
 
   beforeEach(async function () {
-    organizationRepository = {
-      getIdByCertificationCenterId: sinon.stub(),
+    centerRepository = {
+      findActiveScoOrganizationId: sinon.stub(),
     };
     divisionRepository = {
       findByOrganizationIdForCurrentSchoolYear: sinon.stub(),
@@ -25,7 +27,9 @@ describe('Unit | UseCase | find-divisions-by-certification-center', function () 
       const certificationCenter = domainBuilder.buildCertificationCenter({ externalId });
       organization = domainBuilder.buildOrganization({ externalId });
 
-      organizationRepository.getIdByCertificationCenterId.withArgs(certificationCenter.id).resolves(organization.id);
+      centerRepository.findActiveScoOrganizationId
+        .withArgs({ certificationCenterId: certificationCenter.id })
+        .resolves(organization.id);
       divisionRepository.findByOrganizationIdForCurrentSchoolYear
         .withArgs({ organizationId: organization.id })
         .resolves([{ name: '3a' }, { name: '3b' }, { name: '5c' }]);
@@ -33,12 +37,35 @@ describe('Unit | UseCase | find-divisions-by-certification-center', function () 
       // when
       const divisions = await findDivisionsByCertificationCenter({
         certificationCenterId: certificationCenter.id,
-        organizationRepository,
+        centerRepository,
         divisionRepository,
       });
 
       // then
       expect(divisions).to.be.deep.equal([{ name: '3a' }, { name: '3b' }, { name: '5c' }]);
+    });
+
+    describe('when the certification center has no active organization', function () {
+      it('should throw a not found error', async function () {
+        // given
+        const certificationCenter = domainBuilder.buildCertificationCenter();
+        organization = domainBuilder.buildOrganization({ externalId: certificationCenter.externalId });
+
+        centerRepository.findActiveScoOrganizationId
+          .withArgs({ certificationCenterId: certificationCenter.id })
+          .resolves(null);
+
+        // when
+        const error = await catchErr(findDivisionsByCertificationCenter)({
+          certificationCenterId: certificationCenter.id,
+          centerRepository,
+          divisionRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal('No organization found for this certification center');
+      });
     });
   });
 });

--- a/api/tests/certification/enrolment/unit/domain/usecases/find-students-for-enrolment_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/find-students-for-enrolment_test.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 
 import { StudentForEnrolment } from '../../../../../../src/certification/enrolment/domain/read-models/StudentForEnrolment.js';
 import { findStudentsForEnrolment } from '../../../../../../src/certification/enrolment/domain/usecases/find-students-for-enrolment.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -11,11 +10,11 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
   const certificationCenterId = 1;
   const userId = 'userId';
   let organization;
-  let organizationRepository, organizationLearnerRepository, certificationCandidateRepository;
+  let centerRepository, organizationLearnerRepository, certificationCandidateRepository;
 
   beforeEach(async function () {
-    organizationRepository = {
-      getIdByCertificationCenterId: sinon.stub(),
+    centerRepository = {
+      findActiveScoOrganizationId: sinon.stub(),
     };
     organizationLearnerRepository = {
       findByOrganizationIdAndUpdatedAtOrderByDivision: sinon.stub(),
@@ -27,23 +26,23 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
     const certificationCenter = domainBuilder.buildCertificationCenter({ id: certificationCenterId, externalId });
     organization = domainBuilder.buildOrganization({ externalId });
 
-    organizationRepository.getIdByCertificationCenterId.withArgs(certificationCenter.id).resolves(organization.id);
+    centerRepository.findActiveScoOrganizationId
+      .withArgs({ certificationCenterId: certificationCenter.id })
+      .resolves(organization.id);
   });
 
   describe('when user has access to certification center', function () {
-    describe('when there is no certification center for the organization ', function () {
+    describe('when there is no active sco organization for the certification center', function () {
       it('should return an empty list of student', async function () {
         // given
-        organizationRepository.getIdByCertificationCenterId
-          .withArgs(certificationCenterId)
-          .rejects(new NotFoundError());
+        centerRepository.findActiveScoOrganizationId.withArgs({ certificationCenterId }).resolves(null);
 
         // when
         const studentsFounds = await findStudentsForEnrolment({
           userId,
           certificationCenterId,
           page: { size: 10, number: 1 },
-          organizationRepository,
+          centerRepository,
           organizationLearnerRepository,
           certificationCandidateRepository,
         });
@@ -85,7 +84,7 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
         sessionId,
         page: { number: 1, size: 10 },
         filter: { divisions: ['3A'] },
-        organizationRepository,
+        centerRepository,
         organizationLearnerRepository,
         certificationCandidateRepository,
       });
@@ -118,7 +117,7 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
           certificationCenterId,
           page: { number: 1, size: 10 },
           filter: {},
-          organizationRepository,
+          centerRepository,
           organizationLearnerRepository,
           certificationCandidateRepository,
         });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { Organization } from '../../../../src/organizational-entities/domain/models/Organization.js';
 import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
@@ -79,48 +77,6 @@ describe('Integration | Repository | Organization', function () {
         expect(error).to.be.an.instanceof(NotFoundError);
         expect(error.message).to.equal('Not found organization for ID 10083');
       });
-    });
-  });
-
-  describe('#getIdByCertificationCenterId', function () {
-    beforeEach(function () {
-      _.map(
-        [
-          { id: 1, type: 'SCO', name: 'organization 1', externalId: '1234567' },
-          { id: 2, type: 'SCO', name: 'organization 2', externalId: '1234568' },
-          { id: 3, type: 'SUP', name: 'organization 3', externalId: '1234568' },
-          { id: 4, type: 'SCO', name: 'organization 4', externalId: '1234569' },
-          { id: 5, type: 'SCO', name: 'organization 5', externalId: '1234569' },
-        ],
-        (organization) => {
-          databaseBuilder.factory.buildOrganization(organization);
-        },
-      );
-
-      databaseBuilder.factory.buildCertificationCenter({
-        id: 10,
-        externalId: '1234568',
-        type: 'SCO',
-      });
-
-      return databaseBuilder.commit();
-    });
-
-    it('should return the id of the organization given the certification center id matching the same type', async function () {
-      // when
-      const organisationId = await organizationRepository.getIdByCertificationCenterId(10);
-
-      // then
-      expect(organisationId).to.equal(2);
-    });
-
-    it('should throw an error if the id does not match a certification center with organization', async function () {
-      // when
-      const error = await catchErr(organizationRepository.getIdByCertificationCenterId)(123456);
-
-      // then
-      expect(error).to.be.instanceOf(NotFoundError);
-      expect(error.message).to.equal('Not found organization for certification center id 123456');
     });
   });
 

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -807,24 +807,24 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
 
   describe('#checkCertificationCenterIsNotScoManagingStudents', function () {
     let checkOrganizationIsScoAndManagingStudentUsecaseStub;
-    let organizationRepositoryStub;
+    let centerRepositoryStub;
 
     let dependencies;
 
     beforeEach(function () {
       checkOrganizationIsScoAndManagingStudentUsecaseStub = { execute: sinon.stub() };
-      organizationRepositoryStub = {
-        getIdByCertificationCenterId: sinon.stub(),
+      centerRepositoryStub = {
+        findActiveScoOrganizationId: sinon.stub(),
       };
 
       dependencies = {
         checkOrganizationIsScoAndManagingStudentUsecase: checkOrganizationIsScoAndManagingStudentUsecaseStub,
-        organizationRepository: organizationRepositoryStub,
+        centerRepository: centerRepositoryStub,
       };
     });
 
     context('Successful cases', function () {
-      context('when certification center does not belong to an organization', function () {
+      context('when certification center does not belong to an active sco organization', function () {
         it('should authorize access to resource when the user is authenticated', async function () {
           // given
           const request = {
@@ -839,7 +839,7 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
             },
           };
           dependencies.checkOrganizationIsScoAndManagingStudentUsecase.execute.resolves(false);
-          dependencies.organizationRepository.getIdByCertificationCenterId.rejects(new NotFoundError());
+          dependencies.centerRepository.findActiveScoOrganizationId.resolves(null);
 
           // when
           const response = await securityPreHandlers.checkCertificationCenterIsNotScoManagingStudents(
@@ -868,7 +868,7 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
             },
           };
           dependencies.checkOrganizationIsScoAndManagingStudentUsecase.execute.resolves(false);
-          dependencies.organizationRepository.getIdByCertificationCenterId.resolves(1);
+          dependencies.centerRepository.findActiveScoOrganizationId.resolves(1);
 
           // when
           const response = await securityPreHandlers.checkCertificationCenterIsNotScoManagingStudents(
@@ -901,7 +901,7 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
             },
           };
           dependencies.checkOrganizationIsScoAndManagingStudentUsecase.execute.resolves(false);
-          dependencies.organizationRepository.getIdByCertificationCenterId.resolves(1);
+          dependencies.centerRepository.findActiveScoOrganizationId.resolves(1);
 
           // when
           const response = await securityPreHandlers.checkCertificationCenterIsNotScoManagingStudents(
@@ -959,7 +959,7 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
           },
         };
         dependencies.checkOrganizationIsScoAndManagingStudentUsecase.execute.resolves(true);
-        dependencies.organizationRepository.getIdByCertificationCenterId.resolves(1);
+        dependencies.centerRepository.findActiveScoOrganizationId.resolves(1);
 
         // when
         const response = await securityPreHandlers.checkCertificationCenterIsNotScoManagingStudents(

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -6,8 +6,10 @@ import { STUDENT_PAGE_SIZE } from '../../../utils/pagination';
 
 export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
   @service currentUser;
-  @service store;
+  @service intl;
+  @service pixToast;
   @service router;
+  @service store;
 
   queryParams = {
     pageNumber: { refreshModel: true },
@@ -23,7 +25,18 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
     const session = await this.store.findRecord('session-enrolment', params.session_id);
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
     const certificationCandidates = await this.store.query('certification-candidate', { sessionId: params.session_id });
-    const divisions = await this.store.query('division', { certificationCenterId });
+
+    let divisions;
+    try {
+      divisions = await this.store.query('division', { certificationCenterId });
+    } catch (error) {
+      const messageKey =
+        error?.errors?.[0]?.status === '404'
+          ? 'pages.sco.enrol-candidates-in-session.certification-candidates-sco.errors.no-active-organization'
+          : 'common.api-error-messages.internal-server-error';
+      this.pixToast.sendErrorNotification({ message: this.intl.t(messageKey) });
+      return this.router.replaceWith('authenticated.sessions.details.certification-candidates', params.session_id);
+    }
 
     const certificationCenterDivisions = divisions.map((division) => {
       return { label: division.name, value: division.name };

--- a/certif/tests/acceptance/session-add-students-test.js
+++ b/certif/tests/acceptance/session-add-students-test.js
@@ -1,7 +1,9 @@
 import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { click, currentURL, visit } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { Response } from 'miragejs';
 import { STUDENT_PAGE_SIZE } from 'pix-certif/utils/pagination';
 import { module, test } from 'qunit';
 
@@ -63,6 +65,44 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), '/espace-ferme');
+      });
+    });
+
+    module('when divisions request fails', function () {
+      test('it should redirect to candidates page and display a specific error toast on 404', async function (assert) {
+        // given
+        this.server.get(
+          '/certification-centers/:id/divisions',
+          () => new Response(404, {}, { errors: [{ status: '404' }] }),
+        );
+
+        // when
+        const screen = await visitScreen(`/sessions/${session.id}/inscription-eleves`);
+
+        // then
+        assert.strictEqual(currentURL(), `/sessions/${session.id}/candidats`);
+        assert
+          .dom(
+            screen.getByText(
+              t('pages.sco.enrol-candidates-in-session.certification-candidates-sco.errors.no-active-organization'),
+            ),
+          )
+          .exists();
+      });
+
+      test('it should redirect to candidates page and display a generic error toast on other errors', async function (assert) {
+        // given
+        this.server.get(
+          '/certification-centers/:id/divisions',
+          () => new Response(500, {}, { errors: [{ status: '500' }] }),
+        );
+
+        // when
+        const screen = await visitScreen(`/sessions/${session.id}/inscription-eleves`);
+
+        // then
+        assert.strictEqual(currentURL(), `/sessions/${session.id}/candidats`);
+        assert.dom(screen.getByText(t('common.api-error-messages.internal-server-error'))).exists();
       });
     });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -292,6 +292,9 @@
           "actions": {
             "enrol-candidates": "Enrol candidates"
           },
+          "errors": {
+            "no-active-organization": "An error occurred, unable to add candidates. Please try again or contact us."
+          },
           "information": "Enrol students and you're readix to go !"
         },
         "information": "If some students don't appear in this list, please re-import the student file in Pix Orga.'<br>' If students are still not visible, please contact",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -292,6 +292,9 @@
           "actions": {
             "enrol-candidates": "Inscrire des candidats"
           },
+          "errors": {
+            "no-active-organization": "Une erreur est survenue, impossible d'ajouter des candidats. Veuillez réessayer ou contactez-nous."
+          },
           "information": "Inscrivez des élèves et c'est partix !"
         },
         "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.'<br>' Si malgré tout des élèves ne sont pas visibles, merci de contacter",


### PR DESCRIPTION
## 🌱 Problème

On est tombé sur le cas où un centre de certif SCO est rattaché à 2 centres de certifs, dont 1 archivé.

Malheureusement, le code vient juste pick la première orga qu’il peut, sans filtrer sur l'état d’activité.

## 🐣 Proposition

Rapatrier la méthode de repo dans le bounded-context certif et filtrer sur l'état de l’orga.

## 🐝 Pour tester

**En RA** 
- Créer une nouvelle session avec le centre de certif SCO
- Essayer d'ajouter des candidats
- Tout devrait se passer comme prévu

**Peut être fait rapidement en local**
- Ajouter une date à la colonne `archivedAt` du centre de certif SCO
- Créer une nouvelle session
- Essayer d'ajouter des candidats
- Le toast est censé apparaître
