### PR TITLE
[TECH] Corriger le test e2e flaky de gestion des élèves SCO (PIX-22391)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
@@ -399,7 +399,7 @@ test.describe('SCO import does not auto-reconcile a learner when the user alread
       );
     });
 
-    test.skip("Remove user reconciliation when the user is already in the target organization with a different INE,  (is it ok, i don't know, but it's here since the beginning of the time)", async ({
+    test("Remove user reconciliation when the user is already in the target organization with a different INE,  (is it ok, i don't know, but it's here since the beginning of the time)", async ({
       page,
     }) => {
       test.slow();
@@ -435,6 +435,7 @@ test.describe('SCO import does not auto-reconcile a learner when the user alread
         }
         await orgaPage.waitForTheImportToComplete(page);
         await page.getByRole('link', { name: 'Se déconnecter' }).click();
+        await page.getByRole('button', { name: 'Je me connecte' }).waitFor();
       });
 
       await test.step('A user creates an account and reconciles with Jean Michel from Org A (INE 12)', async () => {
@@ -476,6 +477,7 @@ test.describe('SCO import does not auto-reconcile a learner when the user alread
         }
         await orgaPage.waitForTheImportToComplete(page);
         await page.getByRole('link', { name: 'Se déconnecter' }).click();
+        await page.getByRole('button', { name: 'Je me connecte' }).waitFor();
       });
 
       await test.step('Jean Michel manually reconciles with Org B (INE 13) via the campaign', async () => {


### PR DESCRIPTION
## 🌱 Problème

Le test e2e `sco-students-management.test.ts:402` était flaky de manière intermittente.

Le step 1 du test se terminait par un clic sur « Se déconnecter », qui déclenche une redirection. Le step 2 enchaînait immédiatement un `page.goto()` vers pix-app avant que cette redirection soit terminée: les deux navigations se percutaient et provoquaient une erreur `net::ERR_ABORTED`, laissant la page blanche.

```
 Error: page.goto: net::ERR_ABORTED at http://localhost:4200/campagnes/YXFEAT977
    Call log:
      - navigating to "http://localhost:4200/campagnes/YXFEAT977", waiting until "load"
      439 |
      440 |       await test.step('A user creates an account and reconciles with Jean Michel from Org A (INE 12)', async...
   > 441 |         await page.goto(`${process.env.PIX_APP_URL}/campagnes/${campaignCodeA}`);
             |                  ^
      442 |         await page.getByRole('button', { name: 'Je commence' }).click();
      443 |         await reconciliationPage.reconcile('Jean', 'Michel', '01/01/1990', false);
      444 |         await expect(page.getByText('Mon identifiant *')).toBeVisible();
        at /root/pix/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts:441:20
        at /root/pix/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts:440:18
```

Illustration d'une page blanche:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/acb92f81-5bbe-4883-8b85-ef9e400850d0" />


## 🐣 Proposition

Attendre que la page de login soit complètement rendue (présence du bouton « Je me connecte ») avant de passer au step suivant, garantissant que la redirection post-logout est terminée.

## 🌷 Remarques

Le test équivalent (ligne 267) n'était pas affecté car son step 1 ne se terminait pas par une déconnexion.

## 🐝 Pour tester

Plus de flaky 🤞🏼 