### PR TITLE
[TECH] Refactoriser l'envoi d'invitation à rejoindre une organisation sur Pix Admin (PIX-21415)

### DIFF
--- a/admin/app/adapters/organization-invitation.js
+++ b/admin/app/adapters/organization-invitation.js
@@ -13,21 +13,10 @@ export default class OrganizationInvitation extends ApplicationAdapter {
     return `${this.host}/${this.namespace}/organizations/${adapterOptions.organizationId}/invitations/${adapterOptions.organizationInvitationId}`;
   }
 
-  createRecord() {
-    return super.createRecord(...arguments).then((response) => {
-      response.data = response.data[0];
-      return response;
+  sendInvitation({ email, locale, role, organizationId }) {
+    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/invitations`;
+    return this.ajax(url, 'POST', {
+      data: { data: { attributes: { email, locale, role } } },
     });
-  }
-
-  queryRecord(store, type, query) {
-    if (query.organizationId) {
-      const url = `${this.host}/${this.namespace}/organizations/${query.organizationId}/invitations`;
-      return this.ajax(url, 'POST', {
-        data: { data: { attributes: { email: query.email, locale: query.locale, role: query.role } } },
-      });
-    }
-
-    return super.queryRecord(...arguments);
   }
 }

--- a/admin/app/controllers/authenticated/organizations/get/invitations.js
+++ b/admin/app/controllers/authenticated/organizations/get/invitations.js
@@ -24,6 +24,8 @@ export default class InvitationsController extends Controller {
   @action
   async createOrganizationInvitation(locale, role) {
     this.isLoading = true;
+    const adapter = this.store.adapterFor('organization-invitation');
+
     const email = this.userEmailToInvite?.trim();
     if (!this._isEmailToInviteValid(email)) {
       this.isLoading = false;
@@ -31,19 +33,13 @@ export default class InvitationsController extends Controller {
     }
 
     try {
-      const organizationInvitation = await this.store.queryRecord('organization-invitation', {
-        email,
-        locale,
-        role,
-        organizationId: this.model.organization.id,
-      });
-
+      await adapter.sendInvitation({ email, locale, role, organizationId: this.model.organization.id });
       await this.model.organization.hasMany('organizationInvitations').reload();
 
       this.pixToast.sendSuccessNotification({
-        message: `Un email a bien a été envoyé à l'adresse ${organizationInvitation.email}.`,
+        message: `Un email a bien a été envoyé à l'adresse ${email}.`,
       });
-      this.userEmailToInvite = null;
+      this.userEmailToInvite = '';
     } catch (err) {
       this.errorResponseHandler.notify(err, this.CUSTOM_ERROR_MESSAGES);
     }
@@ -53,13 +49,10 @@ export default class InvitationsController extends Controller {
   @action
   async sendNewInvitation(organizationInvitation) {
     this.isLoading = true;
+    const adapter = this.store.adapterFor('organization-invitation');
+    const { email, role, locale } = organizationInvitation;
     try {
-      await this.store.queryRecord('organization-invitation', {
-        email: organizationInvitation.email,
-        locale: organizationInvitation.locale,
-        role: organizationInvitation.role,
-        organizationId: this.model.organization.id,
-      });
+      await adapter.sendInvitation({ email, locale, role, organizationId: this.model.organization.id });
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('common.invitations.send-new-confirm', {
           invitationEmail: organizationInvitation.email,

--- a/admin/tests/acceptance/authenticated/organizations/invitations-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/invitations-management-test.js
@@ -1,5 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { click, fillIn } from '@ember/test-helpers';
+import { click, fillIn, settled } from '@ember/test-helpers';
 import { setupIntl } from 'ember-intl/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -33,7 +33,8 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
       await click(screen.getByRole('button', { name: 'Inviter un membre' }));
 
       // then
-      const createdInvitation = screen.getByRole('cell', { name: 'user@example.com' });
+      const createdInvitation = await screen.findByRole('cell', { name: 'user@example.com' });
+      await settled();
 
       assert.ok(createdInvitation);
       assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail du membre à inviter' })).hasNoValue();
@@ -62,6 +63,8 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
 
       // then
       const createdInvitation = screen.queryByRole('cell', { name: 'user@example.com' });
+      await settled();
+
       assert.notOk(createdInvitation);
       assert.ok(screen.getByText('Une erreur s’est produite, veuillez réessayer.'));
     });

--- a/admin/tests/unit/controllers/authenticated/organizations/get/invitations-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/invitations-test.js
@@ -6,47 +6,45 @@ import sinon from 'sinon';
 module('Unit | Controller | authenticated/organizations/get/invitations', function (hooks) {
   setupTest(hooks);
 
-  let controller;
-  let store;
+  let controller, store, sendInvitationStub, reloadStub, locale, role;
 
   hooks.beforeEach(function () {
     controller = this.owner.lookup('controller:authenticated/organizations/get/invitations');
+    reloadStub = sinon.stub();
+
+    controller.model = {
+      organization: {
+        id: 1,
+        hasMany: sinon.stub(),
+      },
+    };
+    controller.model.organization.hasMany.withArgs('organizationInvitations').returns({
+      reload: reloadStub,
+    });
+
+    controller.userEmailToInvite = 'test@example.net';
+
     store = this.owner.lookup('service:store');
+    store.adapterFor = sinon.stub();
+    sendInvitationStub = sinon.stub();
+    store.adapterFor.withArgs('organization-invitation').returns({ sendInvitation: sendInvitationStub });
+
+    locale = 'fr';
+    role = 'METIER';
   });
 
   module('#createOrganizationInvitation', function () {
-    test('it should create an organization-invitation and reload model if the email is valid', async function (assert) {
+    test('it should call sendInvitation adapter method and reload model if the email is valid', async function (assert) {
       // given
-      const queryRecordStub = sinon.stub();
-      store.queryRecord = queryRecordStub;
-      const reloadStub = sinon.stub();
+      sendInvitationStub.resolves();
 
-      controller.model = {
-        organization: {
-          id: 1,
-          hasMany: sinon.stub(),
-        },
-      };
-      controller.model.organization.hasMany.withArgs('organizationInvitations').returns({
-        reload: reloadStub,
-      });
-
-      controller.userEmailToInvite = 'test@example.net';
-      const locale = 'en';
-      const role = 'MEMBER';
+      const invitationData = { email: controller.userEmailToInvite, locale, role };
 
       // when
       await controller.createOrganizationInvitation(locale, role);
 
       // then
-      assert.ok(
-        queryRecordStub.calledWith('organization-invitation', {
-          email: 'test@example.net',
-          locale,
-          role,
-          organizationId: 1,
-        }),
-      );
+      assert.ok(sendInvitationStub.calledOnceWith({ ...invitationData, organizationId: 1 }));
 
       assert.true(reloadStub.calledOnce);
     });
@@ -56,7 +54,7 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.userEmailToInvite = undefined;
 
       // when
-      controller.createOrganizationInvitation();
+      controller.createOrganizationInvitation(locale, role);
 
       // then
       assert.strictEqual(controller.userEmailToInviteError, 'Ce champ est requis.');
@@ -67,7 +65,7 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.userEmailToInvite = '';
 
       // when
-      controller.createOrganizationInvitation();
+      controller.createOrganizationInvitation(locale, role);
 
       // then
       assert.strictEqual(controller.userEmailToInviteError, 'Ce champ est requis.');
@@ -78,7 +76,7 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.userEmailToInvite = 'not_valid_email';
 
       // when
-      controller.createOrganizationInvitation();
+      controller.createOrganizationInvitation(locale, role);
 
       // then
       assert.strictEqual(controller.userEmailToInviteError, "L'adresse e-mail saisie n'est pas valide.");
@@ -86,12 +84,8 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
 
     test('it should send a notification error if an error occurred', async function (assert) {
       // given
-      const controller = this.owner.lookup('controller:authenticated/organizations/get/invitations');
-      const store = this.owner.lookup('service:store');
       const anError = Symbol('an error');
-      store.queryRecord = sinon.stub().rejects(anError);
-      controller.userEmailToInvite = 'anemail@exmpla.net';
-      controller.model = { organization: { id: 1 } };
+      sendInvitationStub.rejects(anError);
 
       const notifyStub = sinon.stub();
       class ErrorResponseHandler extends Service {
@@ -102,7 +96,7 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.CUSTOM_ERROR_MESSAGES = customErrors;
 
       // when
-      await controller.createOrganizationInvitation('fr', 'MEMBER');
+      await controller.createOrganizationInvitation(locale, role);
 
       // then
       assert.ok(notifyStub.calledWithExactly(anError, customErrors));
@@ -110,10 +104,8 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
   });
 
   module('#sendNewInvitation', function () {
-    test('sends a new invitation', function (assert) {
+    test('sends a new invitation by calling sendInvitation method from adapter', function (assert) {
       // given
-      const queryRecordStub = sinon.stub();
-      store.queryRecord = queryRecordStub;
       controller.model = { organization: { id: 1 } };
       const organizationInvitation = { email: 'test@example.net', locale: 'en', role: 'MEMBER' };
 
@@ -121,20 +113,15 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.sendNewInvitation(organizationInvitation);
 
       // then
-      assert.ok(
-        queryRecordStub.calledWith('organization-invitation', {
-          ...organizationInvitation,
-          organizationId: 1,
-        }),
-      );
+      assert.ok(sendInvitationStub.calledOnceWith({ ...organizationInvitation, organizationId: 1 }));
     });
 
     test('When an error occurs, it should send a notification error', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/organizations/get/invitations');
-      const store = this.owner.lookup('service:store');
+
       const anError = Symbol('an error');
-      store.queryRecord = sinon.stub().rejects(anError);
+      sendInvitationStub.rejects(anError);
       const notifyStub = sinon.stub();
       class ErrorResponseHandler extends Service {
         notify = notifyStub;


### PR DESCRIPTION
## 💥 Problème

Actuellement sur Pix Admin, lorsqu'on envoie une invitation à rejoindre une organisation, on appelle la méthode du store queryRecord. Cette méthode est ensuite définie dans l'adapter pour effectuer une reqête POST vers le endpoint `/api/admin/organizations/{organizationId}/invitations`. On trouve que le choix de la méthode queryRecord n'est pas cohérent avec l'action qui est faite, c'est-à-dire créer une ressource.

## 👩‍🚀 Proposition
On remplace cette méthode par une méthode personnalisée `sendInvitation` dans l'adapter.

## 👁️ Remarques

Il a avait aussi été envisagé de passer par le processus plus classique de création de ressource d'Ember Data à savoir:
- `store.createRecord` puis `store.save()`
Mais cela n'aurait pas fonctionné pour l'action de renvoyer une invitation déjà existante. En effet c'est le même endpoint de l'API qui est requêté pour ces deux actions distinctes (POST sur `/api/admin/organizations/{organizationId}/invitations`), et c'est côté API que l'on regarde si une invitation existe déjà pour cette adresse e-mail. Si non on la créé, si oui on renvoie le mail. Or dans ce deuxième cas on ne veut pas côté front créer un nouveau Record dans le store. D'où le choix de la solution d'une méthode personnalisée d'adapter.

## ♻️ Pour tester
Sur Pix Admin, sur la page d'une organisation:
- naviguer vers l'onglet Invitations
- tenter d'envoyer de nouvelles invitations, d'en supprimer et d'en renvoyer
- constater la non-régression et que tout fonctionne correctement

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
