### PR TITLE
[FEATURE] Prendre en compte les modules en provenance de la release LCMS (PIX-22267)

### DIFF
--- a/api/db/database-builder/factory/learning-content/build-modules.js
+++ b/api/db/database-builder/factory/learning-content/build-modules.js
@@ -1,0 +1,106 @@
+import { databaseBuffer } from '../../database-buffer.js';
+
+const defaultSections = [
+  {
+    id: 'cfaefec9-e185-43b8-8258-e8beff6dd56b',
+    type: 'question-yourself',
+    grains: [
+      {
+        id: '9de10c46-df0e-41f5-a709-81637f0d5cc3',
+        type: 'challenge',
+        title: 'Element text avec tags',
+        components: [
+          {
+            type: 'element',
+            element: {
+              id: 'd5e369ec-2a5e-4692-ac46-5be5a49f2acd',
+              type: 'text',
+              tag: 'context',
+              content: "<p>Ceci&nbsp;est un contenu pour les amateurs de coquille d'escargots.</p>",
+            },
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export function buildModule({
+  id = crypto.randomUUID(),
+  shortId = 'escargou',
+  slug = 'petit-escargot-pignouf',
+  title = 'apprendre à être mou',
+  isBeta = false,
+  visibility = 'public',
+  details = {
+    image: 'https://assets.pix.org/draft/escargots.jpg',
+    description:
+      "<p>Ce module est dédié aux escargots</p><p>Il contient normalement l'intégralité de leurs secrets disponibles à date.</p>",
+    duration: 7,
+    level: 'novice',
+    objectives: ['Connaître les petits secrets des gastéropodes'],
+    tabletSupport: 'inconvenient',
+  },
+  sections = defaultSections,
+  glossary = [
+    {
+      word: 'coquille',
+      description:
+        "Une coquille est un agglomérat de calcaire très résistant. Sa structure cristalline spécifique lui confère une résistance protectrice. Elle prodique à l'escargot toute sa force et sa vitalité.",
+    },
+  ],
+} = {}) {
+  return buildModuleInDB({
+    id,
+    shortId,
+    slug,
+    title,
+    isBeta,
+    visibility,
+    details,
+    sections,
+    glossary,
+  });
+}
+
+export function buildModuleWithNoDefaultValues({
+  id,
+  shortId,
+  slug,
+  title,
+  isBeta,
+  visibility,
+  details,
+  sections,
+  glossary,
+}) {
+  return buildModuleInDB({
+    id,
+    shortId,
+    slug,
+    title,
+    isBeta,
+    visibility,
+    details,
+    sections,
+    glossary,
+  });
+}
+
+function buildModuleInDB({ id, shortId, slug, title, isBeta, visibility, details, sections, glossary }) {
+  const values = {
+    id,
+    shortId,
+    slug,
+    title,
+    isBeta,
+    visibility,
+    ...details,
+    sections: JSON.stringify(sections),
+    glossary: JSON.stringify(glossary),
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'learningcontent.modules',
+    values,
+  });
+}

--- a/api/db/database-builder/factory/learning-content/build.js
+++ b/api/db/database-builder/factory/learning-content/build.js
@@ -4,6 +4,7 @@ import { buildCompetence, buildCompetenceWithNoDefaultValues } from './build-com
 import { buildCourse, buildCourseWithNoDefaultValues } from './build-course.js';
 import { buildFramework, buildFrameworkWithNoDefaultValues } from './build-framework.js';
 import { buildMission, buildMissionWithNoDefaultValues } from './build-mission.js';
+import { buildModule, buildModuleWithNoDefaultValues } from './build-modules.js';
 import { buildSkill, buildSkillWithNoDefaultValues } from './build-skill.js';
 import { buildThematic, buildThematicWithNoDefaultValues } from './build-thematic.js';
 import { buildTube, buildTubeWithNoDefaultValues } from './build-tube.js';
@@ -27,6 +28,7 @@ export function build(learningContent, { noDefaultValues = false } = {}) {
   learningContent.courses?.forEach(noDefaultValues ? buildCourseWithNoDefaultValues : buildCourse);
   learningContent.tutorials?.forEach(noDefaultValues ? buildTutorialWithNoDefaultValues : buildTutorial);
   learningContent.missions?.forEach(noDefaultValues ? buildMissionWithNoDefaultValues : buildMission);
+  learningContent.modules?.forEach(noDefaultValues ? buildModuleWithNoDefaultValues : buildModule);
 
   return nock?.('https://lcms-test.pix.fr/api')
     .get('/releases/latest')

--- a/api/db/database-builder/factory/learning-content/index.js
+++ b/api/db/database-builder/factory/learning-content/index.js
@@ -5,6 +5,7 @@ export * from './build-competence.js';
 export * from './build-course.js';
 export * from './build-framework.js';
 export * from './build-mission.js';
+export * from './build-modules.js';
 export * from './build-skill.js';
 export * from './build-thematic.js';
 export * from './build-tube.js';

--- a/api/src/learning-content/domain/usecases/create-learning-content-release.js
+++ b/api/src/learning-content/domain/usecases/create-learning-content-release.js
@@ -13,6 +13,7 @@ export async function createLearningContentRelease({
   courseRepository,
   tutorialRepository,
   missionRepository,
+  moduleRepository,
 }) {
   const newLearningContent = await lcmsClient.createRelease();
 
@@ -27,6 +28,7 @@ export async function createLearningContentRelease({
     await courseRepository.saveMany(newLearningContent.courses);
     await tutorialRepository.saveMany(newLearningContent.tutorials);
     await missionRepository.saveMany(newLearningContent.missions);
+    await moduleRepository.saveMany(newLearningContent.modules);
   });
 
   frameworkRepository.clearCache();
@@ -39,4 +41,5 @@ export async function createLearningContentRelease({
   courseRepository.clearCache();
   tutorialRepository.clearCache();
   missionRepository.clearCache();
+  moduleRepository.clearCache();
 }

--- a/api/src/learning-content/domain/usecases/dependencies.js
+++ b/api/src/learning-content/domain/usecases/dependencies.js
@@ -12,6 +12,7 @@ import { frameworkRepository } from '../../infrastructure/repositories/framework
 import { lcmsCreateReleaseJobRepository } from '../../infrastructure/repositories/jobs/lcms-create-release-job-repository.js';
 import { lcmsRefreshCacheJobRepository } from '../../infrastructure/repositories/jobs/lcms-refresh-cache-job-repository.js';
 import { missionRepository } from '../../infrastructure/repositories/mission-repository.js';
+import { moduleRepository } from '../../infrastructure/repositories/module-repository.js';
 import { skillRepository } from '../../infrastructure/repositories/skill-repository.js';
 import { thematicRepository } from '../../infrastructure/repositories/thematic-repository.js';
 import { tubeRepository } from '../../infrastructure/repositories/tube-repository.js';
@@ -27,6 +28,7 @@ export const dependencies = {
   lcmsCreateReleaseJobRepository,
   lcmsRefreshCacheJobRepository,
   missionRepository,
+  moduleRepository,
   sharedAreaRepository,
   sharedFrameworkRepository,
   sharedSkillRepository,

--- a/api/src/learning-content/domain/usecases/refresh-learning-content-cache.js
+++ b/api/src/learning-content/domain/usecases/refresh-learning-content-cache.js
@@ -13,6 +13,7 @@ export async function refreshLearningContentCache({
   courseRepository,
   tutorialRepository,
   missionRepository,
+  moduleRepository,
 }) {
   const learningContent = await lcmsClient.getRelease();
 
@@ -27,6 +28,7 @@ export async function refreshLearningContentCache({
     await courseRepository.saveMany(learningContent.courses);
     await tutorialRepository.saveMany(learningContent.tutorials);
     await missionRepository.saveMany(learningContent.missions);
+    await moduleRepository.saveMany(learningContent.modules);
   });
 
   frameworkRepository.clearCache();
@@ -39,4 +41,5 @@ export async function refreshLearningContentCache({
   courseRepository.clearCache();
   tutorialRepository.clearCache();
   missionRepository.clearCache();
+  moduleRepository.clearCache();
 }

--- a/api/src/learning-content/infrastructure/repositories/module-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/module-repository.js
@@ -1,0 +1,27 @@
+import { LearningContentRepository } from './learning-content-repository.js';
+
+class ModuleRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.modules' });
+  }
+
+  toDto({ id, shortId, slug, title, isBeta, sections, details, visibility, glossary }) {
+    return {
+      id,
+      shortId,
+      slug,
+      title,
+      isBeta,
+      sections: JSON.stringify(sections),
+      visibility,
+      glossary: JSON.stringify(glossary),
+      ...details,
+    };
+  }
+
+  clearCache(_id) {
+    // FIXME
+  }
+}
+
+export const moduleRepository = new ModuleRepository();

--- a/api/tests/learning-content/integration/application/jobs/lcms-create-release-job-controller_test.js
+++ b/api/tests/learning-content/integration/application/jobs/lcms-create-release-job-controller_test.js
@@ -519,6 +519,56 @@ describe('Learning Content | Integration | Application | Jobs | Create release',
           competenceId: 'competenceId New Mission',
         },
       ],
+      modules: [
+        {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: '6a68bf32',
+          slug: 'bac-a-sable',
+          title: 'Bac à sable',
+          isBeta: true,
+          visibility: 'private',
+          details: {
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            description:
+              "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+            duration: 5,
+            level: 'novice',
+            objectives: ['Non régression fonctionnelle'],
+            tabletSupport: 'inconvenient',
+          },
+          sections: ['Première section', 'Deuxième section'],
+          glossary: [
+            {
+              word: 'chat',
+              definition:
+                '<p>Le chat, plus spécifiquement désigné sous le nom de chat domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des félins (Félidés).</p>',
+            },
+          ],
+        },
+        {
+          id: '6282925d-4775-4bca-b513-4c3009ec5887',
+          shortId: '6a68bf33',
+          slug: 'bac-a-gravier',
+          title: 'Bac à gravier',
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            image: 'https://example.com/image.webp',
+            description: '<p>Ce module est dédié aux enfants pas sages.</p>',
+            duration: 666,
+            level: 'expert',
+            objectives: ['Régression cognitive'],
+            tabletSupport: 'convenient',
+          },
+          sections: ['Petite section', 'Moyenne section', 'Grande section'],
+          glossary: [
+            {
+              word: 'gravier',
+              definition: '<p>Le gravier c’est des petits cailloux.</p>',
+            },
+          ],
+        },
+      ],
     };
 
     databaseBuilder.factory.learningContent.buildFramework({
@@ -1016,19 +1066,31 @@ describe('Learning Content | Integration | Application | Jobs | Create release',
       cardImageUrl: 'cardImageUrl Missing Mission',
       competenceId: 'competenceId Missing Mission',
     });
+    databaseBuilder.factory.learningContent.buildModule({
+      id: '6282925d-4775-4bca-b513-4c3009ec5886',
+      shortId: '6a68bf32',
+      slug: 'sac-a-sable',
+      title: 'Sac à sable',
+      isBeta: false,
+      visibility: 'protected',
+      details: {
+        image: 'https://assets.pix.org/modules/placeholder.svg',
+        description: '<p>Ce module est dédié à des tests internes à Pix.</p>',
+        duration: 2,
+        level: 'debutant',
+        objectives: ['Régression fonctionnelle'],
+        tabletSupport: 'nia',
+      },
+      sections: ['Deuxième section', 'Première section'],
+      glossary: [
+        {
+          word: 'chien',
+          definition:
+            '<p>Le chien, plus spécifiquement désigné sous le nom de chien domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des canidés.</p>',
+        },
+      ],
+    });
     await databaseBuilder.commit();
-  });
-
-  afterEach(async function () {
-    await knex('learningcontent.frameworks').truncate();
-    await knex('learningcontent.areas').truncate();
-    await knex('learningcontent.competences').truncate();
-    await knex('learningcontent.thematics').truncate();
-    await knex('learningcontent.tubes').truncate();
-    await knex('learningcontent.challenges').truncate();
-    await knex('learningcontent.courses').truncate();
-    await knex('learningcontent.tutorials').truncate();
-    await knex('learningcontent.missions').truncate();
   });
 
   describe('#handle', function () {
@@ -1716,6 +1778,53 @@ describe('Learning Content | Integration | Application | Jobs | Create release',
             documentationUrl: 'documentationUrl New Mission',
             cardImageUrl: 'cardImageUrl New Mission',
             competenceId: 'competenceId New Mission',
+          },
+        ]);
+        const updatedModules = await knex.select('*').from('learningcontent.modules').orderBy('id');
+        expect(updatedModules).to.deep.equal([
+          {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            shortId: '6a68bf32',
+            slug: 'bac-a-sable',
+            title: 'Bac à sable',
+            isBeta: true,
+            visibility: 'private',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            description:
+              "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+            duration: 5,
+            level: 'novice',
+            objectives: ['Non régression fonctionnelle'],
+            tabletSupport: 'inconvenient',
+            sections: ['Première section', 'Deuxième section'],
+            glossary: [
+              {
+                word: 'chat',
+                definition:
+                  '<p>Le chat, plus spécifiquement désigné sous le nom de chat domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des félins (Félidés).</p>',
+              },
+            ],
+          },
+          {
+            id: '6282925d-4775-4bca-b513-4c3009ec5887',
+            shortId: '6a68bf33',
+            slug: 'bac-a-gravier',
+            title: 'Bac à gravier',
+            isBeta: false,
+            visibility: 'public',
+            image: 'https://example.com/image.webp',
+            description: '<p>Ce module est dédié aux enfants pas sages.</p>',
+            duration: 666,
+            level: 'expert',
+            objectives: ['Régression cognitive'],
+            tabletSupport: 'convenient',
+            sections: ['Petite section', 'Moyenne section', 'Grande section'],
+            glossary: [
+              {
+                word: 'gravier',
+                definition: '<p>Le gravier c’est des petits cailloux.</p>',
+              },
+            ],
           },
         ]);
         expect(lcmsApiCall.isDone()).to.be.true;

--- a/api/tests/learning-content/integration/application/jobs/lcms-refresh-cache-job-controller_test.js
+++ b/api/tests/learning-content/integration/application/jobs/lcms-refresh-cache-job-controller_test.js
@@ -519,6 +519,56 @@ describe('Learning Content | Integration | Application | Jobs | Refresh cache', 
           competenceId: 'competenceId New Mission',
         },
       ],
+      modules: [
+        {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: '6a68bf32',
+          slug: 'bac-a-sable',
+          title: 'Bac à sable',
+          isBeta: true,
+          visibility: 'private',
+          details: {
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            description:
+              "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+            duration: 5,
+            level: 'novice',
+            objectives: ['Non régression fonctionnelle'],
+            tabletSupport: 'inconvenient',
+          },
+          sections: ['Première section', 'Deuxième section'],
+          glossary: [
+            {
+              word: 'chat',
+              definition:
+                '<p>Le chat, plus spécifiquement désigné sous le nom de chat domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des félins (Félidés).</p>',
+            },
+          ],
+        },
+        {
+          id: '6282925d-4775-4bca-b513-4c3009ec5887',
+          shortId: '6a68bf33',
+          slug: 'bac-a-gravier',
+          title: 'Bac à gravier',
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            image: 'https://example.com/image.webp',
+            description: '<p>Ce module est dédié aux enfants pas sages.</p>',
+            duration: 666,
+            level: 'expert',
+            objectives: ['Régression cognitive'],
+            tabletSupport: 'convenient',
+          },
+          sections: ['Petite section', 'Moyenne section', 'Grande section'],
+          glossary: [
+            {
+              word: 'gravier',
+              definition: '<p>Le gravier c’est des petits cailloux.</p>',
+            },
+          ],
+        },
+      ],
     };
 
     databaseBuilder.factory.learningContent.buildFramework({
@@ -1016,19 +1066,31 @@ describe('Learning Content | Integration | Application | Jobs | Refresh cache', 
       cardImageUrl: 'cardImageUrl Missing Mission',
       competenceId: 'competenceId Missing Mission',
     });
+    databaseBuilder.factory.learningContent.buildModule({
+      id: '6282925d-4775-4bca-b513-4c3009ec5886',
+      shortId: '6a68bf32',
+      slug: 'sac-a-sable',
+      title: 'Sac à sable',
+      isBeta: false,
+      visibility: 'protected',
+      details: {
+        image: 'https://assets.pix.org/modules/placeholder.svg',
+        description: '<p>Ce module est dédié à des tests internes à Pix.</p>',
+        duration: 2,
+        level: 'debutant',
+        objectives: ['Régression fonctionnelle'],
+        tabletSupport: 'nia',
+      },
+      sections: ['Deuxième section', 'Première section'],
+      glossary: [
+        {
+          word: 'chien',
+          definition:
+            '<p>Le chien, plus spécifiquement désigné sous le nom de chien domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des canidés.</p>',
+        },
+      ],
+    });
     await databaseBuilder.commit();
-  });
-
-  afterEach(async function () {
-    await knex('learningcontent.frameworks').truncate();
-    await knex('learningcontent.areas').truncate();
-    await knex('learningcontent.competences').truncate();
-    await knex('learningcontent.thematics').truncate();
-    await knex('learningcontent.tubes').truncate();
-    await knex('learningcontent.challenges').truncate();
-    await knex('learningcontent.courses').truncate();
-    await knex('learningcontent.tutorials').truncate();
-    await knex('learningcontent.missions').truncate();
   });
 
   describe('#handle', function () {
@@ -1716,6 +1778,54 @@ describe('Learning Content | Integration | Application | Jobs | Refresh cache', 
             documentationUrl: 'documentationUrl New Mission',
             cardImageUrl: 'cardImageUrl New Mission',
             competenceId: 'competenceId New Mission',
+          },
+        ]);
+
+        const refreshedModules = await knex.select('*').from('learningcontent.modules').orderBy('id');
+        expect(refreshedModules).to.deep.equal([
+          {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            shortId: '6a68bf32',
+            slug: 'bac-a-sable',
+            title: 'Bac à sable',
+            isBeta: true,
+            visibility: 'private',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            description:
+              "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+            duration: 5,
+            level: 'novice',
+            objectives: ['Non régression fonctionnelle'],
+            tabletSupport: 'inconvenient',
+            sections: ['Première section', 'Deuxième section'],
+            glossary: [
+              {
+                word: 'chat',
+                definition:
+                  '<p>Le chat, plus spécifiquement désigné sous le nom de chat domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des félins (Félidés).</p>',
+              },
+            ],
+          },
+          {
+            id: '6282925d-4775-4bca-b513-4c3009ec5887',
+            shortId: '6a68bf33',
+            slug: 'bac-a-gravier',
+            title: 'Bac à gravier',
+            isBeta: false,
+            visibility: 'public',
+            image: 'https://example.com/image.webp',
+            description: '<p>Ce module est dédié aux enfants pas sages.</p>',
+            duration: 666,
+            level: 'expert',
+            objectives: ['Régression cognitive'],
+            tabletSupport: 'convenient',
+            sections: ['Petite section', 'Moyenne section', 'Grande section'],
+            glossary: [
+              {
+                word: 'gravier',
+                definition: '<p>Le gravier c’est des petits cailloux.</p>',
+              },
+            ],
           },
         ]);
         expect(lcmsApiCall.isDone()).to.be.true;

--- a/api/tests/learning-content/unit/domain/usecases/create-learning-content-release_test.js
+++ b/api/tests/learning-content/unit/domain/usecases/create-learning-content-release_test.js
@@ -24,6 +24,7 @@ describe('Learning Content | Unit | UseCase | create-learning-content-release', 
       const courses = Symbol('courses');
       const tutorials = Symbol('tutorials');
       const missions = Symbol('missions');
+      const modules = Symbol('modules');
 
       const lcmsClient = {
         createRelease: sinon.stub().resolves({
@@ -37,6 +38,7 @@ describe('Learning Content | Unit | UseCase | create-learning-content-release', 
           courses,
           tutorials,
           missions,
+          modules,
         }),
       };
 
@@ -80,6 +82,10 @@ describe('Learning Content | Unit | UseCase | create-learning-content-release', 
         saveMany: sinon.stub(),
         clearCache: sinon.stub(),
       };
+      const moduleRepository = {
+        saveMany: sinon.stub(),
+        clearCache: sinon.stub(),
+      };
 
       // when
       await createLearningContentRelease({
@@ -94,6 +100,7 @@ describe('Learning Content | Unit | UseCase | create-learning-content-release', 
         courseRepository,
         tutorialRepository,
         missionRepository,
+        moduleRepository,
       });
 
       // then
@@ -109,6 +116,7 @@ describe('Learning Content | Unit | UseCase | create-learning-content-release', 
       expect(courseRepository.saveMany).to.have.been.calledOnceWithExactly(courses);
       expect(tutorialRepository.saveMany).to.have.been.calledOnceWithExactly(tutorials);
       expect(missionRepository.saveMany).to.have.been.calledOnceWithExactly(missions);
+      expect(moduleRepository.saveMany).to.have.been.calledOnceWithExactly(modules);
 
       expect(frameworkRepository.clearCache).to.have.been.calledOnceWithExactly();
       expect(areaRepository.clearCache).to.have.been.calledOnceWithExactly();
@@ -120,6 +128,7 @@ describe('Learning Content | Unit | UseCase | create-learning-content-release', 
       expect(courseRepository.clearCache).to.have.been.calledOnceWithExactly();
       expect(tutorialRepository.clearCache).to.have.been.calledOnceWithExactly();
       expect(missionRepository.clearCache).to.have.been.calledOnceWithExactly();
+      expect(moduleRepository.clearCache).to.have.been.calledOnceWithExactly();
     });
   });
 });

--- a/api/tests/learning-content/unit/domain/usecases/refresh-learning-content-cache_test.js
+++ b/api/tests/learning-content/unit/domain/usecases/refresh-learning-content-cache_test.js
@@ -24,6 +24,7 @@ describe('Learning Content | Unit | Domain | Usecase | Refresh learning content 
       const courses = Symbol('courses');
       const tutorials = Symbol('tutorials');
       const missions = Symbol('missions');
+      const modules = Symbol('modules');
 
       const lcmsClient = {
         getRelease: sinon.stub().resolves({
@@ -37,6 +38,7 @@ describe('Learning Content | Unit | Domain | Usecase | Refresh learning content 
           courses,
           tutorials,
           missions,
+          modules,
         }),
       };
 
@@ -80,6 +82,10 @@ describe('Learning Content | Unit | Domain | Usecase | Refresh learning content 
         saveMany: sinon.stub(),
         clearCache: sinon.stub(),
       };
+      const moduleRepository = {
+        saveMany: sinon.stub(),
+        clearCache: sinon.stub(),
+      };
 
       // when
       await refreshLearningContentCache({
@@ -94,6 +100,7 @@ describe('Learning Content | Unit | Domain | Usecase | Refresh learning content 
         courseRepository,
         tutorialRepository,
         missionRepository,
+        moduleRepository,
       });
 
       // then
@@ -109,6 +116,7 @@ describe('Learning Content | Unit | Domain | Usecase | Refresh learning content 
       expect(courseRepository.saveMany).to.have.been.calledOnceWithExactly(courses);
       expect(tutorialRepository.saveMany).to.have.been.calledOnceWithExactly(tutorials);
       expect(missionRepository.saveMany).to.have.been.calledOnceWithExactly(missions);
+      expect(moduleRepository.saveMany).to.have.been.calledOnceWithExactly(modules);
 
       expect(frameworkRepository.clearCache).to.have.been.calledOnceWithExactly();
       expect(areaRepository.clearCache).to.have.been.calledOnceWithExactly();
@@ -120,6 +128,7 @@ describe('Learning Content | Unit | Domain | Usecase | Refresh learning content 
       expect(courseRepository.clearCache).to.have.been.calledOnceWithExactly();
       expect(tutorialRepository.clearCache).to.have.been.calledOnceWithExactly();
       expect(missionRepository.clearCache).to.have.been.calledOnceWithExactly();
+      expect(moduleRepository.clearCache).to.have.been.calledOnceWithExactly();
     });
   });
 });

--- a/api/tests/learning-content/unit/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/learning-content/unit/infrastructure/repositories/module-repository_test.js
@@ -1,0 +1,58 @@
+import { moduleRepository } from '../../../../../src/learning-content/infrastructure/repositories/module-repository.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Learning Content | Unit | Repositories | module-repository', function () {
+  describe('#toDto', function () {
+    it('maps module data for database storage', async function () {
+      // given
+      const module = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: '6a68bf32',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        isBeta: true,
+        visibility: 'private',
+        details: {
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+          description:
+            "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+          duration: 5,
+          level: 'novice',
+          objectives: ['Non régression fonctionnelle'],
+          tabletSupport: 'inconvenient',
+        },
+        sections: ['Première section', 'Deuxième section'],
+        glossary: [
+          {
+            word: 'chat',
+            definition:
+              '<p>Le chat, plus spécifiquement désigné sous le nom de chat domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des félins (Félidés).</p>',
+          },
+        ],
+      };
+
+      // when
+      const dto = moduleRepository.toDto(module);
+
+      // then
+      expect(dto).to.deep.equal({
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: '6a68bf32',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        isBeta: true,
+        visibility: 'private',
+        image: 'https://assets.pix.org/modules/placeholder-details.svg',
+        description:
+          "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+        duration: 5,
+        level: 'novice',
+        objectives: ['Non régression fonctionnelle'],
+        tabletSupport: 'inconvenient',
+        sections: '["Première section","Deuxième section"]',
+        glossary:
+          '[{"word":"chat","definition":"<p>Le chat, plus spécifiquement désigné sous le nom de chat domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des félins (Félidés).</p>"}]',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌱 Problème

La release LCMS contient maintenant les modules, mais ceux-ci ne sont pas pris en compte par l’API Pix.

## 🐣 Proposition

Dans les jobs de rafraichissement du cache LCMS et de création de release LCMS, insérer les modules en provenance de la release LCMS dans la nouvelle table `learningcontent.modules`.

## 🌷 Remarques

N/A

## 🐝 Pour tester

Déclencher un rafraichissement du cache sur la RA, et constater que les modules sont bien insérés dans la table `learningcontent.modules`.
=> Aller dans PixAdmin