### PR TITLE
[FEATURE] MADDO - enrichir les données des participations (PIX-22452).

### DIFF
--- a/api/config/server-setup-error-handling.js
+++ b/api/config/server-setup-error-handling.js
@@ -4,6 +4,7 @@ import { evaluationDomainErrorMappingConfiguration } from '../src/evaluation/app
 import { authenticationDomainErrorMappingConfiguration } from '../src/identity-access-management/application/http-error-mapper-configuration.js';
 import { legalDocumentsDomainErrorMappingConfiguration } from '../src/legal-documents/application/http-error-mapper-configuration.js';
 import { llmDomainErrorMappingConfiguration } from '../src/llm/application/http-error-mapper-configuration.js';
+import { maddoDomainErrorMappingConfiguration } from '../src/maddo/application/http-error-mapper-configuration.js';
 import { organizationalEntitiesDomainErrorMappingConfiguration } from '../src/organizational-entities/application/http-error-mapper-configuration.js';
 import { prescriptionDomainErrorMappingConfiguration } from '../src/prescription/shared/application/http-error-mapper-configuration.js';
 import { stagesDomainErrorMappingConfiguration } from '../src/prescription/stages/application/http-error-mapper-configuration.js';
@@ -27,6 +28,7 @@ const setupErrorHandling = function (server) {
     ...prescriptionDomainErrorMappingConfiguration,
     ...schoolDomainErrorMappingConfiguration,
     ...profileDomainErrorMappingConfiguration,
+    ...maddoDomainErrorMappingConfiguration,
   ];
 
   const registry = new ErrorMappingRegistry();

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -147,6 +147,7 @@ buildAuthenticationMethod.withOidcProviderAsIdentityProvider = function ({
   externalIdentifier,
   userId,
   identityProvider,
+  authenticationComplement,
   lastLoggedAt = new Date(),
 }) {
   userId = isUndefined(userId) ? buildUser().id : userId;
@@ -160,10 +161,12 @@ buildAuthenticationMethod.withOidcProviderAsIdentityProvider = function ({
     identityProvider,
     externalIdentifier: generatedIdentifier,
     userId,
-    authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
-      firstName: 'oidc',
-      lastName: 'user',
-    }),
+    authenticationComplement:
+      authenticationComplement ??
+      new AuthenticationMethod.OidcAuthenticationComplement({
+        firstName: 'oidc',
+        lastName: 'user',
+      }),
     createdAt: new Date('2020-01-01'),
     updatedAt: new Date('2020-01-02'),
     lastLoggedAt,

--- a/api/src/identity-access-management/domain/models/AuthenticationMethod.js
+++ b/api/src/identity-access-management/domain/models/AuthenticationMethod.js
@@ -22,7 +22,8 @@ class PixAuthenticationComplement {
 
 class OidcAuthenticationComplement {
   constructor(properties) {
-    validateEntity(Joi.object().required().min(1), properties);
+    validateEntity(Joi.object().optional().allow(null), properties);
+    if (!properties) return;
 
     Object.entries(properties).forEach(([key, value]) => {
       this[key] = value;

--- a/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
@@ -374,5 +374,5 @@ function _toAuthenticationComplement(identityProvider, authenticationComplement)
     return new AuthenticationMethod.GARAuthenticationComplement(authenticationComplement);
   }
 
-  return undefined;
+  return new AuthenticationMethod.OidcAuthenticationComplement(authenticationComplement);
 }

--- a/api/src/maddo/application/campaigns-controller.js
+++ b/api/src/maddo/application/campaigns-controller.js
@@ -5,11 +5,13 @@ export async function getCampaignParticipations(
   h,
   dependencies = { getCampaignParticipations: usecases.getCampaignParticipations },
 ) {
-  const { page, since, authenticationData = [] } = request.query;
+  const { page, since, authenticationRequestedData = [] } = request.query;
   const { models: campaignParticipations, meta } = await dependencies.getCampaignParticipations({
     campaignId: request.params.campaignId,
     clientId: request.auth.credentials.client_id,
-    authenticationData: Array.isArray(authenticationData) ? authenticationData : [authenticationData],
+    authenticationRequestedData: Array.isArray(authenticationRequestedData)
+      ? authenticationRequestedData
+      : [authenticationRequestedData],
     page,
     since,
   });

--- a/api/src/maddo/application/campaigns-controller.js
+++ b/api/src/maddo/application/campaigns-controller.js
@@ -5,10 +5,11 @@ export async function getCampaignParticipations(
   h,
   dependencies = { getCampaignParticipations: usecases.getCampaignParticipations },
 ) {
-  const { page, since } = request.query;
+  const { page, since, authenticationData = [] } = request.query;
   const { models: campaignParticipations, meta } = await dependencies.getCampaignParticipations({
     campaignId: request.params.campaignId,
     clientId: request.auth.credentials.client_id,
+    authenticationData: Array.isArray(authenticationData) ? authenticationData : [authenticationData],
     page,
     since,
   });

--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -17,11 +17,12 @@ const register = async function (server) {
             campaignId: identifiersType.campaignId,
           }),
           query: Joi.object({
-            since: Joi.date().iso(),
+            since: Joi.date().iso().optional(),
             page: Joi.object({
               number: Joi.number().integer().empty('').allow(null).optional(),
               size: Joi.number().integer().max(200).empty('').allow(null).optional(),
             }).default({}),
+            authenticationData: Joi.alternatives(Joi.array().items(Joi.string()), Joi.string()).optional(),
           }),
         },
         pre: [organizationPreHandler, isCampaignInJurisdictionPreHandler],
@@ -44,6 +45,11 @@ const register = async function (server) {
                     authenticationId: Joi.number().description(
                       'Si le participant a du utiliser un service SSO externe pour accéder à la campagne, on retourne son identifiant',
                     ),
+                    authenticationData: Joi.object()
+                      .optional()
+                      .description(
+                        "Données d'authentification du provider demandées via le paramètre de requête `authenticationData`",
+                      ),
                     participantId: Joi.number().description('ID du participant'),
                     participantFirstName: Joi.string().description('Prénom du participant'),
                     participantLastName: Joi.string().description('Nom du participant'),

--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -22,7 +22,7 @@ const register = async function (server) {
               number: Joi.number().integer().empty('').allow(null).optional(),
               size: Joi.number().integer().max(200).empty('').allow(null).optional(),
             }).default({}),
-            authenticationData: Joi.alternatives(Joi.array().items(Joi.string()), Joi.string()).optional(),
+            authenticationRequestedData: Joi.alternatives(Joi.array().items(Joi.string()), Joi.string()).optional(),
           }),
         },
         pre: [organizationPreHandler, isCampaignInJurisdictionPreHandler],
@@ -45,10 +45,10 @@ const register = async function (server) {
                     authenticationId: Joi.number().description(
                       'Si le participant a du utiliser un service SSO externe pour accéder à la campagne, on retourne son identifiant',
                     ),
-                    authenticationData: Joi.object()
+                    authenticationRequestedData: Joi.object()
                       .optional()
                       .description(
-                        "Données d'authentification du provider demandées via le paramètre de requête `authenticationData`",
+                        "Données d'authentification du provider demandées via le paramètre de requête `authenticationRequestedData`",
                       ),
                     participantId: Joi.number().description('ID du participant'),
                     participantFirstName: Joi.string().description('Prénom du participant'),

--- a/api/src/maddo/application/http-error-mapper-configuration.js
+++ b/api/src/maddo/application/http-error-mapper-configuration.js
@@ -1,0 +1,9 @@
+import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import { InvalidAuthenticationDataError } from '../domain/errors.js';
+
+export const maddoDomainErrorMappingConfiguration = [
+  {
+    name: InvalidAuthenticationDataError.name,
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code),
+  },
+];

--- a/api/src/maddo/domain/errors.js
+++ b/api/src/maddo/domain/errors.js
@@ -1,0 +1,9 @@
+import { DomainError } from '../../shared/domain/errors.js';
+
+class InvalidAuthenticationDataError extends DomainError {
+  constructor(message = 'Invalid authenticationData') {
+    super(message, 'INVALID_AUTHENTICATION_DATA');
+  }
+}
+
+export { InvalidAuthenticationDataError };

--- a/api/src/maddo/domain/errors.js
+++ b/api/src/maddo/domain/errors.js
@@ -1,7 +1,7 @@
 import { DomainError } from '../../shared/domain/errors.js';
 
 class InvalidAuthenticationDataError extends DomainError {
-  constructor(message = 'Invalid authenticationData') {
+  constructor(message = 'Invalid authenticationRequestedData') {
     super(message, 'INVALID_AUTHENTICATION_DATA');
   }
 }

--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -8,7 +8,7 @@ class CampaignParticipation {
     participantLastName,
     participantExternalId,
     authenticationId,
-    authenticationData,
+    authenticationRequestedData,
     status,
     createdAt,
     sharedAt,
@@ -24,7 +24,7 @@ class CampaignParticipation {
     this.id = id;
     this.status = status;
     this.authenticationId = authenticationId ?? null;
-    this.authenticationData = authenticationData;
+    this.authenticationRequestedData = authenticationRequestedData;
     this.participantFirstName = participantFirstName;
     this.participantLastName = participantLastName;
     this.participantExternalId = participantExternalId;

--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -8,6 +8,7 @@ class CampaignParticipation {
     participantLastName,
     participantExternalId,
     authenticationId,
+    authenticationData,
     status,
     createdAt,
     sharedAt,
@@ -23,6 +24,7 @@ class CampaignParticipation {
     this.id = id;
     this.status = status;
     this.authenticationId = authenticationId ?? null;
+    this.authenticationData = authenticationData;
     this.participantFirstName = participantFirstName;
     this.participantLastName = participantLastName;
     this.participantExternalId = participantExternalId;

--- a/api/src/maddo/domain/usecases/get-campaign-participations.js
+++ b/api/src/maddo/domain/usecases/get-campaign-participations.js
@@ -1,67 +1,97 @@
+import { InvalidAuthenticationDataError } from '../errors.js';
 import { CampaignParticipation } from '../models/CampaignParticipation.js';
 import { TubeCoverage } from '../models/TubeCoverage.js';
-
-const getExternalIdentifierByUserId = async (
-  campaignId,
-  participations,
-  organizationRepository,
-  authenticationMethodRepository,
-) => {
-  const identityProviderForCampaigns =
-    await organizationRepository.findIdentityProviderForCampaignsByCampaignId(campaignId);
-
-  if (!identityProviderForCampaigns) {
-    return {};
-  }
-
-  const userIds = participations.map((participation) => participation.userId).filter(Number);
-  const authenticationMethods = await authenticationMethodRepository.findByUserIdsAndIdentityProvider({
-    userIds,
-    identityProvider: identityProviderForCampaigns,
-  });
-
-  return authenticationMethods.reduce((externalIdentifiersByUserId, method) => {
-    externalIdentifiersByUserId[method.userId] = method.externalIdentifier;
-    return externalIdentifiersByUserId;
-  }, {});
-};
 
 export const getCampaignParticipations = async ({
   campaignId,
   clientId,
   page,
   since,
+  authenticationData,
   campaignsAPI,
   organizationRepository,
   authenticationMethodRepository,
+  oidcProviderRepository,
 }) => {
   const { models: campaignParticipations, meta } = await campaignsAPI.getCampaignParticipations({
     campaignId,
     page,
     since,
   });
+  const identityProviderForCampaigns =
+    await organizationRepository.findIdentityProviderForCampaignsByCampaignId(campaignId);
 
-  const externalIdentifierByUserId = await getExternalIdentifierByUserId(
-    campaignId,
+  const authenticationDataByUserId = await getAuthenticationDataByParticipations({
     campaignParticipations,
-    organizationRepository,
+    authenticationData,
+    identityProviderForCampaigns,
     authenticationMethodRepository,
-  );
+    oidcProviderRepository,
+  });
 
+  const models = campaignParticipations.map((rawCampaignParticipation) => {
+    const userAuthenticationData = authenticationDataByUserId[rawCampaignParticipation.userId];
+    return toDomain(rawCampaignParticipation, userAuthenticationData, clientId, campaignId);
+  });
   return {
-    models: campaignParticipations.map((rawCampaignParticipation) => {
-      rawCampaignParticipation.authenticationId = externalIdentifierByUserId[rawCampaignParticipation.userId] || null;
-      return toDomain(rawCampaignParticipation, clientId, campaignId);
-    }),
+    models,
     meta,
   };
 };
 
-const toDomain = (rawCampaignParticipation, clientId, campaignId) =>
+const toDomain = (rawCampaignParticipation, userAuthenticationData, clientId, campaignId) =>
   new CampaignParticipation({
     ...rawCampaignParticipation,
+    ...userAuthenticationData,
     id: rawCampaignParticipation.id, // needed to invoke the getter
     tubes: rawCampaignParticipation.tubes?.map((tube) => new TubeCoverage(tube)),
     clientId,
     campaignId,
   });
+
+const getAuthenticationDataByParticipations = async ({
+  campaignParticipations,
+  authenticationData,
+  identityProviderForCampaigns,
+  authenticationMethodRepository,
+  oidcProviderRepository,
+}) => {
+  if (!identityProviderForCampaigns) {
+    return {};
+  }
+
+  if (authenticationData) {
+    const claims = await oidcProviderRepository.findOidcProviderClaims(identityProviderForCampaigns);
+    if (!areAuthenticationDataValid(authenticationData, claims)) {
+      throw new InvalidAuthenticationDataError(`Invalid authenticationData, must be some of: ${claims.join(', ')}`);
+    }
+  }
+
+  const userIds = campaignParticipations.map((participation) => participation.userId).filter(Number);
+  const authenticationMethods = await authenticationMethodRepository.findByUserIdsAndIdentityProvider({
+    userIds,
+    identityProvider: identityProviderForCampaigns,
+  });
+
+  return authenticationMethods.reduce((authenticationDataByUserId, method) => {
+    authenticationDataByUserId[method.userId] = {
+      authenticationId: method.externalIdentifier,
+      authenticationData: filterAuthenticationData(authenticationData, method.authenticationComplement),
+    };
+    return authenticationDataByUserId;
+  }, {});
+};
+
+const areAuthenticationDataValid = (authenticationData, claims) => {
+  if (!claims) return false;
+  return authenticationData.every((authenticationClaim) => claims.includes(authenticationClaim));
+};
+
+const filterAuthenticationData = (authenticationData, authenticationComplement) => {
+  if (!authenticationData) return null;
+  const result = {};
+  for (const claim of authenticationData) {
+    result[claim] = authenticationComplement[claim];
+  }
+  return result;
+};

--- a/api/src/maddo/domain/usecases/get-campaign-participations.js
+++ b/api/src/maddo/domain/usecases/get-campaign-participations.js
@@ -7,7 +7,7 @@ export const getCampaignParticipations = async ({
   clientId,
   page,
   since,
-  authenticationData,
+  authenticationRequestedData,
   campaignsAPI,
   organizationRepository,
   authenticationMethodRepository,
@@ -23,7 +23,7 @@ export const getCampaignParticipations = async ({
 
   const authenticationDataByUserId = await getAuthenticationDataByParticipations({
     campaignParticipations,
-    authenticationData,
+    authenticationRequestedData,
     identityProviderForCampaigns,
     authenticationMethodRepository,
     oidcProviderRepository,
@@ -51,7 +51,7 @@ const toDomain = (rawCampaignParticipation, userAuthenticationData, clientId, ca
 
 const getAuthenticationDataByParticipations = async ({
   campaignParticipations,
-  authenticationData,
+  authenticationRequestedData,
   identityProviderForCampaigns,
   authenticationMethodRepository,
   oidcProviderRepository,
@@ -60,10 +60,12 @@ const getAuthenticationDataByParticipations = async ({
     return {};
   }
 
-  if (authenticationData) {
+  if (authenticationRequestedData) {
     const claims = await oidcProviderRepository.findOidcProviderClaims(identityProviderForCampaigns);
-    if (!areAuthenticationDataValid(authenticationData, claims)) {
-      throw new InvalidAuthenticationDataError(`Invalid authenticationData, must be some of: ${claims.join(', ')}`);
+    if (!areAuthenticationDataValid(authenticationRequestedData, claims)) {
+      throw new InvalidAuthenticationDataError(
+        `Invalid authenticationRequestedData, must be some of: ${claims.join(', ')}`,
+      );
     }
   }
 
@@ -76,21 +78,24 @@ const getAuthenticationDataByParticipations = async ({
   return authenticationMethods.reduce((authenticationDataByUserId, method) => {
     authenticationDataByUserId[method.userId] = {
       authenticationId: method.externalIdentifier,
-      authenticationData: filterAuthenticationData(authenticationData, method.authenticationComplement),
+      authenticationRequestedData: filterAuthenticationData(
+        authenticationRequestedData,
+        method.authenticationComplement,
+      ),
     };
     return authenticationDataByUserId;
   }, {});
 };
 
-const areAuthenticationDataValid = (authenticationData, claims) => {
+const areAuthenticationDataValid = (authenticationRequestedData, claims) => {
   if (!claims) return false;
-  return authenticationData.every((authenticationClaim) => claims.includes(authenticationClaim));
+  return authenticationRequestedData.every((authenticationClaim) => claims.includes(authenticationClaim));
 };
 
-const filterAuthenticationData = (authenticationData, authenticationComplement) => {
-  if (!authenticationData) return null;
+const filterAuthenticationData = (authenticationRequestedData, authenticationComplement) => {
+  if (!authenticationRequestedData) return null;
   const result = {};
-  for (const claim of authenticationData) {
+  for (const claim of authenticationRequestedData) {
     result[claim] = authenticationComplement[claim];
   }
   return result;

--- a/api/src/maddo/domain/usecases/index.js
+++ b/api/src/maddo/domain/usecases/index.js
@@ -7,6 +7,7 @@ import { injectDependencies } from '../../../shared/infrastructure/utils/depende
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';
 import * as clientApplicationRepository from '../../infrastructure/repositories/client-application-repository.js';
+import * as oidcProviderRepository from '../../infrastructure/repositories/oidc-provider-repository.js';
 import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
@@ -17,6 +18,7 @@ const dependencies = {
   clientApplicationRepository,
   organizationRepository,
   campaignRepository,
+  oidcProviderRepository,
 };
 
 const usecasesWithoutInjectedDependencies = {

--- a/api/src/maddo/infrastructure/repositories/oidc-provider-repository.js
+++ b/api/src/maddo/infrastructure/repositories/oidc-provider-repository.js
@@ -1,0 +1,10 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+export async function findOidcProviderClaims(identityProvider) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const oidcProvider = await knexConn('oidc-providers').select('claimsToStore').where({ identityProvider }).first();
+  if (!oidcProvider) return [];
+
+  return oidcProvider.claimsToStore?.split(',') ?? [];
+}

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
@@ -415,6 +415,30 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         );
       });
     });
+
+    describe('when an OIDC provider is the authentication provider', function () {
+      it('brings along a OIDC authentication complement', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+          userId: user.id,
+          identityProvider: 'OIDC_PARTNER',
+          authenticationComplement: { hello: 'world' },
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const oidcAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+          userId: user.id,
+          identityProvider: 'OIDC_PARTNER',
+        });
+
+        // then
+        expect(oidcAuthenticationMethod.authenticationComplement).to.deep.equal(
+          new AuthenticationMethod.OidcAuthenticationComplement({ hello: 'world' }),
+        );
+      });
+    });
   });
 
   describe('#findOneByExternalIdentifierAndIdentityProvider', function () {

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -578,5 +578,145 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
         });
       });
     });
+
+    context('when authentication data are requested', function () {
+      let campaign;
+      let authorization;
+
+      beforeEach(async function () {
+        // Build oidc provider
+        const oidcProvider = await databaseBuilder.factory.buildOidcProvider({
+          identityProvider: 'IDENTITY_PROVIDER_EXAMPLE',
+          claimsToStore: 'employeeNumber,population',
+          accessTokenLifespan: '7d',
+          clientId: 'client',
+          clientSecret: 'plainTextSecret',
+          openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
+          organizationName: 'Identity Provider Example',
+          redirectUri: 'https://orga.dev.pix.org/connexion/oidc-example-net',
+          scope: 'openid profile campaigns',
+          slug: 'oidc-example-net',
+          source: 'oidcexamplenet',
+        });
+
+        // Build organization
+        const organization = databaseBuilder.factory.buildOrganization({
+          identityProviderForCampaigns: oidcProvider.identityProvider,
+        });
+        const tag = databaseBuilder.factory.buildTag();
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag.id });
+
+        // Build client application for maddo
+        databaseBuilder.factory.buildClientApplication({
+          clientId: 'app-client-id',
+          jurisdiction: { rules: [{ name: 'tags', value: [tag.name] }] },
+        });
+
+        // Build user and authentication method
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+          authenticationComplement: { population: 'MCF', employeeNumber: 'MCFCH' },
+          externalIdentifier: 'externalIdentifier-1',
+          identityProvider: 'IDENTITY_PROVIDER_EXAMPLE',
+          userId,
+        });
+
+        // Build learner in organization
+        const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          userId,
+        });
+
+        // Build campaign and participation
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        const skillId = databaseBuilder.factory.learningContent.buildSkill({ status: 'actif' }).id;
+        campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id, targetProfileId });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.SHARED,
+          organizationLearnerId: organizationLearner1.id,
+          userId,
+        });
+
+        await databaseBuilder.commit();
+
+        authorization = generateValidRequestAuthorizationHeaderForApplication(
+          'app-client-id',
+          'pix-client',
+          'campaigns meta',
+        );
+      });
+
+      it('returns the campaign participations with authentication data', async function () {
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/participations?authenticationData=employeeNumber`,
+          headers: { authorization },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.campaignParticipations[0].authenticationData).to.deep.equal({ employeeNumber: 'MCFCH' });
+      });
+
+      context('when no authentication data are requested', function () {
+        it('returns the campaign participations without authentication data', async function () {
+          // when
+          const response = await server.inject({
+            method: 'GET',
+            url: `/api/campaigns/${campaign.id}/participations`,
+            headers: { authorization },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.campaignParticipations[0].authenticationData).to.deep.equal({});
+        });
+      });
+
+      context('when multiple authentication data are requested', function () {
+        it('returns the campaign participations with multiple authentication data', async function () {
+          // when
+          const response = await server.inject({
+            method: 'GET',
+            url: `/api/campaigns/${campaign.id}/participations?authenticationData=employeeNumber&authenticationData=population`,
+            headers: { authorization },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.campaignParticipations[0].authenticationData).to.deep.equal({
+            population: 'MCF',
+            employeeNumber: 'MCFCH',
+          });
+        });
+      });
+
+      context('when invalid authentication data are requested', function () {
+        it('returns a bad request error', async function () {
+          // when
+          const response = await server.inject({
+            method: 'GET',
+            url: `/api/campaigns/${campaign.id}/participations?authenticationData=foo`,
+            headers: { authorization },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
+          expect(JSON.parse(response.payload)).to.deep.equal({
+            errors: [
+              {
+                status: '400',
+                code: 'INVALID_AUTHENTICATION_DATA',
+                title: 'Bad Request',
+                detail: 'Invalid authenticationData, must be some of: employeeNumber, population',
+              },
+            ],
+          });
+        });
+      });
+    });
   });
 });

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -652,13 +652,15 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
         // when
         const response = await server.inject({
           method: 'GET',
-          url: `/api/campaigns/${campaign.id}/participations?authenticationData=employeeNumber`,
+          url: `/api/campaigns/${campaign.id}/participations?authenticationRequestedData=employeeNumber`,
           headers: { authorization },
         });
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result.campaignParticipations[0].authenticationData).to.deep.equal({ employeeNumber: 'MCFCH' });
+        expect(response.result.campaignParticipations[0].authenticationRequestedData).to.deep.equal({
+          employeeNumber: 'MCFCH',
+        });
       });
 
       context('when no authentication data are requested', function () {
@@ -672,7 +674,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result.campaignParticipations[0].authenticationData).to.deep.equal({});
+          expect(response.result.campaignParticipations[0].authenticationRequestedData).to.deep.equal({});
         });
       });
 
@@ -681,13 +683,13 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           // when
           const response = await server.inject({
             method: 'GET',
-            url: `/api/campaigns/${campaign.id}/participations?authenticationData=employeeNumber&authenticationData=population`,
+            url: `/api/campaigns/${campaign.id}/participations?authenticationRequestedData=employeeNumber&authenticationRequestedData=population`,
             headers: { authorization },
           });
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result.campaignParticipations[0].authenticationData).to.deep.equal({
+          expect(response.result.campaignParticipations[0].authenticationRequestedData).to.deep.equal({
             population: 'MCF',
             employeeNumber: 'MCFCH',
           });
@@ -699,7 +701,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           // when
           const response = await server.inject({
             method: 'GET',
-            url: `/api/campaigns/${campaign.id}/participations?authenticationData=foo`,
+            url: `/api/campaigns/${campaign.id}/participations?authenticationRequestedData=foo`,
             headers: { authorization },
           });
 
@@ -711,7 +713,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
                 status: '400',
                 code: 'INVALID_AUTHENTICATION_DATA',
                 title: 'Bad Request',
-                detail: 'Invalid authenticationData, must be some of: employeeNumber, population',
+                detail: 'Invalid authenticationRequestedData, must be some of: employeeNumber, population',
               },
             ],
           });

--- a/api/tests/maddo/infrastructure/integration/repositories/oidc-providers_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/oidc-providers_test.js
@@ -1,0 +1,66 @@
+import { findOidcProviderClaims } from '../../../../../src/maddo/infrastructure/repositories/oidc-provider-repository.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Maddo | Infrastructure | Repositories | Integration | oidc-providers', function () {
+  describe('findOidcProviderClaims', function () {
+    it('returns claims of an oidc provider', async function () {
+      // given
+      const oidcProvider = await databaseBuilder.factory.buildOidcProvider({
+        identityProvider: 'IDENTITY_PROVIDER_EXAMPLE',
+        claimsToStore: 'employeeNumber,population',
+        accessTokenLifespan: '7d',
+        clientId: 'client',
+        clientSecret: 'plainTextSecret',
+        openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
+        organizationName: 'Identity Provider Example',
+        redirectUri: 'https://orga.dev.pix.org/connexion/oidc-example-net',
+        scope: 'openid profile campaigns',
+        slug: 'oidc-example-net',
+        source: 'oidcexamplenet',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const claims = await findOidcProviderClaims(oidcProvider.identityProvider);
+
+      // then
+      expect(claims).to.deep.equals(['employeeNumber', 'population']);
+    });
+
+    context('when no claims to store', function () {
+      it('returns an empty array', async function () {
+        // given
+        const oidcProvider = await databaseBuilder.factory.buildOidcProvider({
+          identityProvider: 'IDENTITY_PROVIDER_EXAMPLE',
+          accessTokenLifespan: '7d',
+          clientId: 'client',
+          clientSecret: 'plainTextSecret',
+          openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
+          organizationName: 'Identity Provider Example',
+          redirectUri: 'https://orga.dev.pix.org/connexion/oidc-example-net',
+          scope: 'openid profile campaigns',
+          slug: 'oidc-example-net',
+          source: 'oidcexamplenet',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const claims = await findOidcProviderClaims(oidcProvider.identityProvider);
+
+        // then
+        expect(claims).to.deep.equals([]);
+      });
+    });
+
+    context('when oidc provider not found', function () {
+      it('returns an empty array', async function () {
+        // when
+        const claims = await findOidcProviderClaims('xxx');
+
+        // then
+        expect(claims).to.deep.equals([]);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -218,12 +218,6 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
     });
 
     context('OidcAuthenticationComplement', function () {
-      it('cannot be created without properties', function () {
-        // when
-        expect(() => new AuthenticationMethod.OidcAuthenticationComplement()).to.throw(ObjectValidationError);
-        expect(() => new AuthenticationMethod.OidcAuthenticationComplement({})).to.throw(ObjectValidationError);
-      });
-
       it('can hold any properties', function () {
         // given
         const properties = { family_name: 'AAAAA', given_name: 'BBBBBB' };
@@ -232,7 +226,21 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
         const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement(properties);
 
         // then
-        expect(authenticationComplement).to.be.instanceOf(Object);
+        expect(authenticationComplement).to.be.instanceOf(AuthenticationMethod.OidcAuthenticationComplement);
+        expect(authenticationComplement.family_name).to.equal('AAAAA');
+        expect(authenticationComplement.given_name).to.equal('BBBBBB');
+      });
+
+      context('when no properties', function () {
+        [undefined, null, {}].forEach((value) => {
+          it(`returns the OidcAuthenticationComplement for input: "${value}"`, function () {
+            // when
+            const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement(value);
+
+            // then
+            expect(authenticationComplement).to.be.instanceOf(AuthenticationMethod.OidcAuthenticationComplement);
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## 💥 Problème
On souhaite proposer des claims liés aux utilisateurs issus de SSO externes dans l'appel API MADDO de récupération des participations aux campagnes.

## 👩‍🚀 Proposition
Enrichir la réponse de l'API MADDO des participations avec les claims "EmployeeNumber" et "Population" sauvegardés en base, dans les cas où les claims demandés existent.

## ♻️ Pour tester

**Dans Pix Admin avec `superadmin@example.net` :** 
- Créer un tag `ORGA`
- Noter l'id d'un Profil Cible avec des `tubes` (il faut que l'onglet "détails" du profil cible affiche des compétences), par ex `Pix (Niv1 ~ 5) - Badges - Stages`
- Créer une orga avec
  - un identity provider pour les campagnes
  - un tag `ORGA`
  - un profil cible
  - un membre (exemple: `superadmin@example.net`)
  - l'identity Provider que l'on veut tester

**Via le script `api/scripts/identity-access-management/client-applications.js`:**
Créer une client application avec la juridiction sur le tag et les meta campaign...

```
node scripts/identity-access-management/client-applications.js add --name="maddo-orga" --clientId="maddo-orga" --clientSecret="maddo-orga" --scope="meta" --scope="campaigns" --jurisdiction='{ "rules": [{ "name": "tags", "value": ["ORGA"] }] }'
```

**Dans Pix Orga avec `superadmin@example.net` :**
- Créer une campagne.

**Dans Pix App.org**
- Il faut participer à la campagne en se connectant via le SSO

**Via cURL sur l'api MADDO ici `http://localhost:3000`** (mais si vous voulez changer de port : `PORT=3003 npm run dev:maddo` ) :
Faire un appel curl avec `clientId` / `clientSecret` pour récupérer un token :
```
ACCESS_TOKEN=$(curl --no-progress-meter -X POST --data 'grant_type=client_credentials' --data 'client_id=maddo-orga' --data 'client_secret=maddo-orga' --data 'scope=meta campaigns' http://localhost:3000/api/application/token | jq -r .access_token)
```

Faire un appel curl pour récupérer les participations de la campagne (récupérer l'id de la campagne) :
  - sans `authenticationRequestedData` : data attendue sans les claims
  - avec `authenticationRequestedData` pour récupérer 1 claim
  - avec `authenticationRequestedData` pour récupérer 2 claims
  - avec `authenticationRequestedData` avec de mauvais claims : réponse attendue :  `INVALID_AUTHENTICATION_DATA`

```
curl --no-progress-meter -X GET "http://localhost:3000/api/campaigns/1000001/participations?authenticationRequestedData=claim1&authenticationRequestedData=claim2" -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" | jq
```