### PR TITLE
[TECH] Ajoute une API interne pour récupérer les informations des learners à partir d'une liste d'ids (PIX-22586)

### DIFF
--- a/api/src/prescription/organization-learner/application/api/organization-learners-api.js
+++ b/api/src/prescription/organization-learner/application/api/organization-learners-api.js
@@ -1,4 +1,8 @@
+import { tagRepository } from '../../../../organizational-entities/infrastructure/repositories/tag.repository.js';
+import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
+import { findOrganizationLearnersWithOrganizationByIds } from '../../domain/usecases/find-organization-learners-with-organization-by-ids.js';
 import { usecases } from '../../domain/usecases/index.js';
+import * as libOrganizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import { OrganizationLearner } from './models/OrganizationLearner.js';
 import { OrganizationLearnerWithOrganization } from './read-models/OrganizationLearnerWithOrganization.js';
 
@@ -144,5 +148,16 @@ export const findByUserId = async (userId) => {
 
 export const findWithOrganizationByUserId = async ({ userId }) => {
   const learners = await usecases.findOrganizationLearnersWithOrganizationByUserId({ userId });
+  return learners.map((learner) => new OrganizationLearnerWithOrganization(learner));
+};
+
+export const findWithOrganizationByIds = async ({ organizationLearnerIds, organizationId }) => {
+  const learners = await findOrganizationLearnersWithOrganizationByIds({
+    organizationLearnerIds,
+    organizationId,
+    libOrganizationLearnerRepository,
+    organizationRepository,
+    tagRepository,
+  });
   return learners.map((learner) => new OrganizationLearnerWithOrganization(learner));
 };

--- a/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-organization-by-ids.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-organization-by-ids.js
@@ -1,0 +1,26 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+const findOrganizationLearnersWithOrganizationByIds = withTransaction(async function ({
+  organizationLearnerIds,
+  organizationId,
+  organizationRepository,
+  libOrganizationLearnerRepository,
+  tagRepository,
+}) {
+  const organizationLearners = await libOrganizationLearnerRepository.findByIds({ ids: organizationLearnerIds });
+  const organization = await organizationRepository.get(organizationId);
+  const tags = await tagRepository.findByIds(organization.tags.map((tag) => tag.id));
+  const tagNames = tags.map((tag) => tag.name);
+
+  return organizationLearners.map((organizationLearner) => ({
+    organizationLearner,
+    organization: {
+      id: organization.id,
+      isManagingStudents: organization.isManagingStudents,
+      tags: tagNames,
+      type: organization.type,
+    },
+  }));
+});
+
+export { findOrganizationLearnersWithOrganizationByIds };

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-organization-by-ids_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-organization-by-ids_test.js
@@ -1,0 +1,34 @@
+import { tagRepository } from '../../../../../../src/organizational-entities/infrastructure/repositories/tag.repository.js';
+import { findOrganizationLearnersWithOrganizationByIds } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-organization-by-ids.js';
+import * as organizationLearnerRepository from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
+import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | UseCases | find-organization-learners-with-organization-by-ids', function () {
+  it('should return organization learners with their organization and tags', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization({ isManagingStudents: true, type: 'SCO' });
+    const tag = databaseBuilder.factory.buildTag({ name: 'tagName' });
+    databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag.id });
+    const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id });
+    await databaseBuilder.commit();
+
+    // when
+    const result = await findOrganizationLearnersWithOrganizationByIds({
+      organizationLearnerIds: [organizationLearner.id],
+      organizationId: organization.id,
+      organizationRepository,
+      libOrganizationLearnerRepository: organizationLearnerRepository,
+      tagRepository,
+    });
+
+    // then
+    expect(result).to.have.lengthOf(1);
+    expect(result[0].organizationLearner.id).to.equal(organizationLearner.id);
+    expect(result[0].organization.id).to.equal(organization.id);
+    expect(result[0].organization.isManagingStudents).to.equal(true);
+    expect(result[0].organization.type).to.equal('SCO');
+    expect(result[0].organization.tags).to.deep.equal(['tagName']);
+  });
+});


### PR DESCRIPTION
## 💥 Problème

Aujourd'hui, on utilise une grosse API interne pour récupéré toutes les données néccessaires au fonctionnement du système de quêtes même quand elles sont pas néccessaires.

## 👩‍🚀 Proposition

On va se diriger vers une système d'introspection qui va chercher uniquement les données néccessaires à la quête en cours de traitement. La première étape est de découpé en plus petites API internes.

Cette PR introduit une API interne pour récupérer les learners d'une liste de learner ids.



## 👁️ Remarques

⚠️ Dépendant de https://github.com/1024pix/pix/pull/16108 ⚠️ 

## ♻️ Pour tester

LA CI au vert 🍏
