### PR TITLE
[TECH] :recycle: Fais en sorte que la `startDate` de la version soit optionnelle

### DIFF
--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -10,7 +10,7 @@ export class Version {
     scope: Joi.string()
       .required()
       .valid(...Object.values(SCOPES)),
-    startDate: Joi.date().required(),
+    startDate: Joi.date().allow(null).optional(),
     expirationDate: Joi.date().allow(null).optional(),
     assessmentDuration: Joi.number().required(),
     minimumAnswersRequiredToValidateACertification: Joi.number().required(),


### PR DESCRIPTION
## 💥 Problème

Nous avons fait la modification de la base de donnée. Nous pouvons maintenant modifier les contraintes sur l'objet

## 👩‍🚀 Proposition

Rendre la StartDate de la version de référentiel de certification optionnelle.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester

CI Verte puisque pour l'instant, ce n'est pas possible à faire dans l'interface

