### PR TITLE
[TECH] Supprime le critère SkillProfile qui n'est plus utilisé en production (PIX-22553)

### DIFF
--- a/api/src/quest/domain/models/Requirement.js
+++ b/api/src/quest/domain/models/Requirement.js
@@ -11,7 +11,6 @@ export const COMPARISONS = {
 
 export const TYPES = {
   COMPOSE: 'compose',
-  SKILL_PROFILE: 'skillProfile',
   CAPPED_TUBES: 'cappedTubes',
   OBJECT: {
     ORGANIZATION_LEARNER: 'organizationLearner',
@@ -199,52 +198,6 @@ export class ObjectRequirement extends BaseRequirement {
   }
 }
 
-export class SkillProfileRequirement extends BaseRequirement {
-  #skillIds;
-  #threshold;
-
-  constructor({ data }) {
-    super({ requirement_type: TYPES.SKILL_PROFILE, comparison: null });
-    this.#skillIds = data.skillIds;
-    this.#threshold = data.threshold;
-  }
-
-  /**
-   * @returns {Object}
-   */
-  get data() {
-    return {
-      skillIds: Object.freeze(this.#skillIds),
-      threshold: this.#threshold,
-    };
-  }
-
-  /**
-   * @param {Eligibility|Success} dataInput
-   * @returns {Boolean}
-   */
-  isFulfilled(dataInput) {
-    const masteryPercentage = dataInput.getMasteryPercentageForSkills(this.#skillIds);
-
-    const isFulfilled = masteryPercentage >= this.#threshold;
-    logger.debug({ name: SkillProfileRequirement.name, masteryPercentage, threshold: this.#threshold, isFulfilled });
-    return isFulfilled;
-    // la comparaison ici pourrait être celle du requirement ? pour pouvoir avoir de la flexi sur =<>=
-  }
-
-  /**
-   * @returns {Object}
-   */
-  toDTO() {
-    const superDto = super.toDTO();
-    delete superDto.comparison;
-    return {
-      ...superDto,
-      data: this.data,
-    };
-  }
-}
-
 const cappedTubesRequirementSchema = Joi.object({
   requirement_type: TYPES.CAPPED_TUBES,
   data: Joi.object({
@@ -323,8 +276,6 @@ export function buildRequirement({ requirement_type, data, comparison }) {
     return new ComposedRequirement({ data, comparison });
   } else if (objectTypes.includes(requirement_type)) {
     return new ObjectRequirement({ requirement_type, data, comparison });
-  } else if (requirement_type === TYPES.SKILL_PROFILE) {
-    return new SkillProfileRequirement({ data });
   } else if (requirement_type === TYPES.CAPPED_TUBES) {
     return new CappedTubesRequirement({ data });
   }

--- a/api/tests/quest/acceptance/application/quest-route_test.js
+++ b/api/tests/quest/acceptance/application/quest-route_test.js
@@ -121,7 +121,7 @@ describe('Quest | Acceptance | Application | Quest Route ', function () {
       await databaseBuilder.commit();
       // TODO j'ai l'impression qu'en séparateur en ; il capte pas les différents headers
       const input = `Quest ID,Json configuration for quest
-,"{""rewardType"":""attestations"",""rewardId"":1,""eligibilityRequirements"":[{""requirement_type"":""organization"",""data"":{""type"":{""data"":""SCO"",""comparison"":""equal""}}, ""comparison"": ""all""}],""successRequirements"":[{""requirement_type"":""skillProfile"",""data"":{""skillIds"":[""skillA"",""skillB""],""threshold"":66}}]}"`;
+,"{""rewardType"":""attestations"",""rewardId"":1,""eligibilityRequirements"":[{""requirement_type"":""organization"",""data"":{""type"":{""data"":""SCO"",""comparison"":""equal""}}, ""comparison"": ""all""}],""successRequirements"":[{""requirement_type"":""cappedTubes"",""data"":{""cappedTubes"":[{""tubeId"":""tubeA"",""level"":3}],""threshold"":66}}]}"`;
 
       const options = {
         method: 'POST',

--- a/api/tests/quest/integration/domain/usecases/check-user-quest-success_test.js
+++ b/api/tests/quest/integration/domain/usecases/check-user-quest-success_test.js
@@ -71,6 +71,14 @@ describe('Integration | Quest | Domain | UseCases | check-user-quest-success', f
       campaignId: firstCampaign.id,
       userId,
     });
+    databaseBuilder.factory.learningContent.buildTube({ id: 'tubeId1' });
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'skillId1',
+      tubeId: 'tubeId1',
+      status: 'actif',
+      level: 1,
+    });
+    databaseBuilder.factory.buildCampaignSkill({ campaignId: firstCampaign.id, skillId: 'skillId1' });
     const userKnowledgeElements = [
       {
         userId,
@@ -95,9 +103,9 @@ describe('Integration | Quest | Domain | UseCases | check-user-quest-success', f
       ],
       successRequirements: [
         {
-          requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
           data: {
-            skillIds: ['skillId1'],
+            cappedTubes: [{ tubeId: 'tubeId1', level: 1 }],
             threshold: 50,
           },
         },
@@ -127,6 +135,14 @@ describe('Integration | Quest | Domain | UseCases | check-user-quest-success', f
       campaignId: firstCampaign.id,
       userId,
     });
+    databaseBuilder.factory.learningContent.buildTube({ id: 'tubeId1' });
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'skillId1',
+      tubeId: 'tubeId1',
+      status: 'actif',
+      level: 1,
+    });
+    databaseBuilder.factory.buildCampaignSkill({ campaignId: firstCampaign.id, skillId: 'skillId1' });
     const userKnowledgeElements = [
       {
         userId,
@@ -151,9 +167,9 @@ describe('Integration | Quest | Domain | UseCases | check-user-quest-success', f
       ],
       successRequirements: [
         {
-          requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
           data: {
-            skillIds: ['skillId1'],
+            cappedTubes: [{ tubeId: 'tubeId1', level: 1 }],
             threshold: 50,
           },
         },
@@ -198,9 +214,9 @@ describe('Integration | Quest | Domain | UseCases | check-user-quest-success', f
       ],
       successRequirements: [
         {
-          requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
           data: {
-            skillIds: ['skillId1'],
+            cappedTubes: [{ tubeId: 'tubeId1', level: 1 }],
             threshold: 50,
           },
         },

--- a/api/tests/quest/integration/domain/usecases/reward-user_test.js
+++ b/api/tests/quest/integration/domain/usecases/reward-user_test.js
@@ -12,95 +12,6 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 const { INVALIDATED, VALIDATED } = KnowledgeElement.StatusType;
 const userId = 1234;
 
-const setupContextWithProfileSkillQuest = async ({
-  userId,
-  isEligible = true,
-  hasSecondLearner = false,
-  hasValidatedKnowledgeElements = true,
-  hasAlreadySucceededTheQuest = false,
-}) => {
-  databaseBuilder.factory.buildUser({ id: userId });
-  const questOrganization = 'PRO';
-  const userOrganization = isEligible ? questOrganization : 'SCO';
-
-  const userKnowledgeElements = [
-    {
-      userId,
-      skillId: 'skillId1',
-      status: hasValidatedKnowledgeElements ? VALIDATED : INVALIDATED,
-    },
-    {
-      userId,
-      skillId: 'skillId2',
-      status: hasValidatedKnowledgeElements ? VALIDATED : INVALIDATED,
-    },
-    {
-      userId,
-      skillId: 'skillId3',
-      status: hasValidatedKnowledgeElements ? VALIDATED : INVALIDATED,
-    },
-  ];
-  userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
-
-  const organization = databaseBuilder.factory.buildOrganization({ type: userOrganization });
-  if (hasSecondLearner) {
-    databaseBuilder.factory.buildOrganizationLearner({
-      userId,
-      organizationId: databaseBuilder.factory.buildOrganization({ type: userOrganization }).id,
-    });
-  }
-  const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
-    userId,
-    organizationId: organization.id,
-  });
-
-  const { id: campaignId } = databaseBuilder.factory.buildCampaign({
-    organizationId: organization.id,
-  });
-
-  databaseBuilder.factory.buildCampaignParticipation({
-    campaignId,
-    organizationLearnerId,
-    userId,
-  });
-
-  const successRequirements = [
-    {
-      requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-      data: {
-        skillIds: ['skillId1', 'skillId2', 'skillId3'],
-        threshold: 50,
-      },
-    },
-  ];
-
-  const quest = databaseBuilder.factory.buildQuest({
-    rewardType: REWARD_TYPES.ATTESTATION,
-    eligibilityRequirements: [
-      {
-        requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
-        comparison: REQUIREMENT_COMPARISONS.ALL,
-        data: {
-          type: {
-            data: questOrganization,
-            comparison: CRITERION_COMPARISONS.EQUAL,
-          },
-        },
-      },
-    ],
-    successRequirements,
-  });
-
-  if (hasAlreadySucceededTheQuest) {
-    databaseBuilder.factory.buildProfileReward({
-      rewardId: quest.rewardId,
-      userId,
-    });
-  }
-
-  await databaseBuilder.commit();
-};
-
 const setupContextWithCappedTubesQuest = async ({
   userId,
   isEligible = true,
@@ -233,299 +144,6 @@ const setupContextWithCappedTubesQuest = async ({
 };
 
 describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
-  describe('skillProfile', function () {
-    context('when user is eligible and meets success requirements', function () {
-      beforeEach(async function () {
-        await setupContextWithProfileSkillQuest({ userId });
-      });
-
-      it('should reward the user', async function () {
-        //when
-        await usecases.rewardUser({ userId });
-
-        // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-        expect(profileRewards).to.have.lengthOf(1);
-        expect(profileRewards[0].userId).to.equal(userId);
-      });
-    });
-
-    context('when user is eligible twice and meets success requirements in second learner', function () {
-      beforeEach(async function () {
-        await setupContextWithProfileSkillQuest({ userId, hasSecondLearner: true });
-      });
-
-      it('should reward the user', async function () {
-        //when
-        await usecases.rewardUser({ userId });
-
-        // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-        expect(profileRewards).to.have.lengthOf(1);
-        expect(profileRewards[0].userId).to.equal(userId);
-      });
-    });
-
-    context('when user is eligible with two organization learner for the same quest', function () {
-      let userId;
-
-      beforeEach(async function () {
-        userId = databaseBuilder.factory.buildUser().id;
-        const questOrganization = 'PRO';
-        const userKnowledgeElements = [
-          {
-            userId,
-            skillId: 'skillId1',
-            status: VALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skillId2',
-            status: VALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skillId3',
-            status: VALIDATED,
-          },
-        ];
-        userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
-
-        const firstOrganization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
-        const secondOrganization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
-
-        [firstOrganization.id, secondOrganization.id].forEach((organizationId) => {
-          const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
-            userId,
-            organizationId,
-          });
-
-          const { id: campaignId } = databaseBuilder.factory.buildCampaign({
-            organizationId,
-          });
-          const { id: secondCampaignId } = databaseBuilder.factory.buildCampaign({
-            organizationId,
-          });
-
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId,
-            organizationLearnerId,
-            userId,
-          });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: secondCampaignId,
-            organizationLearnerId,
-            userId,
-          });
-        });
-
-        const rewardId = databaseBuilder.factory.buildAttestation().id;
-
-        databaseBuilder.factory.buildQuest({
-          rewardType: REWARD_TYPES.ATTESTATION,
-          rewardId,
-          eligibilityRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                type: {
-                  data: questOrganization,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-          ],
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-              data: {
-                skillIds: ['skillId1', 'skillId2', 'skillId3'],
-                threshold: 50,
-              },
-            },
-          ],
-        });
-
-        await databaseBuilder.commit();
-      });
-
-      it('should reward the user only once', async function () {
-        //when
-        await usecases.rewardUser({ userId });
-
-        // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-        expect(profileRewards).to.have.lengthOf(1);
-      });
-    });
-
-    context('when user is eligible at two quests with the same rewardId', function () {
-      let userId;
-
-      beforeEach(async function () {
-        userId = databaseBuilder.factory.buildUser().id;
-        const questOrganization = 'PRO';
-        const userKnowledgeElements = [
-          {
-            userId,
-            skillId: 'skillId1',
-            status: VALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skillId2',
-            status: VALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skillId3',
-            status: VALIDATED,
-          },
-        ];
-        userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
-
-        const organization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
-        const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
-          userId,
-          organizationId: organization.id,
-        });
-
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({
-          organizationId: organization.id,
-        });
-        const { id: secondCampaignId } = databaseBuilder.factory.buildCampaign({
-          organizationId: organization.id,
-        });
-
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId,
-          organizationLearnerId,
-          userId,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: secondCampaignId,
-          organizationLearnerId,
-          userId,
-        });
-        const rewardId = databaseBuilder.factory.buildAttestation().id;
-
-        databaseBuilder.factory.buildQuest({
-          rewardType: REWARD_TYPES.ATTESTATION,
-          rewardId,
-          eligibilityRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                type: {
-                  data: questOrganization,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-          ],
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-              data: {
-                skillIds: ['skillId1', 'skillId2', 'skillId3'],
-                threshold: 50,
-              },
-            },
-          ],
-        });
-        databaseBuilder.factory.buildQuest({
-          rewardType: REWARD_TYPES.ATTESTATION,
-          rewardId,
-          eligibilityRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                type: {
-                  data: questOrganization,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-          ],
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-              data: {
-                skillIds: ['skillId1', 'skillId2', 'skillId3'],
-                threshold: 50,
-              },
-            },
-          ],
-        });
-
-        await databaseBuilder.commit();
-      });
-
-      it('should reward the user only once', async function () {
-        //when
-        await usecases.rewardUser({ userId });
-
-        // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-        expect(profileRewards).to.have.lengthOf(1);
-      });
-    });
-
-    context('when user is not eligible', function () {
-      beforeEach(async function () {
-        await setupContextWithProfileSkillQuest({ userId, isEligible: false });
-      });
-
-      it('should not reward the user', async function () {
-        //when
-        await usecases.rewardUser({ userId });
-
-        // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-        expect(profileRewards).to.have.lengthOf(0);
-      });
-    });
-
-    context('when user is eligible but does not meet success requirements', function () {
-      beforeEach(async function () {
-        await setupContextWithProfileSkillQuest({ userId, hasValidatedKnowledgeElements: false });
-      });
-
-      it('should not reward the user', async function () {
-        //when
-        await usecases.rewardUser({ userId });
-
-        // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-        expect(profileRewards).to.have.lengthOf(0);
-      });
-    });
-
-    context('when user has already earned a reward for the quest', function () {
-      beforeEach(async function () {
-        await setupContextWithProfileSkillQuest({
-          userId,
-          isEligible: true,
-          hasAlreadySucceededTheQuest: true,
-          hasValidatedKnowledgeElements: true,
-        });
-      });
-
-      it('should not reward the user a second time', async function () {
-        //when
-        await usecases.rewardUser({ userId });
-
-        // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-        expect(profileRewards).to.have.lengthOf(1);
-        expect(profileRewards[0].userId).to.equal(userId);
-      });
-    });
-  });
-
   describe('cappedTube', function () {
     context('when user is eligible and meets success requirements', function () {
       beforeEach(async function () {
@@ -559,24 +177,19 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
       beforeEach(async function () {
         userId = databaseBuilder.factory.buildUser().id;
         const questOrganization = 'PRO';
-        const userKnowledgeElements = [
-          {
-            userId,
-            skillId: 'skillId1',
-            status: VALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skillId2',
-            status: VALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skillId3',
-            status: VALIDATED,
-          },
-        ];
+
+        const userKnowledgeElements = [{ userId, skillId: 'skillId1_tube1', status: VALIDATED }];
         userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
+
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'firstTube', level: 1 });
+        databaseBuilder.factory.learningContent.buildTube({ id: 'firstTube' });
+        databaseBuilder.factory.learningContent.buildSkill({
+          id: 'skillId1_tube1',
+          tubeId: 'firstTube',
+          status: 'actif',
+          level: 1,
+        });
 
         const organization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
         const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
@@ -586,72 +199,47 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
 
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({
           organizationId: organization.id,
+          targetProfileId,
         });
-        const { id: secondCampaignId } = databaseBuilder.factory.buildCampaign({
-          organizationId: organization.id,
-        });
-
+        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillId1_tube1' });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
           userId,
         });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: secondCampaignId,
-          organizationLearnerId,
-          userId,
-        });
+
         const rewardId = databaseBuilder.factory.buildAttestation().id;
+
+        const eligibilityRequirements = [
+          {
+            requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
+            comparison: REQUIREMENT_COMPARISONS.ALL,
+            data: { type: { data: questOrganization, comparison: CRITERION_COMPARISONS.EQUAL } },
+          },
+          {
+            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+            comparison: REQUIREMENT_COMPARISONS.ALL,
+            data: { targetProfileId: { data: targetProfileId, comparison: CRITERION_COMPARISONS.EQUAL } },
+          },
+        ];
+        const successRequirements = [
+          {
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+            data: { cappedTubes: [{ tubeId: 'firstTube', level: 1 }], threshold: 50 },
+          },
+        ];
 
         databaseBuilder.factory.buildQuest({
           rewardType: REWARD_TYPES.ATTESTATION,
           rewardId,
-          eligibilityRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                type: {
-                  data: questOrganization,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-          ],
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-              data: {
-                skillIds: ['skillId1', 'skillId2', 'skillId3'],
-                threshold: 50,
-              },
-            },
-          ],
+          eligibilityRequirements,
+          successRequirements,
         });
         databaseBuilder.factory.buildQuest({
           rewardType: REWARD_TYPES.ATTESTATION,
           rewardId,
-          eligibilityRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                type: {
-                  data: questOrganization,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-          ],
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-              data: {
-                skillIds: ['skillId1', 'skillId2', 'skillId3'],
-                threshold: 50,
-              },
-            },
-          ],
+          eligibilityRequirements,
+          successRequirements,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -150,33 +150,23 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
         eligibilityRequirements: [],
         successRequirements: [
           {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-            data: {
-              skillIds: ['skillA', 'skillB'],
-              threshold: 100,
-            },
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+            data: { cappedTubes: [{ tubeId: 'tubeA', level: 1 }], threshold: 100 },
           },
           {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-            data: {
-              skillIds: ['skillC', 'skillD'],
-              threshold: 50,
-            },
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+            data: { cappedTubes: [{ tubeId: 'tubeB', level: 1 }], threshold: 50 },
           },
         ],
       });
       const success = new Success({
         knowledgeElements: [
-          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA' },
-          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
-          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillC' },
-          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillD' },
+          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA', createdAt: new Date() },
+          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillC', createdAt: new Date() },
         ],
-        skills: [
+        campaignSkills: [
           { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillC', tubeId: 'tubeB', difficulty: 1 },
         ],
       });
       const data = new DataForQuest({ success });
@@ -192,33 +182,23 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
         eligibilityRequirements: [],
         successRequirements: [
           {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-            data: {
-              skillIds: ['skillA', 'skillB'],
-              threshold: 100,
-            },
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+            data: { cappedTubes: [{ tubeId: 'tubeA', level: 1 }], threshold: 100 },
           },
           {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-            data: {
-              skillIds: ['skillC', 'skillD'],
-              threshold: 50,
-            },
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+            data: { cappedTubes: [{ tubeId: 'tubeB', level: 1 }], threshold: 50 },
           },
         ],
       });
       const success = new Success({
         knowledgeElements: [
-          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA' },
-          { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillB' },
-          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillC' },
-          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillD' },
+          { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA', createdAt: new Date() },
+          { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC', createdAt: new Date() },
         ],
-        skills: [
+        campaignSkills: [
           { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillC', tubeId: 'tubeB', difficulty: 1 },
         ],
       });
       const data = new DataForQuest({ success });
@@ -234,33 +214,23 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
         eligibilityRequirements: [],
         successRequirements: [
           {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-            data: {
-              skillIds: ['skillA', 'skillB'],
-              threshold: 100,
-            },
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+            data: { cappedTubes: [{ tubeId: 'tubeA', level: 1 }], threshold: 100 },
           },
           {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-            data: {
-              skillIds: ['skillC', 'skillD'],
-              threshold: 50,
-            },
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+            data: { cappedTubes: [{ tubeId: 'tubeB', level: 1 }], threshold: 50 },
           },
         ],
       });
       const success = new Success({
         knowledgeElements: [
-          { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillA' },
-          { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillB' },
-          { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
-          { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
+          { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillA', createdAt: new Date() },
+          { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC', createdAt: new Date() },
         ],
-        skills: [
+        campaignSkills: [
           { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
-          { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillC', tubeId: 'tubeB', difficulty: 1 },
         ],
       });
       const data = new DataForQuest({ success });
@@ -837,9 +807,9 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
         ],
         successRequirements: [
           {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
             data: {
-              skillIds: ['id1', 'id2'],
+              cappedTubes: [{ tubeId: 'tubeA', level: 3 }],
               threshold: 70,
             },
           },
@@ -902,9 +872,9 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
         ],
         successRequirements: [
           {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
             data: {
-              skillIds: ['id1', 'id2'],
+              cappedTubes: [{ tubeId: 'tubeA', level: 3 }],
               threshold: 70,
             },
           },

--- a/api/tests/quest/unit/domain/models/Requirement_test.js
+++ b/api/tests/quest/unit/domain/models/Requirement_test.js
@@ -6,7 +6,6 @@ import {
   COMPARISONS,
   ComposedRequirement,
   ObjectRequirement,
-  SkillProfileRequirement,
   TYPES,
 } from '../../../../../src/quest/domain/models/Requirement.js';
 import { Success } from '../../../../../src/quest/domain/models/Success.js';
@@ -97,23 +96,6 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
 
         // then
         expect(requirement instanceof ObjectRequirement).to.be.true;
-      });
-    });
-
-    context('when requirement_type is "skillProfile"', function () {
-      it('should build an SkillProfileRequirement', function () {
-        // given
-        const buildData = {
-          requirement_type: TYPES.SKILL_PROFILE,
-          comparison: 'irrelevant',
-          data: {},
-        };
-
-        // when
-        const requirement = buildRequirement(buildData);
-
-        // then
-        expect(requirement instanceof SkillProfileRequirement).to.be.true;
       });
     });
 
@@ -622,115 +604,6 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
             },
           },
           comparison: COMPARISONS.ALL,
-        });
-      });
-    });
-  });
-
-  describe('SkillProfileRequirement', function () {
-    describe('isFulfilled', function () {
-      context("when dataInput's masteryPercentage is below threshold", function () {
-        it('should return false', function () {
-          const requirement = new SkillProfileRequirement({
-            data: {
-              skillIds: ['skillB', 'skillA', 'skillC', 'skillE'],
-              threshold: 51,
-            },
-          });
-          const successWith50MasteryPercentage = new Success({
-            knowledgeElements: [
-              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA' },
-              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
-              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
-              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
-            ],
-            skills: [
-              { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
-            ],
-          });
-
-          expect(requirement.isFulfilled(successWith50MasteryPercentage)).to.be.false;
-        });
-      });
-
-      context("when dataInput's masteryPercentage is equal to threshold", function () {
-        it('should return true', function () {
-          const requirement = new SkillProfileRequirement({
-            data: {
-              skillIds: ['skillB', 'skillA', 'skillC', 'skillE'],
-              threshold: 50,
-            },
-          });
-          const successWith50MasteryPercentage = new Success({
-            knowledgeElements: [
-              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA' },
-              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
-              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
-              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
-            ],
-            skills: [
-              { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
-            ],
-          });
-
-          expect(requirement.isFulfilled(successWith50MasteryPercentage)).to.be.true;
-        });
-      });
-
-      context("when dataInput's masteryPercentage is above threshold", function () {
-        it('should return true', function () {
-          const requirement = new SkillProfileRequirement({
-            data: {
-              skillIds: ['skillB', 'skillA', 'skillC', 'skillE'],
-              threshold: 49,
-            },
-          });
-          const successWith50MasteryPercentage = new Success({
-            knowledgeElements: [
-              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA' },
-              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
-              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
-              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
-            ],
-            skills: [
-              { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
-              { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
-            ],
-          });
-
-          expect(requirement.isFulfilled(successWith50MasteryPercentage)).to.be.true;
-        });
-      });
-    });
-
-    describe('toDTO', function () {
-      it('should transform into a DTO', function () {
-        // given
-        const requirement = new SkillProfileRequirement({
-          data: {
-            skillIds: ['id1', 'id2'],
-            threshold: 70,
-          },
-        });
-
-        // when
-        const DTO = requirement.toDTO();
-
-        // then
-        expect(DTO).to.deep.equal({
-          requirement_type: TYPES.SKILL_PROFILE,
-          data: {
-            skillIds: ['id1', 'id2'],
-            threshold: 70,
-          },
         });
       });
     });


### PR DESCRIPTION
## 🌱 Problème

Initialement, nous utilisions directement les acquis pour vérifier sur les participants a une quête avaient validé certains critères. Cependant en se basant sur les acquis directement on s'expose à leur obsolescence. Nous avons donc ajouté un critère se basant sur les sujets cappés. Depuis toutes les quêtes ont été migrées vers ce nouveau critère.

## 🐣 Proposition

Supprimer le critère SkillProfile qui n'est plus utilisé en production.

## 🌷 Remarques

On a vérifié en production avec les requêtes suivantes : 

SELECT * FROM quests WHERE "successRequirements"::text ilike '%skillProfile%'
SELECT * FROM quests WHERE "eligibilityRequirements"::text ilike '%skillProfile%'

Elles ne retournent aucuns résultats.

## 🐝 Pour tester

La CI est verte 🍏 
