### PR TITLE
[BUGFIX] Safari >=26.4 : Problème si 2 épreuves successives de même type (PIX-22597)

### DIFF
--- a/mon-pix/app/templates/assessments/challenge.gjs
+++ b/mon-pix/app/templates/assessments/challenge.gjs
@@ -1,3 +1,4 @@
+import { array } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AssessmentBanner from 'mon-pix/components/assessment-banner';
@@ -70,22 +71,25 @@ import TimedChallengeInstructions from 'mon-pix/components/timed-challenge-instr
       {{/if}}
 
       {{#if @controller.displayChallenge}}
-        <Content
-          @answer={{@model.answer}}
-          @assessment={{@model.assessment}}
-          @challenge={{@model.challenge}}
-          @focusedOutOfWindow={{@controller.focusedOutOfWindow}}
-          @hasFocusedOutOfWindow={{@controller.hasFocusedOutOfWindow}}
-          @hideOutOfFocusBorder={{@controller.hideOutOfFocusBorder}}
-          @isFocusedChallengeAndUserHasFocusedOutOfChallenge={{@controller.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
-          @isTextToSpeechActivated={{@controller.isTextToSpeechActivated}}
-          @resetAllChallengeInfo={{@controller.resetAllChallengeInfo}}
-          @resetChallengeInfoOnResume={{@controller.resetChallengeInfoOnResume}}
-          @setFocusedOutOfChallenge={{@controller.setFocusedOutOfChallenge}}
-          @showOutOfFocusBorder={{@controller.showOutOfFocusBorder}}
-          @submitLiveAlert={{@controller.submitLiveAlert}}
-          @timeoutChallenge={{@controller.timeoutChallenge}}
-        />
+        {{! SAFARI >=26.4 WORKAROUND: forces unmount/mount of content when challenge changes }}
+        {{#each (array @model.challenge)}}
+          <Content
+            @answer={{@model.answer}}
+            @assessment={{@model.assessment}}
+            @challenge={{@model.challenge}}
+            @focusedOutOfWindow={{@controller.focusedOutOfWindow}}
+            @hasFocusedOutOfWindow={{@controller.hasFocusedOutOfWindow}}
+            @hideOutOfFocusBorder={{@controller.hideOutOfFocusBorder}}
+            @isFocusedChallengeAndUserHasFocusedOutOfChallenge={{@controller.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
+            @isTextToSpeechActivated={{@controller.isTextToSpeechActivated}}
+            @resetAllChallengeInfo={{@controller.resetAllChallengeInfo}}
+            @resetChallengeInfoOnResume={{@controller.resetChallengeInfoOnResume}}
+            @setFocusedOutOfChallenge={{@controller.setFocusedOutOfChallenge}}
+            @showOutOfFocusBorder={{@controller.showOutOfFocusBorder}}
+            @submitLiveAlert={{@controller.submitLiveAlert}}
+            @timeoutChallenge={{@controller.timeoutChallenge}}
+          />
+        {{/each}}
       {{/if}}
     </main>
 


### PR DESCRIPTION
## 🌱 Problème

À partir de la version 26.4 de Safari, si un utilisateur rencontre 2 épreuves successives du même type, l’état des composants d’affichage de l’épreuve ne se réinitialise pas bien, ce qui se manifeste par différents problèmes :
 - Le bouton Valider reste à l’état de chargement
 - Si l’utilisateur fait Précédent, puis Poursuivre, puis répond à la 2ème épreuve, une réponse incohérente peut être soumise

## 🐣 Proposition

Forcer la réinitialisation des composants d’affichage de l’épreuve lorsqu’on change d’épreuve.

## 🌷 Remarques

N/A

## 🐝 Pour tester

En utilisant Safari v26.4, passer le test statique suivant : https://app-pr16069.review.pix.fr/courses/coursePr16069
