### PR TITLE
[BUGFIX] Réparer l'affichage de la page de détail d'un centre de certif (PIX-22593)

### DIFF
--- a/admin/app/adapters/certification-center.js
+++ b/admin/app/adapters/certification-center.js
@@ -3,6 +3,16 @@ import ApplicationAdapter from './application';
 export default class CertificationCenterAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
+  findHasMany(store, snapshot, _url, relationship) {
+    if (relationship.key === 'certificationCenterMemberships') {
+      return this.ajax(
+        `${this.host}/${this.namespace}/certification-centers/${snapshot.id}/certification-center-memberships`,
+        'GET',
+      );
+    }
+    return super.findHasMany(...arguments);
+  }
+
   archiveCertificationCenter(certificationCenterId) {
     return this.ajax(`${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/archive`, 'POST');
   }


### PR DESCRIPTION
## 🌱 Problème

Suite à cette PR https://github.com/1024pix/pix/pull/16037, un bug a été introduit. L'appel vers le détail des memberships déclenche une erreur 404 dû à une mauvaise config de l'adapter Ember.

## 🐣 Proposition

Supprimer le commit qui introduit ce bug.

## 🌷 Remarques
RAS

## 🐝 Pour tester
Sur Pix admin,
- vérifier qu'on peut accéder à la page de détail d'un centre de certif.