### PR TITLE
[TECH] :card_file_box:  Ajoute une table de stockage d'évènement de certification (PIX-22787)

### DIFF
--- a/api/db/migrations/20260519105810_create-certification-events-table.js
+++ b/api/db/migrations/20260519105810_create-certification-events-table.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'certification_events';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.string('eventName').comment('Name of the event');
+    table.integer('candidateId').index().notNullable().comment('Certification candidate ID');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now()).comment('Timestamp of the event');
+    table.jsonb('metadata').comment('metadata, if any, to add informations about event');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 💥 Problème

Nous construisons une timeline à partir des différentes dates stockées dans différentes tables. Ce n'est pas toujours très évident de comprendre la suite d'évènement d'une certification.


## 👩‍🚀 Proposition

Créer une table dans laquelle nous allons pouvoir enregistrer des évènements d'une certification au fur et à mesure qu'ils surviennent

## 👁️ Remarques

Il y a un doute (et une discussion en cours) à propos de cette table. Il est sans doute intéressant d'avoir une colonne `certificationCourseId`, mais c'est à confirmer.

Il y a un début de documentation à propos de ce que nous expérimentons : https://1024pix.atlassian.net/wiki/spaces/DC/pages/6074073102/Suite+d+v+nement+d+une+certification

## ♻️ Pour tester

La migration a bien créé la table sur la RA
