### PR TITLE
[TECH] Modification de la table `certification_versions` (PIX-22695).

### DIFF
--- a/api/db/migrations/20260511142458_add-comment-column-and-make-start-date-nullable-in-certification-versions-table.js
+++ b/api/db/migrations/20260511142458_add-comment-column-and-make-start-date-nullable-in-certification-versions-table.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'certification_versions';
+const COMMENTS_COLUMN = 'comments';
+const START_DATE_COLUMN = 'startDate';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COMMENTS_COLUMN, 500).comment('Comments for version creation');
+    table.timestamp(START_DATE_COLUMN).nullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex(TABLE_NAME).update({ [START_DATE_COLUMN]: new Date('2030-01-01') });
+
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COMMENTS_COLUMN);
+    table.timestamp(START_DATE_COLUMN).notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 💥 Problème

La colonne `startDate` de la table `certification_versions` n'est pour le moment pas `nullable`.
Nous souhaitons nous baser sur cette colonne afin de déterminer le statut d'une version, notamment si celle-ci est à l'état de `brouillon/draft`

Nous souhaitons également pouvoir ajouter des commentaires lors de la création d'une version. 

## 👩‍🚀 Proposition

Ajout d'une colonne `comments`
Colonne `startDate` qui devient `nullable`

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester

- La colonne `startDate` est nullable
- La table `certification_versions` contient désormais une colonne `comments` (string, 500 caractères)

Exécuter le rollback

- La colonne `startDate` est `not nullable`
- La colonne `comments` n'existe plus
