### PR TITLE
[TECH] Renommer les classes CSS du composant InaccessibleContent

### DIFF
--- a/mon-pix/app/components/inaccessible-content.gjs
+++ b/mon-pix/app/components/inaccessible-content.gjs
@@ -9,20 +9,20 @@ export default class InaccessibleContent extends Component {
   }
   <template>
     <PixBlock ...attributes>
-      <div class="campaign-landing-page__start__image__container">
-        <div class="campaign-landing-page__pix-logo">
-          <img class="campaign-landing-page__image" src="/images/pix-logo.svg" alt="{{t 'navigation.pix'}}" />
+      <div class="inaccessible-content__image-container">
+        <div class="inaccessible-content__pix-logo">
+          <img class="inaccessible-content__image" src="/images/pix-logo.svg" alt="{{t 'navigation.pix'}}" />
         </div>
       </div>
-      <div class="campaign-landing-page-error">
-        <h1 class="campaign-landing-page-error__title">{{yield to="title"}}</h1>
+      <div class="inaccessible-content__error">
+        <h1 class="inaccessible-content__error__title">{{yield to="title"}}</h1>
         {{#if (has-block "content")}}
           {{yield to="content"}}
         {{/if}}
         {{#if (has-block "instructions")}}
-          <div class="campaign-landing-page-error__instructions">{{yield to="instructions"}}</div>
+          <div class="inaccessible-content__error__instructions">{{yield to="instructions"}}</div>
         {{/if}}
-        <PixButtonLink @route="authenticated" class="campaign-landing-page__error-button">
+        <PixButtonLink @route="authenticated" class="inaccessible-content__button">
           {{t this.buttonText}}
         </PixButtonLink>
       </div>

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -175,6 +175,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 /* pages */
 @use 'pages/assessment-results' as *;
 @use 'pages/campaign-landing-page' as *;
+@use 'pages/inaccessible-content' as *;
 @use 'pages/campaign-tutorial' as *;
 @use 'pages/challenge' as *;
 @use 'pages/competence-results' as *;

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -107,22 +107,3 @@
   text-align: center;
 }
 
-/* ------------------------ ERROR ------------------------ */
-
-.campaign-landing-page-error {
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 50px;
-
-  &__title {
-    @extend %pix-title-xs;
-
-    margin-bottom: var(--pix-spacing-6x);
-    text-align: center;
-  }
-}
-
-.campaign-landing-page__error-button {
-  width: fit-content;
-  margin: auto;
-}

--- a/mon-pix/app/styles/pages/_inaccessible-content.scss
+++ b/mon-pix/app/styles/pages/_inaccessible-content.scss
@@ -1,0 +1,59 @@
+@use 'pix-design-tokens/breakpoints';
+@use 'pix-design-tokens/typography';
+
+.inaccessible-content {
+  &__image-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    width: 90%;
+    margin: auto;
+    margin-top: var(--pix-spacing-8x);
+    margin-bottom: var(--pix-spacing-8x);
+
+    @include breakpoints.device-is('tablet') {
+      flex-direction: row;
+    }
+  }
+
+  &__pix-logo {
+    display: flex;
+    gap: var(--pix-spacing-8x);
+    margin: auto;
+  }
+
+  &__image {
+    height: 42px;
+
+    @include breakpoints.device-is('tablet') {
+      height: 70px;
+    }
+  }
+
+  &__error {
+    display: flex;
+    flex-direction: column;
+    gap: 31px;
+    align-items: center;
+    padding: var(--pix-spacing-10x, 40px) var(--pix-spacing-6x, 24px);
+
+    @extend %pix-body-m;
+
+    &__title {
+      @extend %pix-title-s;
+
+      margin-bottom: var(--pix-spacing-6x);
+      text-align: center;
+    }
+
+    &__instructions {
+      font-weight: bold;
+    }
+  }
+
+  &__button {
+    width: fit-content;
+    margin: auto;
+  }
+}


### PR DESCRIPTION
## 💥 Problème

Le composant InaccessibleContent utilisait des classes CSS préfixées "campaign-landing-page" alors qu'il est aussi utilisé pour les parcours combinés.

## 👩‍🚀 Proposition
Les classes sont renommées en "inaccessible-content__*" et les styles sont extraits dans un fichier SCSS dédié.

## 👁️ Remarques
Code généré par Claude

## ♻️ Pour tester
Désactiver le featureToggle areCombinedCoursesEnabled sur le CLI Scalingo

Pix App
J'ai un code -> COMBINIX1
Vérifier que l'écran est conforme à celui en dev.

Réactiver le featureToogle areCombinedCoursesEnabled
Archiver une campagne présente dans les seeds
J'ai un code -> code de la campagne archivée
Vérifier que l'écran est conforme à celui en dev.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
