### PR TITLE
[TECH] Renommer les usecases et repositories d'import de participants (PIX-22738)

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/import-learners/import-from-fregata-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/import-learners/import-from-fregata-job-controller.js
@@ -23,7 +23,7 @@ class ImportFromFregataJobController extends JobController {
     const i18n = getI18n(locale);
 
     try {
-      await usecases.importOrganizationLearnersFromSIECLECSVFormat({
+      await usecases.importLearnersFromFregataFile({
         organizationImportId,
         i18n,
       });

--- a/api/src/prescription/learner-management/application/jobs/import-learners/import-from-generic-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/import-learners/import-from-generic-job-controller.js
@@ -21,7 +21,7 @@ class ImportFromGenericJobController extends JobController {
     const { organizationImportId } = data;
 
     try {
-      return await usecases.saveOrganizationLearnersFile({ organizationImportId });
+      return await usecases.importLearnersFromGenericFile({ organizationImportId });
     } catch (err) {
       if (!(err instanceof DomainError)) {
         throw err;

--- a/api/src/prescription/learner-management/application/jobs/import-learners/import-from-siecle-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/import-learners/import-from-siecle-job-controller.js
@@ -21,7 +21,7 @@ class ImportFromSiecleJobController extends JobController {
     const { organizationImportId } = data;
 
     try {
-      return await usecases.addOrUpdateOrganizationLearners({ organizationImportId });
+      return await usecases.importLearnersFromSiecleFile({ organizationImportId });
     } catch (err) {
       if (!(err instanceof DomainError)) {
         throw err;

--- a/api/src/prescription/learner-management/application/jobs/import-learners/import-from-sup-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/import-learners/import-from-sup-job-controller.js
@@ -39,7 +39,7 @@ class ImportFromSupJobController extends JobController {
           client: 'PIX_ORGA',
         });
       }
-      await usecases.importSupOrganizationLearners({
+      await usecases.importLearnersFromSupFile({
         organizationImportId,
         i18n,
       });

--- a/api/src/prescription/learner-management/application/jobs/validate-learners-file/validate-fregata-file-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/validate-learners-file/validate-fregata-file-job-controller.js
@@ -24,7 +24,7 @@ class ValidateFregataFileJobController extends JobController {
     const i18n = getI18n(locale);
 
     try {
-      await usecases.validateCsvFile({ organizationImportId, i18n, type: 'FREGATA', Parser: FregataParser });
+      await usecases.validateFregataFile({ organizationImportId, i18n, Parser: FregataParser });
     } catch (err) {
       if (!(err instanceof DomainError)) {
         throw err;

--- a/api/src/prescription/learner-management/application/jobs/validate-learners-file/validate-siecle-file-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/validate-learners-file/validate-siecle-file-job-controller.js
@@ -20,7 +20,7 @@ class ValidateSiecleFileJobController extends JobController {
   async handle({ data }) {
     const { organizationImportId } = data;
     try {
-      await usecases.validateSiecleXmlFile({ organizationImportId });
+      await usecases.validateSiecleFile({ organizationImportId });
     } catch (err) {
       if (!(err instanceof DomainError)) {
         throw err;

--- a/api/src/prescription/learner-management/application/jobs/validate-learners-file/validate-sup-file-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/validate-learners-file/validate-sup-file-job-controller.js
@@ -24,7 +24,7 @@ class ValidateSupFileJobController extends JobController {
     const i18n = getI18n(locale);
 
     try {
-      await usecases.validateCsvFile({ organizationImportId, i18n, type, Parser: SupParser });
+      await usecases.validateSupFile({ organizationImportId, i18n, type, Parser: SupParser });
     } catch (err) {
       if (!(err instanceof DomainError)) {
         throw err;

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/send-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/send-organization-learners-file.js
@@ -11,7 +11,7 @@ const sendOrganizationLearnersFile = async function ({
   userId,
   organizationId,
   organizationLearnerImportFormatRepository,
-  validateCommonOrganizationImportFileJobRepository,
+  validateGenericFileJobRepository,
   organizationImportRepository,
   importStorage,
   dependencies = { createReadStream, getDataBuffer },
@@ -42,7 +42,7 @@ const sendOrganizationLearnersFile = async function ({
     encoding = parser.getEncoding();
 
     filename = await importStorage.sendFile({ filepath: payload.path });
-    await validateCommonOrganizationImportFileJobRepository.performAsync(
+    await validateGenericFileJobRepository.performAsync(
       new ValidateGenericFileJob({ organizationImportId: organizationImport.id }),
     );
   } catch (error) {

--- a/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-fregata-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-fregata-file.js
@@ -2,11 +2,11 @@ const { chunk } = lodash;
 
 import lodash from 'lodash';
 
-import { withTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { ORGANIZATION_LEARNER_CHUNK_SIZE } from '../../../../shared/infrastructure/constants.js';
-import { FregataParser } from '../../infrastructure/serializers/csv/parsers/fregata-parser.js';
+import { withTransaction } from '../../../../../shared/domain/DomainTransaction.js';
+import { ORGANIZATION_LEARNER_CHUNK_SIZE } from '../../../../../shared/infrastructure/constants.js';
+import { FregataParser } from '../../../infrastructure/serializers/csv/parsers/fregata-parser.js';
 
-const importOrganizationLearnersFromSIECLECSVFormat = withTransaction(async function ({
+const importLearnersFromFregataFile = withTransaction(async function ({
   organizationImportId,
   organizationLearnerRepository,
   organizationImportRepository,
@@ -52,4 +52,4 @@ const importOrganizationLearnersFromSIECLECSVFormat = withTransaction(async func
   }
 });
 
-export { importOrganizationLearnersFromSIECLECSVFormat };
+export { importLearnersFromFregataFile };

--- a/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-generic-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-generic-file.js
@@ -4,7 +4,7 @@ import { getDataBuffer } from '../../../infrastructure/utils/bufferize/get-data-
 import { AggregateImportError } from '../../errors.js';
 import { ImportOrganizationLearnerSet } from '../../models/ImportOrganizationLearnerSet.js';
 
-const saveOrganizationLearnersFile = async function ({
+const importLearnersFromGenericFile = async function ({
   organizationImportId,
   organizationLearnerImportFormatRepository,
   organizationLearnerRepository,
@@ -70,4 +70,4 @@ const saveOrganizationLearnersFile = async function ({
   }
 };
 
-export { saveOrganizationLearnersFile };
+export { importLearnersFromGenericFile };

--- a/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-siecle-file.js
@@ -1,13 +1,13 @@
 import lodash from 'lodash';
 
-import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { ORGANIZATION_LEARNER_CHUNK_SIZE } from '../../../../shared/infrastructure/constants.js';
-import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser.js';
-import { SiecleFileStreamer } from '../../infrastructure/utils/xml/siecle-file-streamer.js';
+import { DomainTransaction } from '../../../../../shared/domain/DomainTransaction.js';
+import { ORGANIZATION_LEARNER_CHUNK_SIZE } from '../../../../../shared/infrastructure/constants.js';
+import { SiecleParser } from '../../../infrastructure/serializers/xml/siecle-parser.js';
+import { SiecleFileStreamer } from '../../../infrastructure/utils/xml/siecle-file-streamer.js';
 
 const { chunk } = lodash;
 
-async function addOrUpdateOrganizationLearners({
+async function importLearnersFromSiecleFile({
   organizationImportId,
   organizationLearnerRepository,
   organizationImportRepository,
@@ -58,4 +58,4 @@ async function addOrUpdateOrganizationLearners({
   });
 }
 
-export { addOrUpdateOrganizationLearners };
+export { importLearnersFromSiecleFile };

--- a/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-sup-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-sup-file.js
@@ -1,8 +1,8 @@
-import { SupParser } from '../../infrastructure/serializers/csv/parsers/sup-parser.js';
-import { getDataBuffer } from '../../infrastructure/utils/bufferize/get-data-buffer.js';
-import { AggregateImportError } from '../errors.js';
+import { SupParser } from '../../../infrastructure/serializers/csv/parsers/sup-parser.js';
+import { getDataBuffer } from '../../../infrastructure/utils/bufferize/get-data-buffer.js';
+import { AggregateImportError } from '../../errors.js';
 
-const importSupOrganizationLearners = async function ({
+const importLearnersFromSupFile = async function ({
   organizationImportId,
   i18n,
   supOrganizationLearnerRepository,
@@ -36,4 +36,4 @@ const importSupOrganizationLearners = async function ({
   }
 };
 
-export { importSupOrganizationLearners };
+export { importLearnersFromSupFile };

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -76,7 +76,6 @@ const dependencies = {
   validateOrganizationImportFileJobRepository,
 };
 
-import { addOrUpdateOrganizationLearners } from './add-or-update-organization-learners.js';
 import { anonymizeUser } from './anonymize-user.js';
 import { computeOrganizationLearnerCertificability } from './compute-organization-learner-certificability.js';
 import { deleteOrganizationLearners } from './delete-organization-learners.js';
@@ -90,11 +89,12 @@ import { getOrganizationLearnerFilters } from './get-organization-learner-filter
 import { getOrganizationLearnersCsvTemplate } from './get-organization-learners-csv-template.js';
 import { handlePayloadTooLargeError } from './handle-payload-too-large-error.js';
 import { hasBeenLearner } from './has-been-learner.js';
-import { saveOrganizationLearnersFile } from './import-from-feature/save-organization-learners-file.js';
 import { sendOrganizationLearnersFile } from './import-from-feature/send-organization-learners-file.js';
 import { validateOrganizationLearnersFile } from './import-from-feature/validate-organization-learners-file.js';
-import { importOrganizationLearnersFromSIECLECSVFormat } from './import-organization-learners-from-siecle-csv-format.js';
-import { importSupOrganizationLearners } from './import-sup-organization-learners.js';
+import { importLearnersFromFregataFile } from './import-learners/import-learners-from-fregata-file.js';
+import { importLearnersFromGenericFile } from './import-learners/import-learners-from-generic-file.js';
+import { importLearnersFromSiecleFile } from './import-learners/import-learners-from-siecle-file.js';
+import { importLearnersFromSupFile } from './import-learners/import-learners-from-sup-file.js';
 import { reconcileCommonOrganizationLearner } from './reconcile-common-organization-learner.js';
 import { reconcileScoOrganizationLearnerAutomatically } from './reconcile-sco-organization-learner-automatically.js';
 import { reconcileScoOrganizationLearnerManually } from './reconcile-sco-organization-learner-manually.js';
@@ -108,10 +108,10 @@ import { validateCsvFile } from './validate-csv-file.js';
 import { validateSiecleXmlFile } from './validate-siecle-xml-file.js';
 
 const usecasesWithoutInjectedDependencies = {
-  saveOrganizationLearnersFile,
+  importLearnersFromGenericFile,
   sendOrganizationLearnersFile,
   validateOrganizationLearnersFile,
-  addOrUpdateOrganizationLearners,
+  importLearnersFromSiecleFile,
   anonymizeUser,
   computeOrganizationLearnerCertificability,
   deleteOrganizationLearners,
@@ -125,8 +125,8 @@ const usecasesWithoutInjectedDependencies = {
   getOrganizationLearnersCsvTemplate,
   handlePayloadTooLargeError,
   hasBeenLearner,
-  importOrganizationLearnersFromSIECLECSVFormat,
-  importSupOrganizationLearners,
+  importLearnersFromFregataFile,
+  importLearnersFromSupFile,
   reconcileCommonOrganizationLearner,
   reconcileScoOrganizationLearnerAutomatically,
   reconcileScoOrganizationLearnerManually,

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -90,7 +90,6 @@ import { getOrganizationLearnersCsvTemplate } from './get-organization-learners-
 import { handlePayloadTooLargeError } from './handle-payload-too-large-error.js';
 import { hasBeenLearner } from './has-been-learner.js';
 import { sendOrganizationLearnersFile } from './import-from-feature/send-organization-learners-file.js';
-import { validateOrganizationLearnersFile } from './import-from-feature/validate-organization-learners-file.js';
 import { importLearnersFromFregataFile } from './import-learners/import-learners-from-fregata-file.js';
 import { importLearnersFromGenericFile } from './import-learners/import-learners-from-generic-file.js';
 import { importLearnersFromSiecleFile } from './import-learners/import-learners-from-siecle-file.js';
@@ -104,13 +103,15 @@ import { updateOrganizationLearnerName } from './update-organization-learner-nam
 import { updateStudentNumber } from './update-student-number.js';
 import { uploadCsvFile } from './upload-csv-file.js';
 import { uploadSiecleFile } from './upload-siecle-file.js';
-import { validateCsvFile } from './validate-csv-file.js';
-import { validateSiecleXmlFile } from './validate-siecle-xml-file.js';
+import { validateFregataFile } from './validate-learners-file/validate-fregata-file.js';
+import { validateGenericFile } from './validate-learners-file/validate-generic-file.js';
+import { validateSiecleFile } from './validate-learners-file/validate-siecle-file.js';
+import { validateSupFile } from './validate-learners-file/validate-sup-file.js';
 
 const usecasesWithoutInjectedDependencies = {
   importLearnersFromGenericFile,
   sendOrganizationLearnersFile,
-  validateOrganizationLearnersFile,
+  validateOrganizationLearnersFile: validateGenericFile,
   importLearnersFromSiecleFile,
   anonymizeUser,
   computeOrganizationLearnerCertificability,
@@ -136,8 +137,9 @@ const usecasesWithoutInjectedDependencies = {
   updateStudentNumber,
   uploadCsvFile,
   uploadSiecleFile,
-  validateCsvFile,
-  validateSiecleXmlFile,
+  validateFregataFile,
+  validateSupFile,
+  validateSiecleFile,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -18,13 +18,13 @@ import * as campaignParticipationRepositoryFromBC from '../../../campaign-partic
 import * as libOrganizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import * as registrationOrganizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/registration-organization-learner-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
-import { importCommonOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js';
-import { importOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-organization-learners-job-repository.js';
-import { importScoCsvOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository.js';
-import { importSupOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js';
-import { validateCommonOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js';
+import { importFromFregataJobRepository } from '../../infrastructure/repositories/jobs/import-from-fregata-job-repository.js';
+import { importFromGenericFileJobRepository } from '../../infrastructure/repositories/jobs/import-from-generic-file-job-repository.js';
+import { importFromSiecleJobRepository } from '../../infrastructure/repositories/jobs/import-from-siecle-job-repository.js';
+import { importFromSupJobRepository } from '../../infrastructure/repositories/jobs/import-from-sup-job-repository.js';
 import { validateFregataFileJobRepository } from '../../infrastructure/repositories/jobs/validate-fregata-file-job-repository.js';
-import { validateOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js';
+import { validateGenericFileJobRepository } from '../../infrastructure/repositories/jobs/validate-generic-file-job-repository.js';
+import { validateSiecleFileJobRepository } from '../../infrastructure/repositories/jobs/validate-siecle-file-job-repository.js';
 import { validateSupFileJobRepository } from '../../infrastructure/repositories/jobs/validate-sup-file-job-repository.js';
 import * as organizationImportRepository from '../../infrastructure/repositories/organization-import-repository.js';
 import * as organizationLearnerFilterRepository from '../../infrastructure/repositories/organization-learner-filter-repository.js';
@@ -46,11 +46,11 @@ const dependencies = {
   campaignRepository,
   auditLoggingJobRepository,
   featureToggles,
-  importCommonOrganizationLearnersJobRepository,
-  importOrganizationLearnersJobRepository,
-  importScoCsvOrganizationLearnersJobRepository,
+  importFromGenericFileJobRepository,
+  importFromSiecleJobRepository,
+  importFromFregataJobRepository,
   importStorage,
-  importSupOrganizationLearnersJobRepository,
+  importFromSupJobRepository,
   libOrganizationLearnerRepository,
   logger,
   membershipRepository,
@@ -70,10 +70,10 @@ const dependencies = {
   userRecommendedTrainingRepository,
   userReconciliationService,
   userRepository,
-  validateCommonOrganizationImportFileJobRepository,
+  validateGenericFileJobRepository,
   validateFregataFileJobRepository,
   validateSupFileJobRepository,
-  validateOrganizationImportFileJobRepository,
+  validateSiecleFileJobRepository,
 };
 
 import { anonymizeUser } from './anonymize-user.js';

--- a/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
@@ -13,7 +13,7 @@ const uploadSiecleFile = async function ({
   payload,
   importStorage,
   organizationImportRepository,
-  validateOrganizationImportFileJobRepository,
+  validateSiecleFileJobRepository,
   siecleService = {
     unzip: zip.unzip,
     detectEncoding,
@@ -52,7 +52,7 @@ const uploadSiecleFile = async function ({
     }
   });
 
-  await validateOrganizationImportFileJobRepository.performAsync(
+  await validateSiecleFileJobRepository.performAsync(
     new ValidateSiecleFileJob({ organizationImportId: organizationImport.id }),
   );
 };

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-fregata-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-fregata-file.js
@@ -5,7 +5,7 @@ const validateFregataFile = async function ({
   Parser,
   organizationImportId,
   i18n,
-  importScoCsvOrganizationLearnersJobRepository,
+  importFromFregataJobRepository,
   organizationImportRepository,
   importStorage,
 }) {
@@ -24,7 +24,7 @@ const validateFregataFile = async function ({
 
     warningsData = warnings;
 
-    await importScoCsvOrganizationLearnersJobRepository.performAsync(
+    await importFromFregataJobRepository.performAsync(
       new ImportFromFregataJob({
         organizationImportId: organizationImport.id,
         locale: i18n.getLocale(),

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-fregata-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-fregata-file.js
@@ -1,13 +1,10 @@
-import { AggregateImportError } from '../errors.js';
-import { ImportFromFregataJob } from '../models/jobs/ImportFromFregataJob.js';
-import { ImportFromSupJob } from '../models/jobs/ImportFromSupJob.js';
+import { AggregateImportError } from '../../errors.js';
+import { ImportFromFregataJob } from '../../models/jobs/ImportFromFregataJob.js';
 
-const validateCsvFile = async function ({
+const validateFregataFile = async function ({
   Parser,
   organizationImportId,
   i18n,
-  type,
-  importSupOrganizationLearnersJobRepository,
   importScoCsvOrganizationLearnersJobRepository,
   organizationImportRepository,
   importStorage,
@@ -27,24 +24,12 @@ const validateCsvFile = async function ({
 
     warningsData = warnings;
 
-    if (type) {
-      if (type === 'FREGATA') {
-        await importScoCsvOrganizationLearnersJobRepository.performAsync(
-          new ImportFromFregataJob({
-            organizationImportId: organizationImport.id,
-            locale: i18n.getLocale(),
-          }),
-        );
-      } else {
-        await importSupOrganizationLearnersJobRepository.performAsync(
-          new ImportFromSupJob({
-            organizationImportId: organizationImport.id,
-            type,
-            locale: i18n.getLocale(),
-          }),
-        );
-      }
-    }
+    await importScoCsvOrganizationLearnersJobRepository.performAsync(
+      new ImportFromFregataJob({
+        organizationImportId: organizationImport.id,
+        locale: i18n.getLocale(),
+      }),
+    );
   } catch (error) {
     if (error instanceof AggregateImportError) {
       errors.push(...error.meta);
@@ -61,4 +46,4 @@ const validateCsvFile = async function ({
   }
 };
 
-export { validateCsvFile };
+export { validateFregataFile };

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js
@@ -32,9 +32,7 @@ const validateGenericFile = async function ({
     });
 
     learnerSet.addLearners(learners);
-    await importFromGenericFileJobRepository.performAsync(
-      new ImportFromGenericFileJob({ organizationImportId }),
-    );
+    await importFromGenericFileJobRepository.performAsync(new ImportFromGenericFileJob({ organizationImportId }));
   } catch (error) {
     if (Array.isArray(error)) {
       errors.push(...error);

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js
@@ -7,7 +7,7 @@ import { ImportFromGenericFileJob } from '../../models/jobs/ImportFromGenericFil
 const validateGenericFile = async function ({
   organizationImportId,
   organizationLearnerImportFormatRepository,
-  importCommonOrganizationLearnersJobRepository,
+  importFromGenericFileJobRepository,
   organizationImportRepository,
   importStorage,
   dependencies = { getDataBuffer },
@@ -32,7 +32,7 @@ const validateGenericFile = async function ({
     });
 
     learnerSet.addLearners(learners);
-    await importCommonOrganizationLearnersJobRepository.performAsync(
+    await importFromGenericFileJobRepository.performAsync(
       new ImportFromGenericFileJob({ organizationImportId }),
     );
   } catch (error) {

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js
@@ -4,7 +4,7 @@ import { AggregateImportError } from '../../errors.js';
 import { ImportOrganizationLearnerSet } from '../../models/ImportOrganizationLearnerSet.js';
 import { ImportFromGenericFileJob } from '../../models/jobs/ImportFromGenericFileJob.js';
 
-const validateOrganizationLearnersFile = async function ({
+const validateGenericFile = async function ({
   organizationImportId,
   organizationLearnerImportFormatRepository,
   importCommonOrganizationLearnersJobRepository,
@@ -50,4 +50,4 @@ const validateOrganizationLearnersFile = async function ({
   }
 };
 
-export { validateOrganizationLearnersFile };
+export { validateGenericFile };

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-siecle-file.js
@@ -19,7 +19,7 @@ const validateSiecleFile = async function ({
   organizationRepository,
   organizationImportRepository,
   importStorage,
-  importOrganizationLearnersJobRepository,
+  importFromSiecleJobRepository,
 }) {
   const organizationImport = await DomainTransaction.execute(async () => {
     const organizationImport = await organizationImportRepository.get(organizationImportId);
@@ -61,7 +61,7 @@ const validateSiecleFile = async function ({
     }
   });
 
-  await importOrganizationLearnersJobRepository.performAsync(
+  await importFromSiecleJobRepository.performAsync(
     new ImportFromSiecleJob({ organizationImportId: organizationImport.id }),
   );
 };

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-siecle-file.js
@@ -1,20 +1,20 @@
 import lodash from 'lodash';
 
-import { AggregateImportError, SiecleXmlImportError } from '../errors.js';
+import { AggregateImportError, SiecleXmlImportError } from '../../errors.js';
 
 const { isEmpty } = lodash;
 
-import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser.js';
-import { SiecleFileStreamer } from '../../infrastructure/utils/xml/siecle-file-streamer.js';
-import { ImportFromSiecleJob } from '../models/jobs/ImportFromSiecleJob.js';
+import { DomainTransaction } from '../../../../../shared/domain/DomainTransaction.js';
+import { SiecleParser } from '../../../infrastructure/serializers/xml/siecle-parser.js';
+import { SiecleFileStreamer } from '../../../infrastructure/utils/xml/siecle-file-streamer.js';
+import { ImportFromSiecleJob } from '../../models/jobs/ImportFromSiecleJob.js';
 
 const ERRORS = {
   EMPTY: 'EMPTY',
   INVALID_FILE_EXTENSION: 'INVALID_FILE_EXTENSION',
 };
 
-const validateSiecleXmlFile = async function ({
+const validateSiecleFile = async function ({
   organizationImportId,
   organizationRepository,
   organizationImportRepository,
@@ -66,4 +66,4 @@ const validateSiecleXmlFile = async function ({
   );
 };
 
-export { validateSiecleXmlFile };
+export { validateSiecleFile };

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-sup-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-sup-file.js
@@ -6,7 +6,7 @@ const validateSupFile = async function ({
   organizationImportId,
   i18n,
   type,
-  importSupOrganizationLearnersJobRepository,
+  importFromSupJobRepository,
   organizationImportRepository,
   importStorage,
 }) {
@@ -25,7 +25,7 @@ const validateSupFile = async function ({
 
     warningsData = warnings;
 
-    await importSupOrganizationLearnersJobRepository.performAsync(
+    await importFromSupJobRepository.performAsync(
       new ImportFromSupJob({
         organizationImportId: organizationImport.id,
         type,

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-sup-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-sup-file.js
@@ -1,0 +1,51 @@
+import { AggregateImportError } from '../../errors.js';
+import { ImportFromSupJob } from '../../models/jobs/ImportFromSupJob.js';
+
+const validateSupFile = async function ({
+  Parser,
+  organizationImportId,
+  i18n,
+  type,
+  importSupOrganizationLearnersJobRepository,
+  organizationImportRepository,
+  importStorage,
+}) {
+  const organizationImport = await organizationImportRepository.get(organizationImportId);
+  const errors = [];
+  let warningsData;
+
+  try {
+    const parser = await importStorage.getParser(
+      { Parser, filename: organizationImport.filename },
+      organizationImport.organizationId,
+      i18n,
+    );
+
+    const { warnings } = parser.parse(parser.getFileEncoding());
+
+    warningsData = warnings;
+
+    await importSupOrganizationLearnersJobRepository.performAsync(
+      new ImportFromSupJob({
+        organizationImportId: organizationImport.id,
+        type,
+        locale: i18n.getLocale(),
+      }),
+    );
+  } catch (error) {
+    if (error instanceof AggregateImportError) {
+      errors.push(...error.meta);
+    } else {
+      errors.push(error);
+    }
+
+    await importStorage.deleteFile({ filename: organizationImport.filename });
+
+    throw error;
+  } finally {
+    organizationImport.validate({ errors, warnings: warningsData });
+    await organizationImportRepository.save(organizationImport);
+  }
+};
+
+export { validateSupFile };

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-fregata-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-fregata-job-repository.js
@@ -10,4 +10,4 @@ class ImportFromFregataJobRepository extends JobRepository {
   }
 }
 
-export const importScoCsvOrganizationLearnersJobRepository = new ImportFromFregataJobRepository();
+export const importFromFregataJobRepository = new ImportFromFregataJobRepository();

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-generic-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-generic-file-job-repository.js
@@ -10,4 +10,4 @@ class ImportFromGenericFileJobRepository extends JobRepository {
   }
 }
 
-export const importCommonOrganizationLearnersJobRepository = new ImportFromGenericFileJobRepository();
+export const importFromGenericFileJobRepository = new ImportFromGenericFileJobRepository();

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-siecle-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-siecle-job-repository.js
@@ -10,4 +10,4 @@ class ImportFromSiecleJobRepository extends JobRepository {
   }
 }
 
-export const importOrganizationLearnersJobRepository = new ImportFromSiecleJobRepository();
+export const importFromSiecleJobRepository = new ImportFromSiecleJobRepository();

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-sup-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-sup-job-repository.js
@@ -10,4 +10,4 @@ class ImportFromSupJobRepository extends JobRepository {
   }
 }
 
-export const importSupOrganizationLearnersJobRepository = new ImportFromSupJobRepository();
+export const importFromSupJobRepository = new ImportFromSupJobRepository();

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-generic-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-generic-file-job-repository.js
@@ -10,4 +10,4 @@ class ValidateGenericFileJobRepository extends JobRepository {
   }
 }
 
-export const validateCommonOrganizationImportFileJobRepository = new ValidateGenericFileJobRepository();
+export const validateGenericFileJobRepository = new ValidateGenericFileJobRepository();

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-siecle-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-siecle-file-job-repository.js
@@ -10,4 +10,4 @@ class ValidateSiecleFileJobRepository extends JobRepository {
   }
 }
 
-export const validateOrganizationImportFileJobRepository = new ValidateSiecleFileJobRepository();
+export const validateSiecleFileJobRepository = new ValidateSiecleFileJobRepository();

--- a/api/tests/prescription/learner-management/integration/domain/usecases/import-learners/import-learners-from-generic-file_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/import-learners/import-learners-from-generic-file_test.js
@@ -76,7 +76,7 @@ O-Ren;Ishii;5B;01/02/1980`,
 
   it('save two learner on organization', async function () {
     // when
-    await usecases.saveOrganizationLearnersFile({ organizationImportId: organizationImport.id });
+    await usecases.importLearnersFromGenericFile({ organizationImportId: organizationImport.id });
 
     const learners = await knex('organization-learners')
       .select('firstName', 'lastName', 'attributes')
@@ -96,7 +96,7 @@ O-Ren;Ishii;5B;01/02/1980`,
     await databaseBuilder.commit();
 
     // when
-    await usecases.saveOrganizationLearnersFile({ organizationImportId: organizationImport.id });
+    await usecases.importLearnersFromGenericFile({ organizationImportId: organizationImport.id });
 
     const filters = await knex('organization_learner_filters').where('organization_id', organizationId);
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-fregata-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-fregata-job-repository_test.js
@@ -1,14 +1,14 @@
 import { ImportFromFregataJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromFregataJob.js';
-import { importScoCsvOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository.js';
+import { importFromFregataJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-from-fregata-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
 import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
-describe('Integration | Prescription | Infrastructure | Repository | Jobs | importScoCsvOrganizationLearnersJobRepository', function () {
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | importFromFregataJobRepository', function () {
   describe('#performAsync', function () {
     it('publish a job', async function () {
       // when
-      await importScoCsvOrganizationLearnersJobRepository.performAsync(
+      await importFromFregataJobRepository.performAsync(
         new ImportFromFregataJob({ organizationImportId: 4123132, locale: 'fr' }),
       );
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-generic-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-generic-file-job-repository_test.js
@@ -1,14 +1,14 @@
 import { ImportFromGenericFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromGenericFileJob.js';
-import { importCommonOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js';
+import { importFromGenericFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-from-generic-file-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
 import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
-describe('Integration | Prescription | Infrastructure | Repository | Jobs | importCommonOrganizationLearnersJobRepository', function () {
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | importFromGenericFileJobRepository', function () {
   describe('#performAsync', function () {
     it('publish a job', async function () {
       // when
-      await importCommonOrganizationLearnersJobRepository.performAsync(
+      await importFromGenericFileJobRepository.performAsync(
         new ImportFromGenericFileJob({ organizationImportId: 4123132 }),
       );
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-siecle-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-siecle-job-repository_test.js
@@ -8,9 +8,7 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
   describe('#performAsync', function () {
     it('publish a job', async function () {
       // when
-      await importFromSiecleJobRepository.performAsync(
-        new ImportFromSiecleJob({ organizationImportId: 4123132 }),
-      );
+      await importFromSiecleJobRepository.performAsync(new ImportFromSiecleJob({ organizationImportId: 4123132 }));
 
       // then
       await expect(ImportFromSiecleJob.name).to.have.have.been.performed.withJob({

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-siecle-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-siecle-job-repository_test.js
@@ -1,14 +1,14 @@
 import { ImportFromSiecleJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromSiecleJob.js';
-import { importOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js';
+import { importFromSiecleJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-from-siecle-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
 import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
-describe('Integration | Prescription | Infrastructure | Repository | Jobs | importOrganizationLearnersJobRepository', function () {
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | importFromSiecleJobRepository', function () {
   describe('#performAsync', function () {
     it('publish a job', async function () {
       // when
-      await importOrganizationLearnersJobRepository.performAsync(
+      await importFromSiecleJobRepository.performAsync(
         new ImportFromSiecleJob({ organizationImportId: 4123132 }),
       );
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-sup-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-sup-job-repository_test.js
@@ -1,14 +1,14 @@
 import { ImportFromSupJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromSupJob.js';
-import { importSupOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js';
+import { importFromSupJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-from-sup-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
 import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
-describe('Integration | Prescription | Infrastructure | Repository | Jobs | importSupOrganizationLearnersJobRepository', function () {
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | importFromSupJobRepository', function () {
   describe('#performAsync', function () {
     it('publish a job', async function () {
       // when
-      await importSupOrganizationLearnersJobRepository.performAsync(
+      await importFromSupJobRepository.performAsync(
         new ImportFromSupJob({ organizationImportId: 4123132, type: 'REPLACE', locale: 'fr' }),
       );
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-generic-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-generic-file-job-repository_test.js
@@ -1,14 +1,14 @@
 import { ValidateGenericFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ValidateGenericFileJob.js';
-import { validateCommonOrganizationImportFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js';
+import { validateGenericFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-generic-file-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
 import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
-describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateCommonOrganizationImportFileJobRepository', function () {
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateGenericFileJobRepository', function () {
   describe('#performAsync', function () {
     it('publish a job', async function () {
       // when
-      await validateCommonOrganizationImportFileJobRepository.performAsync(
+      await validateGenericFileJobRepository.performAsync(
         new ValidateGenericFileJob({ organizationImportId: 4123132 }),
       );
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-siecle-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-siecle-file-job-repository_test.js
@@ -8,9 +8,7 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
   describe('#performAsync', function () {
     it('publish a job', async function () {
       // when
-      await validateSiecleFileJobRepository.performAsync(
-        new ValidateSiecleFileJob({ organizationImportId: 4123132 }),
-      );
+      await validateSiecleFileJobRepository.performAsync(new ValidateSiecleFileJob({ organizationImportId: 4123132 }));
 
       // then
       await expect(ValidateSiecleFileJob.name).to.have.been.performed.withJob({

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-siecle-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-siecle-file-job-repository_test.js
@@ -1,14 +1,14 @@
 import { ValidateSiecleFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ValidateSiecleFileJob.js';
-import { validateOrganizationImportFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js';
+import { validateSiecleFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-siecle-file-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
 import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
-describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateOrganizationImportFileJobRepository', function () {
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateSiecleFileJobRepository', function () {
   describe('#performAsync', function () {
     it('publish a job', async function () {
       // when
-      await validateOrganizationImportFileJobRepository.performAsync(
+      await validateSiecleFileJobRepository.performAsync(
         new ValidateSiecleFileJob({ organizationImportId: 4123132 }),
       );
 

--- a/api/tests/prescription/learner-management/unit/application/jobs/import-learners/import-from-fregata-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/import-learners/import-from-fregata-job-controller_test.js
@@ -35,7 +35,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromFregataJobControl
 
   describe('#handle', function () {
     it('should call usecase', async function () {
-      sinon.stub(usecases, 'importOrganizationLearnersFromSIECLECSVFormat');
+      sinon.stub(usecases, 'importLearnersFromFregataFile');
 
       // given
       const handler = new ImportFromFregataJobController();
@@ -45,8 +45,8 @@ describe('Unit | Prescription | Application | Jobs | ImportFromFregataJobControl
       await handler.handle({ data });
 
       // then
-      expect(usecases.importOrganizationLearnersFromSIECLECSVFormat).to.have.been.calledOnce;
-      expect(usecases.importOrganizationLearnersFromSIECLECSVFormat).to.have.been.calledWithExactly({
+      expect(usecases.importLearnersFromFregataFile).to.have.been.calledOnce;
+      expect(usecases.importLearnersFromFregataFile).to.have.been.calledWithExactly({
         organizationImportId: data.organizationImportId,
         i18n: getI18n(data.locale),
       });
@@ -54,7 +54,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromFregataJobControl
 
     it('should not throw when error is from domain', async function () {
       const error = new OrganizationLearnersCouldNotBeSavedError();
-      sinon.stub(usecases, 'importOrganizationLearnersFromSIECLECSVFormat').rejects(error);
+      sinon.stub(usecases, 'importLearnersFromFregataFile').rejects(error);
 
       // given
       const errorStub = sinon.stub();
@@ -69,7 +69,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromFregataJobControl
 
     it('should throw when error is not from domain', async function () {
       const error = new Error();
-      sinon.stub(usecases, 'importOrganizationLearnersFromSIECLECSVFormat').rejects(error);
+      sinon.stub(usecases, 'importLearnersFromFregataFile').rejects(error);
 
       // given
       const handler = new ImportFromFregataJobController();

--- a/api/tests/prescription/learner-management/unit/application/jobs/import-learners/import-from-generic-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/import-learners/import-from-generic-job-controller_test.js
@@ -34,7 +34,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromGenericJobControl
 
   describe('#handle', function () {
     it('should call usecase', async function () {
-      sinon.stub(usecases, 'saveOrganizationLearnersFile');
+      sinon.stub(usecases, 'importLearnersFromGenericFile');
 
       // given
       const handler = new ImportFromGenericJobController();
@@ -44,13 +44,13 @@ describe('Unit | Prescription | Application | Jobs | ImportFromGenericJobControl
       await handler.handle({ data });
 
       // then
-      expect(usecases.saveOrganizationLearnersFile).to.have.been.calledOnce;
-      expect(usecases.saveOrganizationLearnersFile).to.have.been.calledWithExactly(data);
+      expect(usecases.importLearnersFromGenericFile).to.have.been.calledOnce;
+      expect(usecases.importLearnersFromGenericFile).to.have.been.calledWithExactly(data);
     });
 
     it('should not throw when error is from domain', async function () {
       const error = new OrganizationLearnersCouldNotBeSavedError();
-      sinon.stub(usecases, 'saveOrganizationLearnersFile').rejects(error);
+      sinon.stub(usecases, 'importLearnersFromGenericFile').rejects(error);
 
       // given
       const errorStub = sinon.stub();
@@ -65,7 +65,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromGenericJobControl
 
     it('should throw when error is not from domain', async function () {
       const error = new Error();
-      sinon.stub(usecases, 'saveOrganizationLearnersFile').rejects(error);
+      sinon.stub(usecases, 'importLearnersFromGenericFile').rejects(error);
 
       // given
       const handler = new ImportFromGenericJobController();

--- a/api/tests/prescription/learner-management/unit/application/jobs/import-learners/import-from-siecle-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/import-learners/import-from-siecle-job-controller_test.js
@@ -34,7 +34,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromSiecleJobControll
 
   describe('#handle', function () {
     it('should call usecase', async function () {
-      sinon.stub(usecases, 'addOrUpdateOrganizationLearners');
+      sinon.stub(usecases, 'importLearnersFromSiecleFile');
 
       // given
       const handler = new ImportFromSiecleJobController();
@@ -44,13 +44,13 @@ describe('Unit | Prescription | Application | Jobs | ImportFromSiecleJobControll
       await handler.handle({ data });
 
       // then
-      expect(usecases.addOrUpdateOrganizationLearners).to.have.been.calledOnce;
-      expect(usecases.addOrUpdateOrganizationLearners).to.have.been.calledWithExactly(data);
+      expect(usecases.importLearnersFromSiecleFile).to.have.been.calledOnce;
+      expect(usecases.importLearnersFromSiecleFile).to.have.been.calledWithExactly(data);
     });
 
     it('should not throw when error is from domain', async function () {
       const error = new OrganizationLearnersCouldNotBeSavedError();
-      sinon.stub(usecases, 'addOrUpdateOrganizationLearners').rejects(error);
+      sinon.stub(usecases, 'importLearnersFromSiecleFile').rejects(error);
 
       // given
       const errorStub = sinon.stub();
@@ -65,7 +65,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromSiecleJobControll
 
     it('should throw when error is not from domain', async function () {
       const error = new Error();
-      sinon.stub(usecases, 'addOrUpdateOrganizationLearners').rejects(error);
+      sinon.stub(usecases, 'importLearnersFromSiecleFile').rejects(error);
 
       // given
       const handler = new ImportFromSiecleJobController();

--- a/api/tests/prescription/learner-management/unit/application/jobs/import-learners/import-from-sup-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/import-learners/import-from-sup-job-controller_test.js
@@ -43,7 +43,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromSupJobController'
 
     it('should not throw when error is from domain', async function () {
       const error = new OrganizationLearnersCouldNotBeSavedError();
-      sinon.stub(usecases, 'importSupOrganizationLearners').rejects(error);
+      sinon.stub(usecases, 'importLearnersFromSupFile').rejects(error);
 
       // given
       const errorStub = sinon.stub();
@@ -57,7 +57,7 @@ describe('Unit | Prescription | Application | Jobs | ImportFromSupJobController'
 
     it('should throw when error is not from domain', async function () {
       const error = new Error();
-      sinon.stub(usecases, 'importSupOrganizationLearners').rejects(error);
+      sinon.stub(usecases, 'importLearnersFromSupFile').rejects(error);
 
       // given
       const errorStub = sinon.stub();

--- a/api/tests/prescription/learner-management/unit/application/jobs/validate-learners-file/validate-fregata-file-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/validate-learners-file/validate-fregata-file-job-controller_test.js
@@ -35,8 +35,8 @@ describe('Unit | Prescription | Application | Jobs | ValidateFregataFileJobContr
   });
 
   describe('#handle', function () {
-    it('should call usecase with FregataParser and FREGATA type', async function () {
-      sinon.stub(usecases, 'validateCsvFile');
+    it('should call usecase with FregataParser', async function () {
+      sinon.stub(usecases, 'validateFregataFile');
       // given
       const handler = new ValidateFregataFileJobController();
       const data = { organizationImportId: Symbol('organizationImportId'), locale: 'en' };
@@ -45,17 +45,16 @@ describe('Unit | Prescription | Application | Jobs | ValidateFregataFileJobContr
       await handler.handle({ data });
 
       // then
-      expect(usecases.validateCsvFile).to.have.been.calledOnceWithExactly({
+      expect(usecases.validateFregataFile).to.have.been.calledOnceWithExactly({
         organizationImportId: data.organizationImportId,
         i18n: getI18n(data.locale),
-        type: 'FREGATA',
         Parser: FregataParser,
       });
     });
 
     it('should not throw when error is from domain', async function () {
       const error = new S3FileDoesNotExistError();
-      sinon.stub(usecases, 'validateCsvFile').rejects(error);
+      sinon.stub(usecases, 'validateFregataFile').rejects(error);
 
       // given
       const warnStub = sinon.stub();
@@ -71,7 +70,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateFregataFileJobContr
 
     it('should throw when error is not from domain', async function () {
       const error = new Error();
-      sinon.stub(usecases, 'validateCsvFile').rejects(error);
+      sinon.stub(usecases, 'validateFregataFile').rejects(error);
 
       // given
       const handler = new ValidateFregataFileJobController();

--- a/api/tests/prescription/learner-management/unit/application/jobs/validate-learners-file/validate-siecle-file-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/validate-learners-file/validate-siecle-file-job-controller_test.js
@@ -34,7 +34,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateSiecleFileJobContro
 
   describe('#handle', function () {
     it('should call usecase', async function () {
-      sinon.stub(usecases, 'validateSiecleXmlFile');
+      sinon.stub(usecases, 'validateSiecleFile');
       // given
       const handler = new ValidateSiecleFileJobController();
       const data = { organizationImportId: Symbol('organizationImportId') };
@@ -43,14 +43,14 @@ describe('Unit | Prescription | Application | Jobs | ValidateSiecleFileJobContro
       await handler.handle({ data });
 
       // then
-      expect(usecases.validateSiecleXmlFile).to.have.been.calledOnceWithExactly({
+      expect(usecases.validateSiecleFile).to.have.been.calledOnceWithExactly({
         organizationImportId: data.organizationImportId,
       });
     });
 
     it('should not throw when error is from domain', async function () {
       const error = new S3FileDoesNotExistError();
-      sinon.stub(usecases, 'validateSiecleXmlFile').rejects(error);
+      sinon.stub(usecases, 'validateSiecleFile').rejects(error);
 
       // given
       const warnStub = sinon.stub();
@@ -66,7 +66,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateSiecleFileJobContro
 
     it('should throw when error is not from domain', async function () {
       const error = new Error();
-      sinon.stub(usecases, 'validateSiecleXmlFile').rejects(error);
+      sinon.stub(usecases, 'validateSiecleFile').rejects(error);
 
       // given
       const handler = new ValidateSiecleFileJobController();

--- a/api/tests/prescription/learner-management/unit/application/jobs/validate-learners-file/validate-sup-file-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/validate-learners-file/validate-sup-file-job-controller_test.js
@@ -36,7 +36,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateSupFileJobControlle
 
   describe('#handle', function () {
     it('should call usecase with SupParser on type `ADDITIONAL_STUDENT`', async function () {
-      sinon.stub(usecases, 'validateCsvFile');
+      sinon.stub(usecases, 'validateSupFile');
       // given
       const handler = new ValidateSupFileJobController();
       const data = { organizationImportId: Symbol('organizationImportId'), locale: 'en', type: 'ADDITIONAL_STUDENT' };
@@ -45,7 +45,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateSupFileJobControlle
       await handler.handle({ data });
 
       // then
-      expect(usecases.validateCsvFile).to.have.been.calledOnceWithExactly({
+      expect(usecases.validateSupFile).to.have.been.calledOnceWithExactly({
         organizationImportId: data.organizationImportId,
         i18n: getI18n(data.locale),
         type: data.type,
@@ -54,7 +54,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateSupFileJobControlle
     });
 
     it('should call usecase with SupParser on type `REPLACE_STUDENT`', async function () {
-      sinon.stub(usecases, 'validateCsvFile');
+      sinon.stub(usecases, 'validateSupFile');
       // given
       const handler = new ValidateSupFileJobController();
       const data = { organizationImportId: Symbol('organizationImportId'), locale: 'en', type: 'REPLACE_STUDENT' };
@@ -63,7 +63,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateSupFileJobControlle
       await handler.handle({ data });
 
       // then
-      expect(usecases.validateCsvFile).to.have.been.calledOnceWithExactly({
+      expect(usecases.validateSupFile).to.have.been.calledOnceWithExactly({
         organizationImportId: data.organizationImportId,
         i18n: getI18n(data.locale),
         type: data.type,
@@ -73,7 +73,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateSupFileJobControlle
 
     it('should not throw when error is from domain', async function () {
       const error = new S3FileDoesNotExistError();
-      sinon.stub(usecases, 'validateCsvFile').rejects(error);
+      sinon.stub(usecases, 'validateSupFile').rejects(error);
 
       // given
       const warnStub = sinon.stub();
@@ -89,7 +89,7 @@ describe('Unit | Prescription | Application | Jobs | ValidateSupFileJobControlle
 
     it('should throw when error is not from domain', async function () {
       const error = new Error();
-      sinon.stub(usecases, 'validateCsvFile').rejects(error);
+      sinon.stub(usecases, 'validateSupFile').rejects(error);
 
       // given
       const handler = new ValidateSupFileJobController();

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -26,7 +26,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     unlinkStub = sinon.stub();
   });
 
-  context('#importSupOrganizationLearners', function () {
+  context('#importLearnersFromSupFile', function () {
     it('should call uploadCsvFile usecase and return 200', async function () {
       const params = { id: organizationId };
       const request = {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/send-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/send-organization-learners-file_test.js
@@ -11,7 +11,7 @@ import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
   let organizationImportRepositoryStub,
     organizationLearnerImportFormatRepositoryStub,
-    validateCommonOrganizationImportFileJobRepositoryStub,
+    validateGenericFileJobRepositoryStub,
     organizationLearnerRepositoryStub,
     commonCsvLearnerParserStub,
     dependencieStub,
@@ -46,11 +46,11 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
       deleteFile: sinon.stub(),
     };
 
-    validateCommonOrganizationImportFileJobRepositoryStub = {
+    validateGenericFileJobRepositoryStub = {
       performAsync: sinon.stub(),
     };
 
-    validateCommonOrganizationImportFileJobRepositoryStub.performAsync
+    validateGenericFileJobRepositoryStub.performAsync
       .withArgs(new ValidateGenericFileJob({ organizationImportId }))
       .resolves();
 
@@ -112,7 +112,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
         organizationImportRepository: organizationImportRepositoryStub,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
         organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-        validateCommonOrganizationImportFileJobRepository: validateCommonOrganizationImportFileJobRepositoryStub,
+        validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
         dependencies: dependencieStub,
       });
 
@@ -139,7 +139,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
         organizationImportRepository: organizationImportRepositoryStub,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
         organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-        validateCommonOrganizationImportFileJobRepository: validateCommonOrganizationImportFileJobRepositoryStub,
+        validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
         dependencies: dependencieStub,
       });
 
@@ -175,7 +175,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationLearnerRepository: organizationLearnerRepositoryStub,
           organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-          validateCommonOrganizationImportFileJobRepository: validateCommonOrganizationImportFileJobRepositoryStub,
+          validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
           dependencies: dependencieStub,
         });
 
@@ -204,7 +204,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationLearnerRepository: organizationLearnerRepositoryStub,
           organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-          validateCommonOrganizationImportFileJobRepository: validateCommonOrganizationImportFileJobRepositoryStub,
+          validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
           dependencies: dependencieStub,
         });
 
@@ -245,7 +245,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
             organizationImportRepository: organizationImportRepositoryStub,
             organizationLearnerRepository: organizationLearnerRepositoryStub,
             organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-            validateCommonOrganizationImportFileJobRepository: validateCommonOrganizationImportFileJobRepositoryStub,
+            validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
             dependencies: dependencieStub,
           });
         } catch {
@@ -270,7 +270,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
             organizationImportRepository: organizationImportRepositoryStub,
             organizationLearnerRepository: organizationLearnerRepositoryStub,
             organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-            validateCommonOrganizationImportFileJobRepository: validateCommonOrganizationImportFileJobRepositoryStub,
+            validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
             dependencies: dependencieStub,
           });
         } catch {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-fregata-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-fregata-file_test.js
@@ -1,13 +1,13 @@
 import sinon from 'sinon';
 
-import { OrganizationImportStatus } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
-import { importOrganizationLearnersFromSIECLECSVFormat } from '../../../../../../src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js';
-import { FregataParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/parsers/fregata-parser.js';
-import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
-import { expect } from '../../../../../test-helper.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
+import { OrganizationImportStatus } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
+import { importLearnersFromFregataFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-fregata-file.js';
+import { FregataParser } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/parsers/fregata-parser.js';
+import { DomainTransaction } from '../../../../../../../src/shared/domain/DomainTransaction.js';
+import { expect } from '../../../../../../test-helper.js';
+import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 
-describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', function () {
+describe('Unit | UseCase | importLearnersFromFregataFile', function () {
   let organizationId,
     organizationImportId,
     learners,
@@ -71,7 +71,7 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
 
   context('when there is no errors', function () {
     it('add learners from csv fivle', async function () {
-      await importOrganizationLearnersFromSIECLECSVFormat({
+      await importLearnersFromFregataFile({
         organizationImportId,
         i18n,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
@@ -101,7 +101,7 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
     });
 
     it('should chunk the called insertion', async function () {
-      await importOrganizationLearnersFromSIECLECSVFormat({
+      await importLearnersFromFregataFile({
         organizationImportId,
         i18n,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
@@ -117,7 +117,7 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
     });
 
     it('should delete file on s3', async function () {
-      await importOrganizationLearnersFromSIECLECSVFormat({
+      await importLearnersFromFregataFile({
         organizationImportId,
         i18n,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
@@ -130,7 +130,7 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
 
     it('should save imported state', async function () {
       // when
-      await importOrganizationLearnersFromSIECLECSVFormat({
+      await importLearnersFromFregataFile({
         organizationImportId,
         i18n,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
@@ -151,7 +151,7 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
 
     it('should save IMPORT_ERROR status with error', async function () {
       // when
-      const error = await catchErr(importOrganizationLearnersFromSIECLECSVFormat)({
+      const error = await catchErr(importLearnersFromFregataFile)({
         organizationImportId,
         i18n,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
@@ -166,7 +166,7 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
     });
 
     it('should delete file on s3', async function () {
-      await catchErr(importOrganizationLearnersFromSIECLECSVFormat)({
+      await catchErr(importLearnersFromFregataFile)({
         organizationImportId,
         i18n,
         organizationLearnerRepository: organizationLearnerRepositoryStub,

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-generic-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-generic-file_test.js
@@ -2,12 +2,12 @@ import sinon from 'sinon';
 
 import { AggregateImportError } from '../../../../../../../src/prescription/learner-management/domain/errors.js';
 import { ImportOrganizationLearnerSet } from '../../../../../../../src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js';
-import { saveOrganizationLearnersFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js';
+import { importLearnersFromGenericFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-generic-file.js';
 import { GenericParser } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/parsers/generic-parser.js';
 import { expect } from '../../../../../../test-helper.js';
 import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 
-describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
+describe('Unit | UseCase | importLearnersFromGenericFile', function () {
   let organizationImportRepositoryStub,
     organizationLearnerImportFormatRepositoryStub,
     commonCsvLearnerParserStub,
@@ -121,7 +121,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
       organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).rejects(error);
 
       // when
-      const saveError = await catchErr(saveOrganizationLearnersFile)({
+      const saveError = await catchErr(importLearnersFromGenericFile)({
         organizationImportId,
         importStorage: importStorageStub,
         organizationImportRepository: organizationImportRepositoryStub,
@@ -157,7 +157,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
         organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).rejects(error);
 
         // when
-        await catchErr(saveOrganizationLearnersFile)({
+        await catchErr(importLearnersFromGenericFile)({
           organizationImportId,
           importStorage: importStorageStub,
           organizationImportRepository: organizationImportRepositoryStub,
@@ -178,7 +178,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
         organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).rejects([error, error]);
 
         // when
-        await catchErr(saveOrganizationLearnersFile)({
+        await catchErr(importLearnersFromGenericFile)({
           organizationImportId,
           importStorage: importStorageStub,
           organizationImportRepository: organizationImportRepositoryStub,

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-siecle-file_test.js
@@ -1,13 +1,13 @@
 import sinon from 'sinon';
 
-import { addOrUpdateOrganizationLearners } from '../../../../../../src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js';
-import { SiecleParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/xml/siecle-parser.js';
-import { SiecleFileStreamer } from '../../../../../../src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js';
-import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
-import { expect } from '../../../../../test-helper.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
+import { importLearnersFromSiecleFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-siecle-file.js';
+import { SiecleParser } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/xml/siecle-parser.js';
+import { SiecleFileStreamer } from '../../../../../../../src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js';
+import { DomainTransaction } from '../../../../../../../src/shared/domain/DomainTransaction.js';
+import { expect } from '../../../../../../test-helper.js';
+import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 
-describe('Unit | UseCase | add-or-update-organization-learners', function () {
+describe('Unit | UseCase | importLearnersFromSiecleFile', function () {
   const organizationImportId = 1234;
   let organizationId;
   let organizationLearnerRepositoryStub;
@@ -66,7 +66,7 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
   it('should save learners', async function () {
     organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners.resolves();
 
-    await addOrUpdateOrganizationLearners({
+    await importLearnersFromSiecleFile({
       organizationImportId,
       importStorage: importStorageStub,
       organizationImportRepository: organizationImportRepositoryStub,
@@ -101,7 +101,7 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
   it('should handle errors', async function () {
     const s3Error = new Error('s3 error');
     importStorageStub.readFile.rejects(s3Error);
-    const error = await catchErr(addOrUpdateOrganizationLearners)({
+    const error = await catchErr(importLearnersFromSiecleFile)({
       organizationImportId,
       importStorage: importStorageStub,
       organizationImportRepository: organizationImportRepositoryStub,
@@ -118,7 +118,7 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
   it('should save import state even if deleteFile crash but log error for tracking', async function () {
     const s3DeleteError = new Error('s3 delete error');
     importStorageStub.deleteFile.rejects(s3DeleteError);
-    await addOrUpdateOrganizationLearners({
+    await importLearnersFromSiecleFile({
       organizationImportId,
       importStorage: importStorageStub,
       organizationImportRepository: organizationImportRepositoryStub,

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-sup-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-sup-file_test.js
@@ -2,18 +2,18 @@ import { Readable } from 'node:stream';
 
 import sinon from 'sinon';
 
-import { OrganizationImportStatus } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
-import { importSupOrganizationLearners } from '../../../../../../src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js';
-import { SupHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/headers/sup-header.js';
-import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { expect } from '../../../../../test-helper.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
+import { OrganizationImportStatus } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
+import { importLearnersFromSupFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-sup-file.js';
+import { SupHeader } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/headers/sup-header.js';
+import { getI18n } from '../../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { expect } from '../../../../../../test-helper.js';
+import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 
 const i18n = getI18n();
 
 const supOrganizationLearnerImportHeader = new SupHeader(i18n).columns.map((column) => column.name).join(';');
 
-describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
+describe('Unit | UseCase | importLearnersFromSupFile', function () {
   let organizationImportId, organizationId;
   let organizationImport, organizationImportRepositoryStub, supOrganizationLearnerRepositoryStub, importStorageStub;
 
@@ -49,7 +49,7 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
       organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
       importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(input));
 
-      await importSupOrganizationLearners({
+      await importLearnersFromSupFile({
         organizationImportId,
         i18n,
         supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
@@ -100,7 +100,7 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
       organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
       importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(input));
 
-      await importSupOrganizationLearners({
+      await importLearnersFromSupFile({
         organizationImportId,
         i18n,
         importStorage: importStorageStub,
@@ -125,7 +125,7 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
         importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(csvContent));
 
         // when
-        await importSupOrganizationLearners({
+        await importLearnersFromSupFile({
           organizationImportId,
           i18n,
           supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
@@ -154,7 +154,7 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
         supOrganizationLearnerRepositoryStub.addStudents.rejects(insertError);
 
         // when
-        const error = await catchErr(importSupOrganizationLearners)({
+        const error = await catchErr(importLearnersFromSupFile)({
           organizationImportId,
           i18n,
           supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
@@ -21,7 +21,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
   let s3filename;
   let filename;
   let filepath;
-  let validateOrganizationImportFileJobRepositoryStub;
+  let validateSiecleFileJobRepositoryStub;
   let domainTransactionStub;
 
   beforeEach(function () {
@@ -36,11 +36,11 @@ describe('Unit | UseCase | upload-siecle-file', function () {
 
     payload = { path: filename };
 
-    validateOrganizationImportFileJobRepositoryStub = {
+    validateSiecleFileJobRepositoryStub = {
       performAsync: sinon.stub(),
     };
 
-    validateOrganizationImportFileJobRepositoryStub.performAsync
+    validateSiecleFileJobRepositoryStub.performAsync
       .withArgs({ organizationImportId: Symbol('OrganizationImportId') })
       .resolves();
 
@@ -96,7 +96,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           siecleService: siecleServiceStub,
           importStorage: importStorageStub,
-          validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
+          validateSiecleFileJobRepository: validateSiecleFileJobRepositoryStub,
         });
 
         expect(rmStub).to.have.been.calledWithExactly('tmp', { recursive: true });
@@ -116,7 +116,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           siecleService: siecleServiceStub,
           importStorage: importStorageStub,
-          validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
+          validateSiecleFileJobRepository: validateSiecleFileJobRepositoryStub,
           dependencies: { logger: loggerStub },
         });
 
@@ -142,7 +142,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
         organizationImportRepository: organizationImportRepositoryStub,
         siecleService: siecleServiceStub,
         importStorage: importStorageStub,
-        validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
+        validateSiecleFileJobRepository: validateSiecleFileJobRepositoryStub,
       });
 
       // then
@@ -171,7 +171,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           siecleService: siecleServiceStub,
           importStorage: importStorageStub,
-          validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
+          validateSiecleFileJobRepository: validateSiecleFileJobRepositoryStub,
         });
 
         //then
@@ -181,7 +181,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           errors: [error],
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
-        expect(validateOrganizationImportFileJobRepositoryStub.performAsync).not.called;
+        expect(validateSiecleFileJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save organizationImport if zip is invalid', async function () {
@@ -197,7 +197,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           siecleService: siecleServiceStub,
           importStorage: importStorageStub,
-          validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
+          validateSiecleFileJobRepository: validateSiecleFileJobRepositoryStub,
         });
 
         //then
@@ -207,7 +207,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           errors: [zipError],
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
-        expect(validateOrganizationImportFileJobRepositoryStub.performAsync).not.called;
+        expect(validateSiecleFileJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save organizationImport if there is detectEncoding fails', async function () {
@@ -223,7 +223,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           siecleService: siecleServiceStub,
           importStorage: importStorageStub,
-          validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
+          validateSiecleFileJobRepository: validateSiecleFileJobRepositoryStub,
         });
 
         //then
@@ -233,7 +233,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           errors: [encodingError],
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
-        expect(validateOrganizationImportFileJobRepositoryStub.performAsync).not.called;
+        expect(validateSiecleFileJobRepositoryStub.performAsync).not.called;
       });
     });
   });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-fregata-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-fregata-file_test.js
@@ -23,7 +23,7 @@ describe('Unit | UseCase | validateFregataFile', function () {
     organizationImport,
     organizationImportRepositoryStub,
     importStorageStub,
-    importScoCsvOrganizationLearnersJobRepositoryStub;
+    importFromFregataJobRepositoryStub;
 
   beforeEach(function () {
     organizationImportId = Symbol('organizationImportId');
@@ -67,7 +67,7 @@ describe('Unit | UseCase | validateFregataFile', function () {
       deleteFile: sinon.stub(),
     };
 
-    importScoCsvOrganizationLearnersJobRepositoryStub = {
+    importFromFregataJobRepositoryStub = {
       performAsync: sinon.stub(),
     };
   });
@@ -86,7 +86,7 @@ describe('Unit | UseCase | validateFregataFile', function () {
         Parser: SupParser,
         organizationImportId,
         i18n,
-        importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
+        importFromFregataJobRepository: importFromFregataJobRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
       });
@@ -109,14 +109,14 @@ describe('Unit | UseCase | validateFregataFile', function () {
       await validateFregataFile({
         Parser: SupParser,
         organizationImportId,
-        importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
+        importFromFregataJobRepository: importFromFregataJobRepositoryStub,
         i18n,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
       });
 
       // then
-      expect(importScoCsvOrganizationLearnersJobRepositoryStub.performAsync).to.have.been.calledOnceWithExactly(
+      expect(importFromFregataJobRepositoryStub.performAsync).to.have.been.calledOnceWithExactly(
         new ImportFromFregataJob({
           locale: 'fr',
           organizationImportId,
@@ -147,7 +147,7 @@ describe('Unit | UseCase | validateFregataFile', function () {
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           importStorage: importStorageStub,
-          importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
+          importFromFregataJobRepository: importFromFregataJobRepositoryStub,
         });
         expect(error).to.eq(s3Error);
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
@@ -173,7 +173,7 @@ describe('Unit | UseCase | validateFregataFile', function () {
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           importStorage: importStorageStub,
-          importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
+          importFromFregataJobRepository: importFromFregataJobRepositoryStub,
         });
         expect(error).to.eq(s3Error);
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
@@ -202,7 +202,7 @@ describe('Unit | UseCase | validateFregataFile', function () {
         Parser: SupParser,
         organizationImportId,
         i18n,
-        importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
+        importFromFregataJobRepository: importFromFregataJobRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
       });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-fregata-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-fregata-file_test.js
@@ -1,30 +1,28 @@
 import iconv from 'iconv-lite';
 import sinon from 'sinon';
 
-import { IMPORT_STATUSES } from '../../../../../../src/prescription/learner-management/domain/constants.js';
-import { AggregateImportError } from '../../../../../../src/prescription/learner-management/domain/errors.js';
-import { ImportFromFregataJob } from '../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromFregataJob.js';
-import { ImportFromSupJob } from '../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromSupJob.js';
-import { OrganizationImportStatus } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
-import { validateCsvFile } from '../../../../../../src/prescription/learner-management/domain/usecases/validate-csv-file.js';
-import { SupHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/headers/sup-header.js';
-import { SupParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/parsers/sup-parser.js';
-import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { expect } from '../../../../../test-helper.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
+import { IMPORT_STATUSES } from '../../../../../../../src/prescription/learner-management/domain/constants.js';
+import { AggregateImportError } from '../../../../../../../src/prescription/learner-management/domain/errors.js';
+import { ImportFromFregataJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromFregataJob.js';
+import { OrganizationImportStatus } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
+import { validateFregataFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/validate-learners-file/validate-fregata-file.js';
+import { SupHeader } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/headers/sup-header.js';
+import { SupParser } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/parsers/sup-parser.js';
+import { getI18n } from '../../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { expect } from '../../../../../../test-helper.js';
+import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 
 const i18n = getI18n();
 
 const supOrganizationLearnerImportHeader = new SupHeader(i18n).columns.map((column) => column.name).join(';');
 
-describe('Unit | UseCase | validateCsvFile', function () {
+describe('Unit | UseCase | validateFregataFile', function () {
   let organizationImportId, organizationId;
   let csvContent,
     expectedWarnings,
     organizationImport,
     organizationImportRepositoryStub,
     importStorageStub,
-    importSupOrganizationLearnersJobRepositoryStub,
     importScoCsvOrganizationLearnersJobRepositoryStub;
 
   beforeEach(function () {
@@ -69,10 +67,6 @@ describe('Unit | UseCase | validateCsvFile', function () {
       deleteFile: sinon.stub(),
     };
 
-    importSupOrganizationLearnersJobRepositoryStub = {
-      performAsync: sinon.stub(),
-    };
-
     importScoCsvOrganizationLearnersJobRepositoryStub = {
       performAsync: sinon.stub(),
     };
@@ -88,10 +82,11 @@ describe('Unit | UseCase | validateCsvFile', function () {
         .resolves(SupParser.buildParser(csvContent, organizationId, i18n));
 
       // when
-      await validateCsvFile({
+      await validateFregataFile({
         Parser: SupParser,
         organizationImportId,
         i18n,
+        importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
       });
@@ -102,76 +97,38 @@ describe('Unit | UseCase | validateCsvFile', function () {
       expect(organizationImport.errors).to.deep.equal(expectedWarnings);
     });
 
-    describe('performJob', function () {
-      it('should perform sup job when type other than FREGATA is detected', async function () {
-        // given
-        const type = Symbol('type');
-        organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
+    it('should perform fregata job', async function () {
+      // given
+      organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
 
-        importStorageStub.getParser
-          .withArgs({ Parser: SupParser, filename: organizationImport.filename }, organizationId, i18n)
-          .resolves(SupParser.buildParser(csvContent, organizationId, i18n));
+      importStorageStub.getParser
+        .withArgs({ Parser: SupParser, filename: organizationImport.filename }, organizationId, i18n)
+        .resolves(SupParser.buildParser(csvContent, organizationId, i18n));
 
-        // when
-        await validateCsvFile({
-          Parser: SupParser,
-          type,
-          organizationImportId,
-          importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
-          i18n,
-          organizationImportRepository: organizationImportRepositoryStub,
-          importStorage: importStorageStub,
-        });
-
-        // then
-        expect(importSupOrganizationLearnersJobRepositoryStub.performAsync).to.have.been.calledOnceWithExactly(
-          new ImportFromSupJob({
-            type,
-            locale: 'fr',
-            organizationImportId,
-          }),
-        );
+      // when
+      await validateFregataFile({
+        Parser: SupParser,
+        organizationImportId,
+        importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
+        i18n,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
       });
 
-      it('should perform sco csv job when type is detected', async function () {
-        // given
-        const type = 'FREGATA';
-        organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
-
-        importStorageStub.getParser
-          .withArgs({ Parser: SupParser, filename: organizationImport.filename }, organizationId, i18n)
-          .resolves(SupParser.buildParser(csvContent, organizationId, i18n));
-
-        // when
-        await validateCsvFile({
-          Parser: SupParser,
-          type,
+      // then
+      expect(importScoCsvOrganizationLearnersJobRepositoryStub.performAsync).to.have.been.calledOnceWithExactly(
+        new ImportFromFregataJob({
+          locale: 'fr',
           organizationImportId,
-          importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
-          i18n,
-          organizationImportRepository: organizationImportRepositoryStub,
-          importStorage: importStorageStub,
-        });
-
-        // then
-        expect(importScoCsvOrganizationLearnersJobRepositoryStub.performAsync).to.have.been.calledOnceWithExactly(
-          new ImportFromFregataJob({
-            locale: 'fr',
-            organizationImportId,
-          }),
-        );
-      });
+        }),
+      );
     });
   });
 
   context('when there is errors', function () {
-    let importSupOrganizationLearnersJobRepositoryStub, organizationImportStub;
+    let organizationImportStub;
 
     beforeEach(function () {
-      importSupOrganizationLearnersJobRepositoryStub = {
-        performAsync: sinon.stub(),
-      };
-
       organizationImportStub = {
         id: 1,
         filename: Symbol('filename'),
@@ -186,11 +143,11 @@ describe('Unit | UseCase | validateCsvFile', function () {
       it('should save error when there is an error reading file from S3', async function () {
         const s3Error = new Error('s3 error');
         importStorageStub.getParser.rejects(s3Error);
-        const error = await catchErr(validateCsvFile)({
+        const error = await catchErr(validateFregataFile)({
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           importStorage: importStorageStub,
-          importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+          importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
         });
         expect(error).to.eq(s3Error);
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
@@ -212,11 +169,11 @@ describe('Unit | UseCase | validateCsvFile', function () {
         const s3Error = new Error('s3 error');
         importStorageStub.deleteFile.rejects(s3Error);
 
-        const error = await catchErr(validateCsvFile)({
+        const error = await catchErr(validateFregataFile)({
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           importStorage: importStorageStub,
-          importSupOrganizationLearnersJobRepositoryStub: importSupOrganizationLearnersJobRepositoryStub,
+          importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
         });
         expect(error).to.eq(s3Error);
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
@@ -241,10 +198,11 @@ describe('Unit | UseCase | validateCsvFile', function () {
         .resolves(SupParser.buildParser(csvContent, organizationId, i18n));
 
       // when
-      await catchErr(validateCsvFile)({
+      await catchErr(validateFregataFile)({
         Parser: SupParser,
         organizationImportId,
         i18n,
+        importScoCsvOrganizationLearnersJobRepository: importScoCsvOrganizationLearnersJobRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
       });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-generic-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-generic-file_test.js
@@ -3,12 +3,12 @@ import sinon from 'sinon';
 import { AggregateImportError } from '../../../../../../../src/prescription/learner-management/domain/errors.js';
 import { ImportOrganizationLearnerSet } from '../../../../../../../src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js';
 import { ImportFromGenericFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromGenericFileJob.js';
-import { validateOrganizationLearnersFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/import-from-feature/validate-organization-learners-file.js';
+import { validateGenericFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js';
 import { GenericParser } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/parsers/generic-parser.js';
 import { expect } from '../../../../../../test-helper.js';
 import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 
-describe('Unit | UseCase | validateOrganizationLearnersFile', function () {
+describe('Unit | UseCase | validateGenericFile', function () {
   let organizationImportRepositoryStub,
     organizationLearnerImportFormatRepositoryStub,
     importCommonOrganizationLearnersJobRepositoryStub,
@@ -104,7 +104,7 @@ describe('Unit | UseCase | validateOrganizationLearnersFile', function () {
       importOrganizationLearnerSetStub.addLearners.withArgs(parsedLearners);
 
       // when
-      await validateOrganizationLearnersFile({
+      await validateGenericFile({
         organizationImportId,
         importStorage: importStorageStub,
         organizationImportRepository: organizationImportRepositoryStub,
@@ -134,7 +134,7 @@ describe('Unit | UseCase | validateOrganizationLearnersFile', function () {
         organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).rejects(error);
 
         // when
-        const validateError = await catchErr(validateOrganizationLearnersFile)({
+        const validateError = await catchErr(validateGenericFile)({
           organizationImportId,
           importStorage: importStorageStub,
           organizationImportRepository: organizationImportRepositoryStub,
@@ -161,7 +161,7 @@ describe('Unit | UseCase | validateOrganizationLearnersFile', function () {
           organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).rejects(error);
 
           // when
-          await catchErr(validateOrganizationLearnersFile)({
+          await catchErr(validateGenericFile)({
             organizationImportId,
             importStorage: importStorageStub,
             organizationImportRepository: organizationImportRepositoryStub,
@@ -184,7 +184,7 @@ describe('Unit | UseCase | validateOrganizationLearnersFile', function () {
           organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).rejects([error, error]);
 
           // when
-          await catchErr(validateOrganizationLearnersFile)({
+          await catchErr(validateGenericFile)({
             organizationImportId,
             importStorage: importStorageStub,
             organizationImportRepository: organizationImportRepositoryStub,

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-generic-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-generic-file_test.js
@@ -11,7 +11,7 @@ import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 describe('Unit | UseCase | validateGenericFile', function () {
   let organizationImportRepositoryStub,
     organizationLearnerImportFormatRepositoryStub,
-    importCommonOrganizationLearnersJobRepositoryStub,
+    importFromGenericFileJobRepositoryStub,
     commonCsvLearnerParserStub,
     importOrganizationLearnerSetStub,
     dependencieStub,
@@ -43,9 +43,9 @@ describe('Unit | UseCase | validateGenericFile', function () {
       deleteFile: sinon.stub(),
     };
 
-    importCommonOrganizationLearnersJobRepositoryStub = { performAsync: sinon.stub() };
+    importFromGenericFileJobRepositoryStub = { performAsync: sinon.stub() };
 
-    importCommonOrganizationLearnersJobRepositoryStub.performAsync
+    importFromGenericFileJobRepositoryStub.performAsync
       .withArgs(new ImportFromGenericFileJob({ organizationImportId }))
       .resolves();
 
@@ -109,7 +109,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
         importStorage: importStorageStub,
         organizationImportRepository: organizationImportRepositoryStub,
         organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-        importCommonOrganizationLearnersJobRepository: importCommonOrganizationLearnersJobRepositoryStub,
+        importFromGenericFileJobRepository: importFromGenericFileJobRepositoryStub,
         dependencies: dependencieStub,
       });
 
@@ -139,7 +139,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
           importStorage: importStorageStub,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-          importCommonOrganizationLearnersJobRepository: importCommonOrganizationLearnersJobRepositoryStub,
+          importFromGenericFileJobRepository: importFromGenericFileJobRepositoryStub,
           dependencies: dependencieStub,
         });
 
@@ -166,7 +166,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
             importStorage: importStorageStub,
             organizationImportRepository: organizationImportRepositoryStub,
             organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-            importCommonOrganizationLearnersJobRepository: importCommonOrganizationLearnersJobRepositoryStub,
+            importFromGenericFileJobRepository: importFromGenericFileJobRepositoryStub,
             dependencies: dependencieStub,
           });
 
@@ -189,7 +189,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
             importStorage: importStorageStub,
             organizationImportRepository: organizationImportRepositoryStub,
             organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-            importCommonOrganizationLearnersJobRepository: importCommonOrganizationLearnersJobRepositoryStub,
+            importFromGenericFileJobRepository: importFromGenericFileJobRepositoryStub,
             dependencies: dependencieStub,
           });
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-siecle-file_test.js
@@ -3,14 +3,14 @@ import sinon from 'sinon';
 import {
   AggregateImportError,
   SiecleXmlImportError,
-} from '../../../../../../src/prescription/learner-management/domain/errors.js';
-import { ImportFromSiecleJob } from '../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromSiecleJob.js';
-import { validateSiecleXmlFile } from '../../../../../../src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js';
-import { SiecleParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/xml/siecle-parser.js';
-import { SiecleFileStreamer } from '../../../../../../src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js';
-import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
-import { expect } from '../../../../../test-helper.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
+} from '../../../../../../../src/prescription/learner-management/domain/errors.js';
+import { ImportFromSiecleJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromSiecleJob.js';
+import { validateSiecleFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/validate-learners-file/validate-siecle-file.js';
+import { SiecleParser } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/xml/siecle-parser.js';
+import { SiecleFileStreamer } from '../../../../../../../src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js';
+import { DomainTransaction } from '../../../../../../../src/shared/domain/DomainTransaction.js';
+import { expect } from '../../../../../../test-helper.js';
+import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | validate-siecle-xml-file', function () {
   const organizationId = 1234;
@@ -75,7 +75,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
   });
 
   it('should validate the xml file', async function () {
-    await validateSiecleXmlFile({
+    await validateSiecleFile({
       organizationImportId,
       organizationImportRepository: organizationImportRepositoryStub,
       organizationRepository: organizationRepositoryStub,
@@ -93,7 +93,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
       it('should save error when there is an error reading file from S3', async function () {
         const s3Error = new Error('s3 error');
         importStorageStub.readFile.rejects(s3Error);
-        const error = await catchErr(validateSiecleXmlFile)({
+        const error = await catchErr(validateSiecleFile)({
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
@@ -113,7 +113,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
         parserStub.parse.rejects(new AggregateImportError([new Error('parsing')]));
         const s3Error = new Error('s3 error');
         importStorageStub.deleteFile.rejects(s3Error);
-        const error = await catchErr(validateSiecleXmlFile)({
+        const error = await catchErr(validateSiecleFile)({
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
@@ -133,7 +133,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
       it('should save parsing errors', async function () {
         const parsingErrors = [new Error('parsing'), new Error('parsing2')];
         parserStub.parse.rejects(new AggregateImportError(parsingErrors));
-        const error = await catchErr(validateSiecleXmlFile)({
+        const error = await catchErr(validateSiecleFile)({
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
@@ -152,7 +152,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
       it('should save empty learner error', async function () {
         parserStub.parse.resolves([]);
 
-        const error = await catchErr(validateSiecleXmlFile)({
+        const error = await catchErr(validateSiecleFile)({
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-siecle-file_test.js
@@ -25,13 +25,13 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
   let dataStub;
   let externalIdSymbol;
   let domainTransactionStub;
-  let importOrganizationLearnersJobRepositoryStub;
+  let importFromSiecleJobRepositoryStub;
 
   beforeEach(function () {
     domainTransactionStub = Symbol('domainTransaction');
     sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn(domainTransactionStub));
 
-    importOrganizationLearnersJobRepositoryStub = {
+    importFromSiecleJobRepositoryStub = {
       performAsync: sinon.stub(),
     };
 
@@ -46,7 +46,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
       validate: sinon.stub(),
     };
 
-    importOrganizationLearnersJobRepositoryStub.performAsync
+    importFromSiecleJobRepositoryStub.performAsync
       .withArgs(new ImportFromSiecleJob({ organizationLearnerId: 1 }))
       .resolves();
     organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImportStub);
@@ -80,7 +80,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
       organizationImportRepository: organizationImportRepositoryStub,
       organizationRepository: organizationRepositoryStub,
       importStorage: importStorageStub,
-      importOrganizationLearnersJobRepository: importOrganizationLearnersJobRepositoryStub,
+      importFromSiecleJobRepository: importFromSiecleJobRepositoryStub,
     });
     expect(parserStub.parseUAJ).to.have.been.calledWithExactly(externalIdSymbol);
     expect(parserStub.parse).to.have.been.calledWithExactly();
@@ -98,7 +98,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
           importStorage: importStorageStub,
-          importOrganizationLearnersJobRepository: importOrganizationLearnersJobRepositoryStub,
+          importFromSiecleJobRepository: importFromSiecleJobRepositoryStub,
         });
         expect(error).to.eq(s3Error);
         expect(organizationImportStub.validate).to.have.been.calledWith({ errors: [s3Error] });
@@ -106,7 +106,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           filename: organizationImportStub.filename,
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
-        expect(importOrganizationLearnersJobRepositoryStub.performAsync).not.called;
+        expect(importFromSiecleJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save error when there is an error deleting file from S3', async function () {
@@ -118,14 +118,14 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
           importStorage: importStorageStub,
-          importOrganizationLearnersJobRepository: importOrganizationLearnersJobRepositoryStub,
+          importFromSiecleJobRepository: importFromSiecleJobRepositoryStub,
         });
         expect(error).to.eq(s3Error);
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
           filename: organizationImportStub.filename,
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
-        expect(importOrganizationLearnersJobRepositoryStub.performAsync).not.called;
+        expect(importFromSiecleJobRepositoryStub.performAsync).not.called;
       });
     });
 
@@ -138,7 +138,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
           importStorage: importStorageStub,
-          importOrganizationLearnersJobRepository: importOrganizationLearnersJobRepositoryStub,
+          importFromSiecleJobRepository: importFromSiecleJobRepositoryStub,
         });
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
           filename: organizationImportStub.filename,
@@ -146,7 +146,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
         expect(error).to.be.instanceof(AggregateImportError);
         expect(organizationImportStub.validate).to.have.been.calledWith({ errors: parsingErrors });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
-        expect(importOrganizationLearnersJobRepositoryStub.performAsync).not.called;
+        expect(importFromSiecleJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save empty learner error', async function () {
@@ -157,7 +157,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
           importStorage: importStorageStub,
-          importOrganizationLearnersJobRepository: importOrganizationLearnersJobRepositoryStub,
+          importFromSiecleJobRepository: importFromSiecleJobRepositoryStub,
         });
 
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
@@ -168,7 +168,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           true,
         );
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
-        expect(importOrganizationLearnersJobRepositoryStub.performAsync).not.called;
+        expect(importFromSiecleJobRepositoryStub.performAsync).not.called;
       });
     });
   });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-sup-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-sup-file_test.js
@@ -23,7 +23,7 @@ describe('Unit | UseCase | validateSupFile', function () {
     organizationImport,
     organizationImportRepositoryStub,
     importStorageStub,
-    importSupOrganizationLearnersJobRepositoryStub;
+    importFromSupJobRepositoryStub;
 
   beforeEach(function () {
     organizationImportId = Symbol('organizationImportId');
@@ -67,7 +67,7 @@ describe('Unit | UseCase | validateSupFile', function () {
       deleteFile: sinon.stub(),
     };
 
-    importSupOrganizationLearnersJobRepositoryStub = {
+    importFromSupJobRepositoryStub = {
       performAsync: sinon.stub(),
     };
   });
@@ -86,7 +86,7 @@ describe('Unit | UseCase | validateSupFile', function () {
         Parser: SupParser,
         organizationImportId,
         i18n,
-        importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+        importFromSupJobRepository: importFromSupJobRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
       });
@@ -111,14 +111,14 @@ describe('Unit | UseCase | validateSupFile', function () {
         Parser: SupParser,
         type,
         organizationImportId,
-        importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+        importFromSupJobRepository: importFromSupJobRepositoryStub,
         i18n,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
       });
 
       // then
-      expect(importSupOrganizationLearnersJobRepositoryStub.performAsync).to.have.been.calledOnceWithExactly(
+      expect(importFromSupJobRepositoryStub.performAsync).to.have.been.calledOnceWithExactly(
         new ImportFromSupJob({
           type,
           locale: 'fr',
@@ -150,7 +150,7 @@ describe('Unit | UseCase | validateSupFile', function () {
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           importStorage: importStorageStub,
-          importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+          importFromSupJobRepository: importFromSupJobRepositoryStub,
         });
         expect(error).to.eq(s3Error);
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
@@ -176,7 +176,7 @@ describe('Unit | UseCase | validateSupFile', function () {
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           importStorage: importStorageStub,
-          importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+          importFromSupJobRepository: importFromSupJobRepositoryStub,
         });
         expect(error).to.eq(s3Error);
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
@@ -205,7 +205,7 @@ describe('Unit | UseCase | validateSupFile', function () {
         Parser: SupParser,
         organizationImportId,
         i18n,
-        importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+        importFromSupJobRepository: importFromSupJobRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
       });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-sup-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-sup-file_test.js
@@ -1,0 +1,217 @@
+import iconv from 'iconv-lite';
+import sinon from 'sinon';
+
+import { IMPORT_STATUSES } from '../../../../../../../src/prescription/learner-management/domain/constants.js';
+import { AggregateImportError } from '../../../../../../../src/prescription/learner-management/domain/errors.js';
+import { ImportFromSupJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromSupJob.js';
+import { OrganizationImportStatus } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
+import { validateSupFile } from '../../../../../../../src/prescription/learner-management/domain/usecases/validate-learners-file/validate-sup-file.js';
+import { SupHeader } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/headers/sup-header.js';
+import { SupParser } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/parsers/sup-parser.js';
+import { getI18n } from '../../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { expect } from '../../../../../../test-helper.js';
+import { catchErr } from '../../../../../../tooling/test-utils/error.js';
+
+const i18n = getI18n();
+
+const supOrganizationLearnerImportHeader = new SupHeader(i18n).columns.map((column) => column.name).join(';');
+
+describe('Unit | UseCase | validateSupFile', function () {
+  let organizationImportId, organizationId;
+  let csvContent,
+    expectedWarnings,
+    organizationImport,
+    organizationImportRepositoryStub,
+    importStorageStub,
+    importSupOrganizationLearnersJobRepositoryStub;
+
+  beforeEach(function () {
+    organizationImportId = Symbol('organizationImportId');
+    organizationId = 1234;
+    csvContent = iconv.encode(
+      `${supOrganizationLearnerImportHeader}
+    Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+    `.trim(),
+      'utf-8',
+    );
+
+    expectedWarnings = [
+      {
+        studentNumber: '123456',
+        field: 'study-scheme',
+        value: 'BAD',
+        code: 'unknown',
+      },
+      {
+        studentNumber: '123456',
+        field: 'diploma',
+        value: 'BAD',
+        code: 'unknown',
+      },
+    ];
+    organizationImport = new OrganizationImportStatus({
+      id: organizationImportId,
+      filename: 'file.csv',
+      organizationId,
+      createdBy: 2,
+      encoding: 'utf-8',
+    });
+
+    organizationImportRepositoryStub = {
+      get: sinon.stub(),
+      save: sinon.stub(),
+    };
+
+    importStorageStub = {
+      getParser: sinon.stub(),
+      deleteFile: sinon.stub(),
+    };
+
+    importSupOrganizationLearnersJobRepositoryStub = {
+      performAsync: sinon.stub(),
+    };
+  });
+
+  context('when there is no errors', function () {
+    it('should save validated state', async function () {
+      // given
+      organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
+
+      importStorageStub.getParser
+        .withArgs({ Parser: SupParser, filename: organizationImport.filename }, organizationId, i18n)
+        .resolves(SupParser.buildParser(csvContent, organizationId, i18n));
+
+      // when
+      await validateSupFile({
+        Parser: SupParser,
+        organizationImportId,
+        i18n,
+        importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+      });
+
+      // then
+      expect(organizationImportRepositoryStub.save).to.have.been.calledOnceWithExactly(organizationImport);
+      expect(organizationImport.status).to.equal(IMPORT_STATUSES.VALIDATED);
+      expect(organizationImport.errors).to.deep.equal(expectedWarnings);
+    });
+
+    it('should perform sup job', async function () {
+      // given
+      const type = Symbol('type');
+      organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
+
+      importStorageStub.getParser
+        .withArgs({ Parser: SupParser, filename: organizationImport.filename }, organizationId, i18n)
+        .resolves(SupParser.buildParser(csvContent, organizationId, i18n));
+
+      // when
+      await validateSupFile({
+        Parser: SupParser,
+        type,
+        organizationImportId,
+        importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+        i18n,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+      });
+
+      // then
+      expect(importSupOrganizationLearnersJobRepositoryStub.performAsync).to.have.been.calledOnceWithExactly(
+        new ImportFromSupJob({
+          type,
+          locale: 'fr',
+          organizationImportId,
+        }),
+      );
+    });
+  });
+
+  context('when there is errors', function () {
+    let organizationImportStub;
+
+    beforeEach(function () {
+      organizationImportStub = {
+        id: 1,
+        filename: Symbol('filename'),
+        encoding: Symbol('encoding'),
+        validate: sinon.stub(),
+        save: sinon.stub(),
+      };
+      organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImportStub);
+    });
+
+    context('when there is s3 errors', function () {
+      it('should save error when there is an error reading file from S3', async function () {
+        const s3Error = new Error('s3 error');
+        importStorageStub.getParser.rejects(s3Error);
+        const error = await catchErr(validateSupFile)({
+          organizationImportId,
+          organizationImportRepository: organizationImportRepositoryStub,
+          importStorage: importStorageStub,
+          importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+        });
+        expect(error).to.eq(s3Error);
+        expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
+          filename: organizationImportStub.filename,
+        });
+        expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+        expect(organizationImportStub.validate).to.have.been.calledWithExactly({
+          errors: [s3Error],
+          warnings: undefined,
+        });
+      });
+
+      it('should save error when there is an error deleting file from S3', async function () {
+        const parserStub = { parse: sinon.stub() };
+        importStorageStub.getParser
+          .withArgs({ Parser: SupParser, filename: organizationImport.filename }, organizationId, i18n)
+          .resolves(parserStub);
+        parserStub.parse.rejects(new AggregateImportError([new Error('parsing')]));
+        const s3Error = new Error('s3 error');
+        importStorageStub.deleteFile.rejects(s3Error);
+
+        const error = await catchErr(validateSupFile)({
+          organizationImportId,
+          organizationImportRepository: organizationImportRepositoryStub,
+          importStorage: importStorageStub,
+          importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+        });
+        expect(error).to.eq(s3Error);
+        expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
+          filename: organizationImportStub.filename,
+        });
+        expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+      });
+    });
+
+    it('should save VALIDATION_ERROR status', async function () {
+      // given
+      organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
+      const csvContent = iconv.encode(
+        `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          `.trim(),
+        'utf-8',
+      );
+      importStorageStub.getParser
+        .withArgs({ Parser: SupParser, filename: organizationImport.filename }, organizationId, i18n)
+        .resolves(SupParser.buildParser(csvContent, organizationId, i18n));
+
+      // when
+      await catchErr(validateSupFile)({
+        Parser: SupParser,
+        organizationImportId,
+        i18n,
+        importSupOrganizationLearnersJobRepository: importSupOrganizationLearnersJobRepositoryStub,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+      });
+
+      // then
+      expect(organizationImportRepositoryStub.save.firstCall.firstArg.status).to.equal('VALIDATION_ERROR');
+    });
+  });
+});


### PR DESCRIPTION
## 🌱 Problème

Les usecases et repositories liés à l'import et à la validation de fichiers d'apprenants avaient des noms génériques ou imprécis (ex. `validate-csv-file`, `import-from-fregata-job-repository`) qui ne reflétaient pas clairement leur rôle ou leur source de données.

## 🐣 Proposition

- Renommage des usecases d'import : `import-learners-from-fregata-file`, `import-learners-from-siecle-file`, `import-learners-from-sup-file`, `import-learners-from-generic-file`
- Découpage et renommage des usecases de validation : `validate-fregata-file`, `validate-siecle-file`, `validate-sup-file`, `validate-generic-file` (en remplacement de `validate-csv-file`)
- Renommage des repositories de jobs correspondants : `import-from-fregata-job-repository`, `import-from-siecle-job-repository`, etc.

## 🌷 Remarques

Refactoring purement mécanique, aucun changement de comportement.

## 🐝 Pour tester
- [ ] Faites des imports
- [ ] 🟢 
