### PR TITLE
[TECH] Ajoute une API interne pour récupérer les learners d'un utilisateur (PIX-22576)

### DIFF
--- a/api/src/prescription/organization-learner/application/api/organization-learners-api.js
+++ b/api/src/prescription/organization-learner/application/api/organization-learners-api.js
@@ -1,5 +1,6 @@
 import { usecases } from '../../domain/usecases/index.js';
 import { OrganizationLearner } from './models/OrganizationLearner.js';
+import { OrganizationLearnerWithOrganization } from './read-models/OrganizationLearnerWithOrganization.js';
 
 /**
  * @module OrganizationLearnerApi
@@ -139,4 +140,9 @@ export const get = async (organizationLearnerId) => {
 export const findByUserId = async (userId) => {
   const learners = await usecases.findOrganizationLearnersByUserId({ userId });
   return learners.map((learner) => _toAPIModel(learner));
+};
+
+export const findWithOrganizationByUserId = async ({ userId }) => {
+  const learners = await usecases.findOrganizationLearnersWithOrganizationByUserId({ userId });
+  return learners.map((learner) => new OrganizationLearnerWithOrganization(learner));
 };

--- a/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithOrganization.js
+++ b/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithOrganization.js
@@ -1,0 +1,18 @@
+export class OrganizationLearnerWithOrganization {
+  id = null;
+  organizationLearner = null;
+  organization = null;
+
+  constructor({ organizationLearner, organization }) {
+    this.id = organizationLearner.id;
+    this.organizationLearner = {
+      id: organizationLearner.id,
+    };
+    this.organization = {
+      id: organization.id,
+      isManagingStudents: organization.isManagingStudents,
+      tags: organization.tags,
+      type: organization.type,
+    };
+  }
+}

--- a/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerWithOrganization.js
+++ b/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerWithOrganization.js
@@ -1,0 +1,15 @@
+export class OrganizationLearnerWithOrganization {
+  id = null;
+  organizationLearner = null;
+  organization = null;
+  constructor({ organizationLearner, organization }) {
+    this.id = organizationLearner.id;
+    this.organizationLearner = organizationLearner;
+    this.organization = {
+      id: organization.id,
+      isManagingStudents: organization.isManagingStudents,
+      tags: organization.tags.map((tag) => tag.name),
+      type: organization.type,
+    };
+  }
+}

--- a/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-organization.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-organization.js
@@ -1,0 +1,22 @@
+import { OrganizationLearnerWithOrganization } from '../read-models/OrganizationLearnerWithOrganization.js';
+
+export const findOrganizationLearnersWithOrganizationByUserId = async function ({
+  userId,
+  organizationRepository,
+  libOrganizationLearnerRepository,
+}) {
+  const organizationLearners = await libOrganizationLearnerRepository.findByUserId({ userId });
+
+  const results = [];
+  for (const organizationLearner of organizationLearners) {
+    const organization = await organizationRepository.get(organizationLearner.organizationId);
+    results.push(
+      new OrganizationLearnerWithOrganization({
+        organizationLearner,
+        organization,
+      }),
+    );
+  }
+
+  return results;
+};

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -93,6 +93,7 @@ import { findAssociationBetweenUserAndOrganizationLearner } from './find-associa
 import { findDivisionsByOrganization } from './find-divisions-by-organization.js';
 import { findGroupsByOrganization } from './find-groups-by-organization.js';
 import { findOrganizationLearnersByUserId } from './find-organization-learners-by-user-id.js';
+import { findOrganizationLearnersWithOrganizationByUserId } from './find-organization-learners-with-organization.js';
 import { findPaginatedFilteredAttestationParticipantsStatus } from './find-paginated-filtered-attestation-participants-status.js';
 import { findPaginatedFilteredParticipants } from './find-paginated-filtered-participants.js';
 import { findPaginatedFilteredScoParticipants } from './find-paginated-filtered-sco-participants.js';
@@ -117,6 +118,7 @@ const usecasesWithoutInjectedDependencies = {
   findDivisionsByOrganization,
   findGroupsByOrganization,
   findOrganizationLearnersByUserId,
+  findOrganizationLearnersWithOrganizationByUserId,
   findPaginatedFilteredAttestationParticipantsStatus,
   findPaginatedFilteredParticipants,
   findPaginatedFilteredScoParticipants,

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1915,9 +1915,11 @@ describe('Integration | Repository | Organization Learner Management | Organizat
     it('should return all the organizationLearners for a given user ID', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
+      const otherUserId = databaseBuilder.factory.buildUser().id;
 
       const firstOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner({ userId });
       const secondOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner({ userId });
+      databaseBuilder.factory.buildOrganizationLearner({ userId: otherUserId });
 
       await databaseBuilder.commit();
 
@@ -1925,7 +1927,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       const organizationLearners = await organizationLearnerRepository.findByUserId({ userId });
 
       // then
-      expect(_.map(organizationLearners, 'id')).to.have.members([
+      expect(_.map(organizationLearners, 'id')).to.deep.equal([
         firstOrganizationLearner.id,
         secondOrganizationLearner.id,
       ]);

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-organization_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-organization_test.js
@@ -1,0 +1,67 @@
+import { tagRepository } from '../../../../../../src/organizational-entities/infrastructure/repositories/tag.repository.js';
+import { findOrganizationLearnersWithOrganizationByUserId } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-organization.js';
+import * as organizationLearnerRepository from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
+import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | UseCases | find-organization-learners-with-organization', function () {
+  it('should return organization learners with their organization', async function () {
+    // given
+    const user = databaseBuilder.factory.buildUser();
+    const organization = databaseBuilder.factory.buildOrganization({ isManagingStudents: true, type: 'SCO' });
+    const tag = databaseBuilder.factory.buildTag({ name: 'tagName' });
+    databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag.id });
+    const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+      userId: user.id,
+      organizationId: organization.id,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await findOrganizationLearnersWithOrganizationByUserId({
+      userId: user.id,
+      organizationRepository,
+      libOrganizationLearnerRepository: organizationLearnerRepository,
+      tagRepository,
+    });
+
+    // then
+    expect(result).to.have.lengthOf(1);
+    expect(result[0].organizationLearner.id).to.equal(organizationLearner.id);
+    expect(result[0].organization.id).to.equal(organization.id);
+    expect(result[0].organization.isManagingStudents).to.equal(true);
+    expect(result[0].organization.type).to.equal('SCO');
+    expect(result[0].organization.tags).to.deep.equal(['tagName']);
+  });
+
+  it('should return all organization learners for a user registered in multiple organizations', async function () {
+    // given
+    const user = databaseBuilder.factory.buildUser();
+    const organization1 = databaseBuilder.factory.buildOrganization();
+    const organization2 = databaseBuilder.factory.buildOrganization();
+    const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+      userId: user.id,
+      organizationId: organization1.id,
+    });
+    const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+      userId: user.id,
+      organizationId: organization2.id,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await findOrganizationLearnersWithOrganizationByUserId({
+      userId: user.id,
+      organizationRepository,
+      libOrganizationLearnerRepository: organizationLearnerRepository,
+      tagRepository,
+    });
+
+    // then
+    const learnerIds = result.map((r) => r.organizationLearner.id);
+    expect(learnerIds).to.have.members([organizationLearner1.id, organizationLearner2.id]);
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-api_test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import { OrganizationLearner } from '../../../../../../src/prescription/organization-learner/application/api/models/OrganizationLearner.js';
 import * as organizationLearnersApi from '../../../../../../src/prescription/organization-learner/application/api/organization-learners-api.js';
+import { OrganizationLearnerWithOrganization } from '../../../../../../src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithOrganization.js';
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 import { expect } from '../../../../../test-helper.js';
 
@@ -154,6 +155,40 @@ describe('Unit | API | Organization Learner', function () {
       // then
       expect(learner).to.be.instanceOf(OrganizationLearner);
       expect(learner.id).to.equal(1242);
+    });
+  });
+
+  describe('#findWithOrganizationByUserId', function () {
+    it('should return organization learners mapped to OrganizationLearnerWithOrganization DTOs', async function () {
+      // given
+      const userId = 1;
+      const organization = { id: 10, isManagingStudents: true, type: 'SCO', tags: ['tag1'] };
+      sinon.stub(usecases, 'findOrganizationLearnersWithOrganizationByUserId').resolves([
+        { organizationLearner: { id: 100 }, organization },
+        { organizationLearner: { id: 200 }, organization },
+      ]);
+
+      // when
+      const results = await organizationLearnersApi.findWithOrganizationByUserId({ userId });
+
+      // then
+      expect(usecases.findOrganizationLearnersWithOrganizationByUserId).to.have.been.calledOnceWith({ userId });
+      expect(results).to.deep.equal([
+        new OrganizationLearnerWithOrganization({ organizationLearner: { id: 100 }, organization }),
+        new OrganizationLearnerWithOrganization({ organizationLearner: { id: 200 }, organization }),
+      ]);
+    });
+
+    it('should return an empty array when no learners found', async function () {
+      // given
+      const userId = 999;
+      sinon.stub(usecases, 'findOrganizationLearnersWithOrganizationByUserId').resolves([]);
+
+      // when
+      const results = await organizationLearnersApi.findWithOrganizationByUserId({ userId });
+
+      // then
+      expect(results).to.deep.equal([]);
     });
   });
 });


### PR DESCRIPTION
## 💥 Problème

Aujourd’hui, on utilise une grosse API interne pour récupérer toutes les données nécessaires au fonctionnement du système de quêtes même quand elles ne sont pas nécessaires.

## 👩‍🚀 Proposition

On va se diriger vers un système d’introspection qui va chercher uniquement les données nécessaires à la quête en cours de traitement. La première étape est de découper en plus petites API internes.

Cette PR introduit une API interne pour récupérer les learners d’un utilisateur.



## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester

LA CI au vert 🍏
