### PR TITLE
[FEATURE] Ajoute le nombre de question, la durée et le statut à la route d'historique des versions de référentiel (PIX-21479)

### DIFF
--- a/api/src/certification/configuration/domain/read-models/FrameworkHistoryEntry.js
+++ b/api/src/certification/configuration/domain/read-models/FrameworkHistoryEntry.js
@@ -1,0 +1,22 @@
+export const FRAMEWORK_HISTORY_STATUSES = {
+  DRAFT: 'DRAFT',
+  ACTIVE: 'ACTIVE',
+  ARCHIVED: 'ARCHIVED',
+};
+
+export class FrameworkHistoryEntry {
+  constructor({ id, startDate, expirationDate, assessmentDuration, maximumAssessmentLength }) {
+    this.id = id;
+    this.startDate = startDate ?? null;
+    this.expirationDate = expirationDate ?? null;
+    this.assessmentDuration = assessmentDuration;
+    this.maximumAssessmentLength = maximumAssessmentLength;
+    this.status = this.#computeStatus();
+  }
+
+  #computeStatus() {
+    if (this.expirationDate) return FRAMEWORK_HISTORY_STATUSES.ARCHIVED;
+    if (this.startDate) return FRAMEWORK_HISTORY_STATUSES.ACTIVE;
+    return FRAMEWORK_HISTORY_STATUSES.DRAFT;
+  }
+}

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -1,12 +1,13 @@
 // @ts-check
 /**
- * @typedef {import('../../../shared/domain/models/Scopes.js').SCOPES} SCOPES
- * @typedef {import('../../../../shared/domain/models/Challenge.js').Challenge} Challenge
+ * @typedef {import("../../../shared/domain/models/Scopes.js").SCOPES} SCOPES
+ * @typedef {import("../../../../shared/domain/models/Challenge.js").Challenge} Challenge
  */
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { Version } from '../../domain/models/Version.js';
+import { FrameworkHistoryEntry } from '../../domain/read-models/FrameworkHistoryEntry.js';
 
 /**
  * @returns {Promise<Version[]>}
@@ -113,16 +114,28 @@ export async function update({ version }) {
 /**
  * @param {object} params
  * @param {SCOPES} params.scope
- * @returns {Promise<Array<number>>}
+ * @returns {Promise<Array<FrameworkHistoryEntry>>}
  */
 export async function getFrameworkHistory({ scope }) {
   const knexConn = DomainTransaction.getConnection();
 
-  return knexConn('certification_versions')
-    .select('id', 'startDate', 'expirationDate')
+  const rows = await knexConn('certification_versions')
+    .select('id', 'startDate', 'expirationDate', 'assessmentDuration', 'challengesConfiguration')
     .where({ scope })
     .orderBy('startDate', 'desc');
+
+  return rows.map(_toFrameworkHistoryEntry);
 }
+
+const _toFrameworkHistoryEntry = ({ id, startDate, expirationDate, assessmentDuration, challengesConfiguration }) => {
+  return new FrameworkHistoryEntry({
+    id,
+    startDate,
+    expirationDate,
+    assessmentDuration,
+    maximumAssessmentLength: challengesConfiguration.maximumAssessmentLength,
+  });
+};
 
 const _toDomain = ({
   id,

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -200,7 +200,7 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
       const olderVersion = databaseBuilder.factory.buildCertificationVersion({
         scope: SCOPES.CORE,
         startDate: new Date('2024-01-11'),
-        expirationDate: newerVersion.expirationDate,
+        expirationDate: newerVersion.startDate,
       });
 
       await databaseBuilder.commit();
@@ -222,8 +222,22 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
         attributes: {
           scope: SCOPES.CORE,
           history: [
-            { id: newerVersion.id, startDate: newerVersion.startDate, expirationDate: newerVersion.expirationDate },
-            { id: olderVersion.id, startDate: olderVersion.startDate, expirationDate: olderVersion.expirationDate },
+            {
+              id: newerVersion.id,
+              startDate: newerVersion.startDate,
+              expirationDate: newerVersion.expirationDate,
+              assessmentDuration: newerVersion.assessmentDuration,
+              maximumAssessmentLength: JSON.parse(newerVersion.challengesConfiguration).maximumAssessmentLength,
+              status: 'ACTIVE',
+            },
+            {
+              id: olderVersion.id,
+              startDate: olderVersion.startDate,
+              expirationDate: olderVersion.expirationDate,
+              assessmentDuration: olderVersion.assessmentDuration,
+              maximumAssessmentLength: JSON.parse(olderVersion.challengesConfiguration).maximumAssessmentLength,
+              status: 'ARCHIVED',
+            },
           ],
         },
       });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -325,29 +325,32 @@ describe('Certification | Configuration | Integration | Repository | Version', f
       const scope = SCOPES.PIX_PLUS_DROIT;
       const otherScope = SCOPES.CLEA;
 
+      const version1Config = { maximumAssessmentLength: 1 };
       const version1 = databaseBuilder.factory.buildCertificationVersion({
         scope,
         startDate: new Date('2024-03-15'),
         assessmentDuration: 90,
-        challengesConfiguration: {},
+        challengesConfiguration: version1Config,
       });
+      const version2Config = { maximumAssessmentLength: 2 };
       const version2 = databaseBuilder.factory.buildCertificationVersion({
         scope,
         startDate: new Date('2025-06-21'),
-        assessmentDuration: 90,
-        challengesConfiguration: {},
+        assessmentDuration: 80,
+        challengesConfiguration: version2Config,
       });
+      const version3Config = { maximumAssessmentLength: 3 };
       const version3 = databaseBuilder.factory.buildCertificationVersion({
         scope,
         startDate: new Date('2026-01-01'),
-        assessmentDuration: 90,
-        challengesConfiguration: {},
+        assessmentDuration: 50,
+        challengesConfiguration: version3Config,
       });
       databaseBuilder.factory.buildCertificationVersion({
         scope: otherScope,
         startDate: new Date('2025-06-21'),
-        assessmentDuration: 90,
-        challengesConfiguration: {},
+        assessmentDuration: 60,
+        challengesConfiguration: { maximumAssessmentLength: 4 },
       });
 
       await databaseBuilder.commit();
@@ -357,9 +360,27 @@ describe('Certification | Configuration | Integration | Repository | Version', f
 
       // then
       expect(frameworkHistory).to.deep.equal([
-        { id: version3.id, startDate: version3.startDate, expirationDate: version3.expirationDate },
-        { id: version2.id, startDate: version2.startDate, expirationDate: version2.expirationDate },
-        { id: version1.id, startDate: version1.startDate, expirationDate: version1.expirationDate },
+        domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
+          id: version3.id,
+          startDate: version3.startDate,
+          expirationDate: version3.expirationDate,
+          assessmentDuration: version3.assessmentDuration,
+          maximumAssessmentLength: version3Config.maximumAssessmentLength,
+        }),
+        domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
+          id: version2.id,
+          startDate: version2.startDate,
+          expirationDate: version2.expirationDate,
+          assessmentDuration: version2.assessmentDuration,
+          maximumAssessmentLength: version2Config.maximumAssessmentLength,
+        }),
+        domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
+          id: version1.id,
+          startDate: version1.startDate,
+          expirationDate: version1.expirationDate,
+          assessmentDuration: version1.assessmentDuration,
+          maximumAssessmentLength: version1Config.maximumAssessmentLength,
+        }),
       ]);
     });
   });

--- a/api/tests/certification/configuration/unit/domain/read-models/FrameworkHistoryEntry_test.js
+++ b/api/tests/certification/configuration/unit/domain/read-models/FrameworkHistoryEntry_test.js
@@ -1,0 +1,45 @@
+import {
+  FRAMEWORK_HISTORY_STATUSES,
+  FrameworkHistoryEntry,
+} from '../../../../../../src/certification/configuration/domain/read-models/FrameworkHistoryEntry.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | ReadModels | FrameworkHistoryEntry', function () {
+  describe('#status', function () {
+    it('should be DRAFT when there are no dates', function () {
+      const entry = new FrameworkHistoryEntry({
+        id: 1,
+        startDate: null,
+        expirationDate: null,
+        assessmentDuration: 90,
+        maximumAssessmentLength: 32,
+      });
+
+      expect(entry.status).to.equal(FRAMEWORK_HISTORY_STATUSES.DRAFT);
+    });
+
+    it('should be ACTIVE when there is a start date but no expiration date', function () {
+      const entry = new FrameworkHistoryEntry({
+        id: 1,
+        startDate: new Date('2024-01-01'),
+        expirationDate: null,
+        assessmentDuration: 90,
+        maximumAssessmentLength: 32,
+      });
+
+      expect(entry.status).to.equal(FRAMEWORK_HISTORY_STATUSES.ACTIVE);
+    });
+
+    it('should be ARCHIVED when there is an expiration date', function () {
+      const entry = new FrameworkHistoryEntry({
+        id: 1,
+        startDate: new Date('2024-01-01'),
+        expirationDate: new Date('2025-01-01'),
+        assessmentDuration: 90,
+        maximumAssessmentLength: 32,
+      });
+
+      expect(entry.status).to.equal(FRAMEWORK_HISTORY_STATUSES.ARCHIVED);
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/framework-history-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/framework-history-serializer_test.js
@@ -1,3 +1,4 @@
+import { FrameworkHistoryEntry } from '../../../../../../src/certification/configuration/domain/read-models/FrameworkHistoryEntry.js';
 import * as serializer from '../../../../../../src/certification/configuration/infrastructure/serializers/framework-history-serializer.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../../test-helper.js';
@@ -6,7 +7,15 @@ describe('Certification | Configuration | Unit | Serializer | framework-history-
   describe('#serialize', function () {
     it('should serialize a framework history to JSONAPI', function () {
       // given
-      const frameworkHistory = [{ id: 456, startDate: new Date('2024-01-01'), expirationDate: new Date('2025-02-02') }];
+      const frameworkHistory = [
+        new FrameworkHistoryEntry({
+          id: 456,
+          startDate: new Date('2024-01-01'),
+          expirationDate: new Date('2025-02-02'),
+          assessmentDuration: 90,
+          maximumAssessmentLength: 32,
+        }),
+      ];
       const scope = SCOPES.PIX_PLUS_DROIT;
 
       // when

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-framework-history-entry.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-framework-history-entry.js
@@ -1,0 +1,17 @@
+import { FrameworkHistoryEntry } from '../../../../../../src/certification/configuration/domain/read-models/FrameworkHistoryEntry.js';
+
+export const buildFrameworkHistoryEntry = ({
+  id = 1,
+  startDate = new Date('2024-01-01'),
+  expirationDate = null,
+  assessmentDuration = 90,
+  maximumAssessmentLength = 32,
+} = {}) => {
+  return new FrameworkHistoryEntry({
+    id,
+    startDate,
+    expirationDate,
+    assessmentDuration,
+    maximumAssessmentLength,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -170,6 +170,7 @@ import { buildComplementaryCertificationBadge } from './certification/complement
 import { buildActiveCalibratedChallenge } from './certification/configuration/build-active-calibrated-challenge.js';
 import { buildCenter as buildConfigurationCenter } from './certification/configuration/build-center.js';
 import { buildCertificationFrameworksChallenge } from './certification/configuration/build-certification-frameworks-challenge.js';
+import { buildFrameworkHistoryEntry } from './certification/configuration/build-framework-history-entry.js';
 import {
   buildScoBlockedAccessDateCollege,
   buildScoBlockedAccessDateLycee,
@@ -256,6 +257,7 @@ const certification = {
     buildActiveCalibratedChallenge,
     buildCenter: buildConfigurationCenter,
     buildCertificationFrameworksChallenge,
+    buildFrameworkHistoryEntry,
     buildVersion: buildConfigurationVersion,
     buildScoBlockedAccessDateCollege,
     buildScoBlockedAccessDateLycee,


### PR DESCRIPTION
## 🌱 Problème

Dans le cadre des travaux de refonte des reférentiel de certification dans Pix Admin, on souhaite remonter davantage d'informations dans le tableau d'historique des versions.

## 🐣 Proposition
Enrichir la route avec le statut, le nombre de question et la durée

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

Sur Pix admin, regarder ce qui est remonté par la route framework-history déclenché lorsqu'on accède aux détails d'un référentiel

<img width="721" height="516" alt="image" src="https://github.com/user-attachments/assets/8fc54309-6c1b-4d5e-a422-c8128ae47405" />