### PR TITLE
[FEATURE] Afficher les images des badges Pix+ (PIX-22622).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -1302,3 +1302,12 @@ DATABASE_IDLE_TIMEOUT_MS=
 # type: key
 # default: none
 DEEPL_API_KEY=
+
+# ========
+# ASSETS MANAGER
+# ========
+
+# presence: optional
+# type: String
+# default: <empty>
+# PIX_ASSETS_MANAGER_URL=https://assets.pix.digital

--- a/api/src/certification/results/domain/models/CertificateSummary.js
+++ b/api/src/certification/results/domain/models/CertificateSummary.js
@@ -2,6 +2,7 @@ import { AssessmentResult } from '../../../../shared/domain/models/AssessmentRes
 import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../shared/domain/constants/mesh-configuration.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { isEduFramework } from '../../../shared/domain/models/Frameworks.js';
+import { hasCoreScope } from '../../../shared/domain/models/Frameworks.js';
 import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/JuryComment.js';
 import { GlobalCertificationLevel } from './v3/GlobalCertificationLevel.js';
 
@@ -49,6 +50,21 @@ export class CertificateSummary {
     this.extraCertificationStatus = extraCertificationStatus;
     this.certificateType = certificateType;
     this.reachedMeshLevel = reachedMeshLevel;
+  }
+
+  get badgeUrl() {
+    if (
+      hasCoreScope(this.certificationFramework) ||
+      !this.reachedMeshLevel ||
+      this.reachedMeshLevel === 'LEVEL_ADMISSIBLE'
+    ) {
+      return null;
+    }
+
+    const framework = this.certificationFramework.toLowerCase();
+    const meshLevel = this.reachedMeshLevel.replace('LEVEL_', '').toLowerCase();
+
+    return `${process.env.PIX_ASSETS_MANAGER_URL}/badges-certifies/v3/${framework}/${meshLevel}.svg`;
   }
 
   static buildFrom({

--- a/api/src/certification/results/domain/models/CertificateSummary.js
+++ b/api/src/certification/results/domain/models/CertificateSummary.js
@@ -1,5 +1,7 @@
 import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../shared/domain/constants/mesh-configuration.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
+import { isEduFramework } from '../../../shared/domain/models/Frameworks.js';
 import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/JuryComment.js';
 import { GlobalCertificationLevel } from './v3/GlobalCertificationLevel.js';
 
@@ -63,6 +65,7 @@ export class CertificateSummary {
     isExtraCertificationAcquired,
     algorithmVersion,
     reachedMeshIndex,
+    eduV3ExternalJuryResult,
   }) {
     let status, extraCertificationStatus;
 
@@ -115,7 +118,19 @@ export class CertificateSummary {
       certificateType,
       reachedMeshLevel: isRejectedV3
         ? null
-        : new GlobalCertificationLevel({ reachedMeshIndex, certificationFramework }).meshLevel,
+        : _getReachedMeshLevel({ reachedMeshIndex, certificationFramework, algorithmVersion, eduV3ExternalJuryResult }),
     });
   }
+}
+
+function _getReachedMeshLevel({ reachedMeshIndex, certificationFramework, algorithmVersion, eduV3ExternalJuryResult }) {
+  if (
+    AlgorithmEngineVersion.isV3(algorithmVersion) &&
+    isEduFramework(certificationFramework) &&
+    Object.values(PIX_PLUS_EDU_EXTERNAL_LEVELS).includes(eduV3ExternalJuryResult)
+  ) {
+    return `LEVEL_${eduV3ExternalJuryResult}`;
+  }
+
+  return new GlobalCertificationLevel({ reachedMeshIndex, certificationFramework }).meshLevel;
 }

--- a/api/src/certification/results/infrastructure/repositories/certificate-summary-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-summary-repository.js
@@ -25,6 +25,7 @@ export async function findByUserId({ userId }) {
       commentByAutoJury: 'assessment-results.commentByAutoJury',
       assessmentResultStatus: 'assessment-results.status',
       reachedMeshIndex: 'assessment-results.reachedMeshIndex',
+      eduV3ExternalJuryResult: 'assessment-results.eduV3ExternalJuryResult',
     })
     .join('sessions', 'sessions.id', 'certification-courses.sessionId')
     .join(

--- a/api/src/certification/results/infrastructure/serializers/certificate-summary-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certificate-summary-serializer.js
@@ -9,6 +9,7 @@ const serialize = function (certificateSummaries, { translate }) {
         ...certificateSummary,
         comment: certificateSummary.juryComment.getComment(translate),
         reachedMeshLevel: certificateSummary.reachedMeshLevel?.split('_').at(-1) ?? null,
+        badgeUrl: certificateSummary.badgeUrl,
       };
     },
     attributes: [
@@ -22,6 +23,7 @@ const serialize = function (certificateSummaries, { translate }) {
       'extraCertificationStatus',
       'certificateType',
       'reachedMeshLevel',
+      'badgeUrl',
     ],
   }).serialize(certificateSummaries);
 };

--- a/api/tests/certification/results/acceptance/application/certificate-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certificate-route_test.js
@@ -450,6 +450,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
               status: CERTIFICATE_STATUSES.VALIDATED,
               'extra-certification-status': EXTRA_CERTIFICATE_STATUSES.NOT_APPLICABLE,
               'reached-mesh-level': null,
+              'badge-url': null,
             },
           },
           {
@@ -466,6 +467,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
               status: CERTIFICATE_STATUSES.VALIDATED,
               'extra-certification-status': EXTRA_CERTIFICATE_STATUSES.NOT_ACQUIRED,
               'reached-mesh-level': 'ADMISSIBLE',
+              'badge-url': null,
             },
           },
         ]);

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-summary-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-summary-repository_test.js
@@ -268,6 +268,56 @@ describe('Integration | Infrastructure | Repository | Certification summary', fu
         });
       });
 
+      describe('when the user has a Pix+ EDU certification with an external jury result', function () {
+        it('should return an array with the certificate summary using the external jury level', async function () {
+          // given
+          const session = databaseBuilder.factory.buildSession({
+            certificationCenter: 'Centre de certif pix',
+          });
+          const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+            sessionId: session.id,
+            framework: Frameworks.EDU_2ND_DEGRE,
+            version: AlgorithmEngineVersion.V3,
+          });
+          const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+            status: AssessmentResult.status.VALIDATED,
+            commentForCandidate: 'blabla',
+            reachedMeshIndex: 0,
+            eduV3ExternalJuryResult: 'EXPERT',
+          });
+          databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+            certificationCourseId: certificationCourse.id,
+            lastAssessmentResultId: assessmentResult.id,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const certificationTaken = await certificateSummaryRepository.findByUserId({
+            userId: certificationCourse.userId,
+          });
+
+          // then
+          expect(certificationTaken).to.deepEqualArray([
+            domainBuilder.certification.results.buildCertificateSummary({
+              id: certificationCourse.id,
+              certificationCenterName: session.certificationCenter,
+              certificationFramework: certificationCourse.framework,
+              certificationStartedAt: certificationCourse.createdAt,
+              extraCertificationStatus: EXTRA_CERTIFICATE_STATUSES.NOT_APPLICABLE,
+              juryComment: {
+                commentByAutoJury: undefined,
+                fallbackComment: assessmentResult.commentForCandidate,
+              },
+              pixScore: assessmentResult.pixScore,
+              status: CERTIFICATE_STATUSES.VALIDATED,
+              verificationCode: certificationCourse.verificationCode,
+              certificateType: CERTIFICATE_TYPES.CERTIFICATE,
+              reachedMeshLevel: 'LEVEL_EXPERT',
+            }),
+          ]);
+        });
+      });
+
       describe('when the user has a double certifications taken', function () {
         it('should return an array with the certificate summary', async function () {
           // given

--- a/api/tests/certification/results/unit/domain/models/CertificateSummary_test.js
+++ b/api/tests/certification/results/unit/domain/models/CertificateSummary_test.js
@@ -4,6 +4,7 @@ import {
   CertificateSummary,
   EXTRA_CERTIFICATE_STATUSES,
 } from '../../../../../../src/certification/results/domain/models/CertificateSummary.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import {
@@ -13,7 +14,6 @@ import {
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-
 describe('Unit | Domain | Models | CertificationSummary', function () {
   context('#static buildFrom', function () {
     const baseData = {
@@ -327,6 +327,80 @@ describe('Unit | Domain | Models | CertificationSummary', function () {
           expect(actualCertificateSummary).to.deepEqualInstance(expectedCertificateSummary);
         });
       });
+    });
+  });
+  context('badgeUrl', function () {
+    it('should return null when certification is not V3', function () {
+      const certificateSummary = CertificateSummary.buildFrom({
+        algorithmVersion: AlgorithmEngineVersion.V2,
+      });
+
+      expect(certificateSummary.badgeUrl).to.equal(null);
+    });
+
+    it('should return null when reachedMeshLevel is null', function () {
+      const certificateSummary = CertificateSummary.buildFrom({
+        algorithmVersion: AlgorithmEngineVersion.V3,
+        assessmentResultStatus: AssessmentResult.status.REJECTED,
+        reachedMeshIndex: 1,
+        certificationFramework: Frameworks.EDU_2ND_DEGRE,
+        eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+      });
+
+      expect(certificateSummary.reachedMeshLevel).to.equal(null);
+      expect(certificateSummary.badgeUrl).to.equal(null);
+    });
+
+    it('should return null when reachedMeshLevel is equal to ADMISSIBLE', function () {
+      const certificateSummary = CertificateSummary.buildFrom({
+        algorithmVersion: AlgorithmEngineVersion.V3,
+        assessmentResultStatus: AssessmentResult.status.VALIDATED,
+        reachedMeshIndex: 1,
+        certificationFramework: Frameworks.EDU_CPE,
+      });
+
+      expect(certificateSummary.reachedMeshLevel).to.equal('LEVEL_ADMISSIBLE');
+      expect(certificateSummary.badgeUrl).to.equal(null);
+    });
+
+    it('should return null if the framework is CORE', function () {
+      const certificateSummary = CertificateSummary.buildFrom({
+        algorithmVersion: AlgorithmEngineVersion.V3,
+        assessmentResultStatus: AssessmentResult.status.VALIDATED,
+        reachedMeshIndex: 1,
+        certificationFramework: Frameworks.CORE,
+      });
+
+      expect(certificateSummary.certificationFramework).to.equal('CORE');
+      expect(certificateSummary.badgeUrl).to.equal(null);
+    });
+
+    it('should return null if the framework is CLEA', function () {
+      const certificateSummary = CertificateSummary.buildFrom({
+        algorithmVersion: AlgorithmEngineVersion.V3,
+        assessmentResultStatus: AssessmentResult.status.VALIDATED,
+        reachedMeshIndex: 1,
+        certificationFramework: Frameworks.CLEA,
+      });
+
+      expect(certificateSummary.certificationFramework).to.equal('CLEA');
+      expect(certificateSummary.badgeUrl).to.equal(null);
+    });
+
+    it('should return the url of the bagde image as a string', function () {
+      process.env.PIX_ASSETS_MANAGER_URL = 'https://super-assert-url.org';
+
+      const certificateSummary = CertificateSummary.buildFrom({
+        algorithmVersion: AlgorithmEngineVersion.V3,
+        assessmentResultStatus: AssessmentResult.status.VALIDATED,
+        reachedMeshIndex: 1,
+        certificationFramework: Frameworks.EDU_2ND_DEGRE,
+        eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+      });
+
+      expect(certificateSummary.badgeUrl).to.equal(
+        'https://super-assert-url.org/badges-certifies/v3/edu_2nd_degre/advanced.svg',
+      );
     });
   });
 });

--- a/api/tests/certification/results/unit/domain/models/CertificateSummary_test.js
+++ b/api/tests/certification/results/unit/domain/models/CertificateSummary_test.js
@@ -241,6 +241,50 @@ describe('Unit | Domain | Models | CertificationSummary', function () {
           expect(actualCertificateSummary.reachedMeshLevel).to.equal('LEVEL_INDEPENDENT_3');
         });
       });
+
+      context('when certification is Pix+ V3 EDU', function () {
+        ['EDU_1ER_DEGRE', 'EDU_2ND_DEGRE', 'EDU_CPE'].forEach((eduFramework) => {
+          context(`for framework ${eduFramework}`, function () {
+            ['ADVANCED', 'EXPERT'].forEach((eduV3ExternalJuryResult) => {
+              it(`should override reachedMeshLevel with the external jury result LEVEL_${eduV3ExternalJuryResult}`, function () {
+                // when
+                const actualCertificateSummary = CertificateSummary.buildFrom({
+                  ...baseData,
+                  certificationFramework: Frameworks[eduFramework],
+                  algorithmVersion: AlgorithmEngineVersion.V3,
+                  assessmentResultStatus: AssessmentResult.status.VALIDATED,
+                  isPublished: true,
+                  isExtraCertificationAcquired: true,
+                  reachedMeshIndex: 0,
+                  eduV3ExternalJuryResult,
+                });
+
+                // then
+                expect(actualCertificateSummary.reachedMeshLevel).to.equal(`LEVEL_${eduV3ExternalJuryResult}`);
+              });
+            });
+
+            [null, 'UNSET'].forEach((eduV3ExternalJuryResult) => {
+              it(`should keep the admissible level when external jury result is ${eduV3ExternalJuryResult}`, function () {
+                // when
+                const actualCertificateSummary = CertificateSummary.buildFrom({
+                  ...baseData,
+                  certificationFramework: Frameworks[eduFramework],
+                  algorithmVersion: AlgorithmEngineVersion.V3,
+                  assessmentResultStatus: AssessmentResult.status.VALIDATED,
+                  isPublished: true,
+                  isExtraCertificationAcquired: true,
+                  reachedMeshIndex: 0,
+                  eduV3ExternalJuryResult,
+                });
+
+                // then
+                expect(actualCertificateSummary.reachedMeshLevel).to.equal('LEVEL_ADMISSIBLE');
+              });
+            });
+          });
+        });
+      });
     });
 
     context('certificate type computation', function () {

--- a/api/tests/certification/results/unit/infrastructure/serializers/certificate-summary-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/certificate-summary-serializer_test.js
@@ -63,6 +63,7 @@ describe('Certification | Results | Unit | Infrastructure | Serializers | certif
             comment:
               "Les conditions de passation du test de certification n'ayant pas été respectées et ayant fait l'objet d'un signalement pour fraude, votre certification a été invalidée en conséquence.",
             'reached-mesh-level': 'CONFIRMED',
+            'badge-url': null,
           },
         },
       });
@@ -82,6 +83,7 @@ describe('Certification | Results | Unit | Infrastructure | Serializers | certif
             comment:
               'The Pix certification exam conditions have not been respected. Your certification exam has been reported for fraud and has consequently been invalidated.',
             'reached-mesh-level': 'CONFIRMED',
+            'badge-url': null,
           },
         },
       });
@@ -117,6 +119,7 @@ describe('Certification | Results | Unit | Infrastructure | Serializers | certif
             'extra-certification-status': EXTRA_CERTIFICATE_STATUSES.NOT_APPLICABLE,
             comment: 'Message à tous les habitants de la galaxie, because it is la fiesta',
             'reached-mesh-level': 'CONFIRMED',
+            'badge-url': null,
           },
         },
       });

--- a/mon-pix/app/components/certifications/shareable-certificate/v3-pix-plus-certificate.gjs
+++ b/mon-pix/app/components/certifications/shareable-certificate/v3-pix-plus-certificate.gjs
@@ -4,14 +4,18 @@ import PixStepper from '@1024pix/pix-ui/components/pix-stepper';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
 import { CERTIFICATE_TYPES } from 'mon-pix/models/certificate-summary';
 
 import Hexagon from '../../user-certifications/list-item/hexagon';
 
 export default class PixPlusCertificate extends Component {
   @service intl;
+
+  @tracked eduCurrentStep = this.args.certificate.level === 'ADMISSIBLE' ? 2 : 3;
 
   get isEduCertification() {
     return this.args.certificate.certificationFramework.includes('EDU');
@@ -65,7 +69,11 @@ export default class PixPlusCertificate extends Component {
         </h2>
 
         {{#if this.isEduCertification}}
-          <PixStepper class="v3-pix-plus-certificate__stepper" @steps={{this.steps}} @currentStep={{2}} />
+          <PixStepper
+            class="v3-pix-plus-certificate__stepper"
+            @steps={{this.steps}}
+            @currentStep={{this.eduCurrentStep}}
+          />
         {{/if}}
 
         <div class="v3-pix-plus-certificate__details">
@@ -99,7 +107,9 @@ export default class PixPlusCertificate extends Component {
           @certificateType={{CERTIFICATE_TYPES.CERTIFICATE}}
           @reachedMeshLevel={{@certificate.level}}
         />
-        <PixTag @color="green">{{this.reachedMeshLabel}}</PixTag>
+        {{#if (eq this.eduCurrentStep 2)}}
+          <PixTag @color="green">{{this.reachedMeshLabel}}</PixTag>
+        {{/if}}
       </div>
     </PixBlock>
 

--- a/mon-pix/app/components/certifications/shareable-certificate/v3-pix-plus-certificate.gjs
+++ b/mon-pix/app/components/certifications/shareable-certificate/v3-pix-plus-certificate.gjs
@@ -6,6 +6,9 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
+import { CERTIFICATE_TYPES } from 'mon-pix/models/certificate-summary';
+
+import Hexagon from '../../user-certifications/list-item/hexagon';
 
 export default class PixPlusCertificate extends Component {
   @service intl;
@@ -91,9 +94,11 @@ export default class PixPlusCertificate extends Component {
         </div>
       </div>
       <div class="v3-pix-plus-certificate__score">
-        <div class="v3-pix-plus-certificate-score__hexagon">
-          <strong class="dash">-</strong>
-        </div>
+        <Hexagon
+          @framework={{@certificate.certificationFramework}}
+          @certificateType={{CERTIFICATE_TYPES.CERTIFICATE}}
+          @reachedMeshLevel={{@certificate.level}}
+        />
         <PixTag @color="green">{{this.reachedMeshLabel}}</PixTag>
       </div>
     </PixBlock>

--- a/mon-pix/app/components/user-certifications/list-item/hexagon.gjs
+++ b/mon-pix/app/components/user-certifications/list-item/hexagon.gjs
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
-import ENV from 'mon-pix/config/environment';
 import { CERTIFICATE_TYPES } from 'mon-pix/models/certificate-summary';
 
 export default class Hexagon extends Component {
@@ -48,20 +47,9 @@ export default class Hexagon extends Component {
     return this.args.isValidated ? this.args.pixScore : '-';
   }
 
-  get badgeUrl() {
-    if (!this.isPixPlusV3 || !this.args.reachedMeshLevel || this.args.reachedMeshLevel === 'ADMISSIBLE') {
-      return null;
-    }
-
-    const framework = this.args.framework.toLowerCase();
-    const meshLevel = this.args.reachedMeshLevel.toLowerCase();
-
-    return `${ENV.APP.PIX_ASSETS_MANAGER_URL}/badges-certifies/v3/${framework}/${meshLevel}.svg`;
-  }
-
   <template>
-    {{#if this.badgeUrl}}
-      <img class={{this.badgeClassNames}} src={{this.badgeUrl}} alt="" />
+    {{#if @badgeUrl}}
+      <img class={{this.badgeClassNames}} src={{@badgeUrl}} alt="" />
     {{else}}
       <div data-testid="pw-certification-card-result" class={{this.hexagonClassNames}}>
         <strong class="score">{{this.score}}</strong>

--- a/mon-pix/app/components/user-certifications/list-item/hexagon.gjs
+++ b/mon-pix/app/components/user-certifications/list-item/hexagon.gjs
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import ENV from 'mon-pix/config/environment';
 import { CERTIFICATE_TYPES } from 'mon-pix/models/certificate-summary';
 
 export default class Hexagon extends Component {
@@ -29,10 +30,25 @@ export default class Hexagon extends Component {
     return this.args.isValidated ? this.args.pixScore : '-';
   }
 
+  get badgeUrl() {
+    if (!this.isPixPlusV3 || !this.args.reachedMeshLevel || this.args.reachedMeshLevel === 'ADMISSIBLE') {
+      return null;
+    }
+
+    const framework = this.args.framework.toLowerCase();
+    const meshLevel = this.args.reachedMeshLevel.toLowerCase();
+
+    return `${ENV.APP.PIX_ASSETS_MANAGER_URL}/badges-certifies/v3/${framework}/${meshLevel}.svg`;
+  }
+
   <template>
-    <div data-testid="pw-certification-card-result" class={{this.classNames}}>
-      <strong class="score">{{this.score}}</strong>
-      <span class="pix">{{t "common.pix"}}</span>
-    </div>
+    {{#if this.badgeUrl}}
+      <img src={{this.badgeUrl}} alt="" />
+    {{else}}
+      <div data-testid="pw-certification-card-result" class={{this.classNames}}>
+        <strong class="score">{{this.score}}</strong>
+        <span class="pix">{{t "common.pix"}}</span>
+      </div>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/components/user-certifications/list-item/hexagon.gjs
+++ b/mon-pix/app/components/user-certifications/list-item/hexagon.gjs
@@ -12,15 +12,33 @@ export default class Hexagon extends Component {
     return !this.hasCoreScope && this.args.certificateType === CERTIFICATE_TYPES.CERTIFICATE;
   }
 
-  get classNames() {
-    const classes = ['certification-item__hexagon'];
+  get isSmall() {
+    return this.args.size === 'small';
+  }
+
+  get hexagonClassNames() {
+    const classes = ['certification-result-hexagon'];
 
     if (this.isPixPlusV3 && this.args.reachedMeshLevel != null) {
-      classes.push('certification-item__hexagon--pix-plus-validated');
+      classes.push('certification-result-hexagon--pix-plus-validated');
     }
 
     if (this.isPixPlusV3 && this.args.reachedMeshLevel === null) {
-      classes.push('certification-item__hexagon--pix-plus-not-validated');
+      classes.push('certification-result-hexagon--pix-plus-not-validated');
+    }
+
+    if (this.isSmall) {
+      classes.push('certification-result-hexagon--small');
+    }
+
+    return classes.join(' ');
+  }
+
+  get badgeClassNames() {
+    const classes = ['certification-result-badge'];
+
+    if (this.isSmall) {
+      classes.push('certification-result-badge--small');
     }
 
     return classes.join(' ');
@@ -43,9 +61,9 @@ export default class Hexagon extends Component {
 
   <template>
     {{#if this.badgeUrl}}
-      <img src={{this.badgeUrl}} alt="" />
+      <img class={{this.badgeClassNames}} src={{this.badgeUrl}} alt="" />
     {{else}}
-      <div data-testid="pw-certification-card-result" class={{this.classNames}}>
+      <div data-testid="pw-certification-card-result" class={{this.hexagonClassNames}}>
         <strong class="score">{{this.score}}</strong>
         <span class="pix">{{t "common.pix"}}</span>
       </div>

--- a/mon-pix/app/components/user-certifications/list-item/index.gjs
+++ b/mon-pix/app/components/user-certifications/list-item/index.gjs
@@ -108,6 +108,7 @@ export default class ListItem extends Component {
           @reachedMeshLevel={{@certificateSummary.reachedMeshLevel}}
           @framework={{@certificateSummary.certificationFramework}}
           @certificateType={{@certificateSummary.certificateType}}
+          @badgeUrl={{@certificateSummary.badgeUrl}}
         />
       </div>
       {{#if this.notObtainedCertificationWithComment}}

--- a/mon-pix/app/components/user-certifications/list-item/index.gjs
+++ b/mon-pix/app/components/user-certifications/list-item/index.gjs
@@ -100,6 +100,7 @@ export default class ListItem extends Component {
           </p>
         </div>
         <Hexagon
+          @size="small"
           @isValidated={{@certificateSummary.isValidated}}
           @pixScore={{@certificateSummary.pixScore}}
           @status={{@certificateSummary.status}}

--- a/mon-pix/app/models/certificate-summary.js
+++ b/mon-pix/app/models/certificate-summary.js
@@ -30,6 +30,7 @@ export default class CertificateSummary extends Model {
   @attr('string') extraCertificationStatus;
   @attr('string') certificateType;
   @attr('string') reachedMeshLevel;
+  @attr('string') badgeUrl;
 
   get isValidated() {
     return this.status === CERTIFICATE_STATUSES.VALIDATED;

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -30,6 +30,7 @@
 @use 'components/certification-banner' as *;
 @use 'components/certification-not-certifiable' as *;
 @use 'components/user-certifications/list-item' as *;
+@use 'components/user-certifications/hexagon' as *;
 @use 'components/user-certifications/v3-pix-plus-certificate' as *;
 @use 'components/certifications/candidate-certificate/v3-certificate' as *;
 @use 'components/certifications/candidate-certificate/v2-certificate' as *;

--- a/mon-pix/app/styles/components/user-certifications/hexagon.scss
+++ b/mon-pix/app/styles/components/user-certifications/hexagon.scss
@@ -1,0 +1,58 @@
+@use 'pix-design-tokens/typography';
+
+.certification-result-hexagon {
+  position: relative;
+  width: 160px;
+  height: 160px;
+  background-image: url('/images/certificate/pix-score-hexagon.svg');
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: contain;
+
+  &--small {
+    width: 120px;
+    height: 120px;
+  }
+
+  &--pix-plus-validated {
+    background-image: url('/images/certificate/pix-plus-hexagon-validated.svg');
+  }
+
+  &--pix-plus-not-validated {
+    background-image: url('/images/certificate/pix-plus-hexagon-not-validated.svg');
+  }
+
+  .score {
+    @extend %pix-title-xs;
+
+    position: absolute;
+    top: 55%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .pix {
+    @extend %pix-body-xs;
+
+    position: absolute;
+    top: 22%;
+    left: 50%;
+    text-transform: uppercase;
+    transform: translateX(-50%);
+  }
+
+  &--pix-plus-validated,
+  &--pix-plus-not-validated {
+    .pix {
+      display: none;
+    }
+  }
+}
+
+.certification-result-badge {
+  width: 120px;
+
+  &--small {
+    width: 90px;
+  }
+}

--- a/mon-pix/app/styles/components/user-certifications/list-item.scss
+++ b/mon-pix/app/styles/components/user-certifications/list-item.scss
@@ -48,52 +48,12 @@ $small-media-width: 500px;
     }
   }
 
-  &__hexagon {
-    position: relative;
-    width: 110px;
-    height: 110px;
-    margin: -10px -10px 0 0;
-    background-image: url('/images/certificate/pix-score-hexagon.svg');
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-size: contain;
-
-    &--pix-plus-validated {
-      background-image: url('/images/certificate/pix-plus-hexagon-validated.svg');
-    }
-
-    &--pix-plus-not-validated {
-      background-image: url('/images/certificate/pix-plus-hexagon-not-validated.svg');
-    }
+  .certification-result-hexagon {
+    translate: 15px -10px;
 
     @media (max-width: $small-media-width) {
+      translate: 0;
       margin: 0 auto;
-    }
-
-    .score {
-      @extend %pix-title-xs;
-
-      position: absolute;
-      top: 55%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
-
-    .pix {
-      @extend %pix-body-xs;
-
-      position: absolute;
-      top: 22%;
-      left: 50%;
-      text-transform: uppercase;
-      transform: translateX(-50%);
-    }
-
-    &--pix-plus-validated,
-    &--pix-plus-not-validated {
-      .pix {
-        display: none;
-      }
     }
   }
 }

--- a/mon-pix/app/styles/components/user-certifications/v3-pix-plus-certificate.scss
+++ b/mon-pix/app/styles/components/user-certifications/v3-pix-plus-certificate.scss
@@ -4,9 +4,10 @@
 
 .v3-pix-plus-certificate__infos-block {
   display: grid;
-    grid-template-columns: 1fr auto;
-    gap: var(--pix-spacing-12x);
-    align-items: center;
+  grid-template-columns: 1fr auto;
+  gap: var(--pix-spacing-12x);
+  align-items: center;
+  padding-right: max(var(--pix-spacing-6x), 4vw);
 
   @include breakpoints.device-is('mobile') {
     display: flex;
@@ -68,29 +69,11 @@
 }
 
 .v3-pix-plus-certificate__score {
-  text-align: center;
-}
-
-.v3-pix-plus-certificate-score__hexagon {
-  position: relative;
-  width: 11rem;
-  height: 12rem;
-  margin-bottom: var(--pix-spacing-1x);
-  background-image: url('/images/certificate/pix-plus-hexagon-validated.svg');
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: contain;
-
-  .dash {
-    @extend %pix-title-l;
-
-    position: absolute;
-    top: 50%;
-    left: 0;
-    width: 100%;
-    color: var(--pix-certif-500);
-    transform: translateY(-50%);
-  }
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
 }
 
 .v3-pix-plus-certificate__results-infos-block {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -50,6 +50,7 @@ module.exports = function (environment) {
         { value: 'nl', nativeName: 'Nederlands', displayedInSwitcher: false },
         { value: 'nl-BE', nativeName: 'Nederlands (België)', displayedInSwitcher: true },
       ],
+      PIX_ASSETS_MANAGER_URL: process.env.PIX_ASSETS_MANAGER_URL,
       FT_FOCUS_CHALLENGE_ENABLED: _isFeatureEnabled(process.env.FT_FOCUS_CHALLENGE_ENABLED) || false,
       isTimerCountdownEnabled: true,
       LOAD_EXTERNAL_SCRIPT: true,
@@ -218,6 +219,7 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+    ENV.APP.PIX_ASSETS_MANAGER_URL = 'https://example-assets.net';
 
     ENV.APP.API_HOST = 'http://localhost:3000';
     ENV.APP.isTimerCountdownEnabled = false;

--- a/mon-pix/sample.env
+++ b/mon-pix/sample.env
@@ -17,6 +17,11 @@
 # default: developement
 # SOURCE_VERSION=v1.2.3
 
+# presence: optional
+# type: String
+# default: <empty>
+# PIX_ASSETS_MANAGER_URL=https://assets.pix.digital
+
 # ====
 # I18n
 # ====

--- a/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-pix-plus-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-pix-plus-certificate-test.gjs
@@ -35,8 +35,7 @@ module('Integration | Component | Certifications | Shareable certificate | v3-pi
       assert.dom(screen.getByText('Université de Lyon')).exists();
       assert.dom(screen.getByText('15/02/2026')).exists();
       assert.dom(screen.getByText('20/02/2026')).exists();
-      assert.dom(screen.getByText(t('pages.user-certifications.meshes.EDU_1ER_DEGRE.ADMISSIBLE'))).exists();
-      assert.dom('.v3-pix-plus-certificate-score__hexagon').exists();
+      assert.dom('.certification-result-hexagon').exists();
     });
   });
 
@@ -112,10 +111,60 @@ module('Integration | Component | Certifications | Shareable certificate | v3-pi
         .dom(screen.getByRole('heading', { level: 2, name: (name) => name.replace(/ /g, ' ').includes(subTitle) }))
         .exists();
     });
+
+    module('level tag', function () {
+      test('it displays the level tag when the level is ADMISSIBLE', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'ADMISSIBLE',
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await render(hbs`
+            <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
+
+        // then
+        assert.dom(screen.getByText(t('pages.user-certifications.meshes.EDU_1ER_DEGRE.ADMISSIBLE'))).exists();
+      });
+
+      test('it does not display the level tag when the level is not ADMISSIBLE', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'EXPERT',
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await render(hbs`
+            <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
+
+        // then
+        assert.dom(screen.queryByText(t('pages.user-certifications.meshes.EDU_1ER_DEGRE.EXPERT'))).doesNotExist();
+      });
+    });
   });
 
   module('for a non-EDU framework', function () {
-    test('it does not display the stepper', async function (assert) {
+    test('it does not display EDU-specific elements', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const certification = store.createRecord('certification', {
@@ -127,6 +176,7 @@ module('Integration | Component | Certifications | Shareable certificate | v3-pi
         deliveredAt: new Date('2026-02-20T10:00:00Z'),
         certificationCenter: 'Université de Lyon',
         certificationFramework: 'DROIT',
+        level: 'EXPERT',
       });
       this.set('certification', certification);
 
@@ -136,31 +186,10 @@ module('Integration | Component | Certifications | Shareable certificate | v3-pi
 
       // then
       assert.dom(screen.queryByText(t('pages.certificate.frameworks.EDU.steps.1'))).doesNotExist();
-    });
-
-    test('it does not display the results block', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certification = store.createRecord('certification', {
-        birthdate: '2000-01-22',
-        birthplace: 'Paris',
-        firstName: 'Jean',
-        lastName: 'Doe',
-        certificationDate: new Date('2026-02-15T10:00:00Z'),
-        deliveredAt: new Date('2026-02-20T10:00:00Z'),
-        certificationCenter: 'Université de Lyon',
-        certificationFramework: 'DROIT',
-      });
-      this.set('certification', certification);
-
-      // when
-      const screen = await render(hbs`
-          <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
-
-      // then
       assert
         .dom(screen.queryByRole('heading', { level: 3, name: t('pages.certificate.results.title') }))
         .doesNotExist();
+      assert.dom(screen.queryByText(t('pages.user-certifications.meshes.DROIT.EXPERT'))).doesNotExist();
     });
 
     test('it displays the obtained certification sub-title', async function (assert) {

--- a/mon-pix/tests/integration/components/user-certifications/list-item/hexagon-test.gjs
+++ b/mon-pix/tests/integration/components/user-certifications/list-item/hexagon-test.gjs
@@ -54,13 +54,13 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
           );
 
           // then
-          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-item__hexagon');
+          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-result-hexagon');
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
+            .doesNotHaveClass('certification-result-hexagon--pix-plus-validated');
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
+            .doesNotHaveClass('certification-result-hexagon--pix-plus-not-validated');
         });
       });
 
@@ -74,13 +74,13 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
           );
 
           // then
-          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-item__hexagon');
+          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-result-hexagon');
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
+            .doesNotHaveClass('certification-result-hexagon--pix-plus-validated');
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
+            .doesNotHaveClass('certification-result-hexagon--pix-plus-not-validated');
         });
       });
 
@@ -100,13 +100,13 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
           );
 
           // then
-          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-item__hexagon');
+          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-result-hexagon');
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
+            .doesNotHaveClass('certification-result-hexagon--pix-plus-validated');
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
+            .doesNotHaveClass('certification-result-hexagon--pix-plus-not-validated');
         });
       });
 
@@ -128,10 +128,10 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
           // then
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .hasClass('certification-item__hexagon--pix-plus-validated');
+            .hasClass('certification-result-hexagon--pix-plus-validated');
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
+            .doesNotHaveClass('certification-result-hexagon--pix-plus-not-validated');
         });
       });
 
@@ -153,10 +153,10 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
           // then
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .hasClass('certification-item__hexagon--pix-plus-not-validated');
+            .hasClass('certification-result-hexagon--pix-plus-not-validated');
           assert
             .dom('[data-testid="pw-certification-card-result"]')
-            .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
+            .doesNotHaveClass('certification-result-hexagon--pix-plus-validated');
         });
       });
     });
@@ -169,8 +169,8 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
         <template>
           <Hexagon
             @isValidated={{true}}
-            @framework="DROIT"
-            @reachedMeshLevel="INDEPENDENT"
+            @framework="EDU_2ND_DEGRE"
+            @reachedMeshLevel="EXPERT"
             @certificateType="CERTIFICATE"
           />
         </template>,
@@ -178,24 +178,7 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
 
       // then
       assert.dom('img').exists();
-      assert.dom('img').hasAttribute('src', /\/badges-certifies\/v3\/droit\/independent\.svg$/);
-    });
-
-    test('uses the "edu" segment in the URL for an EDU framework', async function (assert) {
-      // when
-      await render(
-        <template>
-          <Hexagon
-            @isValidated={{true}}
-            @framework="EDU_2ND_DEGRE"
-            @reachedMeshLevel="PRE_BEGINNER"
-            @certificateType="CERTIFICATE"
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom('img').hasAttribute('src', /\/badges-certifies\/v3\/edu\/pre_beginner\.svg$/);
+      assert.dom('img').hasAttribute('src', /\/badges-certifies\/v3\/edu_2nd_degre\/expert\.svg$/);
     });
 
     test('does not render the score hexagon', async function (assert) {

--- a/mon-pix/tests/integration/components/user-certifications/list-item/hexagon-test.gjs
+++ b/mon-pix/tests/integration/components/user-certifications/list-item/hexagon-test.gjs
@@ -172,6 +172,7 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
             @framework="EDU_2ND_DEGRE"
             @reachedMeshLevel="EXPERT"
             @certificateType="CERTIFICATE"
+            @badgeUrl="https://exmaple-asset.org/badges-certifies/v3/edu_2nd_degre/expert.svg"
           />
         </template>,
       );
@@ -191,6 +192,7 @@ module('Integration | Component | User certifications | List item | Hexagon', fu
             @framework="DROIT"
             @reachedMeshLevel="INDEPENDENT"
             @certificateType="CERTIFICATE"
+            @badgeUrl="super-url"
           />
         </template>,
       );

--- a/mon-pix/tests/integration/components/user-certifications/list-item/hexagon-test.gjs
+++ b/mon-pix/tests/integration/components/user-certifications/list-item/hexagon-test.gjs
@@ -8,156 +8,309 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | User certifications | List item | Hexagon', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when certification is validated', function () {
-    test('displays the pix score and pix label', async function (assert) {
-      // given
-      const pixScore = 654;
-      const isValidated = true;
-      const framework = 'CORE';
-      const reachedMeshLevel = 'LEVEL_PRE_BEGINNER';
+  module('when the score hexagon is displayed', function () {
+    module('score', function () {
+      test('displays the pix score and the pix label when certification is validated', async function (assert) {
+        // given
+        const pixScore = 654;
 
-      // when
-      const screen = await render(
-        <template>
-          <Hexagon
-            @pixScore={{pixScore}}
-            @isValidated={{isValidated}}
-            @framework={{framework}}
-            @reachedMeshLevel={{reachedMeshLevel}}
-          />
-        </template>,
-      );
+        // when
+        const screen = await render(
+          <template>
+            <Hexagon @pixScore={{pixScore}} @isValidated={{true}} @framework="CORE" @certificateType="CERTIFICATE" />
+          </template>,
+        );
 
-      // then
-      assert.dom(screen.getByText('654')).exists();
-      assert.dom(screen.getByText(t('common.pix'))).exists();
+        // then
+        assert.dom(screen.getByText('654')).exists();
+        assert.dom(screen.getByText(t('common.pix'))).exists();
+      });
+
+      test('displays a dash and the pix label when certification is not validated', async function (assert) {
+        // given
+        const pixScore = 654;
+
+        // when
+        const screen = await render(
+          <template>
+            <Hexagon @pixScore={{pixScore}} @isValidated={{false}} @framework="CORE" @certificateType="CERTIFICATE" />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByText('-')).exists();
+        assert.dom(screen.getByText(t('common.pix'))).exists();
+      });
+    });
+
+    module('CSS classes', function () {
+      module('when framework is CORE', function () {
+        test('applies only the base hexagon class', async function (assert) {
+          // when
+          await render(
+            <template>
+              <Hexagon @pixScore={{500}} @isValidated={{true}} @framework="CORE" @certificateType="CERTIFICATE" />
+            </template>,
+          );
+
+          // then
+          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-item__hexagon');
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
+        });
+      });
+
+      module('when framework is CLEA', function () {
+        test('applies only the base hexagon class', async function (assert) {
+          // when
+          await render(
+            <template>
+              <Hexagon @pixScore={{500}} @isValidated={{true}} @framework="CLEA" @certificateType="CERTIFICATE" />
+            </template>,
+          );
+
+          // then
+          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-item__hexagon');
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
+        });
+      });
+
+      module('when certificate is an ATTESTATION', function () {
+        test('applies only the base hexagon class even with a Pix+ framework', async function (assert) {
+          // when
+          await render(
+            <template>
+              <Hexagon
+                @pixScore={{500}}
+                @isValidated={{true}}
+                @framework="DROIT"
+                @reachedMeshLevel="INDEPENDENT"
+                @certificateType="ATTESTATION"
+              />
+            </template>,
+          );
+
+          // then
+          assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-item__hexagon');
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
+        });
+      });
+
+      module('when certificate is a Pix+ V3 with the ADMISSIBLE mesh level', function () {
+        test('applies the pix-plus-validated modifier', async function (assert) {
+          // when
+          await render(
+            <template>
+              <Hexagon
+                @pixScore={{500}}
+                @isValidated={{true}}
+                @framework="DROIT"
+                @reachedMeshLevel="ADMISSIBLE"
+                @certificateType="CERTIFICATE"
+              />
+            </template>,
+          );
+
+          // then
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .hasClass('certification-item__hexagon--pix-plus-validated');
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
+        });
+      });
+
+      module('when certificate is a Pix+ V3 with no reached mesh level', function () {
+        test('applies the pix-plus-not-validated modifier', async function (assert) {
+          // when
+          await render(
+            <template>
+              <Hexagon
+                @pixScore={{500}}
+                @isValidated={{false}}
+                @framework="DROIT"
+                @reachedMeshLevel={{null}}
+                @certificateType="CERTIFICATE"
+              />
+            </template>,
+          );
+
+          // then
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .hasClass('certification-item__hexagon--pix-plus-not-validated');
+          assert
+            .dom('[data-testid="pw-certification-card-result"]')
+            .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
+        });
+      });
     });
   });
 
-  module('when certification is not validated', function () {
-    test('displays a dash and pix label for core scope', async function (assert) {
-      // given
-      const pixScore = 654;
-      const isValidated = false;
-      const framework = 'CORE';
-      const reachedMeshLevel = 'LEVEL_PRE_BEGINNER';
-
-      // when
-      const screen = await render(
-        <template>
-          <Hexagon
-            @pixScore={{pixScore}}
-            @isValidated={{isValidated}}
-            @framework={{framework}}
-            @reachedMeshLevel={{reachedMeshLevel}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.getByText('-')).exists();
-      assert.dom(screen.getByText(t('common.pix'))).exists();
-    });
-  });
-
-  module('hexagon CSS classes', function () {
-    test('has only base class for CORE framework', async function (assert) {
-      // given
-      const framework = 'CORE';
-      const reachedMeshLevel = 'LEVEL_PRE_BEGINNER';
-      const isValidated = true;
-      const pixScore = 500;
-
-      // when
-      await render(
-        <template>
-          <Hexagon
-            @pixScore={{pixScore}}
-            @isValidated={{isValidated}}
-            @framework={{framework}}
-            @reachedMeshLevel={{reachedMeshLevel}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-item__hexagon');
-      assert
-        .dom('[data-testid="pw-certification-card-result"]')
-        .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
-      assert
-        .dom('[data-testid="pw-certification-card-result"]')
-        .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
-    });
-
-    test('has only base class for CLEA framework', async function (assert) {
-      // given
-      const framework = 'CLEA';
-      const reachedMeshLevel = 'LEVEL_ADVANCED_5';
-      const isValidated = true;
-      const pixScore = 500;
-
-      // when
-      await render(
-        <template>
-          <Hexagon
-            @pixScore={{pixScore}}
-            @isValidated={{isValidated}}
-            @framework={{framework}}
-            @reachedMeshLevel={{reachedMeshLevel}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom('[data-testid="pw-certification-card-result"]').hasClass('certification-item__hexagon');
-      assert
-        .dom('[data-testid="pw-certification-card-result"]')
-        .doesNotHaveClass('certification-item__hexagon--pix-plus-validated');
-      assert
-        .dom('[data-testid="pw-certification-card-result"]')
-        .doesNotHaveClass('certification-item__hexagon--pix-plus-not-validated');
-    });
-
-    test('has validated class for Pix+ v3 with a reachedMeshLevel', async function (assert) {
+  module('when the badge image is displayed', function () {
+    test('renders the badge image with the framework and reached mesh level in the URL', async function (assert) {
       // when
       await render(
         <template>
           <Hexagon
             @isValidated={{true}}
             @framework="DROIT"
-            @reachedMeshLevel="LEVEL_INDEPENDENT"
+            @reachedMeshLevel="INDEPENDENT"
             @certificateType="CERTIFICATE"
           />
         </template>,
       );
 
       // then
-      assert
-        .dom('[data-testid="pw-certification-card-result"]')
-        .hasClass('certification-item__hexagon--pix-plus-validated');
+      assert.dom('img').exists();
+      assert.dom('img').hasAttribute('src', /\/badges-certifies\/v3\/droit\/independent\.svg$/);
     });
 
-    test('has not-validated class for Pix+ v3 with null reachedMeshLevel', async function (assert) {
-      // given
-      const reachedMeshLevel = null;
-
+    test('uses the "edu" segment in the URL for an EDU framework', async function (assert) {
       // when
       await render(
         <template>
           <Hexagon
             @isValidated={{true}}
-            @framework="DROIT"
-            @reachedMeshLevel={{reachedMeshLevel}}
+            @framework="EDU_2ND_DEGRE"
+            @reachedMeshLevel="PRE_BEGINNER"
             @certificateType="CERTIFICATE"
           />
         </template>,
       );
 
       // then
-      assert
-        .dom('[data-testid="pw-certification-card-result"]')
-        .hasClass('certification-item__hexagon--pix-plus-not-validated');
+      assert.dom('img').hasAttribute('src', /\/badges-certifies\/v3\/edu\/pre_beginner\.svg$/);
+    });
+
+    test('does not render the score hexagon', async function (assert) {
+      // when
+      await render(
+        <template>
+          <Hexagon
+            @pixScore={{500}}
+            @isValidated={{true}}
+            @framework="DROIT"
+            @reachedMeshLevel="INDEPENDENT"
+            @certificateType="CERTIFICATE"
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom('[data-testid="pw-certification-card-result"]').doesNotExist();
+    });
+  });
+
+  module('when the badge image is not displayed', function () {
+    test('falls back to the score hexagon for an ATTESTATION', async function (assert) {
+      // when
+      await render(
+        <template>
+          <Hexagon
+            @pixScore={{500}}
+            @isValidated={{true}}
+            @framework="DROIT"
+            @reachedMeshLevel="INDEPENDENT"
+            @certificateType="ATTESTATION"
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom('img').doesNotExist();
+      assert.dom('[data-testid="pw-certification-card-result"]').exists();
+    });
+
+    test('falls back to the score hexagon for a CORE framework', async function (assert) {
+      // when
+      await render(
+        <template>
+          <Hexagon
+            @pixScore={{500}}
+            @isValidated={{true}}
+            @framework="CORE"
+            @reachedMeshLevel="INDEPENDENT"
+            @certificateType="CERTIFICATE"
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom('img').doesNotExist();
+      assert.dom('[data-testid="pw-certification-card-result"]').exists();
+    });
+
+    test('falls back to the score hexagon for a CLEA framework', async function (assert) {
+      // when
+      await render(
+        <template>
+          <Hexagon
+            @pixScore={{500}}
+            @isValidated={{true}}
+            @framework="CLEA"
+            @reachedMeshLevel="INDEPENDENT"
+            @certificateType="CERTIFICATE"
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom('img').doesNotExist();
+      assert.dom('[data-testid="pw-certification-card-result"]').exists();
+    });
+
+    test('falls back to the score hexagon when reachedMeshLevel is null', async function (assert) {
+      // when
+      await render(
+        <template>
+          <Hexagon
+            @pixScore={{500}}
+            @isValidated={{true}}
+            @framework="DROIT"
+            @reachedMeshLevel={{null}}
+            @certificateType="CERTIFICATE"
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom('img').doesNotExist();
+      assert.dom('[data-testid="pw-certification-card-result"]').exists();
+    });
+
+    test('falls back to the score hexagon when reachedMeshLevel is ADMISSIBLE', async function (assert) {
+      // when
+      await render(
+        <template>
+          <Hexagon
+            @pixScore={{500}}
+            @isValidated={{true}}
+            @framework="DROIT"
+            @reachedMeshLevel="ADMISSIBLE"
+            @certificateType="CERTIFICATE"
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom('img').doesNotExist();
+      assert.dom('[data-testid="pw-certification-card-result"]').exists();
     });
   });
 });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2431,15 +2431,21 @@
         },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Zulässig",
-          "BELOW_MINIMUM": "Nicht zulässig"
+          "ADVANCED": "Fortgeschrittene",
+          "BELOW_MINIMUM": "Nicht zulässig",
+          "EXPERT": "Experte"
         },
         "EDU_2ND_DEGRE": {
           "ADMISSIBLE": "Zulässig",
-          "BELOW_MINIMUM": "Nicht zulässig"
+          "ADVANCED": "Fortgeschrittene",
+          "BELOW_MINIMUM": "Nicht zulässig",
+          "EXPERT": "Experte"
         },
         "EDU_CPE": {
           "ADMISSIBLE": "Zulässig",
-          "BELOW_MINIMUM": "Nicht zulässig"
+          "ADVANCED": "Fortgeschrittene",
+          "BELOW_MINIMUM": "Nicht zulässig",
+          "EXPERT": "Experte"
         },
         "PRO_SANTE": {
           "ADVANCED": "Fortgeschrittene",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2432,15 +2432,21 @@
         },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Eligible",
-          "BELOW_MINIMUM": "Not eligible"
+          "ADVANCED": "Advanced",
+          "BELOW_MINIMUM": "Not eligible",
+          "EXPERT": "Expert"
         },
         "EDU_2ND_DEGRE": {
           "ADMISSIBLE": "Eligible",
-          "BELOW_MINIMUM": "Not eligible"
+          "ADVANCED": "Advanced",
+          "BELOW_MINIMUM": "Not eligible",
+          "EXPERT": "Expert"
         },
         "EDU_CPE": {
           "ADMISSIBLE": "Eligible",
-          "BELOW_MINIMUM": "Not eligible"
+          "ADVANCED": "Advanced",
+          "BELOW_MINIMUM": "Not eligible",
+          "EXPERT": "Expert"
         },
         "PRO_SANTE": {
           "ADVANCED": "Advanced",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2413,15 +2413,21 @@
         },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Admisible",
-          "BELOW_MINIMUM": "No admisible"
+          "ADVANCED": "Avanzado",
+          "BELOW_MINIMUM": "No admisible",
+          "EXPERT": "Experto"
         },
         "EDU_2ND_DEGRE": {
           "ADMISSIBLE": "Admisible",
-          "BELOW_MINIMUM": "No admisible"
+          "ADVANCED": "Avanzado",
+          "BELOW_MINIMUM": "No admisible",
+          "EXPERT": "Experto"
         },
         "EDU_CPE": {
           "ADMISSIBLE": "Admisible",
-          "BELOW_MINIMUM": "No admisible"
+          "ADVANCED": "Avanzado",
+          "BELOW_MINIMUM": "No admisible",
+          "EXPERT": "Experto"
         },
         "PRO_SANTE": {
           "ADVANCED": "Avanzado",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2432,15 +2432,21 @@
         },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Admissible",
-          "BELOW_MINIMUM": "Non admissible"
+          "ADVANCED": "Avancé",
+          "BELOW_MINIMUM": "Non admissible",
+          "EXPERT": "Expert"
         },
         "EDU_2ND_DEGRE": {
           "ADMISSIBLE": "Admissible",
-          "BELOW_MINIMUM": "Non admissible"
+          "ADVANCED": "Avancé",
+          "BELOW_MINIMUM": "Non admissible",
+          "EXPERT": "Expert"
         },
         "EDU_CPE": {
           "ADMISSIBLE": "Admissible",
-          "BELOW_MINIMUM": "Non admissible"
+          "ADVANCED": "Avancé",
+          "BELOW_MINIMUM": "Non admissible",
+          "EXPERT": "Expert"
         },
         "PRO_SANTE": {
           "ADVANCED": "Avancé",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2424,15 +2424,21 @@
         },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Ammissibile",
-          "BELOW_MINIMUM": "Non ammissibile"
+          "ADVANCED": "Avanzato",
+          "BELOW_MINIMUM": "Non ammissibile",
+          "EXPERT": "Esperto"
         },
         "EDU_2ND_DEGRE": {
           "ADMISSIBLE": "Ammissibile",
-          "BELOW_MINIMUM": "Non ammissibile"
+          "ADVANCED": "Avanzato",
+          "BELOW_MINIMUM": "Non ammissibile",
+          "EXPERT": "Esperto"
         },
         "EDU_CPE": {
           "ADMISSIBLE": "Ammissibile",
-          "BELOW_MINIMUM": "Non ammissibile"
+          "ADVANCED": "Avanzato",
+          "BELOW_MINIMUM": "Non ammissibile",
+          "EXPERT": "Esperto"
         },
         "PRO_SANTE": {
           "ADVANCED": "Avanzato",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2422,15 +2422,21 @@
         },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Toelaatbaar",
-          "BELOW_MINIMUM": "Niet toelaatbaar"
+          "ADVANCED": "Gevorderd",
+          "BELOW_MINIMUM": "Niet toelaatbaar",
+          "EXPERT": "Expert"
         },
         "EDU_2ND_DEGRE": {
           "ADMISSIBLE": "Toelaatbaar",
-          "BELOW_MINIMUM": "Niet toelaatbaar"
+          "ADVANCED": "Gevorderd",
+          "BELOW_MINIMUM": "Niet toelaatbaar",
+          "EXPERT": "Expert"
         },
         "EDU_CPE": {
           "ADMISSIBLE": "Toelaatbaar",
-          "BELOW_MINIMUM": "Niet toelaatbaar"
+          "ADVANCED": "Gevorderd",
+          "BELOW_MINIMUM": "Niet toelaatbaar",
+          "EXPERT": "Expert"
         },
         "PRO_SANTE": {
           "ADVANCED": "Gevorderd",


### PR DESCRIPTION
## 💥 Problème

Jusqu'à présent, nous n'affichons qu'un hexagone vert pour tous les niveaux des certifications Pix+ réussies.

## 👩‍🚀 Proposition

- Les badges sont importés sur PixAssets
- Utiliser le composant `hexagon.gjs` pour afficher les badges atteints dans la liste des certifications ainsi que dans la page de vérificateur.
- L'API gère maintenant les niveaux externes des certifications Pix+ Edu v3.

## ♻️ Pour tester

Visualiser les certifications sur PixApp en RA.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
