### PR TITLE
[BUGFIX] Ajouter un message d'erreur dédié (PIX-21376)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js
@@ -1,3 +1,4 @@
+import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
 import { AuthenticationKeyExpired, MissingUserAccountError } from '../errors.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 
@@ -52,14 +53,25 @@ export const reconcileOidcUser = async function ({
     sessionContent,
   });
 
-  await authenticationMethodRepository.create({
-    authenticationMethod: new AuthenticationMethod({
-      identityProvider,
-      userId,
-      externalIdentifier: externalIdentityId,
-      authenticationComplement,
-    }),
-  });
+  try {
+    await authenticationMethodRepository.create({
+      authenticationMethod: new AuthenticationMethod({
+        identityProvider,
+        userId,
+        externalIdentifier: externalIdentityId,
+        authenticationComplement,
+      }),
+    });
+  } catch (error) {
+    if (error instanceof AlreadyExistingEntityError) {
+      throw new AlreadyExistingEntityError(
+        'Already existing authentication method',
+        'SSO_PROVIDER_ALREADY_LINKED_TO_USER',
+      );
+    }
+
+    throw error;
+  }
 
   await _updateUserLastConnection({
     userId,

--- a/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
@@ -35,7 +35,7 @@ const create = async function ({ authenticationMethod }) {
   } catch (err) {
     if (knexUtils.isUniqConstraintViolated(err)) {
       throw new AlreadyExistingEntityError(
-        `An authentication method already exists for the user ID ${authenticationMethod.userId} and the externalIdentifier ${authenticationMethod.externalIdentifier}.`,
+        `An authentication method already exists for the user ID ${authenticationMethod.userId} and the identityProvider ${authenticationMethod.identityProvider}.`,
       );
     }
 

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
@@ -8,6 +8,7 @@ import {
 import { AuthenticationMethod } from '../../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
 import { reconcileOidcUser } from '../../../../../src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js';
 import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
+import { AlreadyExistingEntityError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
@@ -114,6 +115,48 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
         // then
         expect(error).to.be.instanceOf(MissingUserAccountError);
         expect(error.message).to.be.equal('Les informations de compte requises sont manquantes');
+      });
+    });
+
+    context('when the user has already this authentication method', function () {
+      it('throws an AlreadyExistingEntityError', async function () {
+        // given
+        const sessionContent = { idToken: 'idToken' };
+        const externalIdentifier = 'external_id';
+        const userId = 1;
+        const userInfo = { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' };
+        authenticationSessionService.getByKey.resolves({
+          sessionContent,
+          userInfo,
+        });
+
+        oidcAuthenticationService.createAuthenticationComplement.withArgs({ userInfo, sessionContent }).returns(
+          new AuthenticationMethod.OidcAuthenticationComplement({
+            accessToken: 'accessToken',
+            expiredDate: new Date(),
+          }),
+        );
+
+        authenticationMethodRepository.create.throws(
+          new AlreadyExistingEntityError(
+            `An authentication method already exists for the user ID ${userId} and the identityProvider ${identityProvider}.`,
+          ),
+        );
+
+        // when
+        const error = await catchErr(reconcileOidcUser)({
+          authenticationKey: 'authenticationKey',
+          identityProvider,
+          audience,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          oidcAuthenticationServiceRegistry,
+          userLoginRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+        expect(error.code).to.be.equal('SSO_PROVIDER_ALREADY_LINKED_TO_USER');
       });
     });
 

--- a/orga/app/components/authentication/oidc-association-confirmation.scss
+++ b/orga/app/components/authentication/oidc-association-confirmation.scss
@@ -76,4 +76,9 @@
     width: 100%;
     padding-top: var(--pix-spacing-8x);
   }
+
+  &__container-error {
+    width: 100%;
+    margin-top: var(--pix-spacing-4x);
+  }
 }

--- a/orga/app/services/auth-error-messages.js
+++ b/orga/app/services/auth-error-messages.js
@@ -11,12 +11,14 @@ const AUTHENTICATION_DEFAULT_MESSAGE = {
 const HTTP_STATUS_MAPPING = {
   400: { i18nKey: 'common.api-error-messages.bad-request-error' },
   401: { i18nKey: 'common.api-error-messages.login-unauthorized-error' },
-  409: { i18nKey: 'common.api-error-messages.account-conflict' },
   422: { i18nKey: 'common.api-error-messages.bad-request-error' },
   504: { i18nKey: 'common.api-error-messages.internal-server-error' },
 };
 
 const AUTHENTICATION_ERROR_CODES_MAPPING = {
+  SSO_PROVIDER_ALREADY_LINKED_TO_USER: {
+    i18nKey: 'common.api-error-messages.account-conflict',
+  },
   EXPIRED_AUTHENTICATION_KEY: {
     i18nKey: 'common.api-error-messages.expired-authentication-key',
   },

--- a/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -284,6 +284,37 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
             });
           });
         });
+
+        module('when the SSO provider is already linked to the user', function () {
+          test('the confirmation page displays a dedicated error message', async function (assert) {
+            // given
+            const user = createUserWithMembership();
+            createPrescriberByUser({ user });
+
+            this.server.post(
+              '/oidc/user/reconcile',
+              {
+                errors: [{ code: 'SSO_PROVIDER_ALREADY_LINKED_TO_USER' }],
+              },
+              412,
+            );
+
+            const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+            await click(await screen.getByRole('link', { name: t('pages.oidc.signup.login-button') }));
+            await fillIn(await screen.getByRole('textbox', { name: t('pages.login-form.email.label') }), user.email);
+            await fillIn(await screen.getByLabelText(t('pages.login-form.password')), 'pix123');
+            const loginButton = screen.getByRole('button', { name: t('pages.login-form.associate-account') });
+            await click(loginButton);
+
+            // when
+            await click(await screen.findByText(t('components.authentication.oidc-association-confirmation.confirm')));
+            // eslint-disable-next-line ember/no-settled-after-test-helper
+            await settled();
+
+            // then
+            assert.ok(screen.getByText(t('common.api-error-messages.account-conflict')));
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## 🌱 Problème

Si une méthode d'authentification OIDC existe déjà pour un utilisateur donné, alors toute tentative d'association au même compte avec un nouvel external identifier renvoie un message d'erreur générique : "Impossible de se connecter. Veuillez réessayer dans quelques instants. Si le problème persiste, contactez-nous via le centre d’aide."
Il faut afficher le message dédié : "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support."

## 🐣 Proposition

Afficher le message d'erreur dédié si la méthode d'authentification OIDC existe déjà pour l'utilisateur et pour un fournisseur d'identité donné

## 🌷 Remarques

- Nous en avons profité pour changer le message d'erreur renvoyé par le repository qui était trop restrictif et ne correspondait pas à toutes les erreurs rencontrées.
-  Pour un futur ticket :  la contrainte suivante sur la table `authentication-methods` n'est a priori pas nécessaire 
 `"authentication_methods_identityprovider_externalidentifier_uniq" UNIQUE CONSTRAINT, btree ("identityProvider", "externalIdentifier"), `
à partir du moment où cette contrainte existe aussi - ce qui est le cas actuellement :
  `  "authentication_methods_identityprovider_userid_unique" UNIQUE CONSTRAINT, btree ("identityProvider", "userId")`


## 🐝 Pour tester

- Sur Pix Orga s'identifier via un partenaire OIDC, en associant le compte à un compte Pix déjà existant (Ornella)
- Se déconnecter 
- Faire une nouvelle association avec un `externalIdentifier` différent, mais un compte Pix identique
- Constater que l'erreur s'affiche correctement
