### PR TITLE
[TECH] Limiter les problèmes de mises à jour des paquets lors du démarrage de certains jobs CircleCI

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -1,4 +1,4 @@
-# .circleci/continue_config.yml
+# .circleci/jobs.yml
 #
 #
 # Caching notes:
@@ -256,7 +256,7 @@ commands:
       app_name:
         type: string
     steps:
-      - browser-tools/install-chrome
+      - browser-tools/install_browser_tools
       - attach_workspace:
           at: ~/pix
       - run:
@@ -961,7 +961,7 @@ jobs:
             if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-mon-pix >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
-      - browser-tools/install-chrome
+      - browser-tools/install_browser_tools
       - run:
           name: Manual safety start of X11 server
           command: |
@@ -1045,7 +1045,7 @@ jobs:
             if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-orga >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
-      - browser-tools/install-chrome
+      - browser-tools/install_browser_tools
       - run:
           name: Manual safety start of X11 server
           command: |

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -256,7 +256,6 @@ commands:
       app_name:
         type: string
     steps:
-      - run: sudo apt-get update -y
       - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
@@ -962,7 +961,6 @@ jobs:
             if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-mon-pix >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
-      - run: sudo apt-get update -y
       - browser-tools/install-chrome
       - run:
           name: Manual safety start of X11 server
@@ -1047,7 +1045,6 @@ jobs:
             if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-orga >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
-      - run: sudo apt-get update -y
       - browser-tools/install-chrome
       - run:
           name: Manual safety start of X11 server

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -56,7 +56,7 @@ parameters:
     default: false
 
 orbs:
-  browser-tools: circleci/browser-tools@1.5.3
+  browser-tools: circleci/browser-tools@2.4.2
 
 executors:
   node-docker:


### PR DESCRIPTION
## 💥 Problème

Récemment, il est arrivé que certains jobs sur CircleCI soient en erreur pendant l'exécution de la commande`apt-get update`

```
Err:19 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages
  File has unexpected size (2141657 != 2141661). Mirror sync in progress? [IP: 91.189.91.83 80]
  Hashes of expected file:
   - Filesize:2141661 [weak]
   - SHA256:00621c96108bc48e1ecc1205f9d06b5d0894f5ab0aaddba7056000e440e79040
   - SHA1:0889f27b24177c30409b8b533663418f895f0d9c [weak]
   - MD5Sum:892a9953f92ceb292fbfaa70adff1197 [weak]
  Release file created at: Mon, 04 May 2026 13:50:56 +0000
Get:20 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [2,400 kB]
Get:21 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [3,810 kB]
Fetched 35.9 MB in 4min 30s (133 kB/s)
Reading package lists... Done
W: https://download.docker.com/linux/ubuntu/dists/noble/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/Packages.gz  File has unexpected size (2141657 != 2141661). Mirror sync in progress? [IP: 91.189.91.83 80]
   Hashes of expected file:
    - Filesize:2141661 [weak]
    - SHA256:00621c96108bc48e1ecc1205f9d06b5d0894f5ab0aaddba7056000e440e79040
    - SHA1:0889f27b24177c30409b8b533663418f895f0d9c [weak]
    - MD5Sum:892a9953f92ceb292fbfaa70adff1197 [weak]
   Release file created at: Mon, 04 May 2026 13:50:56 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

## 👩‍🚀 Proposition

### Sens de l'erreur
Cette erreur n'est pas de notre fait.
Lorsqu'on met à jour les paquets sur une machine Ubuntu via `apt-get update`, on télécharge d'un côté les paquets et de l'autre un fichier de métadonnées qui va notamment contenir des infos permettant de vérifier l'intégrité des paquets téléchargés (vérification de taille de fichier et autres SHA 🐱 ).
Comme beaucoup de gens téléchargent tout le temps des paquets, et depuis plusieurs endroits du monde, il existe ce qu'on appelle des miroirs, qui sont des caches. Quand il y a des mises à jour, il peut exister une petite désynchro entre ce qui est présenté par les miroirs et la réalité. Ce souci de désynchro est général résolu rapidement.

### Réflexion sur un mécanisme de retry
Puisque cette erreur est supposée être en temporaire, on peut envisager de soumettre la commande `apt-get update` à un mécanisme de retry afin de ne pas avoir trop de jobs en rouge sur la CI pour les "mauvaises raisons".

En cherchant un peu dans notre config CircleCI actuelle, on a constaté :
- Que la commande `apt-get update` était redondante avec la commande qui suivait, à savoir l'installation de chrome via l'orb mise à disposition par CircleCI, à savoir `browser-tools/install-chrome`
- Que l'orb qu'on utilisait commençait à être un peu vieille (on passe de la 1.5.3 à la 2.4.2)
- Que l'orb, dans sa nouvelle version, introduisait un mécanisme de retry autour du sujet qui nous concerne depuis la 2.4.0

Sources :
https://github.com/CircleCI-Public/browser-tools-orb/releases
https://github.com/CircleCI-Public/browser-tools-orb/pull/162

## 👁️ Remarques
Doc pour le changement de la commande d'installation du navigateur :
https://circleci.com/developer/orbs/orb/circleci/browser-tools

## ♻️ Pour tester
CI verte puis voir si ce problème n'est pas trop redondant (car il n'est pas gratuit 💸 )
