### PR TITLE
[FEATURE] laisse le filtrer division visible sur la page attestation (PIX-22076) 

### DIFF
--- a/orga/app/components/attestations/list.gjs
+++ b/orga/app/components/attestations/list.gjs
@@ -24,7 +24,7 @@ export default class AttestationList extends Component {
   }
 
   get shouldShowDivisions() {
-    return this.args.participantStatuses?.some((participantStatus) => Boolean(participantStatus.division));
+    return this.args.divisionsOptions?.length > 0;
   }
 
   <template>

--- a/orga/tests/integration/components/attestations/list-test.gjs
+++ b/orga/tests/integration/components/attestations/list-test.gjs
@@ -12,6 +12,7 @@ module('Integration | Component | Attestations | List', function (hooks) {
   test('it should display division column and filter if at least one participant has division', async function (assert) {
     // given
     const triggerFiltering = sinon.stub();
+    const divisionsOptions = ['6emeA'];
     const participantStatuses = [
       {
         lastName: 'jean',
@@ -30,7 +31,11 @@ module('Integration | Component | Attestations | List', function (hooks) {
     // when
     const screen = await render(
       <template>
-        <AttestationList @participantStatuses={{participantStatuses}} @onFilter={{triggerFiltering}} />
+        <AttestationList
+          @divisionsOptions={{divisionsOptions}}
+          @participantStatuses={{participantStatuses}}
+          @onFilter={{triggerFiltering}}
+        />
       </template>,
     );
 


### PR DESCRIPTION
## 💥 Problème

Dans une orga sco isManaging students, si on choisit une classe dans le filtre dédié et qu’aucun résultat n’est trouvé, le filtre disparaît et on ne peut plus le modifier. On en peut pas sélectionner plusieurs classes, ni modifier la sélection sans effacer les filtres.

## 👩‍🚀 Proposition

Maintenir en permanence le filtre de classe
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 👁️ Remarques

On modifie la condition d'affichage du filtre pour qu'elle se base sur le fait qu'il y ait des disivions (ou pas)

## ♻️ Pour tester
- Accéder à l’espace Pix Orga avec admin-orga@example.net sur l'orga sco
- Aller sur la page “Attestations”
- Dans la partie Suivi : sélectionner une classe sans résultat
- Le filtre de classe reste disponible

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
