### PR TITLE
[BUGFIX] Script de migration pgboss v9 vers v12

### DIFF
--- a/api/scripts/migrate-pgboss-jobs-v9-to-v12.js
+++ b/api/scripts/migrate-pgboss-jobs-v9-to-v12.js
@@ -22,6 +22,8 @@ export class MigratePgbossJobsV9toV12Script extends ScriptWithJob {
   }
 
   async handle({ options, logger }) {
+    await super.handle({ options, logger });
+
     const nonCompletedJobs = await knex
       .select()
       .from(options.jobTableName)

--- a/api/src/shared/application/scripts/script-with-job.js
+++ b/api/src/shared/application/scripts/script-with-job.js
@@ -10,7 +10,5 @@ export class ScriptWithJob extends Script {
     this.onFinished = async () => {
       await JobClient.instance.stop();
     };
-
-    return super.handle(...arguments);
   }
 }


### PR DESCRIPTION
## 💥 Problème

`JobClient` non initialisé au lancement.

## 👩‍🚀 Proposition

Corriger le système d'héritage de `handle` depuis `ScriptWithJob`

## 👁️ Remarques

N/A

## ♻️ Pour tester

```
node --env-file-if-exists=.env scripts/migrate-pgboss-jobs-v9-to-v12.js --dry-run=false
```