### PR TITLE
[FEATURE] Créer la logique pour lire les modules stockés dans learningContent (PIX-22552)(PIX-22265)

### DIFF
--- a/api/db/database-builder/factory/learning-content/build-module.js
+++ b/api/db/database-builder/factory/learning-content/build-module.js
@@ -16,6 +16,7 @@ const defaultSections = [
               id: 'd5e369ec-2a5e-4692-ac46-5be5a49f2acd',
               type: 'text',
               tag: 'context',
+              isAnswerable: false,
               content: "<p>Ceci&nbsp;est un contenu pour les amateurs de coquille d'escargots.</p>",
             },
           },
@@ -45,12 +46,12 @@ export function buildModule({
   glossary = [
     {
       word: 'coquille',
-      description:
+      definition:
         "Une coquille est un agglomérat de calcaire très résistant. Sa structure cristalline spécifique lui confère une résistance protectrice. Elle prodique à l'escargot toute sa force et sa vitalité.",
     },
   ],
 } = {}) {
-  return buildModuleInDB({
+  const values = {
     id,
     shortId,
     slug,
@@ -60,7 +61,9 @@ export function buildModule({
     details,
     sections,
     glossary,
-  });
+  };
+  buildModuleInDB(values);
+  return values;
 }
 
 export function buildModuleWithNoDefaultValues({
@@ -74,7 +77,7 @@ export function buildModuleWithNoDefaultValues({
   sections,
   glossary,
 }) {
-  return buildModuleInDB({
+  const values = {
     id,
     shortId,
     slug,
@@ -84,7 +87,9 @@ export function buildModuleWithNoDefaultValues({
     details,
     sections,
     glossary,
-  });
+  };
+  buildModuleInDB(values);
+  return values;
 }
 
 function buildModuleInDB({ id, shortId, slug, title, isBeta, visibility, details, sections, glossary }) {

--- a/api/db/database-builder/factory/learning-content/build.js
+++ b/api/db/database-builder/factory/learning-content/build.js
@@ -4,7 +4,7 @@ import { buildCompetence, buildCompetenceWithNoDefaultValues } from './build-com
 import { buildCourse, buildCourseWithNoDefaultValues } from './build-course.js';
 import { buildFramework, buildFrameworkWithNoDefaultValues } from './build-framework.js';
 import { buildMission, buildMissionWithNoDefaultValues } from './build-mission.js';
-import { buildModule, buildModuleWithNoDefaultValues } from './build-modules.js';
+import { buildModule, buildModuleWithNoDefaultValues } from './build-module.js';
 import { buildSkill, buildSkillWithNoDefaultValues } from './build-skill.js';
 import { buildThematic, buildThematicWithNoDefaultValues } from './build-thematic.js';
 import { buildTube, buildTubeWithNoDefaultValues } from './build-tube.js';

--- a/api/db/database-builder/factory/learning-content/index.js
+++ b/api/db/database-builder/factory/learning-content/index.js
@@ -5,7 +5,7 @@ export * from './build-competence.js';
 export * from './build-course.js';
 export * from './build-framework.js';
 export * from './build-mission.js';
-export * from './build-modules.js';
+export * from './build-module.js';
 export * from './build-skill.js';
 export * from './build-thematic.js';
 export * from './build-tube.js';

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -22,7 +22,20 @@ async function getById({ id, moduleDatasource }) {
 }
 
 async function getByShortId({ shortId, moduleDatasource }) {
-  return await _getModuleFromDatasource({ ref: 'shortId', moduleDatasource, query: shortId });
+  if (!isFetchingModulesFromLearningContentEnabled.value) {
+    return await _getModuleFromDatasource({ ref: 'shortId', moduleDatasource, query: shortId });
+  }
+
+  const cacheKey = `getByShortId(${shortId})`;
+  const findByShortIdCallback = (knex) => knex.where('shortId', shortId).limit(1);
+
+  const [module] = await getInstance().find(cacheKey, findByShortIdCallback);
+
+  if (!module) {
+    throw new NotFoundError();
+  }
+
+  return toDomainFromDbObject(module);
 }
 
 async function getBySlug({ slug, moduleDatasource }) {

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -1,21 +1,32 @@
 import crypto from 'node:crypto';
 
-import { NotFoundError } from '../../../shared/domain/errors.js';
-import { LearningContentResourceNotFound } from '../../../shared/domain/errors.js';
+import { LearningContentResourceNotFound, NotFoundError } from '../../../shared/domain/errors.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { LearningContentRepository } from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import { ModuleDoesNotExistError } from '../../domain/errors.js';
 import { ModuleFactory } from '../factories/module-factory.js';
 
+const isFetchingModulesFromLearningContentEnabled = featureToggles.use('isFetchingModulesFromLearningContentEnabled');
+
 async function getById({ id, moduleDatasource }) {
-  return await _getModule({ ref: 'id', moduleDatasource, query: id });
+  if (!isFetchingModulesFromLearningContentEnabled.value) {
+    return _getModuleFromDatasource({ ref: 'id', moduleDatasource, query: id });
+  }
+
+  const module = await getInstance().load(id);
+  if (!module) {
+    throw new NotFoundError();
+  }
+
+  return toDomainFromDbObject(module);
 }
 
 async function getByShortId({ shortId, moduleDatasource }) {
-  return await _getModule({ ref: 'shortId', moduleDatasource, query: shortId });
+  return await _getModuleFromDatasource({ ref: 'shortId', moduleDatasource, query: shortId });
 }
 
 async function getBySlug({ slug, moduleDatasource }) {
-  return await _getModule({ ref: 'slug', moduleDatasource, query: slug });
+  return await _getModuleFromDatasource({ ref: 'slug', moduleDatasource, query: slug });
 }
 
 async function list({ moduleDatasource }) {
@@ -31,19 +42,27 @@ function _computeModuleVersion(moduleData) {
   return hash.copy().digest('hex');
 }
 
-async function _getModule({ ref, moduleDatasource, query }) {
+async function _getModuleFromDatasource({ ref, moduleDatasource, query }) {
   try {
     const method = getModuleMethod(ref, moduleDatasource);
     const moduleData = await method(query);
-    const version = _computeModuleVersion(moduleData);
 
-    return await ModuleFactory.build({ ...moduleData, version });
+    return await toDomain(moduleData);
   } catch (error) {
     if (error instanceof LearningContentResourceNotFound || error instanceof ModuleDoesNotExistError) {
       throw new NotFoundError();
     }
     throw error;
   }
+}
+
+async function toDomainFromDbObject({ image, description, duration, level, tabletSupport, objectives, ...moduleRest }) {
+  return toDomain({ ...moduleRest, details: { image, description, duration, level, tabletSupport, objectives } });
+}
+
+async function toDomain(moduleData) {
+  const version = _computeModuleVersion(moduleData);
+  return ModuleFactory.build({ ...moduleData, version });
 }
 
 function getModuleMethod(ref, moduleDatasource) {

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -39,7 +39,20 @@ async function getByShortId({ shortId, moduleDatasource }) {
 }
 
 async function getBySlug({ slug, moduleDatasource }) {
-  return await _getModuleFromDatasource({ ref: 'slug', moduleDatasource, query: slug });
+  if (!isFetchingModulesFromLearningContentEnabled.value) {
+    return await _getModuleFromDatasource({ ref: 'slug', moduleDatasource, query: slug });
+  }
+
+  const cacheKey = `getBySlug(${slug})`;
+  const findBySlugCallback = (knex) => knex.where('slug', slug).limit(1);
+
+  const [module] = await getInstance().find(cacheKey, findBySlugCallback);
+
+  if (!module) {
+    throw new NotFoundError();
+  }
+
+  return toDomainFromDbObject(module);
 }
 
 async function list({ moduleDatasource }) {

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -55,9 +55,18 @@ async function getBySlug({ slug, moduleDatasource }) {
   return toDomainFromDbObject(module);
 }
 
-async function list({ moduleDatasource }) {
-  const modulesData = await moduleDatasource.list();
-  return Promise.all(modulesData.map(async (moduleData) => await ModuleFactory.build(moduleData)));
+async function list({ moduleDatasource } = {}) {
+  if (!isFetchingModulesFromLearningContentEnabled.value) {
+    const modulesData = await moduleDatasource.list();
+    return Promise.all(modulesData.map(async (moduleData) => await ModuleFactory.build(moduleData)));
+  }
+
+  const cacheKey = 'list';
+  const listCallback = (knex) => knex.orderBy('slug');
+
+  const modules = await getInstance().find(cacheKey, listCallback);
+
+  return Promise.all(modules.map(toDomainFromDbObject));
 }
 
 export { getById, getByShortId, getBySlug, list };

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { LearningContentResourceNotFound } from '../../../shared/domain/errors.js';
+import { LearningContentRepository } from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import { ModuleDoesNotExistError } from '../../domain/errors.js';
 import { ModuleFactory } from '../factories/module-factory.js';
 
@@ -56,4 +57,20 @@ function getModuleMethod(ref, moduleDatasource) {
     default:
       return moduleDatasource.getById;
   }
+}
+
+export function clearCache(id) {
+  return getInstance().clearCache(id);
+}
+
+const TABLE_NAME = 'learningcontent.modules';
+
+/** @type {LearningContentRepository} */
+let instance;
+
+function getInstance() {
+  if (!instance) {
+    instance = new LearningContentRepository({ tableName: TABLE_NAME, idType: 'uuid' });
+  }
+  return instance;
 }

--- a/api/src/learning-content/infrastructure/repositories/module-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/module-repository.js
@@ -1,3 +1,4 @@
+import { clearCache } from '../../../devcomp/infrastructure/repositories/module-repository.js';
 import { LearningContentRepository } from './learning-content-repository.js';
 
 class ModuleRepository extends LearningContentRepository {
@@ -19,8 +20,8 @@ class ModuleRepository extends LearningContentRepository {
     };
   }
 
-  clearCache(_id) {
-    // FIXME
+  clearCache(id) {
+    clearCache(id);
   }
 }
 

--- a/api/src/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-repository.js
@@ -44,7 +44,7 @@ export class LearningContentRepository {
   /**
    * @param {{
    *   tableName: string
-   *   idType?: 'text' | 'integer'
+   *   idType?: 'text' | 'integer' | 'uuid'
    * }} config
    */
   constructor({ tableName, idType = 'text' }) {

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -481,153 +481,191 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
   });
 
   describe('#list', function () {
-    describe('errors', function () {
-      describe('if there are no duplicated IDs in modules content', function () {
-        it('should result an empty array of duplicated IDs ', async function () {
-          const modules = await moduleDatasource.list();
-          const ids = [];
-          const shortIds = [];
+    describe('when isFetchingModulesFromLearningContentEnabled feature toggle is false', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isFetchingModulesFromLearningContentEnabled', false);
+        await setImmediate();
+      });
 
-          const duplicateIds = new Set();
-          const duplicateShortIds = new Set();
+      describe('errors', function () {
+        describe('if there are no duplicated IDs in modules content', function () {
+          it('should result an empty array of duplicated IDs ', async function () {
+            const modules = await moduleDatasource.list();
+            const ids = [];
+            const shortIds = [];
 
-          for (const module of modules) {
-            if (ids.includes(module.id)) {
-              duplicateIds.add(module.id);
-            }
-            ids.push(module.id);
+            const duplicateIds = new Set();
+            const duplicateShortIds = new Set();
 
-            if (shortIds.includes(module.shortId)) {
-              duplicateShortIds.add(module.shortId);
-            }
-            shortIds.push(module.shortId);
-
-            for (const section of module.sections) {
-              if (ids.includes(section.id)) {
-                duplicateIds.add(section.id);
+            for (const module of modules) {
+              if (ids.includes(module.id)) {
+                duplicateIds.add(module.id);
               }
-              ids.push(section.id);
+              ids.push(module.id);
 
-              for (const grain of section.grains) {
-                if (ids.includes(grain.id)) {
-                  duplicateIds.add(grain.id);
+              if (shortIds.includes(module.shortId)) {
+                duplicateShortIds.add(module.shortId);
+              }
+              shortIds.push(module.shortId);
+
+              for (const section of module.sections) {
+                if (ids.includes(section.id)) {
+                  duplicateIds.add(section.id);
                 }
-                ids.push(grain.id);
+                ids.push(section.id);
 
-                for (const component of grain.components) {
-                  switch (component.type) {
-                    case 'element':
-                      if (ids.includes(component.element.id)) {
-                        duplicateIds.add(component.element.id);
-                      }
-                      if (component.element.type === 'flashcards') {
-                        for (const card of component.element.cards) {
-                          if (ids.includes(card.id)) {
-                            duplicateIds.add(card.id);
-                          }
-                          ids.push(card.id);
+                for (const grain of section.grains) {
+                  if (ids.includes(grain.id)) {
+                    duplicateIds.add(grain.id);
+                  }
+                  ids.push(grain.id);
+
+                  for (const component of grain.components) {
+                    switch (component.type) {
+                      case 'element':
+                        if (ids.includes(component.element.id)) {
+                          duplicateIds.add(component.element.id);
                         }
-                      }
-                      ids.push(component.element.id);
-                      break;
-                    case 'stepper':
-                      for (const step of component.steps) {
-                        for (const element of step.elements) {
-                          if (ids.includes(element.id)) {
-                            duplicateIds.add(element.id);
-                          }
-                          if (element.type === 'flashcards') {
-                            for (const card of element.cards) {
-                              if (ids.includes(card.id)) {
-                                duplicateIds.add(card.id);
-                              }
-                              ids.push(card.id);
+                        if (component.element.type === 'flashcards') {
+                          for (const card of component.element.cards) {
+                            if (ids.includes(card.id)) {
+                              duplicateIds.add(card.id);
                             }
+                            ids.push(card.id);
                           }
-                          ids.push(element.id);
                         }
-                      }
-                      break;
+                        ids.push(component.element.id);
+                        break;
+                      case 'stepper':
+                        for (const step of component.steps) {
+                          for (const element of step.elements) {
+                            if (ids.includes(element.id)) {
+                              duplicateIds.add(element.id);
+                            }
+                            if (element.type === 'flashcards') {
+                              for (const card of element.cards) {
+                                if (ids.includes(card.id)) {
+                                  duplicateIds.add(card.id);
+                                }
+                                ids.push(card.id);
+                              }
+                            }
+                            ids.push(element.id);
+                          }
+                        }
+                        break;
+                    }
                   }
                 }
               }
             }
-          }
 
-          expect([...duplicateIds]).to.deep.equal([]);
-          expect([...duplicateShortIds]).to.deep.equal([]);
+            expect([...duplicateIds]).to.deep.equal([]);
+            expect([...duplicateShortIds]).to.deep.equal([]);
+          });
         });
+      });
+
+      it('should return a list of Module instances', async function () {
+        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+        const expectedFoundModule = {
+          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+          shortId: 'gbsri73s',
+          slug: existingModuleSlug,
+          title: 'Bien écrire son adresse mail',
+          isBeta: true,
+          visibility: 'public',
+          details: {
+            image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+            description:
+              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+            duration: 12,
+            level: 'novice',
+            tabletSupport: 'comfortable',
+            objectives: [
+              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+              'Comprendre les fonctions des parties d’une adresse mail',
+            ],
+          },
+          sections: [
+            {
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
+                {
+                  id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                  type: 'lesson',
+                  title: 'Explications : les parties d’une adresse mail',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                        type: 'text',
+                        tag: ' ',
+                        content:
+                          "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          glossary: [
+            {
+              word: 'Pix',
+              definition:
+                'Pix est un service public en ligne pour évaluer, développer, et certifier ses compétences numériques.',
+            },
+          ],
+        };
+        const moduleDatasourceStub = {
+          list: sinon.stub(),
+        };
+        moduleDatasourceStub.list.resolves([expectedFoundModule]);
+        sinon.spy(ModuleFactory, 'build');
+
+        // when
+        const modules = await moduleRepository.list({ moduleDatasource: moduleDatasourceStub });
+
+        // then
+        expect(ModuleFactory.build).to.have.been.calledWith(expectedFoundModule);
+        expect(modules).to.be.an('array');
+        expect(modules[0]).to.be.instanceof(Module);
       });
     });
 
-    it('should return a list of Module instances', async function () {
-      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-      const expectedFoundModule = {
-        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-        shortId: 'gbsri73s',
-        slug: existingModuleSlug,
-        title: 'Bien écrire son adresse mail',
-        isBeta: true,
-        visibility: 'public',
-        details: {
-          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
-          description:
-            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-          duration: 12,
-          level: 'novice',
-          tabletSupport: 'comfortable',
-          objectives: [
-            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-            'Comprendre les fonctions des parties d’une adresse mail',
-          ],
-        },
-        sections: [
-          {
-            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
-            type: 'practise',
-            grains: [
-              {
-                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-                type: 'lesson',
-                title: 'Explications : les parties d’une adresse mail',
-                components: [
-                  {
-                    type: 'element',
-                    element: {
-                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                      type: 'text',
-                      tag: ' ',
-                      content:
-                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-        glossary: [
-          {
-            word: 'Pix',
-            definition:
-              'Pix est un service public en ligne pour évaluer, développer, et certifier ses compétences numériques.',
-          },
-        ],
-      };
-      const moduleDatasourceStub = {
-        list: sinon.stub(),
-      };
-      moduleDatasourceStub.list.resolves([expectedFoundModule]);
-      sinon.spy(ModuleFactory, 'build');
+    describe('when isFetchingModulesFromLearningContentEnabled feature toggle is true', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isFetchingModulesFromLearningContentEnabled', true);
+        await setImmediate();
+      });
 
-      // when
-      const modules = await moduleRepository.list({ moduleDatasource: moduleDatasourceStub });
+      it('should return a list of Module instances', async function () {
+        const expectedModules = [
+          databaseBuilder.factory.learningContent.buildModule({ shortId: 'niconico', slug: 'petit-escargot' }),
+          databaseBuilder.factory.learningContent.buildModule({ shortId: 'cacacaca', slug: 'porte-sur-son-dos' }),
+          databaseBuilder.factory.learningContent.buildModule({
+            shortId: 'pipipipi',
+            slug: 'saaaaaa-maisoneeeeeetteuuuuuuh',
+          }),
+        ];
+        await databaseBuilder.commit();
 
-      // then
-      expect(ModuleFactory.build).to.have.been.calledWith(expectedFoundModule);
-      expect(modules).to.be.an('array');
-      expect(modules[0]).to.be.instanceof(Module);
+        // when
+        const modules = await moduleRepository.list();
+
+        // then
+        expect(modules).to.have.lengthOf(3);
+        expect(modules[0]).to.be.instanceOf(Module).and.deep.contain(expectedModules[0]);
+        expect(modules[0].version).to.be.a('string').of.length(64);
+        expect(modules[1]).to.be.instanceOf(Module).and.deep.contain(expectedModules[1]);
+        expect(modules[1].version).to.be.a('string').of.length(64);
+        expect(modules[2]).to.be.instanceOf(Module).and.deep.contain(expectedModules[2]);
+        expect(modules[2].version).to.be.a('string').of.length(64);
+      });
     });
   });
 });

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -233,7 +233,60 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
   });
 
   describe('getByShortId', function () {
-    describe('errors', function () {
+    describe('when isFetchingModulesFromLearningContentEnabled feature toggle is false', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isFetchingModulesFromLearningContentEnabled', false);
+        await setImmediate();
+      });
+
+      describe('errors', function () {
+        it('should throw a NotFoundError if the module does not exist', async function () {
+          // given
+          const nonExistingModuleShortId = 'm4tthia5';
+
+          // when
+          const error = await catchErr(moduleRepository.getByShortId)({
+            shortId: nonExistingModuleShortId,
+            moduleDatasource,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(NotFoundError);
+        });
+
+        it('should throw an Error if module does not build correctly', async function () {
+          // given
+          const moduleDatasourceStub = {
+            getByShortId: async () => {
+              return {
+                id: 1,
+                shortId: 'm4tthia5',
+                slug: 'incomplete module',
+              };
+            },
+          };
+
+          sinon.stub(ModuleFactory, 'build').throws(new ModuleInstantiationError());
+
+          // when
+          const error = await catchErr(moduleRepository.getByShortId)({
+            shortId: 'm4tthia5',
+            moduleDatasource: moduleDatasourceStub,
+          });
+
+          // then
+          expect(error).not.to.be.instanceOf(NotFoundError);
+          expect(error).to.be.instanceOf(ModuleInstantiationError);
+        });
+      });
+    });
+
+    describe('when isFetchingModulesFromLearningContentEnabled feature toggle is true', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isFetchingModulesFromLearningContentEnabled', true);
+        await setImmediate();
+      });
+
       it('should throw a NotFoundError if the module does not exist', async function () {
         // given
         const nonExistingModuleShortId = 'm4tthia5';
@@ -241,35 +294,24 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         // when
         const error = await catchErr(moduleRepository.getByShortId)({
           shortId: nonExistingModuleShortId,
-          moduleDatasource,
         });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
       });
-      it('should throw an Error if module does not build correctly', async function () {
-        // given
-        const moduleDatasourceStub = {
-          getByShortId: async () => {
-            return {
-              id: 1,
-              shortId: 'm4tthia5',
-              slug: 'incomplete module',
-            };
-          },
-        };
 
-        sinon.stub(ModuleFactory, 'build').throws(new ModuleInstantiationError());
+      it('reads the module from DB', async function () {
+        // given
+        const shortId = 'm4tthia5';
+        const expectedModule = databaseBuilder.factory.learningContent.buildModule({ shortId });
+        await databaseBuilder.commit();
 
         // when
-        const error = await catchErr(moduleRepository.getByShortId)({
-          shortId: 'm4tthia5',
-          moduleDatasource: moduleDatasourceStub,
-        });
+        const module = await moduleRepository.getByShortId({ shortId });
 
         // then
-        expect(error).not.to.be.instanceOf(NotFoundError);
-        expect(error).to.be.instanceOf(ModuleInstantiationError);
+        expect(module).to.be.instanceOf(Module).and.deep.contain(expectedModule);
+        expect(module.version).to.be.a('string').of.length(64);
       });
     });
   });

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import { setImmediate } from 'node:timers/promises';
 
 import sinon from 'sinon';
 
@@ -8,130 +9,226 @@ import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources
 import { ModuleFactory } from '../../../../src/devcomp/infrastructure/factories/module-factory.js';
 import * as moduleRepository from '../../../../src/devcomp/infrastructure/repositories/module-repository.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
+import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect } from '../../../test-helper.js';
+import { databaseBuilder } from '../../../tooling/databases.js';
 import { catchErr } from '../../../tooling/test-utils/error.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
   describe('#getById', function () {
-    describe('errors', function () {
-      it('should throw a NotFoundError if the module does not exist', async function () {
-        // given
-        const nonExistingModuleSlug = 'uuid-dresser-des-pokemons';
+    describe('when isFetchingModulesFromLearningContentEnabled feature toggle is false', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isFetchingModulesFromLearningContentEnabled', false);
+      });
+
+      describe('errors', function () {
+        it('should throw a NotFoundError if the module does not exist', async function () {
+          // given
+          const nonExistingModuleSlug = 'uuid-dresser-des-pokemons';
+
+          // when
+          const error = await catchErr(moduleRepository.getById)({ slug: nonExistingModuleSlug, moduleDatasource });
+
+          // then
+          expect(error).to.be.instanceOf(NotFoundError);
+        });
+
+        it('should throw a NotFoundError if the module instantiation throw an error', async function () {
+          // given
+          const moduleDatasourceStub = {
+            getById: async () => {
+              return {
+                id: 1,
+                slug: 'module-with-error',
+              };
+            },
+          };
+
+          // when
+          const error = await catchErr(moduleRepository.getById)({
+            id: 1,
+            moduleDatasource: moduleDatasourceStub,
+          });
+
+          // then
+          expect(error).not.to.be.instanceOf(NotFoundError);
+        });
+      });
+
+      it('should return a Module instance with its version', async function () {
+        const existingModuleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+        const expectedFoundModule = {
+          id: existingModuleId,
+          shortId: 'gbsri73s',
+          slug: 'existingModuleSlug',
+          title: 'Bien écrire son adresse mail',
+          isBeta: true,
+          visibility: 'public',
+          details: {
+            image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+            description:
+              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+            duration: 12,
+            level: 'novice',
+            tabletSupport: 'comfortable',
+            objectives: [
+              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+              'Comprendre les fonctions des parties d’une adresse mail',
+            ],
+          },
+          sections: [
+            {
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
+                {
+                  id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                  type: 'lesson',
+                  title: 'Explications : les parties d’une adresse mail',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                        type: 'text',
+                        tag: ' ',
+                        content:
+                          "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          glossary: [
+            {
+              word: 'Pix',
+              definition:
+                'Pix est un service public en ligne pour évaluer, développer, et certifier ses compétences numériques.',
+            },
+          ],
+        };
+        const moduleDatasourceStub = {
+          getById: sinon.stub(),
+        };
+        moduleDatasourceStub.getById.withArgs(existingModuleId).resolves(expectedFoundModule);
+        sinon.spy(ModuleFactory, 'build');
+
+        const version = Symbol('version');
+        const digestStub = sinon.stub().returns(version);
+        const updateStub = sinon.stub();
+        const createHashStub = sinon.stub(crypto, 'createHash').returns({
+          copy: () => {
+            return {
+              digest: digestStub,
+            };
+          },
+          update: updateStub,
+        });
 
         // when
-        const error = await catchErr(moduleRepository.getById)({ slug: nonExistingModuleSlug, moduleDatasource });
+        const module = await moduleRepository.getById({
+          id: existingModuleId,
+          moduleDatasource: moduleDatasourceStub,
+        });
+
+        // then
+        expect(ModuleFactory.build).to.have.been.calledWith({ ...expectedFoundModule, version });
+        expect(module).to.be.instanceof(Module);
+        expect(createHashStub).to.have.been.calledOnceWith('sha256');
+        expect(updateStub).to.have.been.calledOnceWith(JSON.stringify(expectedFoundModule));
+        expect(digestStub).to.have.been.calledOnceWith('hex');
+      });
+    });
+
+    describe('when isFetchingModulesFromLearningContentEnabled feature toggle is true', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isFetchingModulesFromLearningContentEnabled', true);
+        await setImmediate();
+      });
+
+      it('should throw a NotFoundError if the module does not exist', async function () {
+        // given
+        const nonExistingModuleId = 'bfbdb571-e2af-48d4-a999-63e934ada2f9';
+
+        // when
+        const error = await catchErr(moduleRepository.getById)({ id: nonExistingModuleId });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
       });
 
-      it('should throw a NotFoundError if the module instanciation throw an error', async function () {
-        // given
-        const moduleDatasourceStub = {
-          getById: async () => {
-            return {
-              id: 1,
-              slug: 'module-with-error',
-            };
+      it('should return a Module instance with its version', async function () {
+        const existingModuleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+        const expectedFoundModule = {
+          id: existingModuleId,
+          shortId: 'gbsri73s',
+          slug: 'existingModuleSlug',
+          title: 'Bien écrire son adresse mail',
+          isBeta: true,
+          visibility: 'public',
+          details: {
+            image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+            description:
+              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+            duration: 12,
+            level: 'novice',
+            tabletSupport: 'comfortable',
+            objectives: [
+              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+              'Comprendre les fonctions des parties d’une adresse mail',
+            ],
           },
+          sections: [
+            {
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
+                {
+                  id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                  type: 'lesson',
+                  title: 'Explications : les parties d’une adresse mail',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                        type: 'text',
+                        tag: ' ',
+                        isAnswerable: false,
+                        content:
+                          "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          glossary: [
+            {
+              word: 'Pix',
+              definition:
+                'Pix est un service public en ligne pour évaluer, développer, et certifier ses compétences numériques.',
+            },
+          ],
         };
 
+        databaseBuilder.factory.learningContent.buildModule(expectedFoundModule);
+        await databaseBuilder.commit();
+
         // when
-        const error = await catchErr(moduleRepository.getById)({
-          id: 1,
-          moduleDatasource: moduleDatasourceStub,
+        const module = await moduleRepository.getById({
+          id: existingModuleId,
         });
 
         // then
-        expect(error).not.to.be.instanceOf(NotFoundError);
+        expect(module).to.be.instanceOf(Module).and.deep.contain(expectedFoundModule);
+        expect(module.version).to.be.a('string').of.length(64);
       });
-    });
-
-    it('should return a Module instance with its version', async function () {
-      const existingModuleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
-      const expectedFoundModule = {
-        id: existingModuleId,
-        shortId: 'gbsri73s',
-        slug: 'existingModuleSlug',
-        title: 'Bien écrire son adresse mail',
-        isBeta: true,
-        visibility: 'public',
-        details: {
-          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
-          description:
-            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-          duration: 12,
-          level: 'novice',
-          tabletSupport: 'comfortable',
-          objectives: [
-            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-            'Comprendre les fonctions des parties d’une adresse mail',
-          ],
-        },
-        sections: [
-          {
-            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
-            type: 'practise',
-            grains: [
-              {
-                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-                type: 'lesson',
-                title: 'Explications : les parties d’une adresse mail',
-                components: [
-                  {
-                    type: 'element',
-                    element: {
-                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                      type: 'text',
-                      tag: ' ',
-                      content:
-                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-        glossary: [
-          {
-            word: 'Pix',
-            definition:
-              'Pix est un service public en ligne pour évaluer, développer, et certifier ses compétences numériques.',
-          },
-        ],
-      };
-      const moduleDatasourceStub = {
-        getById: sinon.stub(),
-      };
-      moduleDatasourceStub.getById.withArgs(existingModuleId).resolves(expectedFoundModule);
-      sinon.spy(ModuleFactory, 'build');
-
-      const version = Symbol('version');
-      const digestStub = sinon.stub().returns(version);
-      const updateStub = sinon.stub();
-      const createHashStub = sinon.stub(crypto, 'createHash').returns({
-        copy: () => {
-          return {
-            digest: digestStub,
-          };
-        },
-        update: updateStub,
-      });
-
-      // when
-      const module = await moduleRepository.getById({
-        id: existingModuleId,
-        moduleDatasource: moduleDatasourceStub,
-      });
-
-      // then
-      expect(ModuleFactory.build).to.have.been.calledWith({ ...expectedFoundModule, version });
-      expect(module).to.be.instanceof(Module);
-      expect(createHashStub).to.have.been.calledOnceWith('sha256');
-      expect(updateStub).to.have.been.calledOnceWith(JSON.stringify(expectedFoundModule));
-      expect(digestStub).to.have.been.calledOnceWith('hex');
     });
   });
 

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -317,7 +317,141 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
   });
 
   describe('#getBySlug', function () {
-    describe('errors', function () {
+    describe('when isFetchingModulesFromLearningContentEnabled feature toggle is false', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isFetchingModulesFromLearningContentEnabled', false);
+        await setImmediate();
+      });
+
+      describe('errors', function () {
+        it('should throw a NotFoundError if the module does not exist', async function () {
+          // given
+          const nonExistingModuleSlug = 'dresser-des-pokemons';
+
+          // when
+          const error = await catchErr(moduleRepository.getBySlug)({ slug: nonExistingModuleSlug, moduleDatasource });
+
+          // then
+          expect(error).to.be.instanceOf(NotFoundError);
+        });
+
+        it('should throw a NotFoundError if the module instanciation throw an error', async function () {
+          // given
+          const moduleSlug = 'incomplete-module';
+          const moduleDatasourceStub = {
+            getBySlug: async () => {
+              return {
+                id: 1,
+                slug: moduleSlug,
+              };
+            },
+          };
+
+          // when
+          const error = await catchErr(moduleRepository.getBySlug)({
+            slug: moduleSlug,
+            moduleDatasource: moduleDatasourceStub,
+          });
+
+          // then
+          expect(error).not.to.be.instanceOf(NotFoundError);
+        });
+      });
+
+      it('should return a Module instance with its version', async function () {
+        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+        const expectedFoundModule = {
+          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+          shortId: 'gbsri73s',
+          slug: existingModuleSlug,
+          title: 'Bien écrire son adresse mail',
+          isBeta: true,
+          visibility: 'public',
+          details: {
+            image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+            description:
+              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+            duration: 12,
+            level: 'novice',
+            tabletSupport: 'comfortable',
+            objectives: [
+              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+              'Comprendre les fonctions des parties d’une adresse mail',
+            ],
+          },
+          sections: [
+            {
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
+                {
+                  id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                  type: 'lesson',
+                  title: 'Explications : les parties d’une adresse mail',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                        type: 'text',
+                        tag: ' ',
+                        content:
+                          "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          glossary: [
+            {
+              word: 'Pix',
+              definition:
+                'Pix est un service public en ligne pour évaluer, développer, et certifier ses compétences numériques.',
+            },
+          ],
+        };
+        const moduleDatasourceStub = {
+          getBySlug: sinon.stub(),
+        };
+        moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
+        sinon.spy(ModuleFactory, 'build');
+
+        const version = Symbol('version');
+        const digestStub = sinon.stub().returns(version);
+        const updateStub = sinon.stub();
+        const createHashStub = sinon.stub(crypto, 'createHash').returns({
+          copy: () => {
+            return {
+              digest: digestStub,
+            };
+          },
+          update: updateStub,
+        });
+
+        // when
+        const module = await moduleRepository.getBySlug({
+          slug: existingModuleSlug,
+          moduleDatasource: moduleDatasourceStub,
+        });
+
+        // then
+        expect(ModuleFactory.build).to.have.been.calledWith({ ...expectedFoundModule, version });
+        expect(module).to.be.instanceof(Module);
+        expect(createHashStub).to.have.been.calledOnceWith('sha256');
+        expect(updateStub).to.have.been.calledOnceWith(JSON.stringify(expectedFoundModule));
+        expect(digestStub).to.have.been.calledOnceWith('hex');
+      });
+    });
+
+    describe('when isFetchingModulesFromLearningContentEnabled feature toggle is true', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isFetchingModulesFromLearningContentEnabled', true);
+        await setImmediate();
+      });
+
       it('should throw a NotFoundError if the module does not exist', async function () {
         // given
         const nonExistingModuleSlug = 'dresser-des-pokemons';
@@ -329,114 +463,20 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         expect(error).to.be.instanceOf(NotFoundError);
       });
 
-      it('should throw a NotFoundError if the module instanciation throw an error', async function () {
-        // given
-        const moduleSlug = 'incomplete-module';
-        const moduleDatasourceStub = {
-          getBySlug: async () => {
-            return {
-              id: 1,
-              slug: moduleSlug,
-            };
-          },
-        };
+      it('reads the module from DB', async function () {
+        const slug = 'bien-ecrire-son-adresse-mail';
+        const expectedModule = databaseBuilder.factory.learningContent.buildModule({ slug });
+        await databaseBuilder.commit();
 
         // when
-        const error = await catchErr(moduleRepository.getBySlug)({
-          slug: moduleSlug,
-          moduleDatasource: moduleDatasourceStub,
+        const module = await moduleRepository.getBySlug({
+          slug: slug,
         });
 
         // then
-        expect(error).not.to.be.instanceOf(NotFoundError);
+        expect(module).to.be.instanceOf(Module).and.deep.contain(expectedModule);
+        expect(module.version).to.be.a('string').of.length(64);
       });
-    });
-
-    it('should return a Module instance with its version', async function () {
-      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-      const expectedFoundModule = {
-        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-        shortId: 'gbsri73s',
-        slug: existingModuleSlug,
-        title: 'Bien écrire son adresse mail',
-        isBeta: true,
-        visibility: 'public',
-        details: {
-          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
-          description:
-            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-          duration: 12,
-          level: 'novice',
-          tabletSupport: 'comfortable',
-          objectives: [
-            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-            'Comprendre les fonctions des parties d’une adresse mail',
-          ],
-        },
-        sections: [
-          {
-            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
-            type: 'practise',
-            grains: [
-              {
-                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-                type: 'lesson',
-                title: 'Explications : les parties d’une adresse mail',
-                components: [
-                  {
-                    type: 'element',
-                    element: {
-                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                      type: 'text',
-                      tag: ' ',
-                      content:
-                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-        glossary: [
-          {
-            word: 'Pix',
-            definition:
-              'Pix est un service public en ligne pour évaluer, développer, et certifier ses compétences numériques.',
-          },
-        ],
-      };
-      const moduleDatasourceStub = {
-        getBySlug: sinon.stub(),
-      };
-      moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
-      sinon.spy(ModuleFactory, 'build');
-
-      const version = Symbol('version');
-      const digestStub = sinon.stub().returns(version);
-      const updateStub = sinon.stub();
-      const createHashStub = sinon.stub(crypto, 'createHash').returns({
-        copy: () => {
-          return {
-            digest: digestStub,
-          };
-        },
-        update: updateStub,
-      });
-
-      // when
-      const module = await moduleRepository.getBySlug({
-        slug: existingModuleSlug,
-        moduleDatasource: moduleDatasourceStub,
-      });
-
-      // then
-      expect(ModuleFactory.build).to.have.been.calledWith({ ...expectedFoundModule, version });
-      expect(module).to.be.instanceof(Module);
-      expect(createHashStub).to.have.been.calledOnceWith('sha256');
-      expect(updateStub).to.have.been.calledOnceWith(JSON.stringify(expectedFoundModule));
-      expect(digestStub).to.have.been.calledOnceWith('hex');
     });
   });
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -9,6 +9,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import { disconnect as disconnectKnex } from '../db/knex-database-connection.js';
+import * as moduleRepository from '../src/devcomp/infrastructure/repositories/module-repository.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
 import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
@@ -60,6 +61,7 @@ afterEach(async function () {
   courseRepository.clearCache();
   tutorialRepository.clearCache();
   missionRepository.clearCache();
+  moduleRepository.clearCache();
   await featureToggles.resetDefaults();
   await clearMutex();
   try {


### PR DESCRIPTION
## 🌱 Problème

Les modules sont stockés dans le LCMS, mais on continue à lire les fichiers de module stockés dans le mono-repo.

## 🐣 Proposition

Modifier le `module-repository` pour lire les modules dans le LCMS. On utilise un feature toggle pour spécifier qu'on lit les modules dans la base quand le FT est à true.

## 🌷 Remarques

On suit la même logique que pour les autres repositories du learning content, utilisation de’une instance de LearninContentRepository pour récupérer les données et les mettre en cache.

Le feature toggle `isFetchingModulesFromLearningContentEnabled` a été passé à true sur la RA.

## 🐝 Pour tester

- ✅ CI au vert
- Vérifier que le bac à sable a pour titre "Bac à gravier" et fonctionne bien : https://app-pr16062.review.pix.fr/modules/bac-a-sable

