### PR TITLE
[TECH] Mise à jour du package epreuve componente vers la version v4.5.0 

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@1024pix/epreuves-components": "^4.4.0",
+        "@1024pix/epreuves-components": "^4.5.0",
         "@1024pix/oppsy": "^1.0.2",
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.4.0.tgz",
-      "integrity": "sha512-g2XknuLTcnRWR9FIuh3ocgvZu4pXcgqPqcrpiLBTVdGpJH4AzwWYAz2ICMa7CmYj0dcHWRouS95Xw43iRMeghg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.5.0.tgz",
+      "integrity": "sha512-dT60RFp+t3LwqYsdjB5BjV0j12wGIswffcnCLTfuLoNjqQbtchjbSOt3TK9iyvNoDqCrML1M5bf7oAy5JhiPng==",
       "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -91,7 +91,7 @@
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/unit/infrastructure/repositories/module-repository_test.js'"
   },
   "dependencies": {
-    "@1024pix/epreuves-components": "^4.4.0",
+    "@1024pix/epreuves-components": "^4.5.0",
     "@1024pix/oppsy": "^1.0.2",
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -536,6 +536,36 @@
           ]
         },
         {
+          "id": "5d0ae4f9-5e8c-4d97-82d8-b0c23b2ee257",
+          "type": "discovery",
+          "title": "generate-mdp",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "fa07b3c0-bea0-467c-8a25-088b0f5e2e2a",
+                "type": "text",
+                "content": "<p>generate-mdp</p>",
+                "tag": " "
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "583a5b12-3cfd-4d91-8f58-c31ba65a311c",
+                "type": "custom",
+                "instruction": "",
+                "tagName": "generate-mdp",
+                "props": {
+                  "titleLevel": 2
+                },
+                "title": "",
+                "functionalInstruction": ""
+              }
+            }
+          ]
+        },
+        {
           "id": "a4a46051-7879-4b4d-964d-d84a992af59c",
           "type": "discovery",
           "title": "image-quiz",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^4.4.0",
+        "@1024pix/epreuves-components": "^4.5.0",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^60.10.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.4.0.tgz",
-      "integrity": "sha512-g2XknuLTcnRWR9FIuh3ocgvZu4pXcgqPqcrpiLBTVdGpJH4AzwWYAz2ICMa7CmYj0dcHWRouS95Xw43iRMeghg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.5.0.tgz",
+      "integrity": "sha512-dT60RFp+t3LwqYsdjB5BjV0j12wGIswffcnCLTfuLoNjqQbtchjbSOt3TK9iyvNoDqCrML1M5bf7oAy5JhiPng==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^4.4.0",
+    "@1024pix/epreuves-components": "^4.5.0",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^60.10.1",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^4.4.0",
+        "@1024pix/epreuves-components": "^4.5.0",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^60.10.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.4.0.tgz",
-      "integrity": "sha512-g2XknuLTcnRWR9FIuh3ocgvZu4pXcgqPqcrpiLBTVdGpJH4AzwWYAz2ICMa7CmYj0dcHWRouS95Xw43iRMeghg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.5.0.tgz",
+      "integrity": "sha512-dT60RFp+t3LwqYsdjB5BjV0j12wGIswffcnCLTfuLoNjqQbtchjbSOt3TK9iyvNoDqCrML1M5bf7oAy5JhiPng==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^4.4.0",
+    "@1024pix/epreuves-components": "^4.5.0",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^60.10.1",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 💥 Problème

Une nouvelle version du package epreuve componente est dispponible

## 👩‍🚀 Proposition

Mettre à jour du package epreuve componente vers la version v4.5.0 

## 👁️ Remarques
ras

## ♻️ Pour tester
Afficher la page de demo des poi et constater la presence de `generatemdp`
