### PR TITLE
[FEATURE] Script de migration des données CGU de Pix App vers le nouveau modèle (PIX-22574)

### DIFF
--- a/api/src/legal-documents/scripts/convert-users-pix-app-cgu-data.js
+++ b/api/src/legal-documents/scripts/convert-users-pix-app-cgu-data.js
@@ -1,0 +1,116 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { LegalDocumentService } from '../domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../domain/models/LegalDocumentType.js';
+import * as legalDocumentRepository from '../infrastructure/repositories/legal-document.repository.js';
+
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_APP } = LegalDocumentService.VALUES;
+
+const DEFAULT_BATCH_SIZE = 1000;
+const DEFAULT_THROTTLE_DELAY = 300;
+
+export class ConvertUsersPixAppCguData extends Script {
+  constructor() {
+    super({
+      description: 'Converts users pix-app CGU data to legal-document-versions-user-acceptances',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Executes the script in dry run mode',
+          default: false,
+        },
+        batchSize: {
+          type: 'number',
+          describe: 'Size of the batch to process',
+          default: DEFAULT_BATCH_SIZE,
+        },
+        throttleDelay: {
+          type: 'number',
+          describe: 'Delay between batches in milliseconds',
+          default: DEFAULT_THROTTLE_DELAY,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const { dryRun, batchSize, throttleDelay } = options;
+
+    const legalDocument = await legalDocumentRepository.findLastVersionByTypeAndService({
+      type: TOS,
+      service: PIX_APP,
+    });
+
+    if (!legalDocument) {
+      throw new Error(`No legal document found for type: ${TOS}, service: ${PIX_APP}`);
+    }
+
+    let offset = 0;
+    let migrationCount = 0;
+
+    const run = true;
+    while (run) {
+      const usersWithCgu = await this.#findPixAppCguAcceptedUsers({ batchSize, offset });
+
+      if (usersWithCgu.length === 0) {
+        break;
+      }
+
+      logger.info(`Batch #${Math.ceil(offset / batchSize + 1)}`);
+
+      const usersToMigrate = await this.#filterAlreadyMigratedUsers({ legalDocument, users: usersWithCgu });
+
+      if (!dryRun) {
+        await this.#createNewLegalDocumentAcceptanceForUsersBatch({ legalDocument, users: usersToMigrate });
+      }
+
+      migrationCount += usersToMigrate.length;
+      offset += usersWithCgu.length;
+
+      await setTimeout(throttleDelay);
+    }
+
+    logger.info(`Total users ${dryRun ? 'to migrate' : 'migrated'}: ${migrationCount}`);
+  }
+
+  async #findPixAppCguAcceptedUsers({ batchSize, offset }) {
+    const knexConnection = DomainTransaction.getConnection();
+
+    return knexConnection('users').select('*').where('cgu', true).limit(batchSize).offset(offset);
+  }
+
+  async #filterAlreadyMigratedUsers({ legalDocument, users }) {
+    const knexConnection = DomainTransaction.getConnection();
+
+    const alreadyMigratedUsers = await knexConnection('legal-document-version-user-acceptances')
+      .select('userId')
+      .where('legalDocumentVersionId', legalDocument.id)
+      .whereIn(
+        'userId',
+        users.map((user) => user.id),
+      );
+
+    const alreadyMigratedIds = alreadyMigratedUsers.map((user) => user.userId);
+    return users.filter((user) => !alreadyMigratedIds.includes(user.id));
+  }
+
+  async #createNewLegalDocumentAcceptanceForUsersBatch({ legalDocument, users }) {
+    const knexConnection = DomainTransaction.getConnection();
+
+    const chunkSize = 100;
+    const rows = users.map((user) => ({
+      userId: user.id,
+      legalDocumentVersionId: legalDocument.id,
+      acceptedAt: user.lastTermsOfServiceValidatedAt || new Date(),
+    }));
+
+    await knexConnection.batchInsert('legal-document-version-user-acceptances', rows, chunkSize);
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, ConvertUsersPixAppCguData);

--- a/api/src/legal-documents/scripts/convert-users-pix-app-cgu-data.js
+++ b/api/src/legal-documents/scripts/convert-users-pix-app-cgu-data.js
@@ -51,52 +51,42 @@ export class ConvertUsersPixAppCguData extends Script {
     }
 
     let offset = 0;
+    let batchNumber = 0;
     let migrationCount = 0;
 
-    const run = true;
-    while (run) {
-      const usersWithCgu = await this.#findPixAppCguAcceptedUsers({ batchSize, offset });
+    while (true) {
+      const usersToMigrate = await this.#findUsersWithoutCguMigration({ legalDocument, batchSize, offset });
+      if (usersToMigrate.length === 0) break;
 
-      if (usersWithCgu.length === 0) {
-        break;
-      }
-
-      logger.info(`Batch #${Math.ceil(offset / batchSize + 1)}`);
-
-      const usersToMigrate = await this.#filterAlreadyMigratedUsers({ legalDocument, users: usersWithCgu });
+      logger.info(`Batch #${++batchNumber}: ${usersToMigrate.length} users`);
 
       if (!dryRun) {
         await this.#createNewLegalDocumentAcceptanceForUsersBatch({ legalDocument, users: usersToMigrate });
+      } else {
+        offset += batchSize;
       }
 
       migrationCount += usersToMigrate.length;
-      offset += usersWithCgu.length;
-
       await setTimeout(throttleDelay);
     }
 
     logger.info(`Total users ${dryRun ? 'to migrate' : 'migrated'}: ${migrationCount}`);
   }
 
-  async #findPixAppCguAcceptedUsers({ batchSize, offset }) {
+  async #findUsersWithoutCguMigration({ legalDocument, batchSize, offset }) {
     const knexConnection = DomainTransaction.getConnection();
-
-    return knexConnection('users').select('*').where('cgu', true).limit(batchSize).offset(offset);
-  }
-
-  async #filterAlreadyMigratedUsers({ legalDocument, users }) {
-    const knexConnection = DomainTransaction.getConnection();
-
-    const alreadyMigratedUsers = await knexConnection('legal-document-version-user-acceptances')
-      .select('userId')
-      .where('legalDocumentVersionId', legalDocument.id)
-      .whereIn(
-        'userId',
-        users.map((user) => user.id),
-      );
-
-    const alreadyMigratedIds = alreadyMigratedUsers.map((user) => user.userId);
-    return users.filter((user) => !alreadyMigratedIds.includes(user.id));
+    return knexConnection('users')
+      .select('users.id', 'users.lastTermsOfServiceValidatedAt')
+      .where('users.cgu', true)
+      .whereNotExists(
+        knexConnection
+          .select(1)
+          .from('legal-document-version-user-acceptances')
+          .where('legalDocumentVersionId', legalDocument.id)
+          .whereRaw('"legal-document-version-user-acceptances"."userId" = "users"."id"'),
+      )
+      .limit(batchSize)
+      .offset(offset);
   }
 
   async #createNewLegalDocumentAcceptanceForUsersBatch({ legalDocument, users }) {

--- a/api/tests/legal-documents/integration/scripts/convert-users-pix-app-cgu-data.test.js
+++ b/api/tests/legal-documents/integration/scripts/convert-users-pix-app-cgu-data.test.js
@@ -77,8 +77,8 @@ describe('Integration | Legal documents | Scripts | convert-users-pix-app-cgu-da
       await script.handle({ options, logger });
 
       // then
-      expect(logger.info).to.have.been.calledWith('Batch #1');
-      expect(logger.info).to.have.been.calledWith('Batch #2');
+      expect(logger.info).to.have.been.calledWith('Batch #1: 1 users');
+      expect(logger.info).to.have.been.calledWith('Batch #2: 1 users');
       expect(logger.info).to.have.been.calledWith('Total users migrated: 2');
 
       const userAcceptances = await knex('legal-document-version-user-acceptances').where({
@@ -148,7 +148,7 @@ describe('Integration | Legal documents | Scripts | convert-users-pix-app-cgu-da
         await script.handle({ options, logger });
 
         // then
-        expect(logger.info).to.have.been.calledWith('Batch #1');
+        expect(logger.info).to.have.been.calledWith('Batch #1: 1 users');
         expect(logger.info).to.have.been.calledWith('Total users to migrate: 1');
 
         const userAcceptances = await knex('legal-document-version-user-acceptances').where({

--- a/api/tests/legal-documents/integration/scripts/convert-users-pix-app-cgu-data.test.js
+++ b/api/tests/legal-documents/integration/scripts/convert-users-pix-app-cgu-data.test.js
@@ -1,0 +1,174 @@
+import sinon from 'sinon';
+
+import { LegalDocumentService } from '../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { ConvertUsersPixAppCguData } from '../../../../src/legal-documents/scripts/convert-users-pix-app-cgu-data.js';
+import { expect } from '../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../tooling/databases.js';
+
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_APP } = LegalDocumentService.VALUES;
+
+describe('Integration | Legal documents | Scripts | convert-users-pix-app-cgu-data', function () {
+  describe('Options', function () {
+    it('has the correct options', function () {
+      // given
+      const script = new ConvertUsersPixAppCguData();
+
+      // when
+      const { options, permanent } = script.metaInfo;
+
+      // then
+      expect(permanent).to.be.false;
+      expect(options).to.deep.include({
+        dryRun: {
+          type: 'boolean',
+          describe: 'Executes the script in dry run mode',
+          default: false,
+        },
+        batchSize: {
+          type: 'number',
+          describe: 'Size of the batch to process',
+          default: 1000,
+        },
+        throttleDelay: {
+          type: 'number',
+          describe: 'Delay between batches in milliseconds',
+          default: 300,
+        },
+      });
+    });
+  });
+
+  describe('#handle', function () {
+    let clock;
+    let legalDocumentVersion;
+    let logger;
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({ now: new Date('2024-01-01'), toFake: ['Date'] });
+      legalDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({ type: TOS, service: PIX_APP });
+      logger = { info: sinon.stub() };
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('converts Pix App user cgus to legal document user acceptances', async function () {
+      // given
+      const userAcceptedCgu = databaseBuilder.factory.buildUser({
+        cgu: true,
+        lastTermsOfServiceValidatedAt: new Date('2021-01-01'),
+      });
+      const userAcceptedCguWithoutDate = databaseBuilder.factory.buildUser({
+        cgu: true,
+        lastTermsOfServiceValidatedAt: null,
+      });
+      const userNotAcceptedCgu = databaseBuilder.factory.buildUser({
+        cgu: false,
+        lastTermsOfServiceValidatedAt: null,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const script = new ConvertUsersPixAppCguData();
+      const options = { dryRun: false, batchSize: 1, throttleDelay: 0 };
+      await script.handle({ options, logger });
+
+      // then
+      expect(logger.info).to.have.been.calledWith('Batch #1');
+      expect(logger.info).to.have.been.calledWith('Batch #2');
+      expect(logger.info).to.have.been.calledWith('Total users migrated: 2');
+
+      const userAcceptances = await knex('legal-document-version-user-acceptances').where({
+        legalDocumentVersionId: legalDocumentVersion.id,
+      });
+
+      const acceptance1 = userAcceptances.find((user) => user.userId === userAcceptedCgu.id);
+      expect(acceptance1.acceptedAt).to.deep.equal(new Date('2021-01-01'));
+
+      const acceptance2 = userAcceptances.find((user) => user.userId === userAcceptedCguWithoutDate.id);
+      expect(acceptance2.acceptedAt).to.deep.equal(new Date('2024-01-01'));
+
+      const acceptance3 = userAcceptances.find((user) => user.userId === userNotAcceptedCgu.id);
+      expect(acceptance3).to.be.undefined;
+    });
+
+    context('when a user cgu is already converted to legal document user acceptances', function () {
+      it('does not change already converted user acceptances', async function () {
+        // given
+        const alreadyConvertedUser = databaseBuilder.factory.buildUser({
+          cgu: true,
+          lastTermsOfServiceValidatedAt: new Date('2021-01-01'),
+        });
+        const newUserAcceptedCgu = databaseBuilder.factory.buildUser({
+          cgu: true,
+          lastTermsOfServiceValidatedAt: new Date('2021-01-01'),
+        });
+        databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+          legalDocumentVersionId: legalDocumentVersion.id,
+          userId: alreadyConvertedUser.id,
+          acceptedAt: new Date('2020-01-01'),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const script = new ConvertUsersPixAppCguData();
+        const options = { dryRun: false, batchSize: 1, throttleDelay: 0 };
+        await script.handle({ options, logger });
+
+        // then
+        expect(logger.info).to.have.been.calledWith('Total users migrated: 1');
+
+        const userAcceptances = await knex('legal-document-version-user-acceptances').where({
+          legalDocumentVersionId: legalDocumentVersion.id,
+        });
+
+        const acceptance1 = userAcceptances.find((user) => user.userId === alreadyConvertedUser.id);
+        expect(acceptance1.acceptedAt).to.deep.equal(new Date('2020-01-01'));
+
+        const acceptance2 = userAcceptances.find((user) => user.userId === newUserAcceptedCgu.id);
+        expect(acceptance2.acceptedAt).to.deep.equal(new Date('2021-01-01'));
+      });
+    });
+
+    context('when the script has the dry run mode', function () {
+      it('does not create legal document user acceptance', async function () {
+        // given
+        databaseBuilder.factory.buildUser({
+          cgu: true,
+          lastTermsOfServiceValidatedAt: new Date('2021-01-01'),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const script = new ConvertUsersPixAppCguData();
+        const options = { dryRun: true, batchSize: 1, throttleDelay: 0 };
+        await script.handle({ options, logger });
+
+        // then
+        expect(logger.info).to.have.been.calledWith('Batch #1');
+        expect(logger.info).to.have.been.calledWith('Total users to migrate: 1');
+
+        const userAcceptances = await knex('legal-document-version-user-acceptances').where({
+          legalDocumentVersionId: legalDocumentVersion.id,
+        });
+        expect(userAcceptances.length).to.equal(0);
+      });
+    });
+
+    context('when no legal document is found', function () {
+      it('throws an error', async function () {
+        // given
+        const script = new ConvertUsersPixAppCguData();
+
+        // when / then
+        const options = { dryRun: true, batchSize: 1, throttleDelay: 0 };
+        await expect(script.handle({ options, logger })).to.be.rejectedWith(
+          'No legal document found for type: TOS, service: pix-app',
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 💥 Problème

Avec la nouvelle table `legal-document-versions`, nous avons besoin de migrer les acceptations de CGU  de Pix App actuelles des utilisateurs vers le nouveau modèle.

## 👩‍🚀 Proposition

Dans le contexte `legal-documents`, créer un script en utilisant la nouvelle architecture des scripts.

Nom du script : ConvertUsersPixAppCguData

Options:
  --dryRun         Execute the script in dry run mode [boolean] [default: false]
  --batchSize      Size of the batch to process         [number] [default: 1000]
  --throttleDelay  Delay between batches in milliseconds [number] [default: 300]
  --help           Show help                                           [boolean]

    Pour parer la contrainte d'un trop grand nombre d'utilisateurs impactés, Le script va utiliser du batch (batchSize = 1000) et du throttle (throttleDelay = 300).
    Un mode dryRun permet de simuler l'exécution du script sans modification en base de données.

## 👁️ Remarques

Voir la PR correspondante qui avait été réalisée pour Pix Orga : #10787

## ♻️ Pour tester

### PRE-REQUIS

+ Créer une entrée dans la table legal-document-versions :
```shell
node src/legal-documents/scripts/add-new-legal-document-version.js --type 'TOS' --service 'pix-app' --versionAt '2025-01-01'
```

+ Vérifier que le document a été ajouté et noter son id :
```sql
select * from "legal-document-versions";
```

+ Vérifier que la table `legal-document-version-user-acceptances` ne contient pas d'acceptations de document que vous venez d'ajouter :
```sql
select * from "legal-document-version-user-acceptances" where "legalDocumentVersionId" = {legalDocumentVersions.id};
```

+ Noter le nombre d'utilisateurs éligibles à la migration : 
```sql
select count(*) from "users" where "cgu" = true;
```

### TESTS

+ Lancer le script en dry-run :
```shell
node --env-file=.env src/legal-documents/scripts/convert-users-pix-app-cgu-data.js --dryRun
```

+ Vérifier que le nombre d'utilisateurs à migrer est correct

+ Lancer le script en dry-run avec un batch de `100` :
```shell
node --env-file=.env src/legal-documents/scripts/convert-users-pix-app-cgu-data.js --dryRun --batchSize=100
```

+ Vérifier qu'il y a 1 batch exécuté par centaine d'utilisateurs à migrer (donc par ex 6 batchs pour 510 utilisateurs)

+ Lancer la migration : 
```shell
node --env-file=.env src/legal-documents/scripts/convert-users-pix-app-cgu-data.js
```

+ Vérifier que la table `legal-document-version-user-acceptances` est remplie avec tous les utilisateurs à migrer :
```sql
select count(*) from "legal-document-version-user-acceptances" where "legalDocumentVersionId" = {legalDocumentVersions.id};
```