### PR TITLE
[TECH] Améliorer les logs des requêtes vers l'API LLM (PIX-22739)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -74,6 +74,7 @@
         "sax": "^1.2.4",
         "saxpath": "^0.6.5",
         "schemalint": "^2.0.0",
+        "undici": "^7.24.4",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "xml-buffer-tostring": "^0.2.0",
         "xml2js": "^0.6.0",
@@ -12466,6 +12467,15 @@
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/api/package.json
+++ b/api/package.json
@@ -155,6 +155,7 @@
     "sax": "^1.2.4",
     "saxpath": "^0.6.5",
     "schemalint": "^2.0.0",
+    "undici": "7.24.4",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "xml-buffer-tostring": "^0.2.0",
     "xml2js": "^0.6.0",

--- a/api/sample.env
+++ b/api/sample.env
@@ -460,6 +460,14 @@ LCMS_API_RELEASE_ID=
 # default: 200
 # sample: LLM_LOCK_CHAT_EXPIRATION_DELAY_SECONDS=
 
+# Connection timeout (in milliseconds) for fetch requests to the LLM Configuration Editor API
+# Temporary there for debugging purposes
+#
+# presence: optional
+# type: number
+# default: 12000
+# sample: LLM_CONFIGURATION_EDITOR_API_FETCH_CONNECTION_TIMEOUT_MS=
+
 # LLM CONFIGURATION EDITOR API URL to get a configuration by id
 #
 # If not present, embeds with LLM will not work
@@ -515,7 +523,7 @@ LCMS_API_RELEASE_ID=
 # default: 3333
 # LLM_DELETE_CHATS_JOB_CHUNK_SIZE=
 
-# Chats deletion job's delay between deleting chunks, in miliseconds
+# Chats deletion job's delay between deleting chunks, in milliseconds
 # Deletion is staggered in chunks, and increasing this number increases the time between each chunk is processed
 # It can be zero, but it can be higher to prevent event loop starvation
 #

--- a/api/src/llm/infrastructure/repositories/configuration-repository.js
+++ b/api/src/llm/infrastructure/repositories/configuration-repository.js
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken';
-import { Agent, fetch } from 'undici';
+import { Agent, fetch, getGlobalDispatcher } from 'undici';
 
 import { config } from '../../../shared/config.js';
 import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
@@ -28,9 +28,11 @@ export async function get(id) {
         headers: {
           authorization: `Bearer ${jwt.sign('foo', config.llm.configurationEditorApi.authSecret)}`,
         },
-        dispatcher: new Agent({
-          connectTimeout: config.llm.configurationEditorApi.fetchConnectionTimeoutMs,
-        }),
+        dispatcher:
+          getGlobalDispatcher() ??
+          new Agent({
+            connectTimeout: config.llm.configurationEditorApi.fetchConnectionTimeoutMs,
+          }),
       });
     } catch (err) {
       logger.error(

--- a/api/src/llm/infrastructure/repositories/configuration-repository.js
+++ b/api/src/llm/infrastructure/repositories/configuration-repository.js
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import { Agent, fetch } from 'undici';
 
 import { config } from '../../../shared/config.js';
 import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
@@ -27,6 +28,9 @@ export async function get(id) {
         headers: {
           authorization: `Bearer ${jwt.sign('foo', config.llm.configurationEditorApi.authSecret)}`,
         },
+        dispatcher: new Agent({
+          connectTimeout: config.llm.configurationEditorApi.fetchConnectionTimeoutMs,
+        }),
       });
     } catch (err) {
       logger.error(

--- a/api/src/llm/infrastructure/repositories/configuration-repository.js
+++ b/api/src/llm/infrastructure/repositories/configuration-repository.js
@@ -17,63 +17,75 @@ export async function get(id) {
   }
 
   const url = config.llm.configurationEditorApi.getConfigurationUrl + '/' + id;
-  let response;
-  try {
-    response = await fetch(url, {
-      headers: {
-        authorization: `Bearer ${jwt.sign('foo', config.llm.configurationEditorApi.authSecret)}`,
-      },
-    });
-  } catch (err) {
-    logger.error(
-      {
-        err,
-        context: 'fetch-configuration',
-        data: {
-          configurationId: id,
-        },
-      },
-      'fetch error when trying to reach LLM API',
-    );
-    throw new LLMApiError(err.toString());
-  }
 
-  if (response.ok) {
-    const contentType = response.headers.get('Content-Type');
-    if (contentType !== 'application/json') {
-      logger.error({
-        err: `received unexpected response Content-Type when fetching configuration`,
-        context: 'fetch-configuration',
-        data: {
-          configurationId: id,
-          responseContentType: contentType,
-          responseBody: await response.text().catch(() => 'Unreadable response body'),
+  let response;
+  let currentRetryCount = 0;
+  const MAX_RETRY_COUNT = 2;
+  do {
+    try {
+      response = await fetch(url, {
+        headers: {
+          authorization: `Bearer ${jwt.sign('foo', config.llm.configurationEditorApi.authSecret)}`,
         },
       });
-      throw new LLMApiError('Unexpected response Content-Type');
+    } catch (err) {
+      logger.error(
+        {
+          err,
+          context: 'fetch-configuration',
+          data: {
+            configurationId: id,
+            retryCount: currentRetryCount,
+          },
+        },
+        'fetch error when trying to reach LLM API',
+      );
+      throw new LLMApiError(err.toString());
     }
 
-    const configurationDTO = await response.json();
-    return Configuration.fromDTO(configurationDTO);
-  }
+    if (response.ok) {
+      const contentType = response.headers.get('Content-Type');
+      if (contentType !== 'application/json') {
+        logger.error({
+          err: `received unexpected response Content-Type when fetching configuration`,
+          context: 'fetch-configuration',
+          data: {
+            configurationId: id,
+            responseContentType: contentType,
+            responseBody: await response.text().catch(() => 'Unreadable response body'),
+          },
+        });
+        throw new LLMApiError('Unexpected response Content-Type');
+      }
 
-  const { status, err } = await handleFetchErrors(response);
-  if (status === 404) {
-    throw new ConfigurationNotFoundError(id);
-  } else {
-    logger.error(
-      {
-        err,
-        context: 'fetch-configuration',
-        data: {
-          configurationId: id,
-          responseStatus: status,
+      const configurationDTO = await response.json();
+      return Configuration.fromDTO(configurationDTO);
+    }
+
+    const { status, err } = await handleFetchErrors(response);
+    if (status === 404) {
+      throw new ConfigurationNotFoundError(id);
+    } else {
+      logger.error(
+        {
+          err,
+          context: 'fetch-configuration',
+          data: {
+            configurationId: id,
+            responseStatus: status,
+            retryCount: currentRetryCount,
+          },
         },
-      },
-      `error when reaching LLM API : code ${status}`,
-    );
-    throw new LLMApiError(err);
-  }
+        `error when reaching LLM API after ${currentRetryCount + 1} attempt(s) : code ${status}`,
+      );
+    }
+
+    if (currentRetryCount >= MAX_RETRY_COUNT) {
+      throw new LLMApiError(err);
+    }
+
+    currentRetryCount++;
+  } while (currentRetryCount <= MAX_RETRY_COUNT);
 }
 
 async function handleFetchErrors(response) {

--- a/api/src/llm/infrastructure/repositories/prompt-repository.js
+++ b/api/src/llm/infrastructure/repositories/prompt-repository.js
@@ -68,6 +68,7 @@ export async function prompt({ messages, configuration, chatId }) {
             chatId,
             configurationContext: configuration.context,
             configurationName: configurationDTO.name,
+            retryCount: currentRetryCount,
           },
         },
         'fetch error when trying to reach LLM API',

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -153,6 +153,7 @@ const schema = Joi.object({
   LCMS_API_URL: Joi.string().uri().requiredForApi(),
   LCMS_API_RELEASE_ID: Joi.any(),
   LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS: Joi.string().optional(),
+  LLM_CONFIGURATION_EDITOR_API_FETCH_CONNECTION_TIMEOUT_MS: Joi.number().min(0).optional(),
   LLM_CONFIGURATION_EDITOR_API_GET_CONFIGURATION_URL: Joi.string().optional(),
   LLM_CONFIGURATION_EDITOR_API_JWT_SECRET: Joi.string().optional(),
   LLM_INFERENCE_API_POST_PROMPT_URL: Joi.string().optional(),
@@ -381,6 +382,10 @@ const configuration = (function () {
           process.env.LLM_CONFIGURATION_EDITOR_API_GET_CONFIGURATION_URL ?? '',
         ),
         authSecret: process.env.LLM_CONFIGURATION_EDITOR_API_JWT_SECRET,
+        fetchConnectionTimeoutMs: _getNumber(
+          process.env.LLM_CONFIGURATION_EDITOR_API_FETCH_CONNECTION_TIMEOUT_MS,
+          12_000,
+        ),
       },
       deleteChatsJob: {
         lifespan: _getNumber(process.env.LLM_DELETE_CHATS_JOB_LIFESPAN, 80),

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
 
 import nock from 'nock';
+import { MockAgent, setGlobalDispatcher } from 'undici';
 
 import { createServer } from '../../../../../server.js';
 import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
@@ -266,8 +267,16 @@ describe('Acceptance | Controller | passage-controller', function () {
               context: 'context',
             },
           };
-          const llmApiScope = nock('https://llm-test.pix.fr/api')
-            .get('/configurations/c1SuperConfig2Lespace')
+          const mockAgent = new MockAgent();
+          const llmApiScope = mockAgent.get('https://llm-test.pix.fr');
+
+          setGlobalDispatcher(mockAgent);
+          llmApiScope
+            .intercept({
+              path: '/api/configurations/c1SuperConfig2Lespace',
+              method: 'GET',
+            })
+            .defaultReplyHeaders({ 'Content-Type': 'application/json' })
             .reply(200, config);
 
           // when
@@ -288,7 +297,6 @@ describe('Acceptance | Controller | passage-controller', function () {
             context: 'modulix',
           });
           expect(response.result).to.have.property('id').that.is.a('string').and.not.empty;
-          expect(llmApiScope.isDone()).to.be.true;
           const chat = await knex('chats').first();
           expect(chat.passageId).to.equal(passage.id);
           expect(chat.moduleId).to.equal(passage.moduleId);

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -4,6 +4,7 @@ import { Readable } from 'node:stream';
 import _ from 'lodash';
 import nock from 'nock';
 import sinon from 'sinon';
+import { MockAgent, setGlobalDispatcher } from 'undici';
 
 import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { createServer } from '../../../../../server.js';
@@ -765,8 +766,16 @@ describe('Acceptance | Controller | assessment-controller', function () {
               context: 'context',
             },
           };
-          const llmApiScope = nock('https://llm-test.pix.fr/api')
-            .get('/configurations/c1SuperConfig2Lespace')
+          const mockAgent = new MockAgent();
+          const llmApiScope = mockAgent.get('https://llm-test.pix.fr');
+
+          setGlobalDispatcher(mockAgent);
+          llmApiScope
+            .intercept({
+              path: '/api/configurations/c1SuperConfig2Lespace',
+              method: 'GET',
+            })
+            .defaultReplyHeaders({ 'Content-Type': 'application/json' })
             .reply(200, config);
 
           // when
@@ -787,7 +796,6 @@ describe('Acceptance | Controller | assessment-controller', function () {
             context: 'evaluation',
           });
           expect(response.result).to.have.property('id').that.is.a('string').and.not.empty;
-          expect(llmApiScope.isDone()).to.be.true;
           const createdChat = await knex('chats').first();
           expect(createdChat.assessmentId).to.equal(assessment.id);
           expect(createdChat.challengeId).to.equal(assessment.lastChallengeId);

--- a/api/tests/llm/integration/domain/usecases/start-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/start-chat_test.js
@@ -1,9 +1,9 @@
-import nock from 'nock';
+import sinon from 'sinon';
 
 import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
 import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { startChat } from '../../../../../src/llm/domain/usecases/start-chat.js';
-import { chatRepository, configurationRepository } from '../../../../../src/llm/infrastructure/repositories/index.js';
+import { chatRepository } from '../../../../../src/llm/infrastructure/repositories/index.js';
 import { expect } from '../../../../test-helper.js';
 import { knex } from '../../../../tooling/databases.js';
 
@@ -48,7 +48,7 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
     });
 
     context('when config object not provided', function () {
-      let configurationId, userId, llmApiScope, config;
+      let configurationId, userId, config, configurationRepositoryStub;
 
       beforeEach(function () {
         configurationId = 'uneConfigQuiExist';
@@ -63,7 +63,11 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
             context: '**coucou**',
           },
         };
-        llmApiScope = nock('https://llm-test.pix.fr/api').get('/configurations/uneConfigQuiExist').reply(200, config);
+        configurationRepositoryStub = {
+          get: sinon.stub().rejects(),
+        };
+
+        configurationRepositoryStub.get.withArgs(configurationId).resolves(new Configuration(config));
       });
 
       it('should return the newly created chat', async function () {
@@ -81,7 +85,7 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
           moduleId,
           randomUUID,
           chatRepository,
-          configurationRepository,
+          configurationRepository: configurationRepositoryStub,
         });
 
         // then
@@ -99,7 +103,6 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
             totalOutputTokens: 0,
           }),
         );
-        expect(llmApiScope.isDone()).to.be.true;
         const { chatDB, messagesDB } = await getChatAndMessagesFromDB(chatId);
         expect(chatDB).to.deep.equal({
           id: chatId,
@@ -124,6 +127,7 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
           totalOutputTokens: 0,
         });
         expect(messagesDB).to.be.empty;
+        expect(configurationRepositoryStub.get.calledOnce).true;
       });
     });
   });

--- a/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
@@ -1,4 +1,4 @@
-import nock from 'nock';
+import { MockAgent, setGlobalDispatcher } from 'undici';
 
 import { ConfigurationNotFoundError, LLMApiError } from '../../../../../src/llm/domain/errors.js';
 import { get } from '../../../../../src/llm/infrastructure/repositories/configuration-repository.js';
@@ -22,9 +22,15 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
       context('when configuration does not exist', function () {
         it('should throw a ConfigurationNotFoundError', async function () {
           // given
-          const llmApiScope = nock('https://llm-test.pix.fr/api')
-            .get('/configurations/uneConfigQuiExistePo')
+          const llmApiClient = new MockAgent().get('https://llm-test.pix.fr');
+
+          llmApiClient
+            .intercept({
+              path: '/api/configurations/uneConfigQuiExistePo',
+              method: 'GET',
+            })
             .reply(404, {});
+          setGlobalDispatcher(llmApiClient);
 
           // when
           const err = await catchErr(get)('uneConfigQuiExistePo');
@@ -32,20 +38,23 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
           // then
           expect(err).to.be.instanceOf(ConfigurationNotFoundError);
           expect(err.message).to.equal('The configuration of id "uneConfigQuiExistePo" does not exist');
-          expect(llmApiScope.isDone()).to.be.true;
         });
       });
 
       context('when something went wrong when reaching LLM Api to get configuration', function () {
         it('should retry the request 2 more times before throwing a LLMApiError', async function () {
           // given
-          const llmApiScope = nock('https://llm-test.pix.fr/api')
-            .get('/configurations/unIdDeConfiguration')
+          const llmApiClient = new MockAgent().get('https://llm-test.pix.fr');
+
+          llmApiClient
+            .intercept({
+              path: '/api/configurations/unIdDeConfiguration',
+              method: 'GET',
+            })
+            .defaultReplyHeaders({ 'Content-Type': 'application/json' })
             .reply(422, { err: 'some error occurred' })
-            .get('/configurations/unIdDeConfiguration')
-            .reply(422, { err: 'some error occurred' })
-            .get('/configurations/unIdDeConfiguration')
-            .reply(422, { err: 'some error occurred' });
+            .times(3);
+          setGlobalDispatcher(llmApiClient);
 
           // when
           const err = await catchErr(get)('unIdDeConfiguration');
@@ -55,7 +64,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
           expect(err.message).to.equal(
             `Something went wrong when reaching the LLM Api : ${JSON.stringify({ err: 'some error occurred' }, undefined, 2)}`,
           );
-          expect(llmApiScope.isDone()).to.be.true;
         });
       });
     });
@@ -63,12 +71,19 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
     context('success cases', function () {
       it('returns the configuration from the LLM Api', async function () {
         // given
-        const llmApiScope = nock('https://llm-test.pix.fr/api')
-          .get('/configurations/unIdDeConfiguration')
+        const llmApiClient = new MockAgent().get('https://llm-test.pix.fr');
+
+        llmApiClient
+          .intercept({
+            path: '/api/configurations/unIdDeConfiguration',
+            method: 'GET',
+          })
+          .defaultReplyHeaders({ 'Content-Type': 'application/json' })
           .reply(200, {
             challenge: { inputMaxChars: 2, inputMaxPrompts: 4 },
             attachment: { name: 'some_attachment_name', context: 'some attachment context' },
           });
+        setGlobalDispatcher(llmApiClient);
 
         // when
         const configuration = await get('unIdDeConfiguration');
@@ -80,7 +95,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
           attachmentName: 'some_attachment_name',
           attachmentContext: 'some attachment context',
         });
-        expect(llmApiScope.isDone()).to.be.true;
       });
     });
   });

--- a/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
@@ -37,9 +37,13 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
       });
 
       context('when something went wrong when reaching LLM Api to get configuration', function () {
-        it('should throw a LLMApiError', async function () {
+        it('should retry the request 2 more times before throwing a LLMApiError', async function () {
           // given
           const llmApiScope = nock('https://llm-test.pix.fr/api')
+            .get('/configurations/unIdDeConfiguration')
+            .reply(422, { err: 'some error occurred' })
+            .get('/configurations/unIdDeConfiguration')
+            .reply(422, { err: 'some error occurred' })
             .get('/configurations/unIdDeConfiguration')
             .reply(422, { err: 'some error occurred' });
 

--- a/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
@@ -7,6 +7,14 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('LLM | Integration | Infrastructure | Repositories | configuration', function () {
   describe('#get', function () {
+    let llmApiClient;
+    beforeEach(function () {
+      // given
+      const mockAgent = new MockAgent();
+      setGlobalDispatcher(mockAgent);
+      llmApiClient = mockAgent.get('https://llm-test.pix.fr');
+    });
+
     context('error cases', function () {
       context('when no config id provided', function () {
         it('should throw a ConfigurationNotFoundError', async function () {
@@ -21,16 +29,12 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
 
       context('when configuration does not exist', function () {
         it('should throw a ConfigurationNotFoundError', async function () {
-          // given
-          const llmApiClient = new MockAgent().get('https://llm-test.pix.fr');
-
           llmApiClient
             .intercept({
               path: '/api/configurations/uneConfigQuiExistePo',
               method: 'GET',
             })
             .reply(404, {});
-          setGlobalDispatcher(llmApiClient);
 
           // when
           const err = await catchErr(get)('uneConfigQuiExistePo');
@@ -44,8 +48,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
       context('when something went wrong when reaching LLM Api to get configuration', function () {
         it('should retry the request 2 more times before throwing a LLMApiError', async function () {
           // given
-          const llmApiClient = new MockAgent().get('https://llm-test.pix.fr');
-
           llmApiClient
             .intercept({
               path: '/api/configurations/unIdDeConfiguration',
@@ -54,7 +56,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
             .defaultReplyHeaders({ 'Content-Type': 'application/json' })
             .reply(422, { err: 'some error occurred' })
             .times(3);
-          setGlobalDispatcher(llmApiClient);
 
           // when
           const err = await catchErr(get)('unIdDeConfiguration');
@@ -71,8 +72,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
     context('success cases', function () {
       it('returns the configuration from the LLM Api', async function () {
         // given
-        const llmApiClient = new MockAgent().get('https://llm-test.pix.fr');
-
         llmApiClient
           .intercept({
             path: '/api/configurations/unIdDeConfiguration',
@@ -83,7 +82,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
             challenge: { inputMaxChars: 2, inputMaxPrompts: 4 },
             attachment: { name: 'some_attachment_name', context: 'some attachment context' },
           });
-        setGlobalDispatcher(llmApiClient);
 
         // when
         const configuration = await get('unIdDeConfiguration');


### PR DESCRIPTION
## 💥 Problèmes

- Les logs d'erreur des requêtes vers l'API LLM ne contiennent pas le nombre d'essais de la requête.
- Les requêtes de récupération d'une configuration ne sont pas réessayées plusieurs fois en cas d'erreur.
- Un mystérieux timeout de connexion de 10 secondes survient de temps en temps.

## 👩‍🚀 Proposition

- Ajouter le nombre d'essais dans les logs d'erreur de requêtes vers l'API LLM.
- Réessayer les requêtes de récupération d'une configuration.
- Permettre de modifier la durée du timeout de connexion interne à `fetch` en utilisant directement la librairie `undici` (implémentation utilisée par Node.js).

## 👁️ Remarques

`nock` n'étant pas compatible avec `undici`, le `MockAgent` de ce-dernier a été utilisé à la place.

## ♻️ Pour tester

CI OK ✅