### PR TITLE
[BUGFIX] Déclencher les migrations pgboss

### DIFF
--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -44,7 +44,7 @@ export class JobClient {
     if (worker) {
       this.#pgBoss = pgBossFactory
         ? pgBossFactory()
-        : new PgBoss({ connectionString, max: config.pgBoss.workerConnexionPoolMaxSize, migrate: false });
+        : new PgBoss({ connectionString, max: config.pgBoss.workerConnexionPoolMaxSize });
 
       this.#pgBoss.on('error', (err) => {
         logger.error({ event: 'pg-boss-error', err }, 'PGBOSS ERROR');
@@ -66,7 +66,6 @@ export class JobClient {
             max: config.pgBoss.clientConnexionPoolMaxSize,
             supervise: false,
             schedule: false,
-            migrate: false,
           });
       await this.#pgBoss.start();
     }


### PR DESCRIPTION
## 💥 Problème

Dans les RA et les environnements, il est nécessaire de faire les migrations pgboss automatiquement.

## 👩‍🚀 Proposition

Enlever le `migrate: false` à l'initialisation du `JobClient`.

## 👁️ Remarques

N/A

## ♻️ Pour tester

La RA doivent se déployer normalement.