### PR TITLE
[FEATURE] Lier les compétences et domaines dans le retour de la route /courses (PIX-22635)

### DIFF
--- a/api/src/quest/domain/models/CourseItem.js
+++ b/api/src/quest/domain/models/CourseItem.js
@@ -4,7 +4,7 @@ export const COURSE_ITEM_TYPES = {
 };
 
 export class CourseItem {
-  constructor({ id, name, type, nbTubes, nbModules, category, isSimplifiedAccess, areas, competences, createdAt }) {
+  constructor({ id, name, type, nbTubes, nbModules, category, isSimplifiedAccess, areas, createdAt }) {
     this.id = id;
     this.createdAt = createdAt ?? null;
     this.name = name;
@@ -14,6 +14,5 @@ export class CourseItem {
     this.category = category ?? null;
     this.isSimplifiedAccess = isSimplifiedAccess ?? null;
     this.areas = areas ?? [];
-    this.competences = competences ?? [];
   }
 }

--- a/api/src/quest/infrastructure/repositories/course-repository.js
+++ b/api/src/quest/infrastructure/repositories/course-repository.js
@@ -34,8 +34,9 @@ export const findByOrganizationId = async ({ organizationId, locale }) => {
   const allRows = new Map([...blueprintRowsById, ...targetProfileRowsById]);
   const { areasByCompetenceId, competencesByTubeId } = await resolveLearningContent(allRows, locale);
 
-  const toItem = (type) => (row) =>
-    new CourseItem({
+  const toItem = (type) => (row) => {
+    const areas = resolveAreas(row, competencesByTubeId, areasByCompetenceId);
+    return new CourseItem({
       id: row.id,
       name: row.name,
       type,
@@ -43,10 +44,10 @@ export const findByOrganizationId = async ({ organizationId, locale }) => {
       nbModules: row.nbModules,
       category: row.category,
       isSimplifiedAccess: row.isSimplifiedAccess,
-      areas: resolveAreas(row, competencesByTubeId, areasByCompetenceId),
-      competences: resolveCompetences(row, competencesByTubeId),
+      areas,
       createdAt: row.createdAt,
     });
+  };
 
   const blueprintItems = [...blueprintRowsById.values()].map(toItem(COURSE_ITEM_TYPES.BLUEPRINT));
   const targetProfileItems = [...targetProfileRowsById.values()].map(toItem(COURSE_ITEM_TYPES.TARGET_PROFILE));
@@ -134,13 +135,24 @@ const uniqueById = (items) => {
   });
 };
 
-const resolveCompetences = (row, competencesByTubeId) => {
-  const uniqueCompetences = uniqueById(row.tubeIds.map((tubeId) => competencesByTubeId.get(tubeId)));
-  return uniqueCompetences.map((competence) => competence.name);
-};
-
 const resolveAreas = (row, competencesByTubeId, areasByCompetenceId) => {
   const uniqueCompetences = uniqueById(row.tubeIds.map((tubeId) => competencesByTubeId.get(tubeId)));
-  const uniqueAreas = uniqueById(uniqueCompetences.map((competence) => areasByCompetenceId.get(competence.id)));
-  return uniqueAreas.map((area) => area.title);
+
+  const areasMap = new Map();
+  for (const competence of uniqueCompetences) {
+    const area = areasByCompetenceId.get(competence.id);
+    if (!areasMap.has(area.id)) {
+      areasMap.set(area.id, { id: area.id, code: area.code, title: area.title, color: area.color, competences: [] });
+    }
+    areasMap.get(area.id).competences.push({ id: competence.id, name: competence.name, index: competence.index });
+  }
+
+  return [...areasMap.values()]
+    .sort((a, b) => (a.code ?? '').localeCompare(b.code ?? '', undefined, { numeric: true }))
+    .map((area) => ({
+      ...area,
+      competences: area.competences.sort((a, b) =>
+        (a.index ?? '').localeCompare(b.index ?? '', undefined, { numeric: true }),
+      ),
+    }));
 };

--- a/api/src/quest/infrastructure/serializers/course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/course-serializer.js
@@ -4,7 +4,15 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (courseItems) {
   return new Serializer('courses', {
-    attributes: ['name', 'type', 'nbTubes', 'nbModules', 'category', 'isSimplifiedAccess', 'areas', 'competences'],
+    attributes: ['name', 'type', 'nbTubes', 'nbModules', 'category', 'isSimplifiedAccess', 'areas'],
+    areas: {
+      ref: 'id',
+      attributes: ['title', 'code', 'color', 'competences'],
+      competences: {
+        ref: 'id',
+        attributes: ['name', 'index'],
+      },
+    },
   }).serialize(courseItems);
 };
 

--- a/api/tests/quest/acceptance/application/course-route_test.js
+++ b/api/tests/quest/acceptance/application/course-route_test.js
@@ -40,6 +40,53 @@ describe('Quest | Acceptance | Application | Course catalogue Route', function (
         expect(Number(data[0].id)).to.equal(targetProfileFromShare.id);
         expect(data[0].attributes.name).to.equal('Profil partagé');
       });
+
+      it('returns areas as JSON API relationships with nested competences', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId, organizationId });
+
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1' });
+        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
+        databaseBuilder.factory.learningContent.build({
+          areas: [
+            { id: 'recArea1', code: '1', title_i18n: { fr: 'Information et données' }, competenceIds: ['recComp1'] },
+          ],
+          competences: [
+            {
+              id: 'recComp1',
+              name_i18n: { fr: 'Mener une recherche' },
+              areaId: 'recArea1',
+              index: '1.1',
+              origin: 'Pix',
+            },
+          ],
+          tubes: [{ id: 'recTube1', competenceId: 'recComp1' }],
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/organizations/${organizationId}/courses`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        const { data, included } = response.result;
+        expect(data[0].relationships.areas.data).to.deep.equal([{ type: 'areas', id: 'recArea1' }]);
+        const areaInIncluded = included.find((resource) => resource.type === 'areas' && resource.id === 'recArea1');
+        expect(areaInIncluded.attributes).to.include({ title: 'Information et données', code: '1' });
+        expect(areaInIncluded.relationships.competences.data).to.deep.equal([{ type: 'competences', id: 'recComp1' }]);
+        const competenceInIncluded = included.find(
+          (resource) => resource.type === 'competences' && resource.id === 'recComp1',
+        );
+        expect(competenceInIncluded.attributes).to.include({ name: 'Mener une recherche', index: '1.1' });
+      });
     });
 
     context('when displayCatalogue feature toggle is disabled', function () {

--- a/api/tests/quest/integration/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/course-repository_test.js
@@ -141,7 +141,7 @@ describe('Quest | Integration | Repository | course-repository', function () {
       expect(result[0].isSimplifiedAccess).to.equal(false);
     });
 
-    it('resolves areas and competences from learning content for a TARGET_PROFILE item', async function () {
+    it('resolves areas with nested competences from learning content for a TARGET_PROFILE item', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
@@ -149,7 +149,9 @@ describe('Quest | Integration | Repository | course-repository', function () {
       databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
 
       const learningContent = {
-        areas: [{ id: 'recAreaA', title_i18n: { fr: 'Information et données' }, competenceIds: ['recCompA'] }],
+        areas: [
+          { id: 'recAreaA', code: '1', title_i18n: { fr: 'Information et données' }, competenceIds: ['recCompA'] },
+        ],
         competences: [
           { id: 'recCompA', name_i18n: { fr: 'Mener une recherche' }, areaId: 'recAreaA', index: '1.1', origin: 'Pix' },
         ],
@@ -163,11 +165,18 @@ describe('Quest | Integration | Repository | course-repository', function () {
       const result = await courseRepository.findByOrganizationId({ organizationId, locale: 'fr' });
 
       // then
-      expect(result[0].areas).to.deep.equal(['Information et données']);
-      expect(result[0].competences).to.deep.equal(['Mener une recherche']);
+      expect(result[0].areas).to.deep.equal([
+        {
+          id: 'recAreaA',
+          code: '1',
+          title: 'Information et données',
+          color: 'color Domaine A',
+          competences: [{ id: 'recCompA', name: 'Mener une recherche', index: '1.1' }],
+        },
+      ]);
     });
 
-    it('resolves areas and competences aggregated from all target profiles in the quest for a BLUEPRINT item', async function () {
+    it('resolves areas with nested competences aggregated from all target profiles in the quest for a BLUEPRINT item', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const targetProfileId1 = databaseBuilder.factory.buildTargetProfile().id;
@@ -188,8 +197,13 @@ describe('Quest | Integration | Repository | course-repository', function () {
 
       const learningContent = {
         areas: [
-          { id: 'recAreaA', title_i18n: { fr: 'Information et données' }, competenceIds: ['recCompA'] },
-          { id: 'recAreaB', title_i18n: { fr: 'Communication et collaboration' }, competenceIds: ['recCompB'] },
+          { id: 'recAreaA', code: '1', title_i18n: { fr: 'Information et données' }, competenceIds: ['recCompA'] },
+          {
+            id: 'recAreaB',
+            code: '2',
+            title_i18n: { fr: 'Communication et collaboration' },
+            competenceIds: ['recCompB'],
+          },
         ],
         competences: [
           { id: 'recCompA', name_i18n: { fr: 'Mener une recherche' }, areaId: 'recAreaA', index: '1.1', origin: 'Pix' },
@@ -208,8 +222,67 @@ describe('Quest | Integration | Repository | course-repository', function () {
       const result = await courseRepository.findByOrganizationId({ organizationId, locale: 'fr' });
 
       // then
-      expect(result[0].areas).to.deep.equal(['Information et données', 'Communication et collaboration']);
-      expect(result[0].competences).to.deep.equal(['Mener une recherche', 'Interagir']);
+      expect(result[0].areas).to.deep.equal([
+        {
+          id: 'recAreaA',
+          code: '1',
+          title: 'Information et données',
+          color: 'color Domaine A',
+          competences: [{ id: 'recCompA', name: 'Mener une recherche', index: '1.1' }],
+        },
+        {
+          id: 'recAreaB',
+          code: '2',
+          title: 'Communication et collaboration',
+          color: 'color Domaine A',
+          competences: [{ id: 'recCompB', name: 'Interagir', index: '2.1' }],
+        },
+      ]);
+    });
+
+    it('sorts areas by code and competences by index', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1' });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2' });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube3' });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
+
+      const learningContent = {
+        areas: [
+          { id: 'recAreaB', code: '2', title_i18n: { fr: 'Communication' }, competenceIds: ['recCompB'] },
+          { id: 'recAreaA', code: '1', title_i18n: { fr: 'Information' }, competenceIds: ['recCompA1', 'recCompA2'] },
+        ],
+        competences: [
+          { id: 'recCompA2', name_i18n: { fr: 'Gérer des données' }, areaId: 'recAreaA', index: '1.2', origin: 'Pix' },
+          {
+            id: 'recCompA1',
+            name_i18n: { fr: 'Mener une recherche' },
+            areaId: 'recAreaA',
+            index: '1.1',
+            origin: 'Pix',
+          },
+          { id: 'recCompB', name_i18n: { fr: 'Interagir' }, areaId: 'recAreaB', index: '2.1', origin: 'Pix' },
+        ],
+        tubes: [
+          { id: 'recTube1', competenceId: 'recCompA2' },
+          { id: 'recTube2', competenceId: 'recCompA1' },
+          { id: 'recTube3', competenceId: 'recCompB' },
+        ],
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId, locale: 'fr' });
+
+      // then
+      expect(result[0].areas[0].code).to.equal('1');
+      expect(result[0].areas[0].competences[0].index).to.equal('1.1');
+      expect(result[0].areas[0].competences[1].index).to.equal('1.2');
+      expect(result[0].areas[1].code).to.equal('2');
     });
 
     it('does not return target profiles not shared with the organizations', async function () {

--- a/api/tests/quest/unit/infrastructure/serializers/course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/course-serializer_test.js
@@ -4,8 +4,15 @@ import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | course', function () {
   describe('#serialize', function () {
-    it('serializes an array of CourseItems', function () {
+    it('serializes an array of CourseItems with areas as JSON API relationships', function () {
       // given
+      const area = {
+        id: 'recAreaA',
+        code: '1',
+        title: 'Information et données',
+        color: 'jaffa',
+        competences: [{ id: 'recCompA', name: 'Mener une recherche', index: '1.1' }],
+      };
       const courseItems = [
         new CourseItem({
           id: 1,
@@ -15,8 +22,7 @@ describe('Quest | Unit | Infrastructure | Serializers | course', function () {
           nbModules: 3,
           category: null,
           isSimplifiedAccess: null,
-          areas: ['Information et données'],
-          competences: ['Mener une recherche'],
+          areas: [area],
         }),
         new CourseItem({
           id: 2,
@@ -25,8 +31,7 @@ describe('Quest | Unit | Infrastructure | Serializers | course', function () {
           nbTubes: 5,
           category: 'PREDEFINED',
           isSimplifiedAccess: true,
-          areas: ['Information et données'],
-          competences: ['Mener une recherche'],
+          areas: [area],
         }),
       ];
 
@@ -46,8 +51,9 @@ describe('Quest | Unit | Infrastructure | Serializers | course', function () {
               'nb-modules': 3,
               category: null,
               'is-simplified-access': null,
-              areas: ['Information et données'],
-              competences: ['Mener une recherche'],
+            },
+            relationships: {
+              areas: { data: [{ type: 'areas', id: 'recAreaA' }] },
             },
           },
           {
@@ -60,8 +66,25 @@ describe('Quest | Unit | Infrastructure | Serializers | course', function () {
               'nb-modules': null,
               category: 'PREDEFINED',
               'is-simplified-access': true,
-              areas: ['Information et données'],
-              competences: ['Mener une recherche'],
+            },
+            relationships: {
+              areas: { data: [{ type: 'areas', id: 'recAreaA' }] },
+            },
+          },
+        ],
+        included: [
+          {
+            id: 'recCompA',
+            type: 'competences',
+            attributes: { name: 'Mener une recherche', index: '1.1' },
+            relationships: {},
+          },
+          {
+            id: 'recAreaA',
+            type: 'areas',
+            attributes: { title: 'Information et données', code: '1', color: 'jaffa' },
+            relationships: {
+              competences: { data: [{ type: 'competences', id: 'recCompA' }] },
             },
           },
         ],

--- a/orga/app/models/course.js
+++ b/orga/app/models/course.js
@@ -1,4 +1,4 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Course extends Model {
   @attr('string') name;
@@ -7,6 +7,5 @@ export default class Course extends Model {
   @attr('number') nbModules;
   @attr('string') category;
   @attr('boolean') isSimplifiedAccess;
-  @attr({ defaultValue: () => [] }) areas;
-  @attr({ defaultValue: () => [] }) competences;
+  @hasMany('area', { async: false, inverse: null }) areas;
 }


### PR DESCRIPTION
## 🌱 Problème

La route `GET /api/organizations/:id/courses` retournait deux tableaux plats indépendants (`areas` et `competences`) sans lien entre eux, rendant impossible le regroupement des compétences par domaine côté frontend.

## 🐣 Proposition

- Les `areas` sont désormais exposées comme des **relationships JSON API**
- Les domaines sont triés par code (numérique) et les compétences par index à l'intérieur de chaque domaine

## 🐝 Pour tester

```sh
ORG_ID=1005
URL=https://api-pr16095.review.pix.fr/api

TOKEN=$(curl -s ${URL}/token \
  -H 'Accept: */*' \
  -H 'Accept-Language: fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7,ru-FR;q=0.6,ru;q=0.5' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Pragma: no-cache' \
  --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123' \
  | jq -r '.access_token')

curl -s ${URL}/organizations/${ORG_ID}/courses \
  -H "Authorization: Bearer ${TOKEN}" \
  | jq .
```
