### PR TITLE
[TECH] Lire les paliers acquis depuis la base de données (PIX-22419)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipation.js
@@ -37,10 +37,10 @@ export class CampaignAssessmentParticipation {
     this.badges = badges ?? [];
     this.masteryRate = masteryRate != null ? Number(masteryRate) : null;
     this.validatedSkillsCount = validatedSkillsCount;
-    this.reachedStage = reachedStage;
-    this.totalStage = totalStage;
-    this.prescriberTitle = prescriberTitle;
-    this.prescriberDescription = prescriberDescription;
+    this.reachedStage = reachedStage ?? null;
+    this.totalStage = totalStage ?? null;
+    this.prescriberTitle = prescriberTitle ?? null;
+    this.prescriberDescription = prescriberDescription ?? null;
   }
 
   setBadges(badges) {

--- a/api/src/prescription/campaign-participation/domain/usecases/get-campaign-assessment-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-campaign-assessment-participation.js
@@ -6,7 +6,9 @@ const getCampaignAssessmentParticipation = async function ({
   campaignRepository,
   campaignAssessmentParticipationRepository,
   badgeAcquisitionRepository,
-  stageCollectionRepository,
+  stageRepository,
+  stageAcquisitionRepository,
+  compareStagesAndAcquiredStages,
   campaignParticipationRepository,
   knowledgeElementForParticipationService,
   improvementService,
@@ -25,12 +27,21 @@ const getCampaignAssessmentParticipation = async function ({
     const badges = acquiredBadgesByCampaignParticipations[campaignAssessmentParticipation.campaignParticipationId];
     campaignAssessmentParticipation.setBadges(badges);
 
-    const stageCollection = await stageCollectionRepository.findStageCollection({ campaignId });
-    const reachedStage = stageCollection.getReachedStage(
-      campaignAssessmentParticipation.validatedSkillsCount,
-      campaignAssessmentParticipation.masteryRate * 100,
-    );
-    campaignAssessmentParticipation.setStageInfo(reachedStage);
+    const stages = await stageRepository.getByCampaignId(campaignId);
+
+    if (stages.length) {
+      const stageAcquisitions = await stageAcquisitionRepository.getByCampaignParticipation(campaignParticipationId);
+      const { reachedStageNumber, totalNumberOfStages, reachedStage } = compareStagesAndAcquiredStages.compare(
+        stages,
+        stageAcquisitions,
+      );
+      campaignAssessmentParticipation.setStageInfo({
+        reachedStage: reachedStageNumber,
+        totalStage: totalNumberOfStages,
+        prescriberTitle: reachedStage?.prescriberTitle ?? null,
+        prescriberDescription: reachedStage?.prescriberDescription ?? null,
+      });
+    }
     campaignAssessmentParticipation.setProgression(1);
   } else {
     // this is a big duplicate from get progression. need to be factorize

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-campaign-assessment-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-campaign-assessment-participation_test.js
@@ -172,13 +172,13 @@ describe('Integration | UseCase | get-campaign-assessment-participation', functi
   context('stages', function () {
     it('should set stages when participation', async function () {
       // given
-      databaseBuilder.factory.buildStage({
+      const reachedStageId = databaseBuilder.factory.buildStage({
         targetProfileId,
         level: 1,
         prescriberTitle: 'palier 0',
         prescriberDescription: 'message 0',
         threshold: null,
-      });
+      }).id;
       databaseBuilder.factory.buildStage({
         targetProfileId,
         isFirstSkill: true,
@@ -204,6 +204,8 @@ describe('Integration | UseCase | get-campaign-assessment-participation', functi
         type: Assessment.types.CAMPAIGN,
         state: Assessment.states.COMPLETED,
       });
+
+      databaseBuilder.factory.buildStageAcquisition({ stageId: reachedStageId, campaignParticipationId });
 
       await databaseBuilder.commit();
 


### PR DESCRIPTION
## 🌎 Problème

Le usecase `getCampaignAssessmentParticipation` recalculait les paliers atteints à la volée (à partir du `masteryRate` et du `validatedSkillsCount`) alors que ces données sont déjà persistées dans la table `stage-acquisitions`.

## 🔭 Proposition

Remplacer le recalcul par une lecture directe de la table `stage-acquisitions` via `stageAcquisitionRepository.getByCampaignParticipation`, en réutilisant le service `compareStagesAndAcquiredStages` déjà utilisé dans d'autres usecases.

## 🚀 Pour tester

- [x] Sur PixOrga, accéder à la page de détail d'une participation à une campagne d'évaluation avec paliers: vérifier que le palier atteint s'affiche correctement.
- [x] Idem pour une campagne sans paliers: vérifier que rien ne s'affiche.

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑