### PR TITLE
[FEATURE] Ajouter le feature toggle newPixAppLegalDocumentsVersioning (PIX-21742)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -129,4 +129,11 @@ export default {
     devDefaultValues: { test: false, reviewApp: false },
     tags: ['team-devcomp', 'pix-api', 'backend'],
   },
+  newPixAppLegalDocumentsVersioning: {
+    type: 'boolean',
+    description: 'Enable new pix app legal documents versioning for pix',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: false },
+    tags: ['team-acces', 'pix-api', 'backend'],
+  },
 };


### PR DESCRIPTION
## 🌱 Problème

Nous avons besoin d'un feature toggle pour pouvoir mettre en place le nouveau système de lecture et écriture des acceptations de CGU sur Pix App.

## 🐣 Proposition

Ajouter ce feature toggle

## 🌷 Remarques
RAS

## 🐝 Pour tester
- En local, exécuter la commande `npm run toggles -- --key=newPixAppLegalDocumentsVersioning --value=true`
- Vérifier, avec la commande `npm run toggles --list` que le feature toggle est bien passé à `true`.
