### PR TITLE
[TECH] Ajoute un rapport de tests au job de test d'audit logger de la CI.

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -736,9 +736,9 @@ jobs:
             PIX_API_CLIENT_SECRET: $2a$04$vkPRiypzeVQVG92/dCll7.5brjDQZVZc750VwKBc01icXjVIQqRVq
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
       - store_test_results:
-          path: /home/circleci/test-results
+          path: ./test-results
       - store_artifacts:
-          path: /home/circleci/test-results
+          path: ./test-results
 
   # ---------------------------------------------------------------------------
   # Mon Pix

--- a/audit-logger/vitest.config.ts
+++ b/audit-logger/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    reporters: process.env.CI ? 'junit' : 'default',
+    outputFile: process.env.CI ? './test-results/report.xml' : undefined,
     globals: true,
     clearMocks: true,
     watch: false,

--- a/audit-logger/vitest.config.ts
+++ b/audit-logger/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    reporters: process.env.CI ? 'junit' : 'default',
+    reporters: ['default', process.env.CI ? 'junit' : {}],
     outputFile: process.env.CI ? './test-results/report.xml' : undefined,
     globals: true,
     clearMocks: true,

--- a/audit-logger/vitest.config.ts
+++ b/audit-logger/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     clearMocks: true,
     watch: false,
     pool: 'threads',
-    poolOptions: { threads: { singleThread: true } },
+    maxWorkers: 1,
+    isolate: false,
   },
 });


### PR DESCRIPTION
## 🌱 Problème

En regardant pourquoi le job de test d'Audit logger était rouge (https://app.circleci.com/pipelines/gh/1024pix/pix/170257/workflows/7232e014-4078-4685-9e18-415b50ba6b49/jobs/1926102/steps), j'ai constaté que les tests ne généraient pas de rapport de test compatible avec CircleCI, ce qui rend moins simple la compréhension de quel test a échoué.


## 🐣 Proposition

On spécifie, dans le fichier `vitest.config.js`, un reporter et un ouput de type `report.xml` uniquement lors d'une éxécution des tests par la CI.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌷 Remarques

On en profite pour corriger un warning lié à la migration vers vitest v4:
https://vitest.dev/guide/migration.html#pool-rework

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

Se rendre sur le job de tests d'Audit logger et vérifier que l'onglet `Tests` affiche un rapport.

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
