### PR TITLE
[TECH] Notification Slack des tests instables

### DIFF
--- a/.github/workflows/report-flaky-tests.yaml
+++ b/.github/workflows/report-flaky-tests.yaml
@@ -1,0 +1,62 @@
+on:
+  # schedule:
+  #   # Tous les lundis à 8h UTC
+  #   - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  report-flaky-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch flaky tests from CircleCI Insights
+        env:
+          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+        run: |
+          curl -sS --fail \
+            -H "Circle-Token: $CIRCLECI_TOKEN" \
+            "https://circleci.com/api/v2/insights/github/1024pix/pix/flaky-tests" \
+            -o flaky.json
+          echo "Flaky tests count: $(jq '.flaky_tests | length' flaky.json)"
+
+      - name: Build Slack payload
+        run: |
+          COUNT=$(jq '.flaky_tests | length' flaky.json)
+
+          if [ "$COUNT" -eq 0 ]; then
+            jq -n '{
+              text: "✅ Aucun flaky test détecté cette semaine",
+              blocks: [
+                { type: "header", text: { type: "plain_text", text: "✅ Flaky tests — RAS" } },
+                { type: "section", text: { type: "mrkdwn", text: "Aucun flaky test détecté sur la dernière fenêtre CircleCI Insights." } }
+              ]
+            }' > payload.json
+          else
+            TOP=$(jq -r '
+              .flaky_tests
+              | sort_by(-(.times_flaked // 0))
+              | .[0:10]
+              | map("• `\(.classname // "?")::\(.test_name // "?")` — \(.times_flaked // 0)x _(job: \(.job_name // "?"))_")
+              | join("\n")
+            ' flaky.json)
+
+            jq -n --arg count "$COUNT" --arg top "$TOP" '{
+              text: "🪲 Flaky tests — \($count) détecté(s)",
+              blocks: [
+                { type: "header", text: { type: "plain_text", text: "🪲 Rapport flaky tests" } },
+                { type: "section", text: { type: "mrkdwn", text: "Total détectés : *\($count)* — top 10 :" } },
+                { type: "section", text: { type: "mrkdwn", text: $top } },
+                { type: "context", elements: [
+                  { type: "mrkdwn", text: "Source : <https://app.circleci.com/insights/github/1024pix/pix/flaky-tests|CircleCI Insights>" }
+                ]}
+              ]
+            }' > payload.json
+          fi
+
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FLAKY_TESTS_WEBHOOK_URL }}
+        run: |
+          curl -sS --fail -X POST \
+            -H 'Content-Type: application/json' \
+            --data @payload.json \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/report-flaky-tests.yaml
+++ b/.github/workflows/report-flaky-tests.yaml
@@ -10,11 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch flaky tests from CircleCI Insights
-        env:
-          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
         run: |
           curl -sS --fail \
-            -H "Circle-Token: $CIRCLECI_TOKEN" \
             "https://circleci.com/api/v2/insights/github/1024pix/pix/flaky-tests" \
             -o flaky.json
           echo "Flaky tests count: $(jq '.flaky_tests | length' flaky.json)"

--- a/.github/workflows/report-flaky-tests.yaml
+++ b/.github/workflows/report-flaky-tests.yaml
@@ -1,8 +1,8 @@
 name: Flaky tests slack notification
 on:
-  # schedule:
-  #   # Tous les lundis à 8h UTC
-  #   - cron: '0 8 * * 1'
+  schedule:
+    # Tous les lundis à 9h UTC
+    - cron: '0 9 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/report-flaky-tests.yaml
+++ b/.github/workflows/report-flaky-tests.yaml
@@ -1,3 +1,4 @@
+name: Flaky tests slack notification
 on:
   # schedule:
   #   # Tous les lundis à 8h UTC

--- a/.github/workflows/report-flaky-tests.yaml
+++ b/.github/workflows/report-flaky-tests.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Post to Slack
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FLAKY_TESTS_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ENGINEERING_WEBHOOK_URL }}
         run: |
           curl -sS --fail -X POST \
             -H 'Content-Type: application/json' \

--- a/.github/workflows/report-flaky-tests.yaml
+++ b/.github/workflows/report-flaky-tests.yaml
@@ -47,7 +47,7 @@ jobs:
                 { type: "section", text: { type: "mrkdwn", text: "Total détectés : *\($count)* — top 10 :" } },
                 { type: "section", text: { type: "mrkdwn", text: $top } },
                 { type: "context", elements: [
-                  { type: "mrkdwn", text: "Source : <https://app.circleci.com/insights/github/1024pix/pix/flaky-tests|CircleCI Insights>" }
+                  { type: "mrkdwn", text: "Source : <https://app.circleci.com/insights/github/1024pix/pix/workflows/build-and-test/tests|CircleCI Tests>" }
                 ]}
               ]
             }' > payload.json


### PR DESCRIPTION
## 💥 Problème

Les tests flaky ralentissent le process de dev en faisant échouer la CI toujours trop fréquemment.

## 👩‍🚀 Proposition

Inciter à la correction de ces tests en envoyant un message tous les lundis matin dans le canal Slack #engineering.

## ♻️ Pour tester
Test possible uniquement après merge de la PR 🙃 🐍 
Démo possible sur [pix-captain-test](https://github.com/1024pix/pix-captain-test/actions/workflows/flaty-test-message.yml)

<img width="1297" height="390" alt="Capture d’écran 2026-05-05 à 16 54 22" src="https://github.com/user-attachments/assets/984478fd-bb1a-48e9-9b7d-2eb160788842" />

