### PR TITLE
[FEATURE] Ajouter les filtres nom, domaines, compétences (pix-22347) 

### DIFF
--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -10,16 +10,16 @@ export default class CourseCard extends Component {
     switch (this.args.course.type) {
       case 'blueprint': {
         return {
-          color: 'green',
+          color: 'yellow',
           label: 'pages.catalogue.card.tag.blueprint',
-          image: 'https://assets.pix.org/sites/orga/parcours-apprenant.png',
+          image: 'https://assets.pix.org/sites/orga/combined-course.png',
         };
       }
       default: {
         return {
           color: 'blue',
           label: 'pages.catalogue.card.tag.target-profile',
-          image: 'https://assets.pix.org/sites/orga/profile-cible.png',
+          image: 'https://assets.pix.org/sites/orga/target-profile.png',
         };
       }
     }

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -23,14 +23,14 @@ export default class List extends Component {
   }
 
   get categoriesOptions() {
-    return [...new Set(this.filteredItems.flatMap((item) => (item.category ? item.category : [])))].map((item) => ({
+    return [...new Set(this.args.courses.flatMap((item) => (item.category ? item.category : [])))].map((item) => ({
       label: this.intl.t(`pages.campaign-creation.tags.${item}`),
       value: item,
     }));
   }
 
   get areasOptions() {
-    return [...new Set(this.filteredItems.flatMap((item) => (item.areas ? item.areas : [])))]
+    return [...new Set(this.args.courses.flatMap((item) => (item.areas ? item.areas : [])))]
       .sort((a, b) => a.code.localeCompare(b.code, this.locale.currentLanguage, { numeric: true }))
       .map((area) => ({
         label: `${area.code}. ${area.title}`,
@@ -41,7 +41,7 @@ export default class List extends Component {
   get competencesOptions() {
     return [
       ...new Set(
-        this.filteredItems
+        this.args.courses
           .flatMap((item) => (item.areas ? item.areas : []))
           .flatMap((area) => (area.competences ? area.sortedCompetences : [])),
       ),

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -1,21 +1,57 @@
+import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
+import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
 import CourseCard from 'pix-orga/components/catalogue/course-card';
 import EmptyState from 'pix-orga/components/ui/empty-state';
+import ENV from 'pix-orga/config/environment';
 
 export default class List extends Component {
-  get filteredItems() {
-    const { type } = this.args;
+  @service locale;
+  @service intl;
 
-    if (!type || type === 'all') {
-      return this.args.courses;
-    }
-    return this.args.courses.filter((item) => item.type === type);
+  isClearFiltersButtonDisabled() {
+    return !this.args.search;
+  }
+
+  get categories() {
+    return [...new Set(this.filteredItems.flatMap((item) => (item.category ? item.category : [])))].map((item) => ({
+      label: this.intl.t(`pages.campaign-creation.tags.${item}`),
+      value: item,
+    }));
+  }
+
+  get filteredItems() {
+    const { type = 'all', search = '', categories } = this.args;
+    return this.args.courses
+      .filter((item) => {
+        if (type && type !== 'all') {
+          return item.type === type;
+        }
+        return true;
+      })
+      .filter((item) => {
+        if (search.length > 0) {
+          return new RegExp(search, 'i').test(item.name);
+        }
+        return true;
+      })
+      .filter((item) => {
+        if (categories?.length > 0) {
+          return categories.includes(item.category);
+        }
+        return true;
+      });
   }
 
   <template>
+    {{log this.categories}}
     <div class="catalogue">
       <PixTabs @variant="orga" class="catalogue__nav" @ariaLabel={{t "pages.catalogue.tab-filters.label"}}>
         <LinkTo @route="authenticated.catalogue.list" @model="all">
@@ -27,7 +63,42 @@ export default class List extends Component {
             "pages.catalogue.tab-filters.blueprints"
           }}</LinkTo>
       </PixTabs>
+      <PixFilterBanner
+        class="catalogue__filters"
+        @title={{t "common.filters.title"}}
+        aria-label={{t "pages.catalogue.filters.aria-label"}}
+        @details={{t "pages.catalogue.filters.nb-result" count=this.filteredItems.length}}
+        @clearFiltersLabel={{t "common.filters.actions.clear"}}
+        @onClearFilters={{@resetFilter}}
+        @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
+      >
 
+        <PixSearchInput
+          @id="search"
+          value={{@search}}
+          @screenReaderOnly={{true}}
+          @placeholder={{t "pages.catalogue.filters.name.placeholder"}}
+          @debounceTimeInMs={{ENV.pagination.debounce}}
+          @triggerFiltering={{@updateFilter}}
+        >
+          <:label>{{t "pages.catalogue.filters.name.label"}}</:label>
+        </PixSearchInput>
+
+        <PixMultiSelect
+          @isDisabled={{eq this.categories.length 0}}
+          @placeholder={{t "pages.catalogue.filters.categories.label"}}
+          @screenReaderOnly={{true}}
+          @emptyMessage={{t "pages.catalogue.filters.categories.empty"}}
+          @isSearchable={{false}}
+          @locale={{this.locale.currentLocale}}
+          @values={{@categories}}
+          @options={{this.categories}}
+          @onChange={{fn @updateFilter "categories"}}
+        >
+          <:label>{{t "pages.catalogue.filters.categories.label"}}</:label>
+          <:default as |option|>{{option.label}}</:default>
+        </PixMultiSelect>
+      </PixFilterBanner>
       {{#if this.filteredItems}}
         <div class="catalogue__list">
           {{#each this.filteredItems as |course|}}

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -16,19 +16,45 @@ export default class List extends Component {
   @service locale;
   @service intl;
 
-  isClearFiltersButtonDisabled() {
-    return !this.args.search;
+  get isClearFiltersButtonDisabled() {
+    const { search = '', categories, areas, competences } = this.args;
+    return !search && !categories?.length && !areas?.length && !competences?.length;
   }
 
-  get categories() {
+  get categoriesOptions() {
     return [...new Set(this.filteredItems.flatMap((item) => (item.category ? item.category : [])))].map((item) => ({
       label: this.intl.t(`pages.campaign-creation.tags.${item}`),
       value: item,
     }));
   }
 
+  get areasOptions() {
+    return [...new Set(this.filteredItems.flatMap((item) => (item.areas ? item.areas : [])))]
+      .sort((a, b) => a.code.localeCompare(b.code, this.locale.currentLanguage, { numeric: true }))
+      .map((area) => ({
+        label: `${area.code}. ${area.title}`,
+        value: area.id,
+      }));
+  }
+
+  get competencesOptions() {
+    return [
+      ...new Set(
+        this.filteredItems
+          .flatMap((item) => (item.areas ? item.areas : []))
+          .flatMap((area) => (area.competences ? area.sortedCompetences : [])),
+      ),
+    ]
+      .sort((a, b) => a.index.localeCompare(b.index, this.locale.currentLanguage, { numeric: true }))
+      .map((competence) => ({
+        label: `${competence.index} ${competence.name}`,
+        value: competence.id,
+      }));
+  }
+
   get filteredItems() {
-    const { type = 'all', search = '', categories } = this.args;
+    const { type = 'all', search = '', categories, areas, competences } = this.args;
+
     return this.args.courses
       .filter((item) => {
         if (type && type !== 'all') {
@@ -38,7 +64,7 @@ export default class List extends Component {
       })
       .filter((item) => {
         if (search.length > 0) {
-          return new RegExp(search, 'i').test(item.name);
+          return item.name.toLowerCase().includes(search.toLowerCase());
         }
         return true;
       })
@@ -47,11 +73,26 @@ export default class List extends Component {
           return categories.includes(item.category);
         }
         return true;
+      })
+      .filter((item) => {
+        if (areas?.length > 0) {
+          const itemAreaIds = item.areas.map((area) => area.id);
+          return areas.every((area) => itemAreaIds.includes(area));
+        }
+        return true;
+      })
+      .filter((item) => {
+        if (competences?.length > 0) {
+          const itemCompetenceIds = item.areas
+            .flatMap((area) => (area.competences ? area.get('competences') : []))
+            .map((competence) => competence.id);
+          return competences.every((competence) => itemCompetenceIds.includes(competence));
+        }
+        return true;
       });
   }
 
   <template>
-    {{log this.categories}}
     <div class="catalogue">
       <PixTabs @variant="orga" class="catalogue__nav" @ariaLabel={{t "pages.catalogue.tab-filters.label"}}>
         <LinkTo @route="authenticated.catalogue.list" @model="all">
@@ -69,15 +110,14 @@ export default class List extends Component {
         aria-label={{t "pages.catalogue.filters.aria-label"}}
         @details={{t "pages.catalogue.filters.nb-result" count=this.filteredItems.length}}
         @clearFiltersLabel={{t "common.filters.actions.clear"}}
-        @onClearFilters={{@resetFilter}}
+        @onClearFilters={{@resetFilters}}
         @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
       >
-
         <PixSearchInput
           @id="search"
           value={{@search}}
-          @screenReaderOnly={{true}}
           @placeholder={{t "pages.catalogue.filters.name.placeholder"}}
+          @screenReaderOnly={{true}}
           @debounceTimeInMs={{ENV.pagination.debounce}}
           @triggerFiltering={{@updateFilter}}
         >
@@ -96,6 +136,34 @@ export default class List extends Component {
           @onChange={{fn @updateFilter "categories"}}
         >
           <:label>{{t "pages.catalogue.filters.categories.label"}}</:label>
+          <:default as |option|>{{option.label}}</:default>
+        </PixMultiSelect>
+
+        <PixMultiSelect
+          @isDisabled={{eq this.areasOptions.length 0}}
+          @emptyMessage={{t "pages.catalogue.filters.areas.empty"}}
+          @screenReaderOnly={{true}}
+          @locale={{this.locale.currentLocale}}
+          @values={{@areas}}
+          @options={{this.areasOptions}}
+          @onChange={{fn @updateFilter "areas"}}
+        >
+          <:label>{{t "pages.catalogue.filters.areas.label"}}</:label>
+          <:placeholder>{{t "pages.catalogue.filters.areas.placeholder" count=@areas.length}}</:placeholder>
+          <:default as |option|>{{option.label}}</:default>
+        </PixMultiSelect>
+
+        <PixMultiSelect
+          @isDisabled={{eq this.competencesOptions.length 0}}
+          @emptyMessage={{t "pages.catalogue.filters.competences.empty"}}
+          @screenReaderOnly={{true}}
+          @locale={{this.locale.currentLocale}}
+          @values={{@competences}}
+          @options={{this.competencesOptions}}
+          @onChange={{fn @updateFilter "competences"}}
+        >
+          <:label>{{t "pages.catalogue.filters.competences.label"}}</:label>
+          <:placeholder>{{t "pages.catalogue.filters.competences.placeholder" count=@competences.length}}</:placeholder>
           <:default as |option|>{{option.label}}</:default>
         </PixMultiSelect>
       </PixFilterBanner>

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -1,6 +1,7 @@
 import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
@@ -17,8 +18,8 @@ export default class List extends Component {
   @service intl;
 
   get isClearFiltersButtonDisabled() {
-    const { search = '', categories, areas, competences } = this.args;
-    return !search && !categories?.length && !areas?.length && !competences?.length;
+    const { search = '', category, areas, competences } = this.args;
+    return !search && !category && !areas?.length && !competences?.length;
   }
 
   get categoriesOptions() {
@@ -53,7 +54,7 @@ export default class List extends Component {
   }
 
   get filteredItems() {
-    const { type = 'all', search = '', categories, areas, competences } = this.args;
+    const { type = 'all', search = '', category, areas, competences } = this.args;
 
     return this.args.courses
       .filter((item) => {
@@ -69,8 +70,8 @@ export default class List extends Component {
         return true;
       })
       .filter((item) => {
-        if (categories?.length > 0) {
-          return categories.includes(item.category);
+        if (category) {
+          return category === item.category;
         }
         return true;
       })
@@ -124,21 +125,19 @@ export default class List extends Component {
           <:label>{{t "pages.catalogue.filters.name.label"}}</:label>
         </PixSearchInput>
 
-        <PixMultiSelect
-          @isDisabled={{eq this.categories.length 0}}
-          @placeholder={{t "pages.catalogue.filters.categories.label"}}
-          @screenReaderOnly={{true}}
-          @emptyMessage={{t "pages.catalogue.filters.categories.empty"}}
-          @isSearchable={{false}}
-          @locale={{this.locale.currentLocale}}
-          @values={{@categories}}
-          @options={{this.categories}}
-          @onChange={{fn @updateFilter "categories"}}
-        >
-          <:label>{{t "pages.catalogue.filters.categories.label"}}</:label>
-          <:default as |option|>{{option.label}}</:default>
-        </PixMultiSelect>
-
+        {{#if (eq @type "targetProfile")}}
+          <PixSelect
+            @isDisabled={{eq this.categoriesOptions.length 0}}
+            @placeholder={{t "pages.catalogue.filters.categories.all"}}
+            @hideDefaultOption={{false}}
+            @screenReaderOnly={{true}}
+            @value={{@category}}
+            @options={{this.categoriesOptions}}
+            @onChange={{fn @updateFilter "category"}}
+          >
+            <:label>{{t "pages.catalogue.filters.categories.label"}}</:label>
+          </PixSelect>
+        {{/if}}
         <PixMultiSelect
           @isDisabled={{eq this.areasOptions.length 0}}
           @emptyMessage={{t "pages.catalogue.filters.areas.empty"}}

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -55,42 +55,36 @@ export default class List extends Component {
 
   get filteredItems() {
     const { type = 'all', search = '', category, areas, competences } = this.args;
+    const filterByType = (item) => (type && type !== 'all' ? item.type === type : true);
+    const filterByName = (item) => (search.length > 0 ? item.name.toLowerCase().includes(search.toLowerCase()) : true);
+    const filterByCategory = (item) => (category ? category === item.category : true);
 
-    return this.args.courses
-      .filter((item) => {
-        if (type && type !== 'all') {
-          return item.type === type;
-        }
-        return true;
-      })
-      .filter((item) => {
-        if (search.length > 0) {
-          return item.name.toLowerCase().includes(search.toLowerCase());
-        }
-        return true;
-      })
-      .filter((item) => {
-        if (category) {
-          return category === item.category;
-        }
-        return true;
-      })
-      .filter((item) => {
-        if (areas?.length > 0) {
-          const itemAreaIds = item.areas.map((area) => area.id);
-          return areas.every((area) => itemAreaIds.includes(area));
-        }
-        return true;
-      })
-      .filter((item) => {
-        if (competences?.length > 0) {
-          const itemCompetenceIds = item.areas
-            .flatMap((area) => (area.competences ? area.get('competences') : []))
-            .map((competence) => competence.id);
-          return competences.every((competence) => itemCompetenceIds.includes(competence));
-        }
-        return true;
-      });
+    const filterByArea = (item) => {
+      if (areas?.length > 0) {
+        const itemAreaIds = item.areas.map((area) => area.id);
+        return areas.every((area) => itemAreaIds.includes(area));
+      }
+      return true;
+    };
+
+    const filterByCompetence = (item) => {
+      if (competences?.length > 0) {
+        const itemCompetenceIds = item.areas
+          .flatMap((area) => (area.competences ? area.competences : []))
+          .map((competence) => competence.id);
+        return competences.every((competence) => itemCompetenceIds.includes(competence));
+      }
+      return true;
+    };
+
+    return this.args.courses.filter(
+      (item) =>
+        filterByType(item) &&
+        filterByName(item) &&
+        filterByCategory(item) &&
+        filterByArea(item) &&
+        filterByCompetence(item),
+    );
   }
 
   <template>

--- a/orga/app/components/layout/sidebar.gjs
+++ b/orga/app/components/layout/sidebar.gjs
@@ -71,7 +71,7 @@ export default class SidebarMenu extends Component {
   }
 
   get shouldDisplayCatalogEntry() {
-    return this.featureToggles.featureToggles?.displayCatalogue;
+    return this.featureToggles.featureToggles?.displayCatalogue && this.currentUser.canAccessCampaignsPage;
   }
 
   get shouldDisplaySeparator() {

--- a/orga/app/controllers/authenticated/catalogue/list.js
+++ b/orga/app/controllers/authenticated/catalogue/list.js
@@ -3,10 +3,10 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class CatalogueListController extends Controller {
-  queryParams = ['search', 'categories', 'areas', 'competences'];
+  queryParams = ['search', 'category', 'areas', 'competences'];
 
   @tracked search = '';
-  @tracked categories = [];
+  @tracked category = '';
   @tracked areas = [];
   @tracked competences = [];
 
@@ -18,7 +18,7 @@ export default class CatalogueListController extends Controller {
   @action
   resetFilters() {
     this.search = '';
-    this.categories = [];
+    this.category = '';
     this.areas = [];
     this.competences = [];
   }

--- a/orga/app/controllers/authenticated/catalogue/list.js
+++ b/orga/app/controllers/authenticated/catalogue/list.js
@@ -3,17 +3,23 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class CatalogueListController extends Controller {
-  queryParams = ['search', 'categories'];
+  queryParams = ['search', 'categories', 'areas', 'competences'];
 
   @tracked search = '';
   @tracked categories = [];
+  @tracked areas = [];
+  @tracked competences = [];
 
   @action
   updateFilter(fieldName, value) {
     this[fieldName] = value;
   }
 
+  @action
   resetFilters() {
     this.search = '';
+    this.categories = [];
+    this.areas = [];
+    this.competences = [];
   }
 }

--- a/orga/app/controllers/authenticated/catalogue/list.js
+++ b/orga/app/controllers/authenticated/catalogue/list.js
@@ -1,0 +1,19 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class CatalogueListController extends Controller {
+  queryParams = ['search', 'categories'];
+
+  @tracked search = '';
+  @tracked categories = [];
+
+  @action
+  updateFilter(fieldName, value) {
+    this[fieldName] = value;
+  }
+
+  resetFilters() {
+    this.search = '';
+  }
+}

--- a/orga/app/models/area.js
+++ b/orga/app/models/area.js
@@ -5,7 +5,7 @@ export default class Area extends Model {
   @attr('string') title;
   @attr('string') color;
 
-  @hasMany('competence', { async: true, inverse: null }) competences;
+  @hasMany('competence', { async: false, inverse: null }) competences;
 
   get sortedCompetences() {
     return this.hasMany('competences')

--- a/orga/app/styles/pages/authenticated/catalogue.scss
+++ b/orga/app/styles/pages/authenticated/catalogue.scss
@@ -5,6 +5,10 @@
 
   &__filters {
     margin-bottom: var(--pix-spacing-4x);
+
+    .pix-filter-banner__filter > * {
+      flex-basis: 15rem;
+    }
   }
 
   &__list {

--- a/orga/app/styles/pages/authenticated/catalogue.scss
+++ b/orga/app/styles/pages/authenticated/catalogue.scss
@@ -3,6 +3,10 @@
     margin-bottom: var(--pix-spacing-4x);
   }
 
+  &__filters {
+    margin-bottom: var(--pix-spacing-4x);
+  }
+
   &__list {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));

--- a/orga/app/templates/authenticated/catalogue/list.gjs
+++ b/orga/app/templates/authenticated/catalogue/list.gjs
@@ -5,8 +5,10 @@ import List from 'pix-orga/components/catalogue/list';
     @courses={{@model.courses}}
     @type={{@model.type}}
     @updateFilter={{@controller.updateFilter}}
+    @resetFilters={{@controller.resetFilters}}
     @search={{@controller.search}}
     @categories={{@controller.categories}}
-    @resetFilters={{@controller.resetFilters}}
+    @areas={{@controller.areas}}
+    @competences={{@controller.competences}}
   />
 </template>

--- a/orga/app/templates/authenticated/catalogue/list.gjs
+++ b/orga/app/templates/authenticated/catalogue/list.gjs
@@ -7,7 +7,7 @@ import List from 'pix-orga/components/catalogue/list';
     @updateFilter={{@controller.updateFilter}}
     @resetFilters={{@controller.resetFilters}}
     @search={{@controller.search}}
-    @categories={{@controller.categories}}
+    @category={{@controller.category}}
     @areas={{@controller.areas}}
     @competences={{@controller.competences}}
   />

--- a/orga/app/templates/authenticated/catalogue/list.gjs
+++ b/orga/app/templates/authenticated/catalogue/list.gjs
@@ -1,3 +1,12 @@
 import List from 'pix-orga/components/catalogue/list';
 
-<template><List @courses={{@model.courses}} @type={{@model.type}} /></template>
+<template>
+  <List
+    @courses={{@model.courses}}
+    @type={{@model.type}}
+    @updateFilter={{@controller.updateFilter}}
+    @search={{@controller.search}}
+    @categories={{@controller.categories}}
+    @resetFilters={{@controller.resetFilters}}
+  />
+</template>

--- a/orga/tests/integration/components/catalogue/list-test.gjs
+++ b/orga/tests/integration/components/catalogue/list-test.gjs
@@ -1,5 +1,6 @@
-import { render, waitFor } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
+import { waitFor } from '@testing-library/dom';
 import { t } from 'ember-intl/test-support';
 import List from 'pix-orga/components/catalogue/list';
 import { module, test } from 'qunit';
@@ -9,9 +10,10 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Catalogue::List', function (hooks) {
   setupIntlRenderingTest(hooks);
-
+  let store;
   hooks.beforeEach(function () {
     const router = this.owner.lookup('service:router');
+    store = this.owner.lookup('service:store');
     router.transitionTo = () => {};
   });
 
@@ -70,6 +72,7 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         const blueprintLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.blueprints') });
         assert.ok(blueprintLink.href.endsWith('/catalogue/blueprint'));
       });
+
       test('it filters list by type', async function (assert) {
         // given
         const courses = [
@@ -91,7 +94,26 @@ module('Integration | Component | Catalogue::List', function (hooks) {
     });
 
     module('search filter', function () {
-      test('it should filter items list that match search pattern', async function (assert) {
+      test('it prefills search input with initials values', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const search = 'toto';
+        const courses = [
+          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @search={{search}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByLabelText(t('pages.catalogue.filters.name.label'))).hasValue('toto');
+      });
+      test('it filters items list that match search pattern', async function (assert) {
         // given
         const updateFilter = sinon.stub();
         const search = 'super';
@@ -114,7 +136,7 @@ module('Integration | Component | Catalogue::List', function (hooks) {
     });
 
     module('category filter', function () {
-      test('it disabled categories filter if there are no categories to filter', async function (assert) {
+      test('it should be disabled if there are no categories to filter', async function (assert) {
         // given
         const updateFilter = sinon.stub();
         const search = 'combiné';
@@ -136,7 +158,7 @@ module('Integration | Component | Catalogue::List', function (hooks) {
           .exists();
       });
 
-      test('it set categories filter with initial value', async function (assert) {
+      test('it preselects categories filter with initials values', async function (assert) {
         // given
         const updateFilter = sinon.stub();
         const categories = ['PREDEFINED'];
@@ -158,7 +180,7 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         assert.dom(screen.getByRole('checkbox', { name: t('pages.campaign-creation.tags.PREDEFINED') })).isChecked();
       });
 
-      test('it should filter items list that match selected categories', async function (assert) {
+      test('it filters items list that match selected categories', async function (assert) {
         // given
         const updateFilter = sinon.stub();
         const categories = ['PREDEFINED'];
@@ -177,6 +199,264 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         // then
         assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
         assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
+      });
+    });
+
+    module('areas filter', function () {
+      test('it disables filter when there are no areas to filter', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const search = 'combiné';
+        const area1 = store.createRecord('area', { code: '1', name: 'comp 1', competences: [] });
+        const area2 = store.createRecord('area', { code: '1', name: 'comp 2', competences: [] });
+        const courses = [
+          {
+            name: 'Ma super formation',
+            type: 'targetProfile',
+            nbTubes: 5,
+            category: 'PREDEFINED',
+            areas: [area1, area2],
+          },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @search={{search}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: t('pages.catalogue.filters.areas.label', { count: null }),
+              hidden: true,
+            }),
+          )
+          .exists();
+      });
+
+      test('it preselects areas filter with initials values', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [] });
+        const selectedAreas = [area1.id];
+
+        const courses = [
+          {
+            name: 'Ma super formation',
+            type: 'targetProfile',
+            nbTubes: 5,
+            category: 'PREDEFINED',
+            areas: [area1, area2],
+          },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @areas={{selectedAreas}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+        await click(screen.getByRole('button', { name: t('pages.catalogue.filters.areas.label') }));
+        await waitFor(() => screen.findByRole('menu'));
+        // then
+        assert.dom(screen.getByRole('checkbox', { name: `${area1.code}. ${area1.title}` })).isChecked();
+      });
+
+      test('it filters items list that match selected areas using a AND', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [] });
+
+        const selectedAreas = [area1.id, area2.id];
+
+        const courses = [
+          {
+            name: 'Ma super formation',
+            type: 'targetProfile',
+            nbTubes: 5,
+            category: 'PREDEFINED',
+            areas: [area1, area2],
+          },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @areas={{selectedAreas}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+
+        // then
+        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+        assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
+      });
+    });
+
+    module('competences filter', function () {
+      test('it disables filter when there are no compentences to filter', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const search = 'combiné';
+        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: 1 });
+        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: 2 });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [comp1] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [comp2] });
+
+        const courses = [
+          {
+            name: 'Ma super formation',
+            type: 'targetProfile',
+            nbTubes: 5,
+            category: 'PREDEFINED',
+            areas: [area1, area2],
+          },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @search={{search}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.getByRole('button', { name: t('pages.catalogue.filters.competences.label'), hidden: true }))
+          .exists();
+      });
+
+      test('it preselects competences filter with initials values', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: 1 });
+        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: 2 });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [comp1] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [comp2] });
+        const selectedCompetences = [comp1.id];
+        const courses = [
+          {
+            name: 'Ma super formation',
+            type: 'targetProfile',
+            nbTubes: 5,
+            category: 'PREDEFINED',
+            areas: [area1, area2],
+          },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List
+              @competences={{selectedCompetences}}
+              @updateFilter={{updateFilter}}
+              @courses={{courses}}
+              @type="all"
+            />
+          </template>,
+        );
+        await click(screen.getByRole('button', { name: t('pages.catalogue.filters.competences.label') }));
+        await waitFor(() => screen.findByRole('menu'));
+
+        // then
+        assert.dom(screen.getByRole('checkbox', { name: `${comp1.index} ${comp1.name}` })).isChecked();
+      });
+
+      test('it filters items list that match selected competences using a AND', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: 1 });
+        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: 2 });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [comp1] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [comp2] });
+        const selectedCompetences = [comp2.id];
+        const courses = [
+          {
+            name: 'Ma super formation',
+            type: 'targetProfile',
+            nbTubes: 5,
+            category: 'PREDEFINED',
+            areas: [area1, area2],
+          },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+        ];
+        // when
+        const screen = await render(
+          <template>
+            <List
+              @competences={{selectedCompetences}}
+              @updateFilter={{updateFilter}}
+              @courses={{courses}}
+              @type="all"
+            />
+          </template>,
+        );
+        await click(screen.getByRole('button', { name: t('pages.catalogue.filters.competences.label') }));
+        await waitFor(() => screen.findByRole('menu'));
+
+        // then
+        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+        assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
+      });
+    });
+
+    module('reset filters', function () {
+      test('it resets filter values', async function (assert) {
+        // given
+        const resetFilters = sinon.stub();
+        const updateFilter = sinon.stub();
+        const search = 'parcours';
+        const category = 'PREDEFINED';
+        const areas = [1];
+        const competences = [1];
+        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: '1.1' });
+        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: '2.1' });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: '1', competences: [comp1] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: '2', competences: [comp2] });
+        const courses = [
+          {
+            name: 'Ma super formation',
+            type: 'targetProfile',
+            nbTubes: 5,
+            category: 'PREDEFINED',
+            areas: [area1, area2],
+          },
+          {
+            name: 'Mon parcours combiné',
+            type: 'blueprint',
+            nbModules: 2,
+            areas: [area2],
+          },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List
+              @search={{search}}
+              @category={{categories}}
+              @area={{areas}}
+              @competences={{competences}}
+              @updateFilter={{updateFilter}}
+              @resetFilters={{resetFilters}}
+              @courses={{courses}}
+              @type="all"
+            />
+          </template>,
+        );
+        await click(screen.getByRole('button', { name: t('common.filters.actions.clear') }));
+
+        // then
+        assert.ok(resetFilters.calledOnce);
       });
     });
   });

--- a/orga/tests/integration/components/catalogue/list-test.gjs
+++ b/orga/tests/integration/components/catalogue/list-test.gjs
@@ -136,6 +136,24 @@ module('Integration | Component | Catalogue::List', function (hooks) {
     });
 
     module('category filter', function () {
+      test('it hides category filter on all page', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const courses = [
+          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+        ];
+
+        // when
+        const screen = await render(
+          <template><List @updateFilter={{updateFilter}} @courses={{courses}} @type="all" /></template>,
+        );
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('pages.catalogue.filters.categories.label') }))
+          .doesNotExist();
+      });
       test('it should be disabled if there are no categories to filter', async function (assert) {
         // given
         const updateFilter = sinon.stub();
@@ -148,7 +166,7 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         // when
         const screen = await render(
           <template>
-            <List @search={{search}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+            <List @search={{search}} @updateFilter={{updateFilter}} @courses={{courses}} @type="targetProfile" />
           </template>,
         );
 
@@ -158,10 +176,10 @@ module('Integration | Component | Catalogue::List', function (hooks) {
           .exists();
       });
 
-      test('it preselects categories filter with initials values', async function (assert) {
+      test('it preselects category filter with initials values', async function (assert) {
         // given
         const updateFilter = sinon.stub();
-        const categories = ['PREDEFINED'];
+        const category = 'PREDEFINED';
         const courses = [
           { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
           { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
@@ -170,20 +188,20 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         // when
         const screen = await render(
           <template>
-            <List @categories={{categories}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+            <List @category={{category}} @updateFilter={{updateFilter}} @courses={{courses}} @type="targetProfile" />
           </template>,
         );
         await click(screen.getByRole('button', { name: t('pages.catalogue.filters.categories.label') }));
-        await waitFor(() => screen.findByRole('menu'));
-
+        await waitFor(() => screen.findByRole('listbox'));
         // then
-        assert.dom(screen.getByRole('checkbox', { name: t('pages.campaign-creation.tags.PREDEFINED') })).isChecked();
+        const selectedOption = screen.getByRole('option', { selected: true });
+        assert.strictEqual(selectedOption.innerText, t(`pages.campaign-creation.tags.${category}`));
       });
 
       test('it filters items list that match selected categories', async function (assert) {
         // given
         const updateFilter = sinon.stub();
-        const categories = ['PREDEFINED'];
+        const category = 'PREDEFINED';
         const courses = [
           { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
           { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
@@ -192,7 +210,7 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         // when
         const screen = await render(
           <template>
-            <List @categories={{categories}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+            <List @category={{category}} @updateFilter={{updateFilter}} @courses={{courses}} @type="targetProfile" />
           </template>,
         );
 
@@ -241,8 +259,8 @@ module('Integration | Component | Catalogue::List', function (hooks) {
       test('it preselects areas filter with initials values', async function (assert) {
         // given
         const updateFilter = sinon.stub();
-        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [] });
-        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [] });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: '1', competences: [] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: '2', competences: [] });
         const selectedAreas = [area1.id];
 
         const courses = [
@@ -254,6 +272,7 @@ module('Integration | Component | Catalogue::List', function (hooks) {
             areas: [area1, area2],
           },
           { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+          { name: 'Parcours nul', type: 'targetProfile', category: 'OTHER', nbModules: 2, areas: [area2] },
         ];
 
         // when
@@ -271,8 +290,8 @@ module('Integration | Component | Catalogue::List', function (hooks) {
       test('it filters items list that match selected areas using a AND', async function (assert) {
         // given
         const updateFilter = sinon.stub();
-        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [] });
-        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [] });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: '1', competences: [] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: '2', competences: [] });
 
         const selectedAreas = [area1.id, area2.id];
 
@@ -305,10 +324,10 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         // given
         const updateFilter = sinon.stub();
         const search = 'combiné';
-        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: 1 });
-        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: 2 });
-        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [comp1] });
-        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [comp2] });
+        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: '1.1' });
+        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: '2.1' });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: '1', competences: [comp1] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: '2', competences: [comp2] });
 
         const courses = [
           {
@@ -337,10 +356,10 @@ module('Integration | Component | Catalogue::List', function (hooks) {
       test('it preselects competences filter with initials values', async function (assert) {
         // given
         const updateFilter = sinon.stub();
-        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: 1 });
-        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: 2 });
-        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [comp1] });
-        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [comp2] });
+        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: '1.1' });
+        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: '2.1' });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: '1', competences: [comp1] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: '2', competences: [comp2] });
         const selectedCompetences = [comp1.id];
         const courses = [
           {
@@ -374,10 +393,10 @@ module('Integration | Component | Catalogue::List', function (hooks) {
       test('it filters items list that match selected competences using a AND', async function (assert) {
         // given
         const updateFilter = sinon.stub();
-        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: 1 });
-        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: 2 });
-        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: 1, competences: [comp1] });
-        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: 2, competences: [comp2] });
+        const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: '1.1' });
+        const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: '2.1' });
+        const area1 = store.createRecord('area', { id: 1, title: 'area1', code: '1', competences: [comp1] });
+        const area2 = store.createRecord('area', { id: 2, title: 'area2', code: '2', competences: [comp2] });
         const selectedCompetences = [comp2.id];
         const courses = [
           {
@@ -443,7 +462,7 @@ module('Integration | Component | Catalogue::List', function (hooks) {
           <template>
             <List
               @search={{search}}
-              @category={{categories}}
+              @category={{category}}
               @area={{areas}}
               @competences={{competences}}
               @updateFilter={{updateFilter}}

--- a/orga/tests/integration/components/catalogue/list-test.gjs
+++ b/orga/tests/integration/components/catalogue/list-test.gjs
@@ -1,7 +1,9 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, waitFor } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import List from 'pix-orga/components/catalogue/list';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -15,33 +17,52 @@ module('Integration | Component | Catalogue::List', function (hooks) {
 
   module('when there are no items', function () {
     test('it displays an empty state', async function (assert) {
+      // given
       const courses = [];
-      const screen = await render(<template><List @courses={{courses}} /></template>);
+      const updateFilter = sinon.stub();
 
+      // when
+      const screen = await render(<template><List @courses={{courses}} @updateFilter={{updateFilter}} /></template>);
+
+      // then
       assert.dom(screen.getByText(t('pages.catalogue.empty-state'))).exists();
     });
   });
 
   module('when there are course items', function () {
     test('it shows all items', async function (assert) {
+      // given
       const courses = [
         { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
         { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
       ];
+      const updateFilter = sinon.stub();
 
-      const screen = await render(<template><List @courses={{courses}} @type="all" /></template>);
+      // when
+      const screen = await render(
+        <template><List @updateFilter={{updateFilter}} @courses={{courses}} @type="all" /></template>,
+      );
 
+      // then
       assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
       assert.dom(screen.getByRole('heading', { level: 3, name: 'Mon parcours combiné' })).exists();
     });
+
     module('type filters', function () {
       test('it displays navigation links to filter by type', async function (assert) {
+        // given
         const courses = [
           { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
           { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
         ];
+        const updateFilter = sinon.stub();
 
-        const screen = await render(<template><List @courses={{courses}} @type="blueprint" /></template>);
+        // when
+        const screen = await render(
+          <template><List @courses={{courses}} @updateFilter={{updateFilter}} @type="blueprint" /></template>,
+        );
+
+        // then
         const allLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.all') });
         assert.ok(allLink.href.endsWith('/catalogue/all'));
         const targetProfilLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.target-profiles') });
@@ -50,15 +71,112 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         assert.ok(blueprintLink.href.endsWith('/catalogue/blueprint'));
       });
       test('it filters list by type', async function (assert) {
+        // given
         const courses = [
           { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
           { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
         ];
 
-        const screen = await render(<template><List @courses={{courses}} @type="blueprint" /></template>);
+        const updateFilter = sinon.stub();
 
+        // when
+        const screen = await render(
+          <template><List @courses={{courses}} @updateFilter={{updateFilter}} @type="blueprint" /></template>,
+        );
+
+        // then
         const items = screen.getAllByRole('heading', { level: 3 });
         assert.strictEqual(items.length, 1);
+      });
+    });
+
+    module('search filter', function () {
+      test('it should filter items list that match search pattern', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const search = 'super';
+        const courses = [
+          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @search={{search}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+
+        // then
+        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+        assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
+      });
+    });
+
+    module('category filter', function () {
+      test('it disabled categories filter if there are no categories to filter', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const search = 'combiné';
+        const courses = [
+          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @search={{search}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.getByRole('button', { name: t('pages.catalogue.filters.categories.label'), hidden: true }))
+          .exists();
+      });
+
+      test('it set categories filter with initial value', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const categories = ['PREDEFINED'];
+        const courses = [
+          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @categories={{categories}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+        await click(screen.getByRole('button', { name: t('pages.catalogue.filters.categories.label') }));
+        await waitFor(() => screen.findByRole('menu'));
+
+        // then
+        assert.dom(screen.getByRole('checkbox', { name: t('pages.campaign-creation.tags.PREDEFINED') })).isChecked();
+      });
+
+      test('it should filter items list that match selected categories', async function (assert) {
+        // given
+        const updateFilter = sinon.stub();
+        const categories = ['PREDEFINED'];
+        const courses = [
+          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List @categories={{categories}} @updateFilter={{updateFilter}} @courses={{courses}} @type="all" />
+          </template>,
+        );
+
+        // then
+        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+        assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
       });
     });
   });

--- a/orga/tests/integration/components/layout/sidebar-test.gjs
+++ b/orga/tests/integration/components/layout/sidebar-test.gjs
@@ -118,10 +118,10 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       assert.dom(screen.getByRole('link', { name: t('navigation.main.support') })).exists();
     });
     module('canAccessCataloguePage', function () {
-      test('should display Catalogue menu if canAccessCataloguePage is true', async function (assert) {
+      test('displays Catalogue menu if canAccessCataloguePage is true and user can access campaign page ', async function (assert) {
         class CurrentUserStub extends Service {
           organization = Object.create({ id: 5, type: 'PRO' });
-          canAccessMissionsPage = false;
+          canAccessCampaignsPage = true;
         }
         this.owner.register('service:current-user', CurrentUserStub);
         const featureToggleService = this.owner.lookup('service:feature-toggles');
@@ -131,10 +131,23 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
         assert.ok(screen.queryByRole('link', { name: t('navigation.main.catalogue') }));
       });
 
-      test('should not display Catalogue menu if canAccessCataloguePage is false', async function (assert) {
+      test('hides Catalogue menu if canAccessCataloguePage is true and user can not access campaign page', async function (assert) {
         class CurrentUserStub extends Service {
           organization = Object.create({ id: 5, type: 'PRO' });
-          canAccessMissionsPage = false;
+          canAccessCampaignsPage = false;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        const featureToggleService = this.owner.lookup('service:feature-toggles');
+        sinon.stub(featureToggleService, 'featureToggles').value({ displayCatalogue: true });
+        const screen = await render(<template><Sidebar /></template>);
+
+        assert.dom(screen.queryByRole('link', { name: t('navigation.main.catalogue') })).doesNotExist();
+      });
+
+      test('hides Catalogue menu if canAccessCataloguePage is false', async function (assert) {
+        class CurrentUserStub extends Service {
+          organization = Object.create({ id: 5, type: 'PRO' });
+          canAccessCampaignsPage = true;
         }
         this.owner.register('service:current-user', CurrentUserStub);
         const featureToggleService = this.owner.lookup('service:feature-toggles');

--- a/orga/tests/integration/templates/authenticated/catalogue/list-test.gjs
+++ b/orga/tests/integration/templates/authenticated/catalogue/list-test.gjs
@@ -9,6 +9,7 @@ module('Integration | Template | authenticated/catalogue/list', function (hooks)
 
   test('it renders template', async function (assert) {
     // given
+    const controller = { updateFilter: () => {}, resetFilters: () => {} };
     const model = {
       courses: [
         {
@@ -18,7 +19,7 @@ module('Integration | Template | authenticated/catalogue/list', function (hooks)
       type: 'all',
     };
     // when
-    const screen = await render(<template><List @model={{model}} /></template>);
+    const screen = await render(<template><List @controller={{controller}} @model={{model}} /></template>);
 
     // then
     assert.ok(screen.getByText('Combinix'));

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1019,14 +1019,24 @@
       },
       "empty-state": "Derzeit sind keine Kurse verfügbar. Kontaktieren Sie Pix, um welche zu erhalten.",
       "filters": {
+        "areas": {
+          "empty": "Kein Bereich",
+          "label": "Bereiche",
+          "placeholder": "{count, plural, =0 {Bereiche} =1 {Bereich ({count})} other {Bereiche ({count})}}"
+        },
         "aria-label": "Filter nach Kursen",
         "categories": {
           "empty": "Keine Kategorie",
           "label": "Kategorien"
         },
+        "competences": {
+          "empty": "Keine Kompetenz",
+          "label": "Kompetenzen",
+          "placeholder": "{count, plural, =0 {Kompetenzen} =1 {Kompetenz ({count})} other {Kompetenzen ({count})}}"
+        },
         "name": {
           "label": "Name des Kurses",
-          "placeholder": "Kurs 6. Klasse"
+          "placeholder": "Nach Titel suchen"
         },
         "nb-result": "{count, plural, =0 {Kein Kurs} =1 {{count} Kurs} other {{count} Kurse}}"
       },

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1018,6 +1018,18 @@
         "tubes-count": "{count, plural, =0 {Kein Thema} =1 {{count} thema} other {{count} themen}}"
       },
       "empty-state": "Derzeit sind keine Kurse verfügbar. Kontaktieren Sie Pix, um welche zu erhalten.",
+      "filters": {
+        "aria-label": "Filter nach Kursen",
+        "categories": {
+          "empty": "Keine Kategorie",
+          "label": "Kategorien"
+        },
+        "name": {
+          "label": "Name des Kurses",
+          "placeholder": "Kurs 6. Klasse"
+        },
+        "nb-result": "{count, plural, =0 {Kein Kurs} =1 {{count} Kurs} other {{count} Kurse}}"
+      },
       "tab-filters": {
         "all": "Alle",
         "blueprints": "Lernpfade",

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1026,6 +1026,7 @@
         },
         "aria-label": "Filter nach Kursen",
         "categories": {
+          "all": "Alle Kategorien",
           "empty": "Keine Kategorie",
           "label": "Kategorien"
         },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1036,6 +1036,7 @@
         },
         "aria-label": "Filters on courses",
         "categories": {
+          "all": "All categories",
           "empty": "No category",
           "label": "Categories"
         },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1028,6 +1028,18 @@
         "tubes-count": "{count, plural, =0 {No topic} =1 {{count} topic} other {{count} topics}}"
       },
       "empty-state": "No courses available at the moment. Contact Pix to obtain some.",
+      "filters": {
+        "aria-label": "Filters on courses",
+        "categories": {
+          "empty": "No category",
+          "label": "Categories"
+        },
+        "name": {
+          "label": "Course name",
+          "placeholder": "6th grade course"
+        },
+        "nb-result": "{count, plural, =0 {No course} =1 {{count} course} other {{count} courses}}"
+      },
       "tab-filters": {
         "all": "All",
         "blueprints": "Learning courses",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1029,14 +1029,24 @@
       },
       "empty-state": "No courses available at the moment. Contact Pix to obtain some.",
       "filters": {
+        "areas": {
+          "empty": "No domain",
+          "label": "Domains",
+          "placeholder": "{count, plural, =0 {Domains} =1 {Domain ({count})} other {Domains ({count})}}"
+        },
         "aria-label": "Filters on courses",
         "categories": {
           "empty": "No category",
           "label": "Categories"
         },
+        "competences": {
+          "empty": "No competence",
+          "label": "Competences",
+          "placeholder": "{count, plural, =0 {Competences} =1 {Competence ({count})} other {Competences ({count})}}"
+        },
         "name": {
           "label": "Course name",
-          "placeholder": "6th grade course"
+          "placeholder": "Search by title"
         },
         "nb-result": "{count, plural, =0 {No course} =1 {{count} course} other {{count} courses}}"
       },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1030,6 +1030,7 @@
         },
         "aria-label": "Filtros sobre los cursos",
         "categories": {
+          "all": "Todas las categorías",
           "empty": "Ninguna categoría",
           "label": "Categorías"
         },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1022,6 +1022,18 @@
         "tubes-count": "{count, plural, =0 {Sin temas} =1 {{count} tema} other {{count} temas}}"
       },
       "empty-state": "No hay cursos disponibles por el momento. Póngase en contacto con Pix para obtenerlos.",
+      "filters": {
+        "aria-label": "Filtros sobre los cursos",
+        "categories": {
+          "empty": "Ninguna categoría",
+          "label": "Categorías"
+        },
+        "name": {
+          "label": "Nombre del curso",
+          "placeholder": "Curso 1º ESO"
+        },
+        "nb-result": "{count, plural, =0 {Ningún curso} =1 {{count} curso} other {{count} cursos}}"
+      },
       "tab-filters": {
         "all": "Todos",
         "blueprints": "Rutas de aprendizaje",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1023,14 +1023,24 @@
       },
       "empty-state": "No hay cursos disponibles por el momento. Póngase en contacto con Pix para obtenerlos.",
       "filters": {
+        "areas": {
+          "empty": "Ningún dominio",
+          "label": "Dominios",
+          "placeholder": "{count, plural, =0 {Dominios} =1 {Dominio ({count})} other {Dominios ({count})}}"
+        },
         "aria-label": "Filtros sobre los cursos",
         "categories": {
           "empty": "Ninguna categoría",
           "label": "Categorías"
         },
+        "competences": {
+          "empty": "Ninguna competencia",
+          "label": "Competencias",
+          "placeholder": "{count, plural, =0 {Competencias} =1 {Competencia ({count})} other {Competencias ({count})}}"
+        },
         "name": {
           "label": "Nombre del curso",
-          "placeholder": "Curso 1º ESO"
+          "placeholder": "Buscar por título"
         },
         "nb-result": "{count, plural, =0 {Ningún curso} =1 {{count} curso} other {{count} cursos}}"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1017,14 +1017,24 @@
       },
       "empty-state": "Aucun parcours disponible pour l'instant. Contactez Pix pour en obtenir.",
       "filters": {
+        "areas": {
+          "empty": "Aucun domaine",
+          "label": "Domaines",
+          "placeholder": "{count, plural, =0 {Domaines} =1 {Domaine ({count})} other {Domaines ({count})}}"
+        },
         "aria-label": "Filtres sur les parcours",
         "categories": {
           "empty": "Aucune catégorie",
           "label": "Catégories"
         },
+        "competences": {
+          "empty": "Aucune compétence",
+          "label": "Compétences",
+          "placeholder": "{count, plural, =0 {Compétences} =1 {Compétence ({count})} other {Compétences ({count})}}"
+        },
         "name": {
           "label": "Nom du parcours",
-          "placeholder": "Parcours 6e"
+          "placeholder": "Rechercher par titre"
         },
         "nb-result": "{count, plural, =0 {Aucun parcours} =1 {{count} parcours} other {{count} parcours}}"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1016,6 +1016,18 @@
         "tubes-count": "{count, plural, =0 {Aucun sujet} =1 {{count} sujet} other {{count} sujets}}"
       },
       "empty-state": "Aucun parcours disponible pour l'instant. Contactez Pix pour en obtenir.",
+      "filters": {
+        "aria-label": "Filtres sur les parcours",
+        "categories": {
+          "empty": "Aucune catégorie",
+          "label": "Catégories"
+        },
+        "name": {
+          "label": "Nom du parcours",
+          "placeholder": "Parcours 6e"
+        },
+        "nb-result": "{count, plural, =0 {Aucun parcours} =1 {{count} parcours} other {{count} parcours}}"
+      },
       "tab-filters": {
         "all": "Tous",
         "blueprints": "Parcours apprenants",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1024,6 +1024,7 @@
         },
         "aria-label": "Filtres sur les parcours",
         "categories": {
+          "all": "Toutes les catégories",
           "empty": "Aucune catégorie",
           "label": "Catégories"
         },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1020,14 +1020,24 @@
       },
       "empty-state": "Nessun percorso disponibile al momento. Contattare Pix per ottenerne.",
       "filters": {
+        "areas": {
+          "empty": "Nessun dominio",
+          "label": "Domini",
+          "placeholder": "{count, plural, =0 {Domini} =1 {Dominio ({count})} other {Domini ({count})}}"
+        },
         "aria-label": "Filtri sui percorsi",
         "categories": {
           "empty": "Nessuna categoria",
           "label": "Categorie"
         },
+        "competences": {
+          "empty": "Nessuna competenza",
+          "label": "Competenze",
+          "placeholder": "{count, plural, =0 {Competenze} =1 {Competenza ({count})} other {Competenze ({count})}}"
+        },
         "name": {
           "label": "Nome del percorso",
-          "placeholder": "Percorso prima media"
+          "placeholder": "Cerca per titolo"
         },
         "nb-result": "{count, plural, =0 {Nessun percorso} =1 {{count} percorso} other {{count} percorsi}}"
       },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1027,6 +1027,7 @@
         },
         "aria-label": "Filtri sui percorsi",
         "categories": {
+          "all": "Tutte le categorie",
           "empty": "Nessuna categoria",
           "label": "Categorie"
         },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1019,6 +1019,18 @@
         "tubes-count": "{count, plural, =0 {Nessun argomento} =1 {{count} argomento} other {{count} argomenti}}"
       },
       "empty-state": "Nessun percorso disponibile al momento. Contattare Pix per ottenerne.",
+      "filters": {
+        "aria-label": "Filtri sui percorsi",
+        "categories": {
+          "empty": "Nessuna categoria",
+          "label": "Categorie"
+        },
+        "name": {
+          "label": "Nome del percorso",
+          "placeholder": "Percorso prima media"
+        },
+        "nb-result": "{count, plural, =0 {Nessun percorso} =1 {{count} percorso} other {{count} percorsi}}"
+      },
       "tab-filters": {
         "all": "Tutti",
         "blueprints": "Percorsi di apprendimento",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1016,14 +1016,24 @@
       },
       "empty-state": "Er zijn momenteel geen traject beschikbaar. Neem contact op met Pix om er enkele te verkrijgen.",
       "filters": {
+        "areas": {
+          "empty": "Geen domein",
+          "label": "Domeinen",
+          "placeholder": "{count, plural, =0 {Domeinen} =1 {Domein ({count})} other {Domeinen ({count})}}"
+        },
         "aria-label": "Filters op trajecten",
         "categories": {
           "empty": "Geen categorie",
           "label": "Categorieën"
         },
+        "competences": {
+          "empty": "Geen competentie",
+          "label": "Competenties",
+          "placeholder": "{count, plural, =0 {Competenties} =1 {Competentie ({count})} other {Competenties ({count})}}"
+        },
         "name": {
           "label": "Naam van het traject",
-          "placeholder": "Traject groep 8"
+          "placeholder": "Zoeken op titel"
         },
         "nb-result": "{count, plural, =0 {Geen traject} =1 {{count} traject} other {{count} trajecten}}"
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1023,6 +1023,7 @@
         },
         "aria-label": "Filters op trajecten",
         "categories": {
+          "all": "Alle categorieën",
           "empty": "Geen categorie",
           "label": "Categorieën"
         },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1015,6 +1015,18 @@
         "tubes-count": "{count, plural, =0 {Geen onderwerp} =1 {{count} onderwerp} other {{count} onderwerpen}}"
       },
       "empty-state": "Er zijn momenteel geen traject beschikbaar. Neem contact op met Pix om er enkele te verkrijgen.",
+      "filters": {
+        "aria-label": "Filters op trajecten",
+        "categories": {
+          "empty": "Geen categorie",
+          "label": "Categorieën"
+        },
+        "name": {
+          "label": "Naam van het traject",
+          "placeholder": "Traject groep 8"
+        },
+        "nb-result": "{count, plural, =0 {Geen traject} =1 {{count} traject} other {{count} trajecten}}"
+      },
       "tab-filters": {
         "all": "Alle",
         "blueprints": "Leertrajecten",


### PR DESCRIPTION
## 🌱 Problème
Il n'est pas possible de filtrer la liste des parcours :'(
## 🐣 Proposition

On souhaite filtrer les éléments du catalogue en fonction de plusieurs critères

- nom (fuzzy search)
- catégories (multiSelect)
- domaines (multiSelect)
- compétences (multiSelect)

## 🌷 Remarques

L'état des filtres doit être synchroniser dans l’url
Les différentes valeurs possibles des filtres proviendra des valeurs possibles lié au éléments présent dans le catalogue, donc pas nécessairement exhaustif.
Les valeurs possibles des filtres seront mises à jour en fonction de l'état des filtres sélectionnées

## 🐝 Pour tester

- [x] Afficher la page catalogue sur [pixOrga](https://orga-pr16071.review.pix.fr/catalogue)
- [x] Filtre par nom
- [x] Filtrer par catégorie
- [x] Filtrer par domaine
- [x] Filtrer par compétence
- [x] Ré-initialiser les filtres
