### PR TITLE
[FEATURE] Lien de questionnaire spécifique à France Travail (PIX-22701)

### DIFF
--- a/mon-pix/app/components/routes/combined-courses/presentation.gjs
+++ b/mon-pix/app/components/routes/combined-courses/presentation.gjs
@@ -144,7 +144,9 @@ export default class CombinedCoursePresentation extends Component {
   }
 
   get surveyLink() {
-    return ENV.APP.COMBINIX_SURVEY_LINK;
+    return this.args.combinedCourse.organizationId === ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID
+      ? ENV.APP.COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK
+      : ENV.APP.COMBINIX_SURVEY_LINK;
   }
 
   get shouldDisplayRetryModulesText() {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -134,11 +134,14 @@ module.exports = function (environment) {
       AUTHENTICATED_SOURCE_FROM_GAR: 'external',
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
+      FRANCE_TRAVAIL_ORGANIZATION_ID: process.env.FRANCE_TRAVAIL_ORGANIZATION_ID || 1006,
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       AUTO_SHARE_AFTER_DATE: process.env.AUTO_SHARE_AFTER_DATE || '2025-07-18',
       COMBINIX_SURVEY_LINK:
         process.env.COMBINIX_SURVEY_LINK ||
         'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
+      COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK:
+        process.env.COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK || 'https://tally.so/r/rj27xp',
       ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST: process.env.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST || '1005',
       MODULIX_VERIFICATION_RESPONSE_DELAY: 500,
     },
@@ -221,9 +224,10 @@ module.exports = function (environment) {
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
+    ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID = 456;
     ENV.APP.AUTO_SHARE_AFTER_DATE = '2025-07-18';
-    ENV.APP.COMBINIX_SURVEY_LINK =
-      'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms';
+    ENV.APP.COMBINIX_SURVEY_LINK = 'combinix.survey.link';
+    ENV.APP.COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK = 'combinix.france-travail.survey.link';
     ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = '1005';
 
     ENV.companion.disabled = true;

--- a/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
@@ -442,12 +442,32 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
 
       // then
       const link = screen.getByRole('link', { name: t('pages.combined-courses.completed.survey-button') });
-      assert
-        .dom(link)
-        .hasAttribute(
-          'href',
-          'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
-        );
+      assert.dom(link).hasAttribute('href', 'combinix.survey.link');
+      assert.dom(link).hasAttribute('target', '_blank');
+      assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
+    });
+
+    test('should display France Travail survey cta', async function (assert) {
+      // given
+      const FRANCE_TRAVAIL_ORGANIZATION_ID = 456;
+      const store = this.owner.lookup('service:store');
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: true });
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.COMPLETED,
+        code: 'COMBINIX9',
+        organizationId: FRANCE_TRAVAIL_ORGANIZATION_ID,
+      });
+
+      // when
+      const screen = await render(
+        <template><CombinedCoursesPresentation @combinedCourse={{combinedCourse}} /></template>,
+      );
+
+      // then
+      const link = screen.getByRole('link', { name: t('pages.combined-courses.completed.survey-button') });
+      assert.dom(link).hasAttribute('href', 'combinix.france-travail.survey.link');
       assert.dom(link).hasAttribute('target', '_blank');
       assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
     });


### PR DESCRIPTION
## 💥 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

On veut renvoyer les apprenants de France Travail vers un questionnaire spécifique en fin de parcours.

## 👩‍🚀 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Si l'id d'organisation est celui de France Travail, on n'utilise pas le lien du questionnaire générique, mais le nouveau lien spécifique du formulaire France Travail.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Sur mon-pix, se connecter sur le parcours MANAGING1.
Effectuer le parcours.
En fin de parcours, le lien du questionnaire doit être le nouveau ('https://tally.so/r/rj27xp').

En finissant un autre parcours, le lien du questionnaire doit être l'ancien.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
