### PR TITLE
[TECH] Ajoute une API interne pour récupérer les participations d'une liste de learners (PIX-22585)

### DIFF
--- a/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
+++ b/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
@@ -31,6 +31,11 @@ export const findByUserId = async ({ userId }) => {
   return participations.map((participation) => new CampaignParticipation(participation));
 };
 
+export const findByOrganizationLearnerIds = async ({ organizationLearnerIds }) => {
+  const participations = await usecases.findCampaignParticipationsByOrganizationLearnerIds({ organizationLearnerIds });
+  return participations.map((participation) => new CampaignParticipation(participation));
+};
+
 export const deleteCampaignParticipations = async ({
   userId,
   campaignParticipationIds,

--- a/api/src/prescription/campaign-participation/application/api/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/application/api/read-models/CampaignParticipation.js
@@ -1,7 +1,23 @@
 export class CampaignParticipation {
-  constructor({ id, campaignId, targetProfileId }) {
+  constructor({
+    id,
+    campaignId,
+    targetProfileId,
+    organizationLearnerId,
+    status,
+    masteryRate,
+    validatedSkillsCount,
+    totalStagesCount,
+    validatedStagesCount,
+  }) {
     this.id = id;
     this.campaignId = campaignId;
     this.targetProfileId = targetProfileId;
+    this.organizationLearnerId = organizationLearnerId;
+    this.status = status;
+    this.masteryRate = masteryRate ?? null;
+    this.validatedSkillsCount = validatedSkillsCount ?? null;
+    this.totalStagesCount = totalStagesCount ?? null;
+    this.validatedStagesCount = validatedStagesCount ?? null;
   }
 }

--- a/api/src/prescription/campaign-participation/domain/read-models/OrganizationLearnerCampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/OrganizationLearnerCampaignParticipation.js
@@ -1,0 +1,35 @@
+import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
+
+export class OrganizationLearnerCampaignParticipation {
+  id = null;
+  campaignId = null;
+  targetProfileId = null;
+  organizationLearnerId = null;
+  status = CampaignParticipationStatuses.STARTED;
+  masteryRate = 0.0;
+  validatedSkillsCount = 0;
+  totalStagesCount = 0;
+  validatedStagesCount = 0;
+
+  constructor({
+    id,
+    campaignId,
+    targetProfileId,
+    organizationLearnerId,
+    status,
+    masteryRate,
+    validatedSkillsCount,
+    totalStagesCount,
+    validatedStagesCount,
+  }) {
+    this.id = id;
+    this.campaignId = campaignId;
+    this.targetProfileId = targetProfileId;
+    this.organizationLearnerId = organizationLearnerId;
+    this.status = status;
+    this.masteryRate = masteryRate;
+    this.validatedSkillsCount = validatedSkillsCount;
+    this.totalStagesCount = totalStagesCount;
+    this.validatedStagesCount = validatedStagesCount;
+  }
+}

--- a/api/src/prescription/campaign-participation/domain/usecases/find-campaign-participations-by-organization-learner-ids.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/find-campaign-participations-by-organization-learner-ids.js
@@ -1,0 +1,8 @@
+const findCampaignParticipationsByOrganizationLearnerIds = async function ({
+  organizationLearnerIds,
+  campaignParticipationRepository,
+}) {
+  return campaignParticipationRepository.findByOrganizationLearnerIds({ organizationLearnerIds });
+};
+
+export { findCampaignParticipationsByOrganizationLearnerIds };

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -89,6 +89,7 @@ const dependencies = {
 
 import { checkUserHasAccessToCampaignParticipation } from './check-user-has-access-to-campaign-participation.js';
 import { deleteCampaignParticipation } from './delete-campaign-participation.js';
+import { findCampaignParticipationsByOrganizationLearnerIds } from './find-campaign-participations-by-organization-learner-ids.js';
 import { findCampaignParticipationsByUserId } from './find-campaign-participations-by-user-id.js';
 import { findCampaignParticipationsForUserManagement } from './find-campaign-participations-for-user-management.js';
 import { findPaginatedParticipationsForCampaignManagement } from './find-paginated-participations-for-campaign-management.js';
@@ -115,6 +116,7 @@ import { updateParticipantExternalId } from './update-participant-external-id.js
 const usecasesWithoutInjectedDependencies = {
   checkUserHasAccessToCampaignParticipation,
   deleteCampaignParticipation,
+  findCampaignParticipationsByOrganizationLearnerIds,
   findCampaignParticipationsByUserId,
   findCampaignParticipationsForUserManagement,
   findPaginatedParticipationsForCampaignManagement,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -13,6 +13,7 @@ import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/do
 import { KnowledgeElementCollection } from '../../../shared/domain/models/KnowledgeElementCollection.js';
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../domain/read-models/AvailableCampaignParticipation.js';
+import { OrganizationLearnerCampaignParticipation } from '../../domain/read-models/OrganizationLearnerCampaignParticipation.js';
 
 const { STARTED, SHARED } = CampaignParticipationStatuses;
 
@@ -207,6 +208,60 @@ const findOneByCampaignIdAndUserId = async function ({ campaignId, userId }) {
   });
 };
 
+const findByOrganizationLearnerIds = async function ({ organizationLearnerIds }) {
+  const knexConn = DomainTransaction.getConnection();
+  const rows = await knexConn('campaign-participations')
+    .select({
+      id: 'campaign-participations.id',
+      campaignId: 'campaigns.id',
+      targetProfileId: 'campaigns.targetProfileId',
+      organizationLearnerId: 'campaign-participations.organizationLearnerId',
+      status: 'campaign-participations.status',
+      masteryRate: 'campaign-participations.masteryRate',
+      validatedSkillsCount: 'campaign-participations.validatedSkillsCount',
+    })
+    .select(
+      knexConn.raw('NULLIF(COUNT(DISTINCT stages.id), 0) as "totalStagesCount"'),
+      knexConn.raw(
+        'CASE WHEN COUNT(DISTINCT stages.id) = 0 THEN NULL ELSE COUNT(DISTINCT "stage-acquisitions".id) END as "validatedStagesCount"',
+      ),
+    )
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .leftJoin('stages', 'stages.targetProfileId', 'campaigns.targetProfileId')
+    .leftJoin('stage-acquisitions', function () {
+      this.on('stage-acquisitions.stageId', '=', 'stages.id').andOn(
+        'stage-acquisitions.campaignParticipationId',
+        '=',
+        'campaign-participations.id',
+      );
+    })
+    .whereIn('campaign-participations.organizationLearnerId', organizationLearnerIds)
+    .whereNull('campaign-participations.deletedAt')
+    .groupBy(
+      'campaign-participations.id',
+      'campaigns.id',
+      'campaigns.targetProfileId',
+      'campaign-participations.organizationLearnerId',
+      'campaign-participations.status',
+      'campaign-participations.masteryRate',
+      'campaign-participations.validatedSkillsCount',
+    );
+  return rows.map(
+    (row) =>
+      new OrganizationLearnerCampaignParticipation({
+        id: row.id,
+        campaignId: row.campaignId,
+        targetProfileId: row.targetProfileId,
+        organizationLearnerId: row.organizationLearnerId,
+        status: row.status,
+        masteryRate: row.masteryRate != null ? Number(row.masteryRate) : null,
+        validatedSkillsCount: row.validatedSkillsCount ?? null,
+        totalStagesCount: row.totalStagesCount != null ? Number(row.totalStagesCount) : null,
+        validatedStagesCount: row.validatedStagesCount != null ? Number(row.validatedStagesCount) : null,
+      }),
+  );
+};
+
 const getCampaignParticipationsCountByUserId = async function ({ userId }) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn('campaign-participations')
@@ -317,6 +372,7 @@ async function getSharedParticipationIds(campaignId) {
 }
 
 export {
+  findByOrganizationLearnerIds,
   findInfoByCampaignId,
   findOneByCampaignIdAndUserId,
   get,

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/find-campaign-participations-by-organization-learner-ids_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/find-campaign-participations-by-organization-learner-ids_test.js
@@ -1,0 +1,27 @@
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | UseCase | find-campaign-participations-by-organization-learner-ids', function () {
+  it('should return participations for the given organizationLearnerIds', async function () {
+    // given
+    const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+    const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({
+      organizationLearnerId,
+      campaignId,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const results = await usecases.findCampaignParticipationsByOrganizationLearnerIds({
+      organizationLearnerIds: [organizationLearnerId],
+    });
+
+    // then
+    expect(results).to.have.lengthOf(1);
+    expect(results[0].id).to.equal(participationId);
+    expect(results[0].organizationLearnerId).to.equal(organizationLearnerId);
+  });
+});

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import { CampaignParticipationInfo } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignParticipationInfo.js';
 import { CampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/read-models/AvailableCampaignParticipation.js';
+import { OrganizationLearnerCampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/read-models/OrganizationLearnerCampaignParticipation.js';
 import * as campaignParticipationRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import {
   CampaignParticipationStatuses,
@@ -471,6 +472,151 @@ describe('Integration | Repository | Campaign Participation', function () {
         // then
         expect(participations).to.have.lengthOf(0);
       });
+    });
+  });
+
+  describe('#findByOrganizationLearnerIds', function () {
+    it('should return empty array when organizationLearner has no participations', async function () {
+      // given
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      await databaseBuilder.commit();
+
+      // when
+      const results = await campaignParticipationRepository.findByOrganizationLearnerIds({
+        organizationLearnerIds: [organizationLearnerId],
+      });
+
+      // then
+      expect(results).to.deep.equal([]);
+    });
+
+    it('should return participations with all expected fields', async function () {
+      // given
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const otherTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const otherCampaign = databaseBuilder.factory.buildCampaign({ targetProfileId: otherTargetProfileId });
+      const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        campaignId,
+        status: SHARED,
+        masteryRate: '0.80',
+      });
+      const { id: participation2Id } = databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        campaignId: otherCampaign.id,
+        status: SHARED,
+        masteryRate: '0.80',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await campaignParticipationRepository.findByOrganizationLearnerIds({
+        organizationLearnerIds: [organizationLearnerId],
+      });
+
+      // then
+      expect(results).to.have.lengthOf(2);
+      expect(results[0]).to.deep.equal({
+        id: participationId,
+        campaignId,
+        targetProfileId,
+        organizationLearnerId,
+        status: SHARED,
+        masteryRate: 0.8,
+        validatedSkillsCount: null,
+        totalStagesCount: null,
+        validatedStagesCount: null,
+      });
+      expect(results[1]).to.deep.equal({
+        id: participation2Id,
+        campaignId: otherCampaign.id,
+        targetProfileId: otherTargetProfileId,
+        organizationLearnerId,
+        status: SHARED,
+        masteryRate: 0.8,
+        validatedSkillsCount: null,
+        totalStagesCount: null,
+        validatedStagesCount: null,
+      });
+    });
+
+    it('should return participation for the exact learners in list', async function () {
+      const { id: participation1Id, organizationLearnerId: organizationLearner1Id } =
+        databaseBuilder.factory.buildCampaignParticipation();
+      const { id: participation2Id, organizationLearnerId: organizationLearner2Id } =
+        databaseBuilder.factory.buildCampaignParticipation();
+      databaseBuilder.factory.buildCampaignParticipation();
+      await databaseBuilder.commit();
+
+      // when
+      const results = await campaignParticipationRepository.findByOrganizationLearnerIds({
+        organizationLearnerIds: [organizationLearner1Id, organizationLearner2Id],
+      });
+
+      // then
+      expect(results[0]).to.be.instanceOf(OrganizationLearnerCampaignParticipation);
+      expect(results[1]).to.be.instanceOf(OrganizationLearnerCampaignParticipation);
+      expect(results[0].id).to.equal(participation1Id);
+      expect(results[1].id).to.equal(participation2Id);
+      expect(results).to.have.lengthOf(2);
+    });
+
+    it('should return null for totalStagesCount and validatedStagesCount when no stages configured', async function () {
+      // given
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign();
+      databaseBuilder.factory.buildCampaignParticipation({ organizationLearnerId, campaignId });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await campaignParticipationRepository.findByOrganizationLearnerIds({
+        organizationLearnerIds: [organizationLearnerId],
+      });
+
+      // then
+      expect(results[0].totalStagesCount).to.be.null;
+      expect(results[0].validatedStagesCount).to.be.null;
+    });
+
+    it('should return stage counts when stages are configured', async function () {
+      // given
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        campaignId,
+      });
+      databaseBuilder.factory.buildStage({ targetProfileId });
+      const stage = databaseBuilder.factory.buildStage({ targetProfileId });
+      databaseBuilder.factory.buildStageAcquisition({ stageId: stage.id, campaignParticipationId: participationId });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await campaignParticipationRepository.findByOrganizationLearnerIds({
+        organizationLearnerIds: [organizationLearnerId],
+      });
+
+      // then
+      expect(results[0].totalStagesCount).to.equal(2);
+      expect(results[0].validatedStagesCount).to.equal(1);
+    });
+
+    it('should not return deleted participations', async function () {
+      // given
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      databaseBuilder.factory.buildCampaignParticipation({ organizationLearnerId, deletedAt: new Date() });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await campaignParticipationRepository.findByOrganizationLearnerIds({
+        organizationLearnerIds: [organizationLearnerId],
+      });
+
+      // then
+      expect(results).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
## 💥 Problème

Aujourd'hui, on utilise une grosse API interne pour récupéré toutes les données néccessaires au fonctionnement du système de quêtes même quand elles sont pas néccessaires.

## 👩‍🚀 Proposition

On va se diriger vers une système d'introspection qui va chercher uniquement les données néccessaires à la quête en cours de traitement. La première étape est de découpé en plus petites API internes.

Cette PR introduit une API interne pour récupérer les participations d'une liste de learners.



## 👁️ Remarques

⚠️ Dépendant de https://github.com/1024pix/pix/pull/16107 ⚠️

## ♻️ Pour tester

LA CI au vert 🍏
