### PR TITLE
[TECH] Ajout de log pour les jobs et workers

### DIFF
--- a/api/src/shared/application/jobs/pgboss-states-monitoring.job-controller.js
+++ b/api/src/shared/application/jobs/pgboss-states-monitoring.job-controller.js
@@ -1,3 +1,5 @@
+import os from 'node:os';
+
 import { config } from '../../config.js';
 import { JobClient } from '../../infrastructure/jobs/JobClient.js';
 import { logger } from '../../infrastructure/utils/logger.js';
@@ -9,15 +11,22 @@ export class PgBossStatesMonitoringJobController extends JobScheduleController {
   }
 
   async handle({ dependencies = { logger } }) {
-    const stats = await JobClient.instance.getQueuesStats();
+    // log ops metrics for worker
+    const data = {
+      osload: os.loadavg(),
+      osmem: { total: os.totalmem(), free: os.freemem() },
+      osup: os.uptime(),
+      psup: process.uptime(),
+      psmem: process.memoryUsage(),
+      pscpu: process.cpuUsage(),
+    };
+    dependencies.logger.info({ type: 'WORKER_METRICS', tags: ['ops'], data }, 'PGBOSS WORKER METRICS');
 
+    // log all queues stats
+    const stats = await JobClient.instance.getQueuesStats();
     Object.keys(stats).forEach((queueName) => {
       dependencies.logger.info(
-        {
-          event: 'pg-boss-state',
-          name: queueName,
-          queue: stats[queueName],
-        },
+        { event: 'pg-boss-state', name: queueName, queue: stats[queueName] },
         'PGBOSS MONITOR-STATES',
       );
     });

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -479,6 +479,7 @@ const configuration = (function () {
       workerConnexionPoolMaxSize: _getNumber(process.env.PGBOSS_WORKER_CONNECTION_POOL_MAX_SIZE, 15),
       localConcurrency: _getNumber(process.env.PGBOSS_LOCAL_CONCURRENCY, 1),
       retentionSeconds: _getNumber(process.env.PGBOSS_RETENTION_SECONDS, 30 * 24 * 3600),
+      persistWarnings: toBoolean(process.env.PGBOSS_PERSIST_WARNINGS, false),
       statesMonitoringJobCron: process.env.PGBOSS_STATES_MONITORING_JOB_CRON || '* * * * *',
       validationFileJobEnabled: process.env.PGBOSS_VALIDATION_FILE_JOB_ENABLED
         ? toBoolean(process.env.PGBOSS_VALIDATION_FILE_JOB_ENABLED)

--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -180,6 +180,7 @@ export class JobClient {
 
   async send(name, payload, options) {
     this.#assertIsInitialized();
+    logger.info({ type: 'JOB_LOG', handlerName: name }, 'PGBOSS JOB CREATED');
     await this.#pgBoss.send(name, payload, options);
   }
 

--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -44,7 +44,12 @@ export class JobClient {
     if (worker) {
       this.#pgBoss = pgBossFactory
         ? pgBossFactory()
-        : new PgBoss({ connectionString, max: config.pgBoss.workerConnexionPoolMaxSize });
+        : new PgBoss({
+            connectionString,
+            max: config.pgBoss.workerConnexionPoolMaxSize,
+            persistWarnings: config.pgBoss.persistWarnings,
+            warningRetentionDays: 30,
+          });
 
       this.#pgBoss.on('error', (err) => {
         logger.error({ event: 'pg-boss-error', err }, 'PGBOSS ERROR');


### PR DESCRIPTION
**Problème**

On a pas de log quand un job est lancé et on a pas les métriques ops (cpu, mem...) des workers.

**Changement**

Ajout de log : 
- Log d'envoi d'un job dans le `JobClient.send`
- Log des métriques ops via le job `PgBossStatesMonitoringJob`
- Ajout du `persistWarnings` pour suivre les warnings dans le dashboard

**Tests**

Lancer le worker et un job.
> Voir les logs `PGBOSS WORKER METRICS` et `PGBOSS JOB CREATED`