### PR TITLE
[TECH] Fix du test flaky pour la selection d'attestations (PIX-22470)

### DIFF
--- a/admin/tests/integration/components/combined-course-blueprints/select-attestation-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/select-attestation-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, waitFor } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import SelectAttestation from 'pix-admin/components/combined-course-blueprints/select-attestation';
@@ -10,6 +10,7 @@ module('Integration | Component | CombinedCourseBlueprints::SelectAttestation', 
   setupIntlRenderingTest(hooks);
 
   test('it should display every attestation available in select options', async function (assert) {
+    assert.expect(2);
     const attestations = [
       { key: 'KEY_1', label: 'Attestation 1' },
       { key: 'KEY_2', label: 'Attestation 2' },
@@ -19,10 +20,13 @@ module('Integration | Component | CombinedCourseBlueprints::SelectAttestation', 
     await click(
       screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
     );
-    await screen.findByRole('listbox');
 
-    assert.ok(screen.getByRole('option', { name: 'Attestation 1' }));
-    assert.ok(screen.getByRole('option', { name: 'Attestation 2' }));
+    await waitFor(async () => {
+      await screen.findByRole('listbox');
+
+      assert.ok(screen.getByRole('option', { name: 'Attestation 1' }));
+      assert.ok(screen.getByRole('option', { name: 'Attestation 2' }));
+    });
   });
 
   test('it should select an attestation', async function (assert) {


### PR DESCRIPTION
## 🌱 Problème

Test flaky select-attestation-test

## 🐣 Proposition

Ajout d'un waitFor autour du find de listbox

## 🌷 Remarques

A priori le fail était assez rare, mais normalement ça règle le souci

## 🐝 Pour tester
Pix Admin -> lancer les tests
