### PR TITLE
[FEATURE] Suppression des onglets dans la page de résultats de campagne avec recommandation (PIX-22668).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -59,10 +59,6 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
     this.stagedMessageContentShowMoreEnabled = !this.stagedMessageContentShowMoreEnabled;
   }
 
-  @action handleSeeTrainingsClick() {
-    this.args.showTrainings();
-  }
-
   @action handleBackToHomepageDisplay() {
     this.pixMetrics.trackEvent(
       "Affichage du bouton 'Revenir à la page d'accueil dans le cadre du moteur de recommandation'",
@@ -129,21 +125,15 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
         {{/if}}
 
         <div class="evaluation-results-hero-recommendation-engine__actions">
-          {{#if @hasTrainings}}
-            <PixButton @triggerAction={{this.handleSeeTrainingsClick}} @size="medium" @variant="secondary">
-              {{t "pages.skill-review.hero.see-trainings"}}
-            </PixButton>
-          {{else}}
-            {{this.handleBackToHomepageDisplay}}
-            <PixButtonLink
-              @route="authentication.login"
-              @size="small"
-              @variant="secondary-white"
-              onclick={{this.handleBackToHomepageClick}}
-            >
-              {{t "pages.skill-review.actions.back-to-pix"}}
-            </PixButtonLink>
-          {{/if}}
+          {{this.handleBackToHomepageDisplay}}
+          <PixButtonLink
+            @route="authentication.login"
+            @size="small"
+            @variant="secondary-white"
+            onclick={{this.handleBackToHomepageClick}}
+          >
+            {{t "pages.skill-review.actions.back-to-pix"}}
+          </PixButtonLink>
         </div>
       </div>
     </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -1,4 +1,3 @@
-import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -11,7 +10,6 @@ import EvaluationResultsHeroRecommendationEngine from '../../../campaigns/assess
 
 export default class EvaluationResultsRecommendationEngine extends Component {
   @service media;
-  @service tabManager;
 
   get hasTrainings() {
     return Boolean(this.trainings.length);
@@ -23,19 +21,6 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     } else {
       return this.args.model.trainings;
     }
-  }
-
-  @action
-  showTrainings() {
-    const tabElement = document.querySelector('[role="tablist"]');
-    const tabElementTopPosition = tabElement.getBoundingClientRect().top;
-
-    window.scrollTo({
-      top: tabElementTopPosition,
-      behavior: 'smooth',
-    });
-
-    this.tabManager.setActiveTab(2);
   }
 
   get showBadges() {
@@ -60,8 +45,6 @@ export default class EvaluationResultsRecommendationEngine extends Component {
         @campaign={{@model.campaign}}
         @campaignParticipationResult={{@model.campaignParticipationResult}}
         @questResults={{@model.questResults}}
-        @hasTrainings={{this.hasTrainings}}
-        @showTrainings={{this.showTrainings}}
       />
 
       {{#if this.hasTrainings}}

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-import EvaluationResultsTabs from '../../../campaigns/assessment/results/evaluation-results-tabs';
+import Trainings from '../../../campaigns/assessment/results/evaluation-results-tabs/trainings';
 import QuitResults from '../../../campaigns/assessment/results/quit-results';
 import EvaluationResultsHeroRecommendationEngine from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
 
@@ -55,12 +55,15 @@ export default class EvaluationResultsRecommendationEngine extends Component {
         @hasTrainings={{this.hasTrainings}}
         @showTrainings={{this.showTrainings}}
       />
-      <EvaluationResultsTabs
-        @campaign={{@model.campaign}}
-        @campaignParticipationResult={{@model.campaignParticipationResult}}
-        @questResults={{@model.questResults}}
-        @trainings={{this.trainings}}
-      />
+
+      {{#if this.hasTrainings}}
+        <Trainings
+          @trainings={{this.trainings}}
+          @questResults={{@model.questResults}}
+          @campaignParticipationResult={{@model.campaignParticipationResult}}
+          @campaignId={{@model.campaign.id}}
+        />
+      {{/if}}
     </main>
   </template>
 }

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
+import ResultsDetails from '../../../campaigns/assessment/results/evaluation-results-tabs/results-details';
 import Trainings from '../../../campaigns/assessment/results/evaluation-results-tabs/trainings';
 import QuitResults from '../../../campaigns/assessment/results/quit-results';
 import EvaluationResultsHeroRecommendationEngine from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
@@ -64,6 +65,11 @@ export default class EvaluationResultsRecommendationEngine extends Component {
           @campaignId={{@model.campaign.id}}
         />
       {{/if}}
+
+      <ResultsDetails
+        @competenceResults={{@model.campaignParticipationResult.competenceResults}}
+        @totalStage={{@model.campaignParticipationResult.reachedStage.totalStage}}
+      />
     </main>
   </template>
 }

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import ResultsDetails from '../../../campaigns/assessment/results/evaluation-results-tabs/results-details';
+import Rewards from '../../../campaigns/assessment/results/evaluation-results-tabs/rewards';
 import Trainings from '../../../campaigns/assessment/results/evaluation-results-tabs/trainings';
 import QuitResults from '../../../campaigns/assessment/results/quit-results';
 import EvaluationResultsHeroRecommendationEngine from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
@@ -35,6 +36,12 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     });
 
     this.tabManager.setActiveTab(2);
+  }
+
+  get showBadges() {
+    const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
+
+    return badges.some((badge) => badge.isAcquired || badge.isAlwaysVisible);
   }
 
   <template>
@@ -70,6 +77,10 @@ export default class EvaluationResultsRecommendationEngine extends Component {
         @competenceResults={{@model.campaignParticipationResult.competenceResults}}
         @totalStage={{@model.campaignParticipationResult.reachedStage.totalStage}}
       />
+
+      {{#if this.showBadges}}
+        <Rewards @badges={{@model.campaignParticipationResult.campaignParticipationBadges}} />
+      {{/if}}
     </main>
   </template>
 }

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -1,0 +1,148 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import EvaluationResultsRecommendationEngine from 'mon-pix/components/routes/campaigns/assessment/evaluation-results-recommendation-engine';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module(
+  'Integration | Components | Campaigns | Assessment | Evaluation Results Recommendation Engine',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+    let store, campaign;
+
+    hooks.beforeEach(async function () {
+      // given
+      store = this.owner.lookup('service:store');
+
+      campaign = store.createRecord('campaign', {
+        title: 'Campagne avec recommendation de CF',
+      });
+    });
+
+    module('when campaign has trainings', function () {
+      test('should display trainings', async function (assert) {
+        // given
+        const training = store.createRecord('training', {
+          title: 'Super training',
+          duration: { days: 1, hours: 1, minutes: 1 },
+        });
+
+        const model = {
+          campaign,
+          campaignParticipationResult: {
+            campaignParticipationBadges: [Symbol('badges')],
+            competenceResults: [Symbol('competences')],
+            reload: () => {},
+          },
+          trainings: [training],
+        };
+
+        // when
+        const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByRole('heading', { name: t('pages.skill-review.tabs.trainings.title'), level: 2 }))
+          .exists();
+        assert.dom(screen.getByRole('heading', { name: 'Super training', level: 3 })).exists();
+      });
+    });
+
+    module('when campaign has no training', function () {
+      test('should display nothing', async function (assert) {
+        // given
+        const model = {
+          campaign,
+          campaignParticipationResult: {
+            campaignParticipationBadges: [Symbol('badges')],
+            competenceResults: [Symbol('competences')],
+            reload: () => {},
+          },
+          trainings: [],
+        };
+
+        // when
+        const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+
+        // then
+        assert
+          .dom(screen.queryByRole('heading', { name: t('pages.skill-review.tabs.trainings.title'), level: 2 }))
+          .doesNotExist();
+      });
+    });
+
+    test('should display results', async function (assert) {
+      // given
+      const model = {
+        campaign,
+        campaignParticipationResult: {
+          campaignParticipationBadges: [Symbol('badges')],
+          competenceResults: [Symbol('competences')],
+          reload: () => {},
+        },
+        trainings: [],
+      };
+
+      // when
+      const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+
+      // then
+      assert
+        .dom(screen.getByRole('heading', { name: t('pages.skill-review.tabs.results-details.title'), level: 2 }))
+        .exists();
+    });
+
+    module('when campaign has campaign participation badges', function () {
+      test('should display badges', async function (assert) {
+        // given
+        const acquiredBadge = store.createRecord('campaign-participation-badge', {
+          isAcquired: true,
+          altMessage: 'Badge alt text',
+          imageUrl: '/images/background/hexa-pix.svg',
+        });
+
+        const model = {
+          campaign,
+          campaignParticipationResult: {
+            campaignParticipationBadges: [acquiredBadge],
+            competenceResults: [Symbol('competences')],
+            reload: () => {},
+          },
+          trainings: [],
+        };
+
+        // when
+        const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByRole('heading', { name: t('pages.skill-review.tabs.rewards.title'), level: 2 }))
+          .exists();
+      });
+    });
+
+    module('when campaign has no campaign participation badge', function () {
+      test('should display nothing', async function (assert) {
+        // given
+        const model = {
+          campaign,
+          campaignParticipationResult: {
+            campaignParticipationBadges: [],
+            competenceResults: [Symbol('competences')],
+            reload: () => {},
+          },
+          trainings: [],
+        };
+
+        // when
+        const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+
+        // then
+        assert
+          .dom(screen.queryByRole('heading', { name: t('pages.skill-review.tabs.rewards.title'), level: 2 }))
+          .doesNotExist();
+      });
+    });
+  },
+);

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -343,58 +343,26 @@ module(
       });
     });
 
-    module('when campaign is a regular campaign', function () {
-      module('when there are trainings', function () {
-        test('it displays a see-trainings button', async function (assert) {
-          // given
-          stubCurrentUserService(this.owner, { firstName: 'Hermione' });
-          const campaign = { organizationId: 1 };
-          const campaignParticipationResult = { masteryRate: 0.75 };
+    test('it displays a back-to-homepage link', async function (assert) {
+      // given
+      stubCurrentUserService(this.owner, { firstName: 'Hermione' });
+      const campaign = { organizationId: 1, hasCustomResultPageButton: false };
+      const campaignParticipationResult = { masteryRate: 0.75 };
 
-          // when
-          const screen = await render(
-            <template>
-              <EvaluationResultsHeroRecommendationEngine
-                @campaign={{campaign}}
-                @campaignParticipationResult={{campaignParticipationResult}}
-                @hasTrainings={{true}}
-              />
-            </template>,
-          );
+      // when
+      const screen = await render(
+        <template>
+          <EvaluationResultsHeroRecommendationEngine
+            @campaign={{campaign}}
+            @campaignParticipationResult={{campaignParticipationResult}}
+            @hasTrainings={{false}}
+          />
+        </template>,
+      );
 
-          // then
-          assert.dom(screen.getByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).exists();
-          assert.dom(screen.queryByRole('link', { name: t('navigation.back-to-homepage') })).doesNotExist();
-        });
-      });
-
-      module('when there are no trainings', function () {
-        module('when there is no custom result page button', function () {
-          test('it displays a back-to-homepage link', async function (assert) {
-            // given
-            stubCurrentUserService(this.owner, { firstName: 'Hermione' });
-            const campaign = { organizationId: 1, hasCustomResultPageButton: false };
-            const campaignParticipationResult = { masteryRate: 0.75 };
-
-            // when
-            const screen = await render(
-              <template>
-                <EvaluationResultsHeroRecommendationEngine
-                  @campaign={{campaign}}
-                  @campaignParticipationResult={{campaignParticipationResult}}
-                  @hasTrainings={{false}}
-                />
-              </template>,
-            );
-
-            // then
-            assert.dom(screen.getByRole('link', { name: t('pages.skill-review.actions.back-to-pix') })).exists();
-            assert
-              .dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') }))
-              .doesNotExist();
-          });
-        });
-      });
+      // then
+      assert.dom(screen.getByRole('link', { name: t('pages.skill-review.actions.back-to-pix') })).exists();
+      assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).doesNotExist();
     });
   },
 );


### PR DESCRIPTION
## 💥 Problème

Actuellement la nouvelle page de résultat de fin de campagne avec reco conserve les onglets pour les détails de résultat (on était partie de l'existant, la page classique de fin de campagne).

## 👩‍🚀 Proposition

Supprimer les onglets

## 👁️ Remarques

Je supprime également un bouton que l'on a également récupéré de la précédente page, qui permettait d'accéder aux formations sans cliquer sur les onglets. Dans notre nouvelle page, ce bouton n'est plus nécessaire

## ♻️ Pour tester
se connecter avec perfect-profile-user@example.net
Aller ici https://app-pr16156.review.pix.fr/campagnes/EVAL12345/evaluation/resultats pour voir la page sans les onglets

Se connecter avec dave-comp@example.net
Aller ici https://app-pr16156.review.pix.fr/campagnes/EDUMULTIP/evaluation/resultats pour voir la page avec les formations.