### PR TITLE
[BUGFIX] Afficher l'erreur dédiée si un utilisateur ajoute un email déjà existant (PIX-22271)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.gjs
+++ b/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.gjs
@@ -15,6 +15,7 @@ import { t } from 'ember-intl';
         <PixInput
           @id="new-email-for-adding-authentication-method"
           {{on "change" @onChangeNewEmail}}
+          autocomplete="off"
           @validationStatus={{if @showAlreadyExistingEmailError "error" "default"}}
           @errorMessage="Cette adresse e-mail est déjà utilisée"
           type="email"

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
@@ -163,9 +163,7 @@ export default class AuthenticationMethod extends Component {
       this.showAlreadyExistingEmailError = false;
     } catch (response) {
       const errors = response.errors;
-      const emailAlreadyExistingError = errors.some(
-        (error) => error.status === '400' && error.code === 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS',
-      );
+      const emailAlreadyExistingError = errors.some((error) => error.code === 'INVALID_OR_ALREADY_USED_EMAIL');
 
       if (emailAlreadyExistingError) {
         this.showAlreadyExistingEmailError = true;

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -250,16 +250,10 @@ export default function routes() {
     const userHowHasAlreadyTheEmail = schema.users.findBy({ email });
     if (userHowHasAlreadyTheEmail) {
       return new Response(
-        400,
+        422,
         {},
         {
-          errors: [
-            {
-              status: '400',
-              code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS',
-              title: 'Already existing email error',
-            },
-          ],
+          errors: [{ code: 'INVALID_OR_ALREADY_USED_EMAIL' }],
         },
       );
     }

--- a/mon-pix/app/components/user-account/email-verification-code.gjs
+++ b/mon-pix/app/components/user-account/email-verification-code.gjs
@@ -85,20 +85,15 @@ export default class EmailVerificationCode extends Component {
       }
       this.args.disableEmailEditionMode();
     } catch (response) {
-      const status = get(response, 'errors[0].status');
       const code = get(response, 'errors[0].code');
-      if (status === '403') {
-        if (code === 'INVALID_VERIFICATION_CODE') {
-          this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.incorrect-code');
-        } else if (code === 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND') {
-          this.errorMessage = this.intl.t(
-            'pages.user-account.email-verification.errors.email-modification-demand-expired',
-          );
-        }
-      } else if (status === '422') {
-        if (code === 'INVALID_OR_ALREADY_USED_EMAIL') {
-          this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.new-email-already-exist');
-        }
+      if (code === 'INVALID_VERIFICATION_CODE') {
+        this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.incorrect-code');
+      } else if (code === 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND') {
+        this.errorMessage = this.intl.t(
+          'pages.user-account.email-verification.errors.email-modification-demand-expired',
+        );
+      } else if (code === 'INVALID_OR_ALREADY_USED_EMAIL') {
+        this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.new-email-already-exist');
       } else {
         this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.unknown-error');
       }

--- a/mon-pix/app/components/user-account/email-verification-code.gjs
+++ b/mon-pix/app/components/user-account/email-verification-code.gjs
@@ -86,10 +86,8 @@ export default class EmailVerificationCode extends Component {
       this.args.disableEmailEditionMode();
     } catch (response) {
       const status = get(response, 'errors[0].status');
-
+      const code = get(response, 'errors[0].code');
       if (status === '403') {
-        const code = get(response, 'errors[0].code');
-
         if (code === 'INVALID_VERIFICATION_CODE') {
           this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.incorrect-code');
         } else if (code === 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND') {
@@ -97,8 +95,10 @@ export default class EmailVerificationCode extends Component {
             'pages.user-account.email-verification.errors.email-modification-demand-expired',
           );
         }
-      } else if (status === '400') {
-        this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.new-email-already-exist');
+      } else if (status === '422') {
+        if (code === 'INVALID_OR_ALREADY_USED_EMAIL') {
+          this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.new-email-already-exist');
+        }
       } else {
         this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.unknown-error');
       }

--- a/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
@@ -143,7 +143,7 @@ module('Integration | Component | user-account | email-verification-code', funct
     });
 
     module('after entering code', function () {
-      test('shows invalid code message when receiving 403', async function (assert) {
+      test('shows invalid code message when receiving INVALID_VERIFICATION_CODE error code', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const disableEmailEditionMode = sinon.stub();
@@ -151,7 +151,7 @@ module('Integration | Component | user-account | email-verification-code', funct
         this.set('disableEmailEditionMode', disableEmailEditionMode);
         this.set('displayEmailUpdateMessage', displayEmailUpdateMessage);
         this.set('email', 'toto@example.net');
-        const verifyCode = sinon.stub().throws({ errors: [{ status: '403', code: 'INVALID_VERIFICATION_CODE' }] });
+        const verifyCode = sinon.stub().throws({ errors: [{ code: 'INVALID_VERIFICATION_CODE' }] });
         store.createRecord = () => ({ verifyCode });
 
         const screen = await render(hbs`<UserAccount::EmailVerificationCode
@@ -176,7 +176,7 @@ module('Integration | Component | user-account | email-verification-code', funct
         assert.ok(screen.getByText(t('pages.user-account.email-verification.errors.incorrect-code')));
       });
 
-      test('shows demand expired message when receiving 403', async function (assert) {
+      test('shows demand expired message when receiving EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND error code', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const disableEmailEditionMode = sinon.stub();
@@ -187,7 +187,6 @@ module('Integration | Component | user-account | email-verification-code', funct
         const verifyCode = sinon.stub().throws({
           errors: [
             {
-              status: '403',
               code: 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND',
             },
           ],
@@ -218,7 +217,7 @@ module('Integration | Component | user-account | email-verification-code', funct
         );
       });
 
-      test('shows email already exists message when receiving 422', async function (assert) {
+      test('shows email already exists message when receiving INVALID_OR_ALREADY_USED_EMAIL error code', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const disableEmailEditionMode = sinon.stub();
@@ -229,7 +228,6 @@ module('Integration | Component | user-account | email-verification-code', funct
         const verifyCode = sinon.stub().throws({
           errors: [
             {
-              status: '422',
               code: 'INVALID_OR_ALREADY_USED_EMAIL',
             },
           ],

--- a/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
@@ -218,7 +218,7 @@ module('Integration | Component | user-account | email-verification-code', funct
         );
       });
 
-      test('shows email already exists message when receiving 400', async function (assert) {
+      test('shows email already exists message when receiving 422', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const disableEmailEditionMode = sinon.stub();
@@ -229,8 +229,8 @@ module('Integration | Component | user-account | email-verification-code', funct
         const verifyCode = sinon.stub().throws({
           errors: [
             {
-              status: '400',
-              code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS',
+              status: '422',
+              code: 'INVALID_OR_ALREADY_USED_EMAIL',
             },
           ],
         });


### PR DESCRIPTION
## 🌱 Problème

Quand on veut ajouter une adresse e-mail sur un compte mais que celle-ci est déjà utilisée sur un autre compte, on a le message d'erreur "Une erreur est survenue, veuillez réessayer."

## 🐣 Proposition
[CETTE PR REPREND LA PR [BUGFIX] Afficher correctement l'erreur si un utilisateur ajoute un email déjà existant (PIX-22271)#16038 qui a été fermée]

Corriger l'erreur

## 🌷 Remarques

Profiter de cette PR pour :
- désactiver l'autocomplete, peu pertinent pour ce type d'action sur Pix Admin, et source de bug (erreur 400, objet vide dans la payload) lorsqu'il est utilisé.
- corriger une erreur sur Pix App : entre la demande de modification ou d'ajout d'email et la validation du code, si la nouvelle adresse email est utilisée par une création de compte concomitante, alors l'erreur qui s'affiche doit être "Adresse email invalide ou déjà utilisée". Or actuellement c'est "Une erreur est survenue, veuillez réessayer."  - cette erreur n'est pas levée par nos tests car le stub utilisé ne reprend pas l'erreur réelle jetée par le back-end.

## 🐝 Pour tester

Sur la branche dev, **pour reproduire les erreurs** :

**- Sur Pix App** 

-- se connecter avec un compte possédant une adresse email
-- commencer le changement d'adresse email en choisissant une nouvelle adresse et en demandant un code 
-- sur un autre navigateur utiliser cette nouvelle adresse pour créer un nouveau compte
-- revenir sur le premier navigateur, récupérer le code reçu et le soumettre dans le formulaire de validation
-- constater que l'erreur est "Une erreur est survenue, veuillez réessayer." 

**- Sur Pix Admin**

-- aller sur la fiche de l'utilisateur paul-emploi@example.net 
-- dans l'onglet 'connexions', supprimer son adresse email.
-- toujours dans l'onglet 'connexions', cliquer sur "ajouter une adresse email"
-- ajouter une adresse déjà existante
-- constater que l'erreur affichée est "Une erreur est survenue, veuillez réessayer." 

Sur la branche `pix-22271-fix-error-message-for-already-existing-email` : faire les mêmes tests et vérifier que dans les deux cas l'erreur est "Adresse email invalide ou déjà utilisée".
