### PR TITLE
[BUGFIX] Corrige un problème de redirection sur la modal du GAR après avoir saisi un code (PIX-22467)

### DIFF
--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -65,7 +65,7 @@ export default class FillInCampaignCodeController extends Controller {
   }
 
   get routeToTransitionAfterGarModal() {
-    return this.verifiedCode?.type === 'campaign' ? 'campaigns.entry-point' : 'organizations.join.sco-mediacentre';
+    return this.verifiedCode?.type === 'campaign' ? 'campaigns.entry-point' : 'organizations.access';
   }
 
   onStartCampaignError(error) {

--- a/mon-pix/tests/acceptance/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code-test.js
@@ -212,7 +212,13 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
           test('should be redirected to the combined course entry page', async function (assert) {
             // given
             const combinedCourse = server.create('combined-course', { code: 'SOMETHING' });
-            server.create('organization-to-join', { id: 1, code: combinedCourse.code, identityProvider: 'GAR' });
+            server.create('organization-to-join', {
+              id: 1,
+              code: combinedCourse.code,
+              identityProvider: 'GAR',
+              type: 'SCO',
+              isRestricted: true,
+            });
 
             // when
             const screen = await visit(`/campagnes`);
@@ -222,7 +228,7 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
             await click(screen.getByRole('link', { name: 'Continuer' }));
 
             // then
-            assert.strictEqual(currentURL(), '/organisations/SOMETHING/rejoindre/mediacentre');
+            assert.strictEqual(currentURL(), '/organisations/SOMETHING/rejoindre/identification');
           });
         });
 


### PR DESCRIPTION
## 🌱 Problème

Sur la page de saisie d'un code dans le cas où le parcours combiné appartient à un organisation SCO qui a le GAR d'activé. Un utilisateur non connecté ne passant pas par le GAR se retrouvait malgré tout sur la page mediacentre.

## 🐣 Proposition

Corriger la redirection sur le bouton continuer de la modal qui dans le cadre des parcours combinés pointait explicitement vers la page de mediacentre au lieu de redirigé vers la brique accès.

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

- Allez sur la page /campagnes en étant pas connecté
- Saisir le code SCOMBINIX
- Constater qu'on arrive sur la page avec double mire (création de compte avec identifiant + formulaire de connexion)

Pour tester jusqu'au bout il faut aller sur PixOrga choisir un élève le dissocier via PixAdmin puis utiliser le formulaire de création de compte avec identifiant spécifique au SCO.
