### PR TITLE
[TECH] Supprimer le lien erroné memberships du sérialiseur non-admin des organisations (PIX-22626)

### DIFF
--- a/admin/app/adapters/organization-membership.js
+++ b/admin/app/adapters/organization-membership.js
@@ -3,6 +3,15 @@ import ApplicationAdapter from './application';
 export default class OrganizationMembershipAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
+  urlForQuery(query) {
+    if (query.filter?.organizationId) {
+      const { organizationId } = query.filter;
+      delete query.filter.organizationId;
+      return `${this.host}/${this.namespace}/organizations/${organizationId}/memberships`;
+    }
+    return super.urlForQuery(...arguments);
+  }
+
   urlForCreateRecord() {
     return `${this.host}/${this.namespace}/memberships`;
   }

--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -3,22 +3,6 @@ import ApplicationAdapter from './application';
 export default class OrganizationAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  findHasMany(store, snapshot, url, relationship) {
-    url = this.urlPrefix(url, this.buildURL(snapshot.modelName, snapshot.id, null, 'findHasMany'));
-
-    if (relationship.type === 'organization-membership') {
-      const params = new URLSearchParams();
-      if (snapshot.adapterOptions) {
-        for (const [key, value] of Object.entries(snapshot.adapterOptions)) {
-          if (value) params.append(key, value);
-        }
-      }
-      url = `${this.host}/${this.namespace}/organizations/${snapshot.id}/memberships${params.toString() ? '?' + params.toString() : ''}`;
-    }
-
-    return this.ajax(url, 'GET');
-  }
-
   updateRecord(store, type, snapshot) {
     if (snapshot?.adapterOptions?.archiveOrganization) {
       const url = `${this.host}/${this.namespace}/organizations/${snapshot.id}/archive`;

--- a/admin/app/controllers/authenticated/organizations/get/team.js
+++ b/admin/app/controllers/authenticated/organizations/get/team.js
@@ -63,19 +63,8 @@ export default class GetTeamController extends Controller {
 
     try {
       await this.store.createRecord('organization-membership', { organization, user }).save();
-
-      await this.model.organizationMemberships.reload({
-        adapterOptions: {
-          'page[size]': this.pageSize,
-          'page[number]': this.pageNumber,
-          'filter[firstName]': this.firstName,
-          'filter[lastName]': this.lastName,
-          'filter[email]': this.email,
-          'filter[organizationRole]': this.organizationRole,
-        },
-      });
-
       this.userEmailToAdd = null;
+      this.send('refreshModel');
       this.pixToast.sendSuccessNotification({ message: 'Accès attribué avec succès.' });
     } catch {
       this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });

--- a/admin/app/routes/authenticated/organizations/get/team.js
+++ b/admin/app/routes/authenticated/organizations/get/team.js
@@ -1,10 +1,11 @@
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class OrganizationTeamRoute extends Route {
   @service router;
   @service pixToast;
+  @service store;
 
   queryParams = {
     pageNumber: { refreshModel: true },
@@ -29,25 +30,28 @@ export default class OrganizationTeamRoute extends Route {
 
   async model(params) {
     const organization = this.modelFor('authenticated.organizations.get');
+    let organizationMemberships = [];
     try {
-      await organization.hasMany('organizationMemberships').reload({
-        adapterOptions: {
-          'page[size]': params.pageSize,
-          'page[number]': params.pageNumber,
-          'filter[firstName]': params.firstName,
-          'filter[lastName]': params.lastName,
-          'filter[email]': params.email,
-          'filter[organizationRole]': params.organizationRole,
+      organizationMemberships = await this.store.query('organization-membership', {
+        filter: {
+          organizationId: organization.id,
+          firstName: params.firstName,
+          lastName: params.lastName,
+          email: params.email,
+          organizationRole: params.organizationRole,
         },
+        page: { size: params.pageSize, number: params.pageNumber },
       });
     } catch (errorResponse) {
       this._handleResponseError(errorResponse);
     }
 
-    return RSVP.hash({
-      organization,
-      organizationMemberships: organization.organizationMemberships,
-    });
+    return { organization, organizationMemberships };
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 
   resetController(controller, isExiting) {

--- a/admin/tests/unit/adapters/organization-membership-test.js
+++ b/admin/tests/unit/adapters/organization-membership-test.js
@@ -1,4 +1,5 @@
 import { setupTest } from 'ember-qunit';
+import ENV from 'pix-admin/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -16,6 +17,29 @@ module('Unit | Adapter | organization-membership', function (hooks) {
     adapter.ajax.restore();
   });
 
+  module('#urlForQuery', function () {
+    test('builds the correct url when organizationId is provided', function (assert) {
+      // given
+      const query = { filter: { organizationId: '42', firstName: 'John' } };
+
+      // when
+      const url = adapter.urlForQuery(query);
+
+      // then
+      assert.strictEqual(url, `${ENV.APP.API_HOST}/api/admin/organizations/42/memberships`);
+      assert.notOk(query.filter.organizationId, 'organizationId is removed from filter');
+      assert.strictEqual(query.filter.firstName, 'John');
+    });
+
+    test('delegates to super when no organizationId', function (assert) {
+      // given
+      const query = { filter: { firstName: 'John' } };
+
+      // when / then
+      assert.ok(adapter.urlForQuery(query));
+    });
+  });
+
   module('#deleteRecord', function () {
     module('when disabled adapter option is provided', function () {
       test('it should trigger a POST request to /admin/memberships/{id}/disable', async function (assert) {
@@ -28,7 +52,7 @@ module('Unit | Adapter | organization-membership', function (hooks) {
         );
 
         // then
-        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/admin/memberships/1/disable', 'POST', {
+        sinon.assert.calledWith(adapter.ajax, `${ENV.APP.API_HOST}/api/admin/memberships/1/disable`, 'POST', {
           data,
         });
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */

--- a/admin/tests/unit/adapters/organization-test.js
+++ b/admin/tests/unit/adapters/organization-test.js
@@ -17,58 +17,6 @@ module('Unit | Adapters | organization', function (hooks) {
     adapter.ajax.restore();
   });
 
-  module('#findHasMany', function () {
-    module('when type is organization-membership', function () {
-      module('when there are no query params', function () {
-        test('builds the correct url', async function (assert) {
-          // given
-          const snapshot = { modelName: 'organization', id: '1' };
-          const relationship = { type: 'organization-membership' };
-          const url = '/api/organizations/1/memberships';
-
-          // when
-          await adapter.findHasMany({}, snapshot, url, relationship);
-
-          // then
-          assert.ok(adapter.ajax.calledWith(`${ENV.APP.API_HOST}/api/admin/organizations/1/memberships`, 'GET'));
-        });
-      });
-
-      module('when there are query params', function () {
-        test('builds the correct url', async function (assert) {
-          // given
-          const snapshot = { modelName: 'organization', id: '1', adapterOptions: { 'page[size]': 2 } };
-          const relationship = { type: 'organization-membership' };
-          const url = '/api/organizations/1/memberships';
-
-          // when
-          await adapter.findHasMany({}, snapshot, url, relationship);
-
-          // then
-          assert.ok(
-            adapter.ajax.calledWith(
-              `${ENV.APP.API_HOST}/api/admin/organizations/1/memberships?page%5Bsize%5D=2`,
-              'GET',
-            ),
-          );
-        });
-      });
-    });
-
-    test('should build url without query params when type is not membership', async function (assert) {
-      // given
-      const snapshot = { modelName: 'organization', id: '1', adapterOptions: { 'page[size]': 2 } };
-      const relationship = { type: 'target-profile' };
-      const url = '/api/organizations/1/target-profiles';
-
-      // when
-      await adapter.findHasMany({}, snapshot, url, relationship);
-
-      // then
-      assert.ok(adapter.ajax.calledWith(`${ENV.APP.API_HOST}/api/organizations/1/target-profiles`, 'GET'));
-    });
-  });
-
   module('#attachTargetProfile', function () {
     test('should trigger an ajax call with the right url, method and payload', async function (assert) {
       // given

--- a/admin/tests/unit/controllers/authenticated/organizations/get/team-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/team-test.js
@@ -72,14 +72,12 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
         store.createRecord = sinon.stub().returns({ save: sinon.stub() });
 
         controller.model = {
-          organizationMemberships: {
-            reload: sinon.stub().resolves(true),
-          },
           organization: {
             id: '1',
             hasMember: sinon.stub().resolves(false),
           },
         };
+        controller.send = sinon.stub();
         controller.userEmailToAdd = email;
 
         // when
@@ -87,7 +85,7 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
 
         // then
         assert.deepEqual(controller.userEmailToAdd, null);
-        assert.ok(controller.model.organizationMemberships.reload.calledOnce);
+        sinon.assert.calledWith(controller.send, 'refreshModel');
         sinon.assert.calledWith(controller.pixToast.sendSuccessNotification, {
           message: 'Accès attribué avec succès.',
         });
@@ -100,11 +98,8 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
         const user = store.createRecord('user', { email, id: '5' });
 
         store.query = sinon.stub().resolves([user]);
-        store.createRecord = sinon.stub().returns({ save: sinon.stub() });
+        store.createRecord = sinon.stub().returns({ save: sinon.stub().rejects('some error') });
         controller.model = {
-          organizationMemberships: {
-            reload: sinon.stub().rejects('some error'),
-          },
           organization: {
             hasMember: sinon.stub().resolves(false),
             id: '1',

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -16,7 +16,6 @@ const serialize = function (organizations, meta) {
       'isManagingStudents',
       'credit',
       'email',
-      'memberships',
       'targetProfiles',
       'tags',
       'createdBy',
@@ -26,16 +25,6 @@ const serialize = function (organizations, meta) {
       'showSkills',
       'administrationTeamName',
     ],
-    memberships: {
-      ref: 'id',
-      ignoreRelationshipData: true,
-      nullIfMissing: true,
-      relationshipLinks: {
-        related(record, current, parent) {
-          return `/api/organizations/${parent.id}/memberships`;
-        },
-      },
-    },
     targetProfiles: {
       ref: 'id',
       ignoreRelationshipData: true,

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -73,7 +73,7 @@ const serialize = function (organizations, meta) {
       nullIfMissing: true,
       relationshipLinks: {
         related(record, current, parent) {
-          return `/api/organizations/${parent.id}/memberships`;
+          return `/api/admin/organizations/${parent.id}/memberships`;
         },
       },
     },

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -227,7 +227,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         context(`when user has role ${role}`, function () {
           it('returns child organizations list with a 200 HTTP status code', async function () {
             // given
-            const userId = databaseBuilder.factory.buildUser.withRole({ role }).id;
+            const userId = databaseBuilder.factory.buildUser.withRole({
+              role,
+            }).id;
 
             const {
               organization: parentOrganization,
@@ -438,7 +440,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         method: 'POST',
         url: '/api/admin/organizations',
         payload,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
       };
     });
 
@@ -675,7 +679,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           tagId: tag.id,
           organizationId: organization.id,
         });
-        const network = databaseBuilder.factory.buildNetwork({ name: 'Réseau Académique' });
+        const network = databaseBuilder.factory.buildNetwork({
+          name: 'Réseau Académique',
+        });
         const structure = databaseBuilder.factory.buildStructure();
         databaseBuilder.factory.buildFactStructure({
           structureId: structure.id,
@@ -759,7 +765,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               },
               'organization-memberships': {
                 links: {
-                  related: `/api/organizations/${organization.id}/memberships`,
+                  related: `/api/admin/organizations/${organization.id}/memberships`,
                 },
               },
               tags: {
@@ -923,7 +929,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         method: 'PATCH',
         url: `/api/admin/organizations/${organization.id}`,
         payload,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
       };
 
       // when
@@ -1594,7 +1602,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       const options = {
         method: 'GET',
         url: `/api/admin/organizations/${organizationId}/places-statistics`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
       };
 
       // when

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -34,7 +34,9 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
         identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         features: {
-          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: true },
+          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: {
+            active: true,
+          },
         },
         name: 'motherSco',
         countryCode: 99100,
@@ -55,7 +57,9 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
         identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         features: {
-          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: true },
+          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: {
+            active: true,
+          },
         },
         parentOrganizationId: parentOrganization.id,
         parentOrganizationName: parentOrganization.name,
@@ -115,7 +119,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
           relationships: {
             'organization-memberships': {
               links: {
-                related: `/api/organizations/${organization.id}/memberships`,
+                related: `/api/admin/organizations/${organization.id}/memberships`,
               },
             },
             'target-profile-summaries': {
@@ -214,7 +218,9 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         administrationTeamId: '1',
         features: {
           [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true },
-          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: true },
+          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: {
+            active: true,
+          },
           [ORGANIZATION_FEATURE.IS_MANAGING_STUDENTS.key]: { active: true },
           [ORGANIZATION_FEATURE.SHOW_SKILLS.key]: { active: true },
         },

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -12,7 +12,9 @@ describe('Unit | Serializer | organization-serializer', function () {
         domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
         domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
       ];
-      const administrationTeam = domainBuilder.buildAdministrationTeam({ name: 'pouet' });
+      const administrationTeam = domainBuilder.buildAdministrationTeam({
+        name: 'pouet',
+      });
       const organization = domainBuilder.buildOrganizationForAdmin({
         email: 'sco.generic.account@example.net',
         tags,
@@ -48,11 +50,6 @@ describe('Unit | Serializer | organization-serializer', function () {
             'administration-team-name': organization.administrationTeamName,
           },
           relationships: {
-            memberships: {
-              links: {
-                related: `/api/organizations/${organization.id}/memberships`,
-              },
-            },
             'target-profiles': {
               links: {
                 related: `/api/organizations/${organization.id}/target-profiles`,


### PR DESCRIPTION
## 🌱 Problème

Les deux sérialiseurs organisation (`organization-serializer.js` et `organization-for-admin.serializer.js`) généraient des `links.related` invalides (sans `/admin/`) pour la relation `memberships`. Un `findHasMany` override dans l'adapteur Admin compensait silencieusement ce lien en reconstruisant manuellement la bonne URL `/api/admin/...` et en injectant les params de pagination et filtrage. Ce pattern est identique au bug corrigé sur les centres de certif (#16075).

## 🐣 Proposition

- Suppression de `memberships` du sérialiseur non-admin : le mauvais lien n'est plus jamais injecté dans le cache Ember Data.
- Correction du `links.related` dans le sérialiseur for-admin : `/api/admin/organizations/${id}/memberships`.
- Ajout d'un `urlForQuery` dans l'adapteur `organization-membership` qui construit l'URL à partir du `filter.organizationId` (même pattern que `certification-center-membership`).
- La route appelle `store.query()` pour le chargement paginé et filtré et retourne directement le `RecordArray` filtré — le proxy hasMany n'est pas utilisé pour éviter qu'un sideload de l'organisation ne déclenche un fetch non filtré via `links.related`.
- Après ajout d'un membre, le controller déclenche `this.send('refreshModel')` pour relancer le model hook avec les params courants — même pattern que le controller certification-center.
- Suppression du `findHasMany` de l'adapteur `organization`, devenu obsolète.

## 🌷 Remarques

Le sérialiseur Mirage (`tests/mirage/serializers/organization.js`) générait déjà le bon lien `/api/admin/` — c'est pourquoi le bug n'était pas détectable en tests.

## 🐝 Pour tester

- [ ] Naviguer vers une organisation dans Pix Admin (`/organizations/:id/team`)
- [ ] Vérifier que la liste des membres se charge correctement
- [ ] Vérifier que la pagination et les filtres (prénom, nom, email, rôle) fonctionnent
- [ ] Ajouter un membre et vérifier que la liste se rafraîchit sans erreur
- [ ] Désactiver un membre et vérifier que la liste se met à jour
