### PR TITLE
[TECH] Corrige la configuration des tests ember sur orga

### DIFF
--- a/orga/package.json
+++ b/orga/package.json
@@ -35,10 +35,9 @@
     "preinstall": "npx check-engine",
     "dev": "vite",
     "start": "vite",
-    "test": "NODE_ENV=development vite build --mode development && ember exam --path dist --config-file ./testem.cjs",
+    "test": "ember exam --path dist --config-file ./testem.cjs",
     "test:ci": "vite build --mode test && ember exam --path dist --config-file ./testem.cjs --split=$CIRCLE_NODE_TOTAL --partition=$((1 + CIRCLE_NODE_INDEX))",
-    "test:lint": "npm test && npm run lint",
-    "test:ember": "vite build --mode development && ember exam --path dist"
+    "test:lint": "npm test && npm run lint"
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.27",

--- a/orga/vite.config.mjs
+++ b/orga/vite.config.mjs
@@ -1,9 +1,19 @@
+import { fileURLToPath } from 'node:url';
+
 import { classicEmberSupport, ember, extensions } from '@embroider/vite';
 import { babel } from '@rollup/plugin-babel';
 import url from 'postcss-url';
 import sassEmbedded, { NodePackageImporter } from 'sass-embedded';
 import { defineConfig } from 'vite';
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@1024pix\/ember-testing-library$/,
+        replacement: fileURLToPath(import.meta.resolve('@1024pix/ember-testing-library/addon/index.js')),
+      },
+    ],
+  },
   build: {
     sourcemap: true,
   },
@@ -47,6 +57,9 @@ export default defineConfig({
   esbuild: {
     sourcemap: true,
     sourcesContent: true,
+  },
+  optimizeDeps: {
+    exclude: ['ember-exam'],
   },
   test: {
     sourcemap: true,


### PR DESCRIPTION
## 💥 Problème

Certains tests sont en erreur suite au passage sous vite, dans le navigateur ou depuis le cli

## 👩‍🚀 Proposition
On corrige le configuration pour que tout fonctionne comme avabt

## 👁️ Remarques

J'ai utilise claude pour corriger la config

## ♻️ Pour tester
Lancer les tests en local via npm start 
puis aller sur http://localhost:4201/tests
et voir que tout fonctionne

Lancer la commande npm test
voir que tout fonctionne
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

