### PR TITLE
[BUGFIX] Gérer l'erreur 500 à la création d'un parcours combiné sans blueprint (PIX-22481)

### DIFF
--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -1,13 +1,11 @@
 import { createReadStream } from 'node:fs';
 
 import { getDataBuffer } from '../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
-import {
-  extractUserIdFromRequest,
-  getChallengeLocale,
-} from '../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignTypeCombinedCourseSerializer from '../infrastructure/serializers/campaign-type-combined-course-serializer.js';
 import * as combinedCourseDetailsSerializer from '../infrastructure/serializers/combined-course-details-serializer.js';
+import * as combinedCourseForCreationSerializer from '../infrastructure/serializers/combined-course-for-creation-serializer.js';
 import * as combinedCourseListSerializer from '../infrastructure/serializers/combined-course-list-serializer.js';
 import * as combinedCourseParticipationDetailSerializer from '../infrastructure/serializers/combined-course-participation-detail-serializer.js';
 import * as combinedCourseParticipationSerializer from '../infrastructure/serializers/combined-course-participation-serializer.js';
@@ -72,7 +70,7 @@ const findParticipations = async (request, _, dependencies = { combinedCoursePar
 };
 
 const start = async function (request, h) {
-  const userId = extractUserIdFromRequest(request);
+  const { userId } = request.auth.credentials;
   const code = request.params.code;
 
   await usecases.startCombinedCourse({
@@ -84,7 +82,7 @@ const start = async function (request, h) {
 };
 
 const reassessStatus = async function (request, h) {
-  const userId = extractUserIdFromRequest(request);
+  const { userId } = request.auth.credentials;
   const code = request.params.code;
 
   await usecases.updateCombinedCourseProgress({
@@ -104,19 +102,18 @@ const createCombinedCourses = async function (request, h) {
   return h.response(null).code(204);
 };
 
-const createCombinedCourse = async function (request, h, dependencies = { campaignTypeCombinedCourseSerializer }) {
-  const data = request.payload.data;
+const createCombinedCourse = async function (
+  request,
+  h,
+  dependencies = { campaignTypeCombinedCourseSerializer, combinedCourseForCreationSerializer },
+) {
   const { userId } = request.auth.credentials;
 
-  const organizationId = parseInt(data.relationships.organization.data.id) || null;
-  const combinedCourseBlueprintId = parseInt(data.relationships['combined-course-blueprint'].data.id) || null;
-  const { name } = data.attributes;
+  const combinedCourseForCreation = dependencies.combinedCourseForCreationSerializer.deserialize(request.payload);
 
   const createdCombinedCourse = await usecases.createCombinedCourse({
-    name,
-    combinedCourseBlueprintId,
+    combinedCourseForCreation,
     creatorId: userId,
-    organizationId,
   });
   return h
     .response(

--- a/api/src/quest/domain/models/CombinedCourseForCreation.js
+++ b/api/src/quest/domain/models/CombinedCourseForCreation.js
@@ -1,0 +1,32 @@
+import Joi from 'joi';
+
+import { EntityValidationError } from '../../../shared/domain/errors.js';
+
+const schema = Joi.object({
+  name: Joi.string().required().messages({
+    'string.base': 'CAMPAIGN_NAME_IS_REQUIRED',
+    'string.empty': 'CAMPAIGN_NAME_IS_REQUIRED',
+  }),
+  organizationId: Joi.number().required(),
+  blueprintId: Joi.number().required().messages({
+    'any.required': 'TARGET_PROFILE_IS_REQUIRED',
+    'number.base': 'TARGET_PROFILE_IS_REQUIRED',
+  }),
+});
+
+export class CombinedCourseForCreation {
+  constructor({ name, organizationId, blueprintId } = {}) {
+    this.name = name;
+    this.organizationId = organizationId;
+    this.blueprintId = blueprintId;
+
+    this.#validate({ name, organizationId, blueprintId });
+  }
+
+  #validate(combinedCourse) {
+    const { error } = schema.validate(combinedCourse);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: combinedCourse });
+    }
+  }
+}

--- a/api/src/quest/domain/usecases/create-combined-course.js
+++ b/api/src/quest/domain/usecases/create-combined-course.js
@@ -1,10 +1,9 @@
+import { ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { Campaign } from '../models/Campaign.js';
 
 export const createCombinedCourse = async ({
-  combinedCourseBlueprintId,
-  name,
+  combinedCourseForCreation,
   creatorId,
-  organizationId,
   campaignRepository,
   targetProfileRepository,
   codeGenerator,
@@ -16,8 +15,11 @@ export const createCombinedCourse = async ({
   questRepository,
 }) => {
   const combinedCourseBlueprint = await combinedCourseBlueprintRepository.findById({
-    id: combinedCourseBlueprintId,
+    id: combinedCourseForCreation.blueprintId,
   });
+  if (!combinedCourseBlueprint.organizationIds.includes(combinedCourseForCreation.organizationId)) {
+    throw new ForbiddenAccess();
+  }
 
   let modules = [];
 
@@ -38,7 +40,7 @@ export const createCombinedCourse = async ({
 
   for (const targetProfile of targetProfiles) {
     const campaignForCombinedCourse = Campaign.buildCampaignForCombinedCourse({
-      organizationId,
+      organizationId: combinedCourseForCreation.organizationId,
       targetProfile,
       creatorId,
       combinedCourseCode,
@@ -55,11 +57,11 @@ export const createCombinedCourse = async ({
   });
 
   const combinedCourse = combinedCourseBlueprint.toCombinedCourse({
-    name,
+    name: combinedCourseForCreation.name,
     description: combinedCourseBlueprint.description,
     illustration: combinedCourseBlueprint.illustration,
     code: combinedCourseCode,
-    organizationId,
+    organizationId: combinedCourseForCreation.organizationId,
     campaigns: createdCampaigns,
   });
 

--- a/api/src/quest/infrastructure/serializers/combined-course-for-creation-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-for-creation-serializer.js
@@ -1,0 +1,11 @@
+import { CombinedCourseForCreation } from '../../domain/models/CombinedCourseForCreation.js';
+
+const deserialize = function (payload) {
+  const organizationId = parseInt(payload.data.relationships.organization.data.id) || null;
+  const blueprintId = parseInt(payload.data.relationships['combined-course-blueprint'].data.id) || null;
+  const { name } = payload.data.attributes;
+
+  return new CombinedCourseForCreation({ organizationId, name, blueprintId });
+};
+
+export { deserialize };

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -419,6 +419,10 @@ ${organizationId};"{""name"":""Combinix"",""content"":[],""description"":""ma de
             { type: 'module', value: 'df82ec66' },
           ],
         });
+        databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+          combinedCourseBlueprintId: combinedCourseBlueprint.id,
+          organizationId: organizationId,
+        });
 
         await databaseBuilder.commit();
 

--- a/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
@@ -1,8 +1,11 @@
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { CombinedCourseForCreation } from '../../../../../src/quest/domain/models/CombinedCourseForCreation.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Combined course | Domain | UseCases | create-combined-course', function () {
   it('should create combined course for given payload', async function () {
@@ -43,17 +46,22 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     });
 
     const combinedCourseBlueprintId = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: quest.id }).id;
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId });
 
     await databaseBuilder.commit();
 
     const nameInput = 'Un parcours combiné';
 
+    const combinedCourseForCreation = new CombinedCourseForCreation({
+      blueprintId: combinedCourseBlueprintId,
+      organizationId,
+      name: nameInput,
+    });
+
     // when
     await usecases.createCombinedCourse({
-      combinedCourseBlueprintId,
-      name: nameInput,
+      combinedCourseForCreation,
       creatorId: userId,
-      organizationId,
     });
 
     const campaigns = await knex('campaigns')
@@ -84,5 +92,65 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     expect(campaigns[1].title).to.equal(otherTargetProfile.name);
     expect(campaigns[1].customResultPageButtonUrl.includes('/chargement')).false;
     expect(campaigns[1].customResultPageButtonText).to.equal('Continuer');
+  });
+
+  it('should throw ForbiddenAccess error when blueprint is not linked to the organization', async function () {
+    // given
+    const moduleId1 = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+    const moduleId2 = 'f32a2238-4f65-4698-b486-15d51935d335';
+    const userId = databaseBuilder.factory.buildUser().id;
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const targetProfileWithTraining = databaseBuilder.factory.buildTargetProfile();
+    const otherTargetProfile = databaseBuilder.factory.buildTargetProfile();
+
+    const trainingId = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      title: 'Demo combinix 1',
+      link: '/modules/demo-combinix-1',
+      locale: 'fr-fr',
+    }).id;
+
+    databaseBuilder.factory.buildTargetProfileTraining({
+      targetProfileId: targetProfileWithTraining.id,
+      trainingId: trainingId,
+    });
+
+    const attestation = databaseBuilder.factory.buildAttestation();
+
+    const quest = databaseBuilder.factory.buildQuest({
+      rewardId: attestation.id,
+      rewardType: REWARD_TYPES.ATTESTATION,
+      successRequirements: [
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+          targetProfileId: targetProfileWithTraining.id,
+        }).toDTO(),
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: moduleId1 }).toDTO(),
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: moduleId2 }).toDTO(),
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: otherTargetProfile.id }).toDTO(),
+      ],
+    });
+
+    const combinedCourseBlueprintId = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: quest.id }).id;
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId });
+
+    await databaseBuilder.commit();
+
+    const nameInput = 'Un parcours combiné';
+
+    const combinedCourseForCreation = new CombinedCourseForCreation({
+      blueprintId: combinedCourseBlueprintId,
+      organizationId: otherOrganizationId,
+      name: nameInput,
+    });
+
+    // when
+    const error = await catchErr(usecases.createCombinedCourse)({
+      combinedCourseForCreation,
+      creatorId: userId,
+    });
+
+    expect(error).to.be.instanceOf(ForbiddenAccess);
   });
 });

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -113,7 +113,7 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
     });
   });
 
-  describe('PUT /api/combined-course/{code}/start', function () {
+  describe('PUT /api/combined-courses/{code}/start', function () {
     it('should call prehandler', async function () {
       // given
       sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCombinedCourse').returns(() => true);
@@ -137,7 +137,7 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
     });
   });
 
-  describe('PATCH /api/combined-course/{code}/reassess-status', function () {
+  describe('PATCH /api/combined-courses/{code}/reassess-status', function () {
     it('should call prehandler', async function () {
       // given
       sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCombinedCourse').returns(() => true);
@@ -182,6 +182,54 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
 
       // then
       expect(securityPreHandlers.checkUserBelongsToOrganization).to.have.been.called;
+    });
+  });
+
+  describe('POST /api/combined-courses', function () {
+    it('should call prehandlers', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkOrganizationAccess').returns(() => true);
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(combinedCourseRoute);
+
+      // when
+      const payload = {
+        data: {
+          type: 'campaign',
+          attributes: {
+            name: 'Parcours combiné collège',
+            type: 'COMBINED_COURSE',
+            ['owner-id']: null,
+          },
+          relationships: {
+            'combined-course-blueprint': {
+              data: {
+                type: 'combined-course-blueprints',
+                id: `456`,
+              },
+            },
+            organization: {
+              data: {
+                type: 'organizations',
+                id: `123`,
+              },
+            },
+          },
+        },
+      };
+
+      await httpTestServer.request(
+        'POST',
+        '/api/combined-courses',
+        payload,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
+
+      // then
+      expect(securityPreHandlers.checkOrganizationAccess).to.have.been.called;
     });
   });
 });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-for-creation-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-for-creation-serializer_test.js
@@ -1,0 +1,37 @@
+import * as combinedCourseforCreationSerialzer from '../../../../../src/quest/infrastructure/serializers/combined-course-for-creation-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | combined-course-for-creation', function () {
+  it('#deserialize', async function () {
+    // given
+    const payload = {
+      data: {
+        attributes: {
+          name: 'Mon parcours',
+        },
+        relationships: {
+          organization: {
+            data: {
+              id: 123,
+            },
+          },
+          'combined-course-blueprint': {
+            data: {
+              id: 456,
+            },
+          },
+        },
+      },
+    };
+
+    // when
+    const deserialized = await combinedCourseforCreationSerialzer.deserialize(payload);
+
+    // then
+    expect(deserialized).deep.equal({
+      name: 'Mon parcours',
+      organizationId: 123,
+      blueprintId: 456,
+    });
+  });
+});

--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -428,10 +428,7 @@ export default class CreateForm extends Component {
               @onChange={{this.selectCombinedCourseBlueprint}}
               @value={{@campaign.targetProfile.id}}
               @requiredLabel={{t "common.form.mandatory-fields-title"}}
-              @errorMessage={{if
-                @errors.combinedCourse
-                (t "api-error-messages.campaign-creation.combined-course-blueprint-required")
-              }}
+              @errorMessage={{if @errors.blueprint (t "api-error-messages.campaign-creation.target-profile-required")}}
               @locale={{this.locale.currentLocale}}
               @searchLabel={{t "pages.campaign-creation.combined-course-blueprints-search-placeholder"}}
             >

--- a/orga/tests/integration/components/campaign/create-form-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-test.gjs
@@ -1409,5 +1409,46 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // then
       assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
     });
+
+    test('it should display errors messages when the blueprint id field is empty', async function (assert) {
+      // given
+      const campaignWithErrors = EmberObject.create({
+        errors: {
+          blueprint: [
+            {
+              message: 'TARGET_PROFILE_IS_REQUIRED',
+            },
+          ],
+        },
+      });
+      data.errors = campaignWithErrors.errors;
+
+      const store = this.owner.lookup('service:store');
+      const combinedCourseBlueprint = store.createRecord('combined-course-blueprint', {
+        id: '1',
+        name: 'Blueprint 1',
+      });
+
+      data.combinedCourseBlueprints = [combinedCourseBlueprint];
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+            @combinedCourseBlueprints={{data.combinedCourseBlueprints}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.purpose.combined-course'));
+
+      // then
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
+    });
   });
 });


### PR DESCRIPTION
## 🌱 Problème

À la création d'un parcours combiné, on a une erreur 500 si l'utilisateur n'a pas sélectionné de blueprint.

Nous avons ajouté la gestion de cette erreur, comme cela était fait pour les campagnes.

## 🐣 Proposition

Dans l'API, ajout d'un modèle `CombinedCourseForCreation` (sur le modèle de `CampaignForCreation` côté prescription) pour encapsuler les données de création et porter la validation du schema attendu. On renvoie une `EntityValidationError` si le blueprintId est manquant dans les données.

En front, on traite cette erreur pour afficher un message dans le formulaire de création : même message que lorsque le targetProfile est manquant pour la création d'une campagne.

## 🌷 Remarques

Au passage : 

- dans le usecase `create-combined-course`, ajout d'une vérification que l'organisation a bien le droit d'utiliser le blueprint sélectionné. Sinon on renvoie une erreur `ForbiddenAccess`.

- remplacement de la méthode dépréciée `extractUserIdFromRequest` dans `combined-course-controller`.

- un peu de clean dans les tests de `combined-course-route` (renommages et test qu'on appelle le pre-handler existant).

## 🐝 Pour tester
PixOrga
Avec l'organisation SCO SIECLE -> cliquer sur "Campagnes" puis "Créer une campagne".
Dans le formulaire, renseigner un nom, sélectionner "Développer les compétences des participants", **ne pas sélectionner** de parcours et cliquer sur "Créer la campagne".
-> Le message d'erreur "Veuillez sélectionner un parcours pour votre campagne." doit s'afficher au niveau du select.