### PR TITLE
[BUGFIX] Corriger le flaky sur la réconciliation des apprenants lors d'un import SCO (PIX-22719)

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -104,6 +104,17 @@ const _reconcileOrganizationLearners = async function (studentsToImport, allOrga
   const organizationLearnersWithSameNationalStudentIdsAsImported =
     await studentRepository.findReconciledStudentsByNationalStudentId(nationalStudentIdsFromFile);
 
+  const userIdsWithMultipleNationalStudentIds = new Set(
+    organizationLearnersWithSameNationalStudentIdsAsImported
+      .filter((learner) =>
+        organizationLearnersWithSameNationalStudentIdsAsImported.some(
+          (other) =>
+            other.account.userId === learner.account.userId && other.nationalStudentId !== learner.nationalStudentId,
+        ),
+      )
+      .map((learner) => learner.account.userId),
+  );
+
   organizationLearnersWithSameNationalStudentIdsAsImported.forEach((organizationLearner) => {
     const alreadyReconciledStudentToImport = studentsToImport.find(
       (studentToImport) => studentToImport.userId === organizationLearner.account.userId,
@@ -111,6 +122,10 @@ const _reconcileOrganizationLearners = async function (studentsToImport, allOrga
 
     if (alreadyReconciledStudentToImport) {
       alreadyReconciledStudentToImport.userId = null;
+      return;
+    }
+
+    if (userIdsWithMultipleNationalStudentIds.has(organizationLearner.account.userId)) {
       return;
     }
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -826,6 +826,48 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         expect(expected1.userId).to.be.null;
         expect(expected2.userId).to.be.null;
       });
+
+      it('should save both organization learners with userId as null when one is already reconciled in the target organization', async function () {
+        // - Org A already has INE1 reconciled with userId (existing reconciliation)
+        // - Org B has INE2 reconciled with the same userId
+        // - Importing both INE1 and INE2 into Org A should remove reconciliation from both
+        const { id: orgAId } = databaseBuilder.factory.buildOrganization();
+        const { id: orgBId } = databaseBuilder.factory.buildOrganization();
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildOrganizationLearner({
+          nationalStudentId: 'INE2',
+          organizationId: orgBId,
+          userId,
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          nationalStudentId: 'INE1',
+          organizationId: orgAId,
+          userId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const organizationLearner1 = domainBuilder.buildOrganizationLearner({ nationalStudentId: 'INE1' });
+        const organizationLearner2 = domainBuilder.buildOrganizationLearner({ nationalStudentId: 'INE2' });
+        await DomainTransaction.execute((domainTransaction) => {
+          return addOrUpdateOrganizationOfOrganizationLearners(
+            [organizationLearner1, organizationLearner2],
+            orgAId,
+            domainTransaction,
+          );
+        });
+
+        // then
+        const expected1 = await knex('organization-learners')
+          .where({ nationalStudentId: 'INE1', organizationId: orgAId })
+          .first();
+        const expected2 = await knex('organization-learners')
+          .where({ nationalStudentId: 'INE2', organizationId: orgAId })
+          .first();
+
+        expect(expected1.userId).to.be.null;
+        expect(expected2.userId).to.be.null;
+      });
     });
 
     context('when there are organizationLearners in another organization', function () {

--- a/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
@@ -399,7 +399,7 @@ test.describe('SCO import does not auto-reconcile a learner when the user alread
       );
     });
 
-    test("Remove user reconciliation when the user is already in the target organization with a different INE,  (is it ok, i don't know, but it's here since the beginning of the time)", async ({
+    test("Remove user reconciliation when the user is already in the target organization with a different INE, (is it ok, i don't know, but it's here since the beginning of the time)", async ({
       page,
     }) => {
       test.slow();


### PR DESCRIPTION
## 💥 Problème

Un test E2E était flaky sur le scénario suivant : un même élève (Jean Michel) existe dans deux établissements avec deux INE différents. Quand l'Org A importe les deux INE en même temps, le système doit retirer la réconciliation des deux élèves.

La fonction `_reconcileOrganizationLearners` dépendait de l'ordre retourné par la requête `findReconciledStudentsByNationalStudentId`. Comme les deux enregistrements appartiennent au même user, le `ORDER BY users.id` ne les différenciait pas: ordre non-déterministe en PostgreSQL. Selon l'ordre :

- 🟢 INE de la même org traité en premier: conflit détecté, les deux userId mis à `null`
- 🔴 INE de l'autre org traité en premier: conflit non détecté, INE de la même org gardait son `userId`

## 🚀 Proposition

Avant la boucle de réconciliation, on pré-calcule l'ensemble des `userId` qui apparaissent avec plusieurs `nationalStudentId` différents dans les résultats. Pour ces userId, on saute directement la réconciliation, indépendamment de l'ordre de traitement.

On ajoute aussi un test d'intégration qui couvre ce scénario (Org A avec INE1 réconcilié, Org B avec INE2 même userId, import des deux dans Org A).

## ♻️ Pour tester

🟢 