### PR TITLE
[FEATURE] Améliorer la page de fin de résultat sur le moteur de recommandation (PIX-22437) (PIX-22125)

### DIFF
--- a/api/db/seeds/data/common/tooling/target-profile-tooling.js
+++ b/api/db/seeds/data/common/tooling/target-profile-tooling.js
@@ -173,6 +173,7 @@ async function createStages({
   includeFirstSkill = false,
   countStages,
   shouldInsertPrescriberTitleAndDescription,
+  customMessage,
 }) {
   const values = [0];
   const stageIds = [];
@@ -186,6 +187,7 @@ async function createStages({
         value: null,
         isFirstSkill: true,
         shouldInsertPrescriberTitleAndDescription,
+        customMessage,
       }),
     );
     --currentCountStages;
@@ -210,6 +212,7 @@ async function createStages({
         value,
         isFirstSkill: false,
         shouldInsertPrescriberTitleAndDescription,
+        customMessage,
       }),
     );
   }
@@ -283,11 +286,12 @@ function _createStage({
   value,
   isFirstSkill,
   shouldInsertPrescriberTitleAndDescription,
+  customMessage,
 }) {
   const stageValueStr = isFirstSkill ? 'premier acquis' : `"${value}"`;
   return databaseBuilder.factory.buildStage({
     targetProfileId,
-    message: `Message du palier ${stageValueStr} pour le profil cible ${targetProfileId}`,
+    message: customMessage ?? `Message du palier ${stageValueStr} pour le profil cible ${targetProfileId}`,
     title: `Titre du palier ${stageValueStr} pour le profil cible ${targetProfileId}`,
     level: isFirstSkill ? null : type === 'LEVEL' ? value : null,
     threshold: isFirstSkill ? null : type === 'LEVEL' ? null : value,

--- a/api/db/seeds/data/team-evaluation/data-builder.js
+++ b/api/db/seeds/data/team-evaluation/data-builder.js
@@ -144,6 +144,69 @@ async function createCoreTargetProfile(databaseBuilder) {
       ],
     },
   });
+  await tooling.targetProfile.createBadge({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    badgeId: 703,
+    altMessage: '1 RT certifiable, acquis',
+    imageUrl: 'https://assets.pix.org/badges/Production-de-ressources.svg',
+    message: '1 RT certifiable, acquis',
+    title: '1 RT certifiable, acquis',
+    key: 'SOME_KEY_FOR_RT_703',
+    isCertifiable: true,
+    isAlwaysVisible: true,
+    configBadge: {
+      criteria: [
+        {
+          scope: 'CampaignParticipation',
+          threshold: 0,
+        },
+      ],
+    },
+  });
+  await tooling.targetProfile.createBadge({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    badgeId: 704,
+    altMessage: '1 RT certifiable, acquis',
+    imageUrl: 'https://assets.pix.org/badges/ML_navigation.svg',
+    message: '1 RT certifiable, acquis',
+    title: '1 RT certifiable, acquis',
+    key: 'SOME_KEY_FOR_RT_704',
+    isCertifiable: true,
+    isAlwaysVisible: true,
+    configBadge: {
+      criteria: [
+        {
+          scope: 'CampaignParticipation',
+          threshold: 0,
+        },
+      ],
+    },
+  });
+  await tooling.targetProfile.createBadge({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    badgeId: 705,
+    altMessage: '1 RT certifiable, acquis',
+    imageUrl: 'https://assets.pix.org/badges/Ma%C3%AEtre%20de%20la%20collaboration.svg',
+    message: '1 RT certifiable, acquis',
+    title: '1 RT certifiable, acquis',
+    key: 'SOME_KEY_FOR_RT_705',
+    isCertifiable: true,
+    isAlwaysVisible: true,
+    configBadge: {
+      criteria: [
+        {
+          scope: 'CampaignParticipation',
+          threshold: 0,
+        },
+      ],
+    },
+  });
   await tooling.targetProfile.createStages({
     databaseBuilder,
     targetProfileId,
@@ -151,6 +214,8 @@ async function createCoreTargetProfile(databaseBuilder) {
     type: 'LEVEL',
     countStages: 4,
     includeFirstSkill: true,
+    customMessage:
+      "Vous avez acquis une bonne compréhension des fondamentaux de l’intelligence artificielle. Quelques points restent à améliorer pour renforcer pour mieux utiliser cette nouvelle technologie. Votre score montre une bonne compréhension que vous avez de bonnes pratiques. Avec un peu plus d'entraînement, vous serez prêt à mieux communiquer avec une intelligence artificielle ",
   });
 }
 

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact.gjs
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-const MAX_VISIBLE_BADGES = 2;
+const MAX_VISIBLE_BADGES = 5;
 
 export default class AcquiredBadgesCompact extends Component {
   get visibleBadges() {

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -41,10 +41,6 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
     };
   }
 
-  get isUserAnonymous() {
-    return this.currentUser?.user?.isAnonymous;
-  }
-
   get titleStyles() {
     const baseStyle = 'evaluation-results-hero-recommendation-engine__title';
     const titleSize = this.media.isMobile ? 'extra-small-size' : 'small-size';

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -11,6 +11,7 @@ import AcquiredBadgesCompact from './acquired-badges-compact';
 export default class EvaluationResultsHeroRecommendationEngine extends Component {
   @service currentUser;
   @service pixMetrics;
+  @service media;
 
   get masteryRatePercentage() {
     return Math.round(this.args.campaignParticipationResult.masteryRate * 100);
@@ -32,6 +33,12 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
 
   get isUserAnonymous() {
     return this.currentUser?.user?.isAnonymous;
+  }
+
+  get titleStyles() {
+    const baseStyle = 'evaluation-results-hero-recommendation-engine__title';
+    const titleSize = this.media.isMobile ? 'extra-small-size' : 'small-size';
+    return `${baseStyle} ${baseStyle}--${titleSize}`;
   }
 
   @action handleSeeTrainingsClick() {
@@ -60,11 +67,13 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
   <template>
     <div class="evaluation-results-hero-recommendation-engine">
       <div class="evaluation-results-hero-recommendation-engine__content">
-        <h2 class="evaluation-results-hero-recommendation-engine__title">{{t
+        <h2 class="{{this.titleStyles}}">{{t
             "pages.skill-review.hero.thanks"
             name=this.currentUser.user.firstName
           }}</h2>
-
+        {{#if this.media.isMobile}}
+          <hr class="evaluation-results-hero-recommendation-engine__separator" />
+        {{/if}}
         <p class="evaluation-results-hero-recommendation-engine__percent">
           <strong class="evaluation-results-hero-recommendation-engine__percent-value">
             {{this.masteryRatePercentage}}<span class="evaluation-results-hero-recommendation-engine__percent-unit">

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -124,7 +124,7 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
               @variant="secondary-white"
               onclick={{this.handleBackToHomepageClick}}
             >
-              {{t "navigation.back-to-homepage"}}
+              {{t "pages.skill-review.actions.back-to-pix"}}
             </PixButtonLink>
           {{/if}}
         </div>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -4,6 +4,7 @@ import PixStars from '@1024pix/pix-ui/components/pix-stars';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import MarkdownToHtml from '../../../../markdown-to-html';
@@ -14,8 +15,16 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
   @service pixMetrics;
   @service media;
 
+  @tracked stagedMessageContentShowMoreEnabled = false;
+
   get masteryRatePercentage() {
     return Math.round(this.args.campaignParticipationResult.masteryRate * 100);
+  }
+
+  get stagedMessagebuttonLabel() {
+    return this.stagedMessageContentShowMoreEnabled
+      ? 'pages.skill-review.hero.staged-message.show-less'
+      : 'pages.skill-review.hero.staged-message.show-more';
   }
 
   get hasStagesStars() {
@@ -40,6 +49,18 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
     const baseStyle = 'evaluation-results-hero-recommendation-engine__title';
     const titleSize = this.media.isMobile ? 'extra-small-size' : 'small-size';
     return `${baseStyle} ${baseStyle}--${titleSize}`;
+  }
+
+  get stagedMessageContentShouldBeEllipsed() {
+    const container = document.getElementById('evaluation-results-hero-recommendation-engine-staged-message');
+    const content = document.getElementById('evaluation-results-hero-recommendation-engine-staged-message-content');
+    const isContentOverflowingContainer = content.scrollHeight > container?.offsetHeight;
+
+    return this.media.isMobile && isContentOverflowingContainer;
+  }
+
+  @action toggleStagedMessage() {
+    this.stagedMessageContentShowMoreEnabled = !this.stagedMessageContentShowMoreEnabled;
   }
 
   @action handleSeeTrainingsClick() {
@@ -131,12 +152,29 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
       </div>
     </div>
     {{#if @campaignParticipationResult.hasReachedStage}}
-      <section class="evaluation-results-hero-recommendation-engine-staged-message">
+      <section
+        id="evaluation-results-hero-recommendation-engine-staged-message"
+        class="evaluation-results-hero-recommendation-engine-staged-message"
+      >
         <h2 class="evaluation-results-hero-recommendation-engine-staged-message__title"><MarkdownToHtml
             @isInline={{true}}
             @markdown={{@campaignParticipationResult.reachedStage.title}}
           /></h2>
-        <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.message}} />
+        <span
+          id="evaluation-results-hero-recommendation-engine-staged-message-content"
+          class="evaluation-results-hero-recommendation-engine-staged-message__content
+            {{unless
+              this.stagedMessageContentShowMoreEnabled
+              'evaluation-results-hero-recommendation-engine-staged-message__content--ellipsed'
+            }}"
+        >
+          <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.message}} />
+        </span>
+        {{#if this.stagedMessageContentShouldBeEllipsed}}
+          <PixButton @triggerAction={{this.toggleStagedMessage}} @variant="tertiary">
+            {{t this.stagedMessagebuttonLabel}}
+          </PixButton>
+        {{/if}}
       </section>
     {{/if}}
   </template>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
+import MarkdownToHtml from '../../../../markdown-to-html';
 import AcquiredBadgesCompact from './acquired-badges-compact';
 
 export default class EvaluationResultsHeroRecommendationEngine extends Component {
@@ -129,5 +130,14 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
         </div>
       </div>
     </div>
+    {{#if @campaignParticipationResult.hasReachedStage}}
+      <section class="evaluation-results-hero-recommendation-engine-staged-message">
+        <h2 class="evaluation-results-hero-recommendation-engine-staged-message__title"><MarkdownToHtml
+            @isInline={{true}}
+            @markdown={{@campaignParticipationResult.reachedStage.title}}
+          /></h2>
+        <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.message}} />
+      </section>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -60,9 +60,10 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
   <template>
     <div class="evaluation-results-hero-recommendation-engine">
       <div class="evaluation-results-hero-recommendation-engine__content">
-        <h2 class="evaluation-results-hero-recommendation-engine__title">
-          {{t "pages.skill-review.hero.thanks" name=this.currentUser.user.firstName}}
-        </h2>
+        <h2 class="evaluation-results-hero-recommendation-engine__title">{{t
+            "pages.skill-review.hero.thanks"
+            name=this.currentUser.user.firstName
+          }}</h2>
 
         <p class="evaluation-results-hero-recommendation-engine__percent">
           <strong class="evaluation-results-hero-recommendation-engine__percent-value">

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -8,6 +8,7 @@ import QuitResults from '../../../campaigns/assessment/results/quit-results';
 import EvaluationResultsHeroRecommendationEngine from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
 
 export default class EvaluationResultsRecommendationEngine extends Component {
+  @service media;
   @service tabManager;
 
   get hasTrainings() {
@@ -40,7 +41,9 @@ export default class EvaluationResultsRecommendationEngine extends Component {
       <header class="evaluation-results__header">
         <img class="evaluation-results-header__logo" src="/images/pix-logo-dark.svg" alt="{{t 'common.pix'}}" />
         <h1 class="evaluation-results-header__title">
-          <span>{{@model.campaign.title}}</span>
+          {{#unless this.media.isMobile}}
+            <span>{{@model.campaign.title}}</span>
+          {{/unless}}
           <span class="sr-only">{{t "pages.skill-review.abstract-title"}}</span>
         </h1>
         <QuitResults />

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/acquired-badges-compact.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/acquired-badges-compact.scss
@@ -8,6 +8,10 @@
   margin: 0;
   padding: 0;
 
+  &__item, &__overflow {
+    margin-left: calc(var(--pix-spacing-4x) * -1);
+  }
+
   &__item {
     display: flex;
   }
@@ -23,10 +27,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 3.5rem;
+    width: 3.2rem;
     height: 3.5rem;
     color: var(--pix-primary-300);
     font-weight: var(--pix-font-bold);
-    background: url('/images/background/badge-overflow.svg') center no-repeat;
+    background-image: url('/images/background/badge-overflow.svg');
+    background-repeat: no-repeat;
+    background-size: contain;
   }
 }

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -4,7 +4,7 @@
 @use 'pix-design-tokens/shadows';
 
 .evaluation-results-recommendation-engine {
-  padding: 0 var(--pix-spacing-3x);
+  padding: var(--pix-spacing-3x) var(--pix-spacing-3x) 0 var(--pix-spacing-3x);
 }
 
 .evaluation-results-hero-recommendation-engine {
@@ -127,6 +127,11 @@
 }
 
 @include breakpoints.device-is('tablet') {
+  .evaluation-results-recommendation-engine {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
   .evaluation-results-hero-recommendation-engine {
     gap: var(--pix-spacing-10x);
     justify-content: space-between;

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -1,6 +1,7 @@
 @use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 @use "pix-design-tokens/colors";
+@use 'pix-design-tokens/shadows';
 
 .evaluation-results-recommendation-engine {
   padding: 0 var(--pix-spacing-3x);
@@ -95,6 +96,21 @@
     .pix-button {
       width: 100%;
     }
+  }
+}
+
+.evaluation-results-hero-recommendation-engine-staged-message {
+  @extend %pix-shadow-default;
+
+  margin-bottom: var(--pix-spacing-4x);
+  padding: var(--pix-spacing-6x);
+  background-color: var(--pix-neutral-0);
+  border-radius: 0 0 20px 20px;
+
+  &__title {
+    @extend %pix-title-xxs;
+
+    color: var(--pix-neutral-900);
   }
 }
 

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -24,6 +24,8 @@
     @extend %pix-title-s;
 
     color: var(--pix-neutral-0);
+    line-height: 1.5;
+    white-space: pre-line;
   }
 
   &__percent {

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -1,31 +1,41 @@
+@use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 @use "pix-design-tokens/colors";
+
+.evaluation-results-recommendation-engine {
+  padding: 0 var(--pix-spacing-3x);
+}
 
 .evaluation-results-hero-recommendation-engine {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--pix-spacing-10x);
-  justify-content: space-between;
-  max-width: 80rem;
-  margin: 0 auto var(--pix-spacing-10x);
-  padding: var(--pix-spacing-10x) 15%;
+  gap: var(--pix-spacing-6x);
+  padding: var(--pix-spacing-6x) var(--pix-spacing-3x);
   color: var(--pix-neutral-0);
   background: var(--pix-gradient-default-dark);
-  border-radius: var(--radius-5x, 20px);
+  border-radius: 20px 20px 0 0;
 
   &__content {
     display: flex;
     flex-direction: column;
-    gap: var(--pix-spacing-4x);
-    min-width: min(28rem, 100%);
+    gap: var(--pix-spacing-6x);
+    align-items: center;
+    justify-content: center;
+    width: 100%;
   }
 
   &__title {
-    @extend %pix-title-s;
-
-    color: var(--pix-neutral-0);
     line-height: 1.5;
     white-space: pre-line;
+    text-align: center;
+
+    &--extra-small-size {
+      @extend %pix-title-xxs;
+    }
+
+    &--small-size {
+      @extend %pix-title-s;
+    }
   }
 
   &__percent {
@@ -34,6 +44,7 @@
     color: var(--pix-neutral-0);
     font-weight: 500;
     line-height: 2rem;
+    text-align: center;
   }
 
   &__percent-value {
@@ -42,6 +53,7 @@
   }
 
   &__percent-unit {
+    display: inline-block;
     margin-left: var(--pix-spacing-2x);
     font-size: 2.5rem;
   }
@@ -64,12 +76,59 @@
     color: var(--pix-neutral-0);
   }
 
+  &__separator {
+    width: 100%;
+    height: 0;
+    padding: 0;
+    border: 0;
+    border-top: 1px solid var(--pix-neutral-0);
+  }
+
   &__actions {
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
     gap: var(--pix-spacing-4x);
     align-items: flex-start;
+    width: 100%;
+
+    .pix-button {
+      width: 100%;
+    }
+  }
+}
+
+@include breakpoints.device-is('tablet') {
+  .evaluation-results-hero-recommendation-engine {
+    gap: var(--pix-spacing-10x);
+    justify-content: space-between;
+    max-width: 80rem;
+    margin: 0 auto var(--pix-spacing-1x);
+    padding: var(--pix-spacing-10x) 15%;
+
+    &__content {
+      gap: var(--pix-spacing-4x);
+      align-items: normal;
+      justify-content: normal;
+      min-width: min(28rem, 100%);
+    }
+
+    &__title {
+      text-align: start;
+
+    }
+
+    &__percent {
+      text-align: start;
+    }
+
+    &__actions {
+      width: auto;
+
+      .pix-button {
+        width: auto;
+      }
+    }
   }
 }
 

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -43,19 +43,20 @@
     @extend %pix-subtitle-s;
 
     color: var(--pix-neutral-0);
-    font-weight: 500;
     line-height: 2rem;
     text-align: center;
   }
 
   &__percent-value {
     display: block;
+    font-weight: 500;
     font-size: 3rem;
   }
 
   &__percent-unit {
     display: inline-block;
     margin-left: var(--pix-spacing-2x);
+    font-weight: 500;
     font-size: 2.5rem;
   }
 

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -102,6 +102,7 @@
 .evaluation-results-hero-recommendation-engine-staged-message {
   @extend %pix-shadow-default;
 
+
   margin-bottom: var(--pix-spacing-4x);
   padding: var(--pix-spacing-6x);
   background-color: var(--pix-neutral-0);
@@ -111,6 +112,16 @@
     @extend %pix-title-xxs;
 
     color: var(--pix-neutral-900);
+  }
+
+  &__content {
+    &--ellipsed {
+      display: -webkit-box;
+      -webkit-line-clamp: 4;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 }
 
@@ -143,6 +154,17 @@
 
       .pix-button {
         width: auto;
+      }
+    }
+  }
+
+  .evaluation-results-hero-recommendation-engine-staged-message {
+    &__content {
+      // We are disabling ellipsis behaviour in tablet / desktop view
+      &--ellipsed {
+        display: initial;
+        overflow: initial;
+        text-overflow: initial;
       }
     }
   }

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -1,4 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -62,6 +63,24 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
 
       // then
       assert.dom('.evaluation-results:not(.evaluation-results-recommendation-engine)').doesNotExist();
+    });
+
+    module('when device is mobile', function () {
+      test('should not display campaign title', async function (assert) {
+        // given
+        this.owner.register(
+          'service:media',
+          class MediaService extends Service {
+            isMobile = true;
+          },
+        );
+
+        // when
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+        // then
+        assert.dom(screen.queryByText(campaign.title)).doesNotExist();
+      });
     });
   });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact-test.gjs
@@ -9,12 +9,15 @@ module(
   function (hooks) {
     setupIntlRenderingTest(hooks);
 
-    module('when there are 2 badges or fewer', function () {
+    module('when there are 5 badges or fewer', function () {
       test('it displays all badge icons', async function (assert) {
         // given
         const badges = [
           { altMessage: 'Badge 1', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 1' },
           { altMessage: 'Badge 2', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 2' },
+          { altMessage: 'Badge 3', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 3' },
+          { altMessage: 'Badge 4', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 4' },
+          { altMessage: 'Badge 5', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 5' },
         ];
 
         // when
@@ -23,7 +26,7 @@ module(
         // then
         assert.dom(screen.getByRole('img', { name: 'Badge 1' })).exists();
         assert.dom(screen.getByRole('img', { name: 'Badge 2' })).exists();
-        assert.strictEqual(screen.getAllByRole('listitem').length, 2);
+        assert.strictEqual(screen.getAllByRole('listitem').length, 5);
       });
 
       test('it does not display an overflow counter', async function (assert) {
@@ -31,6 +34,9 @@ module(
         const badges = [
           { altMessage: 'Badge 1', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 1' },
           { altMessage: 'Badge 2', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 2' },
+          { altMessage: 'Badge 3', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 3' },
+          { altMessage: 'Badge 4', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 4' },
+          { altMessage: 'Badge 5', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 5' },
         ];
 
         // when
@@ -38,18 +44,20 @@ module(
 
         // then
         assert.dom(screen.queryByText('+0')).doesNotExist();
-        assert.strictEqual(screen.getAllByRole('listitem').length, 2);
+        assert.strictEqual(screen.getAllByRole('listitem').length, 5);
       });
     });
 
-    module('when there are more than 2 badges', function () {
-      test('it displays only the first 2 badge icons', async function (assert) {
+    module('when there are more than 5 badges', function () {
+      test('it displays only the first 3 badge icons', async function (assert) {
         // given
         const badges = [
           { altMessage: 'Badge 1', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 1' },
           { altMessage: 'Badge 2', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 2' },
           { altMessage: 'Badge 3', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 3' },
           { altMessage: 'Badge 4', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 4' },
+          { altMessage: 'Badge 5', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 5' },
+          { altMessage: 'Badge 6', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 6' },
         ];
 
         // when
@@ -58,8 +66,10 @@ module(
         // then
         assert.dom(screen.getByRole('img', { name: 'Badge 1' })).exists();
         assert.dom(screen.getByRole('img', { name: 'Badge 2' })).exists();
-        assert.dom(screen.queryByRole('img', { name: 'Badge 3' })).doesNotExist();
-        assert.dom(screen.queryByRole('img', { name: 'Badge 4' })).doesNotExist();
+        assert.dom(screen.getByRole('img', { name: 'Badge 3' })).exists();
+        assert.dom(screen.getByRole('img', { name: 'Badge 4' })).exists();
+        assert.dom(screen.getByRole('img', { name: 'Badge 5' })).exists();
+        assert.dom(screen.queryByRole('img', { name: 'Badge 6' })).doesNotExist();
       });
 
       test('it displays an overflow counter with the remaining count', async function (assert) {
@@ -69,13 +79,15 @@ module(
           { altMessage: 'Badge 2', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 2' },
           { altMessage: 'Badge 3', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 3' },
           { altMessage: 'Badge 4', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 4' },
+          { altMessage: 'Badge 5', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 5' },
+          { altMessage: 'Badge 6', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 6' },
         ];
 
         // when
         const screen = await render(<template><AcquiredBadgesCompact @acquiredBadges={{badges}} /></template>);
 
         // then
-        assert.dom(screen.getByText('+2')).exists();
+        assert.dom(screen.getByText('+1')).exists();
       });
     });
   },

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -34,7 +34,11 @@ module(
       test('it displays a congratulation title', async function (assert) {
         // then
         assert
-          .dom(screen.getByRole('heading', { name: t('pages.skill-review.hero.thanks', { name: 'Hermione' }) }))
+          .dom(
+            screen.getByRole('heading', {
+              name: t('pages.skill-review.hero.thanks', { name: 'Hermione' }).replace('\n', ''),
+            }),
+          )
           .exists();
       });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -1,5 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { click, settled } from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl/test-support';
 import EvaluationResultsHeroRecommendationEngine from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index';
 import { module, test } from 'qunit';
@@ -256,6 +258,87 @@ module(
 
           // then
           assert.dom(screen.queryByRole('list')).doesNotExist();
+        });
+      });
+    });
+
+    module('staged message toggle button', function (hooks) {
+      hooks.beforeEach(async function () {
+        // given
+        stubCurrentUserService(this.owner, { id: 1, firstName: 'Hermione' });
+
+        this.owner.register(
+          'service:media',
+          class MediaService extends Service {
+            @tracked isMobile = false;
+          },
+        );
+
+        const campaign = { organizationId: 1 };
+        const campaignParticipationResult = {
+          hasReachedStage: true,
+          reachedStage: {
+            reachedStage: 4,
+            totalStage: 5,
+            message: 'existing message',
+            title: 'existing title',
+          },
+        };
+
+        // when
+        this.screen = await render(
+          <template>
+            <EvaluationResultsHeroRecommendationEngine
+              @campaign={{campaign}}
+              @campaignParticipationResult={{campaignParticipationResult}}
+            />
+          </template>,
+        );
+      });
+
+      test('it does not display the toggle button when not on mobile', async function (assert) {
+        // then
+        assert
+          .dom(this.screen.queryByRole('button', { name: t('pages.skill-review.hero.staged-message.show-more') }))
+          .doesNotExist();
+      });
+
+      module('when on mobile and content overflows', function (hooks) {
+        hooks.beforeEach(async function () {
+          const contentEl = document.getElementById(
+            'evaluation-results-hero-recommendation-engine-staged-message-content',
+          );
+          Object.defineProperty(contentEl, 'scrollHeight', { value: 200, configurable: true });
+
+          const mediaService = this.owner.lookup('service:media');
+          mediaService.isMobile = true;
+          await settled();
+        });
+
+        test('it displays the "show-more" button', async function (assert) {
+          // then
+          assert
+            .dom(this.screen.getByRole('button', { name: t('pages.skill-review.hero.staged-message.show-more') }))
+            .exists();
+        });
+
+        test('clicking the button changes its label to "show-less"', async function (assert) {
+          // then
+          await click(this.screen.getByRole('button', { name: t('pages.skill-review.hero.staged-message.show-more') }));
+
+          assert
+            .dom(this.screen.getByRole('button', { name: t('pages.skill-review.hero.staged-message.show-less') }))
+            .exists();
+        });
+
+        test('clicking "show-less" toggles back to "show-more"', async function (assert) {
+          // then
+          await click(this.screen.getByRole('button', { name: t('pages.skill-review.hero.staged-message.show-more') }));
+          await click(this.screen.getByRole('button', { name: t('pages.skill-review.hero.staged-message.show-less') }));
+
+          assert
+            .dom(this.screen.getByRole('button', { name: t('pages.skill-review.hero.staged-message.show-more') }))
+            .exists();
         });
       });
     });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import EvaluationResultsHeroRecommendationEngine from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index';
 import { module, test } from 'qunit';
@@ -12,16 +13,73 @@ module(
     setupIntlRenderingTest(hooks);
 
     module('global behaviour', function (hooks) {
-      let screen;
-
       hooks.beforeEach(async function () {
+        stubCurrentUserService(this.owner, { id: 1, firstName: 'Hermione' });
+      });
+
+      module('when screen is mobile', function () {
+        test('it display a separator', async function (assert) {
+          // given
+          const campaign = { organizationId: 1 };
+          const campaignParticipationResult = { masteryRate: 0.755 };
+
+          this.owner.register(
+            'service:media',
+            class MediaService extends Service {
+              isMobile = true;
+            },
+          );
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.dom(screen.getByRole('separator')).exists();
+        });
+      });
+
+      module('when screen is not mobile', function () {
+        test('it does not display a separator', async function (assert) {
+          // given
+          const campaign = { organizationId: 1 };
+          const campaignParticipationResult = { masteryRate: 0.755 };
+
+          this.owner.register(
+            'service:media',
+            class MediaService extends Service {
+              isMobile = false;
+            },
+          );
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.dom(screen.queryByRole('separator')).doesNotExist();
+        });
+      });
+
+      test('it displays a congratulation title', async function (assert) {
         // given
         const campaign = { organizationId: 1 };
         const campaignParticipationResult = { masteryRate: 0.755 };
-        stubCurrentUserService(this.owner, { id: 1, firstName: 'Hermione' });
 
         // when
-        screen = await render(
+        const screen = await render(
           <template>
             <EvaluationResultsHeroRecommendationEngine
               @campaign={{campaign}}
@@ -29,9 +87,7 @@ module(
             />
           </template>,
         );
-      });
 
-      test('it displays a congratulation title', async function (assert) {
         // then
         assert
           .dom(
@@ -43,6 +99,20 @@ module(
       });
 
       test('it displays a rounded mastery rate', async function (assert) {
+        // given
+        const campaign = { organizationId: 1 };
+        const campaignParticipationResult = { masteryRate: 0.755 };
+
+        // when
+        const screen = await render(
+          <template>
+            <EvaluationResultsHeroRecommendationEngine
+              @campaign={{campaign}}
+              @campaignParticipationResult={{campaignParticipationResult}}
+            />
+          </template>,
+        );
+
         // then
         const masteryRateElementWithoutWhiteSpaceTrimmed = screen.getByText('76').textContent.replace(/\s/g, '').trim();
         assert.strictEqual(masteryRateElementWithoutWhiteSpaceTrimmed, '76%');

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -305,7 +305,7 @@ module(
             );
 
             // then
-            assert.dom(screen.getByRole('link', { name: t('navigation.back-to-homepage') })).exists();
+            assert.dom(screen.getByRole('link', { name: t('pages.skill-review.actions.back-to-pix') })).exists();
             assert
               .dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') }))
               .doesNotExist();

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -122,12 +122,17 @@ module(
 
     module('stages', function () {
       module('when there are multiple stages', function () {
-        test('it displays reached stage stars', async function (assert) {
+        test('it displays reached stage stars and message', async function (assert) {
           // given
           const campaign = { organizationId: 1 };
           const campaignParticipationResult = {
             hasReachedStage: true,
-            reachedStage: { reachedStage: 4, totalStage: 5 },
+            reachedStage: {
+              reachedStage: 4,
+              totalStage: 5,
+              message: 'existing message stages',
+              title: 'existing title stages',
+            },
           };
 
           // when
@@ -144,6 +149,9 @@ module(
           const stars = { acquired: 3, total: 4 };
           assert.dom(screen.getByText(t('pages.skill-review.stage.starsAcquired', stars))).exists();
           assert.dom(screen.getByText(t('pages.skill-review.stage.recommendedEngine.starsAcquired', stars))).exists();
+
+          assert.dom(screen.getByText(campaignParticipationResult.reachedStage.title)).exists();
+          assert.dom(screen.getByText(campaignParticipationResult.reachedStage.message)).exists();
         });
       });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-hero/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-hero/index-test.gjs
@@ -37,7 +37,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
     test('it should display a congratulation title', async function (assert) {
       // then
       const title = screen.getByRole('heading', {
-        name: t('pages.skill-review.hero.thanks', { name: 'Hermione' }),
+        name: t('pages.skill-review.hero.thanks', { name: 'Hermione' }).replace('\n', ''),
       });
       assert.dom(title).exists();
     });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2177,6 +2177,10 @@
         },
         "see-trainings": "Siehe Ausbildungen",
         "shared-message": "Ihre Ergebnisse wurden am {date} an {time} gesendet.",
+        "staged-message": {
+          "show-less": "Einklappen",
+          "show-more": "Mehr anzeigen"
+        },
         "thanks": "Vielen Dank {name}\n für Ihre Teilnahme!"
       },
       "improve": {

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2177,7 +2177,7 @@
         },
         "see-trainings": "Siehe Ausbildungen",
         "shared-message": "Ihre Ergebnisse wurden am {date} an {time} gesendet.",
-        "thanks": "Vielen Dank {name} für Ihre Teilnahme!"
+        "thanks": "Vielen Dank {name}\n für Ihre Teilnahme!"
       },
       "improve": {
         "description": "Sie können einige Fragen erneut versuchen",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2178,6 +2178,10 @@
         },
         "see-trainings": "See trainings",
         "shared-message": "Your results were sent on {date} at {time}.",
+        "staged-message": {
+          "show-less": "Collapse",
+          "show-more": "Show more"
+        },
         "thanks": "Thank you {name}\n for participating!"
       },
       "improve": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2178,7 +2178,7 @@
         },
         "see-trainings": "See trainings",
         "shared-message": "Your results were sent on {date} at {time}.",
-        "thanks": "Thank you, {name}, for participating!"
+        "thanks": "Thank you {name}\n for participating!"
       },
       "improve": {
         "description": "You can retake some of the questions",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2159,6 +2159,10 @@
         },
         "see-trainings": "Ver los cursos",
         "shared-message": "Tus resultados se enviaron el {date} a las {time}.",
+        "staged-message": {
+          "show-less": "Reducir",
+          "show-more": "Ver más"
+        },
         "thanks": "¡Gracias {name}\n por participar!"
       },
       "improve": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2159,7 +2159,7 @@
         },
         "see-trainings": "Ver los cursos",
         "shared-message": "Tus resultados se enviaron el {date} a las {time}.",
-        "thanks": "¡Gracias, {name}, por participar!"
+        "thanks": "¡Gracias {name}\n por participar!"
       },
       "improve": {
         "description": "Puedes volver a intentar algunas de las preguntas",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2178,6 +2178,10 @@
         },
         "see-trainings": "Voir les formations",
         "shared-message": "Vos résultats ont été envoyés le {date} à {time}.",
+        "staged-message": {
+          "show-less": "Replier",
+          "show-more": "Afficher plus"
+        },
         "thanks": "Merci {name}\n pour votre participation !"
       },
       "improve": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2178,7 +2178,7 @@
         },
         "see-trainings": "Voir les formations",
         "shared-message": "Vos résultats ont été envoyés le {date} à {time}.",
-        "thanks": "Merci {name} pour votre participation !"
+        "thanks": "Merci {name}\n pour votre participation !"
       },
       "improve": {
         "description": "Vous pouvez retenter certaines questions",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2170,6 +2170,10 @@
         },
         "see-trainings": "Vedere i corsi",
         "shared-message": "I risultati sono stati inviati da {date} a {time}.",
+        "staged-message": {
+          "show-less": "Riduci",
+          "show-more": "Mostra di più"
+        },
         "thanks": "Grazie {name}\n per la vostra partecipazione!"
       },
       "improve": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2170,7 +2170,7 @@
         },
         "see-trainings": "Vedere i corsi",
         "shared-message": "I risultati sono stati inviati da {date} a {time}.",
-        "thanks": "Grazie {name} per la vostra partecipazione!"
+        "thanks": "Grazie {name}\n per la vostra partecipazione!"
       },
       "improve": {
         "description": "È possibile riprovare alcune delle domande",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2168,6 +2168,10 @@
         },
         "see-trainings": "Bekijk de cursussen",
         "shared-message": "Je resultaten zijn verzonden op {date} om {time}.",
+        "staged-message": {
+          "show-less": "Inklappen",
+          "show-more": "Meer tonen"
+        },
         "thanks": "Bedankt {name}\n voor je deelname!"
       },
       "improve": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2168,7 +2168,7 @@
         },
         "see-trainings": "Bekijk de cursussen",
         "shared-message": "Je resultaten zijn verzonden op {date} om {time}.",
-        "thanks": "Bedankt {name} voor je deelname!"
+        "thanks": "Bedankt {name}\n voor je deelname!"
       },
       "improve": {
         "description": "Je kunt sommige vragen opnieuw proberen",


### PR DESCRIPTION
## 💥 Problème

Il y a des ajustements à faire sur la page de résultat pour les campagnes de type moteur de recommandation.

## 👩‍🚀 Proposition
Les faire.

## 👁️ Remarques

La liste des changements : 
- Passer le message `Merci {name} pour votre participation !` sur deux lignes.
- Améliorer la version mobile
- Ajouter le bloc pour afficher les messages de palier.
- Quelques correctifs css pour s'aligner avec la maquette.

## ♻️ Pour tester
### Aller sur la page de résultat
- Se [connecter](https://app-pr16106.review.pix.fr/) avec le compte `perfect-profile-user@example.net`.
- Reprendre la campagne Sco Orga team Eval (code EVAL12345 s'il ne s'affiche pas) pour arriver sur la page de résultat
- Mettre à jour le label du bouton pour avoir le texte `Quitter et revenir sur Pix`.

### Tests
- Passer en vue mobile et vérifier que cela fonctionne bien avec la maquette.
- Vérifier que le message `Merci {name} pour votre participation !` est bien sur deux lignes.
- Constater que le message du palier apparaît sur la page 🚀 