### PR TITLE
[FEATURE] Afficher l'onglet Réseau d'une organisation pour tous les rôles (pix-22550)

### DIFF
--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -104,30 +104,28 @@ export default class HeadInformation extends Component {
 
         <ul class="organization-tags-list">
           {{#if this.belongsToNetwork}}
-            {{#if this.accessControl.hasAccessToNetworkFeature}}
-              <PixTag class="organization__child-tag" @color="success">
-                {{t "components.organizations.head-information.network"}}
-                <LinkTo @route="authenticated.networks.get" @model={{@organization.network.id}}>
-                  {{@organization.network.name}}
-                </LinkTo>
-              </PixTag>
-              {{#if @organization.parentOrganizationId}}
-                <li>
-                  <PixTag class="organization__child-tag" @color="success">
-                    {{t "components.organizations.head-information.parent-organization-tag"}}
-                    <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
-                      {{@organization.parentOrganizationName}}
-                    </LinkTo>
-                  </PixTag>
-                </li>
-              {{else}}
-                <li>
-                  <PixTag class="organization__child-tag" @color="success">
-                    {{t "components.organizations.head-information.head-organization-tag"}}
+            <PixTag class="organization__child-tag" @color="success">
+              {{t "components.organizations.head-information.network"}}
+              <LinkTo @route="authenticated.networks.get" @model={{@organization.network.id}}>
+                {{@organization.network.name}}
+              </LinkTo>
+            </PixTag>
+            {{#if @organization.parentOrganizationId}}
+              <li>
+                <PixTag class="organization__child-tag" @color="success">
+                  {{t "components.organizations.head-information.parent-organization-tag"}}
+                  <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
+                    {{@organization.parentOrganizationName}}
+                  </LinkTo>
+                </PixTag>
+              </li>
+            {{else}}
+              <li>
+                <PixTag class="organization__child-tag" @color="success">
+                  {{t "components.organizations.head-information.head-organization-tag"}}
 
-                  </PixTag>
-                </li>
-              {{/if}}
+                </PixTag>
+              </li>
             {{/if}}
           {{/if}}
 

--- a/admin/app/components/organizations/network/actions-section.gjs
+++ b/admin/app/components/organizations/network/actions-section.gjs
@@ -12,7 +12,7 @@ export default class ActionsSection extends Component {
   <template>
     <section class="page-section">
       <div class="content-text content-text--small organization-network__actions-section">
-        {{#if this.accessControl.hasAccessToNetworkFeature}}
+        {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
           <PixButtonLink
             @iconBefore="add"
             @variant="secondary"

--- a/admin/app/routes/authenticated/organizations/get/network.js
+++ b/admin/app/routes/authenticated/organizations/get/network.js
@@ -6,8 +6,6 @@ export default class Network extends Route {
   @service router;
 
   beforeModel() {
-    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier'], 'authenticated.organizations.get.details');
-
     const organization = this.modelFor('authenticated.organizations.get');
 
     if (!organization.network.id) {

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -84,10 +84,6 @@ export default class AccessControlService extends Service {
     );
   }
 
-  get hasAccessToNetworkFeature() {
-    return Boolean(this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier);
-  }
-
   get hasAccessToNetworkActionsScope() {
     return Boolean(this.currentUser.adminMember.isSuperAdmin);
   }

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -71,12 +71,10 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
         </LinkTo>
       {{/if}}
 
-      {{#if @controller.accessControl.hasAccessToNetworkFeature}}
-        {{#if @model.network.id}}
-          <LinkTo @route="authenticated.organizations.get.network" @model={{@model}}>
-            {{t "pages.organization.navbar.network" nbrOfChildren=@model.children.length}}
-          </LinkTo>
-        {{/if}}
+      {{#if @model.network.id}}
+        <LinkTo @route="authenticated.organizations.get.network" @model={{@model}}>
+          {{t "pages.organization.navbar.network" nbrOfChildren=@model.children.length}}
+        </LinkTo>
       {{/if}}
     </PixTabs>
 

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -418,44 +418,6 @@ module('Acceptance | Organizations | Get', function (hooks) {
     });
   });
 
-  module('when the organization belongs to a network', function (hooks) {
-    hooks.beforeEach(async function () {
-      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-
-      server.create('network', { id: '42', name: 'Réseau Île-de-France' });
-
-      server.get('/admin/organizations/:id', () => ({
-        data: {
-          type: 'organizations',
-          id: '1',
-          attributes: {
-            name: 'My Organization',
-            features: { PLACES_MANAGEMENT: { active: true } },
-          },
-          relationships: {
-            network: { data: { type: 'networks', id: '42' } },
-            'organization-memberships': { links: { related: '/api/admin/organizations/1/memberships' } },
-            'target-profile-summaries': { links: { related: '/api/admin/organizations/1/target-profile-summaries' } },
-            children: { links: { related: '/api/admin/organizations/1/children' } },
-            'organization-invitations': { links: { related: '/api/admin/organizations/1/invitations' } },
-          },
-        },
-        included: [{ type: 'networks', id: '42', attributes: { name: 'Réseau Île-de-France' } }],
-      }));
-    });
-
-    test('clicking the network tag navigates to the network detail page', async function (assert) {
-      // given
-      const screen = await visit('/organizations/1/details');
-
-      // when
-      await click(screen.getByRole('link', { name: 'Réseau Île-de-France' }));
-
-      // then
-      assert.strictEqual(currentURL(), '/networks/42');
-    });
-  });
-
   module('When user is authenticated as Certif Admin', function (hooks) {
     hooks.beforeEach(async () => {
       await authenticateAdminMemberWithRole({ isCertif: true })(server);
@@ -473,65 +435,6 @@ module('Acceptance | Organizations | Get', function (hooks) {
       // then
       const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
       assert.notOk(within(navigationTabs).queryByRole('link', { name: t('pages.organization.navbar.tags') }));
-    });
-  });
-
-  module('Network tab Access control', function (hooks) {
-    hooks.beforeEach(() => {
-      const network = server.create('network', { id: '42', name: 'Réseau Île-de-France' });
-      server.create('organization', {
-        id: 99,
-        name: 'My Organization',
-        features: { PLACES_MANAGEMENT: { active: true } },
-        network,
-      });
-    });
-    test('should not be visible for Certif member', async function (assert) {
-      // given
-      await authenticateAdminMemberWithRole({ isCertif: true })(server);
-
-      // when
-      const screen = await visit('/organizations/99');
-
-      // then
-      const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
-      assert.notOk(
-        within(navigationTabs).queryByRole('link', {
-          name: t('pages.organization.navbar.network', { nbrOfChildren: 0 }),
-        }),
-      );
-    });
-
-    test('should not be visible for Support member', async function (assert) {
-      // given
-      await authenticateAdminMemberWithRole({ isSupport: true })(server);
-
-      //when
-      const screen = await visit('/organizations/99');
-
-      // then
-      const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
-      assert.notOk(
-        within(navigationTabs).queryByRole('link', {
-          name: t('pages.organization.navbar.network', { nbrOfChildren: 0 }),
-        }),
-      );
-    });
-
-    test('should be visible for Metier member', async function (assert) {
-      // given
-      await authenticateAdminMemberWithRole({ isMetier: true })(server);
-
-      // when
-      const screen = await visit('/organizations/99');
-
-      // then
-      const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
-      assert.ok(
-        within(navigationTabs).queryByRole('link', {
-          name: t('pages.organization.navbar.network', { nbrOfChildren: 0 }),
-        }),
-      );
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/organizations/get/network-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/network-test.js
@@ -131,37 +131,6 @@ module('Acceptance | Organizations | Network', function (hooks) {
     });
   });
 
-  // Network Tab is not accessible to these roles for the moment so these tests are irrelevent. TODO: delete skip at the end of EPIX PIX-21277
-  [
-    { name: 'METIER', authData: { isMetier: true } },
-    { name: 'SUPPORT', authData: { isSupport: true } },
-  ].forEach((role) => {
-    module.skip(`when user has role "${role.name}"`, function (hooks) {
-      let parentOrganizationId;
-
-      hooks.beforeEach(async function () {
-        await authenticateAdminMemberWithRole(role.authData)(server);
-        const network = this.server.create('network', { name: 'My network' });
-
-        parentOrganizationId = this.server.create('organization', {
-          name: 'Parent Orga name',
-          features: { PLACES_MANAGEMENT: { active: true } },
-          network,
-        }).id;
-      });
-
-      test('it does not display create child organization button', async function (assert) {
-        // when
-        const screen = await visit(`/organizations/${parentOrganizationId}/network`);
-
-        // then
-        assert.notOk(
-          screen.queryByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
-        );
-      });
-    });
-  });
-
   module.skip('when user has role "CERTIF"', function () {
     test('it should not display actions section', async function (assert) {
       await authenticateAdminMemberWithRole({ isCertif: true })(server);

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -81,58 +81,6 @@ module('Integration | Component | organizations/header-information', function (h
             data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
           });
         });
-        module('when user has role CERTIF', function () {
-          test('it does not display a network tag nor Head of network tag', async function (assert) {
-            // given
-            const currentUser = this.owner.lookup('service:currentUser');
-            currentUser.adminMember = { isCertif: true };
-            const headOrganization = store.createRecord('organization', { network });
-
-            // when
-            const screen = await render(<template><HeadInformation @organization={{headOrganization}} /></template>);
-
-            // then
-            assert.dom(screen.queryByRole('link', { name: 'Réseau Île-de-France' })).doesNotExist();
-            assert
-              .dom(screen.queryByText(t('components.organizations.head-information.head-organization-tag')))
-              .doesNotExist();
-          });
-        });
-
-        module('when user has role SUPPORT', function () {
-          test('it does not display a network tag nor Head of network tag', async function (assert) {
-            // given
-            const currentUser = this.owner.lookup('service:currentUser');
-            currentUser.adminMember = { isSupport: true };
-            const headOrganization = store.createRecord('organization', { network });
-
-            // when
-            const screen = await render(<template><HeadInformation @organization={{headOrganization}} /></template>);
-
-            // then
-            assert.dom(screen.queryByRole('link', { name: 'Réseau Île-de-France' })).doesNotExist();
-            assert
-              .dom(screen.queryByText(t('components.organizations.head-information.head-organization-tag')))
-              .doesNotExist();
-          });
-        });
-
-        module('when user has role METIER', function () {
-          test('it displays network tags', async function (assert) {
-            // given
-            const currentUser = this.owner.lookup('service:currentUser');
-            currentUser.adminMember = { isMetier: true };
-            const headOrganization = store.createRecord('organization', { network });
-
-            // when
-            const screen = await render(<template><HeadInformation @organization={{headOrganization}} /></template>);
-
-            // then
-            assert.dom(screen.getByRole('link', { name: 'Réseau Île-de-France' })).exists();
-            assert.dom(screen.getByText(t('components.organizations.head-information.head-organization-tag'))).exists();
-          });
-        });
-
         module('when user is super admin', function () {
           test('it displays a tag with a link to the network', async function (assert) {
             // given

--- a/admin/tests/integration/components/organizations/network-test.gjs
+++ b/admin/tests/integration/components/organizations/network-test.gjs
@@ -17,7 +17,6 @@ module('Integration | Component | organizations/network', function (hooks) {
       class AccessControlStub extends Service {
         hasAccessToOrganizationActionsScope = true;
         hasAccessToAttachChildOrganizationActionsScope = true;
-        hasAccessToNetworkFeature = true;
       }
       this.owner.register('service:access-control', AccessControlStub);
 

--- a/admin/tests/integration/components/organizations/network/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/network/actions-section-test.gjs
@@ -18,12 +18,12 @@ module('Integration | Component | organizations/network/actions-section', functi
   module('create child organization button', function (hooks) {
     hooks.beforeEach(async function () {
       class AccessControlStub extends Service {
-        hasAccessToNetworkFeature = true;
+        hasAccessToOrganizationActionsScope = true;
       }
       this.owner.register('service:access-control', AccessControlStub);
     });
 
-    test('it should display create child organization button when user has access to network feature', async function (assert) {
+    test('it should display create child organization button when user has access to organization actions scope', async function (assert) {
       // given
       const organization = store.createRecord('organization', {
         id: '1',
@@ -44,10 +44,10 @@ module('Integration | Component | organizations/network/actions-section', functi
       );
     });
 
-    test('it should not display create child organization button when user does not have access to network feature', async function (assert) {
+    test('it should not display create child organization button when user does not have access to organization actions scope', async function (assert) {
       // given
       class AccessControlStub extends Service {
-        hasAccessToNetworkFeature = false;
+        hasAccessToOrganizationActionsScope = false;
       }
       this.owner.register('service:access-control', AccessControlStub);
 

--- a/admin/tests/unit/routes/authenticated/organizations/get/network-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/network-test.js
@@ -1,5 +1,4 @@
 import EmberObject from '@ember/object';
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -7,34 +6,14 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/organizations/get/network', function (hooks) {
   setupTest(hooks);
 
-  let route, restrictAccessToStub;
+  let route;
 
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/organizations/get/network');
     sinon.stub(route.router, 'replaceWith');
-
-    restrictAccessToStub = sinon.stub().returns();
-    class AccessControlStub extends Service {
-      restrictAccessTo = restrictAccessToStub;
-    }
-    this.owner.register('service:access-control', AccessControlStub);
   });
 
   module('#beforeModel', function () {
-    test('it should check if current user is super admin or metier', function (assert) {
-      // given
-      const organization = EmberObject.create({ network: { id: 123, name: 'My Network' } });
-      sinon.stub(route, 'modelFor').returns(organization);
-
-      // when
-      route.beforeModel();
-
-      // then
-      assert.ok(
-        restrictAccessToStub.calledWith(['isSuperAdmin', 'isMetier'], 'authenticated.organizations.get.details'),
-      );
-    });
-
     test('it should transition to details route when organization does not belong to a network', async function (assert) {
       // given
       const organization = EmberObject.create({ network: { id: null, name: null } });

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -328,24 +328,4 @@ module('Unit | Service | access-control', function (hooks) {
       });
     });
   });
-
-  module('#hasAccessToNetworkFeature', function () {
-    [
-      { role: 'isSuperAdmin', hasAccess: true },
-      { role: 'isMetier', hasAccess: true },
-      { role: 'isSupport', hasAccess: false },
-      { role: 'isCertif', hasAccess: false },
-    ].forEach(function ({ role, hasAccess }) {
-      test(`should be ${hasAccess} if current admin member is ${role}`, function (assert) {
-        // given
-        const currentUser = this.owner.lookup('service:currentUser');
-        currentUser.adminMember = { [role]: true };
-
-        const service = this.owner.lookup('service:access-control');
-
-        // when / then
-        assert.deepEqual(service.hasAccessToNetworkFeature, hasAccess);
-      });
-    });
-  });
 });


### PR DESCRIPTION
## 🌱 Problème

Dans Pix Admin, sur la page de détail d'une organisation, on a rendu visible au rôle METIER l'onglet Réseau (https://github.com/1024pix/pix/pull/15953). On souhaite désormais que cet onglet soit visible pour tous les rôles de Pix Admin.

## 🐣 Proposition

Supprimer les contrôles de rôles qui conditionnent l'affichage des composants et qui empêchent l'accès à la route.

## 🌷 Remarques

- on affiche désormais également à tous les rôles les tags relatifs au réseau dans le header d'une organisation.
- la création d'organisation fille depuis l'onglet Réseau n'est pas accessible au rôle CERTIF

## 🐝 Pour tester
Sur Pix Admin sur la page de détail d'une organisation faisant partie d'un réseau, tester les 4 rôles:
- SUPER_ADMIN: tags réseaux visibles, onglet Réseau visible, création d'orga fille + rattachement d'orgas possibles
- METIER:  tags réseaux visibles, onglet Réseau visible, création d'orga fille possible (pas de rattachement d'orgas)
- SUPPORT: idem METIER
- CERTIF: tags réseaux visibles, onglet Réseau visible, pas de création d'orga fille, pas de rattachement d'orgas
