### PR TITLE
[BUGFIX] Corrige l'erreur sur la route `/api/junior/activity-answer` (PIX-22740)

### DIFF
--- a/api/src/school/domain/services/correct-answer.js
+++ b/api/src/school/domain/services/correct-answer.js
@@ -6,9 +6,9 @@ import { Assessment } from '../models/Assessment.js';
 const correctAnswer = async function ({
   activityAnswer,
   assessmentId,
+  activityId,
   activityAnswerRepository,
   challengeRepository,
-  activityRepository,
   assessmentRepository,
   examiner: injectedExaminer,
 } = {}) {
@@ -22,7 +22,6 @@ const correctAnswer = async function ({
     throw new ChallengeNotAskedError();
   }
 
-  const activityId = (await activityRepository.getLastActivity(assessmentId)).id;
   const challenge = await challengeRepository.get(activityAnswer.challengeId);
   const examiner = injectedExaminer ?? new Examiner({ validator: challenge.validator });
   const correctedAnswer = examiner.evaluate({
@@ -30,7 +29,8 @@ const correctAnswer = async function ({
     challengeFormat: challenge.format,
   });
 
-  return await activityAnswerRepository.save({ ...correctedAnswer, activityId });
+  const correctAnswerInDb = await activityAnswerRepository.save({ ...correctedAnswer, activityId });
+  return correctAnswerInDb;
 };
 
 export { correctAnswer };

--- a/api/src/school/domain/services/update-current-activity.js
+++ b/api/src/school/domain/services/update-current-activity.js
@@ -4,13 +4,11 @@ import { ActivityInfo } from '../models/ActivityInfo.js';
 export async function updateCurrentActivity({
   assessmentId,
   lastActivity,
+  lastAnswer,
   activityRepository,
-  activityAnswerRepository,
   missionAssessmentRepository,
   missionRepository,
 }) {
-  const lastAnswer = await activityAnswerRepository.findLastByActivity(lastActivity.id);
-
   if (lastAnswer.result.isOK() || lastActivity.isTutorial) {
     const { missionId } = await missionAssessmentRepository.getByAssessmentId(assessmentId);
     const mission = await missionRepository.get(missionId);

--- a/api/src/school/domain/services/update-current-activity.js
+++ b/api/src/school/domain/services/update-current-activity.js
@@ -3,12 +3,12 @@ import { ActivityInfo } from '../models/ActivityInfo.js';
 
 export async function updateCurrentActivity({
   assessmentId,
+  lastActivity,
   activityRepository,
   activityAnswerRepository,
   missionAssessmentRepository,
   missionRepository,
 }) {
-  const lastActivity = await activityRepository.getLastActivity(assessmentId);
   const lastAnswer = await activityAnswerRepository.findLastByActivity(lastActivity.id);
 
   if (lastAnswer.result.isOK() || lastActivity.isTutorial) {
@@ -17,6 +17,7 @@ export async function updateCurrentActivity({
     if (_isActivityFinished(mission, lastActivity, lastAnswer)) {
       return activityRepository.updateStatus({ activityId: lastActivity.id, status: Activity.status.SUCCEEDED });
     }
+
     return lastActivity;
   }
   if (lastAnswer.result.isKO()) {

--- a/api/src/school/domain/usecases/handle-activity-answer.js
+++ b/api/src/school/domain/usecases/handle-activity-answer.js
@@ -16,8 +16,11 @@ const handleActivityAnswer = async function ({
   missionRepository,
 }) {
   return DomainTransaction.execute(async () => {
+    let lastActivity = await activityRepository.getLastActivity(assessmentId);
+
     const correctedAnswer = await correctAnswer({
       activityAnswer,
+      activityId: lastActivity.id,
       assessmentId,
       challengeRepository,
       assessmentRepository,
@@ -26,7 +29,7 @@ const handleActivityAnswer = async function ({
       examiner,
     });
 
-    let lastActivity = await updateCurrentActivity({
+    lastActivity = await updateCurrentActivity({
       assessmentId,
       activityAnswerRepository,
       activityRepository,

--- a/api/src/school/domain/usecases/handle-activity-answer.js
+++ b/api/src/school/domain/usecases/handle-activity-answer.js
@@ -15,7 +15,7 @@ const handleActivityAnswer = async function ({
   missionAssessmentRepository,
   missionRepository,
 }) {
-  return DomainTransaction.execute(async () => {
+  return await DomainTransaction.execute(async () => {
     let lastActivity = await activityRepository.getLastActivity(assessmentId);
 
     const correctedAnswer = await correctAnswer({

--- a/api/src/school/domain/usecases/handle-activity-answer.js
+++ b/api/src/school/domain/usecases/handle-activity-answer.js
@@ -32,7 +32,7 @@ const handleActivityAnswer = async function ({
     lastActivity = await updateCurrentActivity({
       assessmentId,
       lastActivity,
-      activityAnswerRepository,
+      lastAnswer: correctedAnswer,
       activityRepository,
       missionAssessmentRepository,
       missionRepository,

--- a/api/src/school/domain/usecases/handle-activity-answer.js
+++ b/api/src/school/domain/usecases/handle-activity-answer.js
@@ -31,6 +31,7 @@ const handleActivityAnswer = async function ({
 
     lastActivity = await updateCurrentActivity({
       assessmentId,
+      lastActivity,
       activityAnswerRepository,
       activityRepository,
       missionAssessmentRepository,

--- a/api/tests/school/integration/domain/services/correct-answer_test.js
+++ b/api/tests/school/integration/domain/services/correct-answer_test.js
@@ -57,10 +57,10 @@ describe('Integration | UseCases | correct-answer', function () {
           const record = await correctAnswer({
             activityAnswer,
             assessmentId: assessment.id,
+            activityId: activity.id,
             challengeRepository,
             assessmentRepository,
             activityAnswerRepository,
-            activityRepository,
             examiner: alwaysTrueExaminer,
           });
 
@@ -90,10 +90,10 @@ describe('Integration | UseCases | correct-answer', function () {
           const record = await correctAnswer({
             activityAnswer,
             assessmentId: assessment.id,
+            activityId: activity.id,
             challengeRepository,
             assessmentRepository,
             activityAnswerRepository,
-            activityRepository,
             examiner: alwaysFalseExaminer,
           });
 

--- a/api/tests/school/integration/domain/services/update-current-activity_test.js
+++ b/api/tests/school/integration/domain/services/update-current-activity_test.js
@@ -1,6 +1,6 @@
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
+import { ActivityAnswer } from '../../../../../src/school/domain/models/ActivityAnswer.js';
 import { updateCurrentActivity } from '../../../../../src/school/domain/services/update-current-activity.js';
-import * as activityAnswerRepository from '../../../../../src/school/infrastructure/repositories/activity-answer-repository.js';
 import * as activityRepository from '../../../../../src/school/infrastructure/repositories/activity-repository.js';
 import * as missionAssessmentRepository from '../../../../../src/school/infrastructure/repositories/mission-assessment-repository.js';
 import * as missionRepository from '../../../../../src/school/infrastructure/repositories/mission-repository.js';
@@ -26,7 +26,7 @@ describe('Integration | UseCase | update current activity', function () {
             stepIndex: 0,
           });
           const lastActivity = new Activity(activity);
-          databaseBuilder.factory.buildActivityAnswer({
+          const lastAnswer = new ActivityAnswer({
             activityId: lastActivity.id,
             challengeId: 'di_challenge_id',
             result,
@@ -51,8 +51,8 @@ describe('Integration | UseCase | update current activity', function () {
           const currentActivity = await updateCurrentActivity({
             assessmentId,
             lastActivity,
+            lastAnswer,
             activityRepository,
-            activityAnswerRepository,
             missionAssessmentRepository,
             missionRepository,
           });
@@ -82,18 +82,10 @@ describe('Integration | UseCase | update current activity', function () {
             stepIndex: 0,
           });
           const lastActivity = new Activity(activity);
-
-          databaseBuilder.factory.buildActivityAnswer({
-            activityId: lastActivity.id,
-            challengeId: 'di_challenge_id',
-            result,
-            createdAt: new Date('2020-01-01T10:00:00Z'),
-          });
-          databaseBuilder.factory.buildActivityAnswer({
+          const lastAnswer = new ActivityAnswer({
             activityId: lastActivity.id,
             challengeId: 'di_next_challenge_id',
             result,
-            createdAt: new Date('2020-01-01T10:01:00Z'),
           });
 
           databaseBuilder.factory.learningContent.build({
@@ -115,8 +107,8 @@ describe('Integration | UseCase | update current activity', function () {
           const currentActivity = await updateCurrentActivity({
             assessmentId,
             lastActivity,
+            lastAnswer,
             activityRepository,
-            activityAnswerRepository,
             missionAssessmentRepository,
             missionRepository,
           });
@@ -140,7 +132,7 @@ describe('Integration | UseCase | update current activity', function () {
           level: Activity.levels.VALIDATION,
           stepIndex: 0,
         });
-        databaseBuilder.factory.buildActivityAnswer({
+        const lastAnswer = new ActivityAnswer({
           activityId: lastActivity.id,
           challengeId: 'va_challenge_id',
           result: AnswerStatus.statuses.KO,
@@ -166,8 +158,8 @@ describe('Integration | UseCase | update current activity', function () {
         const currentActivity = await updateCurrentActivity({
           assessmentId,
           lastActivity,
+          lastAnswer,
           activityRepository,
-          activityAnswerRepository,
           missionAssessmentRepository,
           missionRepository,
         });
@@ -189,7 +181,7 @@ describe('Integration | UseCase | update current activity', function () {
             status: Activity.status.STARTED,
             stepIndex: 0,
           });
-          databaseBuilder.factory.buildActivityAnswer({
+          const lastAnswer = new ActivityAnswer({
             activityId: lastActivity.id,
             challengeId: 'va_challenge_id',
             result: AnswerStatus.statuses.OK,
@@ -214,61 +206,8 @@ describe('Integration | UseCase | update current activity', function () {
           const currentActivity = await updateCurrentActivity({
             assessmentId,
             lastActivity,
+            lastAnswer,
             activityRepository,
-            activityAnswerRepository,
-            missionAssessmentRepository,
-            missionRepository,
-          });
-
-          const activities = await knex('activities').where({ assessmentId });
-          expect(activities).to.have.lengthOf(1);
-          expect(activities[0].status).to.equal(Activity.status.STARTED);
-          expect(currentActivity.status).equals(Activity.status.STARTED);
-        });
-      });
-
-      context('when activity is not finished but has answer duplicate', function () {
-        it('should not update current activity status', async function () {
-          const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-          const lastActivity = databaseBuilder.factory.buildActivity({
-            assessmentId,
-            level: Activity.levels.VALIDATION,
-            status: Activity.status.STARTED,
-            stepIndex: 0,
-          });
-          databaseBuilder.factory.buildActivityAnswer({
-            activityId: lastActivity.id,
-            challengeId: 'va_challenge_id',
-            result: AnswerStatus.statuses.OK,
-          });
-          // Anwser duplicate
-          databaseBuilder.factory.buildActivityAnswer({
-            activityId: lastActivity.id,
-            challengeId: 'va_challenge_id',
-            result: AnswerStatus.statuses.OK,
-          });
-
-          databaseBuilder.factory.learningContent.build({
-            missions: [
-              learningContentBuilder.buildMission({
-                id: missionId,
-                content: {
-                  steps: [
-                    {
-                      validationChallenges: [['va_challenge_id'], ['va_next_challenge_id']],
-                    },
-                  ],
-                },
-              }),
-            ],
-          });
-          await databaseBuilder.commit();
-
-          const currentActivity = await updateCurrentActivity({
-            assessmentId,
-            lastActivity,
-            activityRepository,
-            activityAnswerRepository,
             missionAssessmentRepository,
             missionRepository,
           });
@@ -289,17 +228,10 @@ describe('Integration | UseCase | update current activity', function () {
             status: Activity.status.STARTED,
             stepIndex: 0,
           });
-          databaseBuilder.factory.buildActivityAnswer({
-            activityId: lastActivity.id,
-            challengeId: 'va_challenge_id',
-            result: AnswerStatus.statuses.OK,
-            createdAt: new Date('2020-01-01T10:00:00Z'),
-          });
-          databaseBuilder.factory.buildActivityAnswer({
+          const lastAnswer = new ActivityAnswer({
             activityId: lastActivity.id,
             challengeId: 'va_next_challenge_id',
             result: AnswerStatus.statuses.OK,
-            createdAt: new Date('2020-01-01T10:01:00Z'),
           });
 
           databaseBuilder.factory.learningContent.build({
@@ -321,8 +253,8 @@ describe('Integration | UseCase | update current activity', function () {
           const currentActivity = await updateCurrentActivity({
             assessmentId,
             lastActivity,
+            lastAnswer,
             activityRepository,
-            activityAnswerRepository,
             missionAssessmentRepository,
             missionRepository,
           });
@@ -344,7 +276,7 @@ describe('Integration | UseCase | update current activity', function () {
           status: Activity.status.STARTED,
           stepIndex: 0,
         });
-        databaseBuilder.factory.buildActivityAnswer({
+        const lastAnswer = new ActivityAnswer({
           activityId: lastActivity.id,
           challengeId: 'va_challenge_id',
           result: AnswerStatus.statuses.SKIPPED,
@@ -369,8 +301,8 @@ describe('Integration | UseCase | update current activity', function () {
         const currentActivity = await updateCurrentActivity({
           assessmentId,
           lastActivity,
+          lastAnswer,
           activityRepository,
-          activityAnswerRepository,
           missionAssessmentRepository,
           missionRepository,
         });

--- a/api/tests/school/integration/domain/services/update-current-activity_test.js
+++ b/api/tests/school/integration/domain/services/update-current-activity_test.js
@@ -19,14 +19,15 @@ describe('Integration | UseCase | update current activity', function () {
       ].forEach(({ message, result }) =>
         it(`should not update current activity status when challenge is ${message}`, async function () {
           const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-          const { id: activityId } = databaseBuilder.factory.buildActivity({
+          const activity = databaseBuilder.factory.buildActivity({
             assessmentId,
             level: Activity.levels.TUTORIAL,
             status: Activity.status.STARTED,
             stepIndex: 0,
           });
+          const lastActivity = new Activity(activity);
           databaseBuilder.factory.buildActivityAnswer({
-            activityId,
+            activityId: lastActivity.id,
             challengeId: 'di_challenge_id',
             result,
           });
@@ -49,6 +50,7 @@ describe('Integration | UseCase | update current activity', function () {
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
+            lastActivity,
             activityRepository,
             activityAnswerRepository,
             missionAssessmentRepository,
@@ -73,20 +75,22 @@ describe('Integration | UseCase | update current activity', function () {
       ].forEach(({ message, result }) =>
         it(`should update current activity with SUCCEEDED status when challenge is ${message}`, async function () {
           const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-          const { id: activityId } = databaseBuilder.factory.buildActivity({
+          const activity = databaseBuilder.factory.buildActivity({
             assessmentId,
             level: Activity.levels.TUTORIAL,
             status: Activity.status.STARTED,
             stepIndex: 0,
           });
+          const lastActivity = new Activity(activity);
+
           databaseBuilder.factory.buildActivityAnswer({
-            activityId,
+            activityId: lastActivity.id,
             challengeId: 'di_challenge_id',
             result,
             createdAt: new Date('2020-01-01T10:00:00Z'),
           });
           databaseBuilder.factory.buildActivityAnswer({
-            activityId,
+            activityId: lastActivity.id,
             challengeId: 'di_next_challenge_id',
             result,
             createdAt: new Date('2020-01-01T10:01:00Z'),
@@ -110,6 +114,7 @@ describe('Integration | UseCase | update current activity', function () {
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
+            lastActivity,
             activityRepository,
             activityAnswerRepository,
             missionAssessmentRepository,
@@ -129,14 +134,14 @@ describe('Integration | UseCase | update current activity', function () {
     context('when last answer is ko', function () {
       it('should update current activity with FAILED status', async function () {
         const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-        const { id: activityId } = databaseBuilder.factory.buildActivity({
+        const lastActivity = databaseBuilder.factory.buildActivity({
           assessmentId,
           status: Activity.status.STARTED,
           level: Activity.levels.VALIDATION,
           stepIndex: 0,
         });
         databaseBuilder.factory.buildActivityAnswer({
-          activityId,
+          activityId: lastActivity.id,
           challengeId: 'va_challenge_id',
           result: AnswerStatus.statuses.KO,
         });
@@ -160,6 +165,7 @@ describe('Integration | UseCase | update current activity', function () {
 
         const currentActivity = await updateCurrentActivity({
           assessmentId,
+          lastActivity,
           activityRepository,
           activityAnswerRepository,
           missionAssessmentRepository,
@@ -177,14 +183,14 @@ describe('Integration | UseCase | update current activity', function () {
       context('when activity is not finished', function () {
         it('should not update current activity status', async function () {
           const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-          const { id: activityId } = databaseBuilder.factory.buildActivity({
+          const lastActivity = databaseBuilder.factory.buildActivity({
             assessmentId,
             level: Activity.levels.VALIDATION,
             status: Activity.status.STARTED,
             stepIndex: 0,
           });
           databaseBuilder.factory.buildActivityAnswer({
-            activityId,
+            activityId: lastActivity.id,
             challengeId: 'va_challenge_id',
             result: AnswerStatus.statuses.OK,
           });
@@ -207,6 +213,7 @@ describe('Integration | UseCase | update current activity', function () {
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
+            lastActivity,
             activityRepository,
             activityAnswerRepository,
             missionAssessmentRepository,
@@ -223,20 +230,20 @@ describe('Integration | UseCase | update current activity', function () {
       context('when activity is not finished but has answer duplicate', function () {
         it('should not update current activity status', async function () {
           const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-          const { id: activityId } = databaseBuilder.factory.buildActivity({
+          const lastActivity = databaseBuilder.factory.buildActivity({
             assessmentId,
             level: Activity.levels.VALIDATION,
             status: Activity.status.STARTED,
             stepIndex: 0,
           });
           databaseBuilder.factory.buildActivityAnswer({
-            activityId,
+            activityId: lastActivity.id,
             challengeId: 'va_challenge_id',
             result: AnswerStatus.statuses.OK,
           });
           // Anwser duplicate
           databaseBuilder.factory.buildActivityAnswer({
-            activityId,
+            activityId: lastActivity.id,
             challengeId: 'va_challenge_id',
             result: AnswerStatus.statuses.OK,
           });
@@ -259,6 +266,7 @@ describe('Integration | UseCase | update current activity', function () {
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
+            lastActivity,
             activityRepository,
             activityAnswerRepository,
             missionAssessmentRepository,
@@ -275,20 +283,20 @@ describe('Integration | UseCase | update current activity', function () {
       context('when activity is finished', function () {
         it('should update current activity with SUCCEEDED status', async function () {
           const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-          const { id: activityId } = databaseBuilder.factory.buildActivity({
+          const lastActivity = databaseBuilder.factory.buildActivity({
             assessmentId,
             level: Activity.levels.VALIDATION,
             status: Activity.status.STARTED,
             stepIndex: 0,
           });
           databaseBuilder.factory.buildActivityAnswer({
-            activityId,
+            activityId: lastActivity.id,
             challengeId: 'va_challenge_id',
             result: AnswerStatus.statuses.OK,
             createdAt: new Date('2020-01-01T10:00:00Z'),
           });
           databaseBuilder.factory.buildActivityAnswer({
-            activityId,
+            activityId: lastActivity.id,
             challengeId: 'va_next_challenge_id',
             result: AnswerStatus.statuses.OK,
             createdAt: new Date('2020-01-01T10:01:00Z'),
@@ -312,6 +320,7 @@ describe('Integration | UseCase | update current activity', function () {
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
+            lastActivity,
             activityRepository,
             activityAnswerRepository,
             missionAssessmentRepository,
@@ -329,14 +338,14 @@ describe('Integration | UseCase | update current activity', function () {
     context('when challenge has been skipped', function () {
       it('should update current activity with SKIPPED status', async function () {
         const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-        const { id: activityId } = databaseBuilder.factory.buildActivity({
+        const lastActivity = databaseBuilder.factory.buildActivity({
           assessmentId,
           level: Activity.levels.VALIDATION,
           status: Activity.status.STARTED,
           stepIndex: 0,
         });
         databaseBuilder.factory.buildActivityAnswer({
-          activityId,
+          activityId: lastActivity.id,
           challengeId: 'va_challenge_id',
           result: AnswerStatus.statuses.SKIPPED,
         });
@@ -359,6 +368,7 @@ describe('Integration | UseCase | update current activity', function () {
 
         const currentActivity = await updateCurrentActivity({
           assessmentId,
+          lastActivity,
           activityRepository,
           activityAnswerRepository,
           missionAssessmentRepository,


### PR DESCRIPTION

## 💥 Problème

On a des régulièrement des erreurs 500 qui popent dans datadog sur la route
Le probleme vient d'un find qui retournait undefined alors qu'on attendait un objet du model dans le service `updateCurrentActivty`.

## 👩‍🚀 Proposition

On propose d'injecter directement les modèles dans le service `updateCurrentActivity`
et dans  `correctAnswer` pour éviter d'avoir à récupérer à nouveau la réponse fraichement enregistrée.


## 👁️ Remarques
On en profite aussi pour rajouter un await sur la domainTransaction avant de retourner le resultat.

## ♻️ Pour tester
RAS
Test de non régression:
Allez sur pixJunior et passer des missions
