### PR TITLE
[FEATURE] Enlever la mention bêta sur les contenus formatifs de type Modules (PIX-22533)

### DIFF
--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2271,7 +2271,7 @@
         "e-learning": "Fernunterricht",
         "hybrid-training": "Hybride Ausbildung",
         "in-person-training": "Präsenzschulungen",
-        "modulix": "Pix-Modul (Beta)",
+        "modulix": "Pix-Modul",
         "webinaire": "Webinar"
       }
     },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2253,7 +2253,7 @@
         "e-learning": "Formación a distancia",
         "hybrid-training": "Formación híbrida",
         "in-person-training": "Formación presencial",
-        "modulix": "Módulo Pix (Beta)",
+        "modulix": "Módulo Pix",
         "webinaire": "Webinario"
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2272,7 +2272,7 @@
         "e-learning": "Formation à distance",
         "hybrid-training": "Formation hybride",
         "in-person-training": "Formation en présentiel",
-        "modulix": "Module Pix (Bêta)",
+        "modulix": "Module Pix",
         "webinaire": "Webinaire"
       }
     },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2264,7 +2264,7 @@
         "e-learning": "Formazione a distanza",
         "hybrid-training": "Formazione ibrida",
         "in-person-training": "Formazione faccia a faccia",
-        "modulix": "Modulo Pix (Beta)",
+        "modulix": "Modulo Pix",
         "webinaire": "Webinar"
       }
     },


### PR DESCRIPTION
## 🌱 Problème

Lorsqu'on a un contenu formatif de type `modulix` recommandé sur la page `Mes Formations`, la mention (bêta) apparait. 

On n'a plus besoin de cette mention car les modules sont maintenant joués en production 🚀 

## 🐣 Proposition

Retirer cette mention

## 🌷 Remarques

RAS

## 🐝 Pour tester
- Se connecter avec l'utilisateur `dave-comp@example.net`
- Reprendre et terminer une des campagnes Devcomp
- Une fois arrivé sur la page des résultats, revenir sur la page d'accueil
- Accéder à l'onglet Mes formations et constater qu'il n'y a plus la mention bêta sur les contenus formatifs de type "Modulix Pix" 😄 