### PR TITLE
[TECH] Supprimer le lien erroné certificationCenterMemberships du sérialiseur non-admin (PIX-22599)

### DIFF
--- a/admin/app/adapters/certification-center.js
+++ b/admin/app/adapters/certification-center.js
@@ -3,16 +3,6 @@ import ApplicationAdapter from './application';
 export default class CertificationCenterAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  findHasMany(store, snapshot, _url, relationship) {
-    if (relationship.key === 'certificationCenterMemberships') {
-      return this.ajax(
-        `${this.host}/${this.namespace}/certification-centers/${snapshot.id}/certification-center-memberships`,
-        'GET',
-      );
-    }
-    return super.findHasMany(...arguments);
-  }
-
   archiveCertificationCenter(certificationCenterId) {
     return this.ajax(`${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/archive`, 'POST');
   }

--- a/admin/app/routes/authenticated/certification-centers/get/team.js
+++ b/admin/app/routes/authenticated/certification-centers/get/team.js
@@ -4,10 +4,8 @@ import Route from '@ember/routing/route';
 export default class AuthenticatedCertificationCentersGetTeamRoute extends Route {
   async model() {
     const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
-    await certificationCenter.hasMany('certificationCenterMemberships').reload();
-
     return {
-      certificationCenterMemberships: certificationCenter.certificationCenterMemberships,
+      certificationCenterMemberships: await certificationCenter.certificationCenterMemberships,
       isCertificationCenterArchived: certificationCenter.isArchived,
       certificationCenterId: certificationCenter.id,
     };

--- a/admin/tests/unit/routes/authenticated/certification-centers/get/team-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get/team-test.js
@@ -14,7 +14,6 @@ module('Unit | Route | authenticated/certification-centers/get/team', function (
       id: 777,
       isArchived: false,
       certificationCenterMemberships,
-      hasMany: sinon.stub().returns({ reload: sinon.stub().resolves() }),
     };
 
     route.modelFor = sinon.stub();
@@ -24,7 +23,6 @@ module('Unit | Route | authenticated/certification-centers/get/team', function (
     const result = await route.model();
 
     // then
-    sinon.assert.calledWith(certificationCenter.hasMany, 'certificationCenterMemberships');
     assert.strictEqual(result.certificationCenterMemberships, certificationCenterMemberships);
     assert.strictEqual(result.certificationCenterId, 777);
   });

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js
@@ -4,19 +4,9 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (certificationCenters, meta) {
   return new Serializer('certification-center', {
-    attributes: ['name', 'type', 'externalId', 'createdAt', 'certificationCenterMemberships', 'habilitations'],
+    attributes: ['name', 'type', 'externalId', 'createdAt', 'habilitations'],
     typeForAttribute: (attribute) => {
       if (attribute === 'habilitations') return 'complementary-certifications';
-    },
-    certificationCenterMemberships: {
-      ref: 'id',
-      ignoreRelationshipData: true,
-      nullIfMissing: true,
-      relationshipLinks: {
-        related(record, current, parent) {
-          return `/api/certification-centers/${parent.id}/certification-center-memberships`;
-        },
-      },
     },
     habilitations: {
       include: true,

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -72,11 +72,6 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
                 habilitations: {
                   data: [],
                 },
-                'certification-center-memberships': {
-                  links: {
-                    related: '/api/certification-centers/1/certification-center-memberships',
-                  },
-                },
               },
             },
             {
@@ -91,11 +86,6 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
               relationships: {
                 habilitations: {
                   data: [],
-                },
-                'certification-center-memberships': {
-                  links: {
-                    related: '/api/certification-centers/2/certification-center-memberships',
-                  },
                 },
               },
             },

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.test.js
@@ -31,11 +31,6 @@ describe('Unit | Organizational Entities | Infrastructure | Serializer | JSONAPI
             'created-at': new Date('2018-01-01T05:43:10Z'),
           },
           relationships: {
-            'certification-center-memberships': {
-              links: {
-                related: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
-              },
-            },
             habilitations: {
               data: [
                 {


### PR DESCRIPTION
## 🌱 Problème

Un sérialiseur non-admin `certification-center.serializer.js` incluait un `links.related` invalide (sans `/admin/`) pour la relation `certificationCenterMemberships`. Ce lien était compensé par un override `findHasMany` dans l'adapteur Admin qui reconstruisait manuellement la bonne URL.

Toute suppression de ce workaround expose immédiatement une 404 sur la page équipe d'un centre de certif dans Pix Admin.

## 🐣 Proposition

- Suppression de `certificationCenterMemberships` du sérialiseur non-admin : le mauvais lien n'est plus injecté dans le cache Ember Data.
- Suppression du `findHasMany` override dans l'adapteur Admin, devenu obsolète.
- Alignement de la route `team.js` sur le pattern déjà utilisé par les invitations (`await certificationCenter.certificationCenterMemberships` directement).

Le sérialiseur non-admin n'est utilisé que pour `GET /api/admin/certification-centers` (liste paginée) — aucune autre app n'est impactée.

## 🌷 Remarques

La relation `certificationCenterInvitations` n'a jamais été ajoutée au sérialiseur non-admin, ce qui explique pourquoi les invitations ont toujours fonctionné sans workaround.

## 🐝 Pour tester

- [ ] Naviguer vers un centre de certif dans Pix Admin (`/certification-centers/:id/team`)
- [ ] Vérifier que la liste des membres se charge sans 404
- [ ] Vérifier que le bouton d'ajout de membre fonctionne
- [ ] Vérifier que la liste des invitations (`/certification-centers/:id/invitations`) est toujours fonctionnelle
