### PR TITLE
[BUGFIX] Corriger l'erreur 500 lors de l'acceptation simultanée d'une invitation d'organisation (PIX-21467).

### DIFF
--- a/api/src/team/infrastructure/repositories/organization-invited-user.repository.js
+++ b/api/src/team/infrastructure/repositories/organization-invited-user.repository.js
@@ -48,15 +48,29 @@ const save = async function ({ organizationInvitedUser }) {
       })
       .where({ id: organizationInvitedUser.currentMembershipId });
   } else {
-    const [{ id: membershipId }] = await knexConn('memberships')
+    const [result] = await knexConn('memberships')
       .insert({
         organizationRole: organizationInvitedUser.currentRole,
         organizationId: organizationInvitedUser.invitation.organizationId,
         userId: organizationInvitedUser.userId,
       })
+      .onConflict()
+      .ignore()
       .returning('id');
 
-    organizationInvitedUser.currentMembershipId = membershipId;
+    if (result) {
+      organizationInvitedUser.currentMembershipId = result.id;
+    } else {
+      const existing = await knexConn('memberships')
+        .select('id')
+        .where({
+          userId: organizationInvitedUser.userId,
+          organizationId: organizationInvitedUser.invitation.organizationId,
+          disabledAt: null,
+        })
+        .first();
+      organizationInvitedUser.currentMembershipId = existing.id;
+    }
   }
 
   await knexConn('user-orga-settings')

--- a/api/tests/team/integration/infrastructure/repositories/organization-invited-user.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/organization-invited-user.repository.test.js
@@ -441,5 +441,41 @@ describe('Integration | Team | Infrastructure | Repository | OrganizationInvited
         expect(organizationInvitationUpdated.updatedAt).to.deep.equal(now);
       });
     });
+
+    describe(' when a concurrent insert already exists', function () {
+      it('does not throw and sets currentMembershipId', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization();
+        const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+          organizationId: organization.id,
+        });
+        const user = databaseBuilder.factory.buildUser();
+        const existingMembership = databaseBuilder.factory.buildMembership({
+          userId: user.id,
+          organizationId: organization.id,
+          organizationRole: 'MEMBER',
+        });
+        const organizationInvitedUser = new OrganizationInvitedUser({
+          userId: user.id,
+          invitation: organizationInvitation,
+          currentRole: 'MEMBER',
+          organizationHasMemberships: 0,
+          currentMembershipId: null,
+          status: OrganizationInvitation.StatusType.ACCEPTED,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await organizationInvitedUserRepository.save({ organizationInvitedUser });
+
+        // then
+        expect(organizationInvitedUser.currentMembershipId).to.equal(existingMembership.id);
+        const updatedInvitation = await knex('organization-invitations')
+          .where({ id: organizationInvitation.id })
+          .first();
+        expect(updatedInvitation.status).to.equal('accepted');
+      });
+    });
   });
 });


### PR DESCRIPTION
## 💥 Problème

Sur la route `POST /api/organization-invitations/{id}/response`, une erreur 500 pouvait survenir lors de l'acceptation d'une invitation d'organisation. Le bug n'est pas récurrent : il n'apparaît qu'en cas de double requête quasi-simultanée (double-clic, réseau instable, retry automatique).

Les deux requêtes passent toutes les deux la vérification "l'utilisateur est-il déjà membre ?" avant que l'une n'ait inséré le membership. La seconde tentative d'`INSERT` viole alors la contrainte d'unicité partielle `("userId", "organizationId") WHERE "disabledAt" IS NULL` → 500 non géré.

## 👩‍🚀 Proposition

Dans `organization-invited-user.repository.js`, la branche d'insertion du membership utilise désormais `.onConflict().ignore()`. En cas de conflit ignoré, un `SELECT` de fallback récupère l'id du membership existant (PostgreSQL ne retourne rien via `RETURNING` sur un `DO NOTHING`).

## 👁️ Remarques

Une PR avait déjà été ouverte en février 2026 ([#15084](https://github.com/1024pix/pix/pull/15084)) avec la même analyse, mais comportait deux lacunes : elle ne tenait pas compte du caractère partiel de l'index (ce qui aurait échoué en prod), et elle ne récupérait pas l'id du membership existant après le conflit — laissant `currentMembershipId` à `null` sur le modèle et faisant retourner `{ id: undefined }` au use case. Le `SELECT` de fallback adresse ce second point.


## ♻️ Pour tester

Ce bug ne se reproduit pas de façon déterministe en conditions normales. Deux approches :

**Option A — Vérification automatisée (recommandée)**

Lancer le test d'intégration dédié :

```bash
cd api && npm run test:api:path -- 'tests/team/integration/infrastructure/repositories/organization-invited-user.repository.test.js'
```

Le test `does not throw and sets currentMembershipId when a concurrent insert already exists` couvre le scénario : il préinsère un membership en base (simulant la première requête), puis appelle `save()` avec un utilisateur qui ne "sait" pas qu'il est déjà membre (simulant la seconde requête arrivant trop tard).

**Option B — Vérification manuelle**

1. Sur Pix Admin, envoyer une invitation à `member-orga@example.net` pour une organisation.
2. Récupérer dans MailPit le code d'invitation (`?code=` dans le lien du mail) et l'id de l'invitation dans l'URL.
3. Récupérer l'id de l'utilisateur `member-orga@example.net` en base.
4. Lancer deux requêtes simultanées :

```
curl -s -X POST http://localhost:3000/api/organization-invitations/{ID}/response \
  -H "Content-Type: application/vnd.api+json" \
  -d '{"data":{"id":"{ID}","type":"organization-invitation-responses","attributes":{"code":"{CODE}","user-id":{USER_ID}}}}' &

curl -s -X POST http://localhost:3000/api/organization-invitations/{ID}/response \
  -H "Content-Type: application/vnd.api+json" \
  -d '{"data":{"id":"{ID}","type":"organization-invitation-responses","attributes":{"code":"{CODE}","user-id":{USER_ID}}}}' &

wait
```

5. Constater qu'on n'a pas d'erreur 500
