### PR TITLE
[FEATURE] Afficher le nombre de campagnes sur l'onglet dans la page de détail d'une organisation (PIX-21446)

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -38,6 +38,7 @@ export default class Organization extends Model {
   @hasMany('tag', { async: true, inverse: null }) tags;
   @hasMany('organization', { async: true, inverse: null }) children;
   @hasMany('organization-invitation', { async: true, inverse: null }) organizationInvitations;
+  @hasMany('campaign', { async: true, inverse: null }) campaigns;
 
   @belongsTo('network', { async: true, inverse: null }) network;
 

--- a/admin/app/routes/authenticated/organizations/get/campaigns.js
+++ b/admin/app/routes/authenticated/organizations/get/campaigns.js
@@ -10,19 +10,20 @@ export default class OrganizationCampaignsRoute extends Route {
   };
 
   async model(params) {
-    const organizationId = this.paramsFor('authenticated.organizations.get').organization_id;
+    const organization = this.modelFor('authenticated.organizations.get');
 
-    const query = {
-      organizationId,
-      'page[number]': params.pageNumber || 1,
-      'page[size]': params.pageSize || 10,
-    };
-    const campaigns = await this.store.query('campaign', query);
+    const cachedCampaigns = organization.hasMany('campaigns').value();
+    if (cachedCampaigns !== null && !params.pageNumber) {
+      return { campaigns: cachedCampaigns, organizationId: organization.id };
+    }
 
-    return {
-      campaigns,
-      organizationId,
-    };
+    const campaigns = await this.store.query('campaign', {
+      organizationId: organization.id,
+      'page[number]': params.pageNumber ?? 1,
+      'page[size]': params.pageSize ?? 10,
+    });
+
+    return { campaigns, organizationId: organization.id };
   }
 
   resetController(controller, isExiting) {

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -56,6 +56,7 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
 
       <LinkTo @route="authenticated.organizations.get.campaigns" @model={{@model}}>
         {{t "pages.organization.navbar.campaigns"}}
+        ({{@model.campaigns.meta.rowCount}})
       </LinkTo>
 
       {{#if @model.isPlacesManagementEnabled}}

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -263,14 +263,17 @@ module('Acceptance | Organizations | Get', function (hooks) {
       module('Campaigns tab', function () {
         test('it should display campaigns tab', async function (assert) {
           // given
-          server.create('campaign');
+          server.create('campaign', { organizationId: ORGANIZATION_ID });
+          server.create('campaign', { organizationId: ORGANIZATION_ID });
 
           // when
           const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
 
           // then
           const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
-          assert.ok(within(navigationTabs).getByRole('link', { name: t('pages.organization.navbar.campaigns') }));
+          assert.ok(
+            within(navigationTabs).getByRole('link', { name: `${t('pages.organization.navbar.campaigns')} (2)` }),
+          );
         });
       });
 

--- a/admin/tests/mirage/handlers/organizations.js
+++ b/admin/tests/mirage/handlers/organizations.js
@@ -65,6 +65,14 @@ function findPaginatedOrganizationMemberships(schema, request) {
   return json;
 }
 
+function findOrganizationCampaigns(schema, request) {
+  const organizationId = request.params.id;
+  const campaigns = schema.campaigns.where({ organizationId }).models;
+  const json = this.serialize({ modelName: 'campaign', models: campaigns }, 'campaign');
+  json.meta = { rowCount: campaigns.length };
+  return json;
+}
+
 function archiveOrganization(schema, request) {
   const id = request.params.id;
 
@@ -86,6 +94,7 @@ function findPaginatedFilteredOrganizations(schema) {
 
 export {
   archiveOrganization,
+  findOrganizationCampaigns,
   findPaginatedFilteredOrganizations,
   findPaginatedOrganizationMemberships,
   getOrganizationInvitations,

--- a/admin/tests/mirage/models/organization.js
+++ b/admin/tests/mirage/models/organization.js
@@ -6,5 +6,6 @@ export default Model.extend({
   tags: hasMany('tag'),
   children: hasMany('organization'),
   organizationInvitations: hasMany('organizationInvitation'),
+  campaigns: hasMany('campaign'),
   network: belongsTo('network'),
 });

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -22,6 +22,7 @@ import { createNetwork, findAllFilteredNetworks, updateNetwork } from './handler
 import { createOrganizationMembership } from './handlers/organization-memberships';
 import {
   archiveOrganization,
+  findOrganizationCampaigns,
   findPaginatedFilteredOrganizations,
   findPaginatedOrganizationMemberships,
   getOrganizationInvitations,
@@ -395,6 +396,7 @@ export default function routes() {
   });
   this.post('/admin/organizations/import-csv', async () => new Response(204));
   this.get('/admin/organizations/:id');
+  this.get('/admin/organizations/:id/campaigns', findOrganizationCampaigns);
   this.get('/admin/organizations/:id/memberships', findPaginatedOrganizationMemberships);
   this.get('/admin/organizations/:id/target-profile-summaries', findOrganizationTargetProfileSummaries);
   this.post('/admin/organizations/:id/attach-target-profiles', attachTargetProfiles);

--- a/admin/tests/mirage/serializers.js
+++ b/admin/tests/mirage/serializers.js
@@ -4,6 +4,7 @@ import application from './serializers/application';
 import area from './serializers/area';
 import autonomousCourseListItem from './serializers/autonomous-course-list-item';
 import badge from './serializers/badge';
+import campaign from './serializers/campaign';
 import campaignParticipation from './serializers/campaign-participation';
 import certification from './serializers/certification';
 import certificationCandidate from './serializers/certification-candidate';
@@ -32,6 +33,7 @@ export default {
   area,
   autonomousCourseListItem,
   badge,
+  campaign,
   campaignParticipation,
   certificationCandidate,
   certificationCenter,

--- a/admin/tests/mirage/serializers/campaign.js
+++ b/admin/tests/mirage/serializers/campaign.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend();

--- a/admin/tests/mirage/serializers/organization.js
+++ b/admin/tests/mirage/serializers/organization.js
@@ -15,6 +15,9 @@ export default ApplicationSerializer.extend({
       organizationInvitations: {
         related: `/api/admin/organizations/${organization.id}/invitations`,
       },
+      campaigns: {
+        related: `/api/admin/organizations/${organization.id}/campaigns`,
+      },
     };
   },
 

--- a/admin/tests/unit/routes/authenticated/organizations/get/campaigns-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/campaigns-test.js
@@ -1,5 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | authenticated/organization/get/campaigns', function (hooks) {
   setupTest(hooks);
@@ -7,6 +8,83 @@ module('Unit | Route | authenticated/organization/get/campaigns', function (hook
 
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/organizations/get/campaigns');
+  });
+
+  module('#model', function (hooks) {
+    let organization;
+
+    hooks.beforeEach(function () {
+      organization = {
+        id: '123',
+        hasMany: sinon.stub(),
+      };
+      route.modelFor = sinon.stub().returns(organization);
+      route.store = { query: sinon.stub() };
+    });
+
+    module('when campaigns are already in cache and there are no pagination params', function () {
+      test('it should return cached campaigns without calling store.query', async function (assert) {
+        // given
+        const cachedCampaigns = [{ id: '1' }, { id: '2' }];
+        organization.hasMany.withArgs('campaigns').returns({ value: sinon.stub().returns(cachedCampaigns) });
+        const params = { pageNumber: undefined, pageSize: undefined };
+
+        // when
+        const result = await route.model(params);
+
+        // then
+        sinon.assert.notCalled(route.store.query);
+        assert.strictEqual(result.campaigns, cachedCampaigns);
+        assert.strictEqual(result.organizationId, '123');
+      });
+    });
+
+    module('when campaigns are already in cache but pagination params are set', function () {
+      test('it should call store.query with the given pagination params', async function (assert) {
+        // given
+        const cachedCampaigns = [{ id: '1' }];
+        organization.hasMany.withArgs('campaigns').returns({ value: sinon.stub().returns(cachedCampaigns) });
+
+        const params = { pageNumber: 2, pageSize: 10 };
+        const campaignsFromApi = [{ id: 3 }];
+        route.store.query.resolves(campaignsFromApi);
+
+        // when
+        const result = await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'campaign', {
+          'page[number]': params.pageNumber,
+          'page[size]': params.pageSize,
+          organizationId: '123',
+        });
+        assert.strictEqual(result.campaigns, campaignsFromApi);
+      });
+    });
+
+    module('when campaigns are not in cache', function () {
+      test('it should call store.query with default pagination params', async function (assert) {
+        // given
+        organization.hasMany.withArgs('campaigns').returns({ value: sinon.stub().returns(null) });
+
+        const params = { pageNumber: undefined, pageSize: undefined };
+        const defaultPageNumber = 1;
+        const defaultPageSize = 10;
+        const campaignsFromApi = [{ id: 3 }];
+        route.store.query.resolves(campaignsFromApi);
+
+        // when
+        const result = await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'campaign', {
+          'page[number]': defaultPageNumber,
+          'page[size]': defaultPageSize,
+          organizationId: '123',
+        });
+        assert.strictEqual(result.campaigns, campaignsFromApi);
+      });
+    });
   });
 
   module('#resetController', function (hooks) {

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -61,6 +61,7 @@ const serialize = function (organizations, meta) {
       'organizationLearnerTypeId',
       'organizationLearnerTypeName',
       'network',
+      'campaigns',
     ],
     network: {
       ref: 'id',
@@ -110,6 +111,16 @@ const serialize = function (organizations, meta) {
       ref: 'id',
       included: true,
       attributes: ['id', 'name'],
+    },
+    campaigns: {
+      ref: 'id',
+      ignoreRelationshipData: true,
+      nullIfMissing: true,
+      relationshipLinks: {
+        related: function (record, current, parent) {
+          return `/api/admin/organizations/${parent.id}/campaigns`;
+        },
+      },
     },
     meta,
   }).serialize(organizations);

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -786,6 +786,11 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                   related: `/api/admin/organizations/${organization.id}/invitations`,
                 },
               },
+              campaigns: {
+                links: {
+                  related: `/api/admin/organizations/${organization.id}/campaigns`,
+                },
+              },
             },
             type: 'organizations',
           },

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -133,6 +133,11 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
                 related: `/api/admin/organizations/${organization.id}/invitations`,
               },
             },
+            campaigns: {
+              links: {
+                related: `/api/admin/organizations/${organization.id}/campaigns`,
+              },
+            },
             tags: {
               data: [
                 {


### PR DESCRIPTION
## 🌱 Problème

Actuellement dans Pix Admin sur la page de détail d'une organisation, il faut cliquer sur l'onglet Campagnes pour savoir combien il y en a.

## 🐣 Proposition

Comme pour les autres onglets, on ajoute le nombre de campagnes sur le titre de l'onglet.

## 🌷 Remarques

- on utilise une relationship JSON API sur l'organization pour que Ember Data puisse aller requêter la route `/api/admin/{organizationId}/campaigns` dès qu'on arrive sur la page de détail de l'orga.
- il y a une gestion de cache au niveau de la route Campaign pour ne pas refaire la requête lorsqu'on clique sur l'onglet Campagnes. Cette requête n'est faite que si au moins une de ces deux conditions est remplie:
1. Si il n'y a pas de campagnes dans le store
2.  si les query params pour la pagination ont changé.

## 🐝 Pour tester
 Dans Pix Admin:
- naviguer sur la page de détail d'une organisation
- constater la nombre de campagnes entre parenthèses (l'orga **Sco Orga team eval** en a plusieurs)
