### PR TITLE
[FEATURE] Ajouter une navigation par type d'object du catalogue (PIX-22346)

### DIFF
--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -1,5 +1,6 @@
 import PixCard from '@1024pix/pix-ui/components/pix-card';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { concat } from '@ember/helper';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
@@ -23,16 +24,11 @@ export default class CourseCard extends Component {
       }
     }
   }
-
-  get category() {
-    return `pages.campaign-creation.tags.${this.args.course.category}`;
-  }
-
   <template>
     <PixCard
       variant="orga"
       @title={{@course.name}}
-      @subtitle={{if @course.category (t this.category)}}
+      @subtitle={{if @course.category (t (concat "pages.campaign-creation.tags." @course.category))}}
       @image={{this.courseInfo.image}}
     >
       <:tag>

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -1,0 +1,42 @@
+import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { LinkTo } from '@ember/routing';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import CourseCard from 'pix-orga/components/catalogue/course-card';
+import EmptyState from 'pix-orga/components/ui/empty-state';
+
+export default class List extends Component {
+  get filteredItems() {
+    const { type } = this.args;
+
+    if (!type || type === 'all') {
+      return this.args.courses;
+    }
+    return this.args.courses.filter((item) => item.type === type);
+  }
+
+  <template>
+    <div class="catalogue">
+      <PixTabs @variant="orga" class="catalogue__nav" @ariaLabel={{t "pages.catalogue.tab-filters.label"}}>
+        <LinkTo @route="authenticated.catalogue.list" @model="all">
+          {{t "pages.catalogue.tab-filters.all"}}</LinkTo>
+        <LinkTo @route="authenticated.catalogue.list" @model="targetProfile">{{t
+            "pages.catalogue.tab-filters.target-profiles"
+          }}</LinkTo>
+        <LinkTo @route="authenticated.catalogue.list" @model="blueprint">{{t
+            "pages.catalogue.tab-filters.blueprints"
+          }}</LinkTo>
+      </PixTabs>
+
+      {{#if this.filteredItems}}
+        <div class="catalogue__list">
+          {{#each this.filteredItems as |course|}}
+            <CourseCard @course={{course}} />
+          {{/each}}
+        </div>
+      {{else}}
+        <EmptyState @infoText={{t "pages.catalogue.empty-state"}} />
+      {{/if}}
+    </div>
+  </template>
+}

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -110,7 +110,9 @@ Router.map(function () {
       this.route('participations', { path: '/' });
       this.route('participation-detail', { path: '/participations/:participation_id' });
     });
-    this.route('catalogue');
+    this.route('catalogue', function () {
+      this.route('list', { path: '/:type' });
+    });
   });
 
   this.route('logout');

--- a/orga/app/routes/authenticated/catalogue.js
+++ b/orga/app/routes/authenticated/catalogue.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class AuthenticatedCatalogue extends Route {
-  @service('store') store;
   @service currentUser;
   @service router;
   @service featureToggles;
@@ -14,11 +13,5 @@ export default class AuthenticatedCatalogue extends Route {
     if (!this.featureToggles.featureToggles?.displayCatalogue) {
       return this.router.replaceWith('authenticated.index');
     }
-  }
-
-  async model() {
-    return await this.store.findAll('course', {
-      adapterOptions: { organizationId: this.currentUser.organization.id },
-    });
   }
 }

--- a/orga/app/routes/authenticated/catalogue/index.js
+++ b/orga/app/routes/authenticated/catalogue/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AuthenticatedCatalogueIndex extends Route {
+  @service router;
+
+  beforeModel() {
+    return this.router.replaceWith('authenticated.catalogue.list', 'all');
+  }
+}

--- a/orga/app/routes/authenticated/catalogue/list.js
+++ b/orga/app/routes/authenticated/catalogue/list.js
@@ -6,6 +6,8 @@ export default class AuthenticatedCatalogueFilter extends Route {
   @service currentUser;
   @service router;
 
+  #currentOrgaId = null;
+
   beforeModel(transition) {
     if (!['all', 'blueprint', 'targetProfile'].includes(transition.to.params?.type)) {
       return this.router.replaceWith('authenticated.catalogue.list', 'all');
@@ -13,14 +15,24 @@ export default class AuthenticatedCatalogueFilter extends Route {
   }
 
   async model({ type }) {
-    const items = this.store.peekAll('course');
+    this.handleCache();
+    let courses = this.store.peekAll('course');
 
-    if (items.length) {
-      return { courses: items, type };
+    if (courses.length === 0) {
+      courses = await this.store.findAll('course', {
+        backgroundReload: false,
+        adapterOptions: { organizationId: this.currentUser.organization.id },
+      });
     }
-    const courses = await this.store.findAll('course', {
-      adapterOptions: { organizationId: this.currentUser.organization.id },
-    });
+
     return { courses, type };
+  }
+
+  handleCache() {
+    const orgId = this.currentUser.organization.id;
+    if (this.#currentOrgaId !== orgId) {
+      this.store.unloadAll('course');
+    }
+    this.#currentOrgaId = orgId;
   }
 }

--- a/orga/app/routes/authenticated/catalogue/list.js
+++ b/orga/app/routes/authenticated/catalogue/list.js
@@ -1,0 +1,26 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AuthenticatedCatalogueFilter extends Route {
+  @service store;
+  @service currentUser;
+  @service router;
+
+  beforeModel(transition) {
+    if (!['all', 'blueprint', 'targetProfile'].includes(transition.to.params?.type)) {
+      return this.router.replaceWith('authenticated.catalogue.list', 'all');
+    }
+  }
+
+  async model({ type }) {
+    const items = this.store.peekAll('course');
+
+    if (items.length) {
+      return { courses: items, type };
+    }
+    const courses = await this.store.findAll('course', {
+      adapterOptions: { organizationId: this.currentUser.organization.id },
+    });
+    return { courses, type };
+  }
+}

--- a/orga/app/styles/pages/authenticated/catalogue.scss
+++ b/orga/app/styles/pages/authenticated/catalogue.scss
@@ -1,6 +1,12 @@
 .catalogue {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 12px;
-  width: 100%;
+  &__nav {
+    margin-bottom: var(--pix-spacing-4x);
+  }
+
+  &__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: var(--pix-spacing-3x);
+    width: 100%;
+  }
 }

--- a/orga/app/templates/authenticated/catalogue.gjs
+++ b/orga/app/templates/authenticated/catalogue.gjs
@@ -1,6 +1,5 @@
 import { t } from 'ember-intl';
 import pageTitle from 'ember-page-title/helpers/page-title';
-import CourseCard from 'pix-orga/components/courses/course-card';
 import PageTitle from 'pix-orga/components/ui/page-title';
 
 <template>
@@ -10,9 +9,5 @@ import PageTitle from 'pix-orga/components/ui/page-title';
       {{t "pages.catalogue.title"}}
     </:title>
   </PageTitle>
-  <div class="catalogue">
-    {{#each @model as |course|}}
-      <CourseCard @course={{course}} />
-    {{/each}}
-  </div>
+  {{outlet}}
 </template>

--- a/orga/app/templates/authenticated/catalogue/list.gjs
+++ b/orga/app/templates/authenticated/catalogue/list.gjs
@@ -1,0 +1,3 @@
+import List from 'pix-orga/components/catalogue/list';
+
+<template><List @courses={{@model.courses}} @type={{@model.type}} /></template>

--- a/orga/tests/integration/components/catalogue/course-card-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-card-test.gjs
@@ -1,11 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
-import CourseCard from 'pix-orga/components/courses/course-card';
+import CourseCard from 'pix-orga/components/catalogue/course-card';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | Courses::CourseCard', function (hooks) {
+module('Integration | Component | Catalogue::CourseCard', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('for a "targetProfile" type course', function () {

--- a/orga/tests/integration/components/catalogue/list-test.gjs
+++ b/orga/tests/integration/components/catalogue/list-test.gjs
@@ -1,0 +1,65 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import List from 'pix-orga/components/catalogue/list';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Catalogue::List', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const router = this.owner.lookup('service:router');
+    router.transitionTo = () => {};
+  });
+
+  module('when there are no items', function () {
+    test('it displays an empty state', async function (assert) {
+      const courses = [];
+      const screen = await render(<template><List @courses={{courses}} /></template>);
+
+      assert.dom(screen.getByText(t('pages.catalogue.empty-state'))).exists();
+    });
+  });
+
+  module('when there are course items', function () {
+    test('it shows all items', async function (assert) {
+      const courses = [
+        { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+        { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+      ];
+
+      const screen = await render(<template><List @courses={{courses}} @type="all" /></template>);
+
+      assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
+      assert.dom(screen.getByRole('heading', { level: 3, name: 'Mon parcours combiné' })).exists();
+    });
+    module('type filters', function () {
+      test('it displays navigation links to filter by type', async function (assert) {
+        const courses = [
+          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+        ];
+
+        const screen = await render(<template><List @courses={{courses}} @type="blueprint" /></template>);
+        const allLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.all') });
+        assert.ok(allLink.href.endsWith('/catalogue/all'));
+        const targetProfilLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.target-profiles') });
+        assert.ok(targetProfilLink.href.endsWith('/catalogue/targetProfile'));
+        const blueprintLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.blueprints') });
+        assert.ok(blueprintLink.href.endsWith('/catalogue/blueprint'));
+      });
+      test('it filters list by type', async function (assert) {
+        const courses = [
+          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+        ];
+
+        const screen = await render(<template><List @courses={{courses}} @type="blueprint" /></template>);
+
+        const items = screen.getAllByRole('heading', { level: 3 });
+        assert.strictEqual(items.length, 1);
+      });
+    });
+  });
+});

--- a/orga/tests/integration/templates/authenticated/catalogue-test.gjs
+++ b/orga/tests/integration/templates/authenticated/catalogue-test.gjs
@@ -9,17 +9,10 @@ module('Integration | Template | authenticated/catalogue', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('it renders template', async function (assert) {
-    // given
-    const model = [
-      {
-        name: 'Combinix',
-      },
-    ];
     // when
-    const screen = await render(<template><Catalogue @model={{model}} /></template>);
+    const screen = await render(<template><Catalogue /></template>);
 
     // then
     assert.ok(screen.getByRole('heading', { name: t('pages.catalogue.title'), level: 1 }));
-    assert.ok(screen.getByText('Combinix'));
   });
 });

--- a/orga/tests/integration/templates/authenticated/catalogue/list-test.gjs
+++ b/orga/tests/integration/templates/authenticated/catalogue/list-test.gjs
@@ -1,0 +1,26 @@
+import { render } from '@1024pix/ember-testing-library';
+import List from 'pix-orga/templates/authenticated/catalogue/list';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Template | authenticated/catalogue/list', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it renders template', async function (assert) {
+    // given
+    const model = {
+      courses: [
+        {
+          name: 'Combinix',
+        },
+      ],
+      type: 'all',
+    };
+    // when
+    const screen = await render(<template><List @model={{model}} /></template>);
+
+    // then
+    assert.ok(screen.getByText('Combinix'));
+  });
+});

--- a/orga/tests/unit/routes/authenticated/catalogue-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue-test.js
@@ -45,24 +45,4 @@ module('Unit | Route | authenticated/catalogue', function (hooks) {
       assert.ok(routerService.replaceWith.calledOnceWithExactly('authenticated.index'));
     });
   });
-
-  module('model', function () {
-    test('fetch courses ', async function (assert) {
-      // given
-      const route = this.owner.lookup('route:authenticated/catalogue');
-      const store = this.owner.lookup('service:store');
-      const currentUser = this.owner.lookup('service:current-user');
-      const organizationId = Symbol('organizationId');
-      sinon.stub(currentUser, 'organization').value({ id: organizationId });
-      const courses = Symbol('Courses');
-
-      sinon.stub(store, 'findAll').withArgs('course', { adapterOptions: { organizationId } }).resolves(courses);
-
-      // when
-      const result = await route.model();
-      // then
-      assert.ok(store.findAll.calledOnce);
-      assert.strictEqual(result, courses);
-    });
-  });
 });

--- a/orga/tests/unit/routes/authenticated/catalogue/index-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue/index-test.js
@@ -1,0 +1,27 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/catalogue/index', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('beforeModel', function () {
+    test('it should redirect to catalogue all list page', async function (assert) {
+      // given
+
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'replaceWith');
+      const route = this.owner.lookup('route:authenticated/catalogue/index');
+
+      // when
+      await route.beforeModel();
+
+      //then
+      assert.ok(routerService.replaceWith.calledOnceWithExactly('authenticated.catalogue.list', 'all'));
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/catalogue/list-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue/list-test.js
@@ -51,7 +51,10 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
       const courses = Symbol('Courses');
 
       sinon.stub(store, 'peekAll').withArgs('course').returns([]);
-      sinon.stub(store, 'findAll').withArgs('course', { adapterOptions: { organizationId } }).resolves(courses);
+      sinon
+        .stub(store, 'findAll')
+        .withArgs('course', { backgroundReload: false, adapterOptions: { organizationId } })
+        .resolves(courses);
 
       // when
       const result = await route.model({ type: 'all' });
@@ -62,17 +65,75 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
     });
     test('it returns cached courses without calling the API when the store is not empty', async function (assert) {
       // given
+      const currentUser = this.owner.lookup('service:current-user');
+      const organizationId = Symbol('organizationId');
+      sinon.stub(currentUser, 'organization').value({ id: organizationId });
       const route = this.owner.lookup('route:authenticated/catalogue/list');
       const store = this.owner.lookup('service:store');
       const courses = [Symbol('Course')];
       sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
       sinon.stub(store, 'findAll');
+      sinon.stub(store, 'unloadAll');
 
       // when
       const result = await route.model({ type: 'all' });
       // then
       assert.ok(store.findAll.notCalled);
       assert.deepEqual(result, { courses, type: 'all' });
+    });
+    test('it unload cached courses when organization change', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      const organizationId = Symbol('organizationId');
+      sinon.stub(currentUser, 'organization').value({ id: organizationId });
+      const route = this.owner.lookup('route:authenticated/catalogue/list');
+      const store = this.owner.lookup('service:store');
+      const courses = [Symbol('Course')];
+      sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
+      sinon.stub(store, 'findAll');
+      sinon.stub(store, 'unloadAll');
+
+      // when
+      const result = await route.model({ type: 'all' });
+      // then
+      assert.ok(store.findAll.notCalled);
+      assert.deepEqual(result, { courses, type: 'all' });
+    });
+  });
+  module('handleCache', function () {
+    test('it unloads course items from cache when organization change', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      const organizationId = Symbol('organizationId');
+      sinon.stub(currentUser, 'organization').value({ id: organizationId });
+
+      const route = this.owner.lookup('route:authenticated/catalogue/list');
+      const store = this.owner.lookup('service:store');
+      sinon.stub(store, 'unloadAll');
+
+      // when
+      route.handleCache();
+
+      // then
+      assert.ok(store.unloadAll.calledOnceWithExactly('course'));
+    });
+    test('it do nothing when organizationhas not changed', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      const organizationId = Symbol('organizationId');
+      sinon.stub(currentUser, 'organization').value({ id: organizationId });
+
+      const route = this.owner.lookup('route:authenticated/catalogue/list');
+      const store = this.owner.lookup('service:store');
+      sinon.stub(store, 'unloadAll');
+      route.handleCache();
+      store.unloadAll.reset();
+
+      // when
+      route.handleCache();
+
+      // then
+      assert.ok(store.unloadAll.notCalled);
     });
   });
 });

--- a/orga/tests/unit/routes/authenticated/catalogue/list-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue/list-test.js
@@ -1,0 +1,78 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/catalogue/list', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('beforeModel', function () {
+    ['all', 'targetProfile', 'blueprint'].forEach((type) => {
+      test(`it should not redirect if param type=${type}`, async function (assert) {
+        // given
+        const routerService = this.owner.lookup('service:router');
+        sinon.stub(routerService, 'replaceWith');
+        const route = this.owner.lookup('route:authenticated/catalogue/list');
+
+        // when
+        await route.beforeModel({ to: { params: { type } } });
+
+        //then
+        assert.ok(routerService.replaceWith.notCalled);
+      });
+    });
+
+    test('it should redirect to catalogue list page with type=all if type params is not supported', async function (assert) {
+      // given
+
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'replaceWith');
+      const route = this.owner.lookup('route:authenticated/catalogue/list');
+
+      // when
+      await route.beforeModel({ to: { params: null } });
+
+      //then
+      assert.ok(routerService.replaceWith.calledOnceWithExactly('authenticated.catalogue.list', 'all'));
+    });
+  });
+
+  module('model', function () {
+    test('it fetches courses from the API when none are present in the store', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/catalogue/list');
+      const store = this.owner.lookup('service:store');
+      const currentUser = this.owner.lookup('service:current-user');
+      const organizationId = Symbol('organizationId');
+      sinon.stub(currentUser, 'organization').value({ id: organizationId });
+      const courses = Symbol('Courses');
+
+      sinon.stub(store, 'peekAll').withArgs('course').returns([]);
+      sinon.stub(store, 'findAll').withArgs('course', { adapterOptions: { organizationId } }).resolves(courses);
+
+      // when
+      const result = await route.model({ type: 'all' });
+
+      // then
+      assert.ok(store.findAll.calledOnce);
+      assert.deepEqual(result, { courses, type: 'all' });
+    });
+    test('it returns cached courses without calling the API when the store is not empty', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/catalogue/list');
+      const store = this.owner.lookup('service:store');
+      const courses = [Symbol('Course')];
+      sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
+      sinon.stub(store, 'findAll');
+
+      // when
+      const result = await route.model({ type: 'all' });
+      // then
+      assert.ok(store.findAll.notCalled);
+      assert.deepEqual(result, { courses, type: 'all' });
+    });
+  });
+});

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -298,7 +298,7 @@
       "explanation": {
         "ASSESSMENT": "Bewertungskampagne",
         "CAMPAIGN": "Bewertungskampagne",
-        "COMBINED_COURSE": "Lerner-Parcours",
+        "COMBINED_COURSE": "Lernpfad",
         "EXAM": "Testmodus [beta]",
         "FORMATION": "Ausbildung",
         "MODULE": "Modul",
@@ -307,7 +307,7 @@
       "information": {
         "ASSESSMENT": "Bewertung",
         "CAMPAIGN": "Bewertung",
-        "COMBINED_COURSE": "Lerner-Parcours",
+        "COMBINED_COURSE": "Lernpfad",
         "EXAM": "Testmodus [beta]",
         "FORMATION": "Ausbildung",
         "MODULE": "Modul",

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1017,6 +1017,13 @@
         },
         "tubes-count": "{count, plural, =0 {Kein Thema} =1 {{count} thema} other {{count} themen}}"
       },
+      "empty-state": "Derzeit sind keine Kurse verfügbar. Kontaktieren Sie Pix, um welche zu erhalten.",
+      "tab-filters": {
+        "all": "Alle",
+        "blueprints": "Lernpfade",
+        "label": "Kurstyp",
+        "target-profiles": "Kurse"
+      },
       "title": "Kurskatalog"
     },
     "certifications": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1027,6 +1027,13 @@
         },
         "tubes-count": "{count, plural, =0 {No topic} =1 {{count} topic} other {{count} topics}}"
       },
+      "empty-state": "No courses available at the moment. Contact Pix to obtain some.",
+      "tab-filters": {
+        "all": "All",
+        "blueprints": "Learning courses",
+        "label": "Course type",
+        "target-profiles": "Courses"
+      },
       "title": "Courses catalogue"
     },
     "certifications": {

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1016,10 +1016,17 @@
         "modules-count": "{count, plural, =0 {Sin módulos} =1 {{count} Módulo} other {{count} Módulos}}",
         "simplified-access": "Acceso sin cuenta",
         "tag": {
-          "blueprint": "Cursos para estudiantes",
+          "blueprint": "Ruta de aprendizaje",
           "target-profile": "Cursos"
         },
         "tubes-count": "{count, plural, =0 {Sin temas} =1 {{count} tema} other {{count} temas}}"
+      },
+      "empty-state": "No hay cursos disponibles por el momento. Póngase en contacto con Pix para obtenerlos.",
+      "tab-filters": {
+        "all": "Todos",
+        "blueprints": "Rutas de aprendizaje",
+        "label": "Tipo de curso",
+        "target-profiles": "Cursos"
       },
       "title": "Catálogo de cursos"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1015,6 +1015,13 @@
         },
         "tubes-count": "{count, plural, =0 {Aucun sujet} =1 {{count} sujet} other {{count} sujets}}"
       },
+      "empty-state": "Aucun parcours disponible pour l'instant. Contactez Pix pour en obtenir.",
+      "tab-filters": {
+        "all": "Tous",
+        "blueprints": "Parcours apprenants",
+        "label": "Type de parcours",
+        "target-profiles": "Parcours"
+      },
       "title": "Catalogue de parcours"
     },
     "certifications": {

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1013,10 +1013,17 @@
         "modules-count": "{count, plural, =0 {Nessun modulo} =1 {{count} modulo} other {{count} moduli}}",
         "simplified-access": "Accesso senza account",
         "tag": {
-          "blueprint": "Percorso dello studente",
+          "blueprint": "Percorso di apprendimento",
           "target-profile": "Percorso"
         },
         "tubes-count": "{count, plural, =0 {Nessun argomento} =1 {{count} argomento} other {{count} argomenti}}"
+      },
+      "empty-state": "Nessun percorso disponibile al momento. Contattare Pix per ottenerne.",
+      "tab-filters": {
+        "all": "Tutti",
+        "blueprints": "Percorsi di apprendimento",
+        "label": "Tipo di percorso",
+        "target-profiles": "Percorsi"
       },
       "title": "Catalogo dei percorsi"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1009,10 +1009,17 @@
         "modules-count": "{count, plural, =0 {Geen module} =1 {{count} module} other {{count} modules}}",
         "simplified-access": "Toegang zonder account",
         "tag": {
-          "blueprint": "Leertraject voor leerlingen",
-          "target-profile": "Leertrajecten"
+          "blueprint": "Leerprogramma",
+          "target-profile": "Leertraject"
         },
         "tubes-count": "{count, plural, =0 {Geen onderwerp} =1 {{count} onderwerp} other {{count} onderwerpen}}"
+      },
+      "empty-state": "Er zijn momenteel geen leertrajecten beschikbaar. Neem contact op met Pix om er enkele te verkrijgen.",
+      "tab-filters": {
+        "all": "Alle",
+        "blueprints": "leerprogramma's",
+        "label": "Type leertraject",
+        "target-profiles": "Leertrajecten"
       },
       "title": "Overzicht van leertrajecten"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -296,7 +296,7 @@
     "activity-type": {
       "explanation": {
         "ASSESSMENT": "Beoordelingscampagne",
-        "COMBINED_COURSE": "Leerprogramma",
+        "COMBINED_COURSE": "Leetraject",
         "EXAM": "Vraagmodus",
         "FORMATION": "Training",
         "MODULE": "Module",
@@ -304,7 +304,7 @@
       },
       "information": {
         "ASSESSMENT": "Beoordeling",
-        "COMBINED_COURSE": "Leerprogramma",
+        "COMBINED_COURSE": "Leetraject",
         "EXAM": "Vraagmodus",
         "FORMATION": "Training",
         "MODULE": "Module",
@@ -538,7 +538,7 @@
       "catalogue": "Catalogus",
       "certifications": "Certificeringen",
       "close": "Sluit de navigatie",
-      "combined-courses": "Leerprogramma's",
+      "combined-courses": "Leetrajecten",
       "documentation": "Documentatie",
       "home": "Home",
       "missions": "Opdrachten",
@@ -662,7 +662,7 @@
       "empty-state": "Geen deelnemers op het moment",
       "empty-state-with-copy-link": "Geen deelnemers op het moment! Stuur ze de volgende link om mee te doen aan je campagne.",
       "included-in-combined-course": "Deze evaluatiecampagne maakt deel uit van het",
-      "included-in-combined-course-end": "-leerprogramma.",
+      "included-in-combined-course-end": "-leetraject.",
       "link": "Link",
       "multiple-sendings": {
         "status": {
@@ -674,7 +674,7 @@
       "name": "Naam Campagne",
       "tab": {
         "activity": "Activiteit",
-        "combined-courses": "Leerprogramma's",
+        "combined-courses": "Leetrajecten",
         "results": "Resultaten ({count, number})",
         "review": "Analyse",
         "settings": "Instellingen"
@@ -744,8 +744,8 @@
         "create": "De campagne maken",
         "delete": "Wissen"
       },
-      "combined-course-blueprints-label": "Selecteer een leerprogramma",
-      "combined-course-blueprints-list-label": "Selecteer een leerprogramma",
+      "combined-course-blueprints-label": "Selecteer een leetraject",
+      "combined-course-blueprints-list-label": "Selecteer een leetraject",
       "copy-of": "Kopie van",
       "external-id-label": {
         "label": "Type externe user-ID",
@@ -788,7 +788,7 @@
         "assessment": "Deelnemers evalueren",
         "assessment-info": "Een beoordelingscampagne stelt deelnemers in staat om getest te worden op specifieke onderwerpen.",
         "combined-course": "De vaardigheden van de deelnemers ontwikkelen",
-        "combined-course-info": "Een leerprogramma helpt deelnemers om nieuwe vaardigheden te verwerven.",
+        "combined-course-info": "Een leetraject helpt deelnemers om nieuwe vaardigheden te verwerven.",
         "exam": "Vraagmodus",
         "exam-info": "Met een campagne in de “quizmodus” kunnen deelnemers worden getest op specifieke onderwerpen, zonder rekening te houden met hun gebruikersprofiel of er invloed op te hebben. De aangeboden tests zijn gepersonaliseerd voor elke deelnemer, afhankelijk van hoe ver ze gevorderd zijn in het traject.",
         "label": "Wat is het doel van je campagne?",
@@ -1009,17 +1009,17 @@
         "modules-count": "{count, plural, =0 {Geen module} =1 {{count} module} other {{count} modules}}",
         "simplified-access": "Toegang zonder account",
         "tag": {
-          "blueprint": "Leerprogramma",
-          "target-profile": "Leertraject"
+          "blueprint": "Leertraject",
+          "target-profile": "Traject"
         },
         "tubes-count": "{count, plural, =0 {Geen onderwerp} =1 {{count} onderwerp} other {{count} onderwerpen}}"
       },
-      "empty-state": "Er zijn momenteel geen leertrajecten beschikbaar. Neem contact op met Pix om er enkele te verkrijgen.",
+      "empty-state": "Er zijn momenteel geen traject beschikbaar. Neem contact op met Pix om er enkele te verkrijgen.",
       "tab-filters": {
         "all": "Alle",
-        "blueprints": "leerprogramma's",
-        "label": "Type leertraject",
-        "target-profiles": "Leertrajecten"
+        "blueprints": "Leertrajecten",
+        "label": "Type traject",
+        "target-profiles": "Trajecten"
       },
       "title": "Overzicht van leertrajecten"
     },
@@ -1083,9 +1083,9 @@
       }
     },
     "combined-courses": {
-      "empty-state": "Geen leerprogramma beschikbaar op dit moment.",
+      "empty-state": "Geen leetraject beschikbaar op dit moment.",
       "table": {
-        "caption": "Lijst van leerprogramma's",
+        "caption": "Lijst van leetrajecten",
         "column": {
           "code": "Code",
           "completed": "Deelnemers die voltooid hebben",


### PR DESCRIPTION

## 🌱 Problème
Lorsque le catalogue contient plusieurs dizaine de parcours, il est difficile de retrouver un parcours en particulier.

## 🐣 Proposition

On souhaite pouvoir filtrer par type d'objet pour faciliter la navigation dans le catalogue

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

- [x] Aller sur la page catalogue
- [x] Filter les éléments par type en utilisant la navigation par onglets
