### PR TITLE
[BUGFIX] Réinitialisation des références de feature toggles

### DIFF
--- a/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
+++ b/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
@@ -166,6 +166,8 @@ export class FeatureTogglesClient {
       const defaultValue = this.#getFeatureToggleDefaultValue(featureToggle);
       await this.storage.save({ key, value: defaultValue });
     }
+
+    this.#topic.publish({ type: 'resetDefaults' });
   }
 
   #getFeatureToggleDefaultValue(featureToggle) {
@@ -187,19 +189,40 @@ export class FeatureTogglesClient {
    * }} message
    */
   async #onMessage(message) {
-    if (message.type !== 'set') return;
+    switch (message.type) {
+      case 'set': {
+        const oldValue = this.#currentValues[message.key];
+        const newValue = await this.get(message.key);
 
-    const oldValue = this.#currentValues[message.key];
-    const newValue = await this.get(message.key);
+        // skip updating/notifying on strict equality,
+        // array/object types will update/notify
+        // even if internal values don't change
+        if (newValue === oldValue) return;
 
-    // skip updating/notifying on strict equality,
-    // array/object types will update/notify
-    // even if internal values don't change
-    if (newValue === oldValue) return;
+        this.#currentValues[message.key] = newValue;
 
-    this.#currentValues[message.key] = newValue;
+        this.#eventTarget.dispatchEvent(new FeatureTogglesEvent('set', message.key, newValue, oldValue));
 
-    this.#eventTarget.dispatchEvent(new FeatureTogglesEvent('set', message.key, newValue, oldValue));
+        break;
+      }
+
+      case 'resetDefaults': {
+        for (const [key, newValue] of Object.entries(await this.all())) {
+          const oldValue = this.#currentValues[key];
+
+          // skip updating/notifying on strict equality,
+          // array/object types will update/notify
+          // even if internal values don't change
+          if (newValue === oldValue) continue;
+
+          this.#currentValues[key] = newValue;
+
+          this.#eventTarget.dispatchEvent(new FeatureTogglesEvent('set', key, newValue, oldValue));
+
+          break;
+        }
+      }
+    }
   }
 }
 

--- a/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles-client.test.js
+++ b/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles-client.test.js
@@ -213,6 +213,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
         it('returns the up to date value of the feature toggle', async function () {
           // given
           const values = ['fizz', 'buzz', 'fizzbuzz'];
+          const expectedValues = [...values, config[key].defaultValue];
 
           // when
           const readValues = [];
@@ -221,9 +222,12 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
             await setImmediate(); // let the event loop run pubsub
             readValues.push(featureToggleRef.value);
           }
+          await featureToggles.resetDefaults();
+          await setImmediate(); // let the event loop run pubsub
+          readValues.push(featureToggleRef.value);
 
           // then
-          expect(readValues).to.deep.equal(values);
+          expect(readValues).to.deep.equal(expectedValues);
         });
       });
 
@@ -232,6 +236,12 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
           // given
           const callback = sinon.stub();
           const values = ['fizz', 'buzz', 'fizzbuzz'];
+          const expectedCalls = [
+            [values[0], config[key].defaultValue],
+            [values[1], values[0]],
+            [values[2], values[1]],
+            [config[key].defaultValue, values[2]],
+          ];
 
           // when
           const unwatch = featureToggleRef.watch(callback);
@@ -239,15 +249,19 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
             await featureToggles.set(key, value);
             await setImmediate(); // let the event loop run pubsub
           }
+          await featureToggles.resetDefaults();
+          await setImmediate(); // let the event loop run pubsub
           unwatch();
           await featureToggles.set(key, 'not received');
           await setImmediate(); // let the event loop run pubsub
+          await featureToggles.resetDefaults();
+          await setImmediate(); // let the event loop run pubsub
 
           // then
-          expect(callback).to.have.been.calledThrice;
-          expect(callback.firstCall).to.have.been.calledWithExactly(values[0], config[key].defaultValue);
-          expect(callback.secondCall).to.have.been.calledWithExactly(values[1], values[0]);
-          expect(callback.thirdCall).to.have.been.calledWithExactly(values[2], values[1]);
+          expect(callback).to.have.callCount(expectedCalls.length);
+          expectedCalls.forEach((args, i) => {
+            expect(callback.getCall(i)).to.have.been.calledWithExactly(...args);
+          });
         });
       });
     });
@@ -287,6 +301,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
       const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
       await featureToggles.set('myToggle1', true);
+      topic.publish.reset();
 
       // when
       await featureToggles.resetDefaults();
@@ -294,6 +309,8 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
 
       // then
       expect(all).to.deep.equal({ myToggle1: false, myToggle2: true, myToggle3: 'foo' });
+
+      expect(topic.publish).to.have.been.calledOnceWithExactly({ type: 'resetDefaults' });
     });
 
     context('when in test environement', function () {
@@ -311,6 +328,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
         });
         await featureToggles.set('myToggle1', true);
         await featureToggles.set('myToggle2', false);
+        topic.publish.reset();
 
         // when
         await featureToggles.resetDefaults();
@@ -318,6 +336,8 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
         // then
         const all = await featureToggles.all();
         expect(all).to.deep.equal({ myToggle1: false, myToggle2: true });
+
+        expect(topic.publish).to.have.been.calledOnceWithExactly({ type: 'resetDefaults' });
       });
     });
 
@@ -336,6 +356,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
         });
         await featureToggles.set('myToggle1', true);
         await featureToggles.set('myToggle2', false);
+        topic.publish.reset();
 
         // when
         await featureToggles.resetDefaults();
@@ -343,6 +364,8 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
         // then
         const all = await featureToggles.all();
         expect(all).to.deep.equal({ myToggle1: false, myToggle2: true });
+
+        expect(topic.publish).to.have.been.calledOnceWithExactly({ type: 'resetDefaults' });
       });
     });
   });


### PR DESCRIPTION
## 🌱 Problème

Les références de feature toggles obtenues en appelant `featureToggles.use(key)` ne sont pas réinitialisées lors de l’appel à `featureToggles.resetDefaults()`.

## 🐣 Proposition

Réinitialiser les références de feature toggles lors de l’appel à `featureToggles.resetDefaults()`.

## 🌷 Remarques

N/A

## 🐝 Pour tester

N/A