### PR TITLE
[TECH] :recycle: Réduit l'utilisation de `lodash` (pix-22710)

### DIFF
--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { CertificationCandidatesError } from '../../../../shared/domain/errors.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import * as mailCheckImplementation from '../../../../shared/mail/infrastructure/services/mail-check.js';
@@ -152,19 +150,15 @@ export async function extractCertificationCandidatesFromCandidatesImportSheet({
 }
 
 function _filterOutEmptyCandidateData(certificationCandidatesData) {
-  return _(certificationCandidatesData)
-    .mapValues(_nullifyObjectWithOnlyNilValues)
-    .pickBy((value) => value !== null)
-    .value();
-}
-
-function _nullifyObjectWithOnlyNilValues(data) {
-  for (const propName in data) {
-    if (data[propName] != null) {
-      return data;
+  const filteredData = {};
+  Object.keys(certificationCandidatesData).forEach((certificationCandidateId) => {
+    const certificationCandidateData = certificationCandidatesData[certificationCandidateId];
+    const values = Object.values(certificationCandidateData);
+    if (values.filter(Boolean).length !== 0) {
+      filteredData[certificationCandidateId] = certificationCandidateData;
     }
-  }
-  return null;
+  });
+  return filteredData;
 }
 
 function _handleBirthInformationValidationError(cpfBirthInformation, line) {

--- a/api/src/certification/enrolment/infrastructure/candidates-import/candidates-import-transformation-structures.js
+++ b/api/src/certification/enrolment/infrastructure/candidates-import/candidates-import-transformation-structures.js
@@ -1,4 +1,5 @@
 import { convertDateValue } from '../../../../shared/infrastructure/utils/date-utils.js';
+import isEmpty from '../../../../shared/infrastructure/utils/is-empty.js';
 
 // These are transformation structures. They provide all the necessary info
 // on how to transform cell values in an attendance sheet into a target JS object.
@@ -112,14 +113,10 @@ function _includeBillingColumns({ transformationStruct, translate }) {
   });
 }
 
-function _isEmpty(obj) {
-  return [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;
-}
-
 function _toNotEmptyTrimmedStringOrNull(val) {
   const value = String(val ?? '');
   const trimmedValue = value.trim();
-  return _isEmpty(trimmedValue) ? null : trimmedValue;
+  return isEmpty(trimmedValue) ? null : trimmedValue;
 }
 
 function _toNonZeroValueOrNull(val) {

--- a/api/src/certification/enrolment/infrastructure/candidates-import/fill-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/infrastructure/candidates-import/fill-candidates-import-sheet.js
@@ -8,6 +8,7 @@ import * as url from 'node:url';
 
 import _ from 'lodash';
 
+import isEmpty from '../../../../shared/infrastructure/utils/is-empty.js';
 import { CertificationCandidate } from '../../../shared/domain/models/CertificationCandidate.js';
 import * as readOdsUtils from '../utils/ods/read-ods-utils.js';
 import { OdsUtilsBuilder } from '../utils/ods/write-ods-utils.js';
@@ -128,7 +129,7 @@ function _addColumns({ odsBuilder, certificationCenterHabilitations, isScoCertif
 }
 
 function _addComplementaryCertificationColumns({ odsBuilder, certificationCenterHabilitations, translate }) {
-  if (!_.isEmpty(certificationCenterHabilitations)) {
+  if (!isEmpty(certificationCenterHabilitations)) {
     const habilitationColumns = certificationCenterHabilitations.map(({ key, label }) => ({
       headerLabel: [label, translate('candidate-list-template.yes-or-empty')],
       placeholder: [key],

--- a/api/src/certification/enrolment/infrastructure/serializers/session-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/session-serializer.js
@@ -4,7 +4,7 @@ import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function (session) {
+export function serialize(session) {
   return new Serializer('session-enrolment', {
     transform: function (session) {
       return { ...session, status: session.status, invigilatorPassword: session.invigilatorPassword };
@@ -32,9 +32,9 @@ const serialize = function (session) {
       },
     },
   }).serialize(session);
-};
+}
 
-const deserialize = function (json) {
+export function deserialize(json) {
   const attributes = json.data.attributes;
 
   return new SessionEnrolment({
@@ -48,6 +48,4 @@ const deserialize = function (json) {
     status: attributes.status,
     description: attributes.description,
   });
-};
-
-export { deserialize, serialize };
+}

--- a/api/src/certification/enrolment/infrastructure/utils/ods/read-ods-utils.js
+++ b/api/src/certification/enrolment/infrastructure/utils/ods/read-ods-utils.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import XLSX from 'xlsx';
 
 import { UnprocessableEntityError } from '../../../../../shared/application/http-errors.js';
@@ -6,14 +5,14 @@ import { loadOdsZip } from './common-ods-utils.js';
 
 const CONTENT_XML_IN_ODS = 'content.xml';
 
-async function getContentXml({ odsFilePath }) {
+export async function getContentXml({ odsFilePath }) {
   const zip = await loadOdsZip(odsFilePath);
   const contentXmlBufferCompressed = zip.file(CONTENT_XML_IN_ODS);
   const uncompressedBuffer = await contentXmlBufferCompressed.async('nodebuffer');
   return Buffer.from(uncompressedBuffer, 'utf8').toString();
 }
 
-async function extractTableDataFromOdsFile({ odsBuffer, tableHeaderTargetPropertyMap }) {
+export async function extractTableDataFromOdsFile({ odsBuffer, tableHeaderTargetPropertyMap }) {
   const sheetDataRows = await getSheetDataRowsFromOdsBuffer({ odsBuffer });
   const tableHeaders = tableHeaderTargetPropertyMap.map((tt) => tt.header);
   const sheetHeaderRow = _findHeaderRow(sheetDataRows, tableHeaders);
@@ -24,13 +23,13 @@ async function extractTableDataFromOdsFile({ odsBuffer, tableHeaderTargetPropert
   const sheetHeaderPropertyMap = _mapSheetHeadersWithProperties(sheetHeaderRow, tableHeaderTargetPropertyMap);
 
   const dataByLine = _transformSheetDataRows(sheetDataRowsBelowHeader, sheetHeaderPropertyMap);
-  if (_.isEmpty(dataByLine)) {
+  if (isEmpty(dataByLine)) {
     throw new UnprocessableEntityError('No data in table');
   }
   return dataByLine;
 }
 
-async function validateOdsHeaders({ odsBuffer, headers }) {
+export async function validateOdsHeaders({ odsBuffer, headers }) {
   const sheetDataRows = await getSheetDataRowsFromOdsBuffer({ odsBuffer });
   const headerRow = _findHeaderRow(sheetDataRows, headers);
   if (!headerRow) {
@@ -38,7 +37,7 @@ async function validateOdsHeaders({ odsBuffer, headers }) {
   }
 }
 
-async function getSheetDataRowsFromOdsBuffer({ odsBuffer, jsonOptions = { header: 'A' } }) {
+export async function getSheetDataRowsFromOdsBuffer({ odsBuffer, jsonOptions = { header: 'A' } }) {
   let document;
   try {
     document = await XLSX.read(odsBuffer, { type: 'buffer', cellDates: true });
@@ -47,40 +46,52 @@ async function getSheetDataRowsFromOdsBuffer({ odsBuffer, jsonOptions = { header
   }
   const sheet = document.Sheets[document.SheetNames[0]];
   const sheetDataRows = XLSX.utils.sheet_to_json(sheet, jsonOptions);
-  if (_.isEmpty(sheetDataRows)) {
+  if (isEmpty(sheetDataRows)) {
     throw new UnprocessableEntityError('Empty data in sheet');
   }
   return sheetDataRows;
 }
 
 function _extractRowsBelowHeader(sheetHeaderRow, sheetDataRows) {
-  const headerIndex = _.findIndex(sheetDataRows, (row) => _.isEqual(row, sheetHeaderRow));
+  const headerIndex = sheetDataRows.findIndex((row) => row === sheetHeaderRow);
   return _takeRightUntilIndex({ array: sheetDataRows, index: headerIndex + 1 });
 }
 
 function _takeRightUntilIndex({ array, index }) {
-  const countElementsToTake = _.size(array) - index;
-  return _.takeRight(array, countElementsToTake);
+  const countElementsToTake = array.length - index;
+  if (countElementsToTake === 0) return [];
+  return array.slice(countElementsToTake * -1);
 }
 
 function _findHeaderRow(sheetDataRows, tableHeaders) {
-  return _.find(sheetDataRows, (row) => _allHeadersValuesAreInTheRow(row, tableHeaders));
+  return sheetDataRows.find((row) => _allHeadersValuesAreInTheRow(row, tableHeaders));
 }
 
 function _allHeadersValuesAreInTheRow(row, headers) {
-  const cellValuesInRow = _.values(row);
+  const cellValuesInRow = Object.values(row);
   const strippedCellValuesInRow = cellValuesInRow.map(_removeNewlineCharacters);
   const strippedHeaders = headers.map(_removeNewlineCharacters);
-  const headersInRow = _.intersection(strippedCellValuesInRow, strippedHeaders);
+  const headersInRow = strippedCellValuesInRow.filter((value) => strippedHeaders.includes(value));
   return headersInRow.length === headers.length;
 }
 
 function _removeNewlineCharacters(header) {
-  return _.isString(header) ? header.replace(/[\n\r]/g, '') : header;
+  const isHeaderIsString = typeof header.valueOf() === 'string';
+  return isHeaderIsString ? header.replace(/[\n\r]/g, '') : header;
 }
 
 function _mapSheetHeadersWithProperties(sheetHeaderRow, tableHeaderTargetPropertyMap) {
-  return _(sheetHeaderRow).map(_addTargetDatas(tableHeaderTargetPropertyMap)).compact().value();
+  return Object.keys(sheetHeaderRow)
+    .map((key) => {
+      const v = sheetHeaderRow[key];
+
+      const targetProperties = _findTargetPropertiesByHeader(tableHeaderTargetPropertyMap, v);
+      if (targetProperties) {
+        const { property: targetProperty, transformFn } = targetProperties;
+        return { columnName: key, targetProperty, transformFn };
+      }
+    })
+    .filter(Boolean);
 }
 
 function _findTargetPropertiesByHeader(tableHeaderTargetPropertyMap, header) {
@@ -89,17 +100,7 @@ function _findTargetPropertiesByHeader(tableHeaderTargetPropertyMap, header) {
     header: _removeNewlineCharacters(obj.header),
   }));
 
-  return _.find(mapWithSanitizedHeaders, { header: _removeNewlineCharacters(header) });
-}
-
-function _addTargetDatas(tableHeaderTargetPropertyMap) {
-  return (header, columnName) => {
-    const targetProperties = _findTargetPropertiesByHeader(tableHeaderTargetPropertyMap, header);
-    if (targetProperties) {
-      const { property: targetProperty, transformFn } = targetProperties;
-      return { columnName, targetProperty, transformFn };
-    }
-  };
+  return mapWithSanitizedHeaders.find((h) => h.header === _removeNewlineCharacters(header));
 }
 
 function _transformSheetDataRows(sheetDataRows, sheetHeaderPropertyMap) {
@@ -111,15 +112,11 @@ function _transformSheetDataRows(sheetDataRows, sheetHeaderPropertyMap) {
 }
 
 function _transformSheetDataRow(sheetDataRow, sheetHeaderPropertyMap) {
-  return _.reduce(
-    sheetHeaderPropertyMap,
-    (target, { columnName, targetProperty, transformFn }) => {
-      const cellValue = sheetDataRow[columnName];
-      target[targetProperty] = transformFn(cellValue);
-      return target;
-    },
-    {},
-  );
+  return sheetHeaderPropertyMap.reduce((target, { columnName, targetProperty, transformFn }) => {
+    const cellValue = sheetDataRow[columnName];
+    target[targetProperty] = transformFn(cellValue);
+    return target;
+  }, {});
 }
 
-export { extractTableDataFromOdsFile, getContentXml, getSheetDataRowsFromOdsBuffer, validateOdsHeaders };
+const isEmpty = (obj) => [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;

--- a/api/src/certification/enrolment/infrastructure/utils/ods/read-ods-utils.js
+++ b/api/src/certification/enrolment/infrastructure/utils/ods/read-ods-utils.js
@@ -1,6 +1,7 @@
 import XLSX from 'xlsx';
 
 import { UnprocessableEntityError } from '../../../../../shared/application/http-errors.js';
+import isEmpty from '../../../../../shared/infrastructure/utils/is-empty.js';
 import { loadOdsZip } from './common-ods-utils.js';
 
 const CONTENT_XML_IN_ODS = 'content.xml';
@@ -118,5 +119,3 @@ function _transformSheetDataRow(sheetDataRow, sheetHeaderPropertyMap) {
     return target;
   }, {});
 }
-
-const isEmpty = (obj) => [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;

--- a/api/src/certification/enrolment/infrastructure/utils/ods/write-ods-utils.js
+++ b/api/src/certification/enrolment/infrastructure/utils/ods/write-ods-utils.js
@@ -1,5 +1,4 @@
 import xmldom from '@xmldom/xmldom';
-import _ from 'lodash';
 
 import { AddedCellOption } from './added-cell-option.js';
 import { loadOdsZip } from './common-ods-utils.js';
@@ -202,9 +201,9 @@ class OdsUtilsBuilder {
     const cloneRowElement = _deepCloneDomElement(referenceRowElement);
     rowsContainerElement.removeChild(referenceRowElement);
 
-    _.each(dataToInject, (rowDataToInject) => {
+    dataToInject.forEach(function (data) {
       const currentCloneRowElement = _deepCloneDomElement(cloneRowElement);
-      _updateXmlElementWithData(currentCloneRowElement, rowDataToInject, rowTemplateValues);
+      _updateXmlElementWithData(currentCloneRowElement, data, rowTemplateValues);
       rowsContainerElement.appendChild(currentCloneRowElement);
     });
 
@@ -240,10 +239,9 @@ function updateXmlRows({ stringifiedXml, rowMarkerPlaceholder, rowTemplateValues
 
   const cloneRowElement = _deepCloneDomElement(referenceRowElement);
   rowsContainerElement.removeChild(referenceRowElement);
-
-  _.each(dataToInject, (rowDataToInject) => {
+  dataToInject.forEach(function (data) {
     const currentCloneRowElement = _deepCloneDomElement(cloneRowElement);
-    _updateXmlElementWithData(currentCloneRowElement, rowDataToInject, rowTemplateValues);
+    _updateXmlElementWithData(currentCloneRowElement, data, rowTemplateValues);
     rowsContainerElement.appendChild(currentCloneRowElement);
   });
 

--- a/api/src/certification/enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js
+++ b/api/src/certification/enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js
@@ -7,8 +7,6 @@ import localizedFormat from 'dayjs/plugin/localizedFormat.js';
 import { PDFDocument, rgb } from 'pdf-lib';
 dayjs.extend(localizedFormat);
 
-import _ from 'lodash';
-
 import { ENGLISH_SPOKEN, FRENCH_SPOKEN } from '../../../../../shared/domain/services/locale-service.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -18,7 +16,7 @@ const CANDIDATES_PER_PAGE = 20;
 const SESSION_DETAIL_DEFAULT_COLOR = rgb(0, 0, 0);
 const DATE_OF_BIRTH_DEFAULT_X = 239;
 
-async function getAttendanceSheetPdfBuffer({
+export async function getAttendanceSheetPdfBuffer({
   dirname = __dirname,
   fontkit = pdfLibFontkit,
   creationDate = new Date(),
@@ -46,7 +44,7 @@ async function getAttendanceSheetPdfBuffer({
   const pageInformationFont = await _embedFontIntoPdf({ pdfDoc, dirname, font: 'Nunito-Regular.ttf' });
 
   const certificationCandidates = session.certificationCandidates;
-  const certificationCandidatesSplitByPage = _.chunk(certificationCandidates, CANDIDATES_PER_PAGE);
+  const certificationCandidatesSplitByPage = chunk(certificationCandidates, CANDIDATES_PER_PAGE);
 
   for (const [index, candidatesGroup] of certificationCandidatesSplitByPage.entries()) {
     const page = pdfDoc.addPage();
@@ -417,4 +415,8 @@ function _getSessionStartTimeFormat({ lang }) {
   return 'LT';
 }
 
-export { getAttendanceSheetPdfBuffer };
+function chunk(input, size) {
+  return input.reduce((arr, item, idx) => {
+    return idx % size === 0 ? [...arr, [item]] : [...arr.slice(0, -1), [...arr.slice(-1)[0], item]];
+  }, []);
+}

--- a/api/src/certification/enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js
+++ b/api/src/certification/enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js
@@ -8,6 +8,7 @@ import { PDFDocument, rgb } from 'pdf-lib';
 dayjs.extend(localizedFormat);
 
 import { ENGLISH_SPOKEN, FRENCH_SPOKEN } from '../../../../../shared/domain/services/locale-service.js';
+import chunk from '../../../../../shared/infrastructure/utils/chunk.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -413,10 +414,4 @@ function _getSessionStartTimeFormat({ lang }) {
     return 'HH:mm';
   }
   return 'LT';
-}
-
-function chunk(input, size) {
-  return input.reduce((arr, item, idx) => {
-    return idx % size === 0 ? [...arr, [item]] : [...arr.slice(0, -1), [...arr.slice(-1)[0], item]];
-  }, []);
 }

--- a/api/src/certification/evaluation/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/evaluation/domain/services/algorithm-methods/flash.js
@@ -3,37 +3,35 @@
  * @typedef {import('../../../../../evaluation/domain/models/Answer.js').Answer} Answer
  */
 
-import lodash from 'lodash';
-
 import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
-
-const { orderBy, range } = lodash;
 
 const DEFAULT_CAPACITY = 0;
 const START_OF_SAMPLES = -9;
 const STEP_OF_SAMPLES = 18 / 80;
-const END_OF_SAMPLES = 9 + STEP_OF_SAMPLES;
-const samples = range(START_OF_SAMPLES, END_OF_SAMPLES, STEP_OF_SAMPLES);
+const END_OF_SAMPLES = 9;
+const samples = generateSampleArray(START_OF_SAMPLES, END_OF_SAMPLES, STEP_OF_SAMPLES);
 const DEFAULT_PROBABILITY_TO_ANSWER = 1;
 const DEFAULT_ERROR_RATE = 5;
 const ERROR_RATE_CLASS_INTERVAL = 9 / 80;
 
 const MAX_NUMBER_OF_RETURNED_CHALLENGES = 5;
 
-export {
-  getCapacityAndErrorRate,
-  getCapacityAndErrorRateHistory,
-  getChallengesForNonAnsweredSkills,
-  getPossibleNextChallenges,
-  getReward,
-};
+function generateSampleArray(start, end, step) {
+  let i = start;
+  const resultArray = [];
+  while (i < end) {
+    resultArray.push(i);
+    i += step;
+  }
+  return resultArray;
+}
 
 /**
  * @param {object} params
  * @param {CalibratedChallenge[]} params.availableChallenges
  * @param {number} [params.capacity=DEFAULT_CAPACITY]
  */
-function getPossibleNextChallenges({ availableChallenges, capacity = DEFAULT_CAPACITY }) {
+export function getPossibleNextChallenges({ availableChallenges, capacity = DEFAULT_CAPACITY }) {
   const challengesWithReward = availableChallenges.map((challenge) => {
     return {
       challenge,
@@ -55,7 +53,7 @@ function getPossibleNextChallenges({ availableChallenges, capacity = DEFAULT_CAP
  * @param {number} [params.capacity=DEFAULT_CAPACITY]
  * @param {number} params.variationPercent
  */
-function getCapacityAndErrorRate({ allAnswers, challenges, capacity = DEFAULT_CAPACITY, variationPercent }) {
+export function getCapacityAndErrorRate({ allAnswers, challenges, capacity = DEFAULT_CAPACITY, variationPercent }) {
   if (challenges.length === 0 || allAnswers.length === 0) {
     return { capacity, errorRate: DEFAULT_ERROR_RATE };
   }
@@ -77,7 +75,12 @@ function getCapacityAndErrorRate({ allAnswers, challenges, capacity = DEFAULT_CA
  * @param {number} [params.capacity=DEFAULT_CAPACITY]
  * @param {number} params.variationPercent
  */
-function getCapacityAndErrorRateHistory({ allAnswers, challenges, capacity = DEFAULT_CAPACITY, variationPercent }) {
+export function getCapacityAndErrorRateHistory({
+  allAnswers,
+  challenges,
+  capacity = DEFAULT_CAPACITY,
+  variationPercent,
+}) {
   let latestCapacity = capacity;
 
   let likelihood = samples.map(() => DEFAULT_PROBABILITY_TO_ANSWER);
@@ -185,7 +188,8 @@ function _computeNormalizedPosteriori(likelihood, normalizedGaussian) {
  * @returns {number}
  */
 function _computeCapacity(previousCapacity, variationPercent, normalizedPosteriori) {
-  const rawNextCapacity = lodash.sum(samples.map((sample, index) => sample * normalizedPosteriori[index]));
+  const rawCapacities = samples.map((sample, index) => sample * normalizedPosteriori[index]);
+  const rawNextCapacity = rawCapacities.reduce((accumulator, capacity) => accumulator + capacity, 0);
 
   return variationPercent
     ? _limitCapacityVariation(previousCapacity, rawNextCapacity, variationPercent)
@@ -199,9 +203,8 @@ function _computeCapacity(previousCapacity, variationPercent, normalizedPosterio
  * @returns {number}
  */
 function _computeCorrectedErrorRate(latestCapacity, normalizedPosteriori) {
-  const rawErrorRate = lodash.sum(
-    samples.map((sample, index) => normalizedPosteriori[index] * (sample - latestCapacity) ** 2),
-  );
+  const errorRates = samples.map((sample, index) => normalizedPosteriori[index] * (sample - latestCapacity) ** 2);
+  const rawErrorRate = errorRates.reduce((accumulator, rate) => accumulator + rate, 0);
 
   // oxfmt-ignore
   return Math.sqrt(rawErrorRate - (ERROR_RATE_CLASS_INTERVAL ** 2) / 12.0);
@@ -213,7 +216,7 @@ function _computeCorrectedErrorRate(latestCapacity, normalizedPosteriori) {
  * @param {Answer[]} params.allAnswers
  * @param {CalibratedChallenge[]} params.challenges
  */
-function getChallengesForNonAnsweredSkills({ allAnswers, challenges }) {
+export function getChallengesForNonAnsweredSkills({ allAnswers, challenges }) {
   const alreadyAnsweredSkillsIds = allAnswers
     .map((answer) => _findChallengeForAnswer(challenges, answer))
     .map((challenge) => challenge.skill.id);
@@ -247,24 +250,14 @@ function _limitCapacityVariation(previousCapacity, nextCapacity, variationPercen
  * @param {number} capacity
  * @returns {CalibratedChallenge[]}
  */
-function _findBestPossibleChallenges(challengesWithReward, capacity) {
+function _findBestPossibleChallenges(challengesWithReward) {
   /**
    * @param {{challenge: CalibratedChallenge, reward: number}} challengeWithReward
    * @returns {boolean}
    */
-  const canChallengeBeSuccessful = (challengeWithReward) => {
-    const { challenge } = challengeWithReward;
-    const minimumSuccessRate = 0;
-    const successProbability = _getProbability(capacity, challenge.discriminant, challenge.difficulty);
-
-    return successProbability >= minimumSuccessRate;
-  };
-
-  const orderedChallengesWithReward = orderBy(
-    challengesWithReward,
-    [canChallengeBeSuccessful, 'reward'],
-    ['desc', 'desc'],
-  );
+  const orderedChallengesWithReward = challengesWithReward.sort((a, b) => {
+    return a.reward > b.reward ? -1 : a.reward < b.reward ? 1 : 0;
+  });
 
   const possibleChallengesWithReward = orderedChallengesWithReward.slice(0, MAX_NUMBER_OF_RETURNED_CHALLENGES);
 
@@ -291,7 +284,7 @@ function _findChallengeForAnswer(challenges, answer) {
  * @param {number} params.discriminant
  * @param {number} params.difficulty
  */
-function getReward({ capacity, discriminant, difficulty }) {
+export function getReward({ capacity, discriminant, difficulty }) {
   const probability = _getProbability(capacity, discriminant, difficulty);
   return probability * (1 - probability) * Math.pow(discriminant, 2);
 }
@@ -328,6 +321,6 @@ function _getGaussianValue({ gaussianMean, value }) {
  * @returns {number[]}
  */
 function _normalizeDistribution(data) {
-  const sum = lodash.sum(data);
+  const sum = data.reduce((s, d) => s + d, 0);
   return data.map((value) => value / sum);
 }

--- a/api/src/certification/evaluation/domain/services/verify-certificate-code-service.js
+++ b/api/src/certification/evaluation/domain/services/verify-certificate-code-service.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { config } from '../../../../shared/config.js';
 import { CertificateVerificationCodeGenerationTooManyTrials } from '../../../../shared/domain/errors.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
@@ -11,11 +9,12 @@ const NB_CHAR = 8;
 const NB_OF_TRIALS = 1000;
 
 function _generateCode() {
-  return 'P-' + _.times(NB_CHAR, _randomCharacter).join('');
-}
-
-function _randomCharacter() {
-  return _.sample(availableCharacters);
+  const chars = Array.from(availableCharacters);
+  for (let i = NB_CHAR; i >= 0; i--) {
+    const j = Math.floor(Math.random() * (chars.length - 1));
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+  return 'P-' + chars.slice(0, NB_CHAR).join('');
 }
 
 const generateCertificateVerificationCode = async function ({

--- a/api/src/certification/results/domain/usecases/get-certificates-for-session.js
+++ b/api/src/certification/results/domain/usecases/get-certificates-for-session.js
@@ -1,10 +1,7 @@
-import compact from 'lodash/compact.js';
-import isEmpty from 'lodash/isEmpty.js';
-
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 
-const getCertificatesForSession = async function ({
+export async function getCertificatesForSession({
   sessionId,
   certificateRepository,
   sharedCertificationCourseRepository,
@@ -17,7 +14,7 @@ const getCertificatesForSession = async function ({
     throw new NotFoundError();
   }
 
-  const certificates = compact(
+  const certificates = (
     await PromiseUtils.mapSeries(certificationCourses, async (certificationCourse) => {
       try {
         return await certificateRepository.getCertificate({
@@ -28,14 +25,14 @@ const getCertificatesForSession = async function ({
           throw error;
         }
       }
-    }),
-  );
+    })
+  ).filter(Boolean);
 
   if (isEmpty(certificates)) {
     throw new NotFoundError('No certificats found');
   }
 
   return certificates;
-};
+}
 
-export { getCertificatesForSession };
+const isEmpty = (obj) => [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;

--- a/api/src/certification/results/domain/usecases/get-certificates-for-session.js
+++ b/api/src/certification/results/domain/usecases/get-certificates-for-session.js
@@ -1,4 +1,5 @@
 import { NotFoundError } from '../../../../shared/domain/errors.js';
+import isEmpty from '../../../../shared/infrastructure/utils/is-empty.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 
 export async function getCertificatesForSession({
@@ -34,5 +35,3 @@ export async function getCertificatesForSession({
 
   return certificates;
 }
-
-const isEmpty = (obj) => [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
@@ -13,7 +11,7 @@ import { Certificate } from '../../domain/models/v3/Certificate.js';
 import { CertifiedBadge } from '../../domain/read-models/CertifiedBadge.js';
 import * as competenceTreeRepository from './competence-tree-repository.js';
 
-const findByDivisionForScoIsManagingStudentsOrganization = async function ({ organizationId, division, locale }) {
+export async function findByDivisionForScoIsManagingStudentsOrganization({ organizationId, division, locale }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationCourseDTOs = await _selectCertificationCourseDTOs(knexConn)
     .select({ organizationLearnerId: 'view-active-organization-learners.id' })
@@ -43,17 +41,21 @@ const findByDivisionForScoIsManagingStudentsOrganization = async function ({ org
 
   const mostRecentCertificationsPerOrganizationLearner =
     _filterMostRecentCertificationCoursePerOrganizationLearner(certificationCourseDTOs);
-  return Promise.all(
-    _(mostRecentCertificationsPerOrganizationLearner)
-      .orderBy(['lastName', 'firstName'], ['asc', 'asc'])
+
+  return await Promise.all(
+    mostRecentCertificationsPerOrganizationLearner
+      .sort((a, b) => {
+        const akey = a.lastName + a.firstName;
+        const bkey = b.lastName + b.firstName;
+        return akey > bkey ? 1 : bkey > akey ? -1 : 0;
+      })
       .map((certificationCourseDTO) => {
         return _toDomainForCertificationAttestation({ certificationCourseDTO, competenceTree, certifiedBadges: [] });
-      })
-      .value(),
+      }),
   );
-};
+}
 
-const getCertificate = async function ({ certificationCourseId, locale }) {
+export async function getCertificate({ certificationCourseId, locale }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationCourseDTO = await _selectCertificationCourseDTOs(knexConn)
     .where('certification-courses.id', '=', certificationCourseId)
@@ -68,9 +70,9 @@ const getCertificate = async function ({ certificationCourseId, locale }) {
   const certifiedBadges = await _getCertifiedBadges(knexConn, certificationCourseDTO.id);
 
   return _toDomainForCertificationAttestation({ certificationCourseDTO, competenceTree, certifiedBadges });
-};
+}
 
-const getPrivateCertificate = async function (id, { locale } = {}) {
+export async function getPrivateCertificate(id, { locale } = {}) {
   const knexConn = DomainTransaction.getConnection();
   const certificationCourseDTO = await _selectPrivateCertificates(knexConn)
     .where('certification-courses.id', '=', id)
@@ -92,9 +94,9 @@ const getPrivateCertificate = async function (id, { locale } = {}) {
     competenceTree,
     certifiedBadges,
   });
-};
+}
 
-const getShareableCertificate = async function ({ certificationCourseId, locale }) {
+export async function getShareableCertificate({ certificationCourseId, locale }) {
   const knexConn = DomainTransaction.getConnection();
   const shareableCertificateDTO = await _selectShareableCertificates(knexConn)
     .groupBy('certification-courses.id', 'sessions.id', 'assessment-results.id')
@@ -110,14 +112,7 @@ const getShareableCertificate = async function ({ certificationCourseId, locale 
   const certifiedBadges = await _getCertifiedBadges(knexConn, shareableCertificateDTO.id);
 
   return _toDomainForShareableCertificate({ shareableCertificateDTO, competenceTree, certifiedBadges });
-};
-
-export {
-  findByDivisionForScoIsManagingStudentsOrganization,
-  getCertificate,
-  getPrivateCertificate,
-  getShareableCertificate,
-};
+}
 
 function _selectCertificationCourseDTOs(knexConn) {
   return _getCertificateQuery(knexConn)

--- a/api/src/certification/results/infrastructure/serializers/certified-profile-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certified-profile-serializer.js
@@ -1,16 +1,15 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
-const { kebabCase } = lodash;
-
 const { Serializer } = jsonapiSerializer;
 
-import lodash from 'lodash';
-
 const typeForAttribute = (attribute) => {
-  return kebabCase(attribute);
+  return attribute
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
 };
 
-const serialize = function (certifiedProfile) {
+export function serialize(certifiedProfile) {
   return new Serializer('certified-profiles', {
     typeForAttribute,
     attributes: ['userId', 'certifiedSkills', 'certifiedTubes', 'certifiedCompetences', 'certifiedAreas'],
@@ -35,6 +34,4 @@ const serialize = function (certifiedProfile) {
       attributes: ['name', 'color'],
     },
   }).serialize(certifiedProfile);
-};
-
-export { serialize };
+}

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -3,8 +3,8 @@
  * @typedef {import('../../../../../src/certification/session-management/domain/usecases/index.js').MailService} MailService
  * @typedef {import('../../../../../src/certification/session-management/domain/usecases/index.js').SessionManagementRepository} SessionManagementRepository
  */
-import lodash from 'lodash';
-
+import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import {
   CertificationCourseNotPublishableError,
   SendingEmailToRefererError,
@@ -12,11 +12,6 @@ import {
 } from '../errors.js';
 import { SessionAlreadyPublishedError } from '../errors.js';
 import { mailService } from './mail-service.js';
-
-const { some, uniqBy } = lodash;
-
-import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
-import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 
 /**
  * @param {object} params
@@ -166,22 +161,22 @@ function _distinctCandidatesResultRecipientEmails(certificationCandidates, start
   const candidatesWithStartedCertificationCourse = certificationCandidates.filter((candidate) =>
     userIdsSet.has(candidate.userId),
   );
-
-  return uniqBy(candidatesWithStartedCertificationCourse, (candidate) => candidate.resultRecipientEmail?.toLowerCase())
-    .map((candidate) => candidate.resultRecipientEmail)
+  const recipientEmails = candidatesWithStartedCertificationCourse
+    .map((candidate) => candidate.resultRecipientEmail?.toLowerCase())
     .filter(Boolean);
+  return [...new Set(recipientEmails)];
 }
 
 function _someHaveSucceeded(emailingAttempts) {
-  return some(emailingAttempts, (emailAttempt) => emailAttempt.hasSucceeded());
+  return emailingAttempts?.some((emailAttempt) => emailAttempt.hasSucceeded());
 }
 
 function _noneHaveFailed(emailingAttempts) {
-  return !some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
+  return !emailingAttempts?.some((emailAttempt) => emailAttempt.hasFailed());
 }
 
 function _someHaveFailed(emailingAttempts) {
-  return some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
+  return emailingAttempts?.some((emailAttempt) => emailAttempt.hasFailed());
 }
 
 function _failedAttemptsEmail(emailingAttempts) {

--- a/api/src/certification/session-management/infrastructure/serializers/session-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-serializer.js
@@ -1,11 +1,12 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 import _ from 'lodash';
 
+import isEmpty from '../../../../shared/infrastructure/utils/is-empty.js';
 import { SessionManagement } from '../../domain/models/SessionManagement.js';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function ({ session, hasSomeCleaAcquired }) {
+export function serialize({ session, hasSomeCleaAcquired }) {
   const attributes = [
     'status',
     'examinerGlobalComment',
@@ -37,9 +38,9 @@ const serialize = function ({ session, hasSomeCleaAcquired }) {
       },
     },
   }).serialize(session);
-};
+}
 
-const deserialize = function (json) {
+export function deserialize(json) {
   const attributes = json.data.attributes;
 
   const result = new SessionManagement({
@@ -52,11 +53,9 @@ const deserialize = function (json) {
     version: attributes['version'],
   });
 
-  if (_.isEmpty(_.trim(result.examinerGlobalComment))) {
+  if (isEmpty(_.trim(result.examinerGlobalComment))) {
     result.examinerGlobalComment = SessionManagement.NO_EXAMINER_GLOBAL_COMMENT;
   }
 
   return result;
-};
-
-export { deserialize, serialize };
+}

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -9,6 +9,7 @@ import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import isEmpty from '../../../../shared/infrastructure/utils/is-empty.js';
 import { ABORT_REASONS } from '../constants/abort-reasons.js';
 import { AlgorithmEngineVersion } from './AlgorithmEngineVersion.js';
 
@@ -193,7 +194,7 @@ export class CertificationCourse {
 
   correctFirstName(modifiedFirstName) {
     const sanitizedString = _sanitizedString(modifiedFirstName);
-    if (_isEmpty(sanitizedString)) {
+    if (isEmpty(sanitizedString)) {
       throw new EntityValidationError({
         invalidAttributes: [{ attribute: 'firstName', message: "Candidate's first name must not be blank or empty" }],
       });
@@ -203,7 +204,7 @@ export class CertificationCourse {
 
   correctLastName(modifiedLastName) {
     const sanitizedString = _sanitizedString(modifiedLastName);
-    if (_isEmpty(sanitizedString)) {
+    if (isEmpty(sanitizedString)) {
       throw new EntityValidationError({
         invalidAttributes: [{ attribute: 'lastName', message: "Candidate's last name must not be blank or empty" }],
       });
@@ -213,14 +214,14 @@ export class CertificationCourse {
 
   correctBirthplace(modifiedBirthplace) {
     const sanitizedString = _sanitizedString(modifiedBirthplace);
-    if (!_isEmpty(sanitizedString?.trim())) {
+    if (!isEmpty(sanitizedString?.trim())) {
       this._birthplace = sanitizedString;
     }
   }
 
   correctSex(modifiedSex) {
     const sanitizedString = _sanitizedString(modifiedSex);
-    if (!_isEmpty(sanitizedString) && !['M', 'F'].includes(sanitizedString)) {
+    if (!isEmpty(sanitizedString) && !['M', 'F'].includes(sanitizedString)) {
       throw new EntityValidationError({
         invalidAttributes: [{ attribute: 'sex', message: "Candidate's sex must be M or F" }],
       });
@@ -365,8 +366,4 @@ function _sanitizedString(string) {
   const withUnifiedWithSpaces = trimmedString?.replace(multipleWhiteSpacesInARow, ' ');
 
   return withUnifiedWithSpaces;
-}
-
-function _isEmpty(obj) {
-  return [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;
 }

--- a/api/src/certification/shared/domain/services/certification-cpf-service.js
+++ b/api/src/certification/shared/domain/services/certification-cpf-service.js
@@ -1,14 +1,13 @@
+import isEmpty from '../../../../shared/infrastructure/utils/is-empty.js';
 import { normalizeAndSortChars } from '../../../../shared/infrastructure/utils/string-utils.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../constants/certification-candidates-errors.js';
 
-const isEmpty = (obj) => [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;
-
-const CpfValidationStatus = {
+export const CpfValidationStatus = {
   FAILURE: 'FAILURE',
   SUCCESS: 'SUCCESS',
 };
 
-class CpfBirthInformationValidation {
+export class CpfBirthInformationValidation {
   constructor({ birthCountry, birthINSEECode, birthPostalCode, birthCity, errors = [] } = { errors: [] }) {
     this.birthCountry = birthCountry;
     this.birthINSEECode = birthINSEECode;
@@ -142,7 +141,7 @@ async function _getBirthInformationByPostalCode({
   }
 }
 
-async function getBirthInformation({
+export async function getBirthInformation({
   birthCountry,
   birthCity,
   birthPostalCode,
@@ -247,5 +246,3 @@ function _getActualCity(cities) {
   const actualCity = cities.find((city) => city.isActualName);
   return actualCity.name;
 }
-
-export { CpfBirthInformationValidation, CpfValidationStatus, getBirthInformation };

--- a/api/src/shared/infrastructure/utils/chunk.js
+++ b/api/src/shared/infrastructure/utils/chunk.js
@@ -1,0 +1,7 @@
+export default function chunk(items, size) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}

--- a/api/src/shared/infrastructure/utils/is-empty.js
+++ b/api/src/shared/infrastructure/utils/is-empty.js
@@ -1,0 +1,3 @@
+export default function isEmpty(obj) {
+  return [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;
+}

--- a/api/tests/school/integration/domain/usecases/play-mission_test.js
+++ b/api/tests/school/integration/domain/usecases/play-mission_test.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
 import { Assessment } from '../../../../../src/school/domain/models/Assessment.js';
 import { usecases } from '../../../../../src/school/domain/usecases/index.js';
@@ -39,14 +37,10 @@ describe('Integration | UseCases | play-mission', function () {
         organizationLearnerId,
       });
 
-      const assessment = {
-        state: Assessment.states.STARTED,
-        type: Assessment.types.PIX1D_MISSION,
-        method: Assessment.methods.PIX1D,
-      };
       const record = await knex('assessments').where({ id: result.id }).first();
-
-      expect(_.pick(record, Object.keys(assessment))).to.deep.equal(assessment);
+      expect(record.state).to.deep.equal(Assessment.states.STARTED);
+      expect(record.type).to.deep.equal(Assessment.types.PIX1D_MISSION);
+      expect(record.method).to.deep.equal(Assessment.methods.PIX1D);
     });
 
     it('should save a new mission assessment', async function () {
@@ -74,13 +68,10 @@ describe('Integration | UseCases | play-mission', function () {
         organizationLearnerId,
       });
 
-      const expectedMissionAssesment = {
-        missionId,
-        organizationLearnerId,
-        assessmentId: result.id,
-      };
       const missionAssesment = await knex('mission-assessments').where({ assessmentId: result.id }).first();
-      expect(_.pick(missionAssesment, Object.keys(expectedMissionAssesment))).to.deep.equal(expectedMissionAssesment);
+      expect(missionAssesment.missionId).to.deep.equal(missionId);
+      expect(missionAssesment.organizationLearnerId).to.deep.equal(organizationLearnerId);
+      expect(missionAssesment.assessmentId).to.deep.equal(result.id);
     });
 
     it('should save an activity', async function () {
@@ -108,13 +99,10 @@ describe('Integration | UseCases | play-mission', function () {
         organizationLearnerId,
       });
 
-      const activity = {
-        level: Activity.levels.VALIDATION,
-        status: Activity.status.STARTED,
-        alternativeVersion: 0,
-      };
       const record = await knex('activities').where({ assessmentId: result.id }).first();
-      expect(_.pick(record, Object.keys(activity))).to.deep.equal(activity);
+      expect(record.level).to.deep.equal(Activity.levels.VALIDATION);
+      expect(record.status).to.deep.equal(Activity.status.STARTED);
+      expect(record.alternativeVersion).to.deep.equal(0);
     });
 
     it('should return the school assessment', async function () {
@@ -137,21 +125,31 @@ describe('Integration | UseCases | play-mission', function () {
       });
       await databaseBuilder.commit();
 
-      const assessment = await usecases.playMission({
+      const {
+        // eslint-disable-next-line no-unused-vars
+        createdAt: _createdAt,
+        // eslint-disable-next-line no-unused-vars
+        updatedAt: _updatedAt,
+        ...assessment
+      } = await usecases.playMission({
         missionId,
         organizationLearnerId,
       });
 
-      const expectedAssessment = domainBuilder.buildSchoolAssessment({
+      const {
+        // eslint-disable-next-line no-unused-vars
+        createdAt: __createdAt,
+        // eslint-disable-next-line no-unused-vars
+        updatedAt: __updatedAt,
+        ...expectedAssessment
+      } = domainBuilder.buildSchoolAssessment({
         missionId,
         organizationLearnerId,
         id: assessment.id,
         state: Assessment.states.STARTED,
       });
 
-      expect(_.omit(assessment, ['createdAt', 'updatedAt'])).to.deep.equal(
-        _.omit(expectedAssessment, ['createdAt', 'updatedAt']),
-      );
+      expect(assessment).to.deep.equal(expectedAssessment);
     });
 
     context('when the organizationLearnerId provided does not exist', function () {


### PR DESCRIPTION
## 💥 Problème

Nous utilisons des fonctions proposées par une bibliothèque externe (`lodash`) alors que nous pourrions faire ces opérations en natif. 

## 👩‍🚀 Proposition

Remplacer les fonctions `lodash` par des fonctions natives.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
