### PR TITLE
[TECH] Ajouter un test e2e de non-régression pour la réconciliation SCO (PIX-22411)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
@@ -10,6 +10,7 @@ import {
   buildFreshPixOrgaUser,
   createGARUser,
   createOrganizationInDB,
+  knex,
 } from '../../helpers/db.ts';
 import { ChallengePage, HomePage, ReconciliationLoginPage, ReconciliationPage } from '../../pages/pix-app/index.ts';
 import { PixOrgaPage } from '../../pages/pix-orga/PixOrgaPage.ts';
@@ -198,5 +199,183 @@ test('Managing sco learners', async ({ page }) => {
     await expect(page.getByRole('table', { name: 'Tableau des élèves trié' })).toBeVisible();
     const row = page.getByRole('row').filter({ hasText: 'Bernard' });
     await expect(row.getByRole('button', { name: 'Afficher les actions' })).not.toBeVisible();
+  });
+});
+
+test.describe('SCO import does not auto-reconcile a learner when the user already has a different INE in the target organization', () => {
+  let UAJ_FREGATA: string;
+
+  const CSV_HEADER =
+    "Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Code sexe*;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*";
+
+  test.beforeEach(async () => {
+    UAJ_FREGATA = randomUUID().slice(-8);
+
+    const { organizationId: orgAId } = await buildFreshPixOrgaUser(
+      'Admin',
+      'FregataA',
+      `admin-fregata-a-${UAJ_FREGATA}@example.net`,
+      'pix123',
+      'ADMIN',
+      { type: 'SCO', externalId: `SCO_FREGATA_A-${UAJ_FREGATA}`, isManagingStudents: true },
+    );
+
+    const { organizationId: orgBId } = await buildFreshPixOrgaUser(
+      'Admin',
+      'FregataB',
+      `admin-fregata-b-${UAJ_FREGATA}@example.net`,
+      'pix123',
+      'ADMIN',
+      { type: 'SCO', externalId: `SCO_FREGATA_B-${UAJ_FREGATA}`, isManagingStudents: true },
+    );
+
+    let tagRow = await knex('tags').where({ name: 'AGRICULTURE' }).first();
+    if (!tagRow) {
+      [tagRow] = await knex('tags').insert({ name: 'AGRICULTURE' }).returning('*');
+    }
+    await knex('organization-tags')
+      .insert([
+        { organizationId: orgAId, tagId: tagRow.id },
+        { organizationId: orgBId, tagId: tagRow.id },
+      ])
+      .onConflict(['organizationId', 'tagId'])
+      .ignore();
+
+    // CSV A : Jean Michel avec INE 12
+    await writeFile(
+      path.join(os.tmpdir(), `fregata-a-${UAJ_FREGATA}.csv`),
+      `${CSV_HEADER}\n12;Jean;;;Michel;;Masculin;01/01/1990;75056;;75;99100;ST;1234;CLASSE1\n`,
+    );
+
+    // CSV B-initial : Jean Michel avec INE 13 (premier import Org B)
+    await writeFile(
+      path.join(os.tmpdir(), `fregata-b-${UAJ_FREGATA}.csv`),
+      `${CSV_HEADER}\n13;Jean;;;Michel;;Masculin;01/01/1990;75056;;75;99100;ST;1234;CLASSE1\n`,
+    );
+
+    // CSV B-second : Jean Michel avec INE 12 uniquement (INE 13 sera disabled)
+    await writeFile(
+      path.join(os.tmpdir(), `fregata-b2-${UAJ_FREGATA}.csv`),
+      `${CSV_HEADER}\n12;Jean;;;Michel;;Masculin;01/01/1990;75056;;75;99100;ST;1234;CLASSE1\n`,
+    );
+  });
+
+  test('Prevents auto-reconciliation when the user is already in the target organization with a different INE', async ({
+    page,
+  }) => {
+    test.slow();
+    const orgaPage = new PixOrgaPage(page);
+    const reconciliationPage = new ReconciliationPage(page);
+    const challengePage = new ChallengePage(page);
+    let campaignCodeA: string;
+    let campaignCodeB: string;
+    let campaignCodeB2: string;
+
+    await test.step('Organization A: login, create a campaign and import Jean Michel (INE 12)', async () => {
+      await page.goto(process.env.PIX_ORGA_URL as string);
+      await orgaPage.login(`admin-fregata-a-${UAJ_FREGATA}@example.net`, 'pix123');
+      await page.getByRole('button').filter({ hasText: 'Je me connecte' }).waitFor({ state: 'detached' });
+      await orgaPage.acceptCGU();
+
+      await page.getByRole('link', { name: 'Campagnes', exact: true }).click();
+      await page.getByRole('link', { name: 'Créer une campagne' }).click();
+      await orgaPage.createEvaluationCampaign({
+        campaignName: 'campagne fregata A',
+        targetProfileName: 'PC pour Playwright',
+      });
+      campaignCodeA = (await page.locator('dd.campaign-header-title__campaign-code > span').textContent()) ?? '';
+
+      await page.getByRole('link', { name: 'Élèves' }).click();
+      await page.getByRole('link', { name: 'Importer', exact: true }).click();
+      await page.locator('#students-file-upload').setInputFiles(path.join(os.tmpdir(), `fregata-a-${UAJ_FREGATA}.csv`));
+
+      const hasLoader = await page.locator('.app-loader').isVisible();
+      if (hasLoader) {
+        await page.waitForSelector('.app-loader', { state: 'detached' });
+      }
+      await orgaPage.waitForTheImportToComplete(page);
+    });
+
+    await test.step('A user creates an account and reconciles with Jean Michel from Org A (INE 12)', async () => {
+      await page.goto(process.env.PIX_APP_URL + `/campagnes/${campaignCodeA}`);
+      await page.getByRole('button', { name: 'Je commence' }).click();
+      await reconciliationPage.reconcile('Jean', 'Michel', '01/01/1990', false);
+      await expect(page.getByText('Mon identifiant *')).toBeVisible();
+      await page.getByRole('textbox', { name: 'Mot de passe * (8 caractères' }).fill('Pix12345');
+      await page.getByRole('button', { name: 'Afficher le mot de passe' }).click();
+      await page.getByRole('button', { name: "Je m'inscris" }).click();
+      await expect(page.getByText('Vous pouvez rechercher sur')).toBeVisible();
+      await page.getByRole('button', { name: 'Ignorer' }).click();
+      await challengePage.leave();
+    });
+
+    await test.step('Org B: login, create a campaign and import Jean Michel (INE 13)', async () => {
+      await page.goto(process.env.PIX_ORGA_URL as string);
+      await page.getByRole('link', { name: 'Se déconnecter' }).click();
+      await orgaPage.login(`admin-fregata-b-${UAJ_FREGATA}@example.net`, 'pix123');
+      await page.getByRole('button').filter({ hasText: 'Je me connecte' }).waitFor({ state: 'detached' });
+      await orgaPage.acceptCGU();
+
+      await page.getByRole('link', { name: 'Campagnes', exact: true }).click();
+      await page.getByRole('link', { name: 'Créer une campagne' }).click();
+      await orgaPage.createEvaluationCampaign({
+        campaignName: 'campagne fregata B',
+        targetProfileName: 'PC pour Playwright',
+      });
+      campaignCodeB = (await page.locator('dd.campaign-header-title__campaign-code > span').textContent()) ?? '';
+
+      await page.getByRole('link', { name: 'Élèves' }).click();
+      await page.getByRole('link', { name: 'Importer', exact: true }).click();
+      await page.locator('#students-file-upload').setInputFiles(path.join(os.tmpdir(), `fregata-b-${UAJ_FREGATA}.csv`));
+
+      const hasLoader = await page.locator('.app-loader').isVisible();
+      if (hasLoader) {
+        await page.waitForSelector('.app-loader', { state: 'detached' });
+      }
+      await orgaPage.waitForTheImportToComplete(page);
+    });
+
+    await test.step('Jean Michel manually reconciles with Org B (INE 13) via the campaign', async () => {
+      // INE 13 est inconnu, pas d'auto-réconciliation à l'import : Jean Michel doit se réconcilier manuellement.
+      await page.goto(process.env.PIX_APP_URL + `/campagnes/${campaignCodeB}`);
+      await page.getByRole('button', { name: 'Je commence' }).click();
+      await reconciliationPage.reconcile('Jean', 'Michel', '01/01/1990', true);
+      await challengePage.leave();
+    });
+
+    await test.step('Org B: second import with INE 12 only — INE 13 is disabled, we block auto-reconciliation of INE 12', async () => {
+      // Après cet import : INE 13 sera disabled (absent du CSV), INE 12 sera créé.
+      // On détecte que U1 est déjà dans Org B (via INE 13 disabled) avec un INE différent
+      // → INE 12 reste sans userId.
+      await page.goto(process.env.PIX_ORGA_URL as string);
+      await page.getByRole('link', { name: 'Campagnes', exact: true }).click();
+      await page.getByRole('link', { name: 'Créer une campagne' }).click();
+      await orgaPage.createEvaluationCampaign({
+        campaignName: 'campagne fregata B2',
+        targetProfileName: 'PC pour Playwright',
+      });
+      campaignCodeB2 = (await page.locator('dd.campaign-header-title__campaign-code > span').textContent()) ?? '';
+
+      await page.getByRole('link', { name: 'Élèves' }).click();
+      await page.getByRole('link', { name: 'Importer', exact: true }).click();
+      await page
+        .locator('#students-file-upload')
+        .setInputFiles(path.join(os.tmpdir(), `fregata-b2-${UAJ_FREGATA}.csv`));
+
+      const hasLoader = await page.locator('.app-loader').isVisible();
+      if (hasLoader) {
+        await page.waitForSelector('.app-loader', { state: 'detached' });
+      }
+      await orgaPage.waitForTheImportToComplete(page);
+    });
+
+    await test.step('Jean Michel cannot access the new Organization B campaign (INE 12 was not auto-reconciled)', async () => {
+      await page.goto(process.env.PIX_APP_URL + `/campagnes/${campaignCodeB2}`);
+      // Jean Michel est connecté, mais n'est plus réconcilié avec Orga B :
+      // - INE 13 est disabled : aucun learner actif avec userId=U1 dans Org B
+      // - INE 12 a userId=null
+      await page.getByRole('button', { name: 'Je commence' }).click();
+      await expect(page.getByRole('heading', { name: /Oups, la page demandée/ })).toBeVisible({ timeout: 15000 });
+    });
   });
 });


### PR DESCRIPTION
## 🌱 Problème

Il manque un test e2e sur l'auto-réconciliation d'un élève importé avec un utilisateur déjà présent dans l'organisation cible sous un INE différent.

## 🐣 Proposition

Ajout d'un test e2e Playwright couvrant le scénario complet :

1. Org A (SCO AGRI) importe Jean Michel (INE 12), l'utilsateur crée un compte et se réconcilie
2. Org B (SCO AGRI) importe Jean Michel (INE 13), l'utiliateur se réconcilie manuellement via la campagne
3. Org B réimporte avec uniquement INE 12: INE 13 passe \`disabled\`
4. Jean Michel ne peut pas accéder à la campagne Org B : INE 12 n'a pas été auto-réconcilié avec l'utilisateur

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/662c4b1c-9493-4e0a-9cc0-606c09a7c2c9" />


## 🐝 Pour tester

🟢 