### PR TITLE
[FEATURE] Accéder aux nouvelles données des contenus formatif dans la page de fin de parcours (PIX-22715).

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -1,3 +1,4 @@
+import { Training } from '../../../src/devcomp/domain/models/Training.js';
 import { databaseBuffer } from '../database-buffer.js';
 
 /**
@@ -13,7 +14,11 @@ import { databaseBuffer } from '../database-buffer.js';
  *  editorLogoUrl: string,
  *  isDisabled: boolean,
  *  createdAt: Date,
- *  updatedAt: Date
+ *  updatedAt: Date,
+ *  deliveryMode: string,
+ *   registrationRequired: boolean,
+ *   program: string,
+ *   objectives: string[],
  * }} Training
  */
 
@@ -30,6 +35,10 @@ function buildTraining({
   isDisabled = false,
   createdAt = new Date(),
   updatedAt = new Date(),
+  deliveryMode = Training.modes.HYBRID,
+  registrationRequired = false,
+  program = 'Programme du contenu formatif',
+  objectives = [],
 } = {}) {
   const values = {
     id,
@@ -44,6 +53,10 @@ function buildTraining({
     isDisabled,
     createdAt,
     updatedAt,
+    deliveryMode,
+    registrationRequired,
+    program,
+    objectives,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'trainings',

--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -1,3 +1,4 @@
+import { Training } from '../../../../src/devcomp/domain/models/Training.js';
 import { DEVCOMP_BASE_TRAINING_ID, PIX_EDU_SMALL_TARGET_PROFILE_ID } from './constants.js';
 
 export function buildTrainings(databaseBuilder) {
@@ -7,6 +8,7 @@ export function buildTrainings(databaseBuilder) {
     title: 'Apprendre à manger un croissant comme les français',
     internalTitle: 'Apprendre à manger un croissant comme les français',
     locales: ['fr'],
+    objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({
@@ -36,6 +38,11 @@ export function buildTrainings(databaseBuilder) {
     editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
     type: 'modulix',
     locales: ['fr'],
+    objectives: [
+      'Comprendre que les conversations avec les IA génératives sont réutilisées',
+      'Savoir rédiger un prompt qui n’inclut pas d’informations personnelles',
+    ],
+    registrationRequired: true,
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({
@@ -65,6 +72,8 @@ export function buildTrainings(databaseBuilder) {
     editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
     type: 'modulix',
     locales: ['fr'],
+    objectives: ['Connaître les principaux risques liés aux mots de passe', 'Savoir créer un mot de passe solide'],
+    deliveryMode: Training.modes.ONSITE,
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({
@@ -89,6 +98,9 @@ export function buildTrainings(databaseBuilder) {
     title: 'Apprendre à peindre comme Monet',
     internalTitle: 'Apprendre à peindre comme Monet',
     locales: ['fr-fr'],
+    objectives: ['Connaître Monet', 'Avoir les bases pour peindre'],
+    deliveryMode: Training.modes.REMOTE,
+    registrationRequired: true,
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({
@@ -118,6 +130,11 @@ export function buildTrainings(databaseBuilder) {
     editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
     type: 'modulix',
     locales: ['fr-fr'],
+    objectives: [
+      'Comprendre que les conversations avec les IA génératives sont réutilisées',
+      'Savoir rédiger un prompt qui n’inclut pas d’informations personnelles',
+    ],
+    deliveryMode: Training.modes.REMOTE,
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({
@@ -142,6 +159,7 @@ export function buildTrainings(databaseBuilder) {
     title: 'Eat a croissant like the french',
     internalTitle: 'Eat a croissant like the french',
     locales: ['en'],
+    objectives: ['How to tell if a croissant is of good quality', 'Buy a croissant to eat'],
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({

--- a/api/src/devcomp/domain/models/Training.js
+++ b/api/src/devcomp/domain/models/Training.js
@@ -1,3 +1,9 @@
+const modes = {
+  HYBRID: 'hybrid',
+  ONSITE: 'onSite',
+  REMOTE: 'remote',
+};
+
 class Training {
   constructor({
     id,
@@ -11,6 +17,10 @@ class Training {
     editorName,
     editorLogoUrl,
     trainingTriggers,
+    deliveryMode,
+    registrationRequired,
+    program,
+    objectives,
   } = {}) {
     this.id = id;
     this.title = title;
@@ -23,6 +33,10 @@ class Training {
     this.editorName = editorName;
     this.editorLogoUrl = editorLogoUrl;
     this.trainingTriggers = trainingTriggers;
+    this.deliveryMode = deliveryMode;
+    this.registrationRequired = registrationRequired;
+    this.program = program;
+    this.objectives = objectives;
   }
 
   shouldBeObtained(knowledgeElements, skills) {
@@ -34,4 +48,6 @@ class Training {
   }
 }
 
-export { Training };
+Training.modes = modes;
+
+export { modes, Training };

--- a/api/src/devcomp/domain/read-models/UserRecommendedTraining.js
+++ b/api/src/devcomp/domain/read-models/UserRecommendedTraining.js
@@ -1,5 +1,18 @@
 class UserRecommendedTraining {
-  constructor({ id, title, link, type, duration, locales, editorName, editorLogoUrl } = {}) {
+  constructor({
+    id,
+    title,
+    link,
+    type,
+    duration,
+    locales,
+    editorName,
+    editorLogoUrl,
+    deliveryMode,
+    registrationRequired,
+    program,
+    objectives,
+  } = {}) {
     this.id = id;
     this.title = title;
     this.link = link;
@@ -8,6 +21,10 @@ class UserRecommendedTraining {
     this.locales = locales;
     this.editorName = editorName;
     this.editorLogoUrl = editorLogoUrl;
+    this.deliveryMode = deliveryMode;
+    this.registrationRequired = registrationRequired;
+    this.program = program;
+    this.objectives = objectives;
   }
 }
 

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -94,6 +94,10 @@ const serialize = function (training = {}, meta) {
       'editorName',
       'editorLogoUrl',
       'targetProfileSummaries',
+      'deliveryMode',
+      'registrationRequired',
+      'program',
+      'objectives',
     ],
     targetProfileSummaries: {
       ref: 'id',

--- a/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -1,4 +1,5 @@
 import { createServer } from '../../../../../server.js';
+import { Training } from '../../../../../src/devcomp/domain/models/Training.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
@@ -44,6 +45,10 @@ describe('Acceptance | API | Campaign Participations', function () {
         type: training.type,
         'editor-name': training.editorName,
         'editor-logo-url': training.editorLogoUrl,
+        'delivery-mode': Training.modes.HYBRID,
+        'registration-required': false,
+        program: 'Programme du contenu formatif',
+        objectives: [],
       });
     });
   });

--- a/api/tests/devcomp/acceptance/application/user-trainings/users-trainings-route_test.js
+++ b/api/tests/devcomp/acceptance/application/user-trainings/users-trainings-route_test.js
@@ -1,4 +1,5 @@
 import { createServer } from '../../../../../server.js';
+import { Training } from '../../../../../src/devcomp/domain/models/Training.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
@@ -42,6 +43,10 @@ describe('Acceptance | Routes | UserTrainingsRoute', function () {
             duration: { days: 0, hours: 6, minutes: 0 },
             link: 'http://mon-link.com',
             locales: ['fr-fr'],
+            objectives: [],
+            program: 'Programme du contenu formatif',
+            'registration-required': false,
+            'delivery-mode': Training.modes.HYBRID,
             title: 'title',
             type: 'webinaire',
             'editor-name': "Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité",

--- a/api/tests/devcomp/unit/domain/models/Training_test.js
+++ b/api/tests/devcomp/unit/domain/models/Training_test.js
@@ -31,16 +31,25 @@ describe('Unit | Devcomp | Domain | Models | Training', function () {
       });
 
       // then
-      expect(training.id).to.equal(1);
-      expect(training.title).to.equal('Training 1');
-      expect(training.link).to.equal('https://example.net');
-      expect(training.type).to.equal('webinar');
-      expect(training.duration).to.deep.equal({ hours: 5 });
-      expect(training.locales).to.deep.equal(['fr-fr']);
-      expect(training.targetProfileIds).to.deep.equal([1]);
-      expect(training.editorName).to.equal('Example');
-      expect(training.editorLogoUrl).to.equal('https://example.net/logo.svg');
-      expect(training.trainingTriggers).to.deep.equal(trainingTriggers);
+      expect(training).to.deep.equal({
+        deliveryMode: 'remote',
+        duration: {
+          hours: 5,
+        },
+        editorLogoUrl: 'https://example.net/logo.svg',
+        editorName: 'Example',
+        id: 1,
+        internalTitle: 'Training 1 internal title',
+        link: 'https://example.net',
+        locales: ['fr-fr'],
+        objectives: ['objective 1', 'objective 2'],
+        program: 'training program',
+        registrationRequired: false,
+        targetProfileIds: [1],
+        title: 'Training 1',
+        trainingTriggers,
+        type: 'webinar',
+      });
     });
   });
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -1,3 +1,4 @@
+import { Training } from '../../../../../../src/devcomp/domain/models/Training.js';
 import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -345,6 +346,10 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             locales: ['fr-fr'],
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/editor_logo_url.svg',
+            'delivery-mode': Training.modes.REMOTE,
+            objectives: ['objective 1', 'objective 2'],
+            program: 'training program',
+            'registration-required': false,
           },
           relationships: {
             'target-profile-summaries': {
@@ -391,6 +396,10 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             locales: ['fr-fr'],
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/editor_logo_url.svg',
+            'delivery-mode': Training.modes.REMOTE,
+            objectives: ['objective 1', 'objective 2'],
+            program: 'training program',
+            'registration-required': false,
           },
           relationships: {
             'target-profile-summaries': {

--- a/api/tests/tooling/domain-builder/factory/build-training.js
+++ b/api/tests/tooling/domain-builder/factory/build-training.js
@@ -14,6 +14,10 @@ const buildTraining = function ({
   editorName = 'Ministère education nationale',
   editorLogoUrl = 'https://assets.pix.org/contenu-formatif/editeur/editor_logo_url.svg',
   trainingTriggers,
+  deliveryMode = Training.modes.REMOTE,
+  registrationRequired = false,
+  program = 'training program',
+  objectives = ['objective 1', 'objective 2'],
 } = {}) {
   return new Training({
     id,
@@ -27,6 +31,10 @@ const buildTraining = function ({
     editorName,
     editorLogoUrl,
     trainingTriggers,
+    deliveryMode,
+    registrationRequired,
+    program,
+    objectives,
   });
 };
 


### PR DESCRIPTION
## 💥 Problème

Les nouvelles colonnes sont disponibles dans la table `trainings` : "deliveryMode", "objectives", "program" et "registration-required".

Ces nouvelles données doivent être accessibles depuis la page de fin de parcours sur Pix App

## 👩‍🚀 Proposition

Coté API uniquement, remonter les nouvelles infos des contenus formatif.

## 🦀 Remarques

Le dernier commit met à jour 2 tests d'acceptance car 2 routes sont impactés dans cette modification : 

- la route des trainings remontés dans la page de fin de parcours (celle du chantier en cours)
- la route des trainings remontés pour l'utilisateur quand il consulte sa page formations.

Si la route des trainings de l'utilisateur n'est pas concerné par le chantier actuel, il est prévue qu'elle profite d'une mise à jour future qui comprendra l'ajout des nouvelles infos.

## ♻️ Pour tester

Se connecter sur Pix App avec dave-comp@example.net

https://app-pr16209.review.pix.fr/campagnes/EDUMULTIP/evaluation/resultats

Ouvrir la console et constater que la route des contenu formatif remonte les nouvelles données.


<img width="1456" height="798" alt="Capture d’écran 2026-05-13 à 11 39 28" src="https://github.com/user-attachments/assets/aceba544-9f3f-48b8-b66b-8ea91e3e2c84" />
