### PR TITLE
[FEATURE] Ajout de nouvelles colonnes dans la table trainings pour la recommandation de contenus formatifs (PIX-22714).

### DIFF
--- a/api/db/migrations/20260512100315_add-columns-for-recommendation-engine-on-trainings-table.js
+++ b/api/db/migrations/20260512100315_add-columns-for-recommendation-engine-on-trainings-table.js
@@ -1,0 +1,39 @@
+const TABLE_NAME = 'trainings';
+const DELIVERY_MODE_COLUMN_NAME = 'deliveryMode';
+const PROGRAM_COLUMN_NAME = 'program';
+const REGISTRATION_REQUIRED_COLUMN_NAME = 'registrationRequired';
+const OBJECTIVES_COLUMN_NAME = 'objectives';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(DELIVERY_MODE_COLUMN_NAME).comment('geographical arrangements for the training course');
+    table.text(PROGRAM_COLUMN_NAME).comment('training program');
+    table
+      .boolean(REGISTRATION_REQUIRED_COLUMN_NAME)
+      .defaultTo(false)
+      .comment('registration requirement for attending the training course');
+    table
+      .specificType(OBJECTIVES_COLUMN_NAME, 'text[]')
+      .defaultTo('{}')
+      .comment('List of objectives to be achieved during the training course');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(DELIVERY_MODE_COLUMN_NAME);
+    table.dropColumn(PROGRAM_COLUMN_NAME);
+    table.dropColumn(REGISTRATION_REQUIRED_COLUMN_NAME);
+    table.dropColumn(OBJECTIVES_COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 💥 Problème

Le nouveau chantier de recommandation des contenus formatifs comprend l'ajout, sur la page de fin de parcours sur Pix App, la possibilité de sélectionner le contenu formatif recommandé et d'avoir des informations complètes sur ce dernier : 
- l'inscription obligatoire (ou non) pour le passer
- les objectifs de ce contenu F
- le programme du contenu F
- la modalité géographique pour passer ce contenu F : en présentiel, en distanciel ou les deux (hybride)

Ces informations là n'existent pas actuellement dans le code des contenu F (trainings)

## 👩‍🚀 Proposition

Ajouter 4 nouvelles colonnes : 

- `deliveryMode`, une colonne `string`
- `registrationRequired`, une colonne `boolean`, par défaut à false
- `program`, une colonne `text`
- `objectives`, une colonne `text[]`, par défaut vide

Elles sont nullables car tous les trainings ne sont pas tous liés à des recommandations de fin de parcours.


## 👁️ Remarques

50% du temps passé sur ce ticket c'était pour trouver les commentaires. J'suis pas inspiré.

## ♻️ Pour tester


<img width="1055" height="778" alt="Capture d’écran 2026-05-13 à 10 34 10" src="https://github.com/user-attachments/assets/f386bf69-9ca8-43ad-8fe0-c51ea6d151e6" />

