### PR TITLE
[FEATURE] Ajouter une page "intercalaire" listant les versions d'un réf de certif (PIX-21480)

### DIFF
--- a/admin/app/adapters/certification-framework.js
+++ b/admin/app/adapters/certification-framework.js
@@ -2,4 +2,8 @@ import ApplicationAdapter from './application';
 
 export default class CertificationFrameworkAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
+
+  urlForFindRecord(id) {
+    return `${this.host}/${this.namespace}/certification-frameworks/${id}/target-profiles`;
+  }
 }

--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -19,11 +19,11 @@ export default class CertificationFramework extends Component {
 
   async #onMount() {
     const frameworkKey = this.args.frameworkKey;
-    const complementaryCertification = this.args.complementaryCertification;
+    const certificationFramework = this.args.certificationFramework;
 
-    if (complementaryCertification) {
-      await complementaryCertification.reload();
-      this.targetProfilesHistory = complementaryCertification.targetProfilesHistory;
+    if (certificationFramework && this.args.hasTargetProfilesHistory) {
+      await certificationFramework.reload();
+      this.targetProfilesHistory = certificationFramework.targetProfilesHistory;
     }
 
     const frameworkHistory = await this.store.queryRecord('framework-history', frameworkKey);

--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -1,20 +1,14 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
-import FrameworkDetails from './framework/framework-details';
 import FrameworkHistory from './framework/framework-history';
 import History from './target-profile/history';
 
 export default class CertificationFramework extends Component {
-  @service currentUser;
   @service store;
   @tracked targetProfilesHistory;
-  @tracked currentConsolidatedFramework;
   @tracked frameworkHistory;
 
   constructor() {
@@ -32,38 +26,11 @@ export default class CertificationFramework extends Component {
       this.targetProfilesHistory = complementaryCertification.targetProfilesHistory;
     }
 
-    this.currentConsolidatedFramework = await this.store.findRecord(
-      'certification-consolidated-framework',
-      frameworkKey,
-    );
-
     const frameworkHistory = await this.store.queryRecord('framework-history', frameworkKey);
     this.frameworkHistory = frameworkHistory?.history;
   }
 
   <template>
-    {{#if this.currentUser.adminMember.isSuperAdmin}}
-      <PixBlock @variant="admin">
-        {{#unless this.currentConsolidatedFramework}}
-          <PixNotificationAlert @withIcon={{true}} class="framework__no-current">
-            {{t "components.complementary-certifications.item.framework.no-current-framework"}}
-          </PixNotificationAlert>
-          <br />
-        {{/unless}}
-
-        <PixButtonLink
-          class="framework__creation-button"
-          @route="authenticated.certification-frameworks.item.framework.new-version"
-        >
-          {{t "components.complementary-certifications.item.framework.create-button"}}
-        </PixButtonLink>
-      </PixBlock>
-    {{/if}}
-
-    {{#if this.currentConsolidatedFramework}}
-      <FrameworkDetails @currentConsolidatedFramework={{this.currentConsolidatedFramework}} />
-    {{/if}}
-
     {{#if this.frameworkHistory}}
       <FrameworkHistory @history={{this.frameworkHistory}} />
     {{/if}}

--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -1,7 +1,6 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { t } from 'ember-intl';
 
 import FrameworkHistory from './framework/framework-history';
 import History from './target-profile/history';

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -1,13 +1,12 @@
-import PixIcon from "@1024pix/pix-ui/components/pix-icon";
-import PixIconButton from "@1024pix/pix-ui/components/pix-icon-button";
-import PixTable from "@1024pix/pix-ui/components/pix-table";
-import PixTableColumn from "@1024pix/pix-ui/components/pix-table-column";
-import PixTag from "@1024pix/pix-ui/components/pix-tag";
-import { concat, get } from "@ember/helper";
-import Component from "@glimmer/component";
-import { t } from "ember-intl";
-import formatDate from "ember-intl/helpers/format-date";
-import { eq, not } from "ember-truth-helpers";
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { concat, get } from '@ember/helper';
+import { t } from 'ember-intl';
+import formatDate from 'ember-intl/helpers/format-date';
+import { eq, not } from 'ember-truth-helpers';
 
 const STATUS_COLORS = { ACTIVE: 'success', DRAFT: 'tertiary', ARCHIVED: 'secondary' };
 
@@ -20,96 +19,94 @@ function formatDuration(minutes) {
   return `${h}h ${m}min`;
 }
 
-export default class FrameworkHistory extends Component {
-  <template>
-    <section class="framework-versions">
-      <PixTable
-        @variant="admin"
-        @caption={{t "components.complementary-certifications.item.framework.history.table.caption"}}
-        @data={{@history}}
-      >
-        <:columns as |version context|>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t "components.complementary-certifications.item.framework.history.table.columns.version-id"}}
-            </:header>
-            <:cell>
-              {{version.id}}
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t
-                "components.complementary-certifications.item.framework.history.table.columns.maximum-assessment-length"
-              }}
-            </:header>
-            <:cell>
-              {{version.maximumAssessmentLength}}
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              <PixIcon @name="time" @ariaHidden={{true}} />
-              {{t "components.complementary-certifications.item.framework.history.table.columns.assessment-duration"}}
-            </:header>
-            <:cell>
-              {{formatDuration version.assessmentDuration}}
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              <PixIcon @name="calendar" @ariaHidden={{true}} />
-              {{t "components.complementary-certifications.item.framework.history.table.columns.start-date"}}
-            </:header>
-            <:cell>
-              <strong>{{if version.startDate (formatDate version.startDate) "-"}}</strong>
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              <PixIcon @name="calendar" @ariaHidden={{true}} />
-              {{t "components.complementary-certifications.item.framework.history.table.columns.expiration-date"}}
-            </:header>
-            <:cell>
-              <strong>{{if version.expirationDate (formatDate version.expirationDate) "-"}}</strong>
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t "components.complementary-certifications.item.framework.history.table.columns.status"}}
-            </:header>
-            <:cell>
-              <PixTag @color={{get STATUS_COLORS version.status}}>
-                {{t (concat "components.complementary-certifications.item.framework.history.statuses." version.status)}}
-              </PixTag>
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t "components.complementary-certifications.item.framework.history.table.columns.actions"}}
-            </:header>
-            <:cell>
-              <PixIconButton
-                @triggerAction={{this.viewVersion}}
-                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.view"}}
-                @iconName="eye"
-              />
-              <PixIconButton
-                @triggerAction={{this.editVersion}}
-                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.edit"}}
-                @iconName="edit"
-                @isDisabled={{not (eq version.status "DRAFT")}}
-              />
-              <PixIconButton
-                @triggerAction={{this.deleteVersion}}
-                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.delete"}}
-                @iconName="delete"
-                @isDisabled={{not (eq version.status "DRAFT")}}
-              />
-            </:cell>
-          </PixTableColumn>
-        </:columns>
-      </PixTable>
-    </section>
-  </template>
-}
+<template>
+  <section class="framework-versions">
+    <PixTable
+      @variant="admin"
+      @caption={{t "components.complementary-certifications.item.framework.history.table.caption"}}
+      @data={{@history}}
+    >
+      <:columns as |version context|>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.complementary-certifications.item.framework.history.table.columns.version-id"}}
+          </:header>
+          <:cell>
+            {{version.id}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t
+              "components.complementary-certifications.item.framework.history.table.columns.maximum-assessment-length"
+            }}
+          </:header>
+          <:cell>
+            {{version.maximumAssessmentLength}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            <PixIcon @name="time" @ariaHidden={{true}} />
+            {{t "components.complementary-certifications.item.framework.history.table.columns.assessment-duration"}}
+          </:header>
+          <:cell>
+            {{formatDuration version.assessmentDuration}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            <PixIcon @name="calendar" @ariaHidden={{true}} />
+            {{t "components.complementary-certifications.item.framework.history.table.columns.start-date"}}
+          </:header>
+          <:cell>
+            <strong>{{if version.startDate (formatDate version.startDate) "-"}}</strong>
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            <PixIcon @name="calendar" @ariaHidden={{true}} />
+            {{t "components.complementary-certifications.item.framework.history.table.columns.expiration-date"}}
+          </:header>
+          <:cell>
+            <strong>{{if version.expirationDate (formatDate version.expirationDate) "-"}}</strong>
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.complementary-certifications.item.framework.history.table.columns.status"}}
+          </:header>
+          <:cell>
+            <PixTag @color={{get STATUS_COLORS version.status}}>
+              {{t (concat "components.complementary-certifications.item.framework.history.statuses." version.status)}}
+            </PixTag>
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.complementary-certifications.item.framework.history.table.columns.actions"}}
+          </:header>
+          <:cell>
+            <PixIconButton
+              @triggerAction={{this.viewVersion}}
+              @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.view"}}
+              @iconName="eye"
+            />
+            <PixIconButton
+              @triggerAction={{this.editVersion}}
+              @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.edit"}}
+              @iconName="edit"
+              @isDisabled={{not (eq version.status "DRAFT")}}
+            />
+            <PixIconButton
+              @triggerAction={{this.deleteVersion}}
+              @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.delete"}}
+              @iconName="delete"
+              @isDisabled={{not (eq version.status "DRAFT")}}
+            />
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  </section>
+</template>

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -1,47 +1,108 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import { t } from 'ember-intl';
-import formatDate from 'ember-intl/helpers/format-date';
+import PixIcon from "@1024pix/pix-ui/components/pix-icon";
+import PixIconButton from "@1024pix/pix-ui/components/pix-icon-button";
+import PixTable from "@1024pix/pix-ui/components/pix-table";
+import PixTableColumn from "@1024pix/pix-ui/components/pix-table-column";
+import Component from "@glimmer/component";
+import { concat } from "@ember/helper";
+import { eq, not } from "ember-truth-helpers";
+import { t } from "ember-intl";
+import formatDate from "ember-intl/helpers/format-date";
 
-<template>
-  <section class="framework-details">
-    <h2 class="framework-details__title">
-      {{t "components.complementary-certifications.item.framework.history.title"}}
-    </h2>
+function formatDuration(minutes) {
+  if (!minutes) return '-';
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h === 0) return `${m}min`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}min`;
+}
 
-    <PixTable
-      @variant="admin"
-      @caption={{t "components.complementary-certifications.item.framework.history.table.caption"}}
-      @data={{@history}}
-    >
-      <:columns as |version context|>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.complementary-certifications.item.framework.history.table.columns.version-id"}}
-          </:header>
-          <:cell>
-            {{version.id}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.complementary-certifications.item.framework.history.table.columns.start-date"}}
-          </:header>
-          <:cell>
-            {{formatDate version.startDate}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.complementary-certifications.item.framework.history.table.columns.expiration-date"}}
-          </:header>
-          <:cell>
-            {{#if version.expirationDate}}
-              {{formatDate version.expirationDate}}
-            {{/if}}
-          </:cell>
-        </PixTableColumn>
-      </:columns>
-    </PixTable>
-  </section>
-</template>
+export default class FrameworkHistory extends Component {
+  viewVersion() {}
+
+  deleteVersion() {}
+
+  <template>
+    <section class="framework-versions">
+      <PixTable
+        @variant="admin"
+        @caption={{t "components.complementary-certifications.item.framework.history.table.caption"}}
+        @data={{@history}}
+      >
+        <:columns as |version context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.complementary-certifications.item.framework.history.table.columns.version-id"}}
+            </:header>
+            <:cell>
+              {{version.id}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.complementary-certifications.item.framework.history.table.columns.maximum-assessment-length"}}
+            </:header>
+            <:cell>
+              {{version.maximumAssessmentLength}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              <PixIcon @name="time" @ariaHidden={{true}} />
+              {{t "components.complementary-certifications.item.framework.history.table.columns.assessment-duration"}}
+            </:header>
+            <:cell>
+              {{formatDuration version.assessmentDuration}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              <PixIcon @name="calendar" @ariaHidden={{true}} />
+              {{t "components.complementary-certifications.item.framework.history.table.columns.start-date"}}
+            </:header>
+            <:cell>
+              <strong>{{if version.startDate (formatDate version.startDate) "-"}}</strong>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              <PixIcon @name="calendar" @ariaHidden={{true}} />
+              {{t "components.complementary-certifications.item.framework.history.table.columns.expiration-date"}}
+            </:header>
+            <:cell>
+              <strong>{{if version.expirationDate (formatDate version.expirationDate) "-"}}</strong>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.complementary-certifications.item.framework.history.table.columns.status"}}
+            </:header>
+            <:cell>
+              <span class="framework-version-status framework-version-status--{{version.status}}">
+                {{t (concat "components.complementary-certifications.item.framework.history.statuses." version.status)}}
+              </span>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.complementary-certifications.item.framework.history.table.columns.actions"}}
+            </:header>
+            <:cell>
+              <PixIconButton
+                @triggerAction={{this.viewVersion}}
+                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.view"}}
+                @iconName="eye"
+              />
+              <PixIconButton
+                @triggerAction={{this.deleteVersion}}
+                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.delete"}}
+                @iconName="delete"
+                @isDisabled={{not (eq version.status "DRAFT")}}
+              />
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    </section>
+  </template>
+}

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -2,11 +2,14 @@ import PixIcon from "@1024pix/pix-ui/components/pix-icon";
 import PixIconButton from "@1024pix/pix-ui/components/pix-icon-button";
 import PixTable from "@1024pix/pix-ui/components/pix-table";
 import PixTableColumn from "@1024pix/pix-ui/components/pix-table-column";
+import PixTag from "@1024pix/pix-ui/components/pix-tag";
+import { concat, get } from "@ember/helper";
 import Component from "@glimmer/component";
-import { concat } from "@ember/helper";
-import { eq, not } from "ember-truth-helpers";
 import { t } from "ember-intl";
 import formatDate from "ember-intl/helpers/format-date";
+import { eq, not } from "ember-truth-helpers";
+
+const STATUS_COLORS = { ACTIVE: 'success', DRAFT: 'tertiary', ARCHIVED: 'secondary' };
 
 function formatDuration(minutes) {
   if (!minutes) return '-';
@@ -18,10 +21,6 @@ function formatDuration(minutes) {
 }
 
 export default class FrameworkHistory extends Component {
-  viewVersion() {}
-
-  deleteVersion() {}
-
   <template>
     <section class="framework-versions">
       <PixTable
@@ -40,7 +39,9 @@ export default class FrameworkHistory extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{context}}>
             <:header>
-              {{t "components.complementary-certifications.item.framework.history.table.columns.maximum-assessment-length"}}
+              {{t
+                "components.complementary-certifications.item.framework.history.table.columns.maximum-assessment-length"
+              }}
             </:header>
             <:cell>
               {{version.maximumAssessmentLength}}
@@ -78,9 +79,9 @@ export default class FrameworkHistory extends Component {
               {{t "components.complementary-certifications.item.framework.history.table.columns.status"}}
             </:header>
             <:cell>
-              <span class="framework-version-status framework-version-status--{{version.status}}">
+              <PixTag @color={{get STATUS_COLORS version.status}}>
                 {{t (concat "components.complementary-certifications.item.framework.history.statuses." version.status)}}
-              </span>
+              </PixTag>
             </:cell>
           </PixTableColumn>
           <PixTableColumn @context={{context}}>

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -95,6 +95,12 @@ export default class FrameworkHistory extends Component {
                 @iconName="eye"
               />
               <PixIconButton
+                @triggerAction={{this.editVersion}}
+                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.edit"}}
+                @iconName="edit"
+                @isDisabled={{not (eq version.status "DRAFT")}}
+              />
+              <PixIconButton
                 @triggerAction={{this.deleteVersion}}
                 @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.delete"}}
                 @iconName="delete"

--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -1,13 +1,17 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
-import { service } from '@ember/service';
-import Component from '@glimmer/component';
-import { t } from 'ember-intl';
+import PixBreadcrumb from "@1024pix/pix-ui/components/pix-breadcrumb";
+import PixButtonLink from "@1024pix/pix-ui/components/pix-button-link";
+import { service } from "@ember/service";
+import Component from "@glimmer/component";
+import { and } from "ember-truth-helpers";
+import { t } from "ember-intl";
 
 export default class Header extends Component {
   @service intl;
+  @service currentUser;
+  @service router;
 
-  get isComplementaryCertification() {
-    return this.args.complementaryCertification;
+  get isNotCLEA() {
+    return this.args.complementaryCertification?.key !== 'CLEA';
   }
 
   get links() {
@@ -30,25 +34,25 @@ export default class Header extends Component {
 
     <div class="certification-framework-header">
       <h1 class="certification-framework-header__title">
-        <small>
-          {{#if this.isComplementaryCertification}}
-            {{#if @complementaryCertification.hasComplementaryReferential}}
-              {{t "components.complementary-certifications.item.certification-framework"}}
-            {{else}}
-              {{t "components.complementary-certifications.item.target-profile"}}
-            {{/if}}
-          {{else}}
-            {{t "components.complementary-certifications.item.certification-framework"}}
-          {{/if}}
-        </small>
         <span>
-          {{#if this.isComplementaryCertification}}
+          {{#if @complementaryCertification}}
             {{@complementaryCertification.label}}
           {{else}}
             {{t "components.certification-frameworks.labels.CORE"}}
           {{/if}}
         </span>
       </h1>
+
+      {{#if (and this.currentUser.adminMember.isSuperAdmin this.isNotCLEA)}}
+        <PixButtonLink
+          class="framework__creation-button"
+          @route="authenticated.certification-frameworks.item.framework.new-version"
+          @size="large"
+          @iconBefore="add"
+        >
+          {{t "components.complementary-certifications.item.framework.create-button"}}
+        </PixButtonLink>
+      {{/if}}
     </div>
   </template>
 }

--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -9,7 +9,7 @@ export default class Header extends Component {
   @service currentUser;
 
   get frameworkLabel() {
-    return this.intl.t(`components.certification-frameworks.labels.${this.args.certificationFramework?.name}`);
+    return this.intl.t(`components.certification-frameworks.labels.${this.args.certificationFramework.name}`);
   }
 
   get canCreateVersion() {
@@ -44,7 +44,6 @@ export default class Header extends Component {
         <PixButtonLink
           class="framework__creation-button"
           @route="authenticated.certification-frameworks.item.framework.new-version"
-          @size="large"
           @iconBefore="add"
         >
           {{t "components.complementary-certifications.item.framework.create-button"}}

--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -1,17 +1,19 @@
-import PixBreadcrumb from "@1024pix/pix-ui/components/pix-breadcrumb";
-import PixButtonLink from "@1024pix/pix-ui/components/pix-button-link";
-import { service } from "@ember/service";
-import Component from "@glimmer/component";
-import { and } from "ember-truth-helpers";
-import { t } from "ember-intl";
+import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 export default class Header extends Component {
   @service intl;
   @service currentUser;
-  @service router;
 
-  get isNotCLEA() {
-    return this.args.complementaryCertification?.key !== 'CLEA';
+  get frameworkLabel() {
+    return this.intl.t(`components.certification-frameworks.labels.${this.args.certificationFramework?.name}`);
+  }
+
+  get canCreateVersion() {
+    return this.currentUser.adminMember.isSuperAdmin && this.args.certificationFramework?.name !== 'CLEA';
   }
 
   get links() {
@@ -21,8 +23,7 @@ export default class Header extends Component {
         label: this.intl.t('components.layout.sidebar.certification-frameworks'),
       },
       {
-        label:
-          this.args.complementaryCertification?.label || this.intl.t('components.certification-frameworks.labels.CORE'),
+        label: this.frameworkLabel,
       },
     ];
   }
@@ -35,15 +36,11 @@ export default class Header extends Component {
     <div class="certification-framework-header">
       <h1 class="certification-framework-header__title">
         <span>
-          {{#if @complementaryCertification}}
-            {{@complementaryCertification.label}}
-          {{else}}
-            {{t "components.certification-frameworks.labels.CORE"}}
-          {{/if}}
+          {{this.frameworkLabel}}
         </span>
       </h1>
 
-      {{#if (and this.currentUser.adminMember.isSuperAdmin this.isNotCLEA)}}
+      {{#if this.canCreateVersion}}
         <PixButtonLink
           class="framework__creation-button"
           @route="authenticated.certification-frameworks.item.framework.new-version"

--- a/admin/app/components/certification-frameworks/item/target-profile/history.gjs
+++ b/admin/app/components/certification-frameworks/item/target-profile/history.gjs
@@ -3,10 +3,10 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { fn } from '@ember/helper';
 import { t } from 'ember-intl';
 import formatDate from 'ember-intl/helpers/format-date';
 

--- a/admin/app/components/certification-frameworks/item/target-profile/history.gjs
+++ b/admin/app/components/certification-frameworks/item/target-profile/history.gjs
@@ -1,51 +1,68 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import { LinkTo } from '@ember/routing';
-import { t } from 'ember-intl';
-import formatDate from 'ember-intl/helpers/format-date';
+import PixAccordions from "@1024pix/pix-ui/components/pix-accordions";
+import PixIcon from "@1024pix/pix-ui/components/pix-icon";
+import PixTable from "@1024pix/pix-ui/components/pix-table";
+import PixTableColumn from "@1024pix/pix-ui/components/pix-table-column";
+import { LinkTo } from "@ember/routing";
+import { t } from "ember-intl";
+import formatDate from "ember-intl/helpers/format-date";
 
 <template>
-  <section class="page-section">
-    <h2 class="certification-framework-details__history-title page-section__header">
-      {{t "components.complementary-certifications.target-profiles.history-list.title"}}
-    </h2>
-    <PixTable
-      @variant="admin"
-      @data={{@targetProfilesHistory}}
-      @caption={{t "components.complementary-certifications.target-profiles.history-list.caption"}}
-    >
-      <:columns as |row targetProfileHistory|>
-        <PixTableColumn @context={{targetProfileHistory}}>
-          <:header>
-            {{t "components.complementary-certifications.target-profiles.history-list.headers.name"}}
-          </:header>
-          <:cell>
-            <LinkTo
-              @route="authenticated.target-profiles.target-profile"
-              @model={{row.id}}
-              class="certification-framework-details-target-profile__link"
-            >
-              {{row.name}}
-            </LinkTo>
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{targetProfileHistory}}>
-          <:header>
-            {{t "components.complementary-certifications.target-profiles.history-list.headers.attached-at"}}
-          </:header>
-          <:cell>
-            {{formatDate row.attachedAt}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{targetProfileHistory}}>
-          <:header>
-            {{t "components.complementary-certifications.target-profiles.history-list.headers.detached-at"}}
-          </:header>
-          <:cell>
-            {{if row.detachedAt (formatDate row.detachedAt) "-"}}
-          </:cell>
-        </PixTableColumn>
-      </:columns>
-    </PixTable>
+  <section class="page-section framework-target-profiles-history">
+    <PixAccordions>
+      <:title>
+        {{t "components.complementary-certifications.target-profiles.history-list.title"}}
+      </:title>
+      <:content>
+        <PixTable
+          @variant="admin"
+          @data={{@targetProfilesHistory}}
+          @caption={{t "components.complementary-certifications.target-profiles.history-list.caption"}}
+        >
+          <:columns as |row targetProfileHistory|>
+            <PixTableColumn @context={{targetProfileHistory}}>
+              <:header>
+                {{t "components.complementary-certifications.target-profiles.history-list.headers.name"}}
+              </:header>
+              <:cell>
+                {{row.name}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{targetProfileHistory}}>
+              <:header>
+                <PixIcon @name="calendar" @ariaHidden={{true}} />
+              {{t "components.complementary-certifications.target-profiles.history-list.headers.attached-at"}}
+              </:header>
+              <:cell>
+                <strong>{{formatDate row.attachedAt}}</strong>
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{targetProfileHistory}}>
+              <:header>
+                <PixIcon @name="calendar" @ariaHidden={{true}} />
+              {{t "components.complementary-certifications.target-profiles.history-list.headers.detached-at"}}
+              </:header>
+              <:cell>
+                <strong>{{if row.detachedAt (formatDate row.detachedAt) "-"}}</strong>
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{targetProfileHistory}}>
+              <:header>
+                {{t "components.complementary-certifications.target-profiles.history-list.headers.actions"}}
+              </:header>
+              <:cell>
+                <LinkTo
+                  @route="authenticated.target-profiles.target-profile"
+                  @model={{row.id}}
+                  class="framework-target-profiles-history__action-link"
+                  aria-label={{t "components.complementary-certifications.target-profiles.history-list.actions.view"}}
+                >
+                  <PixIcon @name="eye" @ariaHidden={{true}} />
+                </LinkTo>
+              </:cell>
+            </PixTableColumn>
+          </:columns>
+        </PixTable>
+      </:content>
+    </PixAccordions>
   </section>
 </template>

--- a/admin/app/components/certification-frameworks/item/target-profile/history.gjs
+++ b/admin/app/components/certification-frameworks/item/target-profile/history.gjs
@@ -1,68 +1,78 @@
-import PixAccordions from "@1024pix/pix-ui/components/pix-accordions";
-import PixIcon from "@1024pix/pix-ui/components/pix-icon";
-import PixTable from "@1024pix/pix-ui/components/pix-table";
-import PixTableColumn from "@1024pix/pix-ui/components/pix-table-column";
-import { LinkTo } from "@ember/routing";
-import { t } from "ember-intl";
-import formatDate from "ember-intl/helpers/format-date";
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { fn } from '@ember/helper';
+import { t } from 'ember-intl';
+import formatDate from 'ember-intl/helpers/format-date';
 
-<template>
-  <section class="page-section framework-target-profiles-history">
-    <PixAccordions>
-      <:title>
-        {{t "components.complementary-certifications.target-profiles.history-list.title"}}
-      </:title>
-      <:content>
-        <PixTable
-          @variant="admin"
-          @data={{@targetProfilesHistory}}
-          @caption={{t "components.complementary-certifications.target-profiles.history-list.caption"}}
-        >
-          <:columns as |row targetProfileHistory|>
-            <PixTableColumn @context={{targetProfileHistory}}>
-              <:header>
-                {{t "components.complementary-certifications.target-profiles.history-list.headers.name"}}
-              </:header>
-              <:cell>
-                {{row.name}}
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{targetProfileHistory}}>
-              <:header>
-                <PixIcon @name="calendar" @ariaHidden={{true}} />
-              {{t "components.complementary-certifications.target-profiles.history-list.headers.attached-at"}}
-              </:header>
-              <:cell>
-                <strong>{{formatDate row.attachedAt}}</strong>
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{targetProfileHistory}}>
-              <:header>
-                <PixIcon @name="calendar" @ariaHidden={{true}} />
-              {{t "components.complementary-certifications.target-profiles.history-list.headers.detached-at"}}
-              </:header>
-              <:cell>
-                <strong>{{if row.detachedAt (formatDate row.detachedAt) "-"}}</strong>
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{targetProfileHistory}}>
-              <:header>
-                {{t "components.complementary-certifications.target-profiles.history-list.headers.actions"}}
-              </:header>
-              <:cell>
-                <LinkTo
-                  @route="authenticated.target-profiles.target-profile"
-                  @model={{row.id}}
-                  class="framework-target-profiles-history__action-link"
-                  aria-label={{t "components.complementary-certifications.target-profiles.history-list.actions.view"}}
-                >
-                  <PixIcon @name="eye" @ariaHidden={{true}} />
-                </LinkTo>
-              </:cell>
-            </PixTableColumn>
-          </:columns>
-        </PixTable>
-      </:content>
-    </PixAccordions>
-  </section>
-</template>
+export default class TargetProfilesHistory extends Component {
+  @service router;
+
+  @action
+  viewTargetProfile(id) {
+    this.router.transitionTo('authenticated.target-profiles.target-profile', id);
+  }
+
+  <template>
+    <section class="page-section framework-target-profiles-history">
+      <PixAccordions>
+        <:title>
+          {{t "components.complementary-certifications.target-profiles.history-list.title"}}
+        </:title>
+        <:content>
+          <PixTable
+            @variant="admin"
+            @data={{@targetProfilesHistory}}
+            @caption={{t "components.complementary-certifications.target-profiles.history-list.caption"}}
+          >
+            <:columns as |row targetProfileHistory|>
+              <PixTableColumn @context={{targetProfileHistory}}>
+                <:header>
+                  {{t "components.complementary-certifications.target-profiles.history-list.headers.name"}}
+                </:header>
+                <:cell>
+                  {{row.name}}
+                </:cell>
+              </PixTableColumn>
+              <PixTableColumn @context={{targetProfileHistory}}>
+                <:header>
+                  <PixIcon @name="calendar" @ariaHidden={{true}} />
+                  {{t "components.complementary-certifications.target-profiles.history-list.headers.attached-at"}}
+                </:header>
+                <:cell>
+                  <strong>{{formatDate row.attachedAt}}</strong>
+                </:cell>
+              </PixTableColumn>
+              <PixTableColumn @context={{targetProfileHistory}}>
+                <:header>
+                  <PixIcon @name="calendar" @ariaHidden={{true}} />
+                  {{t "components.complementary-certifications.target-profiles.history-list.headers.detached-at"}}
+                </:header>
+                <:cell>
+                  <strong>{{if row.detachedAt (formatDate row.detachedAt) "-"}}</strong>
+                </:cell>
+              </PixTableColumn>
+              <PixTableColumn @context={{targetProfileHistory}}>
+                <:header>
+                  {{t "components.complementary-certifications.target-profiles.history-list.headers.actions"}}
+                </:header>
+                <:cell>
+                  <PixIconButton
+                    @triggerAction={{fn this.viewTargetProfile row.id}}
+                    @ariaLabel={{t "components.complementary-certifications.target-profiles.history-list.actions.view"}}
+                    @iconName="eye"
+                  />
+                </:cell>
+              </PixTableColumn>
+            </:columns>
+          </PixTable>
+        </:content>
+      </PixAccordions>
+    </section>
+  </template>
+}

--- a/admin/app/models/certification-framework.js
+++ b/admin/app/models/certification-framework.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class CertificationFramework extends Model {
   @attr('string') name;
   @attr('date') activeVersionStartDate;
+  @attr() targetProfilesHistory;
 }

--- a/admin/app/routes/authenticated/certification-frameworks.js
+++ b/admin/app/routes/authenticated/certification-frameworks.js
@@ -9,12 +9,8 @@ export default class CertificationFrameworksRoute extends Route {
   async model() {
     try {
       const certificationFrameworks = await this.store.findAll('certification-framework');
-      const complementaryCertifications = await this.store.findAll('complementary-certification');
 
-      return {
-        certificationFrameworks,
-        complementaryCertifications,
-      };
+      return { certificationFrameworks };
     } catch (errorResponse) {
       if (!isEmpty(errorResponse)) {
         errorResponse.errors.forEach((error) => this.pixToast.sendErrorNotification({ message: error.detail }));
@@ -22,6 +18,6 @@ export default class CertificationFrameworksRoute extends Route {
         this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
       }
     }
-    return { certificationFrameworks: [], complementaryCertifications: [] };
+    return { certificationFrameworks: [] };
   }
 }

--- a/admin/app/routes/authenticated/certification-frameworks/item.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item.js
@@ -5,19 +5,27 @@ export default class ItemRoute extends Route {
   @service store;
   @service router;
 
-  beforeModel() {
-    return this.store.findAll('complementary-certification');
-  }
-
-  model(params) {
+  async model(params) {
     this.certificationFrameworkKey = params.certification_framework_key;
-    const complementaryCertifications = this.store.peekAll('complementary-certification');
-    const currentComplementaryCertification = complementaryCertifications.find(
-      (cc) => cc.key === params.certification_framework_key,
+
+    const certificationFrameworks = this.store.peekAll('certification-framework');
+    const currentCertificationFramework = certificationFrameworks.find(
+      (cf) => cf.name === params.certification_framework_key,
     );
+
+    let currentComplementaryCertification;
+    if (params.certification_framework_key === 'CLEA') {
+      const complementaryCertifications = await this.store.findAll('complementary-certification');
+      currentComplementaryCertification = complementaryCertifications.find(
+        (cc) => cc.key === params.certification_framework_key,
+      );
+    }
+
     return {
       frameworkKey: this.certificationFrameworkKey,
+      currentCertificationFramework,
       currentComplementaryCertification,
+      hasTargetProfilesHistory: params.certification_framework_key !== 'CORE',
     };
   }
 

--- a/admin/app/styles/components/certification-frameworks/header.scss
+++ b/admin/app/styles/components/certification-frameworks/header.scss
@@ -4,8 +4,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--pix-spacing-12x);
   margin-top: var(--pix-spacing-6x);
+  margin-bottom: var(--pix-spacing-12x);
 
   &__title {
     span {

--- a/admin/app/styles/components/certification-frameworks/header.scss
+++ b/admin/app/styles/components/certification-frameworks/header.scss
@@ -1,16 +1,13 @@
 @use 'pix-design-tokens/typography';
 
 .certification-framework-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--pix-spacing-12x);
+  margin-top: var(--pix-spacing-6x);
+
   &__title {
-    small {
-      display: block;
-      margin-bottom: var(--pix-spacing-3x);
-      color: var(--pix-neutral-500);
-      text-transform: uppercase;
-
-      @extend %pix-body-s;
-    }
-
     span {
       color: var(--pix-neutral-800);
 

--- a/admin/app/styles/components/certification-frameworks/item/framework.scss
+++ b/admin/app/styles/components/certification-frameworks/item/framework.scss
@@ -24,18 +24,80 @@
 }
 
 /* Framework details */
-.framework-details {
-  margin-top: var(--pix-spacing-6x);
-  padding-top: var(--pix-spacing-6x);
-  border-top: 1px solid var(--pix-neutral-100);
-}
-
 .framework-details__title {
   @extend %pix-title-xs;
 
   margin-bottom: var(--pix-spacing-4x);
 }
 
-.framework__table-empty {
-  margin-top: var(--pix-spacing-6x);
+.framework-versions,
+.framework-target-profiles-history {
+  color: var(--pix-neutral-900);
+
+  .pix-table-header-container {
+    color: var(--pix-primary-900);
+    vertical-align: middle;
+    margin-right: var(--pix-spacing-1x);
+  }
+
+  .pix-icon {
+    color: var(--pix-neutral-800);
+    vertical-align: middle;
+    margin-right: var(--pix-spacing-1x);
+  }
 }
+
+.framework-version-status {
+  display: inline-block;
+  padding: var(--pix-spacing-1x) var(--pix-spacing-3x);
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+
+  &--DRAFT {
+    background-color: var(--pix-tertiary-100);
+    color: var(--pix-tertiary-900);
+  }
+
+  &--ACTIVE {
+    background-color: var(--pix-success-100);
+    color: var(--pix-success-900);
+  }
+
+  &--ARCHIVED {
+    background-color: var(--pix-secondary-100);
+    color: var(--pix-secondary-900);
+  }
+}
+
+/* Target profiles history accordion */
+.framework-target-profiles-history {
+  margin-top: var(--pix-spacing-8x);
+
+  .pix-accordions__title {
+    @extend %pix-title-xs;
+
+    &:hover,
+    &[aria-expanded='true'] {
+      background-color: transparent;
+    }
+  }
+
+  .pix-accordions__content {
+    padding: var(--pix-spacing-4x);
+    color: inherit;
+  }
+
+  a.framework-target-profiles-history__action-link {
+    display: inline-flex;
+    align-items: center;
+    color: var(--pix-neutral-800);
+    text-decoration: none;
+
+    .pix-icon {
+      width: 1.35rem;
+      height: 1.35rem;
+    }
+  }
+}
+

--- a/admin/app/styles/components/certification-frameworks/item/framework.scss
+++ b/admin/app/styles/components/certification-frameworks/item/framework.scss
@@ -35,40 +35,18 @@
   color: var(--pix-neutral-900);
 
   .pix-table-header-container {
+    margin-right: var(--pix-spacing-1x);
     color: var(--pix-primary-900);
     vertical-align: middle;
-    margin-right: var(--pix-spacing-1x);
   }
 
-  .pix-icon {
+  .pix-table-header-container > .pix-icon {
+    margin-right: var(--pix-spacing-1x);
     color: var(--pix-neutral-800);
     vertical-align: middle;
-    margin-right: var(--pix-spacing-1x);
   }
 }
 
-.framework-version-status {
-  display: inline-block;
-  padding: var(--pix-spacing-1x) var(--pix-spacing-3x);
-  border-radius: 12px;
-  font-size: 0.8rem;
-  font-weight: 500;
-
-  &--DRAFT {
-    background-color: var(--pix-tertiary-100);
-    color: var(--pix-tertiary-900);
-  }
-
-  &--ACTIVE {
-    background-color: var(--pix-success-100);
-    color: var(--pix-success-900);
-  }
-
-  &--ARCHIVED {
-    background-color: var(--pix-secondary-100);
-    color: var(--pix-secondary-900);
-  }
-}
 
 /* Target profiles history accordion */
 .framework-target-profiles-history {
@@ -86,18 +64,6 @@
   .pix-accordions__content {
     padding: var(--pix-spacing-4x);
     color: inherit;
-  }
-
-  a.framework-target-profiles-history__action-link {
-    display: inline-flex;
-    align-items: center;
-    color: var(--pix-neutral-800);
-    text-decoration: none;
-
-    .pix-icon {
-      width: 1.35rem;
-      height: 1.35rem;
-    }
   }
 }
 

--- a/admin/app/templates/authenticated/certification-frameworks/index.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/index.gjs
@@ -14,7 +14,6 @@ import List from 'pix-admin/components/certification-frameworks/list';
       <section class="page-section">
         <List
           @certificationFrameworks={{@model.certificationFrameworks}}
-          @complementaryCertifications={{@model.complementaryCertifications}}
         />
       </section>
     </main>

--- a/admin/app/templates/authenticated/certification-frameworks/index.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/index.gjs
@@ -12,9 +12,7 @@ import List from 'pix-admin/components/certification-frameworks/list';
 
     <main class="page-body">
       <section class="page-section">
-        <List
-          @certificationFrameworks={{@model.certificationFrameworks}}
-        />
+        <List @certificationFrameworks={{@model.certificationFrameworks}} />
       </section>
     </main>
   </div>

--- a/admin/app/templates/authenticated/certification-frameworks/item.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item.gjs
@@ -2,10 +2,10 @@ import pageTitle from "ember-page-title/helpers/page-title";
 import Header from "pix-admin/components/certification-frameworks/item/header";
 
 <template>
-  {{pageTitle "Référentiel " @model.label " | Pix Admin" replace=true}}
+  {{pageTitle "Référentiel " @model.frameworkKey " | Pix Admin" replace=true}}
 
   <div class="page">
-    <Header @complementaryCertification={{@model.currentComplementaryCertification}} />
+    <Header @certificationFramework={{@model.currentCertificationFramework}} />
 
     <section class="page-body certification-framework">
       {{outlet}}

--- a/admin/app/templates/authenticated/certification-frameworks/item.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item.gjs
@@ -1,5 +1,5 @@
-import pageTitle from "ember-page-title/helpers/page-title";
-import Header from "pix-admin/components/certification-frameworks/item/header";
+import pageTitle from 'ember-page-title/helpers/page-title';
+import Header from 'pix-admin/components/certification-frameworks/item/header';
 
 <template>
   {{pageTitle "Référentiel " @model.frameworkKey " | Pix Admin" replace=true}}

--- a/admin/app/templates/authenticated/certification-frameworks/item.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item.gjs
@@ -1,5 +1,5 @@
-import pageTitle from 'ember-page-title/helpers/page-title';
-import Header from 'pix-admin/components/certification-frameworks/item/header';
+import pageTitle from "ember-page-title/helpers/page-title";
+import Header from "pix-admin/components/certification-frameworks/item/header";
 
 <template>
   {{pageTitle "Référentiel " @model.label " | Pix Admin" replace=true}}
@@ -7,7 +7,7 @@ import Header from 'pix-admin/components/certification-frameworks/item/header';
   <div class="page">
     <Header @complementaryCertification={{@model.currentComplementaryCertification}} />
 
-    <section class="page-body certification-framework certification-framework__header">
+    <section class="page-body certification-framework">
       {{outlet}}
     </section>
   </div>

--- a/admin/app/templates/authenticated/certification-frameworks/item/framework/index.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item/framework/index.gjs
@@ -3,6 +3,7 @@ import Framework from 'pix-admin/components/certification-frameworks/item/framew
 <template>
   <Framework
     @frameworkKey={{@model.frameworkKey}}
-    @complementaryCertification={{@model.currentComplementaryCertification}}
+    @certificationFramework={{@model.currentCertificationFramework}}
+    @hasTargetProfilesHistory={{@model.hasTargetProfilesHistory}}
   />
 </template>

--- a/admin/tests/acceptance/authenticated/certification-frameworks/item-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/item-test.js
@@ -18,6 +18,7 @@ module('Acceptance | Complementary certifications | Complementary certification 
       key: 'KEY',
       label: 'MARIANNE CERTIF',
     });
+    server.create('certification-framework', { id: 'KEY' });
     server.create('certification-consolidated-framework', {
       id: 'KEY',
     });
@@ -33,6 +34,7 @@ module('Acceptance | Complementary certifications | Complementary certification 
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
+    server.create('certification-framework', { id: 'CLEA' });
     server.create('complementary-certification', {
       id: 1,
       hasComplementaryReferential: false,

--- a/admin/tests/acceptance/authenticated/certification-frameworks/item/attach-target-profile-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/item/attach-target-profile-test.js
@@ -15,9 +15,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
         test('should display complementary certification and current target profile name', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
           server.create('complementary-certification', {
             id: 1,
-            key: 'KEY',
+            key: 'CLEA',
             label: 'MARIANNE CERTIF',
             targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: new Date('2023-10-10T10:50:00Z') }],
           });
@@ -25,7 +26,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             id: 3,
             name: 'ALEX TARGET',
           });
-          const screen = await visit('/certification-frameworks/KEY/target-profile/3');
+          const screen = await visit('/certification-frameworks/CLEA/target-profile/3');
 
           // then
           assert
@@ -42,9 +43,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
           test('it should redirect to target profile details page', async function (assert) {
             // given
             await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
             server.create('complementary-certification', {
               id: 1,
-              key: 'KEY',
+              key: 'CLEA',
               label: 'MARIANNE CERTIF',
               targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: new Date('2023-10-10T10:50:00Z') }],
             });
@@ -52,7 +54,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
               id: 3,
               name: 'ALEX TARGET',
             });
-            const screen = await visit('/certification-frameworks/KEY/target-profile/3');
+            const screen = await visit('/certification-frameworks/CLEA/target-profile/3');
 
             const currentTargetProfileLinks = screen.getAllByRole('link', { name: 'ALEX TARGET' });
 
@@ -69,13 +71,14 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
         test('should not display current target profile name', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
           server.create('complementary-certification', {
             id: 1,
-            key: 'KEY',
+            key: 'CLEA',
             label: 'MARIANNE CERTIF',
             targetProfilesHistory: [],
           });
-          const screen = await visit('/certification-frameworks/KEY/target-profile/-1');
+          const screen = await visit('/certification-frameworks/CLEA/target-profile/-1');
 
           // then
           assert
@@ -93,9 +96,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
         test('it should display the link of the selected target profile with a change button', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
           server.create('complementary-certification', {
             id: 1,
-            key: 'KEY',
+            key: 'CLEA',
             label: 'MARIANNE CERTIF',
             targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: new Date('2023-10-10T10:50:00Z') }],
           });
@@ -108,7 +112,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             name: 'ALEX TARGET',
             badges: [],
           });
-          const screen = await visit('/certification-frameworks/KEY/target-profile/3');
+          const screen = await visit('/certification-frameworks/CLEA/target-profile/3');
           const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
           await fillIn(input, '3');
 
@@ -127,9 +131,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
           test('it should display Notify organisations checkbox', async function (assert) {
             // given
             await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
             server.create('complementary-certification', {
               id: 1,
-              key: 'KEY',
+              key: 'CLEA',
               label: 'MARIANNE CERTIF',
               targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: new Date('2023-10-10T10:50:00Z') }],
             });
@@ -147,7 +152,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
               name: 'ALEX TARGET',
               badges: [badge],
             });
-            const screen = await visit('/certification-frameworks/KEY/target-profile/3');
+            const screen = await visit('/certification-frameworks/CLEA/target-profile/3');
             const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
             await fillIn(input, '5');
             await screen.findByRole('listbox');
@@ -171,9 +176,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
           test('it should not display Notify organisations checkbox', async function (assert) {
             // given
             await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
             server.create('complementary-certification', {
               id: 1,
-              key: 'KEY',
+              key: 'CLEA',
               label: 'MARIANNE CERTIF',
               targetProfilesHistory: [],
             });
@@ -191,7 +197,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
               name: 'ALEX TARGET',
               badges: [badge],
             });
-            const screen = await visit('/certification-frameworks/KEY/target-profile/3');
+            const screen = await visit('/certification-frameworks/CLEA/target-profile/3');
             const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
             await fillIn(input, '5');
             await screen.findByRole('listbox');
@@ -216,9 +222,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
         test('it should save the new attached target profile and redirect to complementary certification details', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
           server.create('complementary-certification', {
             id: 1,
-            key: 'KEY',
+            key: 'CLEA',
             hasExternalJury: true,
             label: 'MARIANNE CERTIF',
             targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: new Date('2023-10-10T10:50:00Z') }],
@@ -237,7 +244,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             name: 'ALEX TARGET',
             badges: [badge],
           });
-          const screen = await visit('/certification-frameworks/KEY/target-profile/3');
+          const screen = await visit('/certification-frameworks/CLEA/target-profile/3');
           const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
           await fillIn(input, '5');
           await screen.findByRole('listbox');
@@ -284,7 +291,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
               ),
             )
             .exists();
-          assert.strictEqual(currentURL(), '/certification-frameworks/KEY/target-profile');
+          assert.strictEqual(currentURL(), '/certification-frameworks/CLEA/target-profile');
         });
       });
 
@@ -292,9 +299,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
         test('it should save the level to 1 by default', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
           server.create('complementary-certification', {
             id: 1,
-            key: 'KEY',
+            key: 'CLEA',
             hasExternalJury: true,
             label: 'MARIANNE CERTIF',
             targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: new Date('2023-10-10T10:50:00Z') }],
@@ -313,7 +321,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             name: 'ALEX TARGET',
             badges: [badge],
           });
-          const screen = await visit('/certification-frameworks/KEY/target-profile/3');
+          const screen = await visit('/certification-frameworks/CLEA/target-profile/3');
           const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
           await fillIn(input, '5');
           await screen.findByRole('listbox');
@@ -358,9 +366,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
       test('it should not allow user to create or update target profile attachment', async function (assert) {
         // given
         await authenticateAdminMemberWithRole({ [role]: hasAccess })(server);
+        server.create('certification-framework', { id: 'CLEA', name: 'CLEA' });
         server.create('complementary-certification', {
           id: 1,
-          key: 'KEY',
+          key: 'CLEA',
           label: 'MARIANNE CERTIF',
           targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: new Date('2023-10-10T10:50:00Z') }],
         });
@@ -368,10 +377,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
           id: 3,
           name: 'ALEX TARGET',
         });
-        await visit('/certification-frameworks/KEY/target-profile/3');
+        await visit('/certification-frameworks/CLEA/target-profile/3');
 
         // then
-        assert.strictEqual(currentURL(), '/certification-frameworks/KEY/target-profile');
+        assert.strictEqual(currentURL(), '/certification-frameworks/CLEA/target-profile');
       });
     });
   });

--- a/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
@@ -11,227 +11,57 @@ module('Integration | Component | certification-frameworks/item/framework', func
   let store;
 
   hooks.beforeEach(function () {
-    const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.adminMember = { isCertif: true };
-
     store = this.owner.lookup('service:store');
-    store.queryRecord = sinon.stub().resolves({});
-  });
-
-  module('when user has a super admin role', function (hooks) {
-    hooks.beforeEach(function () {
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isSuperAdmin: true, isCertif: false };
-    });
-
-    test('it should display a framework creation button', async function (assert) {
-      const complementaryCertification = {
-        key: 'complementary-certification-key',
-        targetProfilesHistory: [],
-        reload: sinon.stub().resolves(),
-      };
-      store.findRecord = sinon.stub().returns();
-
-      const screen = await render(
-        <template>
-          <Framework
-            @complementaryCertification={{complementaryCertification}}
-            @frameworkKey={{complementaryCertification.key}}
-          />
-        </template>,
-      );
-
-      assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
-    });
-
-    test('it should display the information and not the details component when there is no current consolidated framework', async function (assert) {
-      const complementaryCertification = {
-        key: 'complementary-certification-key',
-        targetProfilesHistory: [],
-        reload: sinon.stub().resolves(),
-      };
-      store.findRecord = sinon.stub().returns();
-
-      const screen = await render(
-        <template>
-          <Framework
-            @complementaryCertification={{complementaryCertification}}
-            @frameworkKey={{complementaryCertification.key}}
-          />
-        </template>,
-      );
-
-      assert
-        .dom(screen.getByText(t('components.complementary-certifications.item.framework.no-current-framework')))
-        .exists();
-
-      assert
-        .dom(
-          screen.queryByRole('heading', {
-            name: t('components.complementary-certifications.item.framework.details.title'),
-          }),
-        )
-        .doesNotExist();
-    });
-  });
-
-  module('when user has another accepted role', function () {
-    test('it should not display a framework creation button', async function (assert) {
-      const complementaryCertification = {
-        key: 'complementary-certification-key',
-        targetProfilesHistory: [],
-        reload: sinon.stub().resolves(),
-      };
-      store.findRecord = sinon.stub().returns();
-
-      const screen = await render(
-        <template>
-          <Framework
-            @complementaryCertification={{complementaryCertification}}
-            @frameworkKey={{complementaryCertification.key}}
-          />
-        </template>,
-      );
-
-      assert
-        .dom(screen.queryByText(t('components.complementary-certifications.item.framework.create-button')))
-        .doesNotExist();
-    });
-  });
-
-  module('when a current consolidated framework exists', function () {
-    test('it should display the details component', async function (assert) {
-      const complementaryCertification = {
-        key: 'complementary-certification-key',
-        targetProfilesHistory: [],
-        reload: sinon.stub().resolves(),
-      };
-      store.findRecord = sinon.stub().resolves({
-        hasMany: sinon.stub().returns({
-          value: sinon.stub().returns([]),
-        }),
-      });
-
-      const screen = await render(
-        <template>
-          <Framework
-            @complementaryCertification={{complementaryCertification}}
-            @frameworkKey={{complementaryCertification.key}}
-          />
-        </template>,
-      );
-
-      assert
-        .dom(
-          screen.getByRole('heading', {
-            name: t('components.complementary-certifications.item.framework.details.title'),
-          }),
-        )
-        .exists();
-    });
+    store.queryRecord = sinon.stub().resolves({ history: [] });
   });
 
   module('#frameworkHistory', function () {
-    test('it should not display the framework history when there is no existing framework history', async function (assert) {
-      const complementaryCertification = {
-        key: 'complementary-certification-key',
-        targetProfilesHistory: [],
-        reload: sinon.stub().resolves(),
-      };
-      store.findRecord = sinon.stub().resolves({
-        hasMany: sinon.stub().returns({
-          value: sinon.stub().returns([]),
-        }),
-      });
-      store.queryRecord = sinon.stub().resolves({ history: [] });
-
-      const screen = await render(
-        <template>
-          <Framework
-            @complementaryCertification={{complementaryCertification}}
-            @frameworkKey={{complementaryCertification.key}}
-          />
-        </template>,
-      );
-
-      assert
-        .dom(
-          screen.queryByRole('heading', {
-            name: t('components.complementary-certifications.item.framework.history.title'),
-          }),
-        )
-        .doesNotExist();
-    });
-
     test('it should display the framework history when there are existing framework versions', async function (assert) {
-      const complementaryCertification = {
-        key: 'complementary-certification-key',
-        targetProfilesHistory: [],
-        reload: sinon.stub().resolves(),
-      };
-      store.findRecord = sinon.stub().resolves({
-        hasMany: sinon.stub().returns({
-          value: sinon.stub().returns([]),
-        }),
-      });
-      store.queryRecord = sinon.stub().resolves({ history: ['20250101080000', '20240101080000', '20230101080000'] });
+      // given
+      store.queryRecord = sinon.stub().resolves({ history: ['20250101080000', '20240101080000'] });
 
-      const screen = await render(
-        <template>
-          <Framework
-            @complementaryCertification={{complementaryCertification}}
-            @frameworkKey={{complementaryCertification.key}}
-          />
-        </template>,
-      );
+      // when
+      const screen = await render(<template><Framework @frameworkKey="DROIT" /></template>);
 
+      // then
       assert
         .dom(
-          screen.getByRole('heading', {
-            name: t('components.complementary-certifications.item.framework.history.title'),
+          screen.getByRole('table', {
+            name: t('components.complementary-certifications.item.framework.history.table.caption'),
           }),
         )
         .exists();
+    });
+
+    test('it should not display the framework history when there is no history', async function (assert) {
+      // given
+      store.queryRecord = sinon.stub().resolves({ history: [] });
+
+      // when
+      const screen = await render(<template><Framework @frameworkKey="DROIT" /></template>);
+
+      // then
+      assert
+        .dom(
+          screen.queryByRole('table', {
+            name: t('components.complementary-certifications.item.framework.history.table.caption'),
+          }),
+        )
+        .doesNotExist();
     });
   });
 
   module('when the framework is CORE', function () {
-    test('it should load and display CORE framework', async function (assert) {
-      store.findRecord = sinon.stub().resolves({
-        hasMany: sinon.stub().returns({
-          value: sinon.stub().returns([]),
-        }),
-      });
-      store.queryRecord = sinon.stub().resolves({ history: [] });
-
-      const screen = await render(<template><Framework @frameworkKey="CORE" /></template>);
-
-      assert.ok(
-        store.findRecord.calledWith('certification-consolidated-framework', 'CORE'),
-        'should load CORE framework',
-      );
-      assert
-        .dom(
-          screen.getByRole('heading', {
-            name: t('components.complementary-certifications.item.framework.details.title'),
-          }),
-        )
-        .exists();
-    });
-
     test('it should not display target profiles history section', async function (assert) {
-      store.findRecord = sinon.stub().resolves({
-        hasMany: sinon.stub().returns({
-          value: sinon.stub().returns([]),
-        }),
-      });
-      store.queryRecord = sinon.stub().resolves({ history: [] });
+      // when
+      const screen = await render(
+        <template><Framework @frameworkKey="CORE" @hasTargetProfilesHistory={{false}} /></template>,
+      );
 
-      const screen = await render(<template><Framework @frameworkKey="CORE" /></template>);
-
+      // then
       assert
         .dom(
-          screen.queryByRole('heading', {
+          screen.queryByRole('button', {
             name: t('components.complementary-certifications.target-profiles.history-list.title'),
           }),
         )
@@ -239,71 +69,57 @@ module('Integration | Component | certification-frameworks/item/framework', func
     });
   });
 
-  module('when the framework is a complementary', function () {
-    test('it should load and display complementary framework', async function (assert) {
-      const complementaryCertification = {
-        key: 'DROIT',
-        targetProfilesHistory: [{ id: 1 }, { id: 2 }],
+  module('when the framework has target profiles history', function () {
+    test('it should display target profiles history section', async function (assert) {
+      // given
+      const certificationFramework = {
+        name: 'DROIT',
+        targetProfilesHistory: [{ id: 1, name: 'Profil A', attachedAt: new Date('2024-01-01'), detachedAt: null }],
         reload: sinon.stub().resolves(),
       };
-      store.findRecord = sinon.stub().resolves({
-        hasMany: sinon.stub().returns({
-          value: sinon.stub().returns([]),
-        }),
-      });
-      store.queryRecord = sinon.stub().resolves({ history: [] });
 
+      // when
       const screen = await render(
         <template>
           <Framework
-            @complementaryCertification={{complementaryCertification}}
-            @frameworkKey={{complementaryCertification.key}}
+            @frameworkKey="DROIT"
+            @certificationFramework={{certificationFramework}}
+            @hasTargetProfilesHistory={{true}}
           />
         </template>,
       );
 
-      assert.ok(
-        store.findRecord.calledWith('certification-consolidated-framework', 'DROIT'),
-        'should load complementary framework',
-      );
+      // then
       assert
         .dom(
-          screen.getByRole('heading', {
-            name: t('components.complementary-certifications.item.framework.details.title'),
+          screen.getByRole('button', {
+            name: t('components.complementary-certifications.target-profiles.history-list.title'),
           }),
         )
         .exists();
     });
 
-    test('it should display target profiles history section', async function (assert) {
-      const complementaryCertification = {
-        key: 'DROIT',
-        targetProfilesHistory: [{ id: 1 }, { id: 2 }],
+    test('it should call reload on the certification framework', async function (assert) {
+      // given
+      const certificationFramework = {
+        name: 'DROIT',
+        targetProfilesHistory: [],
         reload: sinon.stub().resolves(),
       };
-      store.findRecord = sinon.stub().resolves({
-        hasMany: sinon.stub().returns({
-          value: sinon.stub().returns([]),
-        }),
-      });
-      store.queryRecord = sinon.stub().resolves({ history: [] });
 
-      const screen = await render(
+      // when
+      await render(
         <template>
           <Framework
-            @complementaryCertification={{complementaryCertification}}
-            @frameworkKey={{complementaryCertification.key}}
+            @frameworkKey="DROIT"
+            @certificationFramework={{certificationFramework}}
+            @hasTargetProfilesHistory={{true}}
           />
         </template>,
       );
 
-      assert
-        .dom(
-          screen.getByRole('heading', {
-            name: t('components.complementary-certifications.target-profiles.history-list.title'),
-          }),
-        )
-        .exists();
+      // then
+      assert.ok(certificationFramework.reload.calledOnce);
     });
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -1,8 +1,8 @@
-import { render } from '@1024pix/ember-testing-library';
-import FrameworkHistory from 'pix-admin/components/certification-frameworks/item/framework/framework-history';
-import { module, test } from 'qunit';
+import { render } from "@1024pix/ember-testing-library";
+import FrameworkHistory from "pix-admin/components/certification-frameworks/item/framework/framework-history";
+import { module, test } from "qunit";
 
-import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from "../../../../../helpers/setup-intl-rendering";
 
 module('Integration | Component | Complementary certifications/Item/Framework | Framework history', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -16,22 +16,28 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
   test('it should display the framework history', async function (assert) {
     // given
     const frameworkHistory = [
-      { id: 456, startDate: new Date('2023-10-10'), expirationDate: '' },
-      { id: 123, startDate: new Date('2020-01-01'), expirationDate: new Date('2023-10-10') },
+      {
+        id: 456,
+        startDate: new Date('2023-10-10'),
+        expirationDate: null,
+        assessmentDuration: 90,
+        maximumAssessmentLength: 32,
+        status: 'ACTIVE',
+      },
+      {
+        id: 123,
+        startDate: new Date('2020-01-01'),
+        expirationDate: new Date('2021-06-15'),
+        assessmentDuration: 105,
+        maximumAssessmentLength: 32,
+        status: 'ARCHIVED',
+      },
     ];
 
     // when
     const screen = await render(<template><FrameworkHistory @history={{frameworkHistory}} /></template>);
 
     // then
-    assert
-      .dom(
-        screen.getByRole('heading', {
-          name: t('components.complementary-certifications.item.framework.history.title'),
-        }),
-      )
-      .exists();
-
     assert
       .dom(
         screen.getByRole('table', {
@@ -42,11 +48,16 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
     assert.strictEqual(screen.getAllByRole('row').length, frameworkHistory.length + 1);
 
-    assert.dom(screen.getByRole('cell', { name: frameworkHistory[0].id })).exists();
-    assert.strictEqual(screen.getAllByRole('cell', { name: intl.formatDate(frameworkHistory[0].startDate) }).length, 2);
-    assert.dom(screen.getByRole('cell', { name: frameworkHistory[0].expirationDate })).exists();
+    assert.dom(screen.getByRole('cell', { name: `${frameworkHistory[0].id}` })).exists();
+    assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkHistory[0].startDate) })).exists();
+    assert
+      .dom(screen.getByText(t('components.complementary-certifications.item.framework.history.statuses.ACTIVE')))
+      .hasClass('pix-tag--success');
 
-    assert.dom(screen.getByRole('cell', { name: frameworkHistory[1].id })).exists();
+    assert.dom(screen.getByRole('cell', { name: `${frameworkHistory[1].id}` })).exists();
     assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkHistory[1].startDate) })).exists();
+    assert
+      .dom(screen.getByText(t('components.complementary-certifications.item.framework.history.statuses.ARCHIVED')))
+      .hasClass('pix-tag--secondary');
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -1,8 +1,8 @@
-import { render } from "@1024pix/ember-testing-library";
-import FrameworkHistory from "pix-admin/components/certification-frameworks/item/framework/framework-history";
-import { module, test } from "qunit";
+import { render } from '@1024pix/ember-testing-library';
+import FrameworkHistory from 'pix-admin/components/certification-frameworks/item/framework/framework-history';
+import { module, test } from 'qunit';
 
-import setupIntlRenderingTest, { t } from "../../../../../helpers/setup-intl-rendering";
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Complementary certifications/Item/Framework | Framework history', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
@@ -4,76 +4,70 @@ import { module, test } from 'qunit';
 
 import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | complementary-certifications/item/header', function (hooks) {
+module('Integration | Component | certification-frameworks/item/header', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when the framework is CORE', function () {
-    test('it should display CORE label in breadcrumb', async function (assert) {
-      // when
-      const screen = await render(<template><Header /></template>);
+  let store;
 
-      // then
-      const nav = screen.getByRole('navigation');
-      assert.ok(within(nav).getByText(t('components.certification-frameworks.labels.CORE')));
-    });
-
-    test('it should display "Référentiel de certification" as title', async function (assert) {
-      // when
-      const screen = await render(<template><Header /></template>);
-
-      // then
-      const expectedTitle = `${t('components.complementary-certifications.item.certification-framework')} ${t('components.certification-frameworks.labels.CORE')}`;
-      assert.ok(screen.getByRole('heading', { name: expectedTitle, level: 1 }));
-    });
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
   });
 
-  module('when the framework is a complementary', function () {
-    module('when hasComplementaryReferential is true', function () {
-      test('it should display "Référentiel de certification" as title', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const complementaryCertification = store.createRecord('complementary-certification', {
-          id: '0',
-          key: 'DROIT',
-          label: 'Pix+Droit',
-          hasComplementaryReferential: true,
-        });
+  test('it should display the framework label in breadcrumb and title', async function (assert) {
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: false };
+    const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
+    // when
+    const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
 
-        // when
-        const screen = await render(
-          <template><Header @complementaryCertification={{complementaryCertification}} /></template>,
-        );
+    // then
+    const nav = screen.getByRole('navigation');
+    assert.ok(within(nav).getByRole('link', { name: t('components.layout.sidebar.certification-frameworks') }));
+    assert.ok(screen.getByRole('heading', { name: t('components.certification-frameworks.labels.DROIT'), level: 1 }));
+  });
 
-        // then
-        const expectedTitle = `${t('components.complementary-certifications.item.certification-framework')} ${complementaryCertification.label}`;
-        assert.ok(screen.getByRole('heading', { name: expectedTitle, level: 1 }));
-        const nav = screen.getByRole('navigation');
-        assert.ok(within(nav).getByRole('link', { name: t('components.layout.sidebar.certification-frameworks') }));
-      });
+  module('#canCreateVersion', function () {
+    test('it should display the create button when user is super admin and framework is not CLEA', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
+
+      // when
+      const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
+
+      // then
+      assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
     });
 
-    module('when hasComplementaryReferential is false', function () {
-      test('it should display "Profil cible" as title', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const complementaryCertification = store.createRecord('complementary-certification', {
-          id: '0',
-          key: 'CLEA',
-          label: 'CléA Numérique',
-          hasComplementaryReferential: false,
-        });
+    test('it should not display the create button when user is not super admin', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: false };
+      const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
 
-        // when
-        const screen = await render(
-          <template><Header @complementaryCertification={{complementaryCertification}} /></template>,
-        );
+      // when
+      const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
 
-        // then
-        const expectedTitle = `${t('components.complementary-certifications.item.target-profile')} ${complementaryCertification.label}`;
-        assert.ok(screen.getByRole('heading', { name: expectedTitle, level: 1 }));
-        const nav = screen.getByRole('navigation');
-        assert.ok(within(nav).getByRole('link', { name: t('components.layout.sidebar.certification-frameworks') }));
-      });
+      // then
+      assert
+        .dom(screen.queryByText(t('components.complementary-certifications.item.framework.create-button')))
+        .doesNotExist();
+    });
+
+    test('it should not display the create button for CLEA even if user is super admin', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const cleaFramework = store.createRecord('certification-framework', { id: 'CLEA', name: 'CLEA' });
+
+      // when
+      const screen = await render(<template><Header @certificationFramework={{cleaFramework}} /></template>);
+
+      // then
+      assert
+        .dom(screen.queryByText(t('components.complementary-certifications.item.framework.create-button')))
+        .doesNotExist();
     });
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/target-profile-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/target-profile-test.gjs
@@ -50,7 +50,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
 
       assert
         .dom(
-          screen.getByRole('heading', {
+          screen.getByRole('button', {
             name: t('components.complementary-certifications.target-profiles.history-list.title'),
           }),
         )
@@ -100,11 +100,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       assert.dom(screen.queryByText('Badge Volcan')).doesNotExist();
 
       assert
-        .dom(
-          screen.queryByRole('heading', {
-            name: t('components.complementary-certifications.target-profiles.history-list.title'),
-          }),
-        )
+        .dom(screen.getByText(t('components.complementary-certifications.target-profiles.history-list.title')))
         .exists();
     });
   });

--- a/admin/tests/integration/components/certification-frameworks/item/target-profile/history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/target-profile/history-test.gjs
@@ -1,42 +1,65 @@
-import { render, within } from '@1024pix/ember-testing-library';
-import History from 'pix-admin/components/certification-frameworks/item/target-profile/history';
-import { module, test } from 'qunit';
+import { render, within } from "@1024pix/ember-testing-library";
+import { click } from "@ember/test-helpers";
+import History from "pix-admin/components/certification-frameworks/item/target-profile/history";
+import { module, test } from "qunit";
 
-import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from "../../../../../helpers/setup-intl-rendering";
 
-module('Integration | Component | complementary-certifications/item/target-profile/history', function (hooks) {
+module('Integration | Component | certification-frameworks/item/target-profile/history', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test("it should display history for complementary certification's target profiles", async function (assert) {
+  test("it should display history for framework's target profiles", async function (assert) {
     // given
-    const store = this.owner.lookup('service:store');
-    const complementaryCertification = store.createRecord('complementary-certification', {
-      targetProfilesHistory: [
-        { id: '1023', name: 'Target Cascade', attachedAt: new Date('2023-10-10T10:50:00Z'), detachedAt: null },
-        {
-          id: '1025',
-          name: 'Target Volcan',
-          attachedAt: new Date('2019-10-08T10:50:00Z'),
-          detachedAt: new Date('2020-10-08T10:50:00Z'),
-        },
-      ],
-    });
+    const targetProfilesHistory = [
+      { id: '1023', name: 'Target Cascade', attachedAt: new Date('2023-10-10T10:50:00Z'), detachedAt: null },
+      {
+        id: '1025',
+        name: 'Target Volcan',
+        attachedAt: new Date('2019-10-08T10:50:00Z'),
+        detachedAt: new Date('2020-10-08T10:50:00Z'),
+      },
+    ];
 
     // when
-    const screen = await render(
-      <template><History @targetProfilesHistory={{complementaryCertification.targetProfilesHistory}} /></template>,
+    const screen = await render(<template><History @targetProfilesHistory={{targetProfilesHistory}} /></template>);
+    await click(
+      screen.getByRole('button', {
+        name: t('components.complementary-certifications.target-profiles.history-list.title'),
+      }),
     );
 
     // then
     const table = screen.getByRole('table', {
       name: t('components.complementary-certifications.target-profiles.history-list.caption'),
     });
-    assert.dom(within(table).getByRole('columnheader', { name: 'Nom du profil cible' })).exists();
-    assert.dom(within(table).getByRole('columnheader', { name: 'Date de rattachement' })).exists();
-    assert.dom(within(table).getByRole('columnheader', { name: 'Date de détachement' })).exists();
-    assert.dom(within(table).getByRole('row', { name: 'Target Cascade 10/10/2023 -' })).exists();
-    assert.dom(within(table).getByRole('row', { name: 'Target Volcan 08/10/2019 08/10/2020' })).exists();
-    assert.dom(within(table).getByRole('link', { name: 'Target Cascade' })).exists();
-    assert.dom(within(table).getByRole('link', { name: 'Target Volcan' })).exists();
+    assert
+      .dom(
+        within(table).getByRole('columnheader', {
+          name: t('components.complementary-certifications.target-profiles.history-list.headers.name'),
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        within(table).getByRole('columnheader', {
+          name: t('components.complementary-certifications.target-profiles.history-list.headers.attached-at'),
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        within(table).getByRole('columnheader', {
+          name: t('components.complementary-certifications.target-profiles.history-list.headers.detached-at'),
+        }),
+      )
+      .exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Target Cascade' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Target Volcan' })).exists();
+    assert.strictEqual(
+      within(table).getAllByRole('button', {
+        name: t('components.complementary-certifications.target-profiles.history-list.actions.view'),
+      }).length,
+      2,
+    );
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/target-profile/history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/target-profile/history-test.gjs
@@ -1,9 +1,9 @@
-import { render, within } from "@1024pix/ember-testing-library";
-import { click } from "@ember/test-helpers";
-import History from "pix-admin/components/certification-frameworks/item/target-profile/history";
-import { module, test } from "qunit";
+import { render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import History from 'pix-admin/components/certification-frameworks/item/target-profile/history';
+import { module, test } from 'qunit';
 
-import setupIntlRenderingTest, { t } from "../../../../../helpers/setup-intl-rendering";
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | certification-frameworks/item/target-profile/history', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/admin/tests/mirage/factories/certification-framework.js
+++ b/admin/tests/mirage/factories/certification-framework.js
@@ -2,16 +2,7 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   name() {
-    const nameMap = {
-      CORE: 'Pix',
-      DROIT: 'Pix+ Droit',
-      EDU_1ER_DEGRE: 'Pix+ Edu 1er degré',
-      EDU_2ND_DEGRE: 'Pix+ Edu 2nd degré',
-      EDU_CPE: 'Pix+ Edu CPE',
-      PRO_SANTE: 'Pix+ Pro Santé',
-      CLEA: 'CléA Numérique',
-    };
-    return nameMap[this.id] || 'Pix';
+    return this.id;
   },
 
   activeVersionStartDate() {

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -597,6 +597,20 @@ export default function routes() {
     return schema.certificationConsolidatedFrameworks.find(request.params.scope);
   });
 
+  this.get('admin/certification-frameworks/:scope/target-profiles', (schema, request) => {
+    const framework = schema.certificationFrameworks.findBy({ name: request.params.scope });
+    return {
+      data: {
+        id: request.params.scope,
+        type: 'certification-frameworks',
+        attributes: {
+          name: request.params.scope,
+          'target-profiles-history': framework?.targetProfilesHistory ?? [],
+        },
+      },
+    };
+  });
+
   this.get('admin/certification-frameworks/:scope/framework-history', (_, request) => {
     return {
       data: {

--- a/admin/tests/unit/routes/authenticated/certification-frameworks/item-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-frameworks/item-test.js
@@ -1,0 +1,70 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/certification-frameworks/item', function (hooks) {
+  setupTest(hooks);
+
+  let route;
+  let store;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/certification-frameworks/item');
+    store = this.owner.lookup('service:store');
+    store.peekAll = sinon.stub();
+    store.findAll = sinon.stub();
+  });
+
+  module('model()', function () {
+    module('when the framework is CLEA', function () {
+      test('it should load complementary-certification and set hasTargetProfilesHistory to true', async function (assert) {
+        // given
+        const cleaFramework = { name: 'CLEA' };
+        const cleaComplementary = { key: 'CLEA' };
+        store.peekAll.withArgs('certification-framework').returns([cleaFramework]);
+        store.peekAll.withArgs('complementary-certification').returns([cleaComplementary]);
+        store.findAll.withArgs('complementary-certification').resolves([cleaComplementary]);
+
+        // when
+        const result = await route.model({ certification_framework_key: 'CLEA' });
+
+        // then
+        assert.ok(store.findAll.calledWith('complementary-certification'));
+        assert.strictEqual(result.currentComplementaryCertification, cleaComplementary);
+        assert.true(result.hasTargetProfilesHistory);
+      });
+    });
+
+    module('when the framework is CORE', function () {
+      test('it should not load complementary-certification and set hasTargetProfilesHistory to false', async function (assert) {
+        // given
+        const coreFramework = { name: 'CORE' };
+        store.peekAll.withArgs('certification-framework').returns([coreFramework]);
+
+        // when
+        const result = await route.model({ certification_framework_key: 'CORE' });
+
+        // then
+        assert.notOk(store.findAll.called);
+        assert.strictEqual(result.currentComplementaryCertification, undefined);
+        assert.false(result.hasTargetProfilesHistory);
+      });
+    });
+
+    module('when the framework is neither CORE nor CLEA', function () {
+      test('it should not load complementary-certification and set hasTargetProfilesHistory to true', async function (assert) {
+        // given
+        const droitFramework = { name: 'DROIT' };
+        store.peekAll.withArgs('certification-framework').returns([droitFramework]);
+
+        // when
+        const result = await route.model({ certification_framework_key: 'DROIT' });
+
+        // then
+        assert.notOk(store.findAll.called);
+        assert.strictEqual(result.currentComplementaryCertification, undefined);
+        assert.true(result.hasTargetProfilesHistory);
+      });
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -631,11 +631,24 @@
           },
           "history": {
             "label": "Versions",
+            "statuses": {
+              "ACTIVE": "Active",
+              "ARCHIVED": "Archived",
+              "DRAFT": "Draft"
+            },
             "table": {
               "caption": "Versions list in descending order",
+              "actions": {
+                "delete": "Delete version",
+                "view": "View version details"
+              },
               "columns": {
+                "actions": "Actions",
+                "assessment-duration": "Duration (min)",
                 "expiration-date": "Expiration date",
+                "maximum-assessment-length": "Nb of questions",
                 "start-date": "Start date",
+                "status": "Status",
                 "version-id": "Version ID"
               }
             },
@@ -663,10 +676,14 @@
         },
         "history-list": {
           "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
+          "actions": {
+            "view": "View target profile"
+          },
           "headers": {
-            "attached-at": "Date de rattachement",
-            "detached-at": "Date de détachement",
-            "name": "Nom du profil cible"
+            "actions": "Actions",
+            "attached-at": "Attachment date",
+            "detached-at": "Detachment date",
+            "name": "Internal name"
           },
           "title": "Historique des profils cibles rattachés"
         }

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -639,6 +639,7 @@
             "table": {
               "actions": {
                 "delete": "Delete version",
+                "edit": "Edit version",
                 "view": "View version details"
               },
               "caption": "Versions list in descending order",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -637,11 +637,11 @@
               "DRAFT": "Draft"
             },
             "table": {
-              "caption": "Versions list in descending order",
               "actions": {
                 "delete": "Delete version",
                 "view": "View version details"
               },
+              "caption": "Versions list in descending order",
               "columns": {
                 "actions": "Actions",
                 "assessment-duration": "Duration (min)",
@@ -675,10 +675,10 @@
           "title": "Badges certifiés du profil cible actuel"
         },
         "history-list": {
-          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
           "actions": {
             "view": "View target profile"
           },
+          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
           "headers": {
             "actions": "Actions",
             "attached-at": "Attachment date",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -647,6 +647,7 @@
             "table": {
               "actions": {
                 "delete": "Supprimer la version",
+                "edit": "Éditer la version",
                 "view": "Voir les détails de la version"
               },
               "caption": "Liste des versions par ordre décroissant",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -639,11 +639,24 @@
           },
           "history": {
             "label": "Versions",
+            "statuses": {
+              "ACTIVE": "Actif",
+              "ARCHIVED": "Archivé",
+              "DRAFT": "En cours d'édition"
+            },
             "table": {
               "caption": "Liste des versions par ordre décroissant",
+              "actions": {
+                "delete": "Supprimer la version",
+                "view": "Voir les détails de la version"
+              },
               "columns": {
+                "actions": "Actions",
+                "assessment-duration": "Durée (min)",
                 "expiration-date": "Date d'expiration",
-                "start-date": "Date de début",
+                "maximum-assessment-length": "Nombre de questions",
+                "start-date": "Date d'activation",
+                "status": "Statut",
                 "version-id": "ID de version"
               }
             },
@@ -671,12 +684,16 @@
         },
         "history-list": {
           "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
+          "actions": {
+            "view": "Voir le profil cible"
+          },
           "headers": {
+            "actions": "Actions",
             "attached-at": "Date de rattachement",
             "detached-at": "Date de détachement",
-            "name": "Nom du profil cible"
+            "name": "Nom interne"
           },
-          "title": "Historique des profils cibles rattachés"
+          "title": "Historique des profils cibles"
         }
       },
       "title": "Tous les référentiels de certification"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -645,11 +645,11 @@
               "DRAFT": "En cours d'édition"
             },
             "table": {
-              "caption": "Liste des versions par ordre décroissant",
               "actions": {
                 "delete": "Supprimer la version",
                 "view": "Voir les détails de la version"
               },
+              "caption": "Liste des versions par ordre décroissant",
               "columns": {
                 "actions": "Actions",
                 "assessment-duration": "Durée (min)",
@@ -683,10 +683,10 @@
           "title": "Badges certifiés du profil cible actuel"
         },
         "history-list": {
-          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
           "actions": {
             "view": "Voir le profil cible"
           },
+          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
           "headers": {
             "actions": "Actions",
             "attached-at": "Date de rattachement",

--- a/api/src/certification/configuration/application/certification-framework-controller.js
+++ b/api/src/certification/configuration/application/certification-framework-controller.js
@@ -40,11 +40,20 @@ const createCertificationVersion = async function (request, h) {
     .code(201);
 };
 
+const getTargetProfileHistory = async function (request) {
+  const scope = request.params.scope;
+  const certificationFramework = await usecases.getComplementaryCertificationTargetProfileHistory({
+    complementaryCertificationKey: scope,
+  });
+  return certificationFrameworkSerializer.serializeWithTargetProfilesHistory(certificationFramework);
+};
+
 const certificationFrameworkController = {
   createCertificationVersion,
   findCertificationFrameworks,
   getActiveConsolidatedFramework,
   getFrameworkHistory,
+  getTargetProfileHistory,
 };
 
 export { certificationFrameworkController };

--- a/api/src/certification/configuration/application/certification-framework-route.js
+++ b/api/src/certification/configuration/application/certification-framework-route.js
@@ -95,6 +95,37 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/certification-frameworks/{scope}/target-profiles',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            scope: Joi.string()
+              .required()
+              .valid(...Object.values(SCOPES).filter((s) => s !== SCOPES.CORE)),
+          }),
+        },
+        handler: certificationFrameworkController.getTargetProfileHistory,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin, Support, Certif et Métier',
+          "Elle renvoie l'historique des profils cibles rattachés à un référentiel de certification.",
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/frameworks/{scope}/new-version',
       config: {

--- a/api/src/certification/configuration/infrastructure/serializers/certification-framework-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/certification-framework-serializer.js
@@ -7,3 +7,22 @@ export function serialize(frameworks) {
     attributes: ['name', 'activeVersionStartDate'],
   }).serialize(frameworks);
 }
+
+export function serializeWithTargetProfilesHistory(certificationFramework) {
+  return new Serializer('certification-framework', {
+    transform: function (record) {
+      const targetProfilesHistory = record.targetProfilesHistory ?? [];
+      return {
+        id: record.key,
+        name: record.key,
+        targetProfilesHistory: targetProfilesHistory.map((targetProfile) => ({
+          id: targetProfile.id,
+          name: targetProfile.name,
+          attachedAt: targetProfile.attachedAt,
+          detachedAt: targetProfile.detachedAt,
+        })),
+      };
+    },
+    attributes: ['name', 'targetProfilesHistory'],
+  }).serialize(certificationFramework);
+}

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -9,7 +9,7 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
-describe('Acceptance | Application | Certification | ComplementaryCertification | certification-framework-route', function () {
+describe('Acceptance | Application | Certification | Configuration | certification-framework-route', function () {
   let server;
   let superAdmin;
 
@@ -239,6 +239,70 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
               status: 'ARCHIVED',
             },
           ],
+        },
+      });
+    });
+  });
+
+  describe('GET /api/admin/certification-frameworks/{scope}/target-profiles', function () {
+    it('should return 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      const attachedAt = new Date('2019-01-01');
+      const scope = SCOPES.PIX_PLUS_DROIT;
+
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        id: 1,
+        label: 'Pix+ Droit',
+        hasExternalJury: true,
+        key: scope,
+      });
+
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ id: 999, name: 'Target' });
+
+      const badge = databaseBuilder.factory.buildBadge({
+        id: 198,
+        key: 'badge',
+        targetProfileId: targetProfile.id,
+      });
+
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        badgeId: badge.id,
+        label: 'badge label',
+        complementaryCertificationId: complementaryCertification.id,
+        createdAt: attachedAt,
+        minimumEarnedPix: 150,
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/certification-frameworks/${scope}/target-profiles`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: {
+          type: 'certification-frameworks',
+          id: scope,
+          attributes: {
+            name: scope,
+            'target-profiles-history': [
+              {
+                id: 999,
+                name: 'Target',
+                attachedAt,
+                detachedAt: null,
+              },
+            ],
+          },
         },
       });
     });

--- a/api/tests/certification/configuration/integration/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/integration/application/certification-framework-route_test.js
@@ -66,4 +66,37 @@ describe('Integration | Certification | Configuration | Application | Router | c
       });
     });
   });
+
+  describe('GET /api/admin/certification-frameworks/{scope}/target-profiles', function () {
+    describe('Error cases', function () {
+      let httpTestServer;
+
+      beforeEach(async function () {
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+      });
+
+      it('should return 400 when scope parameter is not valid', async function () {
+        sinon.stub(certificationFrameworkController, 'getTargetProfileHistory').returns('ok');
+
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/certification-frameworks/INVALID_SCOPE/target-profiles',
+        );
+
+        expect(response.statusCode).to.equal(400);
+      });
+      it('should return 400 when scope parameter is CORE', async function () {
+        sinon.stub(certificationFrameworkController, 'getTargetProfileHistory').returns('ok');
+
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/certification-frameworks/CORE/target-profiles',
+        );
+
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-framework-route_test.js
@@ -107,7 +107,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
     });
   });
 
-  describe('GET /api/admin/certification-frameworks/{complementaryCertificationKey}/framework-history', function () {
+  describe('GET /api/admin/certification-frameworks/{scope}/framework-history', function () {
     describe('when the user authenticated has no role', function () {
       it('should return 403 HTTP status code', async function () {
         // given
@@ -150,6 +150,54 @@ describe('Unit | Certification | Configuration | Application | Router | certific
           // then
           expect(response.statusCode).to.equal(200);
           sinon.assert.calledOnce(certificationFrameworkController.getFrameworkHistory);
+        });
+      });
+    });
+  });
+
+  describe('GET /api/admin/certification-frameworks/{scope}/target-profiles', function () {
+    describe('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(certificationFrameworkController, 'getTargetProfileHistory').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          `/api/admin/certification-frameworks/${SCOPES.PIX_PLUS_DROIT}/target-profiles`,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(certificationFrameworkController.getTargetProfileHistory);
+      });
+    });
+
+    const authorizedRoles = ['SuperAdmin', 'Certif', 'Metier', 'Support'];
+    authorizedRoles.forEach((role) => {
+      describe(`when the user has ${role} role`, function () {
+        it('should return 200 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, `checkAdminMemberHasRole${role}`).returns(true);
+          sinon.stub(certificationFrameworkController, 'getTargetProfileHistory').returns('ok');
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(
+            'GET',
+            `/api/admin/certification-frameworks/${SCOPES.PIX_PLUS_DROIT}/target-profiles`,
+          );
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          sinon.assert.calledOnce(certificationFrameworkController.getTargetProfileHistory);
         });
       });
     });

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/certification-framework-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/certification-framework-serializer_test.js
@@ -45,4 +45,45 @@ describe('Unit | Certification | Configuration | Serializer | certification-fram
       });
     });
   });
+  describe('#serializeWithTargetProfilesHistory', function () {
+    it('should serialize a certification framework with its target profiles history', function () {
+      // given
+      const certificationFramework = {
+        key: 'DROIT',
+        targetProfilesHistory: [
+          { id: 1, name: 'Profil A', attachedAt: new Date('2023-01-01'), detachedAt: null },
+          { id: 2, name: 'Profil B', attachedAt: new Date('2021-06-15'), detachedAt: new Date('2023-01-01') },
+        ],
+      };
+
+      // when
+      const serialized = certificationFrameworkSerializer.serializeWithTargetProfilesHistory(certificationFramework);
+
+      // then
+      expect(serialized).to.deep.equal({
+        data: {
+          type: 'certification-frameworks',
+          id: 'DROIT',
+          attributes: {
+            name: 'DROIT',
+            'target-profiles-history': [
+              { id: 1, name: 'Profil A', attachedAt: new Date('2023-01-01'), detachedAt: null },
+              { id: 2, name: 'Profil B', attachedAt: new Date('2021-06-15'), detachedAt: new Date('2023-01-01') },
+            ],
+          },
+        },
+      });
+    });
+
+    it('should serialize with an empty target profiles history when none exist', function () {
+      // given
+      const certificationFramework = { key: 'DROIT', targetProfilesHistory: null };
+
+      // when
+      const serialized = certificationFrameworkSerializer.serializeWithTargetProfilesHistory(certificationFramework);
+
+      // then
+      expect(serialized.data.attributes['target-profiles-history']).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
## 🌱 Problème

Dans le cadre des travaux de refonte des reférentiel de certification dans Pix Admin, on souhaite afficher une page présentant les différentes versions d'un référentiel ainsi que l'historique des profils cibles.

## 🐣 Proposition

Modifier la page existante selon les maquettes

_Maquette :_ 
<img width="1725" height="1191" alt="image-20260427-094325" src="https://github.com/user-attachments/assets/29790ad1-3dd7-47b2-bd4e-a122727afe32" />

_Nouvelle page :_ 
<img width="1862" height="958" alt="Capture d’écran du 2026-04-29 15-23-12" src="https://github.com/user-attachments/assets/a6d56f4f-d490-4468-ad83-3c1823e66614" />


## 🌷 Remarques

- Impacts visuels sur CléA (je pense que c'est mineur et que ça peut rester ainsi) :
_Sur dev :_ 
<img width="1862" height="1120" alt="Capture d’écran du 2026-04-29 17-20-16" src="https://github.com/user-attachments/assets/8aecadc3-1266-4fd2-9f50-d3475c8e6875" />

_Sur cette branche :_ 
<img width="1862" height="1120" alt="Capture d’écran du 2026-04-29 17-19-48" src="https://github.com/user-attachments/assets/d0f64406-33f8-4155-8374-d9becd0057cc" />

- J'ai profité de cette PR pour retirer de nombreux appels obsolètes vers complementary-certification, mais sans pouvoir supprimer la route, encore utilisée par CléA
- Les bouton "Afficher" et "Supprimer" des versions ne fonctionnent pas actuellement, à faire dans une prochaine PR

## 🐝 Pour tester

J'ai modifié ma BDD en local pour créer des versions de différents statuts