### PR TITLE
[TECH] Mettre à jour le package epreuves component.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@1024pix/epreuves-components": "^4.5.0",
+        "@1024pix/epreuves-components": "^4.6.0",
         "@1024pix/oppsy": "^1.0.2",
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.5.0.tgz",
-      "integrity": "sha512-dT60RFp+t3LwqYsdjB5BjV0j12wGIswffcnCLTfuLoNjqQbtchjbSOt3TK9iyvNoDqCrML1M5bf7oAy5JhiPng==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.0.tgz",
+      "integrity": "sha512-j/rvZ8NL4LccoI8er+aMeXOUXh+lP7LpTa6/X1MYMY5dGmgw82xdAEgAVTXy0l7bBqAI+4pv0E7iM9JeUzJBfg==",
       "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -91,7 +91,7 @@
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/unit/infrastructure/repositories/module-repository_test.js'"
   },
   "dependencies": {
-    "@1024pix/epreuves-components": "^4.5.0",
+    "@1024pix/epreuves-components": "^4.6.0",
     "@1024pix/oppsy": "^1.0.2",
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -187,6 +187,36 @@
           ]
         },
         {
+          "id": "a33af0d8-649b-4138-9958-e51d43010303",
+          "type": "discovery",
+          "title": "autocompletion-mdp",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "54d93d01-03f5-4297-b89c-6ea57b444f55",
+                "type": "text",
+                "content": "<p>autocompletion-mdp</p>",
+                "tag": " "
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4934fe15-f787-49fc-8ebc-12b998e4298a",
+                "type": "custom",
+                "instruction": "",
+                "tagName": "autocompletion-mdp",
+                "props": {
+                  "titleLevel": 2
+                },
+                "title": "",
+                "functionalInstruction": ""
+              }
+            }
+          ]
+        },
+        {
           "id": "5161dd9c-0ed3-43a8-b550-ced9e2c539ba",
           "type": "discovery",
           "title": "calcul-impact",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^4.5.0",
+        "@1024pix/epreuves-components": "^4.6.0",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^60.10.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.5.0.tgz",
-      "integrity": "sha512-dT60RFp+t3LwqYsdjB5BjV0j12wGIswffcnCLTfuLoNjqQbtchjbSOt3TK9iyvNoDqCrML1M5bf7oAy5JhiPng==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.0.tgz",
+      "integrity": "sha512-j/rvZ8NL4LccoI8er+aMeXOUXh+lP7LpTa6/X1MYMY5dGmgw82xdAEgAVTXy0l7bBqAI+4pv0E7iM9JeUzJBfg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^4.5.0",
+    "@1024pix/epreuves-components": "^4.6.0",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^60.10.1",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^4.5.0",
+        "@1024pix/epreuves-components": "^4.6.0",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^60.10.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.5.0.tgz",
-      "integrity": "sha512-dT60RFp+t3LwqYsdjB5BjV0j12wGIswffcnCLTfuLoNjqQbtchjbSOt3TK9iyvNoDqCrML1M5bf7oAy5JhiPng==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.0.tgz",
+      "integrity": "sha512-j/rvZ8NL4LccoI8er+aMeXOUXh+lP7LpTa6/X1MYMY5dGmgw82xdAEgAVTXy0l7bBqAI+4pv0E7iM9JeUzJBfg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^4.5.0",
+    "@1024pix/epreuves-components": "^4.6.0",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^60.10.1",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 💥 Problème

Une nouvelle version du package epreuves component est disponible

## 👩‍🚀 Proposition

Mettre à jour le package epreuves component vers la version 4.6.0.

## 👁️ Remarques

RAS

## ♻️ Pour tester
Se rendre sur la page de demo des modules et vérifier que autocompletion-mdp est disponible.
