### PR TITLE
[TECH] Ajoute une API interne pour récupérer les participations d'un utilisateur (PIX-22575)

### DIFF
--- a/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
+++ b/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
+import { CampaignParticipation } from './read-models/CampaignParticipation.js';
 
 /**
  * @function
@@ -16,6 +17,18 @@ export const getCampaignParticipationsByLearnerIdAndCampaignId = async ({ organi
     organizationLearnerId,
     campaignId,
   });
+};
+
+/**
+ * @function
+ * @name findByUserId
+ *
+ * @param {number} userId
+ * @returns {Promise<Array<{id: number, campaignId: number, targetProfileId: number}>>}
+ */
+export const findByUserId = async ({ userId }) => {
+  const participations = await usecases.findCampaignParticipationsByUserId({ userId });
+  return participations.map((participation) => new CampaignParticipation(participation));
 };
 
 export const deleteCampaignParticipations = async ({

--- a/api/src/prescription/campaign-participation/application/api/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/application/api/read-models/CampaignParticipation.js
@@ -1,0 +1,7 @@
+export class CampaignParticipation {
+  constructor({ id, campaignId, targetProfileId }) {
+    this.id = id;
+    this.campaignId = campaignId;
+    this.targetProfileId = targetProfileId;
+  }
+}

--- a/api/src/prescription/campaign-participation/domain/read-models/UserCampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/UserCampaignParticipation.js
@@ -1,0 +1,9 @@
+class UserCampaignParticipation {
+  constructor({ id, campaignId, targetProfileId }) {
+    this.id = id;
+    this.campaignId = campaignId;
+    this.targetProfileId = targetProfileId;
+  }
+}
+
+export { UserCampaignParticipation };

--- a/api/src/prescription/campaign-participation/domain/usecases/find-campaign-participations-by-user-id.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/find-campaign-participations-by-user-id.js
@@ -1,0 +1,5 @@
+const findCampaignParticipationsByUserId = async function ({ userId, userCampaignParticipationRepository }) {
+  return userCampaignParticipationRepository.findByUserId({ userId });
+};
+
+export { findCampaignParticipationsByUserId };

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -40,6 +40,7 @@ import { participantResultsSharedRepository } from '../../infrastructure/reposit
 import * as participationsForCampaignManagementRepository from '../../infrastructure/repositories/participations-for-campaign-management-repository.js';
 import * as participationsForUserManagementRepository from '../../infrastructure/repositories/participations-for-user-management-repository.js';
 import * as poleEmploiSendingRepository from '../../infrastructure/repositories/pole-emploi-sending-repository.js';
+import * as userCampaignParticipationRepository from '../../infrastructure/repositories/user-campaign-participation-repository.js';
 
 const dependencies = {
   areaRepository,
@@ -77,6 +78,7 @@ const dependencies = {
   participationStartedJobRepository,
   participantResultsSharedRepository,
   poleEmploiSendingRepository,
+  userCampaignParticipationRepository,
   stageAcquisitionRepository,
   stageCollectionRepository,
   stageRepository,
@@ -87,6 +89,7 @@ const dependencies = {
 
 import { checkUserHasAccessToCampaignParticipation } from './check-user-has-access-to-campaign-participation.js';
 import { deleteCampaignParticipation } from './delete-campaign-participation.js';
+import { findCampaignParticipationsByUserId } from './find-campaign-participations-by-user-id.js';
 import { findCampaignParticipationsForUserManagement } from './find-campaign-participations-for-user-management.js';
 import { findPaginatedParticipationsForCampaignManagement } from './find-paginated-participations-for-campaign-management.js';
 import { findUserAnonymisedCampaignAssessments } from './find-user-anonymised-campaign-assessments.js';
@@ -112,6 +115,7 @@ import { updateParticipantExternalId } from './update-participant-external-id.js
 const usecasesWithoutInjectedDependencies = {
   checkUserHasAccessToCampaignParticipation,
   deleteCampaignParticipation,
+  findCampaignParticipationsByUserId,
   findCampaignParticipationsForUserManagement,
   findPaginatedParticipationsForCampaignManagement,
   findUserAnonymisedCampaignAssessments,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/user-campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/user-campaign-participation-repository.js
@@ -1,0 +1,18 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { UserCampaignParticipation } from '../../domain/read-models/UserCampaignParticipation.js';
+
+const findByUserId = async function ({ userId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const rows = await knexConn('campaign-participations')
+    .select({
+      id: 'campaign-participations.id',
+      campaignId: 'campaigns.id',
+      targetProfileId: 'campaigns.targetProfileId',
+    })
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .where({ 'campaign-participations.userId': userId })
+    .whereNull('campaign-participations.deletedAt');
+  return rows.map((row) => new UserCampaignParticipation(row));
+};
+
+export { findByUserId };

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/find-campaign-participations-by-user-id_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/find-campaign-participations-by-user-id_test.js
@@ -1,0 +1,32 @@
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | UseCase | find-campaign-participations-by-user-id', function () {
+  it('should return empty array when user has no participations', async function () {
+    // given
+    const userId = databaseBuilder.factory.buildUser().id;
+    await databaseBuilder.commit();
+
+    // when
+    const results = await usecases.findCampaignParticipationsByUserId({ userId });
+
+    // then
+    expect(results).to.deep.equal([]);
+  });
+
+  it('should return participations for the given userId', async function () {
+    // given
+    const userId = databaseBuilder.factory.buildUser().id;
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+    const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId });
+    await databaseBuilder.commit();
+
+    // when
+    const results = await usecases.findCampaignParticipationsByUserId({ userId });
+
+    // then
+    expect(results).to.deep.equal([{ id: participationId, campaignId, targetProfileId }]);
+  });
+});

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/user-campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/user-campaign-participation-repository_test.js
@@ -1,0 +1,80 @@
+import { UserCampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/read-models/UserCampaignParticipation.js';
+import * as userCampaignParticipationRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/user-campaign-participation-repository.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | Repository | UserCampaignParticipation', function () {
+  describe('#findByUserId', function () {
+    it('should return participations with id, campaignId and targetProfileId', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await userCampaignParticipationRepository.findByUserId({ userId });
+
+      // then
+      expect(results).to.have.lengthOf(1);
+      expect(results[0]).to.be.instanceOf(UserCampaignParticipation);
+      expect(results[0]).to.deep.equal({ id: participationId, campaignId, targetProfileId });
+    });
+
+    it('should return multiple participations', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId });
+      databaseBuilder.factory.buildCampaignParticipation({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await userCampaignParticipationRepository.findByUserId({ userId });
+
+      // then
+      expect(results).to.have.lengthOf(2);
+      expect(results[0]).to.be.instanceOf(UserCampaignParticipation);
+      expect(results[1]).to.be.instanceOf(UserCampaignParticipation);
+    });
+
+    it('should not return deleted participations', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId, deletedAt: new Date() });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await userCampaignParticipationRepository.findByUserId({ userId });
+
+      // then
+      expect(results).to.have.lengthOf(0);
+    });
+
+    it('should return empty array when user has no participations', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const results = await userCampaignParticipationRepository.findByUserId({ userId });
+
+      // then
+      expect(results).to.have.lengthOf(0);
+    });
+
+    it('should not return participations of another user', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId: otherUserId });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await userCampaignParticipationRepository.findByUserId({ userId });
+
+      // then
+      expect(results).to.have.lengthOf(0);
+    });
+  });
+});

--- a/api/tests/prescription/campaign-participation/unit/application/api/campaign-participations-api_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/api/campaign-participations-api_test.js
@@ -1,0 +1,41 @@
+import sinon from 'sinon';
+
+import * as campaignParticipationsApi from '../../../../../../src/prescription/campaign-participation/application/api/campaign-participations-api.js';
+import { CampaignParticipation } from '../../../../../../src/prescription/campaign-participation/application/api/read-models/CampaignParticipation.js';
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | API | Campaign Participations', function () {
+  describe('#findByUserId', function () {
+    it('should return campaign participations mapped to CampaignParticipation DTOs', async function () {
+      // given
+      const userId = 1;
+      sinon.stub(usecases, 'findCampaignParticipationsByUserId').resolves([
+        { id: 10, campaignId: 20, targetProfileId: 30 },
+        { id: 11, campaignId: 21, targetProfileId: 31 },
+      ]);
+
+      // when
+      const results = await campaignParticipationsApi.findByUserId({ userId });
+
+      // then
+      expect(usecases.findCampaignParticipationsByUserId).to.have.been.calledOnceWith({ userId });
+      expect(results).to.deep.equal([
+        new CampaignParticipation({ id: 10, campaignId: 20, targetProfileId: 30 }),
+        new CampaignParticipation({ id: 11, campaignId: 21, targetProfileId: 31 }),
+      ]);
+    });
+
+    it('should return an empty array when user has no participations', async function () {
+      // given
+      const userId = 1;
+      sinon.stub(usecases, 'findCampaignParticipationsByUserId').resolves([]);
+
+      // when
+      const results = await campaignParticipationsApi.findByUserId({ userId });
+
+      // then
+      expect(results).to.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
## 💥 Problème

Aujourd'hui, on utilise une grosse API interne pour récupéré toutes les données néccessaires au fonctionnement du système de quêtes même quand elles sont pas néccessaires. 

## 👩‍🚀 Proposition

On va se diriger vers une système d'introspection qui va chercher uniquement les données néccessaires à la quête en cours de traitement. La première étape est de découpé en plus petites API internes.

Cette PR introduit une API interne pour récupérer les participations d'un utilisateur.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester

LA CI au vert 🍏 
