### PR TITLE
[FEATURE] Importer les traductions allemande et espagnole (PIX-22665-import-translations)

### DIFF
--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1,38 +1,38 @@
 {
   "api-error-messages": {
     "join-error": {
-      "r11": "Sie haben bereits ein Pix-Konto mit der E-Mail-Adresse'<br>'{ value }'<br><br>'Um fortzufahren, melden Sie sich bei diesem Konto an oder bitten Sie eine Lehrkraft um Hilfe.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Documentation - Code R11)",
-      "r12": "Sie haben bereits ein Pix-Konto, das mit dem Benutzernamen in der Form Vorname.Nachname gefolgt von 4 Ziffern verwendet wird:'<br>'{ value }'<br><br>'Um fortzufahren, loggen Sie sich in dieses Konto ein oder bitten Sie eine Lehrkraft um Hilfe.'<br><br>'(Für Lehrkräfte: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R12)",
-      "r13": "Sie haben bereits ein Pix-Konto über das ENT in einer anderen Schule.'<br><br>'Um fortzufahren, wenden Sie sich an eine Lehrkraft, die Ihnen mithilfe von Pix Orga Zugang zu diesem Konto verschaffen kann.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R13)",
-      "r31": "Sie haben bereits ein Pix-Konto mit der E-Mail-Adresse'<br>'{ value }'<br><br>' Um fortzufahren, melden Sie sich bei diesem Konto an oder bitten Sie eine Lehrkraft um Hilfe.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Documentation - Code R31)",
-      "r32": "Sie haben bereits ein Pix-Konto, das mit der ID in der Form Vorname.Nachname gefolgt von 4 Ziffern verwendet wird:'<br>'{ value }'<br><br>'Um fortzufahren, melden Sie sich bei diesem Konto an oder bitten Sie eine Lehrkraft um Hilfe.'<br><br>'(Für Lehrkräfte: siehe 'Problemlösungsset' in Pix Orga > Dokumentation - Code R32)",
-      "r33": "Sie haben bereits ein Pix-Konto über das ENT. Benutzen Sie es, um am Parcours teilzunehmen.",
-      "r70": "Es ist ein Fehler aufgetreten. Melden Sie sich ab und versuchen Sie es erneut.",
+      "r11": "Du hast bereits ein Pix-Konto mit der E-Mail-Adresse'<br>'{ value }'<br><br>'Um fortzufahren, melde dich bei diesem Konto an oder bitte eine Lehrkraft um Hilfe.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Documentation - Code R11)",
+      "r12": "Du hast bereits ein Pix-Konto, das mit dem Benutzernamen in der Form Vorname.Nachname gefolgt von 4 Ziffern verwendet wird:'<br>'{ value }'<br><br>'Um fortzufahren, logge dich in dieses Konto ein oder bitte eine Lehrkraft um Hilfe.'<br><br>'(Für Lehrkräfte: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R12)",
+      "r13": "Du hast bereits ein Pix-Konto über das ENT in einer anderen Schule.'<br><br>'Um fortzufahren, wende dich an eine Lehrkraft, die dir mithilfe von Pix Orga Zugang zu diesem Konto verschaffen kann.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R13)",
+      "r31": "Du hast bereits ein Pix-Konto mit der E-Mail-Adresse'<br>'{ value }'<br><br>' Um fortzufahren, melde dich bei diesem Konto an oder bitte eine Lehrkraft um Hilfe.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Documentation - Code R31)",
+      "r32": "Du hast bereits ein Pix-Konto, das mit der ID in der Form Vorname.Nachname gefolgt von 4 Ziffern verwendet wird:'<br>'{ value }'<br><br>'Um fortzufahren, melde dich bei diesem Konto an oder bitte eine Lehrkraft um Hilfe.'<br><br>'(Für Lehrkräfte: siehe 'Problemlösungsset' in Pix Orga > Dokumentation - Code R32)",
+      "r33": "Du hast bereits ein Pix-Konto über das ENT. Benutze es, um am Lernpfad teilzunehmen.",
+      "r70": "Es ist ein Fehler aufgetreten. Melde dich ab und versuche es erneut.",
       "r90": {
         "account-belonging-to-another-user": "Es scheint, dass ein Schüler dieses Konto bereits verwendet.",
         "details": {
           "code": "(unter Angabe des Codes R90)",
           "contact-support": {
-            "link-text": " wenden Sie sich an den Support",
+            "link-text": " Wende dich an den Support",
             "link-url": "https://support.pix.org/fr/support/tickets/new"
           },
-          "disconnect-user": "Melden Sie sich ansonsten ab und nehmen Sie von Ihrem Konto aus an der Kampagne teil.",
-          "if-account-belonging-to-user": "Wenn das Konto Ihnen gehört,"
+          "disconnect-user": "Melde dich ansonsten ab und nimm von deinem Konto aus an der Kampagne teil.",
+          "if-account-belonging-to-user": "Wenn das Konto dir gehört,"
         }
       }
     },
     "register-error": {
-      "s50": "Diese Kennung existiert bereits",
-      "s51": "Sie haben bereits ein Pix-Konto mit der E-Mail-Adresse'<br>'{ value }'<br><br>' Um fortzufahren, melden Sie sich bei diesem Konto an oder bitten Sie einen Lehrer um Hilfe.'<br><br>'(Für den Lehrer: siehe 'Troubleshooting Kit' in Pix Orga > Documentation - Code R51)",
-      "s52": "Sie haben bereits ein Pix-Konto, das mit der ID in der Form Vorname.Nachname gefolgt von 4 Ziffern verwendet wird:'<br>' { value }'<br><br>'Um fortzufahren, melden Sie sich bei diesem Konto an oder bitten Sie eine Lehrkraft um Hilfe.'<br><br>'(Für Lehrkräfte: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R52)",
-      "s53": "Sie besitzen bereits ein Pix-Konto über das ENT.'<br>'Verwenden Sie es, um sich dem Parcours anzuschließen.",
-      "s61": "Sie haben bereits ein Pix-Konto mit der E-Mail-Adresse'<br>'{ value }'<br><br>' Um fortzufahren, melden Sie sich bei diesem Konto an oder bitten Sie einen Lehrer um Hilfe.'<br><br>'(Für den Lehrer: siehe 'Troubleshooting Kit' in Pix Orga > Documentation - Code R61)",
-      "s62": "Sie haben bereits ein Pix-Konto, das mit der ID in der Form Vorname.Nachname gefolgt von 4 Ziffern verwendet wird:'<br>' { value }'<br><br>'Um fortzufahren, loggen Sie sich in dieses Konto ein oder bitten Sie eine Lehrkraft um Hilfe.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R62)",
-      "s63": "Sie haben bereits ein Pix-Konto über das ENT in einer anderen Schule.'<br><br>'Um fortzufahren, wenden Sie sich an eine Lehrkraft, die Ihnen mithilfe von Pix Orga Zugang zu diesem Konto verschaffen kann.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R63)"
+      "s50": "Dieser Nutzer existiert bereits",
+      "s51": "Du hast bereits ein Pix-Konto mit der E-Mail-Adresse'<br>'{ value }'<br><br>' Um fortzufahren, melde dich bei diesem Konto an oder bitte eine Lehrkraft um Hilfe.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Documentation - Code R51)",
+      "s52": "Du hast bereits ein Pix-Konto, das mit der ID in der Form Vorname.Nachname gefolgt von 4 Ziffern verwendet wird:'<br>' { value }'<br><br>'Um fortzufahren, melde dich bei diesem Konto an oder bitte eine Lehrkraft um Hilfe.'<br><br>'(Für Lehrkräfte: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R52)",
+      "s53": "Du besitzt bereits ein Pix-Konto über das ENT.'<br>'Verwende es, um dich dem Lernpfad anzuschließen.",
+      "s61": "Du hast bereits ein Pix-Konto mit der E-Mail-Adresse'<br>'{ value }'<br><br>' Um fortzufahren, melde dich bei diesem Konto an oder bitte eine Lehrkraft um Hilfe.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Documentation - Code R61)",
+      "s62": "Du hast bereits ein Pix-Konto, das mit der ID in der Form Vorname.Nachname gefolgt von 4 Ziffern verwendet wird:'<br>' { value }'<br><br>'Um fortzufahren, logge dich in dieses Konto ein oder bitte eine Lehrkraft um Hilfe.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R62)",
+      "s63": "Du hast bereits ein Pix-Konto über das ENT in einer anderen Schule.'<br><br>'Um fortzufahren, wende dich an eine Lehrkraft, die dir mithilfe von Pix Orga Zugang zu diesem Konto verschaffen kann.'<br><br>'(Für die Lehrkraft: siehe 'Troubleshooting Kit' in Pix Orga > Dokumentation - Code R63)"
     }
   },
   "application": {
-    "description": "Pix ist eine Online-Plattform zur Bewertung und Zertifizierung der digitalen Kompetenzen von französischsprachigen Bürgern (Schüler, Studenten, Schulabbrecher, Arbeitssuchende, Senioren)."
+    "description": "Pix ist eine Online-Plattform zur Bewertung und Zertifizierung der digitalen Kompetenzen von französischsprachigen Bürger:innen (Schüler:innen, Student:innenen, Schulabbrecher:innen, Arbeitssuchende, Senioren)."
   },
   "common": {
     "actions": {
@@ -43,34 +43,34 @@
       "continue": "Weiter",
       "download": "Download",
       "lets-go": "Los geht's!",
-      "login": "Sich bei Pix anmelden",
+      "login": "Dich bei Pix anmelden",
       "quit": "Verlassen",
-      "refresh-page": "Seite aktualisieren",
-      "send": "Senden Sie",
+      "refresh-page": "Aktualisieren",
+      "send": "Senden",
       "show-less": "Weniger anzeigen",
       "show-more": "Mehr anzeigen",
-      "sign-out": "Sich abmelden",
-      "stay": "Bleiben Sie",
+      "sign-out": "Abmelden",
+      "stay": "Bleiben",
       "validate": "Bestätigen"
     },
     "api-error-messages": {
-      "bad-request-error": "Die von Ihnen eingereichten Daten haben nicht das richtige Format.",
-      "gateway-timeout-error": "Der Dienst unterliegt einer Verlangsamung. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
-      "internal-server-error": "Es ist ein interner Fehler aufgetreten. Unsere Mitarbeiter sind dabei, das Problem zu beheben. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
+      "bad-request-error": "Die von dir eingereichten Daten haben nicht das richtige Format.",
+      "gateway-timeout-error": "Der Dienst unterliegt einer Verlangsamung. Bitte versuche es zu einem späteren Zeitpunkt erneut.",
+      "internal-server-error": "Es ist ein interner Fehler aufgetreten. Unsere Mitarbeiter:innen sind dabei, das Problem zu beheben. Bitte versuche es zu einem späteren Zeitpunkt erneut.",
       "login-unauthorized-error": "Die eingegebene E-Mail-Adresse oder der Benutzername und/oder das Passwort sind falsch.",
       "login-unauthorized-remaining-attempts-error": "Achtung: Du hast noch {remainingAttempts, plural, =0 {0 Versuche} =1 {1 Versuche} other {# Versuche}}, bevor dein Pix-Konto endgültig gesperrt wird.",
-      "login-unauthorized-remaining-attempts-with-user-name-error": "Achtung: Sie haben noch {remainingAttempts, plural, =0 {0 Versuche} =1 {1 Versuch} other {# Versuche}}, bevor Ihr Pix-Konto endgültig gesperrt wird.'<br>'Wenn Sie Ihr Passwort vergessen haben, '<strong>'wenden Sie sich an Ihren Lehrer'</strong>', um Ihr Passwort zurückzusetzen und/oder Ihren Benutzernamen wiederzuerlangen.",
-      "login-unauthorized-with-user-name-error": "Der eingegebene Benutzername und/oder das Passwort sind falsch.'<br>'Wenn Sie es vergessen haben, '<strong>'wenden Sie sich an Ihre Lehrkraft'</strong>', um Ihr Passwort zurückzusetzen und/oder Ihren Benutzernamen wiederzuerlangen.",
-      "login-unexpected-error": "Es kann keine Verbindung hergestellt werden. Bitte versuchen Sie es in Kürze erneut. Wenn das Problem weiterhin besteht, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'kontaktieren Sie uns über das Hilfecenter'</a>'.",
-      "login-user-blocked-error": "Ihr Konto ist gesperrt, weil Sie zu viele Anmeldeversuche unternommen haben. Um es zu entsperren, '<'a href=\"{url}\"'>'kontaktieren Sie uns'</a>'.",
-      "login-user-blocked-with-username-error": "Ihr Konto ist gesperrt, weil Sie zu viele Anmeldeversuche unternommen haben. Um es zu entsperren, '<strong>'wenden Sie sich bitte an Ihren Lehrer'</strong>'. Sollte dieser nicht erreichbar sein, '<'a href=\"{url}\"'>'kontaktieren Sie uns bitte'</a>'.",
-      "login-user-temporary-blocked-error": "Du hast zu viele Anmeldeversuche unternommen, dein Pix-Konto wird vorübergehend für {blockingDurationMinutes} Minuten gesperrt. Versuchen Sie es später noch einmal oder klicken Sie auf '<'a href=\"{url}\"'>'Passwort vergessen'</a>', um es zurückzusetzen.",
-      "login-user-temporary-blocked-with-username-error": "Sie haben zu viele Anmeldeversuche unternommen, Ihr Pix-Konto wird vorübergehend für {blockingDurationMinutes} Minuten gesperrt.'<br>'Wenn Sie Ihr Passwort vergessen haben, '<strong>'wenden Sie sich an Ihre Lehrkraft'</strong>', um Ihr Passwort zurückzusetzen und/oder Ihren Benutzernamen abzurufen."
+      "login-unauthorized-remaining-attempts-with-user-name-error": "Achtung: Du hast noch {remainingAttempts, plural, =0 {0 Versuche} =1 {1 Versuch} other {# Versuche}}, bevor dein Pix-Konto endgültig gesperrt wird.'<br>'Wenn du dein Passwort vergessen hast, '<strong>'wende dich an deine Lehrkraft'</strong>', um dein Passwort zurückzusetzen und/oder deinen Benutzernamen wiederzuerlangen.",
+      "login-unauthorized-with-user-name-error": "Der eingegebene Benutzername und/oder das Passwort sind falsch.'<br>'Wenn du es vergessen hast, '<strong>'wende dich an deine Lehrkraft'</strong>', um dein Passwort zurückzusetzen und/oder deinen Benutzernamen wiederzuerlangen.",
+      "login-unexpected-error": "Es kann keine Verbindung hergestellt werden. Bitte versuche es in Kürze erneut. Wenn das Problem weiterhin besteht, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'kontaktiere uns über das Hilfecenter'</a>'.",
+      "login-user-blocked-error": "Dein Konto ist gesperrt, weil du zu viele Anmeldeversuche unternommen hast. Um es zu entsperren, '<'a href=\"{url}\"'>'kontaktiere uns'</a>'.",
+      "login-user-blocked-with-username-error": "Dein Konto ist gesperrt, weil du zu viele Anmeldeversuche unternommen hast. Um es zu entsperren, '<strong>'wende dich bitte an deine Lehrkraft'</strong>'. Sollte dieser nicht erreichbar sein, '<'a href=\"{url}\"'>'kontaktiere uns bitte'</a>'.",
+      "login-user-temporary-blocked-error": "Du hast zu viele Anmeldeversuche unternommen, dein Pix-Konto wird vorübergehend für {blockingDurationMinutes} Minuten gesperrt. Versuche es später noch einmal oder klicke auf '<'a href=\"{url}\"'>'Passwort vergessen'</a>', um es zurückzusetzen.",
+      "login-user-temporary-blocked-with-username-error": "Du hast zu viele Anmeldeversuche unternommen, dein Pix-Konto wird vorübergehend für {blockingDurationMinutes} Minuten gesperrt.'<br>'Wenn du dein Passwort vergessen hast, '<strong>'wende dich an deine Lehrkraft'</strong>', um dein Passwort zurückzusetzen und/oder deinen Benutzernamen abzurufen."
     },
     "cgu": {
       "cgu": "Nutzungsbedingungen",
       "data-protection-policy": "Datenschutzrichtlinie",
-      "error": "Sie müssen den Nutzungsbedingungen von Pix und der Datenschutzrichtlinie zustimmen, um ein Konto zu erstellen.",
+      "error": "Du musst den Nutzungsbedingungen von Pix und der Datenschutzrichtlinie zustimmen, um ein Konto zu erstellen.",
       "label": "Ich akzeptiere die Nutzungsbedingungen und die Datenschutzrichtlinie von Pix",
       "message": "Ich akzeptiere die '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Nutzungsbedingungen'</a>' und die '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Datenschutzrichtlinie'</a>' von Pix",
       "read-message": "Lies die '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Nutzungsbedingungen'</a>' und die '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Datenschutzrichtlinie'</a>'."
@@ -88,44 +88,44 @@
       },
       "install-documentation-url": "https://cloud.pix.fr/s/g76RwDwsZmZPZZ6",
       "not-detected": {
-        "description": "Die Erweiterung ist möglicherweise nicht installiert oder aktiviert. Lesen Sie das folgende Dokument, um Ihre Zertifizierungssitzung fortzusetzen. Falls nötig, wenden Sie sich an die Aufsichtsperson.",
+        "description": "Die Erweiterung ist möglicherweise nicht installiert oder aktiviert. Lies das folgende Dokument, um deine Zertifizierungssitzung fortzusetzen. Falls nötig, wende dich an die Aufsichtsperson.",
         "link": "Zugang zur Dokumentation",
         "title": "Die Erweiterung Pix Companion<br />wird nicht erkannt"
       }
     },
     "data-protection-policy-information-banner": {
-      "title": "Unsere Datenschutzrichtlinie hat sich weiterentwickelt. Wir laden Sie ein, sie zur Kenntnis zu nehmen :",
+      "title": "Unsere Datenschutzrichtlinie hat sich geändert. Bitte nimm die Änderungen zur Kenntnis:",
       "url-label": "Datenschutzrichtlinie."
     },
     "display": {
       "percentage": "{value, number, ::percent}"
     },
-    "error": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es noch einmal oder wenden Sie sich an den Support.",
+    "error": "Es ist ein Fehler aufgetreten. Bitte versuche es noch einmal oder wende dich an den Support.",
     "form": {
       "error": "Fehler",
-      "invisible-password": "das Passwort verbergen",
+      "invisible-password": "Passwort verbergen",
       "mandatory": "obligatorisch",
       "mandatory-all-fields": "Alle Felder sind Pflichtfelder.",
       "mandatory-fields": "Felder, die mit '<abbr title=\"obligatorisch\" class=\"mandatory-mark\">'*'</abbr>' markiert sind, müssen ausgefüllt werden.",
       "success": "richtig",
       "visible-password": "Passwort anzeigen"
     },
-    "french-education-ministry": "Ministerium für Bildung und Jugend. Freiheit Gleichheit Brüderlichkeit",
+    "french-education-ministry": "Ministerium für Bildung und Jugend. Liberté, Égalité, Fraternité",
     "languages": {
       "en": "Englisch",
       "fr": "Französisch",
       "nl": "Niederländisch"
     },
-    "level": "Ebene",
+    "level": "Level",
     "loading": {
       "default": "Ladevorgang läuft",
-      "results": "Vorbereitung Ihrer Ergebnisse",
-      "test": "Ihr Test wird gerade geladen"
+      "results": "Vorbereitung deiner Ergebnisse",
+      "test": "dein Test wird gerade geladen"
     },
     "new-information-banner": {
       "close-label": "Banner schließen"
     },
-    "no-level": "Keine Stufe",
+    "no-level": "Kein Level",
     "or": "oder",
     "pagination": {
       "action": {
@@ -146,7 +146,7 @@
     },
     "validation": {
       "password": {
-        "error": "Das eingegebene Passwort ist falsch. Ihr Passwort muss länger als 8 Zeichen sein und mindestens eine Zahl, einen Klein- und einen Großbuchstaben enthalten.",
+        "error": "Das eingegebene Passwort ist falsch. dein Passwort muss länger als 8 Zeichen sein und mindestens eine Zahl, einen Klein- und einen Großbuchstaben enthalten.",
         "rules": {
           "contains-digit": "eine Mindestzahl",
           "contains-lowercase": "eine minimale Kleinschreibung",
@@ -178,98 +178,98 @@
       "login-form": {
         "fields": {
           "login": {
-            "error": "Ihre E-Mail-Adresse oder Ihr Benutzername ist nicht ausgefüllt."
+            "error": "Deine E-Mail-Adresse oder dein Benutzername ist nicht ausgefüllt."
           },
           "password": {
-            "error": "Ihr Passwort ist nicht ausgefüllt."
+            "error": "dein Passwort ist nicht ausgefüllt."
           }
         }
       },
       "new-password-input": {
         "completed-message": "{ rulesCompleted } auf { rulesCount } abgeschlossen.",
-        "instructions-label": "Ihr Passwort muss den folgenden Regeln entsprechen:",
+        "instructions-label": "dein Passwort muss den folgenden Regeln entsprechen:",
         "label": "Passwort"
       },
       "oidc-provider-selector": {
         "label": "Nach einer Organisation suchen",
         "placeholder": "Eine Organisation auswählen",
-        "searchLabel": "Suche nach Schlüsselwörtern"
+        "searchLabel": "Suche nach Schlagwörtern"
       },
       "password-reset-demand-form": {
         "actions": {
           "receive-reset-button": "Einen Link zum Zurücksetzen erhalten"
         },
         "contact-us-link": {
-          "link-text": "Besuchen Sie das Hilfezentrum"
+          "link-text": "Besuche das Hilfezentrum"
         },
         "fields": {
           "email": {
-            "error-message-invalid": "Ihre E-Mail-Adresse ist ungültig.",
+            "error-message-invalid": "deine E-Mail-Adresse ist ungültig.",
             "label": "E-Mail-Adresse",
-            "placeholder": "z.B.: jean.dupont@email.com"
+            "placeholder": "z.B.: johannes.mayer@email.com"
           }
         },
-        "no-email-question": "Haben Sie Probleme, sich bei Pix anzumelden?",
+        "no-email-question": "Hast du Probleme, dich bei Pix anzumelden?",
         "rule": "Alle Felder sind Pflichtfelder."
       },
       "password-reset-demand-received-info": {
-        "heading": "Überprüfen Sie Ihre E-Mails",
-        "message": "Wenn Ihre Adresse tatsächlich mit einem Pix-Konto verknüpft ist, wurde Ihnen die Anleitung zum Zurücksetzen Ihres Passworts per E-Mail zugesandt.",
-        "no-email-received-question": "Sie haben keine E-Mail erhalten?",
-        "try-again": "Einen anderen Antrag stellen"
+        "heading": "Überprüfe deine E-Mails",
+        "message": "Wenn deine Adresse tatsächlich mit einem Pix-Konto verknüpft ist, wurde dir die Anleitung zum Zurücksetzen deines Passworts per E-Mail zugesandt.",
+        "no-email-received-question": "Du hast keine E-Mail erhalten?",
+        "try-again": "Eine andere Anfrage stellen"
       },
       "password-reset-form": {
         "actions": {
-          "login": "Ich logge mich ein",
+          "login": "Login",
           "submit": "Mein Passwort zurücksetzen"
         },
         "errors": {
-          "expired-demand": "Es tut uns leid, aber Ihr Antrag zum Zurücksetzen des Passworts wurde bereits verwendet oder ist abgelaufen. Bitte versuchen Sie es erneut.",
-          "forbidden": "Es ist ein Fehler aufgetreten, bitte wenden Sie sich an den Support."
+          "expired-demand": "Es tut uns leid, aber dein Antrag zum Zurücksetzen des Passworts wurde bereits verwendet oder ist abgelaufen. Bitte versuche es erneut.",
+          "forbidden": "Es ist ein Fehler aufgetreten, bitte wende dich an den Support."
         },
         "fields": {
           "password": {
-            "label": "Geben Sie Ihr neues Passwort ein"
+            "label": "Gib dein neues Passwort ein"
           }
         },
         "success-info": {
-          "message": "Ihr Passwort wurde erfolgreich zurückgesetzt."
+          "message": "dein Passwort wurde erfolgreich zurückgesetzt."
         }
       },
       "signup-form": {
         "actions": {
-          "submit": "Ich melde mich an"
+          "submit": "Anmelden"
         },
         "errors": {
           "invalid-or-already-used-email": "Ungültige oder bereits verwendete E-Mail-Adresse"
         },
         "fields": {
           "email": {
-            "error": "Ihre E-Mail-Adresse ist ungültig.",
+            "error": "deine E-Mail-Adresse ist ungültig.",
             "label": "E-Mail-Adresse",
-            "placeholder": "z.B.: jean.dupont@email.com"
+            "placeholder": "z.B.: johannes.mayer@email.com"
           },
           "firstname": {
-            "error": "Ihr Vorname ist nicht ausgefüllt.",
+            "error": "dein Vorname ist nicht ausgefüllt.",
             "label": "Vorname",
             "placeholder": "z.B. Johannes"
           },
           "lastname": {
-            "error": "Ihr Name ist nicht ausgefüllt.",
-            "label": "Name",
-            "placeholder": "z.B.: Dupont"
+            "error": "dein Nachname ist nicht ausgefüllt.",
+            "label": "Nachname",
+            "placeholder": "z.B.: Mayer"
           },
-          "legend": "Informationen für die Anmeldung erforderlich."
+          "legend": "Informationen erforderlich für die Anmeldung."
         }
       },
       "sso-selection-form": {
-        "should-display-account-recovery-banner": "Studentin oder Student? Falls noch nicht geschehen, '<'a href=\"{url}\"'>'rufen Sie die Seite auf, um Ihr Pix'</a>-Konto abzuholen' und behalten Sie Ihren Fortschritt bei."
+        "should-display-account-recovery-banner": "Schülerin oder Schüler? Falls noch nicht geschehen, '<'a href=\"{url}\"'>'rufe die Seite auf, um dein Pix'</a>-Konto abzuholen' und behalte deinen Fortschritt bei."
       }
     },
     "campaigns": {
       "attestation-result": {
         "computing": "Bescheinigung in der Berechnung",
-        "computing-description": "Aufgrund eines technischen Problems können wir Sie nicht darüber informieren, ob Sie Ihr Zeugnis erhalten haben. Bitte loggen Sie sich morgen erneut in Pix, Abschnitt 'Mein Werdegang', ein, um Ihre Ergebnisse einzusehen. Wir entschuldigen uns für die entstandenen Unannehmlichkeiten.",
+        "computing-description": "Aufgrund eines technischen Problems können wir dich nicht darüber informieren, ob du dein Zeugnis erhalten hast. Bitte logge dich morgen erneut in Pix, Abschnitt 'Mein Werdegang', ein, um deine Ergebnisse einzusehen. Wir entschuldigen uns für die entstandenen Unannehmlichkeiten.",
         "not-obtained": "Attest nicht erhalten :",
         "obtained": "Erhaltene Bescheinigung",
         "title": {
@@ -292,23 +292,23 @@
         "steps": {
           "competences": "Berechnung der Punktzahl nach Kompetenzen",
           "rewards": "Vergabe von Auszeichnungen",
-          "trainings": "Identifikation nützlicher Schulungen"
+          "trainings": "Identifikation nützlicher Übungen"
         },
-        "subtitle": "Einen Moment, bitte! Ich mache so schnell wie möglich.",
-        "title": "Berechnung Ihres aktuellen Punktestands..."
+        "subtitle": "Einen Moment, bitte! Wir beeilen uns.",
+        "title": "Berechnung deines aktuellen Punktestands..."
       },
       "start-landing-page": {
         "steps": {
           "step1": {
-            "description": "Beantworten Sie Fragen, die an Ihr Niveau angepasst sind.",
-            "title": "Bewerten Sie sich selbst"
+            "description": "Beantworte Fragen, die an dein Niveau angepasst sind.",
+            "title": "Teste dich selbst"
           },
           "step2": {
-            "description": "Analysieren Sie Ihre Stärken und Verbesserungsmöglichkeiten",
-            "title": "Entdecken Sie Ihre Punktzahl"
+            "description": "Analysiere deine Stärken und Verbesserungsmöglichkeiten",
+            "title": "Entdecke deine Punktzahl"
           },
           "step3": {
-            "description": "Zugang zu Schulungen, die auf Ihre Ergebnisse zugeschnitten sind",
+            "description": "Zugang zu Übungen, die auf deine Ergebnisse zugeschnitten sind",
             "title": "Fortschritt"
           }
         }
@@ -317,35 +317,35 @@
     "invited": {
       "reconciliation": {
         "error-message": {
-          "date-field": "Bitte verwenden Sie das Format tt/mm/jjjj für die Eingabe des Feldes {fieldName}.",
-          "invalid-reconciliation-error": "Überprüfen Sie Ihre Angaben ({fields}) oder wenden Sie sich an eine Lehrkraft.",
-          "mandatory-field": "Bitte füllen Sie das Feld {fieldName} aus"
+          "date-field": "Bitte verwende das Format tt/mm/jjjj für die Eingabe des Feldes {fieldName}.",
+          "invalid-reconciliation-error": "Überprüfe deine Angaben ({fields}) oder wende dich an eine Lehrkraft.",
+          "mandatory-field": "Bitte fülle das Feld {fieldName} aus"
         },
         "field": {
           "birthdate": "Geburtsdatum",
           "firstname": "Vorname",
-          "lastname": "Name",
+          "lastname": "Nachname",
           "sub-label": {
             "date": "Im Format (tt/mm/jjjj), z. B.: {dateFormat}"
           }
         },
-        "title": "Treten Sie der Organisation { organizationName } bei"
+        "title": "Tritt der Organisation { organizationName } bei"
       }
     },
     "locale-switcher": {
-      "label": "Wählen Sie eine Sprache"
+      "label": "Wähle eine Sprache"
     }
   },
   "navigation": {
     "back-to-homepage": "Zurück zur Startseite",
-    "back-to-profile": "Zurück zu den Fähigkeiten",
+    "back-to-profile": "Zurück zu den Kompetenzen",
     "copyrights": "©",
     "error": "Fehler",
     "external-link-title": "In einem neuen Fenster öffnen",
     "footer": {
       "a11y": "Barrierefreiheit: teilweise erfüllt",
       "data-protection-policy": "Datenschutzrichtlinie",
-      "eula": "Allgemeine Nutzungsbedingungen",
+      "eula": "Allgemeine Nutzungsbedingungen (AGBs)",
       "help-center": "Hilfezentrum",
       "label": "Fußnotenmenü",
       "legal-notice": "Rechtliche Hinweise",
@@ -364,7 +364,7 @@
       "link-help": "https://pix.fr/support",
       "skills": "Kompetenzen",
       "start-certification": "Zertifizierung",
-      "trainings": "Meine Schulungen",
+      "trainings": "Meine Übungen",
       "tutorials": "Meine Tutorials"
     },
     "mobile-button-title": "Menü öffnen",
@@ -374,7 +374,7 @@
       "open": "Navigation öffnen"
     },
     "not-logged": {
-      "sign-in": "Sich anmelden",
+      "sign-in": "Anmelden",
       "sign-up": "Anmelden"
     },
     "pix": "Pix",
@@ -382,8 +382,8 @@
     "user": {
       "account": "Mein Konto",
       "certifications": "Meine Zertifizierungen",
-      "sign-out": "Sich abmelden",
-      "tests": "Meine Wege"
+      "sign-out": "Abmelden",
+      "tests": "Meine Pfade"
     },
     "user-logged-menu": {
       "details": "Meine Informationen abrufen"
@@ -394,7 +394,7 @@
       "errors": {
         "account-exists": "Es existiert bereits ein Konto mit dieser E-Mail-Adresse.",
         "key-expired": "Der Wiederherstellungslink ist abgelaufen,",
-        "key-expired-renew-demand-link": "erneuern Sie Ihren Antrag hier.",
+        "key-expired-renew-demand-link": "erneuere deine Anfrage hier.",
         "key-invalid": "Der Link zur Wiederherstellung existiert nicht.",
         "key-used": "Dieses Konto wurde bereits abgerufen.",
         "title": "Ups, ein Fehler ist aufgetreten!"
@@ -402,69 +402,69 @@
       "find-sco-record": {
         "backup-email-confirmation": {
           "ask-for-new-email-message": "sonst liefere eine neue",
-          "email-already-exist-for-account-message": "Die unten angegebene E-Mail-Adresse ist bereits mit Ihrem Konto verknüpft :",
-          "email-is-needed-message": "{ firstName }, wir benötigen Ihre E-Mail-Adresse",
+          "email-already-exist-for-account-message": "Die unten angegebene E-Mail-Adresse ist bereits mit deinem Konto verknüpft :",
+          "email-is-needed-message": "{ firstName }, wir benötigen deine E-Mail-Adresse",
           "email-is-valid-message": "Ob sie gültig ist,",
-          "email-reset-message": "setzen Sie Ihr Passwort zurück",
-          "email-sent-to-choose-password-message": "Wir schicken Ihnen eine E-Mail, damit Sie ein Passwort wählen können.",
+          "email-reset-message": "setze dein Passwort zurück",
+          "email-sent-to-choose-password-message": "Wir schicken dir eine E-Mail, damit du ein Passwort wählen kannst.",
           "form": {
             "actions": {
               "cancel": "Abbrechen",
-              "submit": "Es geht los"
+              "submit": "Absenden"
             },
-            "email": "Ihre E-Mail-Adresse",
+            "email": "deine E-Mail-Adresse",
             "error": {
               "email-already-exist": {
-                "existing-email": "Sie besitzen diese E-Mail-Adresse bereits. Falls sie gültig ist,",
-                "init-password": " setzen Sie Ihr Passwort zurück",
-                "new-email": "Andernfalls geben Sie eine neue ein."
+                "existing-email": "Unter dieser E-Mail-Adresse existiert bereits ein Konto. Falls sie gültig ist,",
+                "init-password": " Setze dein Passwort zurück",
+                "new-email": "Andernfalls gib eine neue ein."
               },
               "empty-email": "Das Feld E-Mail-Adresse ist ein Pflichtfeld.",
               "invalid-or-already-used-email": "Ungültige oder bereits verwendete E-Mail-Adresse",
-              "new-backup-email": "Bitte geben Sie eine gültige E-Mail-Adresse ein, um Ihr Konto abzurufen",
+              "new-backup-email": "Bitte gib eine gültige E-Mail-Adresse ein, um dein Konto abzurufen",
               "new-email-already-exist": "Diese E-Mail-Adresse wird bereits verwendet",
-              "wrong-email-format": "Ihre E-Mail-Adresse ist ungültig."
+              "wrong-email-format": "deine E-Mail-Adresse ist ungültig."
             }
           }
         },
         "confirmation-step": {
           "buttons": {
             "cancel": "Abbrechen",
-            "confirm": "Ich bestätige"
+            "confirm": "Bestätigen"
           },
           "certify-account": "Ich bestätige ehrenwörtlich, dass das mit diesen Daten verknüpfte Konto mir gehört.",
-          "contact-support": "Wenn Sie einen Fehler feststellen oder wenn diese Daten nicht von Ihnen stammen,",
+          "contact-support": "Wenn du einen Fehler feststellst oder wenn diese Daten nicht von dir stammen,",
           "fields": {
-            "first-name": "Ihr Vorname",
-            "last-name": "Ihr Name",
-            "latest-organization-name": "Ihre letzte Einrichtung",
-            "username": "Ihr Benutzername"
+            "first-name": "dein Vorname",
+            "last-name": "dein Nachname",
+            "latest-organization-name": "deine letzte Einrichtung",
+            "username": "dein Benutzername"
           },
-          "found-account": "Wir haben Ihr Konto gefunden :",
+          "found-account": "Wir haben dein Konto gefunden :",
           "good-news": "Gute Nachrichten { firstName }!"
         },
         "conflict": {
-          "found-you-but": "{ firstName }, wir haben Sie gefunden, aber ...",
+          "found-you-but": "{ firstName }, wir haben dich gefunden, aber ...",
           "title": "Konflikt",
-          "warning": "Vorsichtshalber müssen wir Ihre Daten gemeinsam überprüfen."
+          "warning": "Vorsichtshalber müssen wir deine Daten gemeinsam überprüfen."
         },
         "contact-support": {
-          "link-text": "wenden Sie sich an den Support.",
+          "link-text": "Wende dich an den Support.",
           "link-url": "https://pix.fr/support/form/aide-recuperer-mon-compte"
         },
         "send-email-confirmation": {
-          "check-spam": "Wenn Sie diese E-Mail nicht sehen, überprüfen Sie Ihren Spam-Ordner.",
+          "check-spam": "Wenn du diese E-Mail nicht siehst, überprüfe deinen Spam-Ordner.",
           "return": "Zurück zu Pix",
-          "send-email": "Wir haben Ihnen soeben eine E-Mail geschickt, in der Sie ein Passwort wählen können. Sie können ab sofort Ihre E-Mails abrufen.",
-          "title": "Wiederherstellen Ihres Pix-Kontos"
+          "send-email": "Wir haben dir soeben eine E-Mail geschickt, in der du ein Passwort setzen kannst. Du kannst ab sofort deine E-Mails abrufen.",
+          "title": "Wiederherstellen deines Pix-Kontos"
         },
         "student-information": {
           "errors": {
             "empty-first-name": "Das Feld Vorname ist ein Pflichtfeld.",
             "empty-ine-ina": "Das INE-Feld ist ein Pflichtfeld.",
-            "empty-last-name": "Das Namensfeld ist obligatorisch.",
+            "empty-last-name": "Das Feld Nachname ist ein Pflichtfeld.",
             "invalid-ine-ina-format": "Das INE-Feld hat nicht das richtige Format.",
-            "not-found": "Pix erkennt Ihre Daten nicht. Überprüfen Sie, ob sie korrekt sind, sonst"
+            "not-found": "Pix erkennt deine Daten nicht. Überprüfe, ob sie korrekt sind, sonst"
           },
           "form": {
             "birthdate": "Geburtsdatum",
@@ -481,39 +481,39 @@
               "birth-month": "MM",
               "birth-year": "AAAA"
             },
-            "submit": "Finden Sie mich!",
-            "tooltip": "<strong>Wo finde ich meine INE?</strong> <p>Diese Kennung finden Sie meist auf dem Schulzeugnis, ansonsten kann Ihre alte Schule sie Ihnen zur Verfügung stellen.</p>."
+            "submit": "Finde mich!",
+            "tooltip": "<strong>Wo finde ich meine INE?</strong> <p> Deine INE findest du meist auf dem Schulzeugnis, ansonsten kann deine alte Schule sie dir zur Verfügung stellen.</p>."
           },
           "mandatory-all-fields": "Alle Felder sind Pflichtfelder.",
           "subtitle": {
-            "link": "setzen Sie Ihr Passwort hier zurück.",
-            "text": "Wenn Sie ein Konto mit einer gültigen E-Mail-Adresse haben,"
+            "link": "Setze dein Passwort hier zurück.",
+            "text": "Wenn du ein Konto mit einer gültigen E-Mail-Adresse hast,"
           },
-          "title": "Sie haben das Schulsystem verlassen und möchten Ihren Zugang zu Pix wiedererlangen."
+          "title": "Du hast das Schulsystem verlassen und möchtest deinen Zugang zu Pix wiedererlangen."
         },
         "title": "Mein Konto abrufen"
       },
       "support": {
         "recover": " um Unterstützung zu erhalten.",
         "url": "https://support.pix.org/fr/support/tickets/new",
-        "url-text": "Kontaktieren Sie den Support"
+        "url-text": "Kontaktiere den Support"
       },
       "update-sco-record": {
-        "fill-password": "Geben Sie ein Passwort ein und Pix gehört Ihnen!",
+        "fill-password": "Gib ein Passwort ein und Pix gehört dir!",
         "form": {
-          "authentication-methods-removal-notice": "Nach diesem Schritt können Sie sich nicht mehr mit { connections } anmelden.",
-          "choose-password": "Wählen Sie ein Passwort, um Pix weiterhin nutzen zu können.",
+          "authentication-methods-removal-notice": "Nach diesem Schritt kannst du dich nicht mehr mit { connections } anmelden.",
+          "choose-password": "Wähle ein Passwort, um Pix weiterhin nutzen zu können.",
           "email-label": "E-Mail-Adresse",
           "errors": {
             "empty-password": "Das Feld Passwort ist obligatorisch.",
-            "invalid-password": "Ihr Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben und eine Zahl enthalten."
+            "invalid-password": "dein Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben und eine Zahl enthalten."
           },
-          "login-button": "Ich logge mich ein",
-          "new-connection-info": "Keine Sorge, um sich wieder einzuloggen, müssen Sie von nun an nur noch Ihre E-Mail-Adresse und das hier festgelegte Passwort verwenden.",
+          "login-button": "Login",
+          "new-connection-info": "Keine Sorge, um dich wieder einzuloggen, musst du von nun an nur noch deine E-Mail-Adresse und das hier festgelegte Passwort verwenden.",
           "password-label": "Passwort",
           "sco-connections": {
             "gar": "das Medienzentrum",
-            "username": "Ihre Pix-Schul-ID"
+            "username": "deine Pix-Schul-ID"
           }
         },
         "welcome-message": "Willkommen zurück { firstName }!"
@@ -526,10 +526,10 @@
             "extra-information": "Verlassen der Prüfung und Rückkehr zur Startseite"
           }
         },
-        "content": "Alle Ihre Fortschritte werden aufgezeichnet. Sie können dort weitermachen, wo Sie aufgehört haben.",
-        "title": "Brauchen Sie eine Pause?"
+        "content": "Alle deine Fortschritte werden gespeichert. Du kannst dort weitermachen, wo du aufgehört hast.",
+        "title": "Brauchst du eine Pause?"
       },
-      "title": "Prüfung für die Bewertung :"
+      "title": "Prüfung der Bewertung :"
     },
     "assessment-results": {
       "actions": {
@@ -537,12 +537,12 @@
         "return-to-homepage": "Zurück zur Startseite"
       },
       "answers": {
-        "header": "Ihre Antworten"
+        "header": "deine Antworten"
       },
       "title": "Ende des Tests"
     },
     "attestations": {
-      "subtitle": "Greifen Sie auf alle Ihre Pix-Bescheinigungen zu und laden Sie sie herunter.",
+      "subtitle": "Greife auf alle deine Pix-Bescheinigungen zu und lade sie herunter.",
       "title": "Meine Bescheinigungen"
     },
     "authentication": {
@@ -551,35 +551,35 @@
       },
       "sso-selection": {
         "login": {
-          "button": "Ich logge mich ein",
-          "message": "Sie werden nun auf die Login-Seite von \"{providerName}\" weitergeleitet, um sich bei Pix anzumelden."
+          "button": "Einloggen",
+          "message": "Du wirst nun auf die Login-Seite von \"{providerName}\" weitergeleitet, um dich bei Pix anzumelden."
         },
         "signup": {
-          "button": "Ich melde mich an",
-          "link": "Melden Sie sich an",
-          "title": "Sie haben kein Konto?"
+          "button": "Anmelden",
+          "link": "Anmelden",
+          "title": "Du hast kein Konto?"
         },
-        "title": "Wählen Sie Ihre Organisation"
+        "title": "Wähle deine Organisation"
       }
     },
     "autonomous-course": {
       "landing-page": {
         "actions": {
-          "sign-in": "Ich habe bereits ein Konto, ich melde mich an",
+          "sign-in": "Ich habe bereits ein Konto",
           "start-anonymously": "Ich beginne ohne Pix-Konto",
-          "start-connected": "Ich beginne"
+          "start-connected": "Beginnen"
         },
         "texts": {
-          "first-course": "Ist dies Ihre erste Pix-Strecke?",
-          "legal-informations": "Mit oder ohne Pix-Konto werden Informationen über Ihren Fortschritt auf der Strecke an uns weitergeleitet.'<br>'Diese Informationen werden von Pix zur Verbesserung des Dienstes verwendet.",
-          "title": "Beginnen Sie den Parcours :"
+          "first-course": "Ist dies dein erster Pix-Pfad?",
+          "legal-informations": "Mit oder ohne Pix-Konto werden Informationen über deinen Fortschritt auf dem Pfad an uns weitergeleitet.'<br>'Diese Informationen werden von Pix zur Verbesserung des Dienstes verwendet.",
+          "title": "Beginne den Lernpfad :"
         }
       }
     },
     "campaign": {
       "errors": {
-        "existing-participation": "Der Parcours ist für Sie nicht zugänglich.",
-        "existing-participation-info": "Gehen Sie auf Ihren Lehrer zu, damit er Ihre Teilnahme an Pix Orga löscht.",
+        "existing-participation": "Der Lernpfad ist für dich nicht zugänglich.",
+        "existing-participation-info": "Gehe auf deine Lehrkraft zu, damit sie deine Teilnahme an Pix Orga löscht.",
         "existing-participation-user-info": "Es gibt bereits eine Beteiligung, die mit dem Namen {lastName} {firstName} verknüpft ist.",
         "no-longer-accessible": "Ups, die angeforderte Seite ist nicht mehr erreichbar.",
         "not-accessible": "Ups, die angeforderte Seite ist nicht zugänglich."
@@ -588,60 +588,60 @@
     "campaign-landing": {
       "assessment": {
         "action": "Ich beginne",
-        "announcement": "Registrieren Sie sich oder loggen Sie sich auf der Pix-Plattform ein und starten Sie Ihren Test.",
+        "announcement": "Registriere dich oder logge dich auf der Pix-Plattform ein und starte deinen Test.",
         "certify": {
-          "description": "Je nach Ihrer Situation und unter bestimmten Bedingungen können Sie Zugang zu der in der Berufswelt anerkannten Pix-Zertifizierung erhalten, mit der Sie Ihre digitalen Kompetenzen aufwerten können. Für weitere Informationen erkundigen Sie sich bitte bei dem Organisator des Bildungsgangs.",
-          "title": "Die in diesem Parcours validierten Antworten tragen dazu bei, Ihr persönliches Profil der digitalen Kompetenzen auf Pix zu erweitern."
+          "description": "Je nach deiner Situation und unter bestimmten Bedingungen kannst du Zugang zu der in der Berufswelt anerkannten Pix-Zertifizierung erhalten, mit der du deine digitalen Kompetenzen aufwerten kannst. Für weitere Informationen erkundige dich bitte bei dem Organisator des Bildungsgangs.",
+          "title": "Die in diesem Lernpfad validierten Antworten tragen dazu bei, dein persönliches Profil der digitalen Kompetenzen auf Pix zu erweitern."
         },
-        "details": "Während dieses Kurses haben Sie die Möglichkeit, :",
+        "details": "Während dieses Kurses hast du die Möglichkeit, :",
         "develop": {
-          "description": "Alle 5 Fragen visualisieren Sie die richtigen Antworten und erhalten Tipps und eine persönliche Empfehlung für Tutorials, um Ihre Fähigkeiten zu erweitern.",
-          "title": "Ihre Ergebnisse im Verlauf des Tests entdecken und Hinweise auf Fortschritte abrufen."
+          "description": "Nach jeweils 5 Fragen werden die richtigen und falschen Antworten angezeigt und du erhältst Tipps und eine persönliche Empfehlung für Tutorials, um deine Kompetenzen zu erweitern.",
+          "title": "deine Ergebnisse im Verlauf des Tests entdecken und Hinweise auf Fortschritte einsehen."
         },
         "evaluate": {
-          "description": "Sie werden im Internet recherchieren, Ihre digitale Arbeitsumgebung nutzen, Ihr Wissen testen usw.",
-          "title": "Messen Sie Ihre digitalen Kompetenzen mit spielerischen und lernenden Herausforderungen, die sich an Ihren Kenntnisstand anpassen (über einen adaptiven Algorithmus)."
+          "description": "Du wirst im Internet recherchieren, deine digitale Arbeitsumgebung nutzen, dein Wissen testen usw.",
+          "title": "Miss deine digitalen Kompetenzen mit spielerischen und lernenden Herausforderungen, die sich an deinen Kenntnisstand anpassen (über einen adaptiven Algorithmus)."
         },
-        "legal": "Wenn Sie auf \"Ich beginne\" klicken, werden die Informationen über Ihren Fortschritt auf der Strecke an den Organisator der Strecke weitergeleitet, damit er Sie begleiten kann. Am Ende des Parcours werden Ihre Ergebnisse automatisch an den Organisator weitergeleitet.",
-        "title": "Beginnen Sie Ihren Pix-Parcours",
-        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' bereit, Ihre digitalen Kompetenzen zu bewerten?"
+        "legal": "Wenn du auf \"Beginnen\" klickst, werden die Informationen über deinen Fortschritt auf dem Pfad an den Organisator der Pfade weitergeleitet, damit er dich begleiten kann. Am Ende des Lernpfads werden deine Ergebnisse automatisch an den Organisator weitergeleitet.",
+        "title": "Beginne deinen Pix-Lernpfad",
+        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' bereit, deine digitalen Kompetenzen zu bewerten?"
       },
       "profiles-collection": {
         "action": "Los geht's!",
-        "announcement": "Registrieren Sie sich oder loggen Sie sich auf der Pix-Plattform ein und senden Sie Ihr Profil an die Empfängerorganisation.",
-        "legal": "Die Informationen über Ihr PIX-Profil werden an den Organisator weitergeleitet, damit dieser Sie begleiten kann. Sie werden nur mit Ihrer Zustimmung weitergegeben.",
-        "title": "Senden Sie Ihr Profil",
-        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' senden Sie Ihr Profil"
+        "announcement": "Registrier dich oder logge dich auf der Pix-Plattform ein und sende dein Profil an die Empfängerorganisation.",
+        "legal": "Die Informationen über dein PIX-Profil werden an den Organisator weitergeleitet, damit dieser dich begleiten kann. Du wirst nur mit deiner Zustimmung weitergegeben.",
+        "title": "Sende dein Profil",
+        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' sende dein Profil"
       },
       "title": "Präsentation",
-      "warning-message": "Sie sind nicht { firstName } { lastName }?",
-      "warning-message-logout": "Sich abmelden"
+      "warning-message": "Du bist nicht { firstName } { lastName }?",
+      "warning-message-logout": "Abmelden"
     },
     "campaign-participation": {
-      "title": "Parcours"
+      "title": "Lernpfad"
     },
     "campaign-participation-overview": {
       "card": {
         "finished-at": "Beendet am {date}.",
         "results": "{result, number, ::percent} des Erfolgs",
         "resume": {
-          "extra-information": "Fortsetzen der Route {campaignTitle}.",
+          "extra-information": "Fortsetzen des Lernpfads {campaignTitle}.",
           "information": "Übernehmen"
         },
-        "retry": "Mich verbessern",
+        "retry": "Erneut versuchen",
         "see-more": "Details ansehen",
         "stages": "{count} { count, plural, =0 {Stern} =1 {Stern} other {Sterne} } auf {total}.",
         "started-at": "Begonnen am {date}.",
         "tag": {
-          "deleted": "Inaktiv",
-          "disabled": "Inaktiv",
+          "deleted": "Gelöscht",
+          "disabled": "Deaktiviert",
           "finished": "Abgeschlossen",
           "started": "In Arbeit"
         },
-        "text-deleted": "Strecke von Ihrer Organisation deaktiviert.'<br> 'Sie können nicht mehr auf diese Strecke einwirken.",
-        "text-disabled": "Parcours von Ihrer Organisation deaktiviert.'<br>'Sie können Ihre Ergebnisse nicht mehr versenden."
+        "text-deleted": "Pfad von deiner Organisation deaktiviert.'<br> 'Du kannst nicht mehr auf diesen Pfad einwirken.",
+        "text-disabled": "Pfad von deiner Organisation deaktiviert.'<br>'Du kannst deine Ergebnisse nicht mehr versenden."
       },
-      "title": "Parcours"
+      "title": "Pfad"
     },
     "certificate": {
       "actions": {
@@ -649,20 +649,20 @@
         "download-certificate": "Mein Zertifikat herunterladen"
       },
       "back-link": "Zurück zu meinen Zertifizierungen",
-      "candidate": "Bewerberin:",
+      "candidate": "Kandidat:in:",
       "candidate-birth": "Geboren am {birthdate}.",
       "candidate-birth-complete": "Geboren am {birthdate} in {birthplace}.",
       "certification-center": "Zertifizierungsstelle :",
-      "certification-date": "Datum der Passage :",
+      "certification-date": "Datum der Zertifizierung :",
       "certification-value": {
         "paragraphs": {
-          "1": "Die Pix-Zertifizierung ist offiziell anerkannt und belegt, dass Sie digitale Kompetenzen beherrschen. Sie schließen sich einer Gemeinschaft von mehreren Millionen zertifizierten Nutzern an. Herzlichen Glückwunsch zu diesem Meilenstein auf Ihrem Weg!",
-          "2": "Ihre zertifizierte Punktzahl wurde auf der Grundlage Ihrer Antworten während der Zertifizierung berechnet. Sie kann daher von der Anzahl der Pixel abweichen, die in Ihrem Profil angezeigt wird.",
-          "3": "Am Tag Ihrer Zertifizierung war es möglich, die Kompetenzstufe 7 und maximal 895 Pixel (Expertenstufe 1) zu erreichen."
+          "1": "Die Pix-Zertifizierung ist offiziell anerkannt und belegt, dass du digitale Kompetenzen beherrschst. Du schließt dich einer Gemeinschaft von mehreren Millionen zertifizierten Nutzern an. Herzlichen Glückwunsch zu diesem Meilenstein auf deinem Weg!",
+          "2": "Deine zertifizierte Punktzahl wurde auf der Grundlage deiner Antworten während der Zertifizierung berechnet. Sie kann daher von der Anzahl der Pixel abweichen, die in deinem Profil angezeigt wird.",
+          "3": "Am Tag deiner Zertifizierung war es möglich, die Kompetenzstufe 7 und maximal 895 Pixel (Expertenstufe 1) zu erreichen."
         }
       },
       "competences": {
-        "information": "Ihre zertifizierte Punktzahl wurde auf der Grundlage Ihrer Antworten während des Zertifizierungsprozesses berechnet. Sie kann daher von der Anzahl der Pix abweichen, die in Ihrem Profil angezeigt wird. Am Tag Ihrer Zertifizierung war es möglich, das {maxReachableLevelOnCertificationDate} Niveau der Fertigkeiten und {maxReachablePixCountOnCertificationDate} Pix maximal zu erreichen."
+        "information": "Deine zertifizierte Punktzahl wurde auf der Grundlage deiner Antworten während des Zertifizierungsprozesses berechnet. Sie kann daher von der Anzahl der Pix abweichen, die in deinem Profil angezeigt wird. Am Tag deiner Zertifizierung war es möglich, das {maxReachableLevelOnCertificationDate} Niveau der Kompetenzen und {maxReachablePixCountOnCertificationDate} Pix maximal zu erreichen."
       },
       "complementary": {
         "alternative": "Zusätzliche Zertifizierung",
@@ -673,11 +673,11 @@
       "delivered-at": "Datum der Ausstellung :",
       "details": {
         "competences": {
-          "description": "Ihr Pix-Score gibt eine Einschätzung Ihres Niveaus in den 16 numerischen Fertigkeiten.",
-          "title": "Ihr digitales Kompetenzprofil"
+          "description": "Dein Pix-Score gibt eine Einschätzung deines Niveaus in den 16 Kompetenzen.",
+          "title": "Dein digitales Kompetenzprofil"
         }
       },
-      "exam-date": "Datum der Passage :",
+      "exam-date": "Datum der Testung :",
       "framework-title": {
         "CLEA": "Pix-Zertifikat",
         "CORE": "Pix-Zertifikat",
@@ -689,31 +689,31 @@
       },
       "frameworks": {
         "EDU": {
-          "results-infos": "'<p>'Die Zertifizierung erfolgt in zwei Stufen:'</p><ol><li>'Pix-Prüfung: gerade abgeschlossen.'</li><li>'Mündliche Prüfung: außerhalb von Pix vor einer Jury organisiert.'</li></ol><p>'Am Ende der mündlichen Prüfung wird Ihr endgültiges Zertifizierungsniveau vergeben (Experte, Fortgeschritten usw.).'<br/>'Wenden Sie sich an Ihr Zertifizierungszentrum, um die mündliche Prüfung zu organisieren.'</p>'",
-          "results-sub-title": "Der Kandidat ist für die 2. Stufe der Pix+ Édu-Zertifizierung zugelassen!",
+          "results-infos": "'<p>'Die Zertifizierung erfolgt in zwei Stufen:'</p><ol><li>'Pix-Prüfung: gerade abgeschlossen.'</li><li>'Mündliche Prüfung: außerhalb von Pix vor einer Jury organisiert.'</li></ol><p>'Am Ende der mündlichen Prüfung wird dein endgültiges Zertifizierungsniveau vergeben (Expert:in, Fortgeschritten usw.).'<br/>'Wende dich an dein Zertifizierungszentrum, um die mündliche Prüfung zu organisieren.'</p>'",
+          "results-sub-title": "Der Kandidat/Die Kandidatin ist für die 2. Stufe der Pix+ Édu-Zertifizierung zugelassen!",
           "status": "Gültiges Zertifikat",
           "steps": {
             "1": "Pix-Teil",
             "2": "Berufspraktischer'<br/>'Teil",
             "3": "Endergebnis"
           },
-          "sub-title": "Der Kandidat ist für die 2. Stufe zugelassen!"
+          "sub-title": "Der Kandidat/Die Kandidatin ist für die 2. Stufe zugelassen!"
         }
       },
       "global": {
         "explanation": {
-          "default": "Sie haben die Stufe {globalLevelLabel} der Pix-Zertifizierung erreicht!",
-          "pre-beginner-level": "Sie haben Ihren Pix-Zertifizierungstest abgeschlossen, aber Ihre Ergebnisse reichen nicht für die erste Stufe aus."
+          "default": "Du hast die Stufe {globalLevelLabel} der Pix-Zertifizierung erreicht!",
+          "pre-beginner-level": "Du hast deinen Pix-Zertifizierungstest abgeschlossen, aber deine Ergebnisse reichen nicht für die erste Stufe aus."
         },
         "labels": {
-          "advanced": "Fortgeschrittene",
-          "beginner": "Novize",
-          "expert": "Experte",
+          "advanced": "Fortgeschritten",
+          "beginner": "Anfänger:in",
+          "expert": "Experte/Expertin",
           "independent": "Selbstständig",
-          "level": "Ihre Stufe"
+          "level": "Deine Stufe"
         },
         "progress-bar-explanation": {
-          "default": "Fortschrittsbalken, der Ihre erreichte Stufe ( {level}, oder Stufe {globalLevelLabel} ) auf einer maximal erreichbaren Stufe von 7 ( Stufe Expert 1 ) anzeigt.",
+          "default": "Fortschrittsbalken, der deine erreichte Stufe ( {level}, oder Stufe {globalLevelLabel} ) auf einer maximal erreichbaren Stufe von 7 ( Stufe Expert 1 ) anzeigt.",
           "pre-beginner-level": "Fortschrittsbalken, der die maximale Stufe anzeigt, die man in der Zertifizierung erreichen kann (entweder, 7 oder Expert 1 )"
         }
       },
@@ -721,41 +721,39 @@
         "certified": "zertifiziert"
       },
       "issued-on": "Ausgestellt am",
-      "jury-info": "Die Bemerkungen der Jury werden auf der Überprüfungsseite Ihres Zeugnisses nicht geteilt.",
+      "jury-info": "Die Bemerkungen der Jury werden auf der Überprüfungsseite deines Zeugnisses nicht geteilt.",
       "jury-title": "Bemerkungen der Jury",
       "learn-about-certification-results": "Wie sind die Ergebnisse zu interpretieren?",
-      "obtained-certification": "Der Kandidat hat das {frameworkLabel}-Zertifikat erhalten",
       "professionalizing-warning": "Das Pix-Zertifikat wird von France compétences ab einer Mindestpunktzahl von 120 Pix als berufsqualifizierend anerkannt.",
       "results": {
         "sub-title": "Der Kandidat ist für die Zertifizierung {framework} zugelassen.",
-        "title": "Ergebnis lesen:"
+        "title": "Ergebnis:"
       },
       "title": "Pix-Zertifikat",
-      "valid-status": "Gültiges Zertifikat",
       "verification-code": {
         "alt": "Kopieren",
         "copied": "Code kopiert!",
         "copy": "Code kopieren",
-        "information": "Ihr einmaliger Verifizierungscode",
-        "share": "Ihr Zertifikat teilen",
+        "information": "Dein einmaliger Verifizierungscode",
+        "share": "Dein Zertifikat teilen",
         "title": "Verifizierungscode",
-        "tooltip": "Geben Sie diesen Code weiter, damit Dritte die Echtheit Ihres Zertifikats überprüfen können."
+        "tooltip": "Gib diesen Code weiter, damit Dritte die Echtheit deines Zertifikats überprüfen können."
       }
     },
     "certification-ender": {
       "candidate": {
-        "disconnect": "Mein Konto abmelden",
-        "disconnect-tip": "Wenn dieser Computer nicht Ihr eigener ist, denken Sie daran, sich abzumelden.",
-        "ended-by-invigilator": "Ihre Aufsichtsperson hat Ihren Zertifizierungstest beendet. Sie können die Fragen nicht mehr weiter beantworten.",
-        "ended-due-to-finalization": "Die Sitzung wurde von Ihrer Zertifizierungsstelle abgeschlossen. Sie können nicht mehr weiter Fragen beantworten.",
-        "remote-certification": "Wenn Sie Ihre Pix-Zertifizierung aus der Ferne absolvieren, achten Sie darauf, dass Sie sich nach Abschluss Ihres Tests aus dem Überwachungstool ausloggen.",
+        "disconnect": "Abmelden",
+        "disconnect-tip": "Wenn dieser Computer nicht dein eigener ist, denke daran, dich abzumelden.",
+        "ended-by-invigilator": "Deine Aufsichtsperson hat deinen Zertifizierungstest beendet. Du kannst die Fragen nicht mehr weiter beantworten.",
+        "ended-due-to-finalization": "Die Testung wurde von deiner Zertifizierungsstelle abgeschlossen. Du kannst nicht mehr weiter Fragen beantworten.",
+        "remote-certification": "Wenn du deine Pix-Zertifizierung aus der Ferne absolvierst, achte darauf, dass du dich nach Abschluss deines Tests aus dem Überwachungstool ausloggst.",
         "title": "Test beendet!"
       },
       "results": {
-        "disclaimer": "Ihre Ergebnisse, die noch auf die Bestätigung durch die Pix-Teams warten, werden bald in Ihrem Pix-Konto verfügbar sein.",
-        "step-1": "Loggen Sie sich in Ihr Pix-Konto ein und finden Sie Ihre Ergebnisse in der Rubrik \"Meine Zertifizierungen\" (erreichbar durch Anklicken Ihres Vornamens oben rechts auf dem Bildschirm).",
-        "step-2": "Sie können Ihr Zertifikat herunterladen und weitergeben oder den Verifizierungscode, den Sie verwenden müssen, auf der Pix-Website mitteilen.",
-        "title": "Wie kann ich meine Zertifizierungsergebnisse einsehen und weitergeben?"
+        "disclaimer": "Deine Ergebnisse, die noch auf die Bestätigung durch die Pix-Teams warten, werden bald in deinem Pix-Konto verfügbar sein.",
+        "step-1": "Logge dich in deinem Pix-Konto ein und finde deine Ergebnisse in der Rubrik \"Meine Zertifizierungen\" (erreichbar durch Anklicken deines Vornamens oben rechts auf dem Bildschirm).",
+        "step-2": "Du kannst dein Zertifikat herunterladen und weiterleiten oder den Verifizierungscode, den du verwenden musst, auf der Pix-Website eingeben.",
+        "title": "Wie kann ich meine Zertifizierungsergebnisse einsehen und weiterleiten?"
       }
     },
     "certification-frameworks": {
@@ -773,7 +771,7 @@
           "aria-label": "Weiter zum nächsten Bildschirm",
           "label": "Weiter",
           "last-page": {
-            "aria-label": "Weiter zur Einstiegsseite für die Zertifizierung"
+            "aria-label": "Weiter zur Einstiegsseite der Zertifizierung"
           }
         },
         "previous": {
@@ -784,11 +782,11 @@
       "steps": {
         "1": {
           "paragraphs": {
-            "1": "Die {certificationName}-Zertifizierung ist ein '<strong>'adaptiver Test'</strong>', mit dem Ihr Niveau in allen '<strong>'16 digitalen Kompetenzen des Pix-Referenzrahmens'</strong>' bewertet werden kann.",
+            "1": "Die {certificationName}-Zertifizierung ist ein '<strong>'adaptiver Test'</strong>', mit dem dein Niveau in allen '<strong>'16 digitalen Kompetenzen des Pix-Referenzrahmens'</strong>' bewertet werden kann.",
             "2": "Der '<strong>'Schwierigkeitsgrad der Fragen passt sich in Echtzeit'</strong>' an die Antworten an.",
-            "3": "Wenn Ihnen einige Fragen schwierig erscheinen, liegt das daran, dass der Zertifizierungstest versucht, Ihr maximales Niveau zu messen. '<strong>'Wenn Sie eine Frage nicht beantworten können, haben Sie die Möglichkeit, sie zu \"überspringen\"'</strong>': Diese Frage wird im Laufe dieser Zertifizierung nicht noch einmal angeboten und wird nicht validiert.",
-            "4": "Um eine Punktzahl zu erreichen, die Ihren Fähigkeiten so nahe wie möglich kommt '<strong>'ist es notwendig, den Test zu Ende zu führen'</strong>'.",
-            "pix-plus-1": "Die Zertifizierung {certificationName} ist ein '<strong>'adaptiver Test'</strong>', der Ihr Niveau in '<strong>'allen Kompetenzen des Zertifizierungsrahmens {certificationName}'</strong>' bewertet."
+            "3": "Wenn dir einige Fragen schwierig erscheinen, liegt das daran, dass der Zertifizierungstest versucht, dein maximales Niveau zu messen. '<strong>'Wenn du eine Frage nicht beantworten kannst, hast du die Möglichkeit, sie zu \"überspringen\"'</strong>': Diese Frage wird im Laufe dieser Zertifizierung nicht noch einmal angeboten und wird nicht validiert.",
+            "4": "Um eine Punktzahl zu erreichen, die deinen Kompetenzen so nahe wie möglich kommt '<strong>'ist es notwendig, den Test zu Ende zu führen'</strong>'.",
+            "pix-plus-1": "Die Zertifizierung {certificationName} ist ein '<strong>'adaptiver Test'</strong>', der dein Niveau in '<strong>'allen Kompetenzen des Zertifizierungsrahmens {certificationName}'</strong>' bewertet."
           },
           "question": "Wie läuft der Test ab?",
           "title": "Willkommen bei der Zertifizierung {certificationName}."
@@ -799,9 +797,9 @@
           },
           "paragraphs": {
             "1": "Der Zertifizierungstest besteht aus '<strong>'32 Fragen'</strong>'.",
-            "2": "Sie haben maximal '<strong>'{duration}'</strong>' Zeit, um darauf zu antworten*.",
+            "2": "Du hast maximal '<strong>'{duration}'</strong>' Zeit, um darauf zu antworten*.",
             "3": "*ohne eventuelle Zeitzuschläge",
-            "4": "Wenn Sie '<strong>'weniger als 20 Fragen bearbeiten, können wir Ihnen keine Punktzahl ausstellen'</strong>'."
+            "4": "Wenn du '<strong>'weniger als 20 Fragen bearbeitest, können wir dir keine Punktzahl ausstellen'</strong>'."
           },
           "title": "Wie läuft der Zertifizierungstest ab?"
         },
@@ -812,11 +810,11 @@
           },
           "paragraphs": {
             "1": {
-              "text": "Bei Fragen im '<strong>'Freien Modus'</strong>', die mit einem grünen Symbol gekennzeichnet sind: Sie dürfen im Internet recherchieren und die zur Verfügung stehende digitale Umgebung nutzen.'<br>'Allerdings werden '<strong>'bestimmte Websites nicht in Zertifizierung zugänglich sein'</strong>'.",
+              "text": "Bei Fragen im '<strong>'Freien Modus'</strong>', die mit einem grünen Symbol gekennzeichnet sind: Du darfst im Internet recherchieren und die zur Verfügung stehende digitale Umgebung nutzen.'<br>'Allerdings werden '<strong>'bestimmte Websites nicht in Zertifizierung zugänglich sein'</strong>'.",
               "title": "Freier Modus :"
             },
             "2": {
-              "text": "Bei Fragen im '<strong>'Fokusmodus'</strong>', die durch ein gelbes Symbol gekennzeichnet sind: Es ist Ihnen nicht erlaubt, die Seite zu verlassen und zu recherchieren.",
+              "text": "Bei Fragen im '<strong>'Fokusmodus'</strong>', die durch ein gelbes Symbol gekennzeichnet sind: Es ist dir nicht erlaubt, die Seite zu verlassen und zu recherchieren.",
               "title": "Der Fokusmodus :"
             }
           },
@@ -824,23 +822,23 @@
         },
         "4": {
           "list": {
-            "1": "Gehen Sie unten auf der Seite",
-            "2": "Wählen Sie \"Ein Problem mit der Frage melden\".",
-            "3": "Klicken Sie auf \"Ja, ich bin mir sicher\".",
-            "4": "Rufen Sie die Aufsichtsperson an, die eingreift, um Ihnen zu helfen"
+            "1": "Gehe unten auf der Seite",
+            "2": "Wähle \"Ein Problem mit der Frage melden\".",
+            "3": "Klicke auf \"Ja, ich bin mir sicher\".",
+            "4": "Bitte die Aufsichtsperson um Hilfe"
           },
-          "text": "'<strong>'Bei technischen Problemen'</strong>' (z. B. das Bild weigert sich, angezeigt zu werden), führen Sie die folgenden Schritte aus:",
+          "text": "'<strong>'Bei technischen Problemen'</strong>' (z. B. das Bild wird nicht angezeigt), führe die folgenden Schritte aus:",
           "title": "Was tun, wenn ein Problem auftritt?"
         },
         "5": {
           "checkbox-label": "Indem ich dieses Kästchen ankreuze, bestätige ich, dass ich diese Regeln zur Kenntnis genommen habe und mich verpflichte, sie einzuhalten.",
           "list": {
             "1": "'<strong>'Mit einer anderen Person kommunizieren'</strong>', im Raum oder außerhalb, auf physischem oder elektronischem Weg.",
-            "2": "'<strong>'Ein Mobiltelefon oder ein anderes angeschlossenes elektronisches Gerät benutzen'</strong>' (außer dem Computer, auf dem Sie die Zertifizierung ablegen).",
-            "3": "'<strong>'Auf ein System mit künstlicher Intelligenz zurückgreifen'</strong>' oder einen Chatbot.",
-            "4": "'<strong>'Ein Selbsthilfeforum konsultieren'</strong>', das direkt die Antwort auf eine Frage liefert.",
+            "2": "'<strong>'Ein Mobiltelefon oder ein anderes angeschlossenes elektronisches Gerät benutzen'</strong>' (außer dem Computer, auf dem du die Zertifizierung ablegst).",
+            "3": "'<strong>'Auf ein System mit künstlicher Intelligenz zugreifen'</strong>' oder einen Chatbot.",
+            "4": "'<strong>'Ein Forum konsultieren'</strong>', das direkt die Antwort auf eine Frage liefert.",
             "5": "'<strong>'Jedes andere Mittel mobilisieren, das direkt die Antwort auf die Frage liefert '</strong>', ohne die von der Anweisung geforderte Arbeit geleistet zu haben.",
-            "6": "'<strong>'Einen anderen Browser verwenden'</strong>' als den, auf dem Sie Ihren Zertifizierungstest durchführen {certificationName}.",
+            "6": "'<strong>'Einen anderen Browser verwenden'</strong>' als den, auf dem du deinen Zertifizierungstest durchführst {certificationName}.",
             "7": "'<strong>'Identitätsdiebstahl'</strong>' einer anderen Person."
           },
           "pix-companion": "Der Zugriff auf bestimmte Websites wird im Rahmen des Zertifizierungstests durch eine im Browser installierte Erweiterung unterbunden. Ein nachgewiesener Betrug (Versuch, die Erweiterung zu umgehen oder Nichteinhaltung der oben aufgelisteten Verhaltensweisen) kann zur Ungültigkeit der Zertifizierung führen.",
@@ -849,38 +847,38 @@
         }
       },
       "title": "Erklärung der Zertifizierung",
-      "vocal-step-identifier": "Seite {pageId} auf {pageCount}."
+      "vocal-step-identifier": "Seite {pageId} von {pageCount}."
     },
     "certification-joiner": {
       "congratulation-banner": {
         "double-certification": {
-          "eligible": "Sie sind auch für die Zusatzqualifikation :",
-          "outdated": "<strong>Sie sind aufgrund der Weiterentwicklung nicht mehr für die Zertifizierung {doubleCertificationName} berechtigt.</strong><br />Wenden Sie sich an Ihre Schule oder die Organisation, die Ihnen den Parcours angeboten hat, um eine Kampagne zu wiederholen und damit wieder berechtigt zu sein. Ihr Fortschritt wurde beibehalten und Sie müssen nur die neuen Prüfungen spielen, das sollte schnell gehen."
+          "eligible": "Du bist auch für die Zusatzqualifikation geeignet  :",
+          "outdated": "<strong>Du bist aufgrund der Weiterentwicklung nicht mehr für die Zertifizierung {doubleCertificationName} berechtigt.</strong><br />Wende dich an deine Schule oder die Organisation, die dir den Lernpfad angeboten hat, um ihn zu wiederholen und damit wieder berechtigt zu sein. Dein Fortschritt wurde beibehalten und du musst nur die neuen Prüfungen ablegen, das sollte schnell gehen."
         },
         "link": {
           "text": "Wie kann man sich zertifizieren lassen?"
         },
-        "message": "Bravo {fullName}, Ihr Pix-Profil ist zertifizierbar."
+        "message": "Bravo {fullName}, dein Pix-Profil kann zertifiziert werden."
       },
       "error-messages": {
         "generic": {
-          "check-personal-info": "Überprüfen Sie bei der Aufsichtsperson, ob Ihre persönlichen Informationen mit dem Anmeldungsblatt übereinstimmen.",
-          "check-session-number": "Überprüfen Sie die Sitzungsnummer.",
-          "disclaimer": "Die eingegebenen Informationen stimmen mit keinem der für die Sitzung angemeldeten Bewerber überein."
+          "check-personal-info": "Überprüfe bei der Aufsichtsperson, ob deine persönlichen Informationen mit dem Anmeldungsblatt übereinstimmen.",
+          "check-session-number": "Überprüfe die Sitzungsnummer.",
+          "disclaimer": "Die eingegebenen Informationen stimmen mit keinen der für die Testung angemeldeten Bewerber:innen überein."
         },
-        "language-not-supported": "Die Pix-Zertifizierung ist derzeit nicht in {userLanguage} verfügbar. '<br>' Die derzeit verfügbaren Sprachen, um die Zertifizierung zu absolvieren, sind : {availableLanguages}. '<br>' Sie können eine andere Sprache von der Seite",
+        "language-not-supported": "Die Pix-Zertifizierung ist derzeit nicht in {userLanguage} verfügbar. '<br>' Die derzeit verfügbaren Sprachen, um die Zertifizierung zu absolvieren, sind : {availableLanguages}. '<br>' Du kannst eine andere Sprache von der Seite",
         "language-not-supported-link": "Mein Konto",
-        "missing-center-habilitation": "Sie können nicht an der Sitzung teilnehmen. Die Zertifizierungsstelle ist nicht berechtigt, Sie zu dieser Zertifizierung zuzulassen.",
-        "session-not-accessible": "Die Sitzung, an der Sie versuchen teilzunehmen, ist nicht mehr zugänglich.",
-        "wrong-account": "Die eingegebenen Informationen beziehen sich auf einen Kandidaten/eine Kandidatin, der/die sich für die Sitzung angemeldet hat und bereits mit einem anderen Konto angemeldet ist. Vergewissern Sie sich, dass Sie mit dem Konto verbunden sind, das die Zertifizierung gestartet hat.",
-        "wrong-account-sco": "Sie verwenden derzeit ein Konto, das nicht mit Ihrer Schule verknüpft ist.\nMelden Sie sich bei dem Konto an, mit dem Sie Ihre Laufwege absolviert haben, oder bitten Sie die Aufsichtsperson um Hilfe.",
+        "missing-center-habilitation": "Du kannst nicht an der Testung teilnehmen. Die Zertifizierungsstelle ist nicht berechtigt, dich zu dieser Zertifizierung zuzulassen.",
+        "session-not-accessible": "Die Testung, an der du versuchst teilzunehmen, ist nicht mehr zugänglich.",
+        "wrong-account": "Die eingegebenen Informationen beziehen sich auf einen Kandidaten/eine Kandidatin, der/die sich für die Testung angemeldet hat und bereits mit einem anderen Konto angemeldet ist. Vergewissere dich, dass du mit dem Konto verbunden bist, das die Zertifizierung gestartet hat.",
+        "wrong-account-sco": "Du verwendest derzeit ein Konto, das nicht mit deiner Organisation verknüpft ist.\nMelde dich bei dem Konto an, mit dem du deine Laufwege absolviert hast, oder bitte die Aufsichtsperson um Hilfe.",
         "wrong-account-sco-link": {
           "label": "Wie finde ich das mit der Einrichtung verknüpfte Konto?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
         },
-        "wrong-domain-for-pix-plus": "Da die Pix+ Zertifizierungen derzeit nur auf Französisch verfügbar sind, sind sie nicht auf https://pix.org verfügbar.<br/>Bitte loggen Sie sich aus und dann wieder ein über '<a href=\"https://app.pix.fr/connexion\">diesen Link.</a>'."
+        "wrong-domain-for-pix-plus": "Da die Pix+ Zertifizierungen derzeit nur auf Französisch verfügbar sind, sind sie nicht auf https://pix.org verfügbar.<br/>Bitte logge dich aus und dann wieder ein über '<a href=\"https://app.pix.fr/connexion\">diesen Link.</a>'."
       },
-      "first-title": "An einer Sitzung teilnehmen",
+      "first-title": "An einer Testung teilnehmen",
       "form": {
         "actions": {
           "submit": "Weiter"
@@ -893,7 +891,7 @@
           "birth-year": "Geburtsjahr (JJJJ)",
           "first-name": "Vorname",
           "session-number": "Sitzungsnummer",
-          "session-number-information": "Wird nur von der Aufsichtsperson zu Beginn der Sitzung mitgeteilt."
+          "session-number-information": "Wird nur von der Aufsichtsperson zu Beginn der Testung mitgeteilt."
         },
         "fields-validation": {
           "session-number-error": "Die Sitzungsnummer besteht nur aus Zahlen."
@@ -901,70 +899,62 @@
         "placeholders": {
           "birth-day": "JJ",
           "birth-month": "MM",
-          "birth-name": "z.B.: Dupont",
+          "birth-name": "z.B.: Mayer",
           "birth-year": "AAAA",
           "first-name": "z.B. Johannes",
           "session-number": "z.B.: 123456"
         }
       },
-      "title": "An einer Zertifizierungssitzung teilnehmen"
+      "title": "An einer Zertifizierungstestung teilnehmen"
     },
     "certification-not-certifiable": {
       "action": {
         "back": "Zurück zur Startseite"
       },
-      "text": "Um Ihr Profil zertifizieren zu lassen, müssen Sie in mindestens fünf Fertigkeiten eine Stufe über 0 erreicht haben.",
-      "title": "Ihr Profil ist noch nicht zertifizierbar."
+      "text": "Um dein Profil zertifizieren zu lassen, mustt du in mindestens fünf Kompetenzen eine Stufe über 0 erreicht haben.",
+      "title": "Dein Profil ist noch nicht zertifizierbar."
     },
     "certification-results": {
       "action": {
-        "confirm": "Ich bestätige",
-        "logout": "Sich abmelden"
+        "confirm": "Bestätigen",
+        "logout": "Abmelden"
       },
       "finished": {
-        "description": "Ihre Ergebnisse werden in Kürze über Ihr Konto abrufbar sein.",
-        "title": "Bravo, es ist vorbei!",
-        "warning-text": "Wenn dieser Computer nicht Ihr eigener ist, denken Sie daran, sich abzumelden."
+        "description": "Deine Ergebnisse werden in Kürze über dein Konto abrufbar sein.",
+        "title": "Bravo, du hast es geschafft!",
+        "warning-text": "Wenn dieser Computer nicht dein eigener ist, denke daran, dich abzumelden."
       },
       "flag-alt": "Flagge",
       "title": "Test abgeschlossen"
     },
     "certification-start": {
-      "access-code": "Zugangscode, der von der Aufsichtsperson mitgeteilt wird",
+      "access-code": "Zugangscode (von der Aufsichtsperson mitgeteilt)",
       "actions": {
         "submit": "Meinen Test beginnen"
       },
       "cgu": {
         "contact": {
           "email": "dpo@pix.fr",
-          "info": "Gemäß dem Gesetz \"Informatik und Freiheiten\" können Sie Ihr Recht auf Zugang zu den Sie betreffenden Daten ausüben und diese berichtigen lassen, indem Sie eine E-Mail senden an"
+          "info": "Gemäß dem Gesetz \"Informatik und Freiheiten\" kannst du dein Recht auf Zugang zu den dich betreffenden Daten ausüben und diese berichtigen lassen, indem du eine E-Mail sendest an"
         },
         "info": "Indem ich auf \"Meinen Test beginnen\" klicke, stimme ich zu, dass meine Identitätsdaten, die Zertifizierungsnummer und die Umstände der Prüfung, wie sie von der Aufsichtsperson ausgefüllt wurden, an Pix weitergegeben werden. Pix wird sie während der Beratung des Prüfungsausschusses verwenden, um meine Ergebnisse zu erstellen und zu archivieren und um mein Zertifikat auszugeben. Wenn mir diese Zertifizierung von einer Organisation vorgeschrieben wurde, bin ich damit einverstanden, dass Pix meine Ergebnisse an diese Organisation weiterleitet."
       },
-      "core-and-complementary-subscriptions": "Sie sind zusätzlich zur Pix-Zertifizierung für die folgende Zusatzqualifikation angemeldet:",
+      "core-and-complementary-subscriptions": "Du bist zusätzlich zur Pix-Zertifizierung für die folgende Zusatzqualifikation angemeldet:",
       "error-messages": {
         "access-code-error": "Dieser Code existiert nicht oder ist nicht mehr gültig.",
-        "candidate-not-authorized-to-resume": "Bitte wenden Sie sich an Ihre Aufsichtsperson, damit diese die Wiederaufnahme Ihres Tests genehmigt.",
-        "candidate-not-authorized-to-start": "Ihre Aufsichtsperson hat Ihre Anwesenheit im Testraum nicht bestätigt. Sie können daher noch nicht mit Ihrem Zertifizierungstest beginnen. Bitte informieren Sie Ihre Aufsichtsperson.",
-        "generic": "Ein unerwarteter Serverfehler ist gerade aufgetreten.",
-        "missing-code": "Ihr Zugangscode ist nicht ausgefüllt.",
+        "candidate-not-authorized-to-resume": "Bitte wende dich an deine Aufsichtsperson, damit diese die Wiederaufnahme deines Tests genehmigt.",
+        "candidate-not-authorized-to-start": "Deine Aufsichtsperson hat deine Anwesenheit im Testraum nicht bestätigt. Du kannst daher noch nicht mit deinem Zertifizierungstest beginnen. Bitte informiere deine Aufsichtsperson.",
+        "generic": "Ein unerwarteter Serverfehler ist aufgetreten.",
+        "missing-code": "Dein Zugangscode ist nicht ausgefüllt.",
         "session-not-accessible": "Die Zertifizierungssitzung ist nicht mehr zugänglich.",
         "unknown": {
           "summary-label": "Weitere Details anzeigen :"
         }
       },
-      "first-title": "Sie beginnen Ihren Zertifizierungstest",
-      "language-selector": {
-        "confirmation-label": "Ich bestätige, dass ich mit der ausgewählten Sprache für die Beantwortung der Fragen vertraut bin.'<br>'Die Sprachauswahl ist '<strong>'endgültig'</strong>'.",
-        "label": "Zertifizierungssprache",
-        "options": {
-          "english": "Englisch - EN",
-          "french": "Französisch - FR"
-        }
-      },
+      "first-title": "Zertifizierungstest beginnen",
       "link-to-user-certification": "Meine Zertifizierungen ansehen",
-      "non-eligible-subscription": "Sie sind nicht für {complementarySubscriptionLabel} qualifiziert. Sie können dennoch Ihre Pix-Zertifizierung ablegen.",
-      "title": "An einer Zertifizierungssitzung teilnehmen"
+      "non-eligible-subscription": "Du bist nicht für {complementarySubscriptionLabel} qualifiziert. Du aknnst dennoch deine Pix-Zertifizierung ablegen.",
+      "title": "An einer Zertifizierungstestung teilnehmen"
     },
     "certifications-list": {
       "buttons": {
@@ -973,18 +963,18 @@
         "download-certificate": "Zertifikat herunterladen"
       },
       "comment": "Kommentar :",
-      "description": "Greifen Sie auf alle Ihre Pix-Zertifizierungen zu. Sehen Sie sich die Details an und laden Sie Ihre Zertifikate herunter.",
+      "description": "Greife auf alle deine Pix-Zertifizierungen zu. Sieh dir die Details an und lade dein Zertifikate herunter.",
       "information": {
         "certification-center": "Zertifizierungsstelle :",
-        "date": "Datum der Passage :"
+        "date": "Datum der Zertifizierung :"
       },
       "no-certification": {
-        "text": "Sie haben noch keine Pix-Zertifizierung"
+        "text": "Du hast noch keine Pix-Zertifizierung"
       },
       "statuses": {
-        "cancelled": "Abgesagt",
+        "cancelled": "Abgebrochen",
         "not-published": "Warten auf das Ergebnis",
-        "rejected": "Nicht erlangt",
+        "rejected": "Abgelehnt",
         "validated": "Erhalten"
       },
       "title": "Meine Zertifizierungen"
@@ -992,14 +982,14 @@
     "challenge": {
       "actions": {
         "continue": "Weiter",
-        "continue-go-to-next": "Ich fahre fort und gehe zur nächsten Frage",
-        "skip": "Ich passe",
-        "skip-go-to-next": "Ich passe und gehe zur nächsten Frage",
-        "validate": "Ich bestätige",
-        "validate-go-to-next": "Ich bestätige und gehe zur nächsten Frage",
-        "wait-for-invigilator": "Aktionen werden pausiert, bis der Aufseher kommt"
+        "continue-go-to-next": "Fortsetzen und zur nächsten Frage",
+        "skip": "Überspringen",
+        "skip-go-to-next": "Überspringen und zur nächsten Frage",
+        "validate": "Bestätigen",
+        "validate-go-to-next": "Bestätigen und zur nächsten Frage",
+        "wait-for-invigilator": "Aktionen werden pausiert, bis die Aufsichtsperson kommt"
       },
-      "already-answered": "Sie haben diese Frage bereits beantwortet",
+      "already-answered": "Du hast diese Frage bereits beantwortet",
       "answer-input": {
         "numbered-label": "Antwort {number}"
       },
@@ -1011,19 +1001,19 @@
       },
       "certification-feedback-panel": {
         "actions": {
-          "no-send-feedback": "Nein, ich komme auf die Prüfung zurück",
+          "no-send-feedback": "Nein, ich will zur Prüfung zurück",
           "open-close": "Ein Problem mit der Frage melden",
           "send-feedback": "Ja, ich bin mir sicher"
         },
-        "description": "Sind Sie sicher, dass Sie ein Problem melden möchten?",
-        "information": "Wenn Sie ein Problem melden, wird Ihre Zertifizierung pausiert, bis die Aufsichtsperson eingreift, um Ihre Meldung zu bestätigen oder für ungültig zu erklären."
+        "description": "Bist du sicher, dass du ein Problem melden möchtest?",
+        "information": "Wenn du ein Problem meldest, wird deine Zertifizierung pausiert, bis die Aufsichtsperson eingreift, um deine Meldung zu bestätigen oder für ungültig zu erklären."
       },
       "embed-simulator": {
         "actions": {
           "launch": "Beginnen",
-          "launch-label": "Simulation starten",
+          "launch-label": "Anwendung starten",
           "reset": "Zurücksetzen",
-          "reset-label": "Simulation zurücksetzen"
+          "reset-label": "Anwendung zurücksetzen"
         },
         "placeholder": "Laden der aktuellen Anwendung"
       },
@@ -1031,10 +1021,10 @@
         "actions": {
           "open-close": "Ein Problem mit der Frage melden"
         },
-        "description": "Pix freut sich über Ihr Feedback, um die angebotenen Prüfungen zu verbessern!*",
+        "description": "Pix freut sich über dein Feedback, um die angebotenen Inhalte zu verbessern!*",
         "form": {
           "actions": {
-            "submit": "Senden Sie",
+            "submit": "Senden",
             "submit-aria-label": "Meine Meldenachricht senden"
           },
           "fields": {
@@ -1044,7 +1034,7 @@
                 "accessibility": "Die Zugänglichkeit der Prüfung",
                 "answer": "Die Antwort",
                 "download": "Die Datei zum Herunterladen",
-                "embed": "Der Simulator / die Anwendung",
+                "embed": "Die Anwendung",
                 "link": "Der in der Frage angegebene Link",
                 "other": "Andere",
                 "picture": "Das Bild",
@@ -1055,126 +1045,126 @@
             "detail-selection": {
               "add-comment": "Kommentar hinzufügen",
               "aria-first": "Ich habe ein Problem mit",
-              "aria-secondary": "Wählen Sie eine Option, um Ihr Problem zu spezifizieren",
-              "label": "Wählen Sie eine Option, um Ihr Problem zu spezifizieren",
+              "aria-secondary": "Wähle eine Option, um dein Problem zu spezifizieren",
+              "label": "Wähle eine Option, um dein Problem zu spezifizieren",
               "options": {
                 "answer-not-accepted": "Meine Antwort ist richtig, wurde aber nicht bestätigt",
                 "answer-not-agreed": "Ich stimme der Antwort nicht zu",
                 "download": {
                   "edit-failure": {
                     "label": "Ich kann die Datei nicht bearbeiten",
-                    "solution": "Die Datei ist wahrscheinlich im \"Schreibgeschützten Modus\" oder \"Geschützten Modus\" geöffnet. '<br>'Klicken Sie auf \"Bearbeitung aktivieren\" oder \"Dokument bearbeiten\" auf dem Banner am oberen Rand der Datei, wenn es angezeigt wird. '<br>'Andernfalls speichern Sie die Datei unter einem anderen Namen und öffnen Sie diese neue Datei."
+                    "solution": "Die Datei ist wahrscheinlich im \"Schreibgeschützten Modus\" oder \"Geschützten Modus\" geöffnet. '<br>'Klicke auf \"Bearbeitung aktivieren\" oder \"Dokument bearbeiten\" auf dem Banner am oberen Rand der Datei, wenn es angezeigt wird. '<br>'Andernfalls speicheré die Datei unter einem anderen Namen und öffne diese neue Datei."
                   },
                   "lost": {
                     "label": "Ich kann die heruntergeladene Datei nicht finden",
-                    "solution": "Standardmäßig wird eine heruntergeladene Datei in einem Ordner \"Downloads\" oder \"Downloads\" gespeichert. Es kann aber auch sein, dass sie am selben Ort wie Ihr letzter Download..."
+                    "solution": "Standardmäßig wird eine heruntergeladene Datei in einem Ordner \"Downloads\" oder \"Downloads\" gespeichert. Es kann aber auch sein, dass sie am selben Ort wie dein letzter Download..."
                   },
                   "open-failure": {
                     "label": "Ich kann die Datei nicht auf einem Computer öffnen",
-                    "solution": "Wenn Sie eine Datei nicht öffnen können, sehen Sie sich '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'die Hilfe unter der Schaltfläche \"Herunterladen\"'</a>' an. Dort finden Sie empfohlene Software oder Online-Tools."
+                    "solution": "Wenn du eine Datei nicht öffnen kannst, sieh dir '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'die Hilfe unter der Schaltfläche \"Herunterladen\"'</a>' an. Dort findest du empfohlene Software oder Online-Tools."
                   },
                   "other": "Ich habe ein weiteres Problem mit der Datei"
                 },
                 "embed-displayed-on-desktop-with-problems": {
-                  "label": "Auf dem Computer wird der Simulator angezeigt, hat aber ein Problem",
-                  "solution": "Wir bemühen uns, dass die Simulatoren auf allen Geräten, OS und Browsern funktionieren, aber es kann sein, dass Sie ein bestimmtes System verwenden. Sie können hier aufhören und auf einem Computer fortfahren. '<br>'Spezifizieren Sie Ihr Problem, indem Sie Ihren Browser und Ihr Betriebssystem angeben."
+                  "label": "Auf dem Computer wird die Anwendung angezeigt, hat aber ein Problem",
+                  "solution": "Wir bemühen uns, dass die Anwendung auf allen Geräten, OS und Browsern funktionieren, aber es kann sein, dass du ein bestimmtes System verwendest. Du kannst hier aufhören und auf einem Computer fortfahren. '<br>'Spezifiziere dein Problem, indem du deinen Browser und dein Betriebssystem angibst."
                 },
                 "embed-displayed-on-mobile-devices-with-problems": {
-                  "label": "Auf dem Telefon oder Tablet wird der Simulator angezeigt, hat aber ein Problem",
-                  "solution": "Wir bemühen uns, dass die Simulatoren auf allen Geräten, OS und Browsern funktionieren, aber es kann sein, dass Sie ein bestimmtes System verwenden.'<br>'Bitte spezifizieren Sie Ihr Problem, indem Sie Ihren Gerätetyp (Smartphone, Tablet ...), Ihr Betriebssystem und Ihren Browser angeben."
+                  "label": "Auf dem Telefon oder Tablet wird die Anwendung ngezeigt, hat aber ein Problem",
+                  "solution": "Wir bemühen uns, dass die Anwendung auf allen Geräten, OS und Browsern funktionieren, aber es kann sein, dass du ein bestimmtes System verwendest.'<br>'Bitte spezifiziere dein Problem, indem du deinen Gerätetyp (Smartphone, Tablet ...), dein Betriebssystem und deinen Browser angibst."
                 },
                 "embed-not-displayed": {
-                  "label": "Der Simulator / die Anwendung wird nicht angezeigt",
-                  "solution": "Ihre Internetverbindung ist vielleicht zu schwach.'<br>'Laden Sie die Seite neu, indem Sie auf die Schaltfläche Aktualisieren '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' neben der Adressleiste drücken. Warten Sie einen Moment, vielleicht wird der Simulator angezeigt. '<br><br> Falls nicht, können Sie es zu einem anderen Zeitpunkt oder von einem anderen Ort mit einer besseren Verbindung erneut versuchen?"
+                  "label": "Die Anwendung wird nicht angezeigt",
+                  "solution": "Deine Internetverbindung ist vielleicht zu schwach.'<br>'Lade die Seite neu, indem du auf die Schaltfläche Aktualisieren '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' neben der Adressleiste drückst. Warte einen Moment, vielleicht wird der Simulator angezeigt. '<br><br> Falls nicht, kannst du es zu einem anderen Zeitpunkt oder von einem anderen Ort mit einer besseren Verbindung erneut versuchen?"
                 },
-                "embed-other": "Der Simulator / die Anwendung hat ein anderes Problem",
+                "embed-other": "Die Anwendung hat ein anderes Problem",
                 "link-other": "Der Link funktioniert nicht oder hat ein anderes Problem",
                 "link-unauthorized": {
                   "label": "Der Link wird von meiner Organisation / Einrichtung blockiert...",
-                  "solution": "Sie gehören vielleicht einer Organisation an (Schulen, Universitäten, Unternehmen, Behörden, Vereine ...), die ihre Nutzer und Geräte schützt, indem sie die Internetseiten, auf die Sie Zugriff haben, einschränkt.'<br>'"
+                  "solution": "Du gehörst vielleicht einer Organisation an (Schulen, Universitäten, Unternehmen, Behörden, Vereine ...), die deine Accounts und Geräte schützt, indem sie die Internetseiten, auf die du Zugriff hast, einschränkt.'<br>'"
                 },
                 "other-challenge-proposal": "Ich habe eine (geniale) Idee für eine Prüfung",
                 "other-difficulty": "Ich habe ein anderes Problem",
                 "other-site-improvement": "Ich habe einen Verbesserungsvorschlag für die Plattform",
                 "picture-not-displayed": {
                   "label": "Das Bild wird nicht angezeigt",
-                  "solution": "Ihre Internetverbindung ist vielleicht zu schwach. '<br>'Laden Sie die Seite neu, indem Sie auf die Schaltfläche Aktualisieren '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' neben der Adressleiste drücken. Warten Sie einen Moment, vielleicht wird das Bild angezeigt. '<br><br>'Wenn nicht, können Sie es zu einem anderen Zeitpunkt oder von einem anderen Ort mit einer besseren Verbindung aus erneut versuchen?"
+                  "solution": "Deine Internetverbindung ist vielleicht zu schwach. '<br>'Lade die Seite neu, indem du auf die Schaltfläche Aktualisieren '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' neben der Adressleiste drückst. Warte einen Moment, vielleicht wird das Bild angezeigt. '<br><br>'Wenn nicht, kannst du es zu einem anderen Zeitpunkt oder von einem anderen Ort mit einer besseren Verbindung aus erneut versuchen?"
                 },
                 "picture-other": "Das Bild hat ein weiteres Problem",
                 "question-improvement": "Ich möchte eine Verbesserung der Frage vorschlagen",
                 "question-not-understood": "Ich verstehe die Frage nicht",
                 "tutorial-link-error": "Der Link zum Tutorial führt auf eine andere Seite oder eine Fehlerseite",
                 "tutorial-not-accepted": "Das Tutorial ist nicht geeignet",
-                "tutorial-proposal": "Ich habe ein Tutorial für Sie"
+                "tutorial-proposal": "Hier ist ein Tutorial für dich"
               },
-              "problem-suggestion-description": "Beschreiben Sie Ihr Problem oder Ihre Anregung"
+              "problem-suggestion-description": "Beschreibe dein Problem oder Anliegen"
             }
           },
           "status": {
             "error": {
-              "empty-message": "Sie müssen eine Nachricht eingeben.",
-              "max-characters": "Ihre Nachricht ist auf 10.000 Zeichen begrenzt."
+              "empty-message": "Bitte gib eine Nachricht ein.",
+              "max-characters": "Deine Nachricht ist auf 10.000 Zeichen begrenzt."
             },
-            "success": "'<p>'Ihr Kommentar wurde erfolgreich an das Pix-Projektteam weitergeleitet.'</p><p>'Dankex!'</p>'"
+            "success": "'<p>'Dein Kommentar wurde erfolgreich an das Pix-Projektteam weitergeleitet.'</p><p>'Dankex!'</p>'"
           }
         },
         "information": {
-          "data-usage": "'<p>'Pix verarbeitet die Daten in diesem Bereich, um die aufgetretene Schwierigkeit zu verwalten und zu analysieren und von Ihrem Feedback zu profitieren. Sie haben Rechte über Ihre Daten, die Sie ausüben können bei : <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Weitere Informationen über den Schutz Ihrer Daten und Ihre Rechte.'</a></p>'",
-          "guidance": "'<p>'* Achten Sie darauf, was Sie in diesem Bereich schreiben: Bleiben Sie objektiv und sachlich in Ihrem eigenen Interesse und dem anderer.'</p><p>' Insbesondere geben Sie keine Informationen über sich selbst oder Dritte über Gesundheit, Religion, politische, gewerkschaftliche und philosophische Meinungen, ethnische Herkunft sowie über Strafen und Verurteilungen ein.'</p>'"
+          "data-usage": "'<p>'Pix verarbeitet die Daten in diesem Bereich, um die aufgetretene Schwierigkeit zu verwalten und zu analysieren und von deinem Feedback zu profitieren. Du hast Rechte über deine Daten, die du ausüben kannst bei : <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Weitere Informationen über den Schutz deiner Daten und deine Rechte.'</a></p>'",
+          "guidance": "'<p>'* Achte darauf, was du in diesem Bereich schreibst: Bleib objektiv und sachlich in deinem eigenen Interesse und dem anderer.'</p><p>' Gib insbesondere keine Informationen über dich selbst oder Dritte über Gesundheit, Religion, politische, gewerkschaftliche und philosophische Meinungen, ethnische Herkunft sowie über Strafen und Verurteilungen ein.'</p>'"
         },
         "modal": {
-          "content": "'<p><strong>'Sind Sie sicher, dass Sie dieses Problem melden möchten?'</strong></p><p>'Wir danken Ihnen für Ihre Meldung, die vom Pix-Team sorgfältig geprüft wird. Wir berücksichtigen alle Ihre Rückmeldungen, um unseren Service und die Nutzererfahrung kontinuierlich zu verbessern. Eine persönliche Antwort können wir Ihnen leider nicht geben. Vielen Dank für Ihre Mitarbeit.'</p>'",
+          "content": "'<p><strong>'Bist du sicher, dass du dieses Problem melden möchtest?'</strong></p><p>'Wir danken dir für deine Meldung, die vom Pix-Team sorgfältig geprüft wird. Wir berücksichtigen alle deine Rückmeldungen, um unseren Service und die Nutzererfahrung kontinuierlich zu verbessern. Eine persönliche Antwort können wir dir leider nicht geben. Vielen Dank für deine Mitarbeit.'</p>'",
           "title": "Bestätigung der Ausschreibung"
         }
       },
       "has-focused-out-of-window": {
-        "certification": "Wir haben einen Seitenwechsel festgestellt. Ihre Antwort wird als falsch gezählt. Wenn Sie gezwungen waren, die Seite zu wechseln, benachrichtigen Sie Ihre Aufsichtsperson und beantworten Sie die Frage in ihrer Gegenwart.",
-        "default": "Wir haben einen Seitenwechsel festgestellt. Bei der Zertifizierung würde Ihre Antwort nicht validiert werden.",
-        "v3-accessible-certification": "Wir haben einen Seitenwechsel festgestellt. Wenn Sie gezwungen waren, die Seite zu wechseln, um ein Hilfsmittel für digitale Barrierefreiheit (wie einen Screenreader oder eine virtuelle Tastatur) zu verwenden, beantworten Sie die Frage trotzdem.",
-        "v3-certification": "Wir haben einen Seitenwechsel festgestellt. Ihre Antwort wird als falsch gezählt. Wenn Sie gezwungen waren, die Seite zu wechseln, benachrichtigen Sie Ihren Aufseher, damit er dies feststellen und live von seinem \"Aufseherbereich\" aus melden kann."
+        "certification": "Wir haben einen Seitenwechsel festgestellt. Deine Antwort wird als falsch gezählt. Wenn du gezwungen warst, die Seite zu wechseln, benachrichtige deine Aufsichtsperson und beantworte die Frage in ihrer Gegenwart.",
+        "default": "Wir haben einen Seitenwechsel festgestellt. Bei der Zertifizierung würde deine Antwort nicht validiert werden.",
+        "v3-accessible-certification": "Wir haben einen Seitenwechsel festgestellt. Wenn du gezwungen warst, die Seite zu wechseln, um ein Hilfsmittel für digitale Barrierefreiheit (wie einen Screenreader oder eine virtuelle Tastatur) zu verwenden, beantworte die Frage trotzdem.",
+        "v3-certification": "Wir haben einen Seitenwechsel festgestellt. Deine Antwort wird als falsch gezählt. Wenn du gezwungen warst, die Seite zu wechseln, benachrichtige die Aufsichtsperson, damit sie dies feststellen und live von ihrem \"Aufseherbereich\" aus melden kann."
       },
       "illustration": {
         "placeholder": "Aktuelles Bild laden"
       },
       "is-focused-challenge": {
         "info-alert": {
-          "adjusted-course-title": "Beantworten Sie diese Frage ohne Hilfe des Internets oder von Anwendungen.",
-          "subtitle": "Bei der Zertifizierung wird Ihre Antwort nicht validiert, wenn Sie die Seite wechseln.",
-          "title": "Versuchen Sie, diese Frage ohne Hilfe des Internets oder von Anwendungen zu beantworten."
+          "adjusted-course-title": "Beantworte diese Frage ohne Hilfe des Internets oder von Anwendungen.",
+          "subtitle": "Bei der Zertifizierung wird deine Antwort nicht validiert, wenn du die Seite wechselst.",
+          "title": "Versuche, diese Frage ohne Hilfe des Internets oder von Anwendungen zu beantworten."
         }
       },
       "live-alerts": {
         "challenge": {
-          "message": "Benachrichtigen Sie Ihren Aufseher, damit er Ihr Problem feststellen und es direkt in seiner Schnittstelle \"Aufseherbereich\" verwalten kann."
+          "message": "Benachrichtige deine Aufsichtsperson, damit dein Problem festgestellt werden und es direkt in der Schnittstelle \"Aufseherbereich\" verwaltet werden kann."
         },
         "companion": {
-          "message": "Bitte kontaktieren Sie Ihre Aufsichtsperson, damit diese das Vorhandensein der Erweiterung bestätigen kann."
+          "message": "Bitte kontaktiere deine Aufsichtsperson, damit diese die Erweiterung bestätigen kann."
         },
         "refresh": "Seite aktualisieren",
-        "waiting-information": "Warten auf den Aufseher"
+        "waiting-information": "Warte auf die Aufsichtsperson"
       },
       "parts": {
-        "answer-input": "Ihre Antwort",
+        "answer-input": "Deine Antwort",
         "answer-instructions": {
-          "qcm": "Wählen Sie mehrere Antworten aus.",
-          "qcu": "Wählen Sie nur eine Antwort aus."
+          "qcm": "Wähle mehrere Antworten aus.",
+          "qcu": "Wähle nur eine Antwort aus."
         },
         "feedback": "Ein Problem melden",
         "feedback-v3": "Ein Problem mit der Frage melden",
         "instruction": "Aufgabenstellung",
-        "progress": "Ihr Fortschritt",
-        "validation": "Ihre Prüfung bestätigen oder ablegen"
+        "progress": "Dein Fortschritt",
+        "validation": "Deine Prüfung bestätigen oder ablegen"
       },
       "progress-bar": {
         "label": "Frage"
       },
       "skip-error-message": {
-        "qcm": "Wählen Sie zum Bestätigen mindestens zwei Antworten aus. Andernfalls überspringen Sie.",
-        "qcu": "Um zu bestätigen, wählen Sie eine Antwort aus. Andernfalls überspringen Sie.",
-        "qroc": "Zur Bestätigung füllen Sie bitte das Textfeld aus. Andernfalls überspringen Sie.",
-        "qroc-auto-reply": "\"Sie können bestätigen\" wird angezeigt, wenn die Prüfung bestanden wurde. Versuchen Sie es noch einmal oder bestehen Sie.",
-        "qroc-positive-number": "Um zu bestätigen, geben Sie bitte eine Zahl größer oder gleich 0 ein, sonst überspringen.",
-        "qrocm": "Füllen Sie zum Bestätigen bitte alle Antwortfelder aus. Andernfalls überspringen Sie."
+        "qcm": "Wähle zum Bestätigen mindestens zwei Antworten aus. Andernfalls überspringe sie.",
+        "qcu": "Um zu bestätigen, wähle eine Antwort aus. Andernfalls überspringe sie.",
+        "qroc": "Zur Bestätigung fülle bitte das Textfeld aus. Andernfalls überspringe sie.",
+        "qroc-auto-reply": "\"Bestätigen\" wird angezeigt, wenn die Prüfung bestanden wurde. Versuche es noch einmal.",
+        "qroc-positive-number": "Um zu bestätigen, gib bitte eine Zahl größer oder gleich 0 ein, sonst überspringe.",
+        "qrocm": "Fülle zum Bestätigen bitte alle Antwortfelder aus. Andernfalls überspringe sie."
       },
       "statement": {
         "alternative-instruction": {
@@ -1185,38 +1175,38 @@
         },
         "file-download": {
           "actions": {
-            "choose-type": "Wählen Sie den Dateityp, den Sie verwenden möchten",
+            "choose-type": "Wähle den Dateityp, den du verwenden möchtest",
             "download": "Download"
           },
-          "description": "Pix überlässt Ihnen die Wahl des Dateiformats für den Download. Wenn Sie sich nicht sicher sind, welche Option Sie wählen sollen, behalten Sie die Standardauswahl bei. Sie entspricht dem Dateiformat, das von den meisten Programmen unterstützt wird.",
+          "description": "Pix überlässt dir die Wahl des Dateiformats für den Download. Wenn du dir nicht sicher bist, welche Option du wählen sollst, behalte die Standardauswahl bei. Sie entspricht dem Dateiformat, das von den meisten Programmen unterstützt wird.",
           "file-type": ".{fileExtension}-Datei",
-          "help": "Brauchen Sie Hilfe bei '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"diese Datei öffnen, bearbeiten oder finden (öffnet sich in einem neuen Fenster)\">'diese Datei öffnen, bearbeiten oder finden'</a>'?"
+          "help": "Brauchst du Hilfe beim '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"Öffnen, Bearbeiten oder Finden dieser Datei (öffnet sich in einem neuen Fenster)\">'diese Datei öffnen, bearbeiten oder finden'</a>'?"
         },
         "sr-only": {
           "alternative-instruction": "Dieser Probedruck enthält eine Illustration mit einer Textalternative.",
           "embed": "Diese Aufgabe enthält einen Simulator."
         },
         "text-to-speech": {
-          "activate": "Vokalisation aktivieren",
-          "deactivate": "Voicemail ausschalten",
+          "activate": "Lautes vorlesen aktivieren",
+          "deactivate": "Lautes vorlesen ausschalten",
           "play": "Die Aufgabenstellung laut vorlesen",
           "stop": "Das Lesen der Anweisung stoppen"
         },
         "tooltip": {
-          "aria-label": "Zeigen Sie den Hinweis auf die Aufgabe an.",
-          "close": "Ich habe verstanden",
+          "aria-label": "Zeige einen Hinweisan.",
+          "close": "Verstanden",
           "focused": {
-            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'Versuchen Sie, auf dieser Seite zu bleiben, um zu antworten!'</strong><br/>' Für diese Frage ist weder Internet noch eine Anwendung erforderlich.",
+            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'Versuche auf dieser Seite zu bleiben, um zu antworten!'</strong><br/>' Für diese Frage ist weder Internet noch eine Anwendung erforderlich.",
             "title": "Focus-Modus"
           },
           "other": {
-            "content": "Es steht Ihnen frei, das Internet oder Anwendungen zu nutzen, um diese Frage zu beantworten.",
+            "content": "Es steht dir frei, das Internet oder Anwendungen zu nutzen, um diese Frage zu beantworten.",
             "title": "Freier Modus"
           }
         }
       },
       "timed": {
-        "cannot-answer": "Die Zeit ist abgelaufen. Ihre Antwort wird nicht bestätigt."
+        "cannot-answer": "Die Zeit ist abgelaufen. Deine Antwort wird nicht miteinbezogen."
       },
       "title": {
         "default": "Freier Modus - Frage {stepNumber} zu {totalChallengeNumber}.",
@@ -1234,74 +1224,74 @@
       },
       "answers": {
         "already-finished": {
-          "explanation": "Sie haben diese Fragen bereits in früheren Tests beantwortet: Sie können direkt auf Ihre Ergebnisse zugreifen.\n\nMöchten Sie Ihr Ergebnis verbessern? Wenn Sie auf \"Meine Ergebnisse anzeigen\" klicken, haben Sie die Möglichkeit, den Parcours erneut zu versuchen.",
-          "info": "Sie haben bereits geantwortet!"
+          "explanation": "Du hast diese Fragen bereits in früheren Tests beantwortet: Du kannst direkt auf deine Ergebnisse zugreifen.\n\nMöchtest du dein Ergebnis verbessern? Wenn du auf \"Meine Ergebnisse anzeigen\" klickst, hast du die Möglichkeit, den Lernpfad erneut zu versuchen.",
+          "info": "Du hast bereits geantwortet!"
         },
-        "header": "Ihre Antworten"
+        "header": "Deine Antworten"
       },
       "completion-percentage": {
-        "caption": "Fortschritt auf der Strecke",
-        "label": "'<p class=\"sr-only\">'Sie haben '</p>'{completionPercentage}%'<p class=\"sr-only\">' Ihrer Strecke absolviert.'</p>'"
+        "caption": "Fortschritt auf dem Pfad",
+        "label": "'<p class=\"sr-only\">'Du hast '</p>'{completionPercentage}%'<p class=\"sr-only\">' deinen Pfad absolviert.'</p>'"
       },
       "sharing-results": {
-        "information-banner": "Wenn Sie auf die Schaltfläche \"Meine Ergebnisse anzeigen\" klicken, werden Ihre Ergebnisse an den Veranstalter übermittelt."
+        "information-banner": "Wenn du auf die Schaltfläche \"Meine Ergebnisse anzeigen\" klickst, werden deine Ergebnisse an den Organisator übermittelt."
       },
       "title": {
         "assessment-progress": "Fortschritt",
-        "end-of-assessment": "Ende Ihrer Beurteilung"
+        "end-of-assessment": "Ende deiner Beurteilung"
       }
     },
     "combined-courses": {
       "completed": {
-        "description": "Gut gemacht! Sie haben einen wichtigen Schritt getan, um in der digitalen Welt zu navigieren.",
-        "retry-text": "Lust auf eine Wiederholung? Sie können alle Module frei nachspielen!",
+        "description": "Gut gemacht! Du hast einen wichtigen Schritt getan, um in der digitalen Welt zu navigieren.",
+        "retry-text": "Lust auf eine Wiederholung? Du kannst alle Tests frei wiederholen!",
         "survey-button": "Beantwortung des Fragebogens",
-        "survey-button-description": "Beantworten Sie den Fragebogen, um Ihre Meinung über die Strecke zu äußern.",
-        "title": "Herzlichen Glückwunsch! Sie sind fertig!"
+        "survey-button-description": "Beantworte den Fragebogen, um deine Meinung über den Pfad zu äußern.",
+        "title": "Herzlichen Glückwunsch! Du bist fertig!"
       },
       "content": {
-        "resume-button": "Meinen Weg fortsetzen",
+        "resume-button": "Meinen Pfad fortsetzen",
         "start-button": "Meine Reise beginnen",
         "step": "Schritt {stepNumber}."
       },
       "items": {
         "aria-label-completed-campaign": "Dieses Element wird mit einer Erfolgsquote von {value, number, ::percent} abgeschlossen.",
-        "aria-label-completed-campaign-with-stages": "Sie haben {acquired, plural, =0 {keinen Stern} =1 {# Stern} other {# Sterne}} von {total} erhalten.",
+        "aria-label-completed-campaign-with-stages": "Du hast {acquired, plural, =0 {keinen Stern} =1 {# Stern} other {# Sterne}} von {total} erhalten.",
         "aria-label-duration": "Geschätzte Dauer: {duration} Minuten",
-        "completed": "Ergänzt!",
+        "completed": "Beendet!",
         "duration": "≈ {duration} min",
         "formation": {
-          "description": "Schließen Sie Ihre Diagnose ab, um ein auf Ihr Ergebnis abgestimmtes Modulprogramm freizuschalten!",
+          "description": "Schließe deine Diagnose ab, um ein auf dein Ergebnis abgestimmtes Modulprogramm freizuschalten!",
           "title": "Individuelles Programm von Modulen"
         },
-        "tagText": "So weit sind Sie schon!"
+        "tagText": "So weit bist du schon!"
       },
       "process-custom-passages": {
-        "description": "Wir analysieren Ihre Ergebnisse und bauen Ihren persönlichen Lernplan auf.",
+        "description": "Wir analysieren deine Ergebnisse und bauen deinen persönlichen Lernpfad auf.",
         "list": {
-          "generate-personalize-course": "Generieren Sie Ihren persönlichen Lernpfad.",
-          "results-analysis": "Analyse Ihrer Ergebnisse.",
-          "select-passages": "Auswahl geeigneter Schulungen."
+          "generate-personalize-course": "Generiere deinen persönlichen Lernpfad.",
+          "results-analysis": "Analyse deiner Ergebnisse.",
+          "select-passages": "Auswahl geeigneter Übungen."
         },
-        "title": "Berechnung des weiteren Verlaufs der aktuellen Strecke."
+        "title": "Berechnung des weiteren Verlaufs des aktuellen Pfads."
       }
     },
     "comparison-window": {
       "results": {
         "a11y": {
           "good-answer": "Die gegebene Antwort ist gültig",
-          "skipped-answer": "Vergangene Frage",
+          "skipped-answer": "letzte Frage",
           "the-answer-was": "Die richtige Antwort lautet",
-          "timedout": "Sie haben die Zeit überschritten",
+          "timedout": "Du hast die Zeit überschritten",
           "wrong-answer": "Die gegebene Antwort ist falsch"
         },
         "aband": {
-          "title": "Sie haben keine Antwort gegeben",
+          "title": "Du hast keine Antwort gegeben",
           "tooltip": "Ohne Antwort"
         },
         "abandAutoReply": {
-          "title": "Sie haben die Prüfung bestanden",
-          "tooltip": "Vergangene Prüfung"
+          "title": "Du hast die Prüfung bestanden",
+          "tooltip": "Letzte Prüfung"
         },
         "default": {
           "title": "Antwort",
@@ -1312,23 +1302,23 @@
           "wrong": "Die Antwort ist nicht korrekt. '<br>'Die richtige Antwort ist :"
         },
         "focusedOut": {
-          "title": "Sie sind aus der Prüfung herausgekommen",
-          "tooltip": "Prüfung nicht bestanden"
+          "title": "Du hast die Prüfung abgeschlossen",
+          "tooltip": "Prüfung nicht abgeschlossen"
         },
         "ko": {
-          "title": "Sie haben nicht die richtige Antwort",
+          "title": "Das ist nicht die richtige Antwort",
           "tooltip": "Falsche Antwort"
         },
         "koAutoReply": {
-          "title": "Sie haben die Prüfung nicht bestanden",
+          "title": "Du hast die Prüfung nicht bestanden",
           "tooltip": "Nicht bestandene Prüfung"
         },
         "ok": {
-          "title": "Sie haben die richtige Antwort!",
+          "title": "Das ist die richtige Antwort!",
           "tooltip": "Richtige Antwort"
         },
         "okAutoReply": {
-          "title": "Sie haben die Prüfung bestanden",
+          "title": "Du hast die Prüfung bestanden",
           "tooltip": "Erfolgreiche Prüfung"
         },
         "solutions": {
@@ -1336,26 +1326,26 @@
           "or": "oder"
         },
         "timedout": {
-          "title": "Sie haben die Zeit überschritten",
+          "title": "Du hast die Zeit überschritten",
           "tooltip": "Zeit überschritten"
         },
         "tips": {
           "other-proposition": "Anderer Vorschlag",
-          "your-answer": "Ihre Antwort"
+          "your-answer": "Deine Antwort"
         }
       },
-      "upcoming-tutorials": "Demnächst finden Sie hier Tutorials, die Ihnen helfen, diese Art von Prüfungen erfolgreich zu bestehen."
+      "upcoming-tutorials": "Demnächst findest du hier Tutorials, die dir helfen, diese Art von Prüfungen erfolgreich zu bestehen."
     },
     "competence-details": {
       "actions": {
         "continue": {
-          "extra-information": "Übernehmen Sie die Fertigkeit {competenceName}.",
+          "extra-information": "Übernimm die Kompetenz {competenceName}.",
           "label": "Übernehmen"
         },
         "improve": {
           "description": {
             "countdown": "{ daysBeforeImproving, plural, =0 {0 Tag.} =1 {1 Tag.} other {# Tage.} }",
-            "waiting-text": "Versuchen Sie die nächste Ebene in"
+            "waiting-text": "Versuche die nächste Ebene in"
           },
           "improvingText": "Versuche, die nächste Stufe zu erreichen!",
           "label": "Retenter"
@@ -1364,18 +1354,18 @@
           "description": "Zurücksetzen verfügbar in { daysBeforeReset, plural, =0 {0 Tag.} =1 {1 Tag.} other {# Tage.} }",
           "label": "Auf Null zurücksetzen",
           "modal": {
-            "important-message": "Ihre { earnedPix } Pix werden aus der Fertigkeit: { scoreCardName } entfernt.",
-            "important-message-above-level-one": "Deine Stufe { level } und deine { earnedPix } Pix werden von der Fertigkeit: { scoreCardName } entfernt.",
-            "title": "Zurücksetzen der Fertigkeit",
+            "important-message": "Deine { earnedPix } Pix werden aus der Kompetenz: { scoreCardName } entfernt.",
+            "important-message-above-level-one": "Deine Stufe { level } und deine { earnedPix } Pix werden von der Kompetenz: { scoreCardName } entfernt.",
+            "title": "Zurücksetzen der Kompetenzen",
             "warning": {
-              "certification": "wenn Sie Ihr Profil und Ihre verschiedenen Ergebnisse zertifizieren lassen möchten, könnte dies Ihre Zertifizierung beeinträchtigen.",
+              "certification": "wenn du dein Profil und deine verschiedenen Ergebnisse zertifizieren lassen möchtest, könnte dies deine Zertifizierung beeinträchtigen.",
               "header": "Achtung :",
-              "ongoing-assessment": "wenn Sie gerade einen Assessment-Course absolvieren, können Ihnen einige Fragen erneut gestellt werden."
+              "ongoing-assessment": "Wenn du gerade einen Assessment-Course absolvierst, können dir einige Fragen erneut gestellt werden."
             }
           }
         },
         "start": {
-          "extra-information": "Beginne die Fertigkeit {competenceName}.",
+          "extra-information": "Beginne die Kompetenz {competenceName}.",
           "label": "Beginnen"
         }
       },
@@ -1383,66 +1373,66 @@
       "next-level-info": "{ remainingPixToNextLevel } pix vor der Ebene { level }.",
       "title": "Kompetenz",
       "tutorials": {
-        "description": "Hier finden Sie eine Auswahl an Tutorials, die Ihnen helfen können, Pix zu verdienen.",
-        "title": "Kultivieren Sie Ihre Fähigkeiten"
+        "description": "Hier findest du eine Auswahl an Tutorials, die dir helfen können, Pix zu verdienen.",
+        "title": "Kultiviere deine Kompetenzen"
       }
     },
     "competence-result": {
       "header": {
         "congratulations": "Herzlichen Glückwunsch!",
-        "not-bad": "Nicht schlecht, aber nicht max!",
-        "not-bad-subtitle": "Noch ein paar kleine Anstrengungen und Sie werden die erste Stufe ergattern.",
-        "too-bad": "So viel Pix!",
-        "too-bad-subtitle": "Offensichtlich ist heute nicht Ihr Tag, aber beim nächsten Mal werden Sie es besser machen.",
-        "you-have-earned": "Sie haben",
-        "you-have-reached-level": "Sie haben erreicht"
+        "not-bad": "Nicht schlecht!",
+        "not-bad-subtitle": "Noch ein paar kleine Anstrengungen und du wirst das erste Level erreichen.",
+        "too-bad": "So viele Pix!",
+        "too-bad-subtitle": "Offensichtlich ist heute nicht dein Tag, aber beim nächsten Mal wirst du es besser machen.",
+        "you-have-earned": "Du hast",
+        "you-have-reached-level": "Erreicht"
       },
-      "title": "Ergebnisse Ihrer Kompetenz"
+      "title": "Ergebnisse deiner Kompetenz"
     },
     "course": {
       "errors": {
-        "not-accessible": "Ups, die angeforderte Seite ist nicht zugänglich."
+        "not-accessible": "Ups, die angeforderte Seite ist nicht erreichbar."
       }
     },
     "dashboard": {
       "campaigns": {
         "resume": {
           "action": "Weiter",
-          "text": "<h2>Vergessen Sie nicht, Ihre Profilsendung abzuschließen!</h2>"
+          "text": "<h2>Vergiss nicht, deine Profilsendung abzuschließen!</h2>"
         },
-        "subtitle": "Setzen Sie Ihre laufenden Testläufe fort oder senden Sie Ihre Ergebnisse ein.",
-        "tests-link": "Alle meine Wege",
-        "title": "Meine Wege"
+        "subtitle": "Setze deine laufenden Testversuche fort oder sende deine Ergebnisse ein.",
+        "tests-link": "Alle meine Pfade",
+        "title": "Meine Pfade"
       },
       "empty-dashboard": {
-        "link-to-competences": "Meine Fähigkeiten ansehen",
-        "message": "<h2>Bravo Sie haben die empfohlenen Fertigkeiten abgeschlossen!</h2> <p> Um weiterzukommen, üben Sie weiter, indem Sie Fertigkeiten erneut versuchen. </p>"
+        "link-to-competences": "Meine Kompetenzen ansehen",
+        "message": "<h2>Bravo Du hast die empfohlenen Kompetenzen abgeschlossen!</h2> <p> Um weiterzukommen, übe weiter, indem du Kompetenzen erneut versuchst. </p>"
       },
       "improvable-competences": {
-        "extra-information": "Zugriff auf alle Fähigkeiten zum erneuten Versuch",
-        "profile-link": "Alle Fähigkeiten",
-        "subtitle": "Sind Sie bereit, Ihre Fähigkeiten auf die nächste Stufe zu heben?",
-        "title": "Eine Fertigkeit zurückverfolgen"
+        "extra-information": "Zugriff auf alle Kompetenzen zum erneuten Versuch",
+        "profile-link": "Alle Kompetenzen",
+        "subtitle": "Bist du bereit, deine Kompetenzen auf die nächste Stufe zu heben?",
+        "title": "Eine Kompetenz zurückverfolgen"
       },
       "presentation": {
         "link": {
           "text": "Mehr erfahren",
           "url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
         },
-        "message": "<h2>Hallo, lernen Sie Ihr Dashboard kennen.</h2><p>Zugreifen Sie schnell und einfach auf Ihre bereits begonnenen Lernwege und Kompetenztests.<br/> Finden Sie heraus, wie sich Ihr Pix-Score entwickelt und überprüfen Sie, ob Ihr Profil für die Pix-Zertifizierung bereit ist.</p>."
+        "message": "<h2>Hallo, lerne dein Dashboard kennen.</h2><p>Greif schnell und einfach auf deine bereits begonnenen Lernpfade und Kompetenztests.<br/> Finde heraus, wie sich dein Pix-Score entwickelt und überprüfe, ob dein Profil für die Pix-Zertifizierung bereit ist.</p>."
       },
       "recommended-competences": {
-        "extra-information": "Zugriff auf alle empfohlenen Fähigkeiten",
-        "profile-link": "Alle Fähigkeiten",
-        "subtitle": "Erkunden Sie, welche Fähigkeiten für Sie empfohlen werden.",
-        "title": "Empfohlene Fähigkeiten"
+        "extra-information": "Zugriff auf alle empfohlenen Kompetenzen",
+        "profile-link": "Alle Kompetenzen",
+        "subtitle": "Erkunde, welche Kompetenzen für dich empfohlen werden.",
+        "title": "Empfohlene Kompetenzen"
       },
       "score": {
-        "profile-link": "Meine Fähigkeiten ansehen"
+        "profile-link": "Meine Kompetenzen ansehen"
       },
       "started-competences": {
-        "subtitle": "Setzen Sie Ihre Kompetenztests fort, die neuesten finden Sie hier.",
-        "title": "Eine Fertigkeit übernehmen"
+        "subtitle": "Setze deine Kompetenztests fort, die neuesten findest du hier.",
+        "title": "Eine Kompetenz übernehmen"
       },
       "title": "Startseite",
       "welcome": "Hallo { firstName }."
@@ -1452,12 +1442,12 @@
         "label": "Ergebnisse herunterladen"
       },
       "errors": {
-        "invalid-token": "Der Link zum Herunterladen der Sitzungsergebnisse ist ungültig."
+        "invalid-token": "Der Link zum Herunterladen der Sitzungsinformationen ist ungültig."
       },
-      "title": "Herunterladen der Sitzungsergebnisse"
+      "title": "Herunterladen der Sitzungsinformationen"
     },
     "error": {
-      "content-text": "'<p>'Wir möchten Sie bitten, diese Seite neu zu laden oder zur Startseite zurückzukehren.'</p><p>'Sie können uns auch über '<a href=\"https://support.pix.fr/support/tickets/new\">'das Hilfe-Center-Formular'</a>' kontaktieren und uns in der Beschreibung den untenstehenden Fehlercode mitteilen.'</p><p>'Wir bitten Sie, die Unannehmlichkeiten zu entschuldigen.'</p><p>'Das Pix-Team.'</p><p>'",
+      "content-text": "'<p>'Wir bitten dich, diese Seite neu zu laden oder zur Startseite zurückzukehren.'</p><p>'Du kannst uns auch über '<a href=\"https://support.pix.fr/support/tickets/new\">'das Hilfe-Center-Formular'</a>' kontaktieren und uns in der Beschreibung den untenstehenden Fehlercode mitteilen.'</p><p>'Wir bitten dich, die Unannehmlichkeiten zu entschuldigen.'</p><p>'Das Pix-Team.'</p><p>'",
       "first-title": "Ups, ein Fehler ist aufgetreten!"
     },
     "evaluation-results": {
@@ -1467,44 +1457,44 @@
             "cancel": "Abbrechen",
             "leave": "Ja, den Kurs verlassen"
           },
-          "content-information": "Wenn Sie diesen Kurs verlassen, ohne sich anzumelden, können Sie Ihren Fortschritt nicht beibehalten.",
-          "content-instruction": "Möchten Sie fortfahren?",
+          "content-information": "Wenn du diesen Kurs verlässt, ohne dich anzumelden, kannst du deinen Fortschritt nicht beibehalten.",
+          "content-instruction": "Möchtest du fortfahren?",
           "title": "Verlassen und Rückkehr zu pix.de?"
         }
       }
     },
     "fill-in-campaign-code": {
-      "description": "Dieser Code besteht aus 9 Ziffern und/oder Buchstaben. Er wird von Ihrer Einrichtung/Organisation übermittelt und ermöglicht es Ihnen, einen Parcours zu starten oder Ihr Profil zu versenden.",
+      "description": "Dieser Code besteht aus 9 Ziffern und/oder Buchstaben. Er wird von deiner Einrichtung/Organisation übermittelt und ermöglicht es dir, einen Lernpfad zu starten oder dein Profil zu versenden.",
       "errors": {
-        "forbidden": "Ups! Wir können Sie nicht finden. Überprüfen Sie Ihre Angaben, um fortzufahren, oder benachrichtigen Sie den Organisator.",
-        "missing-code": "Bitte geben Sie einen Code ein.",
-        "not-found": "Ihr Code ist falsch. Bitte überprüfen Sie das Format (z. B. ABCDEF234) oder kontaktieren Sie den Organisator."
+        "forbidden": "Ups! Wir können dich nicht finden. Überprüfe deine Angaben, um fortzufahren, oder benachrichtige deine Aufsichtsperson.",
+        "missing-code": "Bitte gib einen Code ein.",
+        "not-found": "Dein Code ist falsch. Bitte überprüfe das Format (z. B. ABCDEF234) oder kontaktiere deine Aufsichtsperson."
       },
-      "first-title-connected": "{ firstName }, geben Sie Ihren Code ein",
-      "first-title-not-connected": "Geben Sie Ihren Code ein",
-      "label": "Geben Sie Ihren Code ein, um zu beginnen",
+      "first-title-connected": "{ firstName }, gib deinen Code ein",
+      "first-title-not-connected": "Gib deinen Code ein",
+      "label": "Gib deinen Code ein, um zu beginnen",
       "mediacentre-start-campaign-modal": {
         "actions": {
           "continue": "Weiter",
           "quit": "Verlassen"
         },
-        "message": "Um auf die Strecke zuzugreifen :",
+        "message": "Um auf die Pfade zuzugreifen :",
         "message-footer": "Logge dich über dein Mediacentre in Pix ein.",
         "organised-by": "vorgeschlagen von",
-        "title": "Zugang zum Parcours über Mediacentre"
+        "title": "Zugang zum Lernpfad über Mediacentre"
       },
-      "start": "Zum Parcours gelangen",
+      "start": "Zum Lernpfad gelangen",
       "title": "Ich habe einen Code",
-      "warning-message": "Sie sind nicht { firstName } { lastName }?",
-      "warning-message-logout": "Sich abmelden"
+      "warning-message": "Du bist nicht { firstName } { lastName }?",
+      "warning-message-logout": "Abmelden"
     },
     "fill-in-certificate-verification-code": {
-      "description": "Die Pix-Zertifizierung bescheinigt einen bestimmten Grad der Beherrschung digitaler Kompetenzen: Geben Sie nachfolgend den \"Überprüfungscode\" des zu überprüfenden Pix-Zertifikats ein.",
+      "description": "Die Pix-Zertifizierung bescheinigt ein bestimmtes Level an digitaler Kompetenz: Gib nachfolgend den \"Überprüfungscode\" des zu überprüfenden Pix-Zertifikats ein.",
       "errors": {
-        "missing-code": "Bitte geben Sie den Verifizierungscode ein.",
+        "missing-code": "Bitte gib den Verifizierungscode ein.",
         "not-found": "Es gibt kein entsprechendes Pix-Zertifikat.",
-        "unallowed-access": "Bitte geben Sie den Verifizierungscode im Format P-XXXXXXXXX in das Feld oben ein.",
-        "wrong-format": "Bitte überprüfen Sie das Format Ihres Codes (P-XXXXXXXX)."
+        "unallowed-access": "Bitte gib den Verifizierungscode im Format P-XXXXXXXXX in das Feld oben ein.",
+        "wrong-format": "Bitte überprüfe das Format deines Codes (P-XXXXXXXX)."
       },
       "first-title": "Ein Pix-Zertifikat überprüfen",
       "label": "Verifizierungscode",
@@ -1513,83 +1503,83 @@
       "verify": "Zertifikat überprüfen"
     },
     "fill-in-participant-external-id": {
-      "announcement": "Der Organisator benötigt die folgenden Informationen, um Sie begleiten zu können:",
+      "announcement": "Der Organisator benötigt die folgenden Informationen, um dich begleiten zu können:",
       "buttons": {
         "cancel": "Abbrechen",
         "continue": "Weiter"
       },
       "errors": {
-        "invalid-external-id": "Ihr { externalIdLabel } ist ungültig.",
+        "invalid-external-id": "Dein { externalIdLabel } ist ungültig.",
         "invalid-external-id-email": "Die E-Mail-Adresse ist ungültig.",
-        "max-length-external-id": "Ihr { externalIdLabel } darf nicht länger als 255 Zeichen sein.",
-        "missing-external-id": "Bitte geben Sie Ihre { externalIdLabel } an."
+        "max-length-external-id": "Dein { externalIdLabel } darf nicht länger als 255 Zeichen sein.",
+        "missing-external-id": "Bitte gib deine { externalIdLabel } an."
       },
-      "first-title": "Bevor Sie beginnen",
+      "first-title": "Bevor du beginnst",
       "title": "Meinen Benutzernamen eingeben"
     },
     "focused-certification-challenge-instructions": {
       "action": "Ich bin bereit",
-      "description": "Bei der/den nächsten Frage(n) dürfen Sie die Seite nicht verlassen.",
+      "description": "Bei der/den nächsten Frage(n) darfst die Seite nicht verlassen.",
       "title": "Fokus-Modus"
     },
     "join": {
       "button": "Los geht's!",
       "fields": {
         "birthdate": {
-          "day-error": "Ihr Geburtsdatum ist ungültig.",
+          "day-error": "Dein Geburtsdatum ist ungültig.",
           "day-format": "JJ",
           "day-label": "Geburtstag",
           "label": "Geburtsdatum",
-          "month-error": "Ihr Geburtsmonat ist ungültig.",
+          "month-error": "Dein Geburtsmonat ist ungültig.",
           "month-format": "MM",
           "month-label": "Geburtsmonat",
-          "year-error": "Ihr Geburtsjahr ist ungültig.",
+          "year-error": "Dein Geburtsjahr ist ungültig.",
           "year-format": "AAAA",
           "year-label": "Geburtsjahr"
         },
         "firstname": {
-          "error": "Ihr Vorname ist nicht ausgefüllt.",
+          "error": "Dein Vorname ist nicht ausgefüllt.",
           "label": "Vorname"
         },
         "lastname": {
-          "error": "Ihr Name ist nicht ausgefüllt.",
-          "label": "Name"
+          "error": "Dein Nachname ist nicht ausgefüllt.",
+          "label": "Nachname"
         }
       },
       "rgpd-legal-notice": "Um zu erfahren, wie deine Daten verarbeitet werden und welche Rechte du hast, kannst du die",
       "rgpd-legal-notice-link": "Informationsvermerke.",
       "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
       "sco": {
-        "associate": "Assoziieren",
+        "associate": "Verbinden",
         "continue-with-pix": "Mit meinem Pix-Konto fortfahren",
-        "error-not-found": "Sind Sie ein Schüler oder eine Schülerin? '<br>' Überprüfen Sie Ihre Angaben (Vorname, Nachname und Geburtsdatum) oder wenden Sie sich an eine Lehrkraft.'<br><br>' Sie sind eine Lehrkraft? '<br>' Der Zugriff auf einen Parcours ist derzeit nicht verfügbar.",
-        "first-title": "Treten Sie der Organisation { organizationName } bei",
-        "invalid-reconciliation-error": "Es ist ein Fehler aufgetreten. '<br>' Bitte wenden Sie sich an den Support.",
-        "login-information-message": "Das Pix-Konto '<b>'{ connectionMethod }'</b>' wird mit dem Schüler verknüpft: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Wenn es sich dabei um Sie handelt, klicken Sie auf \"Verknüpfen\", andernfalls melden Sie sich ab.",
+        "error-not-found": "Bist du ein Schüler oder eine Schülerin? '<br>' Überprüfe deine Angaben (Vorname, Nachname und Geburtsdatum) oder wende dich an eine Lehrkraft.'<br><br>' Du bist eine Lehrkraft? '<br>' Der Zugriff auf einen Lernpfad ist derzeit nicht verfügbar.",
+        "first-title": "Tritt der Organisation { organizationName } bei",
+        "invalid-reconciliation-error": "Es ist ein Fehler aufgetreten. '<br>' Bitte wende dich an den Support.",
+        "login-information-message": "Das Pix-Konto '<b>'{ connectionMethod }'</b>' wird mit dem Schüler/der Schülerin verknüpft: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Wenn es sich dabei um dich handelt, klicke auf \"Verknüpfen\", andernfalls melde dich ab.",
         "login-information-title": "Anmeldeinformationen",
-        "subtitle": "Füllen Sie die fehlenden Informationen aus"
+        "subtitle": "Fülle die fehlenden Informationen aus"
       },
       "sup": {
-        "error": "Bitte überprüfen Sie die eingegebenen Informationen, oder wenn Sie bereits ein Pix-Konto haben, melden Sie sich mit diesem an.",
+        "error": "Bitte überprüfe die eingegebenen Informationen, oder wenn du bereits ein Pix-Konto hast, melde dich mit diesem an.",
         "fields": {
           "student-number": {
-            "error": "Ihre Studentennummer ist nicht ausgefüllt.",
-            "label": "Studentennummer",
-            "modify": "Studentennummer ändern",
-            "not-existing": "Ich habe keine Studentennummer"
+            "error": "Deine Schüler:innennumer ist nicht ausgefüllt.",
+            "label": "Schüler:innennumer",
+            "modify": "Schüler:innennumer ändern",
+            "not-existing": "Ich habe keine Schüler:innennumer"
           }
         },
-        "message": "Geben Sie die Informationen so ein, wie sie auf Ihrem Schülerausweis stehen, um auf den Test zuzugreifen und die Ergebnisse zu versenden. Pix wird sich beim nächsten Mal daran erinnern.",
-        "title": "Melden Sie Ihr Pix-Konto bei {organizationName} an."
+        "message": "Gib die Informationen so ein, wie sie auf deinem Schüler:innenausweis/Student:innenausweis stehen, um auf den Test zuzugreifen und die Ergebnisse zu versenden. Pix wird sich beim nächsten Mal daran erinnern.",
+        "title": "Melde dein Pix-Konto bei {organizationName} an."
       },
       "title": "Beitreten"
     },
     "learning-more": {
-      "info": "Diese Links zu den Tutorials wurden von Pix-Nutzern vorgeschlagen.",
+      "info": "Diese Links zu den Tutorials wurden von Pix-Nutzer:innen vorgeschlagen.",
       "title": "Um mehr zu erfahren"
     },
     "levelup-notif": {
-      "obtained-level": "Level { level } gewonnen!"
+      "obtained-level": "Level { level } geschafft!"
     },
     "llm-preview": {
       "iframe-title": "ChatPix",
@@ -1608,31 +1598,31 @@
         },
         "embed": {
           "start": {
-            "ariaLabel": "Simulator starten",
+            "ariaLabel": "Anwendung starten",
             "name": "Beginnen"
           }
         },
         "flashcards": {
           "answers": {
             "almost": "Fast",
-            "no": "Überhaupt nicht",
+            "no": "Nein",
             "yes": "Ja!"
           },
           "nextCard": "Weiter zu",
           "retry": "Erneut versuchen",
-          "seeAgain": "Frage überarbeiten",
+          "seeAgain": "Überarbeiten",
           "seeAnswer": "Siehe die Antwort",
           "start": "Beginnen"
         },
         "grain": {
           "continue": "Weiter",
-          "skip": "Verpassen Sie",
+          "skip": "Überspringen",
           "skipActivity": "Aktivität überspringen",
           "terminate": "Beenden"
         },
         "interactive-element": {
           "reset": {
-            "ariaLabel": "Simulator zurücksetzen",
+            "ariaLabel": "Anwendung zurücksetzen",
             "name": "Zurücksetzen"
           }
         },
@@ -1651,7 +1641,7 @@
               "name": "Weiter zu"
             },
             "vertical": {
-              "name": "Lesen Sie mehr"
+              "name": "Mehr lesen"
             }
           }
         }
@@ -1661,62 +1651,62 @@
         "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'Etwa '</span>'{duration} min",
         "level": "Ebene",
         "levels": {
-          "advanced": "Fortgeschrittene",
-          "expert": "Experte",
+          "advanced": "Fortgeschritten",
+          "expert": "Expert:in",
           "independent": "Selbstständig",
-          "novice": "Novize"
+          "novice": "Anfänger:in"
         },
         "objectives": "Ziele",
         "smallScreenModal": {
           "cancel": "Zurück zu den Details",
-          "description": "Einige Aktivitäten in diesem Modul sind auf einem kleinen Bildschirm möglicherweise nur schwer durchführbar. Für eine optimale Erfahrung empfehlen wir Ihnen, einen Computer zu verwenden.",
+          "description": "Einige Aktivitäten in diesem Modul sind auf einem kleinen Bildschirm möglicherweise nur schwer durchführbar. Für eine optimale Erfahrung empfehlen wir dir, einen Computer zu verwenden.",
           "startModule": "Beginnen",
-          "title": "Sie scheinen einen kleinen Bildschirm zu verwenden"
+          "title": "Du scheinst einen kleinen Bildschirm zu verwenden"
         },
         "startModule": "Das Modul beginnen"
       },
       "download": {
         "button": "Download",
-        "description": "Wählen Sie das Format entsprechend der Software, die Sie verwenden. Wenn Sie unsicher sind, wählen Sie die erste Datei, sie ist mit den meisten Programmen kompatibel.",
+        "description": "Wähle das Format entsprechend der Software, die du verwendest. Wenn du unsicher bist, wähle die erste Datei, sie ist mit den meisten Programmen kompatibel.",
         "documentationLinkHref": "https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix",
         "documentationLinkLabel": "Wie kann ich diese Datei öffnen, bearbeiten oder finden?",
         "format": "Format {format}",
-        "intro": "Wählen Sie das Dateiformat, das Sie verwenden möchten.",
+        "intro": "Wähle das Dateiformat, das du verwenden möchtest.",
         "label": "Datei im Format {format} herunterladen"
       },
       "elements": {
         "audio": {
-          "consult-transcription": "Lesen Sie die Transkription, um den Inhalt zu erfahren.",
+          "consult-transcription": "Lies die Transkription, um den Inhalt zu erfahren.",
           "missing-content": "Beim Anzeigen des Audios ist ein Fehler aufgetreten."
         },
         "image": {
-          "consult-alternative-text": "Lesen Sie den alternativen Text, um den Inhalt zu erfahren.",
+          "consult-alternative-text": "Lies den alternativen Text, um den Inhalt zu erfahren.",
           "missing-content": "Beim Anzeigen des Bildes ist ein Fehler aufgetreten."
         },
         "short-video": {
-          "consult-transcription": "Lesen Sie die Transkription, um den Inhalt zu erfahren.",
+          "consult-transcription": "Lies die Transkription, um den Inhalt zu erfahren.",
           "missing-content": "Beim Anzeigen des Videos ist ein Fehler aufgetreten."
         },
         "text": {
           "tag": {
             "context": "Kontext",
-            "did-you-know": "Wussten Sie schon?",
+            "did-you-know": "Wusstest du schon?",
             "further-information": "Weitere Informationen",
             "tip": "Tipp"
           }
         }
       },
       "flashcards": {
-        "answerDirection": "Hatten Sie die Antwort?",
+        "answerDirection": "Wusstest du die Antwort?",
         "completed": "Abgeschlossen",
         "counters": {
           "almost": "Fast: {totalAlmost}.",
           "no": "Überhaupt nicht: {totalNo}.",
           "yes": "Ja!: {totalYes}."
         },
-        "direction": "Suchen Sie nach der Antwort und drehen Sie dann die Karte um",
+        "direction": "Suche nach der Antwort und drehe dann die Karte um",
         "navigation": {
-          "longCurrentStep": "Schritt {current} auf {total}.",
+          "longCurrentStep": "Schritt {current} von {total}.",
           "shortCurrentStep": "{current}/{total}"
         },
         "position": "Karte {currentCardPosition}/{totalCards}"
@@ -1738,16 +1728,16 @@
         "aria-label": "Ein Problem oder einen Vorschlag senden",
         "button": "Melden",
         "error-messages": {
-          "missing-comment": "Bitte geben Sie einen Kommentar ein."
+          "missing-comment": "Bitte gib einen Kommentar ein."
         },
         "modal": {
           "categories": {
             "custom-and-embed": {
-              "embed-not-working": "Der Simulator / die Anwendung funktioniert nicht",
+              "embed-not-working": "Die Anwendung funktioniert nicht",
               "instruction-issue": "Ich verstehe die Anweisung nicht"
             },
             "default": {
-              "accessibility-issue": "Problem der Zugänglichkeit",
+              "accessibility-issue": "Barrierefreiheit",
               "other": "Andere"
             },
             "feedback": {
@@ -1758,16 +1748,16 @@
           },
           "confirmation-message": {
             "error": {
-              "info": "Beim Absenden des Kommentars ist ein Fehler aufgetreten.",
-              "retry": "Bitte versuchen Sie es später noch einmal."
+              "info": "Beim Absenden der Meldung ist ein Fehler aufgetreten.",
+              "retry": "Bitte versuche es später noch einmal."
             },
-            "success": "Danke Ihr Kommentar wurde gut berücksichtigt."
+            "success": "Danke, dein Kommentar wurde berücksichtigt."
           },
           "legend": "Erforderliche Informationen, um eine Meldung zu senden",
-          "select-label": "Grund der Ausschreibung",
+          "select-label": "Meldung",
           "textarea-label": "Kommentar",
-          "textarea-placeholder": "Beschreiben Sie uns Ihr Problem oder Ihre Anregung",
-          "title": "Ausschreibung"
+          "textarea-placeholder": "Beschreibe dein Problem oder dein Anliegen",
+          "title": "Meldung"
         }
       },
       "modals": {
@@ -1783,7 +1773,7 @@
           "aria-label": {
             "disabled": "Nicht verfügbar. Vorherigen Schritt beenden",
             "enabled": "Gehe zu Schritt {sectionTitle}.",
-            "steps": "Schritt {indexSection} auf {totalSections}."
+            "steps": "Schritt {indexSection} von {totalSections}."
           }
         },
         "tooltip": {
@@ -1793,7 +1783,7 @@
       "preview": {
         "elements-id-button": {
           "choices": {
-            "no": "Nicht",
+            "no": "Nein",
             "yes": "Ja"
           },
           "label": "ID der Elemente anzeigen"
@@ -1801,7 +1791,7 @@
         "grain-select": {
           "button": "Grain testen",
           "grain-label": "Grain {index} : {title}",
-          "label": "Wählen Sie das zu testende Grain aus"
+          "label": "Wähle das zu testende Grain aus"
         },
         "modulix-editor": "Modulix Editor",
         "showJson": "JSON anzeigen",
@@ -1814,36 +1804,36 @@
         "retry": "Erneut versuchen",
         "score": {
           "title": "Abgeschlossene Serie",
-          "yourScore": "Ihre Punktzahl: {score}/{total}"
+          "yourScore": "Deine Punktzahl: {score}/{total}"
         }
       },
       "qcm": {
-        "direction": "Wählen Sie mehrere Antworten aus."
+        "direction": "Wähle mehrere Antworten aus."
       },
       "qcu": {
-        "direction": "Wählen Sie nur eine Antwort aus."
+        "direction": "Wähle nur eine Antwort aus."
       },
       "qcuDeclarative": {
         "complementaryInstruction": "Es gibt keine richtige oder falsche Antwort.",
-        "direction": "Wählen Sie nur eine Antwort aus."
+        "direction": "Wähle nur eine Antwort aus."
       },
       "qcuDiscovery": {
-        "direction": "Wählen Sie die Antwort aus, die Ihnen am zutreffendsten erscheint."
+        "direction": "Wähle die Antwort aus, die dir am zutreffendsten erscheint."
       },
       "qrocm": {
-        "direction": "Füllen Sie {count, plural, =1 {das Feld} other {die Felder}} aus."
+        "direction": "Fülle {count, plural, =1 {das Feld} other {die Felder}} aus."
       },
       "recap": {
         "backToModuleDetails": "Verlassen",
         "goToHomepage": "Weiter",
-        "subtitle": "Sie haben an den folgenden Zielen gearbeitet:",
+        "subtitle": "Du hast an den folgenden Zielen gearbeitet:",
         "title": "Modul abgeschlossen!"
       },
       "section": {
-        "explore-to-understand": "Erforschen, um zu verstehen",
-        "go-further": "Weitergehen",
+        "explore-to-understand": "Erkunden, um zu verstehen",
+        "go-further": "Weiter",
         "practise": "Üben",
-        "question-yourself": "Sich selbst hinterfragen",
+        "question-yourself": "Dich selbst testen",
         "retain-the-essentials": "Das Wesentliche festhalten"
       },
       "sidebar": {
@@ -1857,13 +1847,13 @@
         }
       },
       "verification-precondition-failed-alert": {
-        "qcm": "Wählen Sie zum Bestätigen mindestens zwei Antworten aus.",
-        "qcu": "Zum Bestätigen wählen Sie eine Antwort aus.",
-        "qrocm": "Füllen Sie zum Bestätigen bitte alle Antwortfelder aus."
+        "qcm": "Wähle zum Bestätigen mindestens zwei Antworten aus.",
+        "qcu": "Zum Bestätigen wähle eine Antwort aus.",
+        "qrocm": "Fülle zum Bestätigen bitte alle Antwortfelder aus."
       }
     },
     "not-connected": {
-      "message": "Sie sind gut abgemeldet.'<br>'Danke, bis bald.",
+      "message": "Deine Abmeldung war erfolgreich.'<br>'Danke, bis bald.",
       "title": "Offline"
     },
     "oidc-reconciliation": {
@@ -1873,35 +1863,35 @@
       "email": "E-Mail-Adresse",
       "external-connection": "Externe Verbindung",
       "external-connection-via": "Verbindung über",
-      "information": "Da die Kompetenzbewertung personalisiert ist, muss Ihr Konto strikt persönlich bleiben.",
+      "information": "Da die Kompetenzbewertung personalisiert ist, muss dein Konto strikt vertraulich bleiben.",
       "return": "Zurück",
-      "sub-title": "Ihrem Pix-Konto wird bald eine neue Anmeldemethode hinzugefügt.",
+      "sub-title": "Deinem Pix-Konto wird bald eine neue Anmeldemethode hinzugefügt.",
       "switch-account": "Konto wechseln",
       "title": "Achtung!",
-      "username": "Kennung"
+      "username": "Username"
     },
     "oidc-signup-or-login": {
       "error": {
-        "account-conflict": "Dieses Konto ist bereits mit dieser Organisation verknüpft. Bitte melden Sie sich mit einem anderen Konto an oder wenden Sie sich an den Support.",
-        "data-sharing-refused": "Wir weisen Sie darauf hin, dass die Übermittlung Ihrer auf der vorherigen Seite präzisierten Daten unerlässlich ist, um auf den Dienst zugreifen und ihn nutzen zu können.",
-        "error-message": "Sie müssen die Nutzungsbedingungen von Pix.",
-        "expired-authentication-key": "Ihre Authentifizierungsanfrage ist abgelaufen.",
-        "invalid-email": "Ihre E-Mail-Adresse ist ungültig.",
+        "account-conflict": "Dieses Konto ist bereits mit dieser Organisation verknüpft. Bitte melde dich mit einem anderen Konto an oder wende dich an den Support.",
+        "data-sharing-refused": "Wir weisen dich darauf hin, dass die Übermittlung deiner auf der vorherigen Seite präzisierten Daten unerlässlich ist, um auf den Dienst zugreifen und ihn nutzen zu können.",
+        "error-message": "Bitte akzeptiere die Nutzungsbedingungen von Pix.",
+        "expired-authentication-key": "Deine Authentifizierungsanfrage ist abgelaufen.",
+        "invalid-email": "Deine E-Mail-Adresse ist ungültig.",
         "login-unauthorized-error": "Die eingegebene E-Mail-Adresse und/oder das Passwort sind falsch.",
-        "password-reset-token-invalid-or-expired": "Es ist zu viel Zeit vergangen, um Ihr neues Passwort zu bestätigen. Kehren Sie zur Anmeldeseite zurück, um Ihren Benutzernamen und Ihr vorläufiges Passwort erneut einzugeben."
+        "password-reset-token-invalid-or-expired": "Es ist zu viel Zeit vergangen, um dein neues Passwort zu bestätigen. Kehre zur Anmeldeseite zurück, um deinen Benutzernamen und dein vorläufiges Passwort erneut einzugeben."
       },
       "login-form": {
-        "button": "Ich logge mich ein",
-        "description": "Melden Sie sich an, um Ihr bestehendes Konto zu verknüpfen und Ihre bereits bewerteten Fähigkeiten abzurufen.",
+        "button": "Login",
+        "description": "Melde dich an, um dein bestehendes Konto zu verknüpfen und deine bereits bewerteten Kompetenzen abzurufen.",
         "email": "E-Mail-Adresse",
         "password": "Passwort",
         "title": "Ich habe bereits ein Pix-Konto"
       },
       "signup-form": {
-        "button": "Ich erstelle mein Konto",
+        "button": "Konto erstellen",
         "claims": {
           "FrEduFonctAdm": "Administrative Funktion",
-          "FrEduNumenHash": "Technische Kennung",
+          "FrEduNumenHash": "Technische Identifikation",
           "discipline": "Disziplin",
           "employeeNumber": "Nummer des Mitarbeiters",
           "population": "Bevölkerung",
@@ -1909,70 +1899,70 @@
           "title": "Funktion"
         },
         "description": "Ein Konto wird anhand der von der Organisation übermittelten Elemente erstellt.",
-        "error": "Es war uns nicht möglich, Ihre Identitätsinformationen von der verwendeten Abteilung abzurufen. Wir bitten Sie, sich an den IT-Support dieser Organisation zu wenden.",
+        "error": "Es war uns nicht möglich, deine Identitätsinformationen von der verwendeten Abteilung abzurufen. Wir bitten dich an den IT-Support deiner Organisation zu wenden.",
         "first-name-label-and-value": "Vorname: {firstName}",
         "last-name-label-and-value": "Name: {lastName}.",
         "title": "Ich habe kein Pix-Konto"
       },
-      "title": "Erstellen Sie Ihr Pix-Konto"
+      "title": "Erstelle dein Pix-Konto"
     },
     "password-reset-demand": {
       "title": "Passwort vergessen"
     },
     "profile": {
       "accessibility": {
-        "title": "Ihr Pix-Profil",
-        "user-score": "Ihre Anzahl an Pix",
-        "user-skills": "Ihre Pix-Fähigkeiten"
+        "title": "Dein Pix-Profil",
+        "user-score": "Deine Anzahl an Pix",
+        "user-skills": "Deine Pix-Kompetenzen"
       },
       "competence-card": {
         "congrats": "Bravo!",
         "details": "Details",
         "image-info": {
-          "first-level": "Die erste Ebene ist im Gange und zu {percentageAheadOfNextLevel}% abgeschlossen.",
+          "first-level": "Die erste Testung ist im Gange und zu {percentageAheadOfNextLevel}% abgeschlossen.",
           "level": "Aktuelle Stufe: {currentLevel}. Die nächste Stufe wird bei {percentageAheadOfNextLevel}% abgeschlossen.",
           "no-level": "Kompetenz nicht begonnen"
         }
       },
-      "description": "Bewerten Sie sich in Ihrem eigenen Tempo in 16 digitalen Fertigkeiten. Wählen Sie eine Fertigkeit und beginnen Sie, Pixel zu verdienen.",
-      "first-title": "Sie haben 16 Fähigkeiten, die Sie testen müssen. '<br>'Konzentrieren Sie sich und los geht's !",
+      "description": "Bewerte dich in deinem eigenen Tempo in 16 digitalen Kompetenzen. Wähle eine Kompetenz und beginne, Pixel zu verdienen.",
+      "first-title": "Du hast 16 Kompetenzen, die du testen müssen. '<br>'Konzentriere dich und los geht's !",
       "resume-campaign-banner": {
         "accessibility": {
-          "resume": "Ihren Weg fortsetzen",
-          "share": "Teilen Sie die Ergebnisse Ihrer Strecke"
+          "resume": "Fortsetzen",
+          "share": "Teile die Ergebnisse der Testung"
         },
         "actions": {
           "continue": "Weiter",
-          "resume": "Übernehmen"
+          "resume": "Fortsetzen"
         },
-        "reminder-continue-campaign": "Sie haben Ihren Parcours nicht abgeschlossen",
-        "reminder-continue-campaign-with-title": "Sie haben die Strecke \"{title}\" nicht abgeschlossen.",
-        "reminder-send-campaign": "Vergessen Sie nicht, Ihre Sendung abzuschließen!",
-        "reminder-send-campaign-with-title": "Parcours \"{title}\" abgeschlossen. Vergessen Sie nicht, Ihre Sendung abzuschließen!"
+        "reminder-continue-campaign": "Du hast deinen Lernpfad nicht abgeschlossen",
+        "reminder-continue-campaign-with-title": "Du hast die Testung \"{title}\" nicht abgeschlossen.",
+        "reminder-send-campaign": "Vergiss nicht, deine Testung abzuschließen!",
+        "reminder-send-campaign-with-title": "Lernpfad \"{title}\" abgeschlossen. Vergiss nicht, deine Testung abzuschließen!"
       },
       "title": "Kompetenzen",
       "total-score-helper": {
-        "explanation": "'<p>'Dies ist die maximale Anzahl an Pixeln, die erreicht werden kann, wenn alle 8 Ebenen des Pix-Referenzsystems verfügbar sind.'</p><p>'Heute liegt '<span class=\"hexagon-score-information__text-strong\">'das Maximum bei {maxReachablePixScore} Pix'</span>', entsprechend der Ebene {maxReachableLevel}.'</p>'",
-        "icon": "Informationen zu Pixeln",
+        "explanation": "'<p>'Dies ist die maximale Anzahl an Pix, die erreicht werden kann, wenn alle 8 Ebenen des Pix-Referenzsystems verfügbar sind.'</p><p>'Heute liegt '<span class=\"hexagon-score-information__text-strong\">'das Maximum bei {maxReachablePixScore} Pix'</span>', entsprechend der Ebene {maxReachableLevel}.'</p>'",
+        "icon": "Informationen zu Pix",
         "label": "Den Tooltip öffnen",
-        "title": "Warum 1024 Pixel?"
+        "title": "Warum 1024 Pix?"
       }
     },
     "profile-already-shared": {
       "actions": {
-        "continue": "Setzen Sie Ihre Pix-Erfahrung fort"
+        "continue": "Setze deine Pix-Erfahrung fort"
       },
-      "explanation": "Sie haben das untenstehende Profil bereits an die Organisation {organization}'<br>'am {date} an {hour,time,hhmm} gesendet.",
+      "explanation": "Du hast das untenstehende Profil bereits an die Organisation {organization}'<br>'am {date} an {hour,time,hhmm} gesendet.",
       "first-title": "Es läuft nicht alles nach Plan",
       "retry": {
         "button": "Mein Profil zurückschicken",
-        "message": "{organization} fordert Sie auf, Ihr Profil erneut zu senden, um Ihren Fortschritt zu messen."
+        "message": "{organization} fordert dich auf, dein Profil erneut zu senden, um deinen Fortschritt zu messen."
       },
       "title": "Profil bereits gesendet"
     },
     "reset-password": {
       "error": {
-        "expired-demand": "Es tut uns leid, aber Ihr Antrag zum Zurücksetzen des Passworts wurde bereits verwendet oder ist abgelaufen. Bitte versuchen Sie es erneut."
+        "expired-demand": "Es tut uns leid, aber dein Code zum Zurücksetzen des Passworts wurde bereits verwendet oder ist abgelaufen. Bitte versuche es erneut."
       },
       "first-title": "Zurücksetzen des Passworts",
       "title": "Mein Passwort ändern"
@@ -1989,9 +1979,9 @@
       "timedout": "Zeit überschritten"
     },
     "sco-signup-or-login": {
-      "invitation": "{ organizationName } lädt Sie ein, sich Pix anzuschließen",
+      "invitation": "{ organizationName } lädt dich ein, bei Pix mitzumachen",
       "login-form": {
-        "button": "Sich anmelden",
+        "button": "Anmelden",
         "fields": {
           "login": {
             "label": "E-Mail-Adresse oder Benutzername"
@@ -2001,55 +1991,55 @@
           }
         },
         "forgotten-password": {
-          "email": "Eine E-Mail-Adresse :",
-          "instruction": "Haben Sie Ihr Passwort vergessen? Sie haben ein Pix-Konto mit :",
-          "other-identity": "Eine Benutzerkennung: Wenden Sie sich an Ihre Lehrkraft, um sie zurückzusetzen",
-          "reset-link": "Klicken Sie hier, um ihn zurückzusetzen"
+          "email": "E-Mail-Adresse :",
+          "instruction": "Hast du dein Passwort vergessen? Du hast ein Pix-Konto mit :",
+          "other-identity": "Eine Benutzerkennung: Wende dich an deine Lehrkraft, um sie zurückzusetzen",
+          "reset-link": "Zum Zurücksetzen hier klicken"
         },
         "title": "Ich habe bereits ein Pix-Konto",
-        "unexpected-user-account-error": "Die E-Mail-Adresse oder der Benutzername ist falsch. Um fortzufahren, müssen Sie sich in Ihr Konto einloggen, das in der Form :"
+        "unexpected-user-account-error": "Die E-Mail-Adresse oder der Benutzername ist falsch. Um fortzufahren, musst du dich in dein Konto einloggen, das in der Form :"
       },
       "signup-form": {
         "button": "Anmelden",
-        "button-form": "Ich melde mich an",
+        "button-form": "Anmelden",
         "fields": {
           "birthdate": {
             "day": {
-              "error": "Ihr Geburtsdatum ist ungültig.",
+              "error": "Dein Geburtsdatum ist ungültig.",
               "label": "Tag der Geburt",
               "placeholder": "JJ"
             },
             "label": "Geburtsdatum (TT/MM/JJJJ)",
             "month": {
-              "error": "Ihr Geburtsmonat ist ungültig.",
+              "error": "Dein Geburtsmonat ist ungültig.",
               "label": "Geburtsmonat",
               "placeholder": "MM"
             },
             "year": {
-              "error": "Ihr Geburtsjahr ist ungültig.",
-              "label": "Jahr der Geburt",
+              "error": "Dein Geburtsjahr ist ungültig.",
+              "label": "Geburtsjahr",
               "placeholder": "AAAA"
             }
           },
           "cgu": "Ich akzeptiere die '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'Nutzungsbedingungen von Pix'</a>'.",
           "email": {
-            "error": "Ihre E-Mail ist ungültig.",
+            "error": "Deine E-Mail ist ungültig.",
             "help": "(z.B. nom@exemple.fr)",
             "label": "E-Mail-Adresse"
           },
           "firstname": {
-            "error": "Ihr Vorname ist nicht ausgefüllt.",
+            "error": "Dein Vorname ist nicht ausgefüllt.",
             "label": "Vorname"
           },
           "lastname": {
-            "error": "Ihr Name ist nicht ausgefüllt.",
+            "error": "Dein Name ist nicht ausgefüllt.",
             "label": "Name"
           },
           "password": {
-            "error": "Ihr Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben und eine Zahl enthalten.",
+            "error": "Dein Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben und eine Zahl enthalten.",
             "help": "(mindestens 8 Zeichen, darunter ein Großbuchstabe, ein Kleinbuchstabe und eine Zahl)",
             "label": "Passwort",
-            "show-button": "das Passwort lesbar machen"
+            "show-button": "Passwort zeigen"
           },
           "username": {
             "label": "Mein Benutzername"
@@ -2058,29 +2048,29 @@
         "not-me": "Das bin ich nicht",
         "options": {
           "email": "Meine E-Mail-Adresse",
-          "text": "Ich melde mich an mit :",
+          "text": "Anmelden mit",
           "username": "Mein Benutzername"
         },
         "rgpd-legal-notice": "Um zu erfahren, wie deine Daten verarbeitet werden und welche Rechte du hast, kannst du die",
         "rgpd-legal-notice-link": "Informationsvermerke.",
         "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
-        "title": "Ich melde mich bei Pix an"
+        "title": "Bei Pix anmelden"
       },
-      "title": "Sich bei Pix anmelden"
+      "title": "Bei Pix anmelden"
     },
     "send-profile": {
-      "disabled-share": "Diese Strecke wurde vom Veranstalter deaktiviert. Das Senden von Ergebnissen ist nicht mehr möglich.",
+      "disabled-share": "Dieser Pfad wurde vom Veranstalter deaktiviert. Das Senden von Ergebnissen ist nicht mehr möglich.",
       "errors": {
-        "archived": "Das Einsenden Ihres Profils ist nicht mehr möglich, da der Organisator die Profilsammlung archiviert hat."
+        "archived": "Das Einsenden deines Profils ist nicht mehr möglich, da der Organisator die Profilsammlung archiviert hat."
       },
-      "first-title": "Senden Sie Ihr Pix-Profil",
+      "first-title": "Sende dein Pix-Profil",
       "form": {
-        "continue": "Setzen Sie Ihre Pix-Erfahrung fort",
+        "continue": "Setze deine Pix-Erfahrung fort",
         "recipient": "Empfänger: {recipient}.",
-        "send": "Ich sende mein Profil",
-        "shared": "Danke, Ihr Profil wurde erfolgreich gesendet!"
+        "send": "Profil senden",
+        "shared": "Danke, dein Profil wurde erfolgreich gesendet!"
       },
-      "instructions": "Sie werden die in Ihrem Pix-Profil vorhandene Punktzahl und die Fertigkeitsstufen übermitteln. '<br>' Alle Änderungen an Ihrem Profil nach dieser Übermittlung werden nicht weitergeleitet. '<br>' Denken Sie daran, dies vor dem Versenden zu überprüfen!",
+      "instructions": "Du wirst die in deinem Pix-Profil vorhandene Punktzahl und die Niveausstufen übermitteln. '<br>' Alle Änderungen in deinem Profil nach dieser Übermittlung werden nicht weitergeleitet. '<br>' Denk daran, dies vor dem Versenden zu überprüfen!",
       "title": "Mein Profil senden"
     },
     "shared-certification": {
@@ -2089,10 +2079,10 @@
     },
     "sign-in": {
       "actions": {
-        "submit": "Ich logge mich ein"
+        "submit": "Einloggen"
       },
       "fields": {
-        "legend": "Informationen, die Sie zum Einloggen benötigen.",
+        "legend": "Login Informationen",
         "login": {
           "label": "E-Mail-Adresse oder Benutzername",
           "placeholder": "z.B.: jean.dupont@email.com"
@@ -2101,167 +2091,163 @@
           "label": "Passwort"
         }
       },
-      "first-title": "Melden Sie sich an",
+      "first-title": "Melde dich an",
       "forgotten-password": "Passwort vergessen?",
-      "title": "Verbindung"
+      "title": "Verbinden"
     },
     "signup": {
       "actions": {
-        "login": "Sich anmelden",
+        "login": "Anmelden",
         "sign-up-on-pix": "Auf Pix registrieren",
-        "submit": "Ich melde mich an"
+        "submit": "Anmelden"
       },
       "fields": {
         "email": {
           "help": "(z.B. nom@exemple.fr)"
         }
       },
-      "first-title": "Melden Sie sich an",
-      "save-progress-message": "Um Ihren Fortschritt zu erhalten und sich weiterhin zu bewerten, melden Sie sich bei Pix!",
+      "first-title": "Melde dich an",
+      "save-progress-message": "Um deinen Fortschritt zu behalten und dich weiterhin zu bewerten, melde dich bei Pix an!",
       "title": "Anmeldung"
     },
     "sitemap": {
       "accessibility": {
         "help": "Hilfe bei Fragen zur Barrierefreiheit auf Pix",
-        "title": "Zugänglichkeit"
+        "title": "Barrierefreiheit"
       },
       "cgu": {
         "policy": "Datenschutzrichtlinie",
-        "subcontractors": "Liste der Unterauftragnehmer"
+        "subcontractors": "Liste der Partner"
       },
       "resources": "Ressourcen",
       "title": "Sitemap"
     },
     "skill-review": {
-      "abstract": "Sie beherrschen '<strong>'{rate, number, ::percent}'</strong><br>'der getesteten Fähigkeiten.",
-      "abstract-title": "Ihr Ergebnis für diesen Kurs",
+      "abstract": "Du beherrscht '<strong>'{rate, number, ::percent}'</strong><br>'der getesteten Kompetenzen.",
+      "abstract-title": "Dein Ergebnis für diesen Kurs",
       "actions": {
         "back-to-pix": "Beenden und zu Pix zurückkehren",
-        "continue": "Setzen Sie Ihre Pix-Erfahrung fort"
+        "continue": "Setze deine Pix-Erfahrung fort"
       },
-      "already-shared": "Vielen Dank, Ihre Ergebnisse wurden erfolgreich versendet!",
+      "already-shared": "Vielen Dank, deine Ergebnisse wurden erfolgreich versendet!",
       "badge-card": {
         "acquired": "Erhalten",
         "acquired-full": "Badge erhalten",
         "certifiable": "Zertifizierer",
         "not-acquired": "Nicht erhalten",
         "not-acquired-full": "Badge nicht erhalten",
-        "progress-bar-label": "Prozentualer Anteil der bestandenen Abzeichen"
+        "progress-bar-label": "Prozentualer Anteil der erhaltenen Badges"
       },
-      "badges-title": "Ihre Namensschilder",
+      "badges-title": "Deine Badges",
       "details": {
-        "caption": "Details zu Ihren Ergebnissen in Form von Prozentsätzen nach Fähigkeiten",
+        "caption": "Details zu deinen Ergebnissen in Form von Prozentsätzen nach Kompetenzen",
         "header-result": "Ergebnisse",
-        "header-skill": "Getestete Fähigkeiten",
+        "header-skill": "Getestete Kompetenzen",
         "percentage": "{rate, number, ::percent}",
         "progress-bar-label": "Prozentualer Anteil der bestandenen Kompetenz",
         "result": "Gesamtergebnis",
-        "title": "Ihre Ergebnisse nach Kompetenz"
+        "title": "Deine Ergebnisse nach Kompetenz"
       },
       "error": "Ups, ein Fehler ist aufgetreten!",
       "hero": {
-        "acquired-badges-title": "Erhaltene Auszeichnungen",
+        "acquired-badges-title": "Erhaltene Badges",
         "explanations": {
-          "trainings": "Um sich weiterzuentwickeln, entdecken Sie unsere Bildungsempfehlungen und finden Sie heraus, welcher Kurs am besten zu Ihnen passt."
+          "trainings": "Um dich weiterzuentwickeln, entdecke unsere Bildungsempfehlungen und finde heraus, welcher Kurs am besten zu dir passt."
         },
-        "hidden-badges": "{ count, plural, =1 {weiteres erworbenes Badge nicht angezeigt} other {weitere erworbene Badges nicht angezeigt} }",
         "mastery-rate": "Erfolgsquote bei Fragen",
         "retry": {
           "actions": {
             "reset": "Auf Null stellen und alles noch einmal versuchen",
-            "retry": "Meinen Kurs bügeln"
+            "retry": "Den Kurs erneut starten"
           },
-          "description": "Ihr Organisator fordert Sie auf, diese Strecke erneut zu absolvieren.",
-          "retryIn": "Sie können diesen Parcours noch nicht wiederholen, kehren Sie zurück in {duration}.",
-          "title": "Verbessern Sie Ihre Ergebnisse"
+          "description": "Dein Organisator fordert dich auf, diesen Pfad erneut zu absolvieren.",
+          "retryIn": "Du kannst diesen Lernpfad noch nicht wiederholen, kehre zurück in {duration}.",
+          "title": "Verbessere deine Ergebnisse"
         },
-        "see-trainings": "Siehe Ausbildungen",
-        "shared-message": "Ihre Ergebnisse wurden am {date} an {time} gesendet.",
+        "see-trainings": "Übung ansehen",
+        "shared-message": "Deine Ergebnisse wurden am {date} an {time} gesendet.",
         "staged-message": {
           "show-less": "Einklappen",
           "show-more": "Mehr anzeigen"
         },
-        "thanks": "Vielen Dank {name}\n für Ihre Teilnahme!"
+        "thanks": "Vielen Dank {name}\n für deine Teilnahme!"
       },
       "improve": {
-        "description": "Sie können einige Fragen erneut versuchen",
-        "title": "Lust, Ihre Ergebnisse zu verbessern?"
+        "description": "Du kannst einige Fragen erneut versuchen",
+        "title": "Lust, deine Ergebnisse zu verbessern?"
       },
-      "information": "Wenn Sie bereits Parcours auf Pix absolviert haben, wurden Ihnen die Fragen, die Sie bereits beantwortet hatten, nicht noch einmal gestellt. Stattdessen werden in dem hier angezeigten Ergebnis alle Ihre Antworten berücksichtigt.",
+      "information": "Wenn du bereits Lernpfade auf Pix absolviert hast, wurden dir die Fragen, die du bereits beantwortet hattest, nicht noch einmal gestellt. Stattdessen werden in dem hier angezeigten Ergebnis alle deine Antworten berücksichtigt.",
       "net-promoter-score": {
         "link": {
           "href": "https://pix.fr",
-          "label": "Ich gebe meine Meinung ab"
+          "label": "Meine Meinung teilen"
         },
-        "text": "Nehmen Sie sich ein paar Minuten Zeit, um uns zu sagen, wie Sie diesen Test fanden, und uns zu helfen, ihn zu verbessern.",
-        "title": "Ihre Meinung zählt!"
+        "text": "Nimm dir ein paar Minuten Zeit, um uns zu sagen, wie du diesen Test fandest, und uns zu helfen, ihn zu verbessern.",
+        "title": "Deine Meinung zählt!"
       },
-      "not-finished": "Sie können Ihre Ergebnisse noch nicht einsenden, wir haben noch einige Fragen an Sie.",
+      "not-finished": "Du kannst deine Ergebnisse noch nicht einsenden, wir haben noch einige Fragen an dich.",
       "reset": {
         "button": "Auf Null stellen und alles noch einmal versuchen",
         "modal": {
-          "text": "Sie sind dabei, Ihren Parcours <strong>{targetProfileName}</strong> auf Null zurückzusetzen, um zu versuchen, Ihr Niveau zu verbessern. Am Ende des Parcours können Sie Ihre Ergebnisse erneut einreichen.",
-          "warning-text": "Ihre Pix, Ihre Stufen und Ihre Zertifizierbarkeit, die Sie auf diesem Weg erhalten haben, werden gelöscht."
+          "text": "Du bist dabei, deinen Lernpfad <strong>{targetProfileName}</strong> auf Null zurückzusetzen, um zu versuchen, dein Niveau zu verbessern. Am Ende des Lernpfads kannst du deine Ergebnisse erneut einreichen.",
+          "warning-text": "Deine Pix, deine Stufen und deine Zertifizierbarkeit, die du auf diesem Weg erhalten hast, werden gelöscht."
         },
-        "notification": "Setzen Sie alles auf Null zurück, um es erneut zu versuchen. Der Organisator hat weiterhin Zugriff auf Ihre zuvor gesendeten Ergebnisse."
+        "notification": "Setze alles auf Null zurück, um es erneut zu versuchen. Der Organisator hat weiterhin Zugriff auf deine zuvor gesendeten Ergebnisse."
       },
       "retry": {
-        "button": "Meinen Kurs bügeln",
-        "message": "{organizationName} lädt Sie ein, diesen Parcours erneut zu absolvieren, um Ihr Ergebnis zu verbessern und weitere Fortschritte zu machen.",
-        "notification": "Wiederholen Sie die nicht bestandenen Fragen, um Ihr Ergebnis zu verbessern und sich weiterzuentwickeln. Der Organisator hat weiterhin Zugriff auf Ihre zuvor gesendeten Ergebnisse."
+        "button": "Meinen Kurs erneut ablegen",
+        "message": "{organizationName} lädt dich ein, diesen Lernpfad erneut zu absolvieren, um dein Ergebnis zu verbessern und weitere Fortschritte zu machen.",
+        "notification": "Wiederhole die nicht bestandenen Fragen, um dein Ergebnis zu verbessern und dich weiterzuentwickeln. Der Organisator hat weiterhin Zugriff auf deine zuvor gesendeten Ergebnisse."
       },
       "retry-and-reset": {
-        "notification": "Wiederholen Sie die nicht bestandenen Fragen oder setzen Sie alles auf Null zurück, um es erneut zu versuchen. Der Organisator hat weiterhin Zugriff auf Ihre zuvor gesendeten Ergebnisse."
+        "notification": "Wiederhole die nicht bestandenen Fragen oder setze alles auf Null zurück, um es erneut zu versuchen. Der Organisator hat weiterhin Zugriff auf deine zuvor gesendeten Ergebnisse."
       },
       "send-status": {
-        "in-progress": "Sendung läuft"
+        "in-progress": "Senden läuft"
       },
       "stage": {
-        "caption": "Details zu Ihren Ergebnissen in Form von Prozenten und Sternen auf der Grundlage von Fähigkeiten",
+        "caption": "Details zu deinen Ergebnissen in Form von Prozenten und Sternen auf der Grundlage von Kompetenzen",
         "masteryPercentage": "{rate, number, ::percent} des Erfolgs",
-        "recommendedEngine": {
-          "starsAcquired": "{acquired} / {total, plural, =0 {Stern} =1 {# Stern} other {# Sterne}}"
-        },
         "starsAcquired": "{acquired, plural, =0 {kein Stern erworben} =1 {# Stern erworben} other {# Sterne erworben}} auf {total}.",
-        "title": "Details zu den Fähigkeiten"
+        "title": "Details zu Kompetenzen"
       },
       "tabs": {
-        "aria-label": "3 Registerkarten mit Details zu Ihren Ergebnissen",
+        "aria-label": "3 Registerkarten mit Details zu deinen Ergebnissen",
         "results-details": {
-          "description": "Entdecken Sie Ihre Kompetenzen im Detail, gegliedert nach spezifischen Bereichen, um Ihre Stärken und Verbesserungsmöglichkeiten besser zu verstehen. Erkennen Sie Ihre Stärken und die Bereiche, auf die Sie Ihre Anstrengungen konzentrieren sollten, um weitere Fortschritte zu erzielen.",
+          "description": "Entdecke deine Kompetenzen im Detail, gegliedert nach spezifischen Bereichen, um deine Stärken und Verbesserungsmöglichkeiten zu verstehen. Erkenne deine Stärken und die Bereiche, auf die du deine Anstrengungen konzentrieren solltest, um weitere Fortschritte zu erzielen.",
           "tab-label": "Details",
           "title": "Details zu den Ergebnissen"
         },
         "rewards": {
-          "description": "Dieser Abschnitt beleuchtet die erhaltenen Auszeichnungen sowie die Erwartungen des Parcours-Organisators. Erfahren Sie, wie Ihre Leistungen bewertet wurden, und erkennen Sie Verbesserungsmöglichkeiten für Ihre Kompetenzentwicklung.",
+          "description": "Dieser Abschnitt behandelt die erhaltenen Auszeichnungen sowie die Erwartungen des Lernpfad-Organisators. Erfahre, wie deine Leistungen bewertet wurden, und erkenne Verbesserungsmöglichkeiten für deine Kompetenzentwicklung.",
           "tab-label": "Auszeichnungen",
           "title": "Belohnungen und Erwartungen des Veranstalters"
         },
         "trainings": {
-          "description": "Erhalten Sie persönliche Trainingsempfehlungen, um sich weiterzuentwickeln und Ihre Neugierde zu nähren, damit Sie Ihr volles Potenzial ausschöpfen können.",
-          "tab-label": "Schulungen",
-          "title": "Möchten Sie mehr erfahren?"
+          "description": "Erhalte persönliche Trainingsempfehlungen, um dich weiterzuentwickeln und deine Neugierde zu stillen, damit du dein volles Potenzial ausschöpfen kannst.",
+          "tab-label": "Übungen",
+          "title": "Möchtest du mehr erfahren?"
         }
       },
       "title": "Ergebnis",
       "trainings": {
-        "description": "Entdecken Sie für Sie empfohlene Fortbildungen, die auf Ihren Ergebnissen basieren, um Fortschritte zu machen!",
-        "title": "Möchten Sie mehr erfahren?"
+        "description": "Entdecke für dich empfohlene Fortbildungen, die auf deinen Ergebnissen basieren, um Fortschritte zu machen!",
+        "title": "Möchtest du mehr erfahren?"
       }
     },
     "terms-of-service": {
       "cgu": "Ich akzeptiere die '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'Nutzungsbedingungen für Pix'</a>'.",
       "form": {
-        "button": "Ich fahre fort",
-        "error-message": "Sie müssen die Nutzungsbedingungen von Pix."
+        "button": "Fortfahren",
+        "error-message": "Bitte akzeptiere die Nutzungsbedingungen von Pix."
       },
-      "message": "Wir haben unsere Nutzungsbedingungen aktualisiert. Bitte akzeptiere sie, damit du deine Erfahrungen auf Pix fortsetzen kannst.",
+      "message": "Wir haben unsere Nutzungsbedingungen aktualisiert. Bitte akzeptiere sie, damit du deine Arbeit auf Pix fortsetzen kannst.",
       "title": "Bedingungen für die Nutzung"
     },
     "timed-challenge-instructions": {
       "action": "Beginnen",
-      "primary": "Sie haben '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' zur Verfügung, um die nächste Frage zu bestehen.",
-      "secondary": "Sie können danach weiter antworten, aber die Frage gilt nicht als bestanden.",
+      "primary": "Du hast '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' zur Verfügung, um die nächste Frage zu bestehen.",
+      "secondary": "Du kannst danach weiter machen, aber die Frage gilt nicht als bestanden.",
       "time": {
         "and": " und",
         "minutes": "{minutes, plural, =0 {} =1 {# Minute} other {# Minuten}}",
@@ -2271,39 +2257,39 @@
     "training": {
       "editor": "Formativer Inhalt vorgeschlagen von",
       "type": {
-        "autoformation": "Selbstlernpfade",
+        "autoformation": "Selbstständiger Lernpfad",
         "e-learning": "Fernunterricht",
         "hybrid-training": "Hybride Ausbildung",
         "in-person-training": "Präsenzschulungen",
-        "modulix": "Pix-Modul",
+        "modulix": "Pix-Modul (Beta)",
         "webinaire": "Webinar"
       }
     },
     "tutorial": {
-      "dot-action-description": "Gehe zu Schritt {stepNumber} auf {stepsCount}.",
-      "dot-action-title": "Schritt {stepNumber} auf {stepsCount}.",
+      "dot-action-description": "Gehe zu Schritt {stepNumber} von {stepsCount}.",
+      "dot-action-title": "Schritt {stepNumber} von {stepsCount}.",
       "dots-nav-label": "Schritte im Lernprogramm",
       "next": "Weiter zu",
       "next-title": "Nächsten Schritt anzeigen",
       "pages": {
         "page0": {
-          "explanation": "Wenn Sie eine Antwort nicht kennen,\nfinden Sie sie wahrscheinlich im Internet.",
-          "title": "Sie können im Internet suchen ..."
+          "explanation": "Wenn du eine Antwort nicht weißt,\nfindest du sie wahrscheinlich im Internet.",
+          "title": "Du kannst im Internet suchen ..."
         },
         "page1": {
-          "explanation": "Wenn dieses Bild angezeigt wird, verwenden Sie nur Ihr Wissen!\n Sie dürfen weder das Internet noch Ihre Software verwenden.",
+          "explanation": "Wenn dieses Bild angezeigt wird, verwende nur dein eigenes Wissen!\n Du darfst weder das Internet noch andere Programme verwenden.",
           "title": "... außer bei bestimmten Fragen"
         },
         "page2": {
-          "explanation": "Nehmen Sie sich die Zeit, die Sie brauchen, um Ihren Parcours zu beenden.\nWenn eine Frage mit einer Zeitmessung versehen ist, wird Ihnen dies angezeigt.",
+          "explanation": "Nimm dir die Zeit, die du brauchst, um deinen Lernpfad zu beenden.\nWenn eine Frage mit einer Zeitmessung versehen ist, wird dir dies angezeigt.",
           "title": "Kein Zeitlimit!"
         },
         "page3": {
-          "explanation": "Greifen Sie auf Tutorials zu, um mehr zu lernen.\nzu jeder Frage und machen Sie Fortschritte.",
+          "explanation": "Greife auf Tutorials zu, um mehr zu lernen.\nBeantworte jede Frage, um Fortschritte zu machen.",
           "title": "Tutorials zum Lernen"
         },
         "page4": {
-          "explanation": "Abhängig von Ihren Antworten,\nPix den Schwierigkeitsgrad der Fragen an.",
+          "explanation": "Abhängig von deinen Antworten,\nPix passt den Schwierigkeitsgrad der Fragen an.",
           "title": "Ein angepasster Schwierigkeitsgrad"
         }
       },
@@ -2319,19 +2305,19 @@
     "update-expired-password": {
       "button": "Zurücksetzen",
       "fields": {
-        "error": "Ihr Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben und eine Zahl enthalten.",
+        "error": "Dein Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben und eine Zahl enthalten.",
         "help": "(mindestens 8 Zeichen, darunter ein Großbuchstabe, ein Kleinbuchstabe und eine Zahl)",
         "label": "Passwort"
       },
       "first-title": "Das Passwort zurücksetzen",
-      "go-to-login": "Ich logge mich ein",
-      "subtitle": "Wählen Sie ein neues Passwort, um fortzufahren",
+      "go-to-login": "Einloggen",
+      "subtitle": "Wähle ein neues Passwort, um fortzufahren",
       "title": "Mein Passwort ändern",
-      "validation": "Ihr Passwort wurde aktualisiert."
+      "validation": "Dein Passwort wurde aktualisiert."
     },
     "user-account": {
       "account-add-or-update-email-with-validation": {
-        "code-reception-information": "Wenn Sie die Eingabe Ihrer E-Mail-Adresse bestätigen, erhalten Sie einen Code per E-Mail.",
+        "code-reception-information": "Bestätige deine E-Mail-Adresse und erhalte anschlißend einen Code per E-Mail.",
         "fields": {
           "email": {
             "add-email": {
@@ -2342,22 +2328,22 @@
             }
           },
           "errors": {
-            "empty-password": "Ihr Passwort darf nicht leer sein.",
-            "invalid-email": "Ihre E-Mail-Adresse ist ungültig.",
+            "empty-password": "Dein Passwort darf nicht leer sein.",
+            "invalid-email": "Deine E-Mail-Adresse ist ungültig.",
             "invalid-or-already-used-email": "Ungültige oder bereits verwendete E-Mail-Adresse",
-            "invalid-password": "Das von Ihnen eingegebene Passwort ist ungültig.",
+            "invalid-password": "Das von dir eingegebene Passwort ist ungültig.",
             "new-email-already-exist": "Diese E-Mail-Adresse wird bereits verwendet.",
-            "unknown-error": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es noch einmal oder wenden Sie sich an den Support."
+            "unknown-error": "Es ist ein Fehler aufgetreten. Bitte versuche es noch einmal oder wende dich an den Support."
           },
           "password": {
             "label": "Passwort",
-            "security-information": "Die Sicherheit Ihrer persönlichen Informationen ist von entscheidender Bedeutung. Wir überprüfen daher, ob Sie der Verursacher dieser Anfrage sind. Geben Sie Ihr Passwort ein, um einen Überprüfungscode zu erhalten."
+            "security-information": "Die Sicherheit deiner persönlichen Informationen ist von entscheidender Bedeutung. Wir überprüfen daher, ob die Anfrage von dir stammt. Gib dein Passwort ein, um einen Überprüfungscode zu erhalten."
           }
         },
         "save-button": "Einen Überprüfungscode erhalten",
         "title": {
           "add-email": "E-Mail-Adresse hinzufügen",
-          "update-email": "Ändern Ihrer E-Mail-Adresse"
+          "update-email": "Ändere deine E-Mail-Adresse"
         }
       },
       "connexion-methods": {
@@ -2365,12 +2351,12 @@
           "connection-via": "Verbindung über {identityProviderOrganizationName}",
           "gar": "Verbindung über ENT/Mediacentre",
           "label": "Externe Verbindung",
-          "other-authentication-label": "Eine andere Verbindungsmethode"
+          "other-authentication-label": "Eine andere Verbindung"
         },
         "edit-button": "Bearbeiten",
         "email": "E-Mail-Adresse",
-        "menu-link-title": "Meine Verbindungsmethoden",
-        "username": "Kennung"
+        "menu-link-title": "Meine Verbindungen",
+        "username": "Username"
       },
       "delete-account": {
         "actions": {
@@ -2378,44 +2364,44 @@
         },
         "menu-link-title": "Mein Konto löschen",
         "modal": {
-          "error-403": "Sie können Ihr Konto nicht löschen. Bitte wenden Sie sich an den Pix-Support.",
-          "question": "Sind Sie sicher, dass Sie Ihr Konto löschen möchten?",
-          "title": "Sie sind dabei, Ihr Konto zu löschen",
-          "warning-1": "Bitte beachten Sie, dass das Konto nach der Löschung nicht wiederhergestellt werden kann.",
-          "warning-2": "Nach Ihrer Bestätigung werden Sie automatisch abgemeldet und Ihr Antrag wird sofort bearbeitet."
+          "error-403": "Du kannst dein Konto nicht löschen. Bitte wende dich an den Pix-Support.",
+          "question": "Bist du sicher, dass du dein Konto löschen möchtest?",
+          "title": "Du bist dabei, dein Konto zu löschen",
+          "warning-1": "Bitte beachte, dass das Konto nach der Löschung nicht wiederhergestellt werden kann.",
+          "warning-2": "Nach deiner Bestätigung wirst du automatisch abgemeldet und dein Antrag wird sofort bearbeitet."
         },
         "more-information": "Weitere Informationen,",
-        "more-information-contact-support": "können Sie sich an den Support wenden.",
+        "more-information-contact-support": "Du kannst dich an den Support wenden.",
         "title": "Mein Konto endgültig löschen",
-        "warning-email": "Diese Aktion kann nicht rückgängig gemacht werden. Alle Fähigkeiten, Wege und {pixScore} Pix, die Sie erhalten haben, werden für das PIX-Konto, das die E-Mail-Adresse <strong>{email}</strong> verwendet, dauerhaft gelöscht.",
-        "warning-other": "Diese Aktion ist unumkehrbar. Alle Fähigkeiten, Wege und {pixScore} Pix, die Sie erhalten haben, werden für das PIX-Konto <strong>{firstName} {lastName}</strong> dauerhaft gelöscht."
+        "warning-email": "Diese Aktion kann nicht rückgängig gemacht werden. Alle Kompetenzen, Pfade und {pixScore} Pix, die du erhalten hast, werden für das PIX-Konto, das die E-Mail-Adresse <strong>{email}</strong> verwendet, dauerhaft gelöscht.",
+        "warning-other": "Diese Aktion ist unumkehrbar. Alle Kompetenzen, Pfade und {pixScore} Pix, die du erhalten hast, werden für das PIX-Konto <strong>{firstName} {lastName}</strong> dauerhaft gelöscht."
       },
       "email-confirmed": "Verifizierte E-Mail-Adresse.",
       "email-verification": {
-        "add-successful": "Ihre E-Mail-Adresse wurde hinzugefügt!",
-        "code-explanation-of-use": "Um sich von Feld zu Feld zu bewegen, verwenden Sie entweder den Tabulator oder die Links- und Rechtspfeile der Tastatur. Um ein Feld auszufüllen, geben Sie Zahlen von 1 bis 9 ein oder verwenden Sie die Pfeile nach oben und unten auf der Tastatur.",
+        "add-successful": "Deine E-Mail-Adresse wurde hinzugefügt!",
+        "code-explanation-of-use": "Um dich von Feld zu Feld zu bewegen, verwende entweder den Tabulator oder die Links- und Rechtspfeile der Tastatur. Um ein Feld auszufüllen, gib Zahlen von 1 bis 9 ein oder verwende die Pfeile nach oben und unten auf der Tastatur.",
         "code-label": "Feld",
-        "code-legend": "Geben Sie den per E-Mail zugesandten Verifizierungscode ein",
+        "code-legend": "Gib den per E-Mail zugesandten Verifizierungscode ein",
         "confirmation-message": "E-Mail gesendet!",
-        "description": "Geben Sie den Verifizierungscode ein, den Sie an der E-Mail-Adresse erhalten haben :",
+        "description": "Gib den Verifizierungscode ein, den du an per E-Mail erhalten hast :",
         "did-not-receive": "Ich habe nichts erhalten,",
         "errors": {
           "email-modification-demand-expired": "Dieser Code ist abgelaufen. Bitte erneuern Sie den Antrag.",
           "incorrect-code": "Der eingegebene Code ist falsch.",
           "new-email-already-exist": "Diese E-Mail-Adresse wird bereits verwendet.",
-          "no-code": "Bitte geben Sie den {numInputs}-stelligen Code ein, den Sie per E-Mail erhalten haben.",
-          "unknown-error": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es noch einmal oder wenden Sie sich an den Support."
+          "no-code": "Bitte gib den {numInputs}-stelligen Code ein, den du per E-Mail erhalten hast.",
+          "unknown-error": "Es ist ein Fehler aufgetreten. Bitte versuche es noch einmal oder wende dich an den Support."
         },
-        "send-back-the-code": "mir den Code zurückschicken",
+        "send-back-the-code": "Den Code zurückschicken",
         "time-code-validation": "Der erhaltene Code ist eine Stunde lang gültig",
-        "title": "Überprüfung Ihrer E-Mail-Adresse",
-        "update-successful": "Ihre E-Mail-Adresse wurde geändert!",
+        "title": "Überprüfung deiner E-Mail-Adresse",
+        "update-successful": "Deine E-Mail-Adresse wurde geändert!",
         "validate-new-email": "Neue E-Mail bestätigen"
       },
       "language": {
         "lang": "Sprache",
         "menu-link-title": "Meine Sprache wählen",
-        "update-successful": "Ihre Sprache wurde verändert!"
+        "update-successful": "Deine Sprache wurde verändert!"
       },
       "personal-information": {
         "first-name": "Vorname",
@@ -2427,11 +2413,11 @@
     "user-certifications": {
       "meshes": {
         "DROIT": {
-          "ADVANCED": "Fortgeschrittene",
-          "BELOW_MINIMUM": "Nicht erlangt",
-          "CONFIRMED": "Bestätigt",
-          "EXPERT": "Experte",
-          "INDEPENDENT": "Selbstständig"
+          "0": "Selbstständig",
+          "1": "Bestätigt",
+          "2": "Fortgeschrittene",
+          "3": "Experte",
+          "BELOW_MINIMUM": "Nicht erlangt"
         },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Zulässig",
@@ -2452,39 +2438,39 @@
           "EXPERT": "Experte"
         },
         "PRO_SANTE": {
-          "ADVANCED": "Fortgeschrittene",
-          "BELOW_MINIMUM": "Nicht erlangt",
-          "CONFIRMED": "Bestätigt",
-          "EXPERT": "Experte",
-          "INDEPENDENT": "Selbstständig"
+          "0": "Selbstständig",
+          "1": "Bestätigt",
+          "2": "Fortgeschrittene",
+          "3": "Experte",
+          "BELOW_MINIMUM": "Nicht erlangt"
         }
       }
     },
     "user-tests": {
       "anonymised-participations": {
-        "course": "Parcours",
+        "course": "Lernpfad",
         "states": {
           "completed": "abgeschlossen",
           "started": "begonnen"
         },
-        "title": "Deaktivierte Strecken"
+        "title": "Deaktivierte Pfade"
       },
-      "description": "Finden Sie Ihre Pix-Parcours, verfolgen Sie Ihren Fortschritt und setzen Sie einfach dort an, wo Sie aufgehört haben.",
-      "title": "Meine Wege"
+      "description": "Finde deinen Pix-Lernpfad, verfolge deinen Fortschritt und mach dort weiter, wo du aufgehört hast.",
+      "title": "Meine Pfade"
     },
     "user-trainings": {
-      "description": "Machen Sie weitere Fortschritte mithilfe von Schulungen, die nach Abschluss Ihrer Beurteilungsrunden empfohlen werden.",
-      "title": "Meine Schulungen"
+      "description": "Mach weitere Fortschritte mithilfe von Übungen, die nach Abschluss deiner Beurteilungen empfohlen werden.",
+      "title": "Meine Übungen"
     },
     "user-tutorials": {
-      "description": "Erweitern Sie Ihre digitalen Kompetenzen mit Tutorials, die auf Ihr Niveau zugeschnitten sind.",
+      "description": "Erweitere deine digitalen Kompetenzen mit Tutorials, die auf dein Niveau zugeschnitten sind.",
       "empty-list-info": {
         "description": {
-          "part1": "Im Laufe Ihrer Tests werden Ihnen Tutorials empfohlen: Klicken Sie auf das Lesezeichen-Symbol",
-          "part2": "um diejenigen aufzunehmen, die Sie hier wiederfinden möchten!"
+          "part1": "Im Laufe deiner Tests werden dir Tutorials empfohlen: Klicke auf das Lesezeichen-Symbol",
+          "part2": "um diejenigen zu speichern, die du hier wiederfinden möchtest!"
         },
         "image-link": "images/illustrations/user-tutorials/illustration-de.svg",
-        "title": "Sie haben noch nichts aufgenommen"
+        "title": "Du hast noch nichts aufgenommen"
       },
       "filter": "Filtern",
       "label": "Tutorials",
@@ -2494,28 +2480,28 @@
           "actions": {
             "evaluate": {
               "extra-information": "Dieses Tutorial als nützlich markieren",
-              "label": "Dieses Tutorial nicht mehr als nützlich ansehen"
+              "label": "Dieses Tutorial entfernen"
             },
             "remove": {
-              "label": "Von meiner Tutorial-Liste entfernen"
+              "label": "Aus meiner Tutorial-Liste entfernen"
             },
             "save": {
               "label": "In meiner Tutorial-Liste speichern"
             }
           },
-          "source": "Durch"
+          "source": "Bereitgestellt von"
         }
       },
       "recommended": "Empfohlen",
       "recommended-empty": {
-        "description": "Um Ihnen Tutorials zu empfehlen, die auf Ihr Niveau zugeschnitten sind, müssen Sie einen Kompetenztest beginnen.",
-        "link": "Ich beginne",
-        "title": "{firstName}, hier finden Sie Ihre Lieblingstutorials wieder"
+        "description": "Um dir Tutorials empfehlen zu können, die auf dein Niveau zugeschnitten sind, musst du einen Kompetenztest beginnen.",
+        "link": "Beginnen",
+        "title": "{firstName}, hier findest du deine Lieblingstutorials wieder"
       },
       "saved": "Registriert",
       "saved-empty": {
-        "description": "Sie müssen ein empfohlenes Tutorial speichern, damit es hier angezeigt wird.",
-        "title": "Sie haben noch keine registrierten Tutorials"
+        "description": "Du musst ein empfohlenes Tutorial speichern, damit es hier angezeigt wird.",
+        "title": "Du hast noch keine registrierten Tutorials"
       },
       "sidebar": {
         "reset": "Zurücksetzen",

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2413,11 +2413,11 @@
     "user-certifications": {
       "meshes": {
         "DROIT": {
-          "0": "Selbstständig",
-          "1": "Bestätigt",
-          "2": "Fortgeschrittene",
-          "3": "Experte",
-          "BELOW_MINIMUM": "Nicht erlangt"
+          "ADVANCED": "Fortgeschrittene",
+          "BELOW_MINIMUM": "Nicht erlangt",
+          "CONFIRMED": "Bestätigt",
+          "EXPERT": "Experte",
+          "INDEPENDENT": "Selbstständig"
         },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Zulässig",
@@ -2438,11 +2438,11 @@
           "EXPERT": "Experte"
         },
         "PRO_SANTE": {
-          "0": "Selbstständig",
-          "1": "Bestätigt",
-          "2": "Fortgeschrittene",
-          "3": "Experte",
-          "BELOW_MINIMUM": "Nicht erlangt"
+          "ADVANCED": "Fortgeschrittene",
+          "BELOW_MINIMUM": "Nicht erlangt",
+          "CONFIRMED": "Bestätigt",
+          "EXPERT": "Experte",
+          "INDEPENDENT": "Selbstständig"
         }
       }
     },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2220,6 +2220,9 @@
       "stage": {
         "caption": "Detalles de tus resultados en porcentaje y estrellas según las competencias",
         "masteryPercentage": "{rate, number, ::percent} de éxito",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired}/{total, plural, =0 {estrella} =1 {# estrella} other {# estrellas}}"
+        },
         "starsAcquired": "{acquired, plural, =0 {ninguna estrella obtenida} =1 {# estrella obtenida} other {# estrellas obtenidas}} de {total}",
         "title": "Detalles de las competencias"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -320,7 +320,7 @@
         "error-message": {
           "date-field": "Utilice el formato dd/mm/aaaa al introducir el campo {fieldName}",
           "invalid-reconciliation-error": "Comprueba tus datos ({fields}) o ponte en contacto con un profesor.",
-          "mandatory-field": "Este campo es obligatorio"
+          "mandatory-field": "Rellena el campo {fieldName}"
         },
         "field": {
           "birthdate": "Fecha de nacimiento",
@@ -771,13 +771,13 @@
       "steps": {
         "1": {
           "paragraphs": {
-            "1": "La Certificación Pix es un '<strong>'test adaptativo'</strong>' para evaluar tu nivel en el '<strong>'conjunto de 16 competencias digitales del marco de referencia Pix'</strong>'.",
+            "1": "La Certificación {certificationName} es un '<strong>'test adaptativo'</strong>' para evaluar tu nivel en el '<strong>'conjunto de 16 competencias digitales del marco de referencia Pix'</strong>'.",
             "2": "La '<strong>'dificultad de las preguntas se adapta en tiempo real'</strong>' en función de las respuestas dadas.",
             "3": "Si algunas preguntas le parecen difíciles, es porque la prueba de certificación pretende medir su nivel máximo. '<strong>'Si no puede responder a una pregunta, tiene la opción de \"saltársela\"'</strong>': no se le volverá a ofrecer durante la certificación y no será validada.",
             "4": "Para obtener una puntuación lo más cercana posible a tu capacidad '<strong>'es necesario llegar hasta el final de la prueba'</strong>'."
           },
           "question": "¿Cómo funciona la prueba de certificación?",
-          "title": "Bienvenido a la certificación Pix"
+          "title": "Bienvenido a la certificación {certificationName}"
         },
         "2": {
           "legend": {
@@ -786,7 +786,7 @@
           },
           "paragraphs": {
             "1": "La prueba de certificación consta de '<strong>'32 preguntas'</strong>'.",
-            "2": "Tienes un máximo de '<strong>'1h45'</strong>' para responder*.",
+            "2": "Tienes un máximo de '<strong>'{duration}'</strong>' para responder*.",
             "3": "*excluyendo cualquier tiempo adicional",
             "4": "Si completas '<strong>'menos de 20 preguntas, no podremos emitir una puntuación'</strong>'."
           },
@@ -827,7 +827,7 @@
             "3": "'<strong>'Utiliza un sistema de inteligencia artificial'</strong>' o un chatbot.",
             "4": "'<strong>'Consulta un foro de autoayuda'</strong>' proporcionando directamente la respuesta a una pregunta.",
             "5": "'<strong>'Movilizar cualquier otro medio que proporcione directamente la respuesta a la pregunta'</strong>', sin haber realizado el trabajo requerido por la instrucción.",
-            "6": "'<strong>'Utiliza un navegador diferente'</strong>' al que está ejecutando tu prueba de Certificación Pix.",
+            "6": "'<strong>'Utiliza un navegador diferente'</strong>' al que está ejecutando tu prueba de Certificación {certificationName}.",
             "7": "'<strong>'Suplantar'</strong>' a otra persona."
           },
           "pix-companion": "El acceso a determinados sitios está prohibido en el marco de la prueba de certificación, gracias a una extensión instalada en el navegador. Cualquier fraude probado (intento de eludir la extensión o incumplimiento de los comportamientos enumerados anteriormente) puede dar lugar a la invalidación de la certificación.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1874,7 +1874,8 @@
       "signup-form": {
         "button": "Creo una cuenta",
         "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
-        "error": "No hemos podido recuperar tu información de identificación del servicio utilizado. Te invitamos a que te pongas en contacto con el servicio de asistencia informática de esta organización.": "Nombre: {firstName}",
+        "error": "No hemos podido recuperar tu información de identificación del servicio utilizado. Te invitamos a que te pongas en contacto con el servicio de asistencia informática de esta organización.",
+        "first-name-label-and-value": "Nombre: {firstName}",
         "last-name-label-and-value": "Apellidos: {lastName}",
         "title": "No tengo una cuenta Pix"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -55,17 +55,17 @@
     },
     "api-error-messages": {
       "bad-request-error": "Los datos que has enviado no están en el formato correcto.",
-      "gateway-timeout-error": "El servicio está experimentando ralentizaciones. Vuelve a intentarlo más tarde.",
+      "gateway-timeout-error": "El servicio puede tardar más de lo normal en responder. Vuelve a intentarlo más tarde.",
       "internal-server-error": "Se ha producido un error interno. Nuestros equipos están resolviendo el problema. Vuelve a intentarlo más tarde.",
       "login-unauthorized-error": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos.",
-      "login-unauthorized-remaining-attempts-error": "Advertencia: le quedan {remainingAttempts, plural, =0 {0 intento} =1 {1 intento} other {# intentos}} antes de que su cuenta Pix sea bloqueada permanentemente.",
-      "login-unauthorized-remaining-attempts-with-user-name-error": "Advertencia: le quedan {remainingAttempts, plural, =0 {0 intento} =1 {1 intento} other {# intentos}} antes de que su cuenta Pix sea bloqueada permanentemente.'<br>'Si olvidas tu contraseña, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecerla y/o recuperar tu inicio de sesión.",
+      "login-unauthorized-remaining-attempts-error": "Advertencia: le quedan {remainingAttempts, plural, =0 {0 intento} =1 {1 intento} other {# intentos}} antes de que tu cuenta Pix sea bloqueada permanentemente.",
+      "login-unauthorized-remaining-attempts-with-user-name-error": "Advertencia: le quedan {remainingAttempts, plural, =0 {0 intento} =1 {1 intento} other {# intentos}} antes de que tu cuenta Pix sea bloqueada permanentemente.'<br>'Si olvidas tu contraseña, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecerla y/o recuperar tu inicio de sesión.",
       "login-unauthorized-with-user-name-error": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos.'<br>'Si olvidas tu contraseña, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecerla y/o recuperar tu inicio de sesión.",
-      "login-unexpected-error": "No se ha podido conectar. Por favor, inténtelo de nuevo en unos momentos. Si el problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'póngase en contacto con nosotros'</a>'.",
+      "login-unexpected-error": "No se ha podido conectar. Por favor, inténtalo de nuevo en unos momentos. Si el problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'pónte en contacto con nosotros'</a>'.",
       "login-user-blocked-error": "Tu cuenta está bloqueada porque has realizado demasiados intentos de conexión. Para desbloquearla, '<'a href=\"{url}\"'>'ponte en contacto con nosotros'</a>'.",
       "login-user-blocked-with-username-error": "Tu cuenta está bloqueada porque has realizado demasiados intentos de conexión. Para desbloquearla, '<strong>'ponte en contacto con tu profesor'</strong>'; si no está disponible, '<'a href=\"{url}\"'>'ponte en contacto con nosotros'</a>'.",
-      "login-user-temporary-blocked-error": "Ha realizado demasiados intentos de inicio de sesión, su cuenta Pix está temporalmente bloqueada durante {blockingDurationMinutes} minutos. Inténtalo de nuevo más tarde o haz clic en '<'a href=\"{url}\"'>'contraseña olvidada'</a>' para restablecerla.",
-      "login-user-temporary-blocked-with-username-error": "Ha realizado demasiados intentos de inicio de sesión, su cuenta Pix está temporalmente bloqueada durante {blockingDurationMinutes} minutos.'<br>'Si olvidas tu contraseña, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecerla y/o recuperar tu inicio de sesión."
+      "login-user-temporary-blocked-error": "Ha realizado demasiados intentos de inicio de sesión, tu cuenta Pix está temporalmente bloqueada durante {blockingDurationMinutes} minutos. Inténtalo de nuevo más tarde o haz clic en '<'a href=\"{url}\"'>'contraseña olvidada'</a>' para restablecerla.",
+      "login-user-temporary-blocked-with-username-error": "Ha realizado demasiados intentos de inicio de sesión, s¡tu cuenta Pix está temporalmente bloqueada durante {blockingDurationMinutes} minutos.'<br>'Si olvidas tu contraseña, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecerla y/o recuperar tu inicio de sesión."
     },
     "cgu": {
       "cgu": "condiciones de uso",
@@ -88,7 +88,7 @@
       },
       "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
       "not-detected": {
-        "description": "Es posible que la extensión no esté instalada o activada. Consulte el siguiente documento para reanudar la sesión de certificación.  Si es necesario, póngase en contacto con el vigilante.",
+        "description": "Es posible que la extensión no esté instalada o activada. Consulta el siguiente documento para reanudar la sesión de certificación.  Si es necesario, ponte en contacto con el servicio de asistencia.",
         "link": "Acceder a la documentación",
         "title": "La extensión Pix Companion<br /> no se detecta"
       }
@@ -110,7 +110,8 @@
       "success": "correcto",
       "visible-password": "Mostrar la contraseña"
     },
-    "french-education-ministry": "Ministerio francés de Educación y Juventud. Libertad igualdad fraternidad",
+    "french-education-ministry": "Ministerio francés de Educación y Juventud. Libertad, igualdad, fraternidad",
+    "french-republic": "República Francesa. Libertad, igualdad, fraternidad.",
     "languages": {
       "en": "Inglés",
       "fr": "Francés",
@@ -125,7 +126,7 @@
     "new-information-banner": {
       "close-label": "Cerrar el banner"
     },
-    "no-level": "No nivel",
+    "no-level": "Sin nivel",
     "or": "o",
     "pagination": {
       "action": {
@@ -171,8 +172,8 @@
         },
         "select-another-organization-link": "Elegir otra organización",
         "signup": {
-          "heading": "Otros medios de registro",
-          "signup-with-featured-identity-provider-link": "Regístrese en {featuredIdentityProvider}"
+          "heading": "Otros métodos de registro",
+          "signup-with-featured-identity-provider-link": "Regístrate en {featuredIdentityProvider}"
         }
       },
       "login-form": {
@@ -209,12 +210,12 @@
             "placeholder": "ej. juan.perez@email.es"
           }
         },
-        "no-email-question": "¿No ingresaste una dirección de correo electrónico?",
+        "no-email-question": "¿No has introducido una dirección de correo electrónico?",
         "rule": "Todos los campos son obligatorios."
       },
       "password-reset-demand-received-info": {
         "heading": "Comprueba tu correo electrónico",
-        "message": "Si tu dirección está asociada a una cuenta Pix, se te han enviado instrucciones por correo electrónico para restablecer tu contraseña.",
+        "message": "Si tu dirección está asociada a una cuenta Pix, se te enviarán instrucciones por correo electrónico para restablecer tu contraseña.",
         "no-email-received-question": "¿No has recibido un correo electrónico?",
         "try-again": "Reenviar correo electrónico de restablecimiento"
       },
@@ -233,7 +234,7 @@
           }
         },
         "success-info": {
-          "message": "Su contraseña ha sido restablecida."
+          "message": "La contraseña ha sido restablecida."
         }
       },
       "signup-form": {
@@ -250,7 +251,7 @@
             "placeholder": "ej. juan.perez@email.es"
           },
           "firstname": {
-            "error": "Su nombre de pila no está rellenado.",
+            "error": "No has indicado tu nombre.",
             "label": "Nombre",
             "placeholder": "ej. Juan"
           },
@@ -263,13 +264,13 @@
         }
       },
       "sso-selection-form": {
-        "should-display-account-recovery-banner": "¿Estudiante? Si aún no lo ha hecho, '<'a href=\"{url}\"'>'acceda a la página para recuperar su cuenta Pix'</a>' y mantenga su progreso."
+        "should-display-account-recovery-banner": "¿Estudiante? Si aún no lo has hecho, '<'a href=\"{url}\"'>'accede a la página para recuperar tu cuenta Pix'</a>' y guarda tu progreso."
       }
     },
     "campaigns": {
       "attestation-result": {
         "computing": "Certificado en curso de cálculo",
-        "computing-description": "Un problema técnico nos ha impedido informarle de sus resultados. Por favor, conéctese de nuevo mañana en Pix, en la sección \"Mi curso\", para comprobar sus resultados. Le pedimos disculpas por las molestias ocasionadas.",
+        "computing-description": "Un problema técnico nos ha impedido informarle de sus resultados. Por favor, conéctate de nuevo mañana en Pix, en la sección \"Mi curso\", para comprobar tus resultados. Te pedimos disculpas por las molestias ocasionadas.",
         "not-obtained": "Certificado no obtenido :",
         "obtained": "Certificado obtenido",
         "title": {
@@ -282,7 +283,7 @@
           "EDUSECU": "Digital y seguridad",
           "EDUSUPPORT": "Crear materiales educativos",
           "EDUVEILLE": "Realizar seguimiento",
-          "MAIRIEBUREAU": "Mairie de Paris - Fundamentos de ofimática",
+          "MAIRIEBUREAU": "Ayuntamiento de París - Fundamentos de ofimática",
           "MINARM": "Base digital",
           "PARENTHOOD": "Conciencia digital",
           "SIXTH_GRADE": "Conciencia digital"
@@ -294,8 +295,8 @@
           "rewards": "Entrega de premios",
           "trainings": "Identificar cursos de formación útiles"
         },
-        "subtitle": "¡Un momento, por favor! Seré tan rápido como pueda.",
-        "title": "Calcular su puntuación actual..."
+        "subtitle": "¡Un momento, por favor! Seré lo mñás rápido posible.",
+        "title": "Calcular tu puntuación actual..."
       },
       "start-landing-page": {
         "steps": {
@@ -375,7 +376,7 @@
     },
     "not-logged": {
       "sign-in": "Conectarse",
-      "sign-up": "Inscribirse"
+      "sign-up": "Registrarse"
     },
     "pix": "Pix",
     "showcase-homepage": "Página de inicio de Pix.{ tld }",
@@ -383,7 +384,7 @@
       "account": "Mi cuenta",
       "certifications": "Mis certificaciones",
       "sign-out": "Desconectarse",
-      "tests": "Mis tests"
+      "tests": "Mis test"
     },
     "user-logged-menu": {
       "details": "Consultar mis datos"
@@ -430,10 +431,10 @@
         "confirmation-step": {
           "buttons": {
             "cancel": "Cancelar",
-            "confirm": "Confirmo"
+            "confirm": "Confirmar"
           },
-          "certify-account": "Certifico que la cuenta asociada a estos datos es mía.",
-          "contact-support": "Si observas un error o si estos datos no son tuyos, ",
+          "certify-account": "Confirmo que la cuenta asociada a estos datos es mía.",
+          "contact-support": "Si detectas un error o si estos datos no son tuyos, ",
           "fields": {
             "first-name": "Tu nombre",
             "last-name": "Tus apellidos",
@@ -446,7 +447,7 @@
         "conflict": {
           "found-you-but": "{ firstName }te hemos encontrado, pero ...",
           "title": "Conflicto",
-          "warning": "Por precaución, tenemos que comprobar juntos tus datos."
+          "warning": "Por precaución, tenemos que comprobar tus datos."
         },
         "contact-support": {
           "link-text": "ponte en contacto con el servicio de asistencia.",
@@ -462,7 +463,7 @@
           "errors": {
             "empty-first-name": "El campo del nombre es obligatorio.",
             "empty-ine-ina": "El campo INE es obligatorio.",
-            "empty-last-name": "El campo apellidos es obligatorio.",
+            "empty-last-name": "El campo de apellidos es obligatorio.",
             "invalid-ine-ina-format": "El campo INE tiene un formato incorrecto.",
             "not-found": "Pix no reconoce tus datos. Por favor, comprueba que son correctos, de lo contrario,"
           },
@@ -542,7 +543,7 @@
       "title": "Fin de la prueba"
     },
     "attestations": {
-      "subtitle": "Acceda a todos sus certificados Pix y descárguelos.",
+      "subtitle": "Accede a todos tus certificados Pix y descárgalos.",
       "title": "Mis títulos"
     },
     "authentication": {
@@ -556,8 +557,8 @@
         },
         "signup": {
           "button": "Crear cuenta",
-          "link": "Inscríbete",
-          "title": "¿No tiene una cuenta?"
+          "link": "Regístrate",
+          "title": "¿No tienes una cuenta?"
         },
         "title": "Elegir otra organización"
       }
@@ -566,19 +567,19 @@
       "landing-page": {
         "actions": {
           "sign-in": "Ya tengo una cuenta, me conecto",
-          "start-anonymously": "Empiezo sin cuenta Pix",
-          "start-connected": "Empiezo"
+          "start-anonymously": "Empezar sin cuenta Pix",
+          "start-connected": "Empezar"
         },
         "texts": {
           "first-course": "¿Es tu primer test Pix?",
           "legal-informations": "Con o sin cuenta Pix, la información relativa a tu progreso en el test nos llegará a nosotros.'<br>'Esta información la utiliza Pix para mejorar el servicio.",
-          "title": "Empieza el test:"
+          "title": "Empezar el test:"
         }
       }
     },
     "campaign": {
       "errors": {
-        "existing-participation": "El test no está accesible para ti.",
+        "existing-participation": "No puedes acceder al test.",
         "existing-participation-info": "Ponte en contacto con tu profesor para que retire tu participación en Pix Orga.",
         "existing-participation-user-info": "Hay una participación asociada a nombre de {lastName} {firstName}",
         "no-longer-accessible": "Uy, la página solicitada ya no está disponible.",
@@ -587,8 +588,8 @@
     },
     "campaign-landing": {
       "assessment": {
-        "action": "Empiezo",
-        "announcement": "Inscríbete o conéctate a la plataforma Pix y comienza tu prueba.",
+        "action": "Empezar",
+        "announcement": "Regístrate o conéctate a la plataforma Pix y comienza la prueba.",
         "certify": {
           "description": "En función de tu situación y con ciertas condiciones, puedes acceder a la certificación Pix, reconocida en el ámbito profesional y que te permite destacar tus competencias digitales. Para más información, ponte en contacto con el organizador del test.",
           "title": "Las respuestas validadas en este test contribuirán a mejorar tu perfil personal de competencias digitales en Pix."
@@ -603,13 +604,13 @@
           "title": "Medir tus competencias digitales con retos lúdicos y de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
         },
         "exam-notice": "Durante la realización de este test, su perfil de competencias no será tomado en cuenta ni modificado. Sus respuestas no tendrán ningún impacto en sus niveles de habilidades ni en su puntuación global de Pix.",
-        "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
+        "legal": "Al hacer clic en «Empezar», te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
         "title-with-username": "'<span>'¿{userFirstName}'</span>','<br>' Listo para evaluar tus habilidades?"
       },
       "profiles-collection": {
         "action": "¡Empecemos!",
-        "announcement": "Inscríbete o conéctate a la plataforma Pix y envía tu perfil a la organización destinataria.",
+        "announcement": "Regístrate o conéctate a la plataforma Pix y envía tu perfil a la organización de destino.",
         "legal": "La información relativa a tu perfil PIX se enviará al organizador para que pueda ayudarte. Solo se transmitirá con tu consentimiento.",
         "title": "Envía tu perfil",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' envía tu perfil"
@@ -629,17 +630,17 @@
           "extra-information": "Retomar el test {campaignTitle}",
           "information": "Retomar"
         },
-        "retry": "Mejorarme a mí mismo",
+        "retry": "Reintentar",
         "see-more": "Ver el detalle",
         "stages": "{count} { count, plural, =0 {estrellas} =1 {estrella} other {estrellas} } de {total}",
-        "started-at": "Empezado el {date}",
+        "started-at": "Empezado el {fecha}",
         "tag": {
-          "deleted": "Inactivo",
+          "deleted": "Eliminado",
           "disabled": "Inactivo",
           "finished": "Finalizado",
           "started": "En curso"
         },
-        "text-deleted": "Test desactivado por tu organización.'<br>'Ya no puedes actuar sobre este test.",
+        "text-deleted": "Test desactivado por tu organización.'<br>'Ya no puedes modificar este test.",
         "text-disabled": "Test desactivado por tu organización.'<br>'Ya no puedes enviar tus resultados."
       },
       "title": "Test"
@@ -648,19 +649,19 @@
       "attestation": "Descargar mi certificado",
       "back-link": "Volver a mis certificaciones",
       "candidate": "Candidato :",
-      "candidate-birth": "Nacido/a el {birthdate}",
-      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
+      "candidate-birth": "Nacido/a el {fecha de nacimiento}",
+      "candidate-birth-complete": "Nacido/a el {fecha de nacimiento} en {lugar de nacimiento}",
       "certification-center": "Centro de certificación :",
       "certification-date": "Fecha de examen :",
       "certification-value": {
         "paragraphs": {
-          "1": "Officially recognised, Pix Certification attests to your mastery of digital skills. You'll be joining a community of millions of certified users. Congratulations on this important step in your career!",
-          "2": "Your certified score has been calculated on the basis of your answers during the certification process. It may therefore differ from the number of pix shown in your profile.",
-          "3": "On the day of your certification, it was possible to reach level 7 and a maximum of 895 pix (Expert 1 level)."
+          "1": "La certificación Pix, reconocida oficialmente, acredita tu dominio de las competencias digitales. Te unirás a una comunidad de millones de usuarios certificados. ¡Enhorabuena por este importante paso en tu carrera profesional!",
+          "2": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de puntos que aparece en tu perfil.",
+          "3":El día de tu certificación, se podía alcanzar el nivel 7 y un máximo de 895 puntos (nivel Experto 1)."
         }
       },
       "competences": {
-        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
+        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, se podía alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
       },
       "complementary": {
         "alternative": "Certificación complementaria",
@@ -672,40 +673,37 @@
       "details": {
         "competences": {
           "description": "Tu puntuación Pix da una estimación de tu nivel en las 16 competencias digitales.",
-          "title": "Su perfil de competencias digitales"
+          "title": "Tu perfil de competencias digitales"
         }
       },
       "exam-date": "Fecha de presentación:",
       "framework-title": {
         "CLEA": "Certificado Pix",
         "CORE": "Certificado Pix",
-        "DROIT": "Certificado Pix+ Derecho",
         "EDU_1ER_DEGRE": "Certificado Pix+ Edu 1.er grado",
         "EDU_2ND_DEGRE": "Certificado Pix+ Edu 2.º grado",
-        "EDU_CPE": "Certificado Pix+ Edu CPE",
-        "PRO_SANTE": "Certificado Pix+ Profesionales de Salud"
+        "EDU_CPE": "Certificado Pix+ Edu CPE"
       },
       "frameworks": {
         "EDU": {
-          "results-infos": "'<p>'La certificación se desarrolla en dos etapas:'</p><ol><li>'Prueba Pix: acaba de realizarla.'</li><li>'Prueba oral: organizada fuera de Pix ante un tribunal.'</li></ol><p>'Al finalizar la prueba oral, se le otorgará su nivel de certificación definitivo (Experto, Avanzado, etc.).'<br/>'Contacte con su centro de certificación para organizar la prueba oral.'</p>'",
-          "results-sub-title": "¡El candidato es admisible para la 2.ª etapa de la certificación Pix+ Édu!",
+          "results-infos": "'<p>'La certificación se desarrolla en dos etapas:'</p><ol><li>'Prueba Pix: acaba de realizarla.'</li><li>'Prueba oral: organizada fuera de Pix ante un tribunal.'</li></ol><p>'Al finalizar la prueba oral, se te otorgará tu nivel de certificación definitivo (Experto, Avanzado, etc.).'<br/>'Contacta con tu centro de certificación para organizar la prueba oral.'</p>'",
           "status": "Certificado válido",
           "sub-title": "¡El candidato es admisible para la 2.ª etapa!"
         }
       },
       "global": {
         "explanation": {
-          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
-          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
+          "default": "¡Has alcanzado el nivel {globalLevelLabel} de la Certificación Pix!",
+          "pre-beginner-level": "Has completado tu test de certificación Pix, pero tus resultados no te permiten obtener el primer nivel."
         },
         "labels": {
-          "advanced": "Advanced",
-          "beginner": "Beginner",
-          "expert": "Expert",
-          "independent": "Independent",
-          "level": "Your level"
+          "advanced": "Avanzado",
+          "beginner": "Principiante",
+          "expert": "Experto",
+          "independent": "Independiente",
+          "level": "Tu nivel"
         },
-        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )"
+        "progressbar-explanation": "Barra de progreso que indica el nivel que has alcanzado ({level}, es decir, el nivel {globalLevelLabel}) de un máximo de 7 niveles (nivel Experto 1)"
       },
       "hexagon-score": {
         "certified": "certificados"
@@ -714,7 +712,6 @@
       "jury-info": "Las observaciones del tribunal no se comparten en la página de comprobación de tu certificado.",
       "jury-title": "Observaciones del tribunal",
       "learn-about-certification-results": "¿Cómo interpretar los resultados?",
-      "obtained-certification": "El candidato ha obtenido la certificación {frameworkLabel}",
       "professionalizing-warning": "El certificado Pix está reconocido como cualificación profesional por France Compétences una vez alcanzada una puntuación mínima de 120 pix.",
       "results": {
         "sub-title": "El candidato es admisible para la certificación {framework}.",
@@ -722,7 +719,6 @@
       },
       "subtitle": "(niveles de {maxReachableLevel})",
       "title": "Certificado Pix",
-      "valid-status": "Certificado válido",
       "verification-code": {
         "alt": "Copiar",
         "copied": "¡Código copiado!",
@@ -737,21 +733,21 @@
       "candidate": {
         "disconnect": "Desconectar mi cuenta",
         "disconnect-tip": "Si no es tu ordenador, recuerda desconectarte.",
-        "ended-by-invigilator": "El vigilante ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
+        "ended-by-invigilator": "El supervisor ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
         "ended-due-to-finalization": "Tu centro de certificación ha finalizado la sesión. Ya no puedes continuar respondiendo a las preguntas.",
         "remote-certification": "Si estás realizando tu certificación Pix de forma remota, asegúrate de desconectarte de la herramienta de supervisión una vez que hayas finalizado la prueba.",
         "title": "¡Prueba finalizada!"
       },
       "results": {
         "disclaimer": "Tus resultados, pendientes de validación por los equipos Pix, estarán pronto disponibles en tu cuenta Pix.",
-        "step-1": "Solo tienes que conectarte a tu cuenta Pix y podrás encontrar tus resultados en tu perfil, en «Mis certificaciones» (accesible haciendo clic en tu nombre en la esquina superior derecha de la pantalla).",
+        "step-1": "Solo tienes que conectarte a tu cuenta Pix y podrás encontrar tus resultados en tu perfil, en «Mis certificaciones» (puedes acceder haciendo clic en tu nombre en la esquina superior derecha de la pantalla).",
         "step-2": "Podrás descargar tu certificado de certificación y compartirlo con otras personas, o incluso indicar el código de comprobación para utilizar en el sitio web de Pix.",
         "title": "¿Consultar y compartir mis resultados de certificación?"
       }
     },
     "certification-frameworks": {
       "CLEA": "CLéA Numérique",
-      "CORE": "Pix certification",
+      "CORE": "Pix certificación",
       "DROIT": "Pix+ Derecho",
       "EDU_1ER_DEGRE": "Pix+ Édu 1er grado",
       "EDU_2ND_DEGRE": "Pix+ Édu 2do grado",
@@ -764,7 +760,7 @@
           "aria-label": "Pasar a la pantalla siguiente",
           "label": "Continuar",
           "last-page": {
-            "aria-label": "Continuar a la página de entrada de la certificación"
+            "aria-label": "Continuar a la página de inicio de la certificación"
           }
         },
         "previous": {
@@ -792,7 +788,7 @@
             "1": "La prueba de certificación consta de '<strong>'32 preguntas'</strong>'.",
             "2": "Tienes un máximo de '<strong>'1h45'</strong>' para responder*.",
             "3": "*excluyendo cualquier tiempo adicional",
-            "4": "Si completa '<strong>'menos de 20 preguntas, no podremos emitirle una puntuación'</strong>'."
+            "4": "Si completas '<strong>'menos de 20 preguntas, no podremos emitir una puntuación'</strong>'."
           },
           "title": "¿Cómo funciona la prueba de certificación?"
         },
@@ -807,8 +803,8 @@
               "title": "Modo libre :"
             },
             "2": {
-              "text": "Para preguntas en '<strong>'modo de enfoque'</strong>', indicado con un icono amarillo: no se le permitirá salir de la página y buscar.",
-              "title": "Modo de enfoque :"
+              "text": "Para preguntas en '<strong>'modo de enfoque'</strong>', indicado con un icono amarillo: no podrás salir de la página y buscar.",
+              "title": "Modo enfoque :"
             }
           },
           "title": "Dos tipos de preguntas"
@@ -818,7 +814,7 @@
             "1": "Ir al final de la página",
             "2": "Seleccione \"Informar de un problema con la pregunta\".",
             "3": "Haga clic en \"Sí, estoy seguro\".",
-            "4": "Llama al vigilante que intervendrá para ayudarte"
+            "4": "Llama al supervisor que intervendrá para ayudarte"
           },
           "text": "'<strong>'En caso de problema técnico'</strong>' (por ejemplo, la imagen se niega a mostrarse), sigue estos pasos:",
           "title": "¿Qué hacer en caso de problema?"
@@ -831,7 +827,7 @@
             "3": "'<strong>'Utiliza un sistema de inteligencia artificial'</strong>' o un chatbot.",
             "4": "'<strong>'Consulta un foro de autoayuda'</strong>' proporcionando directamente la respuesta a una pregunta.",
             "5": "'<strong>'Movilizar cualquier otro medio que proporcione directamente la respuesta a la pregunta'</strong>', sin haber realizado el trabajo requerido por la instrucción.",
-            "6": "'<strong>'Utilice un navegador diferente'</strong>' al que está ejecutando su prueba de Certificación Pix.",
+            "6": "'<strong>'Utiliza un navegador diferente'</strong>' al que está ejecutando tu prueba de Certificación Pix.",
             "7": "'<strong>'Suplantar'</strong>' a otra persona."
           },
           "pix-companion": "El acceso a determinados sitios está prohibido en el marco de la prueba de certificación, gracias a una extensión instalada en el navegador. Cualquier fraude probado (intento de eludir la extensión o incumplimiento de los comportamientos enumerados anteriormente) puede dar lugar a la invalidación de la certificación.",
@@ -846,7 +842,7 @@
       "congratulation-banner": {
         "double-certification": {
           "eligible": "También eres elegible a la certificación complementaria :",
-          "outdated": "<strong>Ya no eres elegible para la certificación {doubleCertificationName} después de su evolución.</strong><br />Ponte de nuevo en contacto con tu centro o la organización que te ofreció el test para realizar de nuevo una campaña y volver a ser elegible. Tu progreso se ha conservado y solo tendrás que hacer las pruebas nuevas, debería ir rápido."
+          "outdated": "<strong>Ya no eres elegible para la certificación {doubleCertificationName} después de la evolución.</strong><br />Ponte de nuevo en contacto con tu centro o la organización que te ofreció el test para realizar de nuevo una campaña y volver a ser elegible. Tu progreso se ha conservado y solo tendrás que hacer las pruebas nuevas, debería ir rápido."
         },
         "link": {
           "text": "¿Cómo puedo obtener el certificado?"
@@ -855,16 +851,16 @@
       },
       "error-messages": {
         "generic": {
-          "check-personal-info": "Comprueba con el vigilante que tus datos personales coinciden con los de la hoja de inscripción.",
+          "check-personal-info": "Comprueba con el supervisor que tus datos personales coinciden con los de la hoja de registro.",
           "check-session-number": "Comprueba el número de sesión.",
-          "disclaimer": "La información introducida no corresponde a ningún candidato inscrito en la sesión."
+          "disclaimer": "La información introducida no corresponde a ningún candidato registrado en la sesión."
         },
         "language-not-supported": "La certificación Pix aún no está disponible en {userLanguage}. '<br>' Los idiomas disponibles actualmente para la certificación son: {availableLanguages}. '<br>' Puedes elegir otro idioma en la página",
         "language-not-supported-link": "Mi cuenta",
-        "missing-center-habilitation": "No puede unirse a la sesión. El centro de certificación no está autorizado para realizar esta certificación.",
+        "missing-center-habilitation": "No puedes unirte a la sesión. El centro de certificación no está autorizado para realizar esta certificación.",
         "session-not-accessible": "La sesión a la que intentas unirte ya no está disponible.",
-        "wrong-account": "La información introducida corresponde a un candidato inscrito en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
-        "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus tests o pide ayuda al vigilante.",
+        "wrong-account": "La información introducida corresponde a un candidato registrado en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
+        "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus test o pide ayuda al supervisor.",
         "wrong-account-sco-link": {
           "label": "¿Cómo encuentro la cuenta vinculada al establecimiento?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
@@ -884,7 +880,7 @@
           "birth-year": "año de nacimiento (AAAA)",
           "first-name": "Nombre",
           "session-number": "Número de sesión",
-          "session-number-information": "Comunicado únicamente por el vigilante al inicio de la sesión"
+          "session-number-information": "Comunicado únicamente por el supervisor al inicio de la sesión"
         },
         "fields-validation": {
           "session-number-error": "El número de sesión se compone únicamente de dígitos."
@@ -909,7 +905,7 @@
     },
     "certification-results": {
       "action": {
-        "confirm": "Confirmo",
+        "confirm": "Confirmar",
         "logout": "Desconectarse"
       },
       "finished": {
@@ -917,11 +913,11 @@
         "title": "¡Enhorabuena, has terminado!",
         "warning-text": "Si no es tu ordenador, recuerda desconectarte."
       },
-      "flag-alt": "Bandera",
+      "flag-alt": "Señalar",
       "title": "Prueba finalizada"
     },
     "certification-start": {
-      "access-code": "Código de acceso comunicado por el vigilante",
+      "access-code": "Código de acceso comunicado por el supervisor",
       "actions": {
         "submit": "Empezar mi prueba"
       },
@@ -932,27 +928,19 @@
         },
         "info": "Al hacer clic en «Empezar mi prueba», acepto que mis datos de identidad, el número de certificación y las circunstancias de la prueba introducidos por el vigilante se transmitan a Pix. Pix utilizará esta información durante las deliberaciones del tribunal para elaborar y archivar mis resultados y expedir mi certificado. Si esta certificación ha sido prescrita por una organización, acepto que Pix pueda comunicarle mis resultados."
       },
-      "core-and-complementary-subscriptions": "Además de la certificación Pix, estás inscrito en la siguiente certificación complementaria:",
+      "core-and-complementary-subscriptions": "Además de la certificación Pix, estás registrado en la siguiente certificación complementaria:",
       "error-messages": {
         "access-code-error": "Este código no existe o ya no es válido.",
-        "candidate-not-authorized-to-resume": "Ponte en contacto con el vigilante para que autorice la reanudación de tu examen.",
-        "candidate-not-authorized-to-start": "El vigilante no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al vigilante.",
+        "candidate-not-authorized-to-resume": "Ponte en contacto con el supervisor para que autorice la reanudación de tu examen.",
+        "candidate-not-authorized-to-start": "El supervisor no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al vigilante.",
         "generic": "Acaba de producirse un error inesperado en el servidor.",
-        "missing-code": "You have not entered your access code.",
+        "missing-code": "No has introducido tu código de acceso.",
         "session-not-accessible": "La sesión de certificación ya no está disponible.",
         "unknown": {
           "summary-label": "Ver más detalles:"
         }
       },
       "first-title": "Estás a punto de empezar tu prueba de certificación",
-      "language-selector": {
-        "confirmation-label": "Confirmo que me siento cómodo con el idioma seleccionado para responder a las preguntas.'<br>'La elección del idioma es '<strong>'definitiva'</strong>'.",
-        "label": "Idioma de certificación",
-        "options": {
-          "english": "Inglés - EN",
-          "french": "Francés - FR"
-        }
-      },
       "link-to-user-certification": "Ver mis certificaciones",
       "non-eligible-subscription": "No eres elegible para {complementarySubscriptionLabel}. Sin embargo, puedes presentarte a la certificación Pix.",
       "title": "Unirse a una sesión de certificación"
@@ -983,16 +971,16 @@
     "challenge": {
       "actions": {
         "continue": "Continuar",
-        "continue-go-to-next": "Continúo y voy a la siguiente pregunta",
-        "skip": "Paso",
-        "skip-go-to-next": "Paso y voy a la siguiente pregunta",
-        "validate": "Valido",
-        "validate-go-to-next": "Valido y voy a la siguiente pregunta",
-        "wait-for-invigilator": "Las acciones se detienen hasta que llegue el vigilante"
+        "continue-go-to-next": "Continuar a la siguiente pregunta",
+        "skip": "Saltar",
+        "skip-go-to-next": "Saltar y continuar a la siguiente pregunta",
+        "validate": "Validar",
+        "validate-go-to-next": "Validar y continuar a la siguiente pregunta",
+        "wait-for-invigilator": "Las acciones se detienen hasta que llegue el supervisor"
       },
       "already-answered": "Ya has respondido a esta pregunta",
       "answer-input": {
-        "numbered-label": "Respuesta {number}"
+        "numbered-label": "Respuesta {número}"
       },
       "certification": {
         "banner": {
@@ -1002,12 +990,12 @@
       },
       "certification-feedback-panel": {
         "actions": {
-          "no-send-feedback": "No, vuelvo a la prueba",
+          "no-send-feedback": "No, volver a la prueba",
           "open-close": "Informar de un problema con la pregunta",
           "send-feedback": "Sí, estoy seguro/a"
         },
         "description": "¿Estás seguro/a de que quieres informar de un problema?",
-        "information": "Al informar de un problema, tu certificación se pausa hasta que el vigilante intervenga para validar o invalidar tu informe."
+        "information": "Al informar de un problema, tu certificación se pausa hasta que el supervisor intervenga para validar o invalidar tu informe."
       },
       "embed-simulator": {
         "actions": {
@@ -1104,7 +1092,7 @@
           "status": {
             "error": {
               "empty-message": "Debes introducir un mensaje.",
-              "max-characters": "Tu mensaje está limitado a 10 000 caracteres."
+              "max-characters": "Tu mensaje está limitado a 10 000 caracteres."
             },
             "success": "'<p>'Tu comentario ha sido enviado al equipo del proyecto Pix.'</p><p>'Gracix!'</p>'"
           }
@@ -1119,10 +1107,10 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al vigilante y responde a la pregunta en su presencia.",
+        "certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor y responde a la pregunta en su presencia.",
         "default": "Hemos detectado un cambio de página.",
         "v3-accessible-certification": "Hemos detectado un cambio de página. Si has tenido que cambiar de página para utilizar una herramienta de accesibilidad digital (como un lector de pantalla o un teclado virtual), responde a la pregunta de todos modos.",
-        "v3-certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al vigilante para que pueda constatarlo e informar de ello, dado el caso."
+        "v3-certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor para que pueda constatarlo e informar de ello, dado el caso."
       },
       "illustration": {
         "placeholder": "Cargando la imagen"
@@ -1136,13 +1124,13 @@
       },
       "live-alerts": {
         "challenge": {
-          "message": "Avisa al vigilante para que identifique el problema."
+          "message": "Avisa al supervisor para que identifique el problema."
         },
         "companion": {
-          "message": "Póngase en contacto con su vigilante para confirmar la presencia de la extensión."
+          "message": "Ponte en contacto con el supervisor para confirmar la presencia de la extensión."
         },
         "refresh": "Actualizar la página",
-        "waiting-information": "Esperando al vigilante..."
+        "waiting-information": "Esperando al supervisor..."
       },
       "parts": {
         "answer-input": "Tu respuesta",
@@ -1160,12 +1148,12 @@
         "label": "Pregunta"
       },
       "skip-error-message": {
-        "qcm": "Para validar, selecciona al menos dos respuestas. De lo contrario, puedes pasar.",
-        "qcu": "Para validar, selecciona una respuesta. De lo contrario, puedes pasar.",
-        "qroc": "Para validar, rellena el campo de texto. De lo contrario, puedes pasar.",
-        "qroc-auto-reply": "«Puedes validar» aparece cuando se supera la prueba. Inténtalo de nuevo o puedes pasar.",
-        "qroc-positive-number": "Para validar, introduce un número mayor o igual que 0; de lo contrario, puedes pasar.",
-        "qrocm": "Para validar, rellena todos los campos de respuesta. De lo contrario, puedes pasar."
+        "qcm": "Para validar, selecciona al menos dos respuestas. De lo contrario, puedes continuar.",
+        "qcu": "Para validar, selecciona una respuesta. De lo contrario, puedes continuar.",
+        "qroc": "Para validar, rellena el campo de texto. De lo contrario, puedes continuar.",
+        "qroc-auto-reply": "«Puedes validar» aparece cuando se supera la prueba. Inténtalo de nuevo o puedes continuar.",
+        "qroc-positive-number": "Para validar, introduce un número mayor o igual que 0; de lo contrario, puedes continuar.",
+        "qrocm": "Para validar, rellena todos los campos de respuesta. De lo contrario, puedes continuar."
       },
       "statement": {
         "alternative-instruction": {
@@ -1188,10 +1176,10 @@
           "embed": "Esta prueba incluye un simulador."
         },
         "text-to-speech": {
-          "activate": "Activar la vocalización",
-          "deactivate": "Desactivar la vocalización",
+          "activate": "Activar texto a voz",
+          "deactivate": "Desactivar texto a voz",
           "play": "Lectura en voz alta",
-          "stop": "Para de leer"
+          "stop": "Dejar de leer"
         },
         "tooltip": {
           "aria-label": "Mostrar la indicación en la prueba.",
@@ -1207,7 +1195,7 @@
         }
       },
       "timed": {
-        "cannot-answer": "El tiempo límite ha pasado. Tu respuesta no será validada."
+        "cannot-answer": "Se ha agotado el tiempo. Tu respuesta no será validada."
       },
       "title": {
         "default": "Modo libre - Pregunta {stepNumber} de {totalChallengeNumber}",
@@ -1245,10 +1233,10 @@
     "combined-courses": {
       "completed": {
         "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital.",
-        "retry-text": "¿Quieres repasar? ¡Puedes volver a reproducir todos los módulos libremente!",
+        "retry-text": "¿Quieres repasar? ¡Puedes volver a reproducir todos los módulos tranquilamente!",
         "survey-button": "Responder a la encuesta de satisfacción",
-        "survey-button-description": "Responda al cuestionario para dar su opinión sobre el recorrido.",
-        "title": "¡Enhorabuena! ¡Ya ha terminado!"
+        "survey-button-description": "Responde al cuestionario para dar tu opinión sobre el recorrido.",
+        "title": "¡Enhorabuena! ¡Ya has terminado!"
       },
       "content": {
         "resume-course": "Reanudar mi curso",
@@ -1284,7 +1272,7 @@
           "skipped-answer": "Pregunta saltada",
           "the-answer-was": "La respuesta correcta es",
           "timedout": "Has superado el límite de tiempo",
-          "wrong-answer": "La respuesta dada es incorrecta"
+          "wrong-answer": "La respuesta es incorrecta"
         },
         "aband": {
           "title": "No has respondido",
@@ -1357,9 +1345,9 @@
           "modal": {
             "important-message": "Tus { earnedPix } Pix se van a eliminar de la competencia: { scoreCardName }.",
             "important-message-above-level-one": "Tu nivel { level } y tus { earnedPix } Pix se van a eliminar de la competencia: { scoreCardName }.",
-            "title": "Puesta a cero de la competencias",
+            "title": "Puesta a cero de la competencia",
             "warning": {
-              "certification": "si deseas que se certifique tu perfil y tus distintos resultados, esto podría afectar a tu certificación.",
+              "certification": "si deseas que se certifique tu perfil y tus resultados, esto podría afectar a tu certificación.",
               "header": "Atención: ",
               "ongoing-assessment": "si tienes una evaluación en curso, es posible que te vuelvan a hacer ciertas preguntas."
             }
@@ -1402,17 +1390,17 @@
           "text": "<h2>No olvides finalizar el envío de tu perfil.</h2>"
         },
         "subtitle": "Continúa con la prueba actual o envía tus resultados",
-        "tests-link": "Todos mis tests",
-        "title": "Mis tests"
+        "tests-link": "Todos mis test",
+        "title": "Mis test"
       },
       "empty-dashboard": {
         "link-to-competences": "Ver mis competencias",
-        "message": "<h2>¡Enhorabuena, has completado las competencias recomendadas!</h2> <p> Para ir más lejos, sigue practicando volviendo a probar competencias. </p>"
+        "message": "<h2>¡Enhorabuena, has completado las competencias recomendadas!</h2> <p> Para avanzar, sigue practicando volviendo a probar competencias. </p>"
       },
       "improvable-competences": {
         "extra-information": "Accede a todas las competencias que puedes volver a intentar",
         "profile-link": "Todas las competencias",
-        "subtitle": "¿Estás listo para pasar tu competencia al siguiente nivel?",
+        "subtitle": "¿Estás listo para pasar al siguiente nivel?",
         "title": "Volver a intentar una competencia"
       },
       "presentation": {
@@ -1420,7 +1408,7 @@
           "text": "Más información",
           "url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
         },
-        "message": "<h2>Hola, descubre tu panel de control.</h2><p>Accede rápida y fácilmente a los tests y pruebas de competencias que ya has empezado.<br/>Comprueba cómo progresa tu puntuación Pix y si tu perfil está listo para la certificación Pix.</p>"
+        "message": "<h2>Hola, descubre tu panel de control.</h2><p>Accede rápida y fácilmente a los test y pruebas de competencias que ya has empezado.<br/>Comprueba cómo progresa tu puntuación Pix y si tu perfil está listo para la certificación Pix.</p>"
       },
       "recommended-competences": {
         "extra-information": "Acceder a todas las competencias recomendadas",
@@ -1432,15 +1420,15 @@
         "profile-link": "Ver mis competencias"
       },
       "started-competences": {
-        "subtitle": "Continúa con tus pruebas de competencias, aquí encontrará las más recientes.",
+        "subtitle": "Continúa con tus pruebas de competencias, aquí encontrarás las más recientes.",
         "title": "Recuperar una competencia"
       },
       "title": "Inicio",
-      "welcome": "Bienvenido { firstName }"
+      "welcome": "Bienvenido/a { firstName }"
     },
     "download-session-results": {
       "button": {
-        "label": "Descargue los resultados"
+        "label": "Descargar los resultados"
       },
       "errors": {
         "invalid-token": "El enlace de descarga de los resultados de la sesión no es válido."
@@ -1456,10 +1444,10 @@
         "leave-without-signup-modal": {
           "actions": {
             "cancel": "Cancelar",
-            "leave": "Sí, dejar el curso"
+            "leave": "Sí, abandonar el curso"
           },
-          "content-information": "Si abandona este curso sin inscribirse, no podrá mantener su progreso.",
-          "content-instruction": "¿Quiere continuar?",
+          "content-information": "Si abandonas este curso sin registrarte, no podrás guardar tu progreso.",
+          "content-instruction": "¿Quieres continuar?",
           "title": "¿Salir y volver a Pix?"
         }
       }
@@ -1591,7 +1579,7 @@
       "buttons": {
         "activity": {
           "retry": "Volver a intentarlo",
-          "verify": "Compruebe mi respuesta"
+          "verify": "Comprobar mi respuesta"
         },
         "element": {
           "alternativeText": "Mostrar el texto alternativo",
@@ -1668,11 +1656,11 @@
       },
       "download": {
         "button": "Descargar",
-        "description": "Elija el formato en función del software que utilice. Si no estás seguro, elige el primer archivo, que es compatible con la mayoría de los programas.",
+        "description": "Elige el formato en función del software que utilices. Si no estás seguro, elige el primer archivo, que es compatible con la mayoría de los programas.",
         "documentationLinkHref": "https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix",
         "documentationLinkLabel": "¿Cómo puedo abrir, modificar o recuperar este archivo?",
         "format": "Formato {format}",
-        "intro": "Elija el formato de archivo que desea utilizar.",
+        "intro": "Elige el formato de archivo que desea utilizar.",
         "label": "Descargue el archivo en {format}"
       },
       "elements": {
@@ -1685,7 +1673,7 @@
           "missing-content": "Se produjo un error al mostrar la imagen."
         },
         "short-video": {
-          "consult-transcription": "Consulte la transcripción para conocer su contenido.",
+          "consult-transcription": "Consulta la transcripción para conocer el contenido.",
           "missing-content": "Se produjo un error al mostrar el vídeo."
         },
         "text": {
@@ -1693,6 +1681,7 @@
             "context": "Contexto",
             "did-you-know": "¿Lo sabías?",
             "further-information": "Más información",
+            "key-points": "Puntos clave",
             "tip": "Consejo"
           }
         }
@@ -1714,12 +1703,11 @@
       },
       "grain": {
         "tag": {
-          "activity": "Actividad",
-          "key-points": "Puntos clave"
+          "activity": "Actividad"
         },
         "title": {
           "lesson": "Lección",
-          "summary": "Recapitular"
+          "summary": "Resumen"
         }
       },
       "interactiveElement": {
@@ -1729,7 +1717,7 @@
         "aria-label": "Enviar un problema o una sugerencia",
         "button": "Señalar",
         "error-messages": {
-          "missing-comment": "Por favor, introduzca un comentario."
+          "missing-comment": "Por favor, introduce un comentario."
         },
         "modal": {
           "categories": {
@@ -1750,14 +1738,14 @@
           "confirmation-message": {
             "error": {
               "info": "Se ha producido un error al enviar el comentario.",
-              "retry": "Vuelva a intentarlo más tarde."
+              "retry": "Vuelve a intentarlo más tarde."
             },
             "success": "Gracias, hemos tomado nota de su comentario."
           },
           "legend": "Información necesaria para enviar una denuncia",
           "select-label": "Motivo de la notificación",
           "textarea-label": "Comentario",
-          "textarea-placeholder": "Descríbanos su problema o sugerencia",
+          "textarea-placeholder": "Describe el problema o sugerencia",
           "title": "Notificación"
         }
       },
@@ -1789,11 +1777,6 @@
           },
           "label": "Mostrar ID de los elementos"
         },
-        "grain-select": {
-          "button": "Probar el grain",
-          "grain-label": "Grain {index} : {title}",
-          "label": "Elige el grain a probar"
-        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",
@@ -1809,23 +1792,23 @@
         }
       },
       "qcm": {
-        "direction": "Seleccione varias respuestas."
+        "direction": "Selecciona varias respuestas."
       },
       "qcu": {
-        "direction": "Seleccione una sola respuesta."
+        "direction": "Selecciona una sola respuesta."
       },
       "qcuDeclarative": {
         "complementaryInstruction": "No hay respuestas correctas o incorrectas.",
-        "direction": "Seleccione una sola respuesta."
+        "direction": "Selecciona una sola respuesta."
       },
       "qcuDiscovery": {
-        "direction": "Seleccione la respuesta que le parezca más adecuada."
+        "direction": "Selecciona la respuesta que te parezca más adecuada."
       },
       "qrocm": {
         "direction": "Rellena {count, plural, =1 {el campo} other {los campos}}."
       },
       "recap": {
-        "backToModuleDetails": "Deje de",
+        "backToModuleDetails": "Salir",
         "goToHomepage": "Continuar",
         "subtitle": "Has trabajado en los siguientes objetivos:",
         "title": "¡Módulo completado!"
@@ -1835,7 +1818,7 @@
         "go-further": "Ve más allá",
         "practise": "Practica",
         "question-yourself": "Pregúntate a ti mismo",
-        "retain-the-essentials": "Retén lo esencial"
+        "retain-the-essentials": "Quédate con lo esencial"
       },
       "sidebar": {
         "button": "Visualizar los pasos del módulo"
@@ -1879,7 +1862,7 @@
         "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
         "invalid-email": "Tu dirección de correo electrónico no es válida.",
         "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas.",
-        "password-reset-token-invalid-or-expired": "Ha pasado demasiado tiempo para validar su nueva contraseña. Vuelva a la página de inicio de sesión para volver a introducir su nombre de usuario y contraseña temporal."
+        "password-reset-token-invalid-or-expired": "Ha pasado demasiado tiempo para validar tu nueva contraseña. Vuelve a la página de inicio de sesión para volver a introducir tu nombre de usuario y contraseña temporal."
       },
       "login-form": {
         "button": "Iniciar sesión",
@@ -1891,8 +1874,7 @@
       "signup-form": {
         "button": "Creo una cuenta",
         "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
-        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-        "first-name-label-and-value": "Nombre: {firstName}",
+        "error": "No hemos podido recuperar tu información de identificación del servicio utilizado. Te invitamos a que te pongas en contacto con el servicio de asistencia informática de esta organización.": "Nombre: {firstName}",
         "last-name-label-and-value": "Apellidos: {lastName}",
         "title": "No tengo una cuenta Pix"
       },
@@ -1916,7 +1898,7 @@
           "no-level": "Competencia sin empezar"
         }
       },
-      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix.",
+      "description": "Ponte a prueba a tu propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix.",
       "first-title": "Tienes 16 competencias en las que hacer pruebas. '<br>'¡Concéntrate y a por ello!",
       "resume-campaign-banner": {
         "accessibility": {
@@ -1968,7 +1950,7 @@
       },
       "ko": "Respuesta incorrecta",
       "ok": "Respuesta correcta",
-      "timedout": "Tiempo superado"
+      "timedout": "Se ha agotado el tiempo"
     },
     "sco-signup-or-login": {
       "invitation": "{ organizationName } te invita a unirte a Pix",
@@ -1992,7 +1974,7 @@
         "unexpected-user-account-error": "La dirección de correo electrónico o el nombre de usuario es incorrecto. Para continuar, debes conectarte a tu cuenta, que tiene la forma: "
       },
       "signup-form": {
-        "button": "Inscribirse",
+        "button": "Registrarse",
         "button-form": "Crear cuenta",
         "fields": {
           "birthdate": {
@@ -2040,7 +2022,7 @@
         "not-me": "No soy yo",
         "options": {
           "email": "Mi dirección de correo electrónico",
-          "text": "Me inscribo con:",
+          "text": "Me registro con:",
           "username": "Mi nombre de usuario"
         },
         "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
@@ -2100,7 +2082,7 @@
       },
       "first-title": "Inscríbete",
       "save-progress-message": "Para hacer un seguimiento de tus progresos y seguir evaluándote, ¡regístrate en Pix!",
-      "title": "Inscripción"
+      "title": "Registro"
     },
     "sitemap": {
       "accessibility": {
@@ -2144,9 +2126,8 @@
       "hero": {
         "acquired-badges-title": "Premios obtenidos",
         "explanations": {
-          "trainings": "Para ayudarle a progresar, eche un vistazo a nuestros cursos de formación recomendados y encuentre los que más le convienen."
+          "trainings": "Para ayudarte a progresar, echa un vistazo a nuestros cursos de formación recomendados y encuentra los que más le convienen."
         },
-        "hidden-badges": "{ count, plural, =1 {insignia adicional obtenida no mostrada} other {insignias adicionales obtenidas no mostradas} }",
         "mastery-rate": "de éxito en las preguntas",
         "retry": {
           "actions": {
@@ -2154,7 +2135,7 @@
             "retry": "Repetir el test"
           },
           "description": "Tu organizador te pedira que repites la prueba.",
-          "retryIn": "Aún no puede retomar este curso. Vuelva dentro de {duration}.",
+          "retryIn": "Aún no puedes retomar este curso. Vuelve dentro de {duration}.",
           "title": "Mejora tus resultados"
         },
         "see-trainings": "Ver los cursos",
@@ -2169,7 +2150,7 @@
         "description": "Puedes volver a intentar algunas de las preguntas",
         "title": "¿Quieres mejorar tus resultados?"
       },
-      "information": "Si ya has completado tests en Pix, las preguntas a las que ya has respondido no se han vuelto a plantear. No obstante, el resultado que aparece aquí tiene en cuenta todas tus respuestas.",
+      "information": "Si ya has completado test en Pix, las preguntas a las que ya has respondido no se han vuelto a plantear. No obstante, el resultado que aparece aquí tiene en cuenta todas tus respuestas.",
       "net-promoter-score": {
         "link": {
           "href": "https://pix.fr",
@@ -2185,7 +2166,7 @@
           "text": "Estás a punto de poner a cero el test <strong>{targetProfileName}</strong>, para intentar mejorar tu nivel. Al final del curso, podrás volver a enviar tus resultados.",
           "warning-text": "Tus Pix, niveles y certificabilidad obtenidos durante este test se van a eliminar."
         },
-        "notification": "Vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+        "notification": "Vuelve a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "retry": {
         "button": "Repetir el test",
@@ -2193,7 +2174,7 @@
         "notification": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
       },
       "retry-and-reset": {
-        "notification": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+        "notification": "Repite las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a tus resultados anteriores."
       },
       "send-status": {
         "in-progress": "Enviando"
@@ -2201,28 +2182,25 @@
       "stage": {
         "caption": "Detalles de tus resultados en porcentaje y estrellas según las competencias",
         "masteryPercentage": "{rate, number, ::percent} de éxito",
-        "recommendedEngine": {
-          "starsAcquired": "{acquired} / {total, plural, =0 {estrella} =1 {# estrella} other {# estrellas}}"
-        },
         "starsAcquired": "{acquired, plural, =0 {ninguna estrella obtenida} =1 {# estrella obtenida} other {# estrellas obtenidas}} de {total}",
         "title": "Detalles de las competencias"
       },
       "tabs": {
         "aria-label": "3 pestañas con los resultados",
         "results-details": {
-          "description": "Descubra tus competencias en detalle, organizadas por áreas específicas, para comprender mejor tus puntos fuertes y tus áreas de mejora. Identifica tus puntos fuertes y las áreas en las que puedes centrar tus esfuerzos para seguir progresando.",
+          "description": "Descubre tus competencias en detalle, organizadas por áreas específicas, para comprender mejor tus puntos fuertes y tus áreas de mejora. Identifica tus puntos fuertes y las áreas en las que puedes centrar tus esfuerzos para seguir progresando.",
           "tab-label": "Detalle de los resultados",
           "title": "Detalle de los resultados"
         },
         "rewards": {
-          "description": "En esta sección se destacan los premios recibidos y las expectativas del organizador del curso. Descubra cómo se ha evaluado su rendimiento e identifique las áreas de mejora en el desarrollo de sus competencias.",
+          "description": "En esta sección se destacan los premios recibidos y las expectativas del organizador del curso. Descubre cómo se ha evaluado su rendimiento e identifique las áreas de mejora en el desarrollo de sus competencias.",
           "tab-label": "Premios",
           "title": "Recompensas y expectativas del organizador"
         },
         "trainings": {
-          "description": "Obtenga recomendaciones de entrenamiento personalizadas para seguir avanzando y alimentar su curiosidad para ayudarle a desarrollar todo su potencial.",
+          "description": "Recibe recomendaciones de entrenamiento personalizadas para seguir avanzando y alimentar su curiosidad para ayudarle a desarrollar todo su potencial.",
           "tab-label": "Formación",
-          "title": "¿Quiere saber más?"
+          "title": "¿Quieres saber más?"
         }
       },
       "title": "Resultado",
@@ -2234,7 +2212,7 @@
     "terms-of-service": {
       "cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'condiciones de uso de Pix'</a>'",
       "form": {
-        "button": "Continúo",
+        "button": "Continuar",
         "error-message": "Debes aceptar las condiciones de uso de Pix."
       },
       "message": "Hemos actualizado nuestras condiciones de uso. Por favor, acéptalas para continuar con tu experiencia Pix.",
@@ -2257,7 +2235,7 @@
         "e-learning": "Formación a distancia",
         "hybrid-training": "Formación híbrida",
         "in-person-training": "Formación presencial",
-        "modulix": "Módulo Pix",
+        "modulix": "Módulo Pix (Beta)",
         "webinaire": "Webinario"
       }
     },
@@ -2290,7 +2268,7 @@
         }
       },
       "pass": "Ignorar",
-      "pass-title": "Sáltate el tutorial y empieza mi viaje",
+      "pass-title": "Sáltate el tutorial y empieza el viaje",
       "start": "Comenzar el test",
       "title": "Tutorial de la campaña"
     },
@@ -2306,30 +2284,48 @@
         "label": "Contraseña"
       },
       "first-title": "Restablecer contraseña",
-      "go-to-login": "Me conecto",
+      "go-to-login": "Conectarme",
       "subtitle": "Elige una nueva contraseña para continuar",
       "title": "Cambiar mi contraseña",
       "validation": "Tu contraseña ha sido actualizada."
     },
     "user-account": {
-      "account-add-or-update-email-with-validation": {
-        "code-reception-information": "Al confirmar tu solicitud para añadir una dirección de correo electrónico, recibirás un código por correo electrónico.",
+      "account-update-email": {
+        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
         "fields": {
-          "email": {
-            "add-email": {
-              "label": "Dirección de correo electrónico"
-            },
-            "update-email": {
-              "label": "Nueva dirección de correo electrónico"
-            }
+          "errors": {
+            "empty-password": "Tu contraseña no puede estar vacía.",
+            "invalid-password": "La contraseña que has introducido no es válida.",
+            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
+            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
+            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
+            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
           },
+          "new-email": {
+            "label": "Nueva dirección de correo electrónico"
+          },
+          "new-email-confirmation": {
+            "label": "Confirmación de la dirección de correo electrónico"
+          },
+          "password": {
+            "label": "Contraseña"
+          }
+        },
+        "password-information": "Introduce tu contraseña para confirmar",
+        "save-button": "Confirmar",
+        "title": "Cambio de la dirección de correo electrónico"
+      },
+      "account-update-email-with-validation": {
+        "fields": {
           "errors": {
             "empty-password": "Tu contraseña no puede estar vacía.",
             "invalid-email": "Tu dirección de correo electrónico no es válida.",
             "invalid-or-already-used-email": "Dirección de correo electrónico no válida o ya utilizada",
             "invalid-password": "La contraseña que has introducido no es válida.",
-            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
-            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia."
+            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando."
+          },
+          "new-email": {
+            "label": "Nueva dirección de correo electrónico"
           },
           "password": {
             "label": "Contraseña",
@@ -2337,17 +2333,13 @@
           }
         },
         "save-button": "Recibir un código de comprobación",
-        "title": {
-          "add-email": "Añadir una dirección de correo electrónico",
-          "update-email": "Cambio de la dirección de correo electrónico"
-        }
+        "title": "Cambio de la dirección de correo electrónico"
       },
       "connexion-methods": {
         "authentication-methods": {
-          "connection-via": "Conexión a través de {identityProviderOrganizationName}",
-          "gar": "Conexión a través de ENT/Mediacentre",
+          "gar": "a través de ENT/Mediacentre",
           "label": "Conexión externa",
-          "other-authentication-label": "Otro método de conexión"
+          "via": "a través de {identityProviderOrganizationName}"
         },
         "edit-button": "Modificar",
         "email": "Dirección de correo electrónico",
@@ -2360,7 +2352,7 @@
         },
         "menu-link-title": "Eliminar mi cuenta",
         "modal": {
-          "error-403": "No puedes eliminar tu cuenta. Póngase en contacto con el servicio de asistencia de Pix.",
+          "error-403": "No puedes eliminar tu cuenta. Ponte en contacto con el servicio de asistencia de Pix.",
           "question": "¿Seguro que quieres eliminar tu cuenta?",
           "title": "Está a punto de eliminar su cuenta",
           "warning-1": "Tenga en cuenta que la cuenta no se puede recuperar después de eliminarla.",
@@ -2369,12 +2361,11 @@
         "more-information": "Para más información,",
         "more-information-contact-support": "puede ponerse en contacto con el servicio de asistencia.",
         "title": "Eliminar mi cuenta definitivamente",
-        "warning-email": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y píxeles que haya obtenido se eliminarán de forma permanente para la cuenta PIX que utilice la dirección de correo electrónico <strong>{email}</strong>.",
-        "warning-other": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y píxeles que haya obtenido se eliminarán permanentemente de la cuenta PIX <strong>{firstName} {lastName}</strong>."
+        "warning-email": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y pix que haya obtenido se eliminarán de forma permanente para la cuenta PIX que utilice la dirección de correo electrónico <strong>{email}</strong>.",
+        "warning-other": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y pix que haya obtenido se eliminarán permanentemente de la cuenta PIX <strong>{firstName} {lastName}</strong>."
       },
       "email-confirmed": "Dirección de correo electrónico verificada.",
       "email-verification": {
-        "add-successful": "¡Tu dirección de correo electrónico ya está registrada!",
         "code-explanation-of-use": "Para pasar de un campo a otro, utiliza el tabulador o las flechas izquierda y derecha del teclado. Para rellenar un campo, introduce dígitos del 1 al 9 o utiliza las flechas arriba y abajo del teclado.",
         "code-label": "Campo",
         "code-legend": "Introducir el código de comprobación enviado por correo electrónico",
@@ -2385,19 +2376,17 @@
           "email-modification-demand-expired": "Este código ha caducado. Por favor, renueva la solicitud.",
           "incorrect-code": "El código introducido es incorrecto.",
           "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
-          "no-code": "Por favor, introduce el código de {numInputs} dígitos que has recibido por correo electrónico.",
           "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia."
         },
         "send-back-the-code": "volver a enviarme el código",
-        "time-code-validation": "El código recibido es válido durante una hora",
+        "time-code-validation": "El código recibido es válido durante 10 minutos",
         "title": "Comprobación de tu dirección de correo electrónico",
-        "update-successful": "Tu dirección de correo electrónico ha sido modificada.",
-        "validate-new-email": "Validar nuevo correo electrónico"
+        "update-successful": "Tu dirección de correo electrónico ha sido modificada."
       },
       "language": {
         "lang": "Idioma",
         "menu-link-title": "Elegir idioma",
-        "update-successful": "El idioma ha sido cambiado."
+        "update-successful": "Se ha cambiado el idioma."
       },
       "personal-information": {
         "first-name": "Nombre",
@@ -2408,13 +2397,6 @@
     },
     "user-certifications": {
       "meshes": {
-        "DROIT": {
-          "ADVANCED": "Avanzado",
-          "BELOW_MINIMUM": "No obtenido",
-          "CONFIRMED": "Confirmado",
-          "EXPERT": "Experto",
-          "INDEPENDENT": "Independiente"
-        },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Admisible",
           "ADVANCED": "Avanzado",
@@ -2451,8 +2433,8 @@
         },
         "title": "rutas desactivadas"
       },
-      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
-      "title": "Mis tests"
+      "description": "Accede a tus test Pix, sigue tu progreso y continúa donde lo dejaste.",
+      "title": "Mis test"
     },
     "user-trainings": {
       "description": "Sigue progresando gracias a las formaciones recomendadas al final de tu evaluación.",
@@ -2491,7 +2473,7 @@
       "recommended": "Recomendados",
       "recommended-empty": {
         "description": "Para poder recomendarte tutoriales adaptados a tu nivel, es necesario que empieces una prueba de competencias.",
-        "link": "Empiezo",
+        "link": "Empezar",
         "title": "{firstName}, encuentra aquí tus tutoriales favoritos"
       },
       "saved": "Guardados",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -633,7 +633,7 @@
         "retry": "Reintentar",
         "see-more": "Ver el detalle",
         "stages": "{count} { count, plural, =0 {estrellas} =1 {estrella} other {estrellas} } de {total}",
-        "started-at": "Empezado el {fecha}",
+        "started-at": "Empezado el {date}",
         "tag": {
           "deleted": "Eliminado",
           "disabled": "Inactivo",
@@ -649,8 +649,8 @@
       "attestation": "Descargar mi certificado",
       "back-link": "Volver a mis certificaciones",
       "candidate": "Candidato :",
-      "candidate-birth": "Nacido/a el {fecha de nacimiento}",
-      "candidate-birth-complete": "Nacido/a el {fecha de nacimiento} en {lugar de nacimiento}",
+      "candidate-birth": "Nacido/a el {birthdate}",
+      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
       "certification-center": "Centro de certificación :",
       "certification-date": "Fecha de examen :",
       "certification-value": {
@@ -980,7 +980,7 @@
       },
       "already-answered": "Ya has respondido a esta pregunta",
       "answer-input": {
-        "numbered-label": "Respuesta {número}"
+        "numbered-label": "Respuesta {number}"
       },
       "certification": {
         "banner": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -657,7 +657,7 @@
         "paragraphs": {
           "1": "La certificación Pix, reconocida oficialmente, acredita tu dominio de las competencias digitales. Te unirás a una comunidad de millones de usuarios certificados. ¡Enhorabuena por este importante paso en tu carrera profesional!",
           "2": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de puntos que aparece en tu perfil.",
-          "3":El día de tu certificación, se podía alcanzar el nivel 7 y un máximo de 895 puntos (nivel Experto 1)."
+          "3":"El día de tu certificación, se podía alcanzar el nivel 7 y un máximo de 895 puntos (nivel Experto 1)."
         }
       },
       "competences": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -646,7 +646,10 @@
       "title": "Test"
     },
     "certificate": {
-      "attestation": "Descargar mi certificado",
+      "actions": {
+        "download-attestation": "Descargar mi atestado",
+        "download-certificate": "Descargar mi certificado"
+      },
       "back-link": "Volver a mis certificaciones",
       "candidate": "Candidato :",
       "candidate-birth": "Nacido/a el {birthdate}",
@@ -688,6 +691,11 @@
         "EDU": {
           "results-infos": "'<p>'La certificación se desarrolla en dos etapas:'</p><ol><li>'Prueba Pix: acaba de realizarla.'</li><li>'Prueba oral: organizada fuera de Pix ante un tribunal.'</li></ol><p>'Al finalizar la prueba oral, se te otorgará tu nivel de certificación definitivo (Experto, Avanzado, etc.).'<br/>'Contacta con tu centro de certificación para organizar la prueba oral.'</p>'",
           "status": "Certificado válido",
+          "steps": {
+            "1": "Sección Pix",
+            "2": "Sección práctica'<br/>'profesional",
+            "3": "Resultado final"
+          },
           "sub-title": "¡El candidato es admisible para la 2.ª etapa!"
         }
       },
@@ -703,7 +711,10 @@
           "independent": "Independiente",
           "level": "Tu nivel"
         },
-        "progressbar-explanation": "Barra de progreso que indica el nivel que has alcanzado ({level}, es decir, el nivel {globalLevelLabel}) de un máximo de 7 niveles (nivel Experto 1)"
+        "progress-bar-explanation": {
+          "default": "Barra de progreso que indica el nivel que has alcanzado ({level}, es decir, el nivel {globalLevelLabel}) de un máximo de 7 niveles (nivel Experto 1)",
+          "pre-beginner-level": "Barra de progreso que indica el nivel máximo que se puede alcanzar en la certificación (es decir, 7 o el nivel Experto 1)"
+        }
       },
       "hexagon-score": {
         "certified": "certificados"
@@ -717,7 +728,6 @@
         "sub-title": "El candidato es admisible para la certificación {framework}.",
         "title": "Lectura del resultado:"
       },
-      "subtitle": "(niveles de {maxReachableLevel})",
       "title": "Certificado Pix",
       "verification-code": {
         "alt": "Copiar",
@@ -774,7 +784,8 @@
             "1": "La Certificación {certificationName} es un '<strong>'test adaptativo'</strong>' para evaluar tu nivel en el '<strong>'conjunto de 16 competencias digitales del marco de referencia Pix'</strong>'.",
             "2": "La '<strong>'dificultad de las preguntas se adapta en tiempo real'</strong>' en función de las respuestas dadas.",
             "3": "Si algunas preguntas le parecen difíciles, es porque la prueba de certificación pretende medir su nivel máximo. '<strong>'Si no puede responder a una pregunta, tiene la opción de \"saltársela\"'</strong>': no se le volverá a ofrecer durante la certificación y no será validada.",
-            "4": "Para obtener una puntuación lo más cercana posible a tu capacidad '<strong>'es necesario llegar hasta el final de la prueba'</strong>'."
+            "4": "Para obtener una puntuación lo más cercana posible a tu capacidad '<strong>'es necesario llegar hasta el final de la prueba'</strong>'.",
+            "pix-plus-1": "La Certificación {certificationName} es un '<strong>'test adaptativo'</strong>' para evaluar tu nivel en el '<strong>'conjunto de competencias del marco de certificación {certificationName}'</strong>'."
           },
           "question": "¿Cómo funciona la prueba de certificación?",
           "title": "Bienvenido a la certificación {certificationName}"
@@ -1238,7 +1249,7 @@
         "title": "¡Enhorabuena! ¡Ya has terminado!"
       },
       "content": {
-        "resume-course": "Reanudar mi curso",
+        "resume-button": "Reanudar mi curso",
         "start-button": "Iniciar el curso",
         "step": "Paso {stepNumber}"
       },
@@ -1872,6 +1883,15 @@
       },
       "signup-form": {
         "button": "Creo una cuenta",
+        "claims": {
+          "FrEduFonctAdm": "Función administrativa",
+          "FrEduNumenHash": "Identificador técnico",
+          "discipline": "Disciplina",
+          "employeeNumber": "Número de empleado",
+          "population": "Población",
+          "rne": "Centro de adscripción",
+          "title": "Función"
+        },
         "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
         "error": "No hemos podido recuperar tu información de identificación del servicio utilizado. Te invitamos a que te pongas en contacto con el servicio de asistencia informática de esta organización.",
         "first-name-label-and-value": "Nombre: {firstName}",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -781,8 +781,7 @@
         },
         "2": {
           "legend": {
-            "strong-text": "32 PREGUNTAS",
-            "text": "1 H 45 min"
+            "strong-text": "32 PREGUNTAS"
           },
           "paragraphs": {
             "1": "La prueba de certificación consta de '<strong>'32 preguntas'</strong>'.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -111,7 +111,6 @@
       "visible-password": "Mostrar la contraseña"
     },
     "french-education-ministry": "Ministerio francés de Educación y Juventud. Libertad, igualdad, fraternidad",
-    "french-republic": "República Francesa. Libertad, igualdad, fraternidad.",
     "languages": {
       "en": "Inglés",
       "fr": "Francés",
@@ -683,13 +682,16 @@
       "framework-title": {
         "CLEA": "Certificado Pix",
         "CORE": "Certificado Pix",
+        "DROIT": "Certificado Pix+ Derecho",
         "EDU_1ER_DEGRE": "Certificado Pix+ Edu 1.er grado",
         "EDU_2ND_DEGRE": "Certificado Pix+ Edu 2.º grado",
-        "EDU_CPE": "Certificado Pix+ Edu CPE"
+        "EDU_CPE": "Certificado Pix+ Edu CPE",
+        "PRO_SANTE": "Certificado Pix+ Profesionales de Salud"
       },
       "frameworks": {
         "EDU": {
           "results-infos": "'<p>'La certificación se desarrolla en dos etapas:'</p><ol><li>'Prueba Pix: acaba de realizarla.'</li><li>'Prueba oral: organizada fuera de Pix ante un tribunal.'</li></ol><p>'Al finalizar la prueba oral, se te otorgará tu nivel de certificación definitivo (Experto, Avanzado, etc.).'<br/>'Contacta con tu centro de certificación para organizar la prueba oral.'</p>'",
+          "results-sub-title": "¡El/la candidato/a es admisible para la etapa 2 de práctica profesional de la certificación Pix+ Édu!",
           "status": "Certificado válido",
           "steps": {
             "1": "Sección Pix",
@@ -723,12 +725,14 @@
       "jury-info": "Las observaciones del tribunal no se comparten en la página de comprobación de tu certificado.",
       "jury-title": "Observaciones del tribunal",
       "learn-about-certification-results": "¿Cómo interpretar los resultados?",
+      "obtained-certification": "El candidato ha obtenido la certificación {frameworkLabel}",
       "professionalizing-warning": "El certificado Pix está reconocido como cualificación profesional por France Compétences una vez alcanzada una puntuación mínima de 120 pix.",
       "results": {
         "sub-title": "El candidato es admisible para la certificación {framework}.",
         "title": "Lectura del resultado:"
       },
       "title": "Certificado Pix",
+      "valid-status": "Certificado válido",
       "verification-code": {
         "alt": "Copiar",
         "copied": "¡Código copiado!",
@@ -951,6 +955,14 @@
         }
       },
       "first-title": "Estás a punto de empezar tu prueba de certificación",
+      "language-selector": {
+        "confirmation-label": "Confirmo que me siento cómodo/a con el idioma seleccionado para responder a las preguntas.'<br>'La elección del idioma es '<strong>'definitiva'</strong>'.",
+        "label": "Idioma de la certificación",
+        "options": {
+          "english": "inglés - EN",
+          "french": "francés - FR"
+        }
+      },
       "link-to-user-certification": "Ver mis certificaciones",
       "non-eligible-subscription": "No eres elegible para {complementarySubscriptionLabel}. Sin embargo, puedes presentarte a la certificación Pix.",
       "title": "Unirse a una sesión de certificación"
@@ -1691,7 +1703,6 @@
             "context": "Contexto",
             "did-you-know": "¿Lo sabías?",
             "further-information": "Más información",
-            "key-points": "Puntos clave",
             "tip": "Consejo"
           }
         }
@@ -1713,7 +1724,8 @@
       },
       "grain": {
         "tag": {
-          "activity": "Actividad"
+          "activity": "Actividad",
+          "key-points": "Puntos clave"
         },
         "title": {
           "lesson": "Lección",
@@ -1786,6 +1798,11 @@
             "yes": "Si"
           },
           "label": "Mostrar ID de los elementos"
+        },
+        "grain-select": {
+          "button": "Probar el grano",
+          "grain-label": "Grano {index} : {title}",
+          "label": "Elige el grano que quieres probar"
         },
         "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
@@ -2148,6 +2165,7 @@
         "explanations": {
           "trainings": "Para ayudarte a progresar, echa un vistazo a nuestros cursos de formación recomendados y encuentra los que más le convienen."
         },
+        "hidden-badges": "{ count, plural, =1 {insignia adicional obtenida no mostrada} other {insignias adicionales obtenidas no mostradas} }",
         "mastery-rate": "de éxito en las preguntas",
         "retry": {
           "actions": {
@@ -2164,7 +2182,7 @@
           "show-less": "Reducir",
           "show-more": "Ver más"
         },
-        "thanks": "¡Gracias {name}\n por participar!"
+        "thanks": "¡Gracias, {name}, por participar!"
       },
       "improve": {
         "description": "Puedes volver a intentar algunas de las preguntas",
@@ -2310,42 +2328,24 @@
       "validation": "Tu contraseña ha sido actualizada."
     },
     "user-account": {
-      "account-update-email": {
-        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
+      "account-add-or-update-email-with-validation": {
+        "code-reception-information": "Al validar tu solicitud de añadir una dirección de correo electrónico, recibirás un código por correo electrónico.",
         "fields": {
-          "errors": {
-            "empty-password": "Tu contraseña no puede estar vacía.",
-            "invalid-password": "La contraseña que has introducido no es válida.",
-            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
-            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
-            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
-            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
+          "email": {
+            "add-email": {
+              "label": "Dirección de correo electrónico"
+            },
+            "update-email": {
+              "label": "Nueva dirección de correo electrónico"
+            }
           },
-          "new-email": {
-            "label": "Nueva dirección de correo electrónico"
-          },
-          "new-email-confirmation": {
-            "label": "Confirmación de la dirección de correo electrónico"
-          },
-          "password": {
-            "label": "Contraseña"
-          }
-        },
-        "password-information": "Introduce tu contraseña para confirmar",
-        "save-button": "Confirmar",
-        "title": "Cambio de la dirección de correo electrónico"
-      },
-      "account-update-email-with-validation": {
-        "fields": {
           "errors": {
             "empty-password": "Tu contraseña no puede estar vacía.",
             "invalid-email": "Tu dirección de correo electrónico no es válida.",
             "invalid-or-already-used-email": "Dirección de correo electrónico no válida o ya utilizada",
             "invalid-password": "La contraseña que has introducido no es válida.",
-            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando."
-          },
-          "new-email": {
-            "label": "Nueva dirección de correo electrónico"
+            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
+            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia."
           },
           "password": {
             "label": "Contraseña",
@@ -2353,13 +2353,17 @@
           }
         },
         "save-button": "Recibir un código de comprobación",
-        "title": "Cambio de la dirección de correo electrónico"
+        "title": {
+          "add-email": "Añadir una dirección de correo electrónico",
+          "update-email": "Cambio de la dirección de correo electrónico"
+        }
       },
       "connexion-methods": {
         "authentication-methods": {
+          "connection-via": "Conexión a través de {identityProviderOrganizationName}",
           "gar": "a través de ENT/Mediacentre",
           "label": "Conexión externa",
-          "via": "a través de {identityProviderOrganizationName}"
+          "other-authentication-label": "Otro método de conexión"
         },
         "edit-button": "Modificar",
         "email": "Dirección de correo electrónico",
@@ -2386,6 +2390,7 @@
       },
       "email-confirmed": "Dirección de correo electrónico verificada.",
       "email-verification": {
+        "add-successful": "¡Tu dirección de correo electrónico ha sido añadida!",
         "code-explanation-of-use": "Para pasar de un campo a otro, utiliza el tabulador o las flechas izquierda y derecha del teclado. Para rellenar un campo, introduce dígitos del 1 al 9 o utiliza las flechas arriba y abajo del teclado.",
         "code-label": "Campo",
         "code-legend": "Introducir el código de comprobación enviado por correo electrónico",
@@ -2396,12 +2401,14 @@
           "email-modification-demand-expired": "Este código ha caducado. Por favor, renueva la solicitud.",
           "incorrect-code": "El código introducido es incorrecto.",
           "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
+          "no-code": "Por favor, introduce el código de {numInputs} dígitos recibido por correo electrónico.",
           "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia."
         },
         "send-back-the-code": "volver a enviarme el código",
         "time-code-validation": "El código recibido es válido durante 10 minutos",
         "title": "Comprobación de tu dirección de correo electrónico",
-        "update-successful": "Tu dirección de correo electrónico ha sido modificada."
+        "update-successful": "Tu dirección de correo electrónico ha sido modificada.",
+        "validate-new-email": "Validar mi nueva dirección de correo electrónico"
       },
       "language": {
         "lang": "Idioma",
@@ -2417,6 +2424,13 @@
     },
     "user-certifications": {
       "meshes": {
+        "DROIT": {
+          "ADVANCED": "Avanzado",
+          "BELOW_MINIMUM": "No obtenida",
+          "CONFIRMED": "Confirmado",
+          "EXPERT": "Experto",
+          "INDEPENDENT": "Independiente"
+        },
         "EDU_1ER_DEGRE": {
           "ADMISSIBLE": "Admisible",
           "ADVANCED": "Avanzado",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -23,11 +23,11 @@
     },
     "register-error": {
       "s50": "Questo identificatore esiste già",
-      "s51": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R51).",
-      "s52": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R52)",
+      "s51": "Hai già un account Pix con l'indirizzo e-mail '<br>'{ value }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R51).",
+      "s52": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{ value }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R52)",
       "s53": "Hai già un account Pix tramite ENT.'<br> 'Usalo per iscriverti al corso.",
-      "s61": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R61).",
-      "s62": "Si dispone già di un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R62)",
+      "s61": "Hai già un account Pix con l'indirizzo e-mail '<br>'{ value }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R61).",
+      "s62": "Si dispone già di un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{ value }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R62)",
       "s63": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentazione - Codice R63)"
     }
   },


### PR DESCRIPTION
## 💥 Problème

Il faut importer les traductions revues par les agences en `es` et `de`.

## 👩‍🚀 Proposition

Importer les traductions et corriger les erreurs de clés manquantes ou non utilisées (fichier de référence : fr.json)

## 👁️ Remarques

Nous avons profité de cette PR pour corriger aussi quatre erreurs de traductions de variables dans le fichier `it.json`  (il n'y a pas d'erreurs de ce type dans les autres langues).

Il reste des problèmes  :
- des clés obsolètes (utilisées nulle part dans le code)
- des clés manquantes dans certaines langues
- des valeurs obsolètes dans certaines langues sur des clés déjà existantes, que nous avons oublié de faire évoluer avec le fichier fr. (Problème présent surtout sur le fichier `es`.)
- éventuellement des différences de formatage entre les fichiers (n'affectant pas toujours le rendu) : `<br>` ou `<br />`, `>` ou `&gt;`, espaces ajoutés etc...

Ces points seront à traiter dans une PR globale de mise à niveau des traductions / amélioration et harmonisation de la syntaxe.

## ♻️ Pour tester

tech : Vérifier la correspondance avec le fichier `fr` 
fonctionnel : Faites un tour sur Pix App : par exemple inscription, connexion, passage d'une campagne, gestion du compte...
