### PR TITLE
[TECH] Ajout d'un event "CandidateEnrolledEvent" lorsqu'un candidat est inscrit en certification (PIX-22908)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -130,4 +130,11 @@ export default {
     devDefaultValues: { test: true, reviewApp: true },
     tags: ['team-combinix', 'pix-api', 'frontend'],
   },
+  isEventSourcingCertificationEnabled: {
+    type: 'boolean',
+    description: 'Enable event sourcing for certification related events',
+    defaultValue: false,
+    devDefaultValues: { test: true, reviewApp: true },
+    tags: ['team-certif', 'pix-api', 'backend'],
+  },
 };

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -39,7 +39,7 @@ export class Candidate {
     subscriptions = [],
     accessibilityAdjustmentNeeded,
     hasStartedTest = false,
-  } = {}) {
+  }) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -182,4 +182,29 @@ export class Candidate {
   isRegisteredToDoubleCertification() {
     return this.subscription === Frameworks.CLEA;
   }
+
+  toDTO() {
+    return {
+      id: this.id,
+      firstName: this.firstName,
+      lastName: this.lastName,
+      sex: this.sex,
+      birthPostalCode: this.birthPostalCode,
+      birthINSEECode: this.birthINSEECode,
+      birthCity: this.birthCity,
+      birthProvinceCode: this.birthProvinceCode,
+      birthCountry: this.birthCountry,
+      email: this.email,
+      resultRecipientEmail: this.resultRecipientEmail,
+      externalId: this.externalId,
+      birthdate: this.birthdate,
+      extraTimePercentage: this.extraTimePercentage,
+      billingMode: this.billingMode,
+      prepaymentCode: this.prepaymentCode,
+      subscription: this.subscription,
+      accessibilityAdjustmentNeeded: this.accessibilityAdjustmentNeeded,
+      sessionId: this.sessionId,
+      organizationLearnerId: this.organizationLearnerId,
+    };
+  }
 }

--- a/api/src/certification/enrolment/domain/models/SCOCertificationCandidate.js
+++ b/api/src/certification/enrolment/domain/models/SCOCertificationCandidate.js
@@ -3,7 +3,7 @@ import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 import { InvalidCertificationCandidate } from '../errors.js';
-import { Subscription } from '../models/Subscription.js';
+import { Subscription } from './Subscription.js';
 
 const scoCertificationCandidateValidationJoiSchema = Joi.object({
   firstName: Joi.string().required().empty(null),
@@ -50,6 +50,22 @@ class SCOCertificationCandidate {
     if (error) {
       throw InvalidCertificationCandidate.fromJoiErrorDetail(error.details[0]);
     }
+  }
+
+  toDTO() {
+    return {
+      id: this.id,
+      firstName: this.firstName,
+      lastName: this.lastName,
+      sex: this.sex,
+      birthINSEECode: this.birthINSEECode,
+      birthCity: this.birthCity,
+      birthCountry: this.birthCountry,
+      birthdate: this.birthdate,
+      subscription: this.subscription,
+      sessionId: this.sessionId,
+      organizationLearnerId: this.organizationLearnerId,
+    };
   }
 }
 

--- a/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
@@ -15,7 +15,6 @@ import {
 } from '../../../../shared/domain/errors.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import * as mailCheckImplementation from '../../../../shared/mail/infrastructure/services/mail-check.js';
-import { pushCandidateEnrolledEvent } from '../../../shared/application/api/event-api.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 
@@ -118,10 +117,7 @@ export async function addCandidateToSession({
     }
   }
 
-  const candidateId = await candidateRepository.insert(candidate);
-  await eventApi.pushCandidateEnrolledEvent({
-    ...candidate.toDTO(),
-    id: candidateId,
-  });
-  return candidateId;
+  const [savedCandidate] = await candidateRepository.save([candidate]);
+  await eventApi.pushCandidateEnrolledEvent(savedCandidate.toDTO());
+  return savedCandidate.id;
 }

--- a/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
@@ -5,6 +5,7 @@
  * @typedef {import ('./index.js').CertificationCpfCountryRepository} CertificationCpfCountryRepository
  * @typedef {import ('./index.js').CertificationCpfCityRepository} CertificationCpfCityRepository
  * @typedef {import ('./index.js').ComplementaryCertificationRepository} ComplementaryCertificationRepository
+ * @typedef {import ('./index.js').EventApi} EventApi
  */
 
 import {
@@ -14,6 +15,7 @@ import {
 } from '../../../../shared/domain/errors.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import * as mailCheckImplementation from '../../../../shared/mail/infrastructure/services/mail-check.js';
+import { pushCandidateEnrolledEvent } from '../../../shared/application/api/event-api.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 
@@ -25,6 +27,7 @@ import { ComplementaryCertificationKeys } from '../../../shared/domain/models/Co
  * @param {CertificationCpfCountryRepository} params.certificationCpfCountryRepository
  * @param {CertificationCpfCityRepository} params.certificationCpfCityRepository
  * @param {ComplementaryCertificationRepository} params.complementaryCertificationRepository
+ * @param {EventApi} params.eventApi
  */
 export async function addCandidateToSession({
   sessionId,
@@ -35,6 +38,7 @@ export async function addCandidateToSession({
   certificationCpfCountryRepository,
   certificationCpfCityRepository,
   complementaryCertificationRepository,
+  eventApi,
   mailCheck = mailCheckImplementation,
   normalizeStringFnc,
 }) {
@@ -114,5 +118,10 @@ export async function addCandidateToSession({
     }
   }
 
-  return candidateRepository.insert(candidate);
+  const candidateId = await candidateRepository.insert(candidate);
+  await eventApi.pushCandidateEnrolledEvent({
+    ...candidate.toDTO(),
+    id: candidateId,
+  });
+  return candidateId;
 }

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -19,6 +19,7 @@ export async function createSessions({
   candidateRepository,
   sessionRepository,
   temporarySessionsStorageForMassImportService,
+  eventApi,
 }) {
   const temporaryCachedSessions = await temporarySessionsStorageForMassImportService.getByKeyAndUserId({
     cachedValidatedSessionsKey,
@@ -49,6 +50,7 @@ export async function createSessions({
           candidates,
           sessionId,
           candidateRepository,
+          eventApi,
         });
       }
     }
@@ -69,9 +71,10 @@ async function _deleteExistingCandidatesInSession({ candidateRepository, session
   await candidateRepository.deleteBySessionId({ sessionId });
 }
 
-async function _saveCandidates({ candidates, sessionId, candidateRepository }) {
+async function _saveCandidates({ candidates, sessionId, candidateRepository, eventApi }) {
   const candidatesToSave = candidates.map((candidate) => {
     return new Candidate({ ...candidate, sessionId });
   });
-  await candidateRepository.save(candidatesToSave);
+  const savedCandidates = await candidateRepository.save(candidatesToSave);
+  await eventApi.pushMultipleCandidatesEnrolledEvent(savedCandidates.map((savedCandidate) => savedCandidate.toDTO()));
 }

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -13,7 +13,7 @@ import { SessionEnrolment } from '../models/SessionEnrolment.js';
  * @param {deps["sessionRepository"]} params.sessionRepository
  * @param {deps["temporarySessionsStorageForMassImportService"]} params.temporarySessionsStorageForMassImportService
  */
-const createSessions = async function ({
+export async function createSessions({
   userId,
   cachedValidatedSessionsKey,
   candidateRepository,
@@ -44,7 +44,7 @@ const createSessions = async function ({
         sessionId = id;
       }
 
-      if (_hasCandidates(candidates)) {
+      if (candidates.length > 0) {
         await _saveCandidates({
           candidates,
           sessionId,
@@ -58,12 +58,6 @@ const createSessions = async function ({
     cachedValidatedSessionsKey,
     userId,
   });
-};
-
-export { createSessions };
-
-function _hasCandidates(candidates) {
-  return candidates.length > 0;
 }
 
 async function _saveNewSessionReturningId({ sessionRepository, sessionDTO }) {
@@ -79,5 +73,5 @@ async function _saveCandidates({ candidates, sessionId, candidateRepository }) {
   const candidatesToSave = candidates.map((candidate) => {
     return new Candidate({ ...candidate, sessionId });
   });
-  await candidateRepository.save({ candidates: candidatesToSave });
+  await candidateRepository.save(candidatesToSave);
 }

--- a/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
@@ -32,6 +32,7 @@ const enrolStudentsToSession = async function ({
   certificationCpfCityRepository,
   certificationCpfCountryRepository,
   certificationCpfService,
+  eventApi,
 } = {}) {
   const session = await sessionRepository.get({ id: sessionId });
   const center = await centerRepository.getById({ id: session.certificationCenterId });
@@ -85,10 +86,13 @@ const enrolStudentsToSession = async function ({
     });
   });
 
-  await scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession({
+  const savedScoCandidates = await scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession({
     sessionId,
     scoCertificationCandidates,
   });
+  await eventApi.pushMultipleCandidatesEnrolledEvent(
+    savedScoCandidates.map((savedCandidate) => savedCandidate.toDTO()),
+  );
 };
 
 export { enrolStudentsToSession };

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -43,7 +43,7 @@ const importCertificationCandidatesFromCandidatesImportSheet = async function ({
 
   await DomainTransaction.execute(async () => {
     await candidateRepository.deleteBySessionId({ sessionId });
-    await candidateRepository.save({ candidates });
+    await candidateRepository.save(candidates);
   });
 };
 

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -11,7 +11,7 @@ import { CandidateAlreadyLinkedToUserError } from '../../../../shared/domain/err
  * @param {CandidateRepository} params.candidateRepository
  * @param {SessionRepository} params.sessionRepository
  */
-const importCertificationCandidatesFromCandidatesImportSheet = async function ({
+export async function importCertificationCandidatesFromCandidatesImportSheet({
   sessionId,
   odsBuffer,
   i18n,
@@ -22,6 +22,7 @@ const importCertificationCandidatesFromCandidatesImportSheet = async function ({
   sessionRepository,
   certificationCandidatesOdsService,
   certificationCpfService,
+  eventApi,
 }) {
   const candidatesInSession = await candidateRepository.findBySessionId({ sessionId });
   const session = await sessionRepository.get({ id: sessionId });
@@ -43,8 +44,7 @@ const importCertificationCandidatesFromCandidatesImportSheet = async function ({
 
   await DomainTransaction.execute(async () => {
     await candidateRepository.deleteBySessionId({ sessionId });
-    await candidateRepository.save(candidates);
+    const savedCandidates = await candidateRepository.save(candidates);
+    await eventApi.pushMultipleCandidatesEnrolledEvent(savedCandidates.map((savedCandidate) => savedCandidate.toDTO()));
   });
-};
-
-export { importCertificationCandidatesFromCandidatesImportSheet };
+}

--- a/api/src/certification/enrolment/domain/usecases/index.js
+++ b/api/src/certification/enrolment/domain/usecases/index.js
@@ -13,6 +13,7 @@ import * as sessionValidator from '../../../shared/domain/validators/session-val
 import * as certificationCandidateRepository from '../../../shared/infrastructure/repositories/certification-candidate-repository.js';
 import * as certificationCenterRepository from '../../../shared/infrastructure/repositories/certification-center-repository.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
+import * as candidateRepository from '../../infrastructure/repositories/candidate-repository.js';
 import { enrolmentRepositories } from '../../infrastructure/repositories/index.js';
 import * as certificationCandidatesOdsService from '../services/certification-candidates-ods-service.js';
 import * as eligibilityService from '../services/eligibility-service.js';
@@ -85,6 +86,7 @@ import * as temporarySessionsStorageForMassImportService from '../services/tempo
 const dependencies = {
   certificationBadgesService,
   ...enrolmentRepositories,
+  candidateRepository,
   sessionCodeService,
   sessionsImportValidationService,
   temporarySessionsStorageForMassImportService,

--- a/api/src/certification/enrolment/domain/usecases/index.js
+++ b/api/src/certification/enrolment/domain/usecases/index.js
@@ -6,6 +6,7 @@ import * as countryRepository from '../../../../shared/infrastructure/repositori
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import * as attendanceSheetPdfUtils from '../../../enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js';
+import * as eventApi from '../../../shared/application/api/event-api.js';
 import * as certificationBadgesService from '../../../shared/domain/services/certification-badges-service.js';
 import * as certificationCpfService from '../../../shared/domain/services/certification-cpf-service.js';
 import * as sessionValidator from '../../../shared/domain/validators/session-validator.js';
@@ -45,6 +46,7 @@ import * as temporarySessionsStorageForMassImportService from '../services/tempo
  * @typedef {import('../../../shared/infrastructure/repositories/certification-candidate-repository.js')} certificationCandidateRepository
  * @typedef {import('../../../../prescription/campaign/infrastructure/repositories/division-repository.js')} divisionRepository
  * @typedef {import('../../../shared/infrastructure/repositories/certification-center-repository.js')} CertificationCenterRepository
+ * @typedef {import('../../../shared/application/api/event-api.js')} EventApi
  **/
 
 /**
@@ -99,6 +101,7 @@ const dependencies = {
   certificationCourseRepository,
   certificationCenterRepository,
   countryRepository,
+  eventApi,
 };
 
 import { addCandidateToSession } from './add-candidate-to-session.js';

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -93,6 +93,7 @@ export async function update(candidate) {
  * @returns {Promise<Candidate[]>}
  */
 export async function save(candidates) {
+  const savedCandidates = [...candidates];
   const knexConn = DomainTransaction.getConnection();
   const candidatesData = candidates.map(adaptModelToDb);
 
@@ -103,17 +104,23 @@ export async function save(candidates) {
   const subscriptionsData = [];
   const complementaryCertificationsData = await knexConn('complementary-certifications').select('id', 'key');
   for (const candidate of candidates) {
-    candidate.id = insertedCandidatesData.find(
+    const savedCandidate = insertedCandidatesData.find(
       (insertedCandidateData) =>
         insertedCandidateData.firstName === candidate.firstName &&
         insertedCandidateData.lastName === candidate.lastName &&
         dayjs(insertedCandidateData.birthdate).format('YYYY-MM-DD') === dayjs(candidate.birthdate).format('YYYY-MM-DD'),
-    ).id;
-    subscriptionsData.push(..._buildLegacySubscriptions(candidate, complementaryCertificationsData));
+    );
+    savedCandidates.push(savedCandidate);
+    subscriptionsData.push(
+      ..._buildLegacySubscriptions(
+        { ...savedCandidate, subscription: candidate.subscription },
+        complementaryCertificationsData,
+      ),
+    );
   }
   await knexConn('certification-subscriptions').insert(subscriptionsData);
 
-  return candidates;
+  return savedCandidates;
 }
 
 /**

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -82,27 +82,17 @@ export async function update(candidate) {
   // TODO: supprimer lors du drop de certification-subscriptions
   const complementaryCertificationsData = await knexConn('complementary-certifications').select('id', 'key');
   await knexConn('certification-subscriptions').where({ certificationCandidateId: candidate.id }).del();
-  await _writeLegacySubscriptions(knexConn, candidate.id, candidate, complementaryCertificationsData);
-}
-
-/**
- * @deprecated use save instead
- * @function
- * @param {Candidate} candidate
- *
- * @returns {Promise<number>}
- */
-export async function insert(candidate) {
-  const insertedIds = await save({ candidates: [candidate] });
-  return insertedIds[0];
+  const subscriptionsData = [];
+  subscriptionsData.push(..._buildLegacySubscriptions(candidate, complementaryCertificationsData));
+  await knexConn('certification-subscriptions').insert(subscriptionsData);
 }
 
 /**
  * @function
  * @param {Candidate[]} candidates
- * @returns {Promise<Number[]>}
+ * @returns {Promise<Candidate[]>}
  */
-export async function save({ candidates }) {
+export async function save(candidates) {
   const knexConn = DomainTransaction.getConnection();
   const candidatesData = candidates.map(adaptModelToDb);
 
@@ -110,19 +100,20 @@ export async function save({ candidates }) {
     .insert(candidatesData)
     .returning(['id', 'firstName', 'lastName', 'birthdate']);
 
+  const subscriptionsData = [];
+  const complementaryCertificationsData = await knexConn('complementary-certifications').select('id', 'key');
   for (const candidate of candidates) {
-    const insertedCandidateId = insertedCandidatesData.find(
+    candidate.id = insertedCandidatesData.find(
       (insertedCandidateData) =>
         insertedCandidateData.firstName === candidate.firstName &&
         insertedCandidateData.lastName === candidate.lastName &&
         dayjs(insertedCandidateData.birthdate).format('YYYY-MM-DD') === dayjs(candidate.birthdate).format('YYYY-MM-DD'),
     ).id;
-    // TODO: supprimer lors du drop de certification-subscriptions
-    const complementaryCertificationsData = await knexConn('complementary-certifications').select('id', 'key');
-    await _writeLegacySubscriptions(knexConn, insertedCandidateId, candidate, complementaryCertificationsData);
+    subscriptionsData.push(..._buildLegacySubscriptions(candidate, complementaryCertificationsData));
   }
+  await knexConn('certification-subscriptions').insert(subscriptionsData);
 
-  return insertedCandidatesData.map(({ id }) => id);
+  return candidates;
 }
 
 /**
@@ -296,19 +287,19 @@ function toDomain(candidateData) {
   });
 }
 
-async function _writeLegacySubscriptions(knexConn, candidateId, candidate, complementaryCertificationsData) {
+function _buildLegacySubscriptions(candidate, complementaryCertificationsData) {
   const subscription = candidate.subscription;
   const rows = [];
   if (!subscription || subscription === Frameworks.CORE) {
     rows.push({
-      certificationCandidateId: candidateId,
+      certificationCandidateId: candidate.id,
       type: SUBSCRIPTION_TYPES.CORE,
       complementaryCertificationId: null,
     });
   } else {
     if (subscription === Frameworks.CLEA) {
       rows.push({
-        certificationCandidateId: candidateId,
+        certificationCandidateId: candidate.id,
         type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
@@ -316,10 +307,10 @@ async function _writeLegacySubscriptions(knexConn, candidateId, candidate, compl
     const complementaryCertificationId =
       complementaryCertificationsData.find((c) => c.key === subscription)?.id ?? null;
     rows.push({
-      certificationCandidateId: candidateId,
+      certificationCandidateId: candidate.id,
       type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
       complementaryCertificationId,
     });
   }
-  await knexConn('certification-subscriptions').insert(rows);
+  return rows;
 }

--- a/api/src/certification/enrolment/infrastructure/repositories/index.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/index.js
@@ -5,7 +5,6 @@ import * as certificationCandidateRepository from '../../../shared/infrastructur
 import * as certificationCenterRepository from '../../../shared/infrastructure/repositories/certification-center-repository.js';
 import * as targetProfileHistoryRepository from '../../../shared/infrastructure/repositories/target-profile-history-repository.js';
 import * as userRepository from '../../../shared/infrastructure/repositories/user-repository.js';
-import * as candidateRepository from './candidate-repository.js';
 import * as centerRepository from './center-repository.js';
 import * as certificationCpfCityRepository from './certification-cpf-city-repository.js';
 import * as certificationCpfCountryRepository from './certification-cpf-country-repository.js';
@@ -20,7 +19,6 @@ import * as sessionRepository from './session-repository.js';
 /**
  * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
  *
- * @typedef {candidateRepository} CandidateRepository
  * @typedef {centerRepository} CenterRepository
  * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {sessionRepository} SessionRepository
@@ -39,7 +37,6 @@ import * as sessionRepository from './session-repository.js';
  * @typedef {complementaryCertificationBadgeWithOffsetVersionRepository} ComplementaryCertificationBadgeWithOffsetVersionRepository
  */
 const repositoriesWithoutInjectedDependencies = {
-  candidateRepository,
   centerRepository,
   certificationCandidateRepository,
   certificationCenterRepository,

--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -3,6 +3,8 @@
  * @typedef {import ('../../domain/models/SCOCertificationCandidate.js').SCOCertificationCandidate} SCOCertificationCandidate
  */
 
+import dayjs from 'dayjs';
+
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 
@@ -10,16 +12,16 @@ import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
  * @function
  * @param {object} params
  * @param {number} params.sessionId
- * @param {Array<SCOCertificationCandidate>} params.scoCertificationCandidates
- * @returns {Promise<void>}
+ * @param {SCOCertificationCandidate[]} params.scoCertificationCandidates
+ * @returns {Promise<SCOCertificationCandidate[]>} - returns only the actually enrolled ones, not the ones already enrolled
  */
-const addNonEnrolledCandidatesToSession = async function ({ sessionId, scoCertificationCandidates }) {
+export async function addNonEnrolledCandidatesToSession({ sessionId, scoCertificationCandidates }) {
   const knexConn = DomainTransaction.getConnection();
 
   const organizationLearnerIds = scoCertificationCandidates.map((candidate) => candidate.organizationLearnerId);
 
   const alreadyEnrolledCandidates = await knexConn
-    .select(['organizationLearnerId'])
+    .select(['id', 'organizationLearnerId'])
     .from('certification-candidates')
     .whereIn('organizationLearnerId', organizationLearnerIds)
     .where({ sessionId });
@@ -29,26 +31,47 @@ const addNonEnrolledCandidatesToSession = async function ({ sessionId, scoCertif
   );
 
   const scoCandidateToDTO = _scoCandidateToDTOForSession(sessionId);
-  const candidateDTOs = scoCertificationCandidates
-    .filter((candidate) => !alreadyEnrolledCandidateOrganizationLearnerIds.has(candidate.organizationLearnerId))
-    .map(scoCandidateToDTO);
+  const scoCertificationCandidatesToEnroll = scoCertificationCandidates.filter((candidate) => {
+    const alreadyEnrolled = alreadyEnrolledCandidateOrganizationLearnerIds.has(candidate.organizationLearnerId);
+    if (alreadyEnrolled) {
+      candidate.id = alreadyEnrolledCandidates.find(
+        (alreadyEnrolledCandidate) =>
+          alreadyEnrolledCandidate.organizationLearnerId === candidate.organizationLearnerId,
+      ).id;
+      return false;
+    }
+    return true;
+  });
+  const candidateDTOs = scoCertificationCandidatesToEnroll.map(scoCandidateToDTO);
 
   if (candidateDTOs.length === 0) return;
 
   // We voluntarily keep the transaction contained in the repository as the usecase initiate a lengthy treatment
   await DomainTransaction.execute(async () => {
     const trxConn = DomainTransaction.getConnection();
-    const insertedCandidateDTOs = await trxConn('certification-candidates').insert(candidateDTOs).returning(['id']);
+    const insertedCandidateDTOs = await trxConn('certification-candidates')
+      .insert(candidateDTOs)
+      .returning(['id', 'firstName', 'lastName', 'birthdate']);
 
-    const subscriptionDTOs = insertedCandidateDTOs.map((insertedCandidateDTO) => ({
-      certificationCandidateId: insertedCandidateDTO.id,
-      type: SUBSCRIPTION_TYPES.CORE,
-    }));
-    await trxConn('certification-subscriptions').insert(subscriptionDTOs);
+    const subscriptionsData = [];
+    for (const scoCertificationCandidate of scoCertificationCandidatesToEnroll) {
+      scoCertificationCandidate.id = insertedCandidateDTOs.find(
+        (insertedCandidateData) =>
+          insertedCandidateData.firstName === scoCertificationCandidate.firstName &&
+          insertedCandidateData.lastName === scoCertificationCandidate.lastName &&
+          dayjs(insertedCandidateData.birthdate).format('YYYY-MM-DD') ===
+            dayjs(scoCertificationCandidate.birthdate).format('YYYY-MM-DD'),
+      ).id;
+
+      subscriptionsData.push({
+        certificationCandidateId: scoCertificationCandidate.id,
+        type: SUBSCRIPTION_TYPES.CORE,
+      });
+    }
+    await trxConn('certification-subscriptions').insert(subscriptionsData);
   });
-};
-
-export { addNonEnrolledCandidatesToSession };
+  return scoCertificationCandidatesToEnroll;
+}
 
 /**
  * @typedef {object} SCOCertificationCandidateDTO

--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -3,8 +3,6 @@
  * @typedef {import ('../../domain/models/SCOCertificationCandidate.js').SCOCertificationCandidate} SCOCertificationCandidate
  */
 
-import dayjs from 'dayjs';
-
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 
@@ -59,8 +57,7 @@ export async function addNonEnrolledCandidatesToSession({ sessionId, scoCertific
         (insertedCandidateData) =>
           insertedCandidateData.firstName === scoCertificationCandidate.firstName &&
           insertedCandidateData.lastName === scoCertificationCandidate.lastName &&
-          dayjs(insertedCandidateData.birthdate).format('YYYY-MM-DD') ===
-            dayjs(scoCertificationCandidate.birthdate).format('YYYY-MM-DD'),
+          insertedCandidateData.birthdate === scoCertificationCandidate.birthdate,
       ).id;
 
       subscriptionsData.push({

--- a/api/src/certification/shared/application/api/event-api.js
+++ b/api/src/certification/shared/application/api/event-api.js
@@ -1,0 +1,83 @@
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+import { CandidateEnrolledEvent } from '../../domain/models/events/CandidateEnrolledEvent.js';
+import * as eventRepository from '../../infrastructure/repositories/event-repository.js';
+
+/**
+ * @function
+ * @name pushCandidateEnrolledEvent
+ *
+ * @param {Object} params
+ * @param {number} params.id
+ * @param {string} params.firstName
+ * @param {string} params.lastName
+ * @param {string} params.sex
+ * @param {string} params.birthPostalCode
+ * @param {string} params.birthINSEECode
+ * @param {string} params.birthCity
+ * @param {string} params.birthProvinceCode
+ * @param {string} params.birthCountry
+ * @param {string} params.email
+ * @param {string} params.resultRecipientEmail
+ * @param {string} params.externalId
+ * @param {string} params.birthdate
+ * @param {number} params.extraTimePercentage
+ * @param {string} params.billingMode
+ * @param {string} params.prepaymentCode
+ * @param {string} params.subscription
+ * @param {boolean} params.accessibilityAdjustmentNeeded
+ * @param {number} params.sessionId
+ * @param {number} params.organizationLearnerId
+ * @returns {Promise<void>}
+ */
+export async function pushCandidateEnrolledEvent({
+  id,
+  firstName,
+  lastName,
+  sex,
+  birthPostalCode,
+  birthINSEECode,
+  birthCity,
+  birthProvinceCode,
+  birthCountry,
+  email,
+  resultRecipientEmail,
+  externalId,
+  birthdate,
+  extraTimePercentage,
+  billingMode,
+  prepaymentCode,
+  subscription,
+  accessibilityAdjustmentNeeded,
+  sessionId,
+  organizationLearnerId,
+}) {
+  try {
+    const event = new CandidateEnrolledEvent({
+      candidateId: id,
+      metadata: {
+        firstName,
+        lastName,
+        sex,
+        birthPostalCode,
+        birthINSEECode,
+        birthCity,
+        birthProvinceCode,
+        birthCountry,
+        email,
+        resultRecipientEmail,
+        externalId,
+        birthdate,
+        extraTimePercentage,
+        billingMode,
+        prepaymentCode,
+        subscription,
+        accessibilityAdjustmentNeeded,
+        sessionId,
+        organizationLearnerId,
+      },
+    });
+    await eventRepository.push(event);
+  } catch (err) {
+    logger.warn(`Error in "pushCandidateEnrolledEvent" for ID ${id}: ${err}`);
+  }
+}

--- a/api/src/certification/shared/application/api/event-api.js
+++ b/api/src/certification/shared/application/api/event-api.js
@@ -3,7 +3,7 @@ import { CandidateEnrolledEvent } from '../../domain/models/events/CandidateEnro
 import * as eventRepository from '../../infrastructure/repositories/event-repository.js';
 
 /**
- * @typedef {Object} CandidateEnrolledParams
+ * @typedef {Object} DtoCandidate
  * @property {number} id
  * @property {string} firstName
  * @property {string} lastName
@@ -29,29 +29,29 @@ import * as eventRepository from '../../infrastructure/repositories/event-reposi
 /**
  * @function
  * @name pushCandidateEnrolledEvent
- * @param {CandidateEnrolledParams} candidateParams
+ * @param {DtoCandidate} dtoCandidate
  * @returns {Promise<void>}
  */
-export async function pushCandidateEnrolledEvent(candidateParams) {
-  await _pushCandidateEnrolledEvents([candidateParams]);
+export async function pushCandidateEnrolledEvent(dtoCandidate) {
+  await _pushCandidateEnrolledEvents([dtoCandidate]);
 }
 
 /**
  * @function
  * @name pushCandidateEnrolledEvent
- * @param {CandidateEnrolledParams[]} manyCandidatesParams
+ * @param {DtoCAndidate[]} dtoCandidates
  * @returns {Promise<void>}
  */
-export async function pushMultipleCandidatesEnrolledEvent(manyCandidatesParams) {
-  await _pushCandidateEnrolledEvents(manyCandidatesParams);
+export async function pushMultipleCandidatesEnrolledEvent(dtoCandidates) {
+  await _pushCandidateEnrolledEvents(dtoCandidates);
 }
 
-async function _pushCandidateEnrolledEvents(candidateEnrolledParamsArray) {
+async function _pushCandidateEnrolledEvents(dtoEnrolledCandidates) {
   const events = [];
-  for (const candidateEnrolledParams of candidateEnrolledParamsArray) {
+  for (const dtoEnrolledCandidate of dtoEnrolledCandidates) {
     const event = new CandidateEnrolledEvent({
-      candidateId: candidateEnrolledParams.id,
-      metadata: candidateEnrolledParams,
+      candidateId: dtoEnrolledCandidate.id,
+      metadata: dtoEnrolledCandidate,
     });
     events.push(event);
   }

--- a/api/src/certification/shared/application/api/event-api.js
+++ b/api/src/certification/shared/application/api/event-api.js
@@ -3,81 +3,63 @@ import { CandidateEnrolledEvent } from '../../domain/models/events/CandidateEnro
 import * as eventRepository from '../../infrastructure/repositories/event-repository.js';
 
 /**
+ * @typedef {Object} CandidateEnrolledParams
+ * @property {number} id
+ * @property {string} firstName
+ * @property {string} lastName
+ * @property {string} sex
+ * @property {string} birthPostalCode
+ * @property {string} birthINSEECode
+ * @property {string} birthCity
+ * @property {string} birthProvinceCode
+ * @property {string} birthCountry
+ * @property {string} email
+ * @property {string} resultRecipientEmail
+ * @property {string} externalId
+ * @property {string} birthdate
+ * @property {number} extraTimePercentage
+ * @property {string} billingMode
+ * @property {string} prepaymentCode
+ * @property {string} subscription
+ * @property {boolean} accessibilityAdjustmentNeeded
+ * @property {number} sessionId
+ * @property {number} organizationLearnerId
+ */
+
+/**
  * @function
  * @name pushCandidateEnrolledEvent
- *
- * @param {Object} params
- * @param {number} params.id
- * @param {string} params.firstName
- * @param {string} params.lastName
- * @param {string} params.sex
- * @param {string} params.birthPostalCode
- * @param {string} params.birthINSEECode
- * @param {string} params.birthCity
- * @param {string} params.birthProvinceCode
- * @param {string} params.birthCountry
- * @param {string} params.email
- * @param {string} params.resultRecipientEmail
- * @param {string} params.externalId
- * @param {string} params.birthdate
- * @param {number} params.extraTimePercentage
- * @param {string} params.billingMode
- * @param {string} params.prepaymentCode
- * @param {string} params.subscription
- * @param {boolean} params.accessibilityAdjustmentNeeded
- * @param {number} params.sessionId
- * @param {number} params.organizationLearnerId
+ * @param {CandidateEnrolledParams} candidateParams
  * @returns {Promise<void>}
  */
-export async function pushCandidateEnrolledEvent({
-  id,
-  firstName,
-  lastName,
-  sex,
-  birthPostalCode,
-  birthINSEECode,
-  birthCity,
-  birthProvinceCode,
-  birthCountry,
-  email,
-  resultRecipientEmail,
-  externalId,
-  birthdate,
-  extraTimePercentage,
-  billingMode,
-  prepaymentCode,
-  subscription,
-  accessibilityAdjustmentNeeded,
-  sessionId,
-  organizationLearnerId,
-}) {
-  try {
+export async function pushCandidateEnrolledEvent(candidateParams) {
+  await _pushCandidateEnrolledEvents([candidateParams]);
+}
+
+/**
+ * @function
+ * @name pushCandidateEnrolledEvent
+ * @param {CandidateEnrolledParams[]} manyCandidatesParams
+ * @returns {Promise<void>}
+ */
+export async function pushMultipleCandidatesEnrolledEvent(manyCandidatesParams) {
+  await _pushCandidateEnrolledEvents(manyCandidatesParams);
+}
+
+async function _pushCandidateEnrolledEvents(candidateEnrolledParamsArray) {
+  const events = [];
+  for (const candidateEnrolledParams of candidateEnrolledParamsArray) {
     const event = new CandidateEnrolledEvent({
-      candidateId: id,
-      metadata: {
-        firstName,
-        lastName,
-        sex,
-        birthPostalCode,
-        birthINSEECode,
-        birthCity,
-        birthProvinceCode,
-        birthCountry,
-        email,
-        resultRecipientEmail,
-        externalId,
-        birthdate,
-        extraTimePercentage,
-        billingMode,
-        prepaymentCode,
-        subscription,
-        accessibilityAdjustmentNeeded,
-        sessionId,
-        organizationLearnerId,
-      },
+      candidateId: candidateEnrolledParams.id,
+      metadata: candidateEnrolledParams,
     });
-    await eventRepository.push(event);
+    events.push(event);
+  }
+  try {
+    await eventRepository.push(events);
   } catch (err) {
-    logger.warn(`Error in "pushCandidateEnrolledEvent" for ID ${id}: ${err}`);
+    logger.warn(
+      `Error in "_pushCandidateEnrolledEvents" for IDs ${events.map(({ candidateId }) => candidateId).join(', ')}: ${err}`,
+    );
   }
 }

--- a/api/src/certification/shared/domain/models/events/BaseEvent.js
+++ b/api/src/certification/shared/domain/models/events/BaseEvent.js
@@ -1,0 +1,11 @@
+export class BaseEvent {
+  constructor({ candidateId, createdAt = new Date(), metadata }) {
+    this.candidateId = candidateId;
+    this.createdAt = createdAt;
+    this.metadata = metadata;
+  }
+
+  get name() {
+    throw new Error('Must implement a derived class event');
+  }
+}

--- a/api/src/certification/shared/domain/models/events/CandidateEnrolledEvent.js
+++ b/api/src/certification/shared/domain/models/events/CandidateEnrolledEvent.js
@@ -1,0 +1,7 @@
+import { BaseEvent } from './BaseEvent.js';
+
+export class CandidateEnrolledEvent extends BaseEvent {
+  get name() {
+    return 'CandidateEnrolledEvent';
+  }
+}

--- a/api/src/certification/shared/infrastructure/repositories/event-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/event-repository.js
@@ -3,20 +3,19 @@ import { featureToggles } from '../../../../shared/infrastructure/feature-toggle
 
 /**
  *
- * @param {BaseEvent} event
- * @param event
+ * @param {BaseEvent[]} events
  * @returns {Promise<void>}
  */
-export async function push(event) {
+export async function push(events) {
   const isEventSourcingCertificationEnabled = await featureToggles.get('isEventSourcingCertificationEnabled');
   if (isEventSourcingCertificationEnabled) {
-    const knexConn = DomainTransaction.getConnection();
-    const eventDTO = {
+    const eventDTOs = events.map((event) => ({
       eventName: event.name,
       candidateId: event.candidateId,
       createdAt: event.createdAt,
       metadata: JSON.stringify(event.metadata),
-    };
-    await knexConn('certification_events').insert(eventDTO);
+    }));
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn.batchInsert('certification_events', eventDTOs).transacting(knexConn);
   }
 }

--- a/api/src/certification/shared/infrastructure/repositories/event-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/event-repository.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 
 /**
  *
@@ -7,12 +8,15 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
  * @returns {Promise<void>}
  */
 export async function push(event) {
-  const knexConn = DomainTransaction.getConnection();
-  const eventDTO = {
-    eventName: event.name,
-    candidateId: event.candidateId,
-    createdAt: event.createdAt,
-    metadata: JSON.stringify(event.metadata),
-  };
-  await knexConn('certification_events').insert(eventDTO);
+  const isEventSourcingCertificationEnabled = await featureToggles.get('isEventSourcingCertificationEnabled');
+  if (isEventSourcingCertificationEnabled) {
+    const knexConn = DomainTransaction.getConnection();
+    const eventDTO = {
+      eventName: event.name,
+      candidateId: event.candidateId,
+      createdAt: event.createdAt,
+      metadata: JSON.stringify(event.metadata),
+    };
+    await knexConn('certification_events').insert(eventDTO);
+  }
 }

--- a/api/src/certification/shared/infrastructure/repositories/event-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/event-repository.js
@@ -1,0 +1,18 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+/**
+ *
+ * @param {BaseEvent} event
+ * @param event
+ * @returns {Promise<void>}
+ */
+export async function push(event) {
+  const knexConn = DomainTransaction.getConnection();
+  const eventDTO = {
+    eventName: event.name,
+    candidateId: event.candidateId,
+    createdAt: event.createdAt,
+    metadata: JSON.stringify(event.metadata),
+  };
+  await knexConn('certification_events').insert(eventDTO);
+}

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -301,67 +301,6 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
     });
   });
 
-  describe('#insert', function () {
-    let candidateData;
-
-    beforeEach(function () {
-      candidateData = {
-        id: null,
-        createdAt: new Date('2020-01-01'),
-        firstName: 'Jean-Charles',
-        lastName: 'Quiberon',
-        sex: 'M',
-        birthPostalCode: 'Code postal',
-        birthINSEECode: 'Insee code',
-        birthCity: 'Ma ville',
-        birthProvinceCode: 'Mon département',
-        birthCountry: 'Mon pays',
-        email: 'jc.quiberon@example.net',
-        resultRecipientEmail: 'ma_maman@example.net',
-        birthdate: '1990-05-06',
-        extraTimePercentage: 0.3,
-        externalId: 'JCQUIB',
-        userId: null,
-        sessionId: 888,
-        organizationLearnerId: null,
-        authorizedToStart: false,
-        complementaryCertificationId: null,
-        billingMode: null,
-        prepaymentCode: null,
-        hasSeenCertificationInstructions: false,
-        accessibilityAdjustmentNeeded: false,
-        reconciledAt: null,
-        subscription: Frameworks.DROIT,
-      };
-      databaseBuilder.factory.buildSession({ id: candidateData.sessionId });
-      databaseBuilder.factory.buildComplementaryCertification({ key: Frameworks.DROIT });
-      return databaseBuilder.commit();
-    });
-
-    it('should insert candidate in DB with subscription', async function () {
-      // given
-      const candidateToInsert = domainBuilder.certification.enrolment.buildCandidate(candidateData);
-
-      // when
-      const candidateId = await candidateRepository.insert(candidateToInsert);
-
-      // then
-      const savedCandidateData = await knex('certification-candidates').select('*').where({ id: candidateId }).first();
-      expect(savedCandidateData.subscription).to.equal(Frameworks.DROIT);
-      expect(parseFloat(savedCandidateData.extraTimePercentage)).to.equal(candidateData.extraTimePercentage);
-
-      const savedSubscriptionsData = await knex('certification-subscriptions')
-        .select('*')
-        .where({ certificationCandidateId: candidateId })
-        .orderBy('type');
-      expect(savedSubscriptionsData).to.have.lengthOf(1);
-      expect(savedSubscriptionsData[0]).to.deepEqualInstanceOmitting(
-        { certificationCandidateId: candidateId, type: SUBSCRIPTION_TYPES.COMPLEMENTARY },
-        ['createdAt', 'complementaryCertificationId'],
-      );
-    });
-  });
-
   describe('#save', function () {
     it("should insert session's candidates in DB with their subscriptions", async function () {
       // given
@@ -403,7 +342,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       });
 
       // when
-      await candidateRepository.save({ candidates: [candidateA, candidateB, candidateC] });
+      await candidateRepository.save([candidateA, candidateB, candidateC]);
 
       // then
       // Candidate A

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -309,6 +309,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       const sessionId = databaseBuilder.factory.buildSession({}).id;
       await databaseBuilder.commit();
       const candidateA = domainBuilder.certification.enrolment.buildCandidate({
+        id: null,
         firstName: 'Lolo',
         lastName: 'Lapraline',
         accessibilityAdjustmentNeeded: true,
@@ -398,6 +399,9 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         },
         ['createdAt'],
       );
+
+      expect(candidateA.id).to.equal(null);
+      expect(savedCandidateAData.id).to.not.equal(null);
 
       // Candidate B
       const savedCandidateBData = await knex('certification-candidates')

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -26,7 +26,7 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
       clock.restore();
     });
 
-    it('adds only the unenrolled candidates', async function () {
+    it('adds only the unenrolled candidates and returns only the indeed enrolled ScoCandidate models with id', async function () {
       // given
       const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner().id;
       const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner().id;
@@ -69,9 +69,13 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
           sessionId,
         }),
       ];
+      scoCandidates[0].id = null;
+      scoCandidates[1].id = null;
+      scoCandidates[2].id = null;
+      scoCandidates[3].id = null;
 
       // when
-      await scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession({
+      const savedScoCandidates = await scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession({
         sessionId,
         scoCertificationCandidates: scoCandidates,
       });
@@ -93,6 +97,11 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
 
       const { count: subscriptionsCount } = await knex('certification-subscriptions').count().first();
       expect(subscriptionsCount).to.equal(actualCandidates.length);
+
+      sinon.assert.match(
+        savedScoCandidates.map(({ id }) => id),
+        [sinon.match.number, sinon.match.number],
+      );
     });
 
     it('saves only candidate core subscription', async function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -23,6 +23,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
   let certificationCpfCountryRepository;
   let certificationCpfCityRepository;
   let complementaryCertificationRepository;
+  let eventApi;
   let mailCheck;
   let normalizeStringFnc;
   let candidateToEnroll;
@@ -58,6 +59,9 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
         }),
       ]),
     };
+    eventApi = {
+      pushCandidateEnrolledEvent: sinon.stub().resolves(),
+    };
     mailCheck = { assertEmailDomainHasMx: sinon.stub() };
     centerRepository.getById.resolves(domainBuilder.certification.enrolment.buildCenter());
     normalizeStringFnc = (str) => str;
@@ -69,6 +73,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
       certificationCpfCountryRepository,
       certificationCpfCityRepository,
       complementaryCertificationRepository,
+      eventApi,
       mailCheck,
       normalizeStringFnc,
     };
@@ -95,6 +100,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
       expect(error).to.be.an.instanceOf(CertificationCandidateOnFinalizedSessionError);
       expect(error.message).to.equal("Cette session a déjà été finalisée, l'ajout de candidat n'est pas autorisé");
       expect(candidateRepository.insert).not.to.have.been.called;
+      expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
     });
   });
 
@@ -134,6 +140,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
           }),
         );
         expect(candidateRepository.insert).not.to.have.been.called;
+        expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
       });
     });
 
@@ -175,6 +182,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
           // then
           expect(error).to.be.instanceof(CertificationCandidateByPersonalInfoTooManyMatchesError);
           expect(candidateRepository.insert).not.to.have.been.called;
+          expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
         });
       });
 
@@ -209,6 +217,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
             expect(error).to.be.an.instanceOf(CertificationCandidatesError);
             expect(error.code).to.equal(CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED.code);
             expect(candidateRepository.insert).not.to.have.been.called;
+            expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
           });
         });
 
@@ -250,6 +259,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
                 });
                 expect(error).to.deepEqualInstance(certificationCandidatesError);
                 expect(candidateRepository.insert).not.to.have.been.called;
+                expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
               });
             });
 
@@ -279,6 +289,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
 
                 expect(error).to.deepEqualInstance(certificationCandidatesError);
                 expect(candidateRepository.insert).not.to.have.been.called;
+                expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
               });
             });
           });
@@ -286,30 +297,6 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
           context('when emails validations succeed', function () {
             beforeEach(function () {
               mailCheck.assertEmailDomainHasMx.resolves();
-            });
-
-            it('should insert the candidate and return the ID', async function () {
-              // given
-              const correctedCandidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
-                ...candidateToEnroll,
-                sessionId,
-                birthCountry: 'COUNTRY',
-                birthINSEECode: 'INSEE_CODE',
-                birthPostalCode: null,
-                birthCity: 'CITY',
-              });
-              candidateRepository.insert.resolves(159);
-
-              // when
-              const id = await addCandidateToSession({
-                sessionId,
-                candidate: candidateToEnroll,
-                ...dependencies,
-              });
-
-              // then
-              expect(candidateRepository.insert).to.have.been.calledWithExactly(correctedCandidateToEnroll);
-              expect(id).to.equal(159);
             });
 
             it('should insert the candidate and return the id', async function () {
@@ -335,6 +322,10 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
 
               // then
               expect(candidateRepository.insert).to.have.been.calledWithExactly(correctedCandidateToEnroll);
+              expect(eventApi.pushCandidateEnrolledEvent).to.have.been.calledOnceWith({
+                ...candidateToEnroll.toDTO(),
+                id: 159,
+              });
               expect(id).to.equal(159);
             });
           });

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -39,7 +39,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
       getById: sinon.stub(),
     };
     candidateRepository = {
-      insert: sinon.stub(),
+      save: sinon.stub(),
       findBySessionId: sinon.stub(),
     };
     certificationCpfService = {
@@ -99,7 +99,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
       // then
       expect(error).to.be.an.instanceOf(CertificationCandidateOnFinalizedSessionError);
       expect(error.message).to.equal("Cette session a déjà été finalisée, l'ajout de candidat n'est pas autorisé");
-      expect(candidateRepository.insert).not.to.have.been.called;
+      expect(candidateRepository.save).not.to.have.been.called;
       expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
     });
   });
@@ -139,7 +139,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
             },
           }),
         );
-        expect(candidateRepository.insert).not.to.have.been.called;
+        expect(candidateRepository.save).not.to.have.been.called;
         expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
       });
     });
@@ -181,7 +181,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
 
           // then
           expect(error).to.be.instanceof(CertificationCandidateByPersonalInfoTooManyMatchesError);
-          expect(candidateRepository.insert).not.to.have.been.called;
+          expect(candidateRepository.save).not.to.have.been.called;
           expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
         });
       });
@@ -216,7 +216,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
             // then
             expect(error).to.be.an.instanceOf(CertificationCandidatesError);
             expect(error.code).to.equal(CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED.code);
-            expect(candidateRepository.insert).not.to.have.been.called;
+            expect(candidateRepository.save).not.to.have.been.called;
             expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
           });
         });
@@ -258,7 +258,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
                   meta: { email: 'jesuisunemail@incorrect.fr' },
                 });
                 expect(error).to.deepEqualInstance(certificationCandidatesError);
-                expect(candidateRepository.insert).not.to.have.been.called;
+                expect(candidateRepository.save).not.to.have.been.called;
                 expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
               });
             });
@@ -288,7 +288,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
                 });
 
                 expect(error).to.deepEqualInstance(certificationCandidatesError);
-                expect(candidateRepository.insert).not.to.have.been.called;
+                expect(candidateRepository.save).not.to.have.been.called;
                 expect(eventApi.pushCandidateEnrolledEvent).not.to.have.been.called;
               });
             });
@@ -310,7 +310,11 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
                 birthPostalCode: null,
                 birthCity: 'CITY',
               });
-              candidateRepository.insert.resolves(159);
+              const savedCandidate = domainBuilder.certification.enrolment.buildCandidate({
+                ...candidateToEnroll.toDTO(),
+                id: 159,
+              });
+              candidateRepository.save.resolves([savedCandidate]);
 
               // when
               const id = await addCandidateToSession({
@@ -321,11 +325,8 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
               });
 
               // then
-              expect(candidateRepository.insert).to.have.been.calledWithExactly(correctedCandidateToEnroll);
-              expect(eventApi.pushCandidateEnrolledEvent).to.have.been.calledOnceWith({
-                ...candidateToEnroll.toDTO(),
-                id: 159,
-              });
+              expect(candidateRepository.save).to.have.been.calledWithExactly([correctedCandidateToEnroll]);
+              expect(eventApi.pushCandidateEnrolledEvent).to.have.been.calledOnceWith(savedCandidate.toDTO());
               expect(id).to.equal(159);
             });
           });

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
 import { createSessions } from '../../../../../../src/certification/enrolment/domain/usecases/create-sessions.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -142,15 +142,13 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           // then
           const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
           expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
-          expect(candidateRepository.save).to.have.been.calledOnceWith({
-            candidates: [
-              domainBuilder.certification.enrolment.buildCandidate({
-                ...candidate,
-                sessionId: 1234,
-                subscription: Frameworks.DROIT,
-              }),
-            ],
-          });
+          expect(candidateRepository.save).to.have.been.calledOnceWith([
+            domainBuilder.certification.enrolment.buildCandidate({
+              ...candidate,
+              sessionId: 1234,
+              subscription: Frameworks.DROIT,
+            }),
+          ]);
         });
       });
     });
@@ -184,15 +182,13 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         expect(candidateRepository.deleteBySessionId).to.have.been.calledOnceWith({
           sessionId: 1234,
         });
-        expect(candidateRepository.save).to.have.been.calledOnceWith({
-          candidates: [
-            domainBuilder.certification.enrolment.buildCandidate({
-              ...candidate,
-              sessionId: 1234,
-              subscription: Frameworks.DROIT,
-            }),
-          ],
-        });
+        expect(candidateRepository.save).to.have.been.calledOnceWith([
+          domainBuilder.certification.enrolment.buildCandidate({
+            ...candidate,
+            sessionId: 1234,
+            subscription: Frameworks.DROIT,
+          }),
+        ]);
       });
     });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -13,6 +13,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
   let centerRepository;
   let candidateRepository;
   let sessionRepository;
+  let eventApi;
   let dependencies;
   let temporarySessionsStorageForMassImportService;
   let candidateData;
@@ -25,12 +26,14 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       getByKeyAndUserId: sinon.stub(),
       remove: sinon.stub(),
     };
+    eventApi = { pushMultipleCandidatesEnrolledEvent: sinon.stub() };
 
     dependencies = {
       centerRepository,
       candidateRepository,
       sessionRepository,
       temporarySessionsStorageForMassImportService,
+      eventApi,
     };
 
     candidateData = {
@@ -55,6 +58,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
+      expect(eventApi.pushMultipleCandidatesEnrolledEvent).not.to.have.been.called;
     });
   });
 
@@ -99,6 +103,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
           expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
           expect(candidateRepository.save).to.not.have.been.called;
+          expect(eventApi.pushMultipleCandidatesEnrolledEvent).not.to.have.been.called;
         });
       });
 
@@ -130,6 +135,15 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           const cachedValidatedSessionsKey = 'uuid';
           sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
           sessionRepository.save.resolves({ id: 1234 });
+          const savedCandidates = [
+            domainBuilder.certification.enrolment.buildCandidate({
+              ...candidate,
+              id: 1111,
+              sessionId: 1234,
+              subscription: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+            }),
+          ];
+          candidateRepository.save.resolves(savedCandidates);
 
           // when
           await createSessions({
@@ -149,6 +163,9 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
               subscription: Frameworks.DROIT,
             }),
           ]);
+          expect(eventApi.pushMultipleCandidatesEnrolledEvent).to.have.been.calledOnceWith(
+            savedCandidates.map((savedCandidate) => savedCandidate.toDTO()),
+          );
         });
       });
     });
@@ -169,6 +186,15 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         const sessionCreatorId = 1234;
         const cachedValidatedSessionsKey = 'uuid';
         sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
+        const savedCandidates = [
+          domainBuilder.certification.enrolment.buildCandidate({
+            ...candidate,
+            id: 1111,
+            sessionId: 1234,
+            subscription: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+          }),
+        ];
+        candidateRepository.save.resolves(savedCandidates);
 
         // when
         await createSessions({
@@ -189,6 +215,9 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
             subscription: Frameworks.DROIT,
           }),
         ]);
+        expect(eventApi.pushMultipleCandidatesEnrolledEvent).to.have.been.calledOnceWith(
+          savedCandidates.map((savedCandidate) => savedCandidate.toDTO()),
+        );
       });
     });
 
@@ -207,6 +236,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       const sessionCreatorId = 1234;
       const cachedValidatedSessionsKey = 'uuid';
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
+      candidateRepository.save.resolves([]);
 
       // when
       await createSessions({

--- a/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
@@ -9,12 +9,56 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session', function () {
+  let scoCertificationCandidateRepository;
+  let organizationLearnerRepository;
+  let centerRepository;
+  let countryRepository;
+  let sessionRepository;
+  const certificationCpfCityRepository = Symbol('certificationCpfCityRepository');
+  const certificationCpfCountryRepository = Symbol('certificationCpfCountryRepository');
+  let certificationCpfService;
+  let eventApi;
+  let dependencies;
+
+  beforeEach(function () {
+    scoCertificationCandidateRepository = {
+      addNonEnrolledCandidatesToSession: sinon.stub(),
+    };
+    organizationLearnerRepository = {
+      findByIds: sinon.stub(),
+    };
+    centerRepository = {
+      getById: sinon.stub(),
+    };
+    countryRepository = {
+      findAll: sinon.stub(),
+    };
+    sessionRepository = {
+      get: sinon.stub(),
+    };
+    certificationCpfService = {
+      getBirthInformation: sinon.stub(),
+    };
+    eventApi = { pushMultipleCandidatesEnrolledEvent: sinon.stub() };
+
+    dependencies = {
+      scoCertificationCandidateRepository,
+      organizationLearnerRepository,
+      centerRepository,
+      countryRepository,
+      sessionRepository,
+      certificationCpfCityRepository,
+      certificationCpfCountryRepository,
+      certificationCpfService,
+      eventApi,
+    };
+  });
+
   context('when referent is allowed to Pix Certif', function () {
     it('enrols n students to a session', async function () {
       // given
       const session = domainBuilder.certification.enrolment.buildSession();
       const sessionId = session.id;
-      const anotherSessionId = sessionId + 1;
 
       const studentIds = [1, 2, 3];
       const { organizationForReferent, organizationLearners } =
@@ -42,14 +86,15 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
         });
       });
 
-      const scoCertificationCandidateRepository = new InMemorySCOCertificationCandidateRepository();
-      const organizationLearnerRepository = { findByIds: sinon.stub() };
-      const countryRepository = { findAll: sinon.stub() };
+      scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession
+        .withArgs({
+          sessionId,
+          scoCertificationCandidates: expectedCertificationCandidates,
+        })
+        .resolves(expectedCertificationCandidates);
       countryRepository.findAll.resolves([country]);
       organizationLearnerRepository.findByIds.withArgs({ ids: studentIds }).resolves(organizationLearners);
-      const sessionRepository = { get: sinon.stub() };
       sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
-      const centerRepository = { getById: sinon.stub() };
       centerRepository.getById.withArgs({ id: session.certificationCenterId }).resolves(
         domainBuilder.certification.enrolment.buildCenter({
           matchingOrganization: domainBuilder.certification.enrolment.buildMatchingOrganization({
@@ -62,18 +107,13 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
       await enrolStudentsToSession({
         sessionId,
         studentIds,
-        scoCertificationCandidateRepository,
-        organizationLearnerRepository,
-        sessionRepository,
-        countryRepository,
-        centerRepository,
+        ...dependencies,
       });
 
       // then
-      expect(scoCertificationCandidateRepository.findBySessionId(sessionId)).to.deep.equal(
-        expectedCertificationCandidates,
+      expect(eventApi.pushMultipleCandidatesEnrolledEvent).to.have.been.calledOnceWith(
+        expectedCertificationCandidates.map((savedCandidate) => savedCandidate.toDTO()),
       );
-      expect(scoCertificationCandidateRepository.findBySessionId(anotherSessionId)).to.deep.equal(undefined);
     });
 
     it('enrols a student by trimming his first name and last name', async function () {
@@ -112,14 +152,15 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
         ],
       });
 
-      const scoCertificationCandidateRepository = new InMemorySCOCertificationCandidateRepository();
-      const organizationLearnerRepository = { findByIds: sinon.stub() };
-      const countryRepository = { findAll: sinon.stub() };
+      scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession
+        .withArgs({
+          sessionId,
+          scoCertificationCandidates: [expectedCertificationCandidate],
+        })
+        .resolves([expectedCertificationCandidate]);
       countryRepository.findAll.resolves([country]);
       organizationLearnerRepository.findByIds.withArgs({ ids: [1] }).resolves([organizationLearner]);
-      const sessionRepository = { get: sinon.stub() };
       sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
-      const centerRepository = { getById: sinon.stub() };
       centerRepository.getById.withArgs({ id: session.certificationCenterId }).resolves(
         domainBuilder.certification.enrolment.buildCenter({
           matchingOrganization: domainBuilder.certification.enrolment.buildMatchingOrganization({
@@ -132,16 +173,12 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
       await enrolStudentsToSession({
         sessionId,
         studentIds: [1],
-        scoCertificationCandidateRepository,
-        organizationLearnerRepository,
-        sessionRepository,
-        countryRepository,
-        centerRepository,
+        ...dependencies,
       });
 
       // then
-      expect(scoCertificationCandidateRepository.findBySessionId(sessionId)).to.deep.equal([
-        expectedCertificationCandidate,
+      expect(eventApi.pushMultipleCandidatesEnrolledEvent).to.have.been.calledOnceWith([
+        expectedCertificationCandidate.toDTO(),
       ]);
     });
 
@@ -153,11 +190,8 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
       const { organizationForReferent, organizationLearners } =
         _buildNonMatchingReferentOrganisationAndOrganizationLearners(studentIds);
 
-      const organizationLearnerRepository = { findByIds: sinon.stub() };
       organizationLearnerRepository.findByIds.withArgs({ ids: studentIds }).resolves(organizationLearners);
-      const sessionRepository = { get: sinon.stub() };
       sessionRepository.get.withArgs({ id: session.id }).resolves(session);
-      const centerRepository = { getById: sinon.stub() };
       centerRepository.getById.withArgs({ id: session.certificationCenterId }).resolves(
         domainBuilder.certification.enrolment.buildCenter({
           matchingOrganization: domainBuilder.certification.enrolment.buildMatchingOrganization({
@@ -170,9 +204,7 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
       const error = await catchErr(enrolStudentsToSession)({
         sessionId: session.id,
         studentIds,
-        organizationLearnerRepository,
-        centerRepository,
-        sessionRepository,
+        ...dependencies,
       });
 
       // then
@@ -193,14 +225,9 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
         name: 'COUBA',
       });
 
-      const scoCertificationCandidateRepository = new InMemorySCOCertificationCandidateRepository();
-      const organizationLearnerRepository = { findByIds: sinon.stub() };
       organizationLearnerRepository.findByIds.withArgs({ ids: studentIds }).resolves(organizationLearners);
-      const countryRepository = { findAll: sinon.stub() };
       countryRepository.findAll.resolves([country]);
-      const sessionRepository = { get: sinon.stub() };
       sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
-      const centerRepository = { getById: sinon.stub() };
       centerRepository.getById.withArgs({ id: session.certificationCenterId }).resolves(
         domainBuilder.certification.enrolment.buildCenter({
           matchingOrganization: domainBuilder.certification.enrolment.buildMatchingOrganization({
@@ -213,11 +240,7 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
       const error = await catchErr(enrolStudentsToSession)({
         sessionId,
         studentIds,
-        scoCertificationCandidateRepository,
-        organizationLearnerRepository,
-        sessionRepository,
-        countryRepository,
-        centerRepository,
+        ...dependencies,
       });
 
       // then
@@ -263,14 +286,15 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
           ],
         });
 
-        const scoCertificationCandidateRepository = new InMemorySCOCertificationCandidateRepository();
-        const organizationLearnerRepository = { findByIds: sinon.stub() };
-        const countryRepository = { findAll: sinon.stub() };
+        scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession
+          .withArgs({
+            sessionId,
+            scoCertificationCandidates: [expectedCertificationCandidate],
+          })
+          .resolves([expectedCertificationCandidate]);
         countryRepository.findAll.resolves([country]);
         organizationLearnerRepository.findByIds.withArgs({ ids: [1] }).resolves([organizationLearner]);
-        const sessionRepository = { get: sinon.stub() };
         sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
-        const centerRepository = { getById: sinon.stub() };
         centerRepository.getById.withArgs({ id: session.certificationCenterId }).resolves(
           domainBuilder.certification.enrolment.buildCenter({
             matchingOrganization: domainBuilder.certification.enrolment.buildMatchingOrganization({
@@ -278,24 +302,13 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
             }),
           }),
         );
-        const certificationCpfService = { getBirthInformation: sinon.stub() };
-        const certificationCpfCountryRepository = {};
-        const certificationCpfCityRepository = {};
-
         certificationCpfService.getBirthInformation.resolves({ birthCity: expectedCertificationCandidate.birthCity });
 
         // when
         await enrolStudentsToSession({
           sessionId,
           studentIds: [1],
-          scoCertificationCandidateRepository,
-          organizationLearnerRepository,
-          sessionRepository,
-          countryRepository,
-          centerRepository,
-          certificationCpfCountryRepository,
-          certificationCpfCityRepository,
-          certificationCpfService,
+          ...dependencies,
         });
 
         // then
@@ -307,8 +320,8 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
         });
-        expect(scoCertificationCandidateRepository.findBySessionId(sessionId)).to.deep.equal([
-          expectedCertificationCandidate,
+        expect(eventApi.pushMultipleCandidatesEnrolledEvent).to.have.been.calledOnceWith([
+          expectedCertificationCandidate.toDTO(),
         ]);
       });
     });
@@ -325,14 +338,10 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
         name: 'FRANCE',
       });
 
-      const scoCertificationCandidateRepository = new InMemorySCOCertificationCandidateRepository();
-      const organizationLearnerRepository = { findByIds: sinon.stub() };
-      const countryRepository = { findAll: sinon.stub() };
+      scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession.resolves([]);
       countryRepository.findAll.resolves([country]);
       organizationLearnerRepository.findByIds.withArgs({ ids: studentIds }).resolves(organizationLearners);
-      const sessionRepository = { get: sinon.stub() };
       sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
-      const centerRepository = { getById: sinon.stub() };
       centerRepository.getById.withArgs({ id: session.certificationCenterId }).resolves(
         domainBuilder.certification.enrolment.buildCenter({
           matchingOrganization: domainBuilder.certification.enrolment.buildMatchingOrganization({
@@ -345,15 +354,11 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
       await enrolStudentsToSession({
         sessionId,
         studentIds,
-        scoCertificationCandidateRepository,
-        centerRepository,
-        organizationLearnerRepository,
-        countryRepository,
-        sessionRepository,
+        ...dependencies,
       });
 
       // then
-      expect(scoCertificationCandidateRepository.findBySessionId(sessionId)).to.deep.equal([]);
+      expect(eventApi.pushMultipleCandidatesEnrolledEvent).to.have.been.calledOnceWith([]);
     });
   });
 });
@@ -378,18 +383,4 @@ function _buildNonMatchingReferentOrganisationAndOrganizationLearners(studentIds
 
   const organizationForReferent = domainBuilder.buildOrganization({ id: 456 });
   return { organizationForReferent, organizationLearners };
-}
-
-class InMemorySCOCertificationCandidateRepository {
-  constructor() {
-    this.addedCandidates = {};
-  }
-
-  addNonEnrolledCandidatesToSession({ sessionId, scoCertificationCandidates }) {
-    this.addedCandidates[sessionId] = scoCertificationCandidates;
-  }
-
-  findBySessionId(sessionId) {
-    return this.addedCandidates[sessionId];
-  }
 }

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -19,6 +19,7 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
   let certificationCpfCountryRepository;
   let centerRepository;
   let sessionRepository;
+  let eventApi;
 
   beforeEach(function () {
     candidateRepository = {
@@ -35,6 +36,7 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
     certificationCpfService = {
       getBirthInformation: sinon.stub(),
     };
+    eventApi = { pushMultipleCandidatesEnrolledEvent: sinon.stub() };
     certificationCpfCountryRepository = Symbol('certificationCpfCountryRepository');
     certificationCpfCityRepository = Symbol('certificationCpfCityRepository');
     centerRepository = Symbol('centerRepository');
@@ -70,10 +72,12 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
           certificationCpfCityRepository,
           centerRepository,
           sessionRepository,
+          eventApi,
         });
 
         // then
         expect(result).to.be.an.instanceOf(CandidateAlreadyLinkedToUserError);
+        expect(eventApi.pushMultipleCandidatesEnrolledEvent).not.to.have.been.called;
       });
     });
 
@@ -117,6 +121,7 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
               centerRepository,
             })
             .resolves(candidates);
+          candidateRepository.save.resolves(candidates);
 
           // when
           await importCertificationCandidatesFromCandidatesImportSheet({
@@ -130,6 +135,7 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
             certificationCpfCityRepository,
             centerRepository,
             sessionRepository,
+            eventApi,
           });
 
           // then
@@ -138,6 +144,9 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
           });
           expect(candidateRepository.save).to.have.been.calledWithExactly(candidates);
           expect(candidateRepository.deleteBySessionId.calledBefore(candidateRepository.save)).to.be.true;
+          expect(eventApi.pushMultipleCandidatesEnrolledEvent).to.have.been.calledOnceWith(
+            candidates.map((savedCandidate) => savedCandidate.toDTO()),
+          );
         });
       });
     });

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -136,7 +136,7 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
           expect(candidateRepository.deleteBySessionId).to.have.been.calledWithExactly({
             sessionId,
           });
-          expect(candidateRepository.save).to.have.been.calledWithExactly({ candidates });
+          expect(candidateRepository.save).to.have.been.calledWithExactly(candidates);
           expect(candidateRepository.deleteBySessionId.calledBefore(candidateRepository.save)).to.be.true;
         });
       });

--- a/api/tests/certification/shared/integration/application/api/event-api_test.js
+++ b/api/tests/certification/shared/integration/application/api/event-api_test.js
@@ -1,0 +1,78 @@
+import sinon from 'sinon';
+
+import { pushCandidateEnrolledEvent } from '../../../../../../src/certification/shared/application/api/event-api.js';
+import { knex } from '../../../../../tooling/databases.js';
+
+describe('Certification | Shared | Integration | Application | API | Event', function () {
+  let clock;
+  const now = new Date('2023-02-02T00:00:00Z');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#pushCandidateEnrolledEvent', function () {
+    it('persists a CandidateEnrolledEvent', async function () {
+      const data = {
+        id: 123,
+        firstName: 'foo firstName',
+        lastName: 'foo lastName',
+        sex: 'foo sex',
+        birthPostalCode: 'foo birthPostalCode',
+        birthINSEECode: 'foo birthINSEECode',
+        birthCity: 'foo birthCity',
+        birthProvinceCode: 'foo birthProvinceCode',
+        birthCountry: 'foo birthCountry',
+        email: 'foo email',
+        resultRecipientEmail: 'foo resultRecipientEmail',
+        externalId: 'foo externalId',
+        birthdate: '2020-01-01',
+        extraTimePercentage: 456,
+        billingMode: 'foo billingMode',
+        prepaymentCode: 'foo prepaymentCode',
+        subscription: 'foo subscription',
+        accessibilityAdjustmentNeeded: true,
+        sessionId: 789,
+        organizationLearnerId: 159,
+      };
+
+      await pushCandidateEnrolledEvent(data);
+
+      // then
+      const events = await knex('certification_events').select();
+      sinon.assert.match(events, [
+        {
+          id: sinon.match.number,
+          eventName: 'CandidateEnrolledEvent',
+          candidateId: 123,
+          createdAt: new Date('2023-02-02T00:00:00Z'),
+          metadata: {
+            firstName: 'foo firstName',
+            lastName: 'foo lastName',
+            sex: 'foo sex',
+            birthPostalCode: 'foo birthPostalCode',
+            birthINSEECode: 'foo birthINSEECode',
+            birthCity: 'foo birthCity',
+            birthProvinceCode: 'foo birthProvinceCode',
+            birthCountry: 'foo birthCountry',
+            email: 'foo email',
+            resultRecipientEmail: 'foo resultRecipientEmail',
+            externalId: 'foo externalId',
+            birthdate: '2020-01-01',
+            extraTimePercentage: 456,
+            billingMode: 'foo billingMode',
+            prepaymentCode: 'foo prepaymentCode',
+            subscription: 'foo subscription',
+            accessibilityAdjustmentNeeded: true,
+            sessionId: 789,
+            organizationLearnerId: 159,
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/certification/shared/integration/application/api/event-api_test.js
+++ b/api/tests/certification/shared/integration/application/api/event-api_test.js
@@ -1,6 +1,9 @@
 import sinon from 'sinon';
 
-import { pushCandidateEnrolledEvent } from '../../../../../../src/certification/shared/application/api/event-api.js';
+import {
+  pushCandidateEnrolledEvent,
+  pushMultipleCandidatesEnrolledEvent,
+} from '../../../../../../src/certification/shared/application/api/event-api.js';
 import { knex } from '../../../../../tooling/databases.js';
 
 describe('Certification | Shared | Integration | Application | API | Event', function () {
@@ -13,6 +16,7 @@ describe('Certification | Shared | Integration | Application | API | Event', fun
 
   afterEach(function () {
     clock.restore();
+    return knex('certification_events').truncate();
   });
 
   describe('#pushCandidateEnrolledEvent', function () {
@@ -51,6 +55,7 @@ describe('Certification | Shared | Integration | Application | API | Event', fun
           candidateId: 123,
           createdAt: new Date('2023-02-02T00:00:00Z'),
           metadata: {
+            id: 123,
             firstName: 'foo firstName',
             lastName: 'foo lastName',
             sex: 'foo sex',
@@ -70,6 +75,118 @@ describe('Certification | Shared | Integration | Application | API | Event', fun
             accessibilityAdjustmentNeeded: true,
             sessionId: 789,
             organizationLearnerId: 159,
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('#pushMultipleCandidatesEnrolledEvent', function () {
+    it('persists several CandidateEnrolledEvents', async function () {
+      const data1 = {
+        id: 123,
+        firstName: 'foo firstName',
+        lastName: 'foo lastName',
+        sex: 'foo sex',
+        birthPostalCode: 'foo birthPostalCode',
+        birthINSEECode: 'foo birthINSEECode',
+        birthCity: 'foo birthCity',
+        birthProvinceCode: 'foo birthProvinceCode',
+        birthCountry: 'foo birthCountry',
+        email: 'foo email',
+        resultRecipientEmail: 'foo resultRecipientEmail',
+        externalId: 'foo externalId',
+        birthdate: '2020-01-01',
+        extraTimePercentage: 456,
+        billingMode: 'foo billingMode',
+        prepaymentCode: 'foo prepaymentCode',
+        subscription: 'foo subscription',
+        accessibilityAdjustmentNeeded: true,
+        sessionId: 789,
+        organizationLearnerId: 159,
+      };
+      const data2 = {
+        id: 111,
+        firstName: 'foo firstName2',
+        lastName: 'foo lastName2',
+        sex: 'foo sex2',
+        birthPostalCode: 'foo birthPostalCode2',
+        birthINSEECode: 'foo birthINSEECode2',
+        birthCity: 'foo birthCity2',
+        birthProvinceCode: 'foo birthProvinceCode2',
+        birthCountry: 'foo birthCountry2',
+        email: 'foo email2',
+        resultRecipientEmail: 'foo resultRecipientEmail2',
+        externalId: 'foo externalId2',
+        birthdate: '2019-09-09',
+        extraTimePercentage: 222,
+        billingMode: 'foo billingMode2',
+        prepaymentCode: 'foo prepaymentCode2',
+        subscription: 'foo subscription2',
+        accessibilityAdjustmentNeeded: false,
+        sessionId: 333,
+        organizationLearnerId: null,
+      };
+
+      await pushMultipleCandidatesEnrolledEvent([data1, data2]);
+
+      // then
+      const events = await knex('certification_events').select();
+      sinon.assert.match(events, [
+        {
+          id: sinon.match.number,
+          eventName: 'CandidateEnrolledEvent',
+          candidateId: 123,
+          createdAt: new Date('2023-02-02T00:00:00Z'),
+          metadata: {
+            id: 123,
+            firstName: 'foo firstName',
+            lastName: 'foo lastName',
+            sex: 'foo sex',
+            birthPostalCode: 'foo birthPostalCode',
+            birthINSEECode: 'foo birthINSEECode',
+            birthCity: 'foo birthCity',
+            birthProvinceCode: 'foo birthProvinceCode',
+            birthCountry: 'foo birthCountry',
+            email: 'foo email',
+            resultRecipientEmail: 'foo resultRecipientEmail',
+            externalId: 'foo externalId',
+            birthdate: '2020-01-01',
+            extraTimePercentage: 456,
+            billingMode: 'foo billingMode',
+            prepaymentCode: 'foo prepaymentCode',
+            subscription: 'foo subscription',
+            accessibilityAdjustmentNeeded: true,
+            sessionId: 789,
+            organizationLearnerId: 159,
+          },
+        },
+        {
+          id: sinon.match.number,
+          eventName: 'CandidateEnrolledEvent',
+          candidateId: 111,
+          createdAt: new Date('2023-02-02T00:00:00Z'),
+          metadata: {
+            id: 111,
+            firstName: 'foo firstName2',
+            lastName: 'foo lastName2',
+            sex: 'foo sex2',
+            birthPostalCode: 'foo birthPostalCode2',
+            birthINSEECode: 'foo birthINSEECode2',
+            birthCity: 'foo birthCity2',
+            birthProvinceCode: 'foo birthProvinceCode2',
+            birthCountry: 'foo birthCountry2',
+            email: 'foo email2',
+            resultRecipientEmail: 'foo resultRecipientEmail2',
+            externalId: 'foo externalId2',
+            birthdate: '2019-09-09',
+            extraTimePercentage: 222,
+            billingMode: 'foo billingMode2',
+            prepaymentCode: 'foo prepaymentCode2',
+            subscription: 'foo subscription2',
+            accessibilityAdjustmentNeeded: false,
+            sessionId: 333,
+            organizationLearnerId: null,
           },
         },
       ]);

--- a/api/tests/certification/shared/integration/infrastructure/repositories/event-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/event-repository_test.js
@@ -1,0 +1,31 @@
+import sinon from 'sinon';
+
+import * as eventRepository from '../../../../../../src/certification/shared/infrastructure/repositories/event-repository.js';
+import { knex } from '../../../../../tooling/databases.js';
+
+describe('Certification | Shared | Integration | Repository | Event', function () {
+  describe('#push', function () {
+    it('should persist the event in db', async function () {
+      const event = {
+        name: 'SomeEvent',
+        candidateId: 123,
+        createdAt: new Date('2021-01-01T00:00:00Z'),
+        metadata: { foo: 'bar' },
+      };
+
+      await eventRepository.push(event);
+
+      // then
+      const events = await knex('certification_events').select();
+      sinon.assert.match(events, [
+        {
+          id: sinon.match.number,
+          eventName: 'SomeEvent',
+          candidateId: 123,
+          createdAt: new Date('2021-01-01T00:00:00Z'),
+          metadata: { foo: 'bar' },
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/certification/shared/integration/infrastructure/repositories/event-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/event-repository_test.js
@@ -1,31 +1,58 @@
+import { setImmediate } from 'node:timers/promises';
+
 import sinon from 'sinon';
 
 import * as eventRepository from '../../../../../../src/certification/shared/infrastructure/repositories/event-repository.js';
+import { featureToggles } from '../../../../../../src/shared/infrastructure/feature-toggles/index.js';
+import { expect } from '../../../../../test-helper.js';
 import { knex } from '../../../../../tooling/databases.js';
 
 describe('Certification | Shared | Integration | Repository | Event', function () {
   describe('#push', function () {
-    it('should persist the event in db', async function () {
-      const event = {
-        name: 'SomeEvent',
-        candidateId: 123,
-        createdAt: new Date('2021-01-01T00:00:00Z'),
-        metadata: { foo: 'bar' },
-      };
-
-      await eventRepository.push(event);
-
-      // then
-      const events = await knex('certification_events').select();
-      sinon.assert.match(events, [
-        {
-          id: sinon.match.number,
-          eventName: 'SomeEvent',
+    context('when FT isEventSourcingCertificationEnabled is true', function () {
+      it('persists the event in db', async function () {
+        await featureToggles.set('isEventSourcingCertificationEnabled', true);
+        await setImmediate();
+        const event = {
+          name: 'SomeEvent',
           candidateId: 123,
           createdAt: new Date('2021-01-01T00:00:00Z'),
           metadata: { foo: 'bar' },
-        },
-      ]);
+        };
+
+        await eventRepository.push(event);
+
+        // then
+        const events = await knex('certification_events').select();
+        sinon.assert.match(events, [
+          {
+            id: sinon.match.number,
+            eventName: 'SomeEvent',
+            candidateId: 123,
+            createdAt: new Date('2021-01-01T00:00:00Z'),
+            metadata: { foo: 'bar' },
+          },
+        ]);
+      });
+    });
+
+    context('when FT isEventSourcingCertificationEnabled is false', function () {
+      it('does nothing', async function () {
+        await featureToggles.set('isEventSourcingCertificationEnabled', false);
+        await setImmediate();
+        const event = {
+          name: 'SomeEvent',
+          candidateId: 123,
+          createdAt: new Date('2021-01-01T00:00:00Z'),
+          metadata: { foo: 'bar' },
+        };
+
+        await eventRepository.push(event);
+
+        // then
+        const events = await knex('certification_events').select();
+        expect(events).to.have.length(0);
+      });
     });
   });
 });

--- a/api/tests/certification/shared/integration/infrastructure/repositories/event-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/event-repository_test.js
@@ -10,27 +10,39 @@ import { knex } from '../../../../../tooling/databases.js';
 describe('Certification | Shared | Integration | Repository | Event', function () {
   describe('#push', function () {
     context('when FT isEventSourcingCertificationEnabled is true', function () {
-      it('persists the event in db', async function () {
+      it('persists the events in db', async function () {
         await featureToggles.set('isEventSourcingCertificationEnabled', true);
         await setImmediate();
-        const event = {
-          name: 'SomeEvent',
+        const event1 = {
+          name: 'SomeEvent1',
           candidateId: 123,
           createdAt: new Date('2021-01-01T00:00:00Z'),
           metadata: { foo: 'bar' },
         };
+        const event2 = {
+          name: 'SomeEvent2',
+          candidateId: 456,
+          createdAt: new Date('2022-02-02T02:00:00Z'),
+          metadata: { list: ['h', 'e', 'y'] },
+        };
 
-        await eventRepository.push(event);
+        await eventRepository.push([event1, event2]);
 
-        // then
         const events = await knex('certification_events').select();
         sinon.assert.match(events, [
           {
             id: sinon.match.number,
-            eventName: 'SomeEvent',
+            eventName: 'SomeEvent1',
             candidateId: 123,
             createdAt: new Date('2021-01-01T00:00:00Z'),
             metadata: { foo: 'bar' },
+          },
+          {
+            id: sinon.match.number,
+            eventName: 'SomeEvent2',
+            candidateId: 456,
+            createdAt: new Date('2022-02-02T02:00:00Z'),
+            metadata: { list: ['h', 'e', 'y'] },
           },
         ]);
       });
@@ -40,16 +52,21 @@ describe('Certification | Shared | Integration | Repository | Event', function (
       it('does nothing', async function () {
         await featureToggles.set('isEventSourcingCertificationEnabled', false);
         await setImmediate();
-        const event = {
-          name: 'SomeEvent',
+        const event1 = {
+          name: 'SomeEvent1',
           candidateId: 123,
           createdAt: new Date('2021-01-01T00:00:00Z'),
           metadata: { foo: 'bar' },
         };
+        const event2 = {
+          name: 'SomeEvent2',
+          candidateId: 456,
+          createdAt: new Date('2022-02-02T02:00:00Z'),
+          metadata: { list: ['h', 'e', 'y'] },
+        };
 
-        await eventRepository.push(event);
+        await eventRepository.push([event1, event2]);
 
-        // then
         const events = await knex('certification_events').select();
         expect(events).to.have.length(0);
       });

--- a/api/tests/shared/integration/domain/DomainTransaction_test.js
+++ b/api/tests/shared/integration/domain/DomainTransaction_test.js
@@ -2,9 +2,9 @@ import sinon from 'sinon';
 
 import { DomainTransaction, withTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
 import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
-import { catchErr } from '../../../../tests/tooling/test-utils/error.js';
 import { expect } from '../../../test-helper.js';
 import { knex } from '../../../tooling/databases.js';
+import { catchErr } from '../../../tooling/test-utils/error.js';
 
 describe('Shared | Integration | Domain | DomainTransaction', function () {
   context('behaviour when nesting', function () {


### PR DESCRIPTION
## 💥 Problème

On aimerait explorer le concept d'event-sourcing, dans un premier temps pour alimenter correctement la timeline du candidat (concept d'aide à la compréhension du déroulé d'une certification à des fins de support / debuggage / curiosité).

## 👩‍🚀 Proposition

On commence par le premier événement qui marque le commencement d'un flux de certification : l'inscription du candidat en certification.

Event-sourcing activé sous `feature-toggle` `isEventSourcingCertificationEnabled` (par défaut à `false` en prod)
## 👁️ Remarques

Je propose de retirer l'intermédiaire qui consistait à poster d'abord un job dans PGBoss puis que ce job push l'event dans la table.
Je pense qu'actuellement le goulet d'étranglement en prod se situe au niveau de la BDD, donc je pense qu'il est préférable pour le moment de ne pas alourdir l'activité côté PG.
Le tout a été placé derrière une API interne, donc si on veut du changement c'est assez localisé

## ♻️ Pour tester
Activer le FT et faire de l'inscription de candidat (hors SCO), toute modalité (ajout individuel, ODS et création de sessions en masse)

Regarder dans la table `certification_events` ce qu'il s'y passe

ne pas oublier d'activer le toggle sur l'api en local : 
`npm run toggles -- -k isEventSourcingCertificationEnabled -v true`

Test fonctionnel fait sur : 
- inscription individuelle
- inscription ODS
- inscription SCO

