### PR TITLE
[FEATURE] Supprimer physiquement les invitations en BDD lors de l'archivage de centre de certification (PIX-22087)

### DIFF
--- a/admin/app/routes/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/routes/authenticated/certification-centers/get/invitations.js
@@ -1,6 +1,15 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class AuthenticatedCertificationCentersGetInvitationsRoute extends Route {
+  @service router;
+  beforeModel() {
+    const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
+    if (certificationCenter.isArchived) {
+      return this.router.replaceWith('authenticated.certification-centers.get');
+    }
+  }
+
   async model() {
     const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
     return {

--- a/admin/app/routes/authenticated/certification-centers/get/team.js
+++ b/admin/app/routes/authenticated/certification-centers/get/team.js
@@ -1,7 +1,16 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class AuthenticatedCertificationCentersGetTeamRoute extends Route {
+  @service router;
+  beforeModel() {
+    const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
+    if (certificationCenter.isArchived) {
+      return this.router.replaceWith('authenticated.certification-centers.get');
+    }
+  }
+
   async model() {
     const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
     return {

--- a/admin/tests/unit/routes/authenticated/certification-centers/get/invitations-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get/invitations-test.js
@@ -5,6 +5,22 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/certification-centers/get/invitations', function (hooks) {
   setupTest(hooks);
 
+  module('#beforeModel', function () {
+    test('it should transition to get route when certification center is archived', async function (assert) {
+      // given
+      const certificationCenter = { id: 1, isArchived: true };
+      const route = this.owner.lookup('route:authenticated/certification-centers/get/invitations');
+      sinon.stub(route.router, 'replaceWith');
+      sinon.stub(route, 'modelFor').returns({ certificationCenter });
+
+      // when
+      await route.beforeModel();
+
+      // then
+      assert.ok(route.router.replaceWith.calledWith('authenticated.certification-centers.get'));
+    });
+  });
+
   test('it should return certification center with its invitations', async function (assert) {
     // given
     const route = this.owner.lookup('route:authenticated/certification-centers/get/invitations');

--- a/admin/tests/unit/routes/authenticated/certification-centers/get/team-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get/team-test.js
@@ -5,6 +5,21 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/certification-centers/get/team', function (hooks) {
   setupTest(hooks);
 
+  module('#beforeModel', function () {
+    test('it should transition to get route when certification center is archived', async function (assert) {
+      // given
+      const certificationCenter = { id: 1, isArchived: true };
+      const route = this.owner.lookup('route:authenticated/certification-centers/get/team');
+      sinon.stub(route.router, 'replaceWith');
+      sinon.stub(route, 'modelFor').returns({ certificationCenter });
+
+      // when
+      await route.beforeModel();
+
+      // then
+      assert.ok(route.router.replaceWith.calledWith('authenticated.certification-centers.get'));
+    });
+  });
   test('it should return certification center memberships', async function (assert) {
     // given
     const route = this.owner.lookup('route:authenticated/certification-centers/get/team');

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1295,12 +1295,12 @@
     },
     "certification-centers": {
       "archive-confirmation-modal": {
-        "attachment": "Le rattachement et l'invitation de nouvelles personnes seront bloqués",
-        "invitations": "Les invitations en attente vont être annulées",
-        "members": "Les membres actifs vont être désactivés",
-        "question": "Êtes-vous sûr de vouloir archiver ce centre de certification?",
-        "title": "Archiver le centre de certification {certificationCenterName}",
-        "warning": "Cette action est irréversible."
+        "attachment": "You are no longer allowed to attach new members or send invitations",
+        "invitations": "All invitations (regardless of status) will be cancelled",
+        "members": "Active members will be deactivated",
+        "question": "Are you sure you want to archive this certification center ?",
+        "title": "Archive this certification center {certificationCenterName}",
+        "warning": "This action cannot be undone."
       },
       "information-view": {
         "habilitations": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1306,7 +1306,7 @@
     "certification-centers": {
       "archive-confirmation-modal": {
         "attachment": "Le rattachement et l'invitation de nouvelles personnes seront bloqués",
-        "invitations": "Les invitations en attente vont être annulées",
+        "invitations": "Toutes les invitations (peu importe le statut) seront supprimées",
         "members": "Les membres actifs vont être désactivés",
         "question": "Êtes-vous sûr de vouloir archiver ce centre de certification?",
         "title": "Archiver le centre de certification {certificationCenterName}",

--- a/api/db/seeds/data/team-acquisition/build-networks.js
+++ b/api/db/seeds/data/team-acquisition/build-networks.js
@@ -264,15 +264,15 @@ function _buildComplexNetwork(databaseBuilder) {
 }
 
 function _buildExtraNetworksForPagination(databaseBuilder) {
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Auvergne-Rhône-Alpes' });
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Bourgogne-Franche-Comté' });
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Bretagne' });
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Centre-Val de Loire' });
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Grand Est' });
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Normandie' });
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Nouvelle-Aquitaine' });
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Occitanie' });
-  databaseBuilder.factory.buildNetwork({ name: 'Réseau Pays de la Loire' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Auvergne-Rhône-Alpes' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Bourgogne-Franche-Comté' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Bretagne' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Centre-Val de Loire' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Grand Est' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Normandie' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Nouvelle-Aquitaine' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Occitanie' });
+  databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Réseau Pays de la Loire' });
 }
 
 export function buildNetworks(databaseBuilder) {

--- a/api/src/team/domain/usecases/archive-certification-center-data.usecase.js
+++ b/api/src/team/domain/usecases/archive-certification-center-data.usecase.js
@@ -12,8 +12,7 @@ export const archiveCertificationCenterData = withTransaction(async function ({
     updatedByUserId: archivedBy,
     disabledAt: archiveDate,
   });
-  await certificationCenterInvitationRepository.markAsCancelledByCertificationCenter({
+  await certificationCenterInvitationRepository.deleteInvitationsByCertificationCenterId({
     certificationCenterId,
-    updatedAt: archiveDate,
   });
 });

--- a/api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
@@ -170,6 +170,15 @@ const markAsCancelledByCertificationCenter = async function ({ certificationCent
 };
 
 /**
+ * @param {Object} params
+ * @param {number} params.certificationCenterId
+ */
+const deleteInvitationsByCertificationCenterId = async function ({ certificationCenterId }) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn.from(CERTIFICATION_CENTER_INVITATIONS).where({ certificationCenterId }).delete();
+};
+
+/**
  * @callback updateModificationDate
  * @param {string} certificationCenterInvitationId
  * @returns {Promise<void>}
@@ -193,6 +202,7 @@ const updateModificationDate = async function (certificationCenterInvitationId) 
  */
 export {
   create,
+  deleteInvitationsByCertificationCenterId,
   findOnePendingByEmailAndCertificationCenterId,
   findPendingByCertificationCenterId,
   get,

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -408,11 +408,9 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
       expect(disabledMembership.updatedByUserId).to.equal(superAdmin.id);
       expect(disabledMembership.disabledAt).to.deep.equal(archivedCenter.archivedAt);
 
-      const cancelledInvitation = await knex('certification-center-invitations')
-        .where({ certificationCenterId })
-        .first();
-      expect(cancelledInvitation.status).to.deep.equal('cancelled');
-      expect(cancelledInvitation.updatedAt).to.deep.equal(archivedCenter.archivedAt);
+      const deletedInvitation = await knex('certification-center-invitations').where({ certificationCenterId });
+
+      expect(deletedInvitation).to.be.empty;
     });
   });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-certification-center.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-certification-center.usecase.test.js
@@ -49,9 +49,9 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     const disabledCertificationCenterMembership = await knex('certification-center-memberships')
       .where({ certificationCenterId: certificationCenter.id })
       .first();
-    const cancelledCertificationCenterInvitation = await knex('certification-center-invitations')
-      .where({ certificationCenterId: certificationCenter.id })
-      .first();
+    const deletedCertificationCenterInvitation = await knex('certification-center-invitations').where({
+      certificationCenterId: certificationCenter.id,
+    });
 
     // then
     expect(archivedCertificationCenter.archivedAt).to.deep.equal(now);
@@ -62,8 +62,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     expect(disabledCertificationCenterMembership.updatedByUserId).to.deep.equal(superAdminUser.id);
     expect(disabledCertificationCenterMembership.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
 
-    expect(cancelledCertificationCenterInvitation.status).to.deep.equal('cancelled');
-    expect(cancelledCertificationCenterInvitation.updatedAt).to.deep.equal(now);
+    expect(deletedCertificationCenterInvitation).to.be.empty;
 
     clock.restore();
   });

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-certification-centers-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-certification-centers-in-batch.usecase.test.js
@@ -70,9 +70,9 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     const disabledCertificationCenter1Membership = await knex('certification-center-memberships')
       .where({ certificationCenterId: certificationCenter1.id })
       .first();
-    const cancelledCertificationCenter1Invitation = await knex('certification-center-invitations')
-      .where({ certificationCenterId: certificationCenter1.id })
-      .first();
+    const deletedCertificationCenter1Invitation = await knex('certification-center-invitations').where({
+      certificationCenterId: certificationCenter1.id,
+    });
 
     const archivedCertificationCenter2 = await knex('certification-centers')
       .where({ id: certificationCenter2.id })
@@ -80,9 +80,9 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     const disabledCertificationCenter2Membership = await knex('certification-center-memberships')
       .where({ certificationCenterId: certificationCenter2.id })
       .first();
-    const cancelledCertificationCenter2Invitation = await knex('certification-center-invitations')
-      .where({ certificationCenterId: certificationCenter2.id })
-      .first();
+    const deletedCertificationCenter2Invitation = await knex('certification-center-invitations').where({
+      certificationCenterId: certificationCenter2.id,
+    });
 
     expect(archivedCertificationCenter1.archivedAt).to.deep.equal(now);
     expect(archivedCertificationCenter1.archivedBy).to.deep.equal(superAdminUser.id);
@@ -92,8 +92,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     expect(disabledCertificationCenter1Membership.updatedByUserId).to.deep.equal(superAdminUser.id);
     expect(disabledCertificationCenter1Membership.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
 
-    expect(cancelledCertificationCenter1Invitation.status).to.deep.equal('cancelled');
-    expect(cancelledCertificationCenter1Invitation.updatedAt).to.deep.equal(now);
+    expect(deletedCertificationCenter1Invitation).to.be.empty;
 
     expect(archivedCertificationCenter2.archivedAt).to.deep.equal(now);
     expect(archivedCertificationCenter2.archivedBy).to.deep.equal(superAdminUser.id);
@@ -103,8 +102,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     expect(disabledCertificationCenter2Membership.updatedByUserId).to.deep.equal(superAdminUser.id);
     expect(disabledCertificationCenter2Membership.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
 
-    expect(cancelledCertificationCenter2Invitation.status).to.deep.equal('cancelled');
-    expect(cancelledCertificationCenter2Invitation.updatedAt).to.deep.equal(now);
+    expect(deletedCertificationCenter2Invitation).to.be.empty;
 
     clock.restore();
   });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-api.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-api.repository.test.js
@@ -34,15 +34,14 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
       const disabledCertificationCenterMembership = await knex('certification-center-memberships')
         .where({ certificationCenterId })
         .first();
-      const cancelledCertificationCenterInvitation = await knex('certification-center-invitations')
-        .where({ certificationCenterId })
-        .first();
+      const deletedCertificationCenterInvitation = await knex('certification-center-invitations').where({
+        certificationCenterId,
+      });
 
       expect(disabledCertificationCenterMembership.disabledAt).to.deep.equal(archiveDate);
       expect(disabledCertificationCenterMembership.updatedByUserId).to.deep.equal(superAdminUser.id);
 
-      expect(cancelledCertificationCenterInvitation.status).to.deep.equal('cancelled');
-      expect(cancelledCertificationCenterInvitation.updatedAt).to.deep.equal(archiveDate);
+      expect(deletedCertificationCenterInvitation).to.be.empty;
     });
   });
 });

--- a/api/tests/team/integration/domain/usecases/archive-certification-center-data.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/archive-certification-center-data.usecase.test.js
@@ -6,7 +6,7 @@ import { databaseBuilder } from '../../../../tooling/databases.js';
 
 describe('Integration | Team | Domain | UseCase | archive-certification-center-data', function () {
   describe('#archiveCertificationCenterData', function () {
-    it('archives memberships and invitations related to a certification center', async function () {
+    it('archives memberships and delete invitations related to a certification center', async function () {
       //given
       const archiveDate = new Date(2023, 3, 14);
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -35,15 +35,15 @@ describe('Integration | Team | Domain | UseCase | archive-certification-center-d
       const disabledCertificationCenterMembership = await knex('certification-center-memberships')
         .where({ certificationCenterId })
         .first();
-      const cancelledCertificationCenterInvitation = await knex('certification-center-invitations')
-        .where({ certificationCenterId })
-        .first();
+
+      const certificationCenterInvitation = await knex('certification-center-invitations').where({
+        certificationCenterId,
+      });
 
       expect(disabledCertificationCenterMembership.disabledAt).to.deep.equal(archiveDate);
       expect(disabledCertificationCenterMembership.updatedByUserId).to.deep.equal(superAdminUser.id);
 
-      expect(cancelledCertificationCenterInvitation.status).to.deep.equal('cancelled');
-      expect(cancelledCertificationCenterInvitation.updatedAt).to.deep.equal(archiveDate);
+      expect(certificationCenterInvitation).to.be.empty;
     });
   });
 });

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-invitation-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-invitation-repository_test.js
@@ -153,6 +153,65 @@ describe('Integration | Team | Infrastructure | Repositories | CertificationCent
     });
   });
 
+  describe('#deleteInvitationsByCertificationCenterId', function () {
+    it('hard delete all invitations (all statuses included) of a given certification center', async function () {
+      // given
+      const pendingStatus = CertificationCenterInvitation.StatusType.PENDING;
+      const cancelledStatus = CertificationCenterInvitation.StatusType.CANCELLED;
+      const acceptedStatus = CertificationCenterInvitation.StatusType.ACCEPTED;
+
+      const givenCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const otherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+      databaseBuilder.factory.buildCertificationCenterInvitation({
+        certificationCenterId: givenCertificationCenterId,
+        status: pendingStatus,
+      });
+      databaseBuilder.factory.buildCertificationCenterInvitation({
+        certificationCenterId: givenCertificationCenterId,
+        status: acceptedStatus,
+      });
+      databaseBuilder.factory.buildCertificationCenterInvitation({
+        certificationCenterId: givenCertificationCenterId,
+        status: cancelledStatus,
+      });
+
+      databaseBuilder.factory.buildCertificationCenterInvitation({
+        certificationCenterId: otherCertificationCenterId,
+        status: pendingStatus,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const [{ count: beforeDeleteForThisCertificationCenterInvitationsCount }] = await knex(
+        'certification-center-invitations',
+      )
+        .where({ certificationCenterId: givenCertificationCenterId })
+        .count();
+
+      await certificationCenterInvitationRepository.deleteInvitationsByCertificationCenterId({
+        certificationCenterId: givenCertificationCenterId,
+      });
+
+      // then
+      expect(beforeDeleteForThisCertificationCenterInvitationsCount).to.equal(3);
+
+      const givenCenterInvitations = await knex('certification-center-invitations').where({
+        certificationCenterId: givenCertificationCenterId,
+      });
+
+      expect(givenCenterInvitations).to.have.lengthOf(0);
+
+      const otherCenterInvitation = await knex('certification-center-invitations')
+        .where({
+          certificationCenterId: otherCertificationCenterId,
+        })
+        .first();
+      expect(otherCenterInvitation.status).to.equal(pendingStatus);
+    });
+  });
+
   describe('#findOnePendingByEmailAndCertificationCenterId', function () {
     it('returns null if no pending invitation exists for the given email and certification center id', async function () {
       // given


### PR DESCRIPTION
## 🌱 Problème
Actuellement, lorsque l'on archive un centre de certification, les invitations au statut "pending" sont annulées (cancelled).

## 🐣 Proposition
Toutes les invitations rattachées au centre de certif, peu importe le statut (pending, cancelled, accepted), doivent être supprimées. Hard delete. Pas besoin de garder une trace de cette information.  

## 🌷 Remarques
Une fois cette PR en prod, on a prévu de faire une requête SQL pour faire cette action de hard delete sur les invitations à l'état cancelled provenant d'un centre de certif archivé

## 🐝 Pour tester
Aller sur un centre de certif
Envoyer une invitation (et l'accepter ou non)
Archiver ce centre de certif
Voir que l'invitation n'est plus présente dans la liste
Verifier que l'invitation précedemment envoyée n'existe plus en BDD
