### PR TITLE
[TECH] Corriger la lenteur des tests unitaires

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -77,7 +77,7 @@
     "test:api": "for testType in 'unit' 'integration' 'acceptance'; do npm run test:api:$testType || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test node --env-file-if-exists=.env ./node_modules/mocha/bin/mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot} --retries=${MOCHA_RETRIES:-0} --timeout=5000",
     "test:api:scripts": "npm run test:api:path -- tests/integration/scripts",
-    "test:api:unit": "TEST_DATABASE_URL=postgres://should.not.reach.db.in.unit.tests TEST_REDIS_URL= npm run test:api:path -- 'tests/**/unit/**/*test.js'",
+    "test:api:unit": "TEST_DATABASE_URL=postgres://should.not.reach.db.in.unit.tests TEST_REDIS_URL= TEST_JOBS_DATABASE_URL=postgres://should.not.reach.db.in.unit.tests npm run test:api:path -- 'tests/**/unit/**/*test.js'",
     "test:api:integration": "npm run test:api:path -- 'tests/**/integration/**/*test.js'",
     "test:api:acceptance": "npm run test:api:path -- 'tests/**/acceptance/**/*test.js'",
     "test:api:debug": "NODE_ENV=test node --env-file-if-exists=.env ./node_modules/mocha/bin/mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",


### PR DESCRIPTION
## 💥 Problème

https://github.com/user-attachments/assets/5756ef18-d714-412c-82b0-f58c13c0fed2

Les tests unitaires prenaient beaucoup trop de temps

## 👩‍🚀 Proposition

Ajouter `TEST_JOBS_DATABASE_URL=postgres://should.not.reach.db.in.unit.tests` dans le script `test:api:unit`, comme c'est déjà fait pour `TEST_DATABASE_URL` et `TEST_REDIS_URL`

## ♻️ Pour tester

Lancer `npm run test:api:unit` et comparer le temps d'exécution avant/après.