### PR TITLE
[FEATURE] Appliquer le nouveau design des cartes de contenu formatifs en fin de parcours sur Pix App (PIX-22716).

### DIFF
--- a/api/db/seeds/data/team-evaluation/data-builder.js
+++ b/api/db/seeds/data/team-evaluation/data-builder.js
@@ -1,3 +1,4 @@
+import { Training } from '../../../../src/devcomp/domain/models/Training.js';
 import { COUNTRY_CANADA_CODE } from '../common/constants.js';
 import * as tooling from '../common/tooling/index.js';
 import { acceptPixOrgaTermsOfService } from '../common/tooling/legal-documents.js';
@@ -15,6 +16,8 @@ import evalCampaignWithStagesUser from './users/eval-campaign-with-stages.js';
 export async function teamEvaluationDataBuilder({ databaseBuilder }) {
   createScoOrganization(databaseBuilder);
   await createCoreTargetProfile(databaseBuilder);
+  createTrainings(databaseBuilder);
+
   await createAssessmentCampaign(databaseBuilder);
 
   // Other users
@@ -247,5 +250,86 @@ async function createAssessmentCampaign(databaseBuilder) {
       participantCount: 30,
     },
     recommendationEngine: true,
+  });
+}
+
+function createTrainings(databaseBuilder) {
+  const inPersonTrainingId = databaseBuilder.factory.buildTraining({
+    title: 'Apprendre à manger une chocolatine comme les français',
+    internalTitle: 'Apprendre à manger une chocolatine comme les français',
+    link: 'https://example.net',
+    duration: '00:30:00',
+    editorName: 'Pix',
+    editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
+    locales: ['fr', 'fr-fr'],
+    type: 'in-person-training',
+    deliveryMode: Training.modes.ONSITE,
+    objectives: [
+      'Tenir la chocolatine sans la casser',
+      'Savoir la croquer avec élégance, en évitant de faire tomber la garniture',
+      'Intégrer la culture française autour de la chocolatine',
+    ],
+    program:
+      'Cette formation intensive alterne théorie et pratique pour maîtriser l’art de déguster une chocolatine. Après une introduction culturelle (chocolatine vs. pain au chocolat, son histoire en France), les participants apprennent la posture idéale, la technique de préhension et la mastication parfaite (sans éclaboussures de chocolat). Un atelier pratique permet de tester ses compétences, suivi d’un quiz final pour valider son niveau de "Françaisitude". À la fin, les participants repartent avec un diplôme (et des miettes sur les doigts). 🥐🇫🇷',
+    registrationRequired: true,
+  }).id;
+
+  const moduleTrainingId = databaseBuilder.factory.buildTraining({
+    title: 'Bac à sable',
+    internalTitle: 'Bac à sable',
+    link: '/modules/6a68bf32/bac-a-sable',
+    duration: '00:25:00',
+    editorName: 'Pix',
+    editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
+    locales: ['fr-fr'],
+    type: 'modulix',
+    deliveryMode: Training.modes.REMOTE,
+    objectives: ['Non régression fonctionnelle', 'Test de nouvelles modalités'],
+    program:
+      "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+    registrationRequired: false,
+  }).id;
+
+  const otherModuleTrainingId = databaseBuilder.factory.buildTraining({
+    title: 'Ce qu’il faut éviter de dire à une IA générative',
+    internalTitle: 'Ce qu’il faut éviter de dire à une IA générative',
+    link: '/modules/e71a9bdd/iagenethique',
+    duration: '00:10:00',
+    editorName: 'Pix',
+    editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
+    locales: ['fr-fr'],
+    type: 'modulix',
+    deliveryMode: Training.modes.HYBRID,
+    registrationRequired: false,
+    objectives: [
+      '<p>Comprendre que les conversations avec les IA génératives sont réutilisées</p>',
+      '<p>Savoir rédiger un prompt qui n’inclut pas d’informations personnelles</p>',
+      '<p>Connaître les risques du partage de données sensibles avec l’IA générative</p>',
+    ],
+    program:
+      '<p>Quand vous discutez avec un logiciel d’intelligence artificielle (IA) générative, la conversation n’est pas privée.</p><p>Tout ce que vous écrivez peut être enregistré et parfois réutilisé pour améliorer l’IA.</p><p>Dans ce module, vous allez comprendre pourquoi les échanges avec une IA générative ne sont pas totalement privés et quelles informations il vaut mieux éviter d’écrire dans vos instructions (prompts).</p>',
+  }).id;
+
+  _addTrainingTriggerAndLinkToTargetProfile(inPersonTrainingId, databaseBuilder);
+  _addTrainingTriggerAndLinkToTargetProfile(moduleTrainingId, databaseBuilder);
+  _addTrainingTriggerAndLinkToTargetProfile(otherModuleTrainingId, databaseBuilder);
+}
+
+function _addTrainingTriggerAndLinkToTargetProfile(trainingId, databaseBuilder) {
+  databaseBuilder.factory.buildTargetProfileTraining({
+    targetProfileId: TARGET_PROFILE_PIX_ID,
+    trainingId: trainingId,
+  });
+
+  const frTrainingTriggerId = databaseBuilder.factory.buildTrainingTrigger({
+    trainingId: trainingId,
+    threshold: 0,
+    type: 'prerequisite',
+  }).id;
+
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: frTrainingTriggerId,
+    tubeId: 'tube1NLpOetQhutFlA',
+    level: 2,
   });
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -1,0 +1,74 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class Card extends Component {
+  @service intl;
+
+  get tagProperties() {
+    const registrationRequired = this.args.training.registrationRequired;
+
+    const color = registrationRequired ? 'blue-light' : 'primary';
+    const iconName = registrationRequired ? 'lock' : 'acute';
+    const translationKey = registrationRequired ? 'yes' : 'no';
+    const text = this.intl.t(
+      `pages.skill-review.recommended-engine.training-card.registration-required.${translationKey}`,
+    );
+
+    return {
+      color,
+      iconName,
+      text,
+    };
+  }
+
+  get deliveryMode() {
+    const deliveryMode = this.args.training.deliveryMode === 'onSite' ? 'on-site' : this.args.training.deliveryMode;
+
+    return this.intl.t(`pages.skill-review.recommended-engine.training-card.delivery-mode.${deliveryMode}`);
+  }
+
+  get formattedDuration() {
+    const days = this.args.training.duration.days ? `${this.args.training.duration.days}j ` : '';
+    const hours = this.args.training.duration.hours ? `${this.args.training.duration.hours}h ` : '';
+    const minutes = this.args.training.duration.minutes ? `${this.args.training.duration.minutes}min` : '';
+    return `${days}${hours}${minutes}`.trim();
+  }
+
+  get type() {
+    return this.intl.t(`pages.training.type.${this.args.training.type}`);
+  }
+
+  <template>
+    <a
+      class="results-recommendation-engine-training-card"
+      href={{@training.link}}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={{t "navigation.external-link-title"}}
+    >
+      <div class="results-recommendation-engine-training-card-image-hero">
+        <img
+          class="results-recommendation-engine-training-card-image-hero__editor-logo"
+          src="{{@training.editorLogoUrl}}"
+          alt=""
+        />
+      </div>
+      <PixTag @color={{this.tagProperties.color}} class="results-recommendation-engine-training-card__tag">
+        <PixIcon
+          class="results-recommendation-engine-training-card__tag-icon"
+          @name={{this.tagProperties.iconName}}
+          @ariaHidden={{true}}
+        />
+        {{this.tagProperties.text}}
+      </PixTag>
+      <section class="results-recommendation-engine-training-card-content">
+        <h3 class="results-recommendation-engine-training-card-content__title">{{@training.title}}</h3>
+        <ul class="results-recommendation-engine-training-card-content__details"><li>{{this.type}}</li><li
+          >{{this.deliveryMode}}</li><li>{{this.formattedDuration}}</li></ul>
+      </section>
+    </a>
+  </template>
+}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -38,6 +38,9 @@ export default class Card extends Component {
   }
 
   get type() {
+    if (this.args.training.isTypeLinkedToALocation) {
+      return this.intl.t('pages.training.type.formation');
+    }
     return this.intl.t(`pages.training.type.${this.args.training.type}`);
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -1,11 +1,16 @@
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { t } from 'ember-intl';
+import { tracked } from '@glimmer/tracking';
 
 export default class Card extends Component {
   @service intl;
+
+  @tracked modalIsOpen = false;
 
   get tagProperties() {
     const registrationRequired = this.args.training.registrationRequired;
@@ -44,14 +49,18 @@ export default class Card extends Component {
     return this.intl.t(`pages.training.type.${this.args.training.type}`);
   }
 
+  @action
+  showModal() {
+    this.modalIsOpen = true;
+  }
+
+  @action
+  closeModal() {
+    this.modalIsOpen = false;
+  }
+
   <template>
-    <a
-      class="results-recommendation-engine-training-card"
-      href={{@training.link}}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label={{t "navigation.external-link-title"}}
-    >
+    <button class="results-recommendation-engine-training-card" type="button" {{on "click" this.showModal}}>
       <div class="results-recommendation-engine-training-card-image-hero">
         <img
           class="results-recommendation-engine-training-card-image-hero__editor-logo"
@@ -68,10 +77,14 @@ export default class Card extends Component {
         {{this.tagProperties.text}}
       </PixTag>
       <section class="results-recommendation-engine-training-card-content">
-        <h3 class="results-recommendation-engine-training-card-content__title">{{@training.title}}</h3>
+        <p class="results-recommendation-engine-training-card-content__title">{{@training.title}}</p>
         <ul class="results-recommendation-engine-training-card-content__details"><li>{{this.type}}</li><li
           >{{this.deliveryMode}}</li><li>{{this.formattedDuration}}</li></ul>
       </section>
-    </a>
+    </button>
+    <PixModal @title={{@training.title}} @showModal={{this.modalIsOpen}} @onCloseButtonClick={{this.closeModal}}>
+      <:content>
+      </:content>
+    </PixModal>
   </template>
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -1,15 +1,18 @@
-import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-export default class EvaluationResultsRecommendationEngineTrainings extends Component {
-  <template>
-    <h2 class="results-recommendation-engine-training__title">{{t "pages.skill-review.recommended-engine.trainings.title"}}</h2>
-    <p class="results-recommendation-engine-training__description">{{t "pages.skill-review.recommended-engine.trainings.description"}}</p>
+import TrainingCard from './training/card';
 
-    <ul class="results-recommendation-engine-training__list">
-      {{#each @trainings as |training|}}
-        <li></li>
-      {{/each}}
-    </ul>
-  </template>
-}
+<template>
+  <h2 class="results-recommendation-engine-training__title">{{t
+      "pages.skill-review.recommended-engine.trainings.title"
+    }}</h2>
+  <p class="results-recommendation-engine-training__description">{{t
+      "pages.skill-review.recommended-engine.trainings.description"
+    }}</p>
+
+  <ul class="results-recommendation-engine-training__list">
+    {{#each @trainings as |training|}}
+      <li><TrainingCard @training={{training}} /></li>
+    {{/each}}
+  </ul>
+</template>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class EvaluationResultsRecommendationEngineTrainings extends Component {
+  <template>
+    <h2 class="results-recommendation-engine-training__title">{{t "pages.skill-review.recommended-engine.trainings.title"}}</h2>
+    <p class="results-recommendation-engine-training__description">{{t "pages.skill-review.recommended-engine.trainings.description"}}</p>
+
+    <ul class="results-recommendation-engine-training__list">
+      {{#each @trainings as |training|}}
+        <li></li>
+      {{/each}}
+    </ul>
+  </template>
+}

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -4,9 +4,9 @@ import { t } from 'ember-intl';
 
 import ResultsDetails from '../../../campaigns/assessment/results/evaluation-results-tabs/results-details';
 import Rewards from '../../../campaigns/assessment/results/evaluation-results-tabs/rewards';
-import Trainings from '../../../campaigns/assessment/results/evaluation-results-tabs/trainings';
 import QuitResults from '../../../campaigns/assessment/results/quit-results';
 import EvaluationResultsHeroRecommendationEngine from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
+import Trainings from '../../../campaigns/assessment/results-recommendation-engine/trainings';
 
 export default class EvaluationResultsRecommendationEngine extends Component {
   @service media;
@@ -48,12 +48,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
       />
 
       {{#if this.hasTrainings}}
-        <Trainings
-          @trainings={{this.trainings}}
-          @questResults={{@model.questResults}}
-          @campaignParticipationResult={{@model.campaignParticipationResult}}
-          @campaignId={{@model.campaign.id}}
-        />
+        <Trainings @trainings={{this.trainings}} />
       {{/if}}
 
       <ResultsDetails

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -1,16 +1,21 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Training extends Model {
-  @attr('string') status;
   @attr('string') title;
   @attr('string') link;
-  @attr('string') type;
   // eslint-disable-next-line ember/no-empty-attrs
-  @attr() locales;
+  @attr() duration;
   @attr('string') editorName;
   @attr('string') editorLogoUrl;
   // eslint-disable-next-line ember/no-empty-attrs
-  @attr() duration;
+  @attr() locales;
+  @attr('string') status;
+  @attr('string') type;
+  @attr('string') deliveryMode;
+  // eslint-disable-next-line ember/no-empty-attrs
+  @attr() objectives;
+  @attr('string') program;
+  @attr('boolean') registrationRequired;
 
   @belongsTo('campaign-participation', { async: true, inverse: 'trainings' }) campaignParticipation;
 

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -38,4 +38,8 @@ export default class Training extends Model {
   get isModulix() {
     return this.type === 'modulix';
   }
+
+  get isTypeLinkedToALocation() {
+    return this.isElearning || this.isHybrid || this.isInPerson;
+  }
 }

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -15,6 +15,7 @@
 @use '../components/attestations/card' as *;
 @use '../components/attestations/content' as *;
 @use '../components/campaigns/assessment/results/evaluation-results-hero/attestation-result' as *;
+@use 'components/campaigns/assessment/results/recommendation-engine/trainings' as *;
 @use 'components/campaigns/assessment/start-landing-page/campaign-landing-page-details' as *;
 @use 'components/campaigns/assessment/start-landing-page/campaign-step' as *;
 @use 'components/authentication/oidc-signup-or-login' as *;

--- a/mon-pix/app/styles/components/campaigns/assessment/results/evaluation-results-tabs/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/evaluation-results-tabs/trainings.scss
@@ -1,3 +1,23 @@
+@use 'pix-design-tokens/typography';
+
+.evaluation-results-tabs {
+  max-width: 66rem;
+  margin: 0 auto;
+}
+
+.evaluation-results-tab__title {
+  @extend %pix-title-s;
+
+  margin-top: var(--pix-spacing-10x);
+}
+
+.evaluation-results-tab__description {
+  @extend %pix-body-m;
+
+  margin-top: var(--pix-spacing-2x);
+  color: var(--pix-neutral-500);
+}
+
 .evaluation-results-tab__trainings-list {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -1,4 +1,6 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/shadows';
+@use 'pix-design-tokens/breakpoints';
 
 .results-recommendation-engine-training {
   &__title {
@@ -15,9 +17,90 @@
   }
 
   &__list {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
-    gap: var(--pix-spacing-6x);
-    margin-top: var(--pix-spacing-8x);
+    display: flex;
+    gap: var(--pix-spacing-8x);
+    margin-top: var(--pix-spacing-4x);
+    padding : 3px 5px 7px;
+    overflow-y: auto;
+    scrollbar-width: none;
+    scroll-behavior: smooth;
   }
 }
+
+.results-recommendation-engine-training-card {
+    @extend %pix-shadow-default;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
+    justify-content: space-between;
+    width: 329px;
+    height: 315px;
+    padding: var(--pix-spacing-3x);
+    padding-bottom: var(--pix-spacing-6x);
+    background-color: var(--pix-neutral-0);
+    border-radius: 16px 0 16px 16px;
+
+  @include breakpoints.device-is('mobile') {
+    min-width: 280px;
+  }
+
+    &__tag {
+      @extend %pix-body-xs;
+
+      width: fit-content;
+    }
+
+  &__tag-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+.results-recommendation-engine-training-card-image-hero {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: start;
+  height: 127px;
+  padding: var(--pix-spacing-7x, 28px) var(--pix-spacing-7x, 28px);
+  background-color: var(--pix-primary-10);
+  border-radius: 12px;
+
+  &__editor-logo {
+    position: relative;
+    z-index: 1;
+    height: 35px;
+  }
+}
+
+.results-recommendation-engine-training-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-3x);
+
+  &__title {
+    @extend %pix-title-xxs;
+
+    display: -webkit-box;
+    min-height: 50px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  &__details {
+    @extend %pix-body-xs;
+
+    display: flex;
+    color: var(--pix-neutral-500);
+  }
+
+  ul li:not(:first-child)::before {
+    margin: 0 var(--pix-spacing-1x);
+    content: '\2022';
+  }
+
+}
+

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -85,6 +85,7 @@
     display: -webkit-box;
     min-height: 50px;
     overflow: hidden;
+    text-align: start;
     text-overflow: ellipsis;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -1,0 +1,23 @@
+@use 'pix-design-tokens/typography';
+
+.results-recommendation-engine-training {
+  &__title {
+    @extend %pix-title-s;
+
+    margin-top: var(--pix-spacing-10x);
+  }
+
+  &__description {
+    @extend %pix-body-m;
+
+    margin-top: var(--pix-spacing-2x);
+    color: var(--pix-neutral-500);
+  }
+
+  &__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
+    gap: var(--pix-spacing-6x);
+    margin-top: var(--pix-spacing-8x);
+  }
+}

--- a/mon-pix/app/styles/pages/_evaluation-results.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results.scss
@@ -276,24 +276,3 @@
 
   margin-bottom: var(--pix-spacing-4x);
 }
-
-/**
- * Evaluation Results Tabs
- */
-.evaluation-results-tabs {
-  max-width: 66rem;
-  margin: 0 auto;
-}
-
-.evaluation-results-tab__title {
-  @extend %pix-title-s;
-
-  margin-top: var(--pix-spacing-10x);
-}
-
-.evaluation-results-tab__description {
-  @extend %pix-body-m;
-
-  margin-top: var(--pix-spacing-2x);
-  color: var(--pix-neutral-500);
-}

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -43,7 +43,9 @@ module(
 
         // then
         assert
-          .dom(screen.getByRole('heading', { name: t('pages.skill-review.tabs.trainings.title'), level: 2 }))
+          .dom(
+            screen.getByRole('heading', { name: t('pages.skill-review.recommended-engine.trainings.title'), level: 2 }),
+          )
           .exists();
         assert.dom(screen.getByRole('heading', { name: 'Super training', level: 3 })).exists();
       });

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -47,7 +47,8 @@ module(
             screen.getByRole('heading', { name: t('pages.skill-review.recommended-engine.trainings.title'), level: 2 }),
           )
           .exists();
-        assert.dom(screen.getByRole('heading', { name: 'Super training', level: 3 })).exists();
+        const trainingTitle = screen.getAllByText('Super training');
+        assert.strictEqual(trainingTitle.length, 2);
       });
     });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -19,8 +19,8 @@ module(
       const screen = await render(<template><TrainingCard @training={{training}} /></template>);
 
       // then
-      assert.dom(screen.getByRole('link', training.link)).exists();
-      assert.dom(screen.getByRole('heading', { name: training.title, level: 3 })).exists();
+      const trainingTitle = screen.getAllByText(training.title);
+      assert.strictEqual(trainingTitle.length, 2);
       assert.dom(screen.getByText('Webinaire')).exists();
       assert.dom(screen.getByText('2h')).exists();
     });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -1,0 +1,119 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import TrainingCard from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/training/card';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
+module(
+  'Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | Training | Card',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+
+    test('it renders with correct fields', async function (assert) {
+      // given
+      const training = _buildTraining();
+
+      // when
+      const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('link', training.link)).exists();
+      assert.dom(screen.getByRole('heading', { name: training.title, level: 3 })).exists();
+      assert.dom(screen.getByText('Webinaire')).exists();
+      assert.dom(screen.getByText('2h')).exists();
+    });
+
+    module('when delivery mode is hybrid', function () {
+      test('it displays a corresponding information', async function (assert) {
+        // given
+        const training = _buildTraining({ deliveryMode: 'hybrid' });
+
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.delivery-mode.hybrid')))
+          .exists();
+      });
+    });
+
+    module('when delivery mode is on-site', function () {
+      test('it displays a corresponding information', async function (assert) {
+        // given
+        const training = _buildTraining({ deliveryMode: 'on-site' });
+
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.delivery-mode.on-site')))
+          .exists();
+      });
+    });
+
+    module('when delivery mode is remote', function () {
+      test('it displays a corresponding information', async function (assert) {
+        // given
+        const training = _buildTraining({ deliveryMode: 'remote' });
+
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.delivery-mode.remote')))
+          .exists();
+      });
+    });
+
+    module('when registration is required', function () {
+      test('it displays a corresponding tag', async function (assert) {
+        // given
+        const training = _buildTraining({ registrationRequired: true });
+
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.registration-required.yes')))
+          .exists();
+      });
+    });
+
+    module('when registration is not required', function () {
+      test('it displays a corresponding tag', async function (assert) {
+        // given
+        const training = _buildTraining({ registrationRequired: false });
+
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.registration-required.no')))
+          .exists();
+      });
+    });
+
+    function _buildTraining({ deliveryMode = 'remote', registrationRequired = true }) {
+      return {
+        title: 'Apprendre à manger un croissant comme les français',
+        link: 'https://example.net/',
+        duration: { hours: 2 },
+        editorLogoUrl:
+          'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+        editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+        locale: 'fr-fr',
+        type: 'webinaire',
+        deliveryMode,
+        objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
+        program: 'Heure 1 : Théorie & culture du croissant, Heure 2 : Pratique et technique de dégustation',
+        registrationRequired,
+      };
+    }
+  },
+);

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -12,7 +12,8 @@ module(
 
     test('it renders with correct fields', async function (assert) {
       // given
-      const training = _buildTraining();
+      const store = this.owner.lookup('service:store');
+      const training = store.createRecord('training', _buildTraining({}));
 
       // when
       const screen = await render(<template><TrainingCard @training={{training}} /></template>);
@@ -27,7 +28,8 @@ module(
     module('when delivery mode is hybrid', function () {
       test('it displays a corresponding information', async function (assert) {
         // given
-        const training = _buildTraining({ deliveryMode: 'hybrid' });
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({ deliveryMode: 'hybrid' }));
 
         // when
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
@@ -42,7 +44,8 @@ module(
     module('when delivery mode is on-site', function () {
       test('it displays a corresponding information', async function (assert) {
         // given
-        const training = _buildTraining({ deliveryMode: 'on-site' });
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({ deliveryMode: 'on-site' }));
 
         // when
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
@@ -57,7 +60,8 @@ module(
     module('when delivery mode is remote', function () {
       test('it displays a corresponding information', async function (assert) {
         // given
-        const training = _buildTraining({ deliveryMode: 'remote' });
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({ deliveryMode: 'remote' }));
 
         // when
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
@@ -72,7 +76,8 @@ module(
     module('when registration is required', function () {
       test('it displays a corresponding tag', async function (assert) {
         // given
-        const training = _buildTraining({ registrationRequired: true });
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({ registrationRequired: true }));
 
         // when
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
@@ -87,7 +92,8 @@ module(
     module('when registration is not required', function () {
       test('it displays a corresponding tag', async function (assert) {
         // given
-        const training = _buildTraining({ registrationRequired: false });
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({ registrationRequired: false }));
 
         // when
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
@@ -99,7 +105,35 @@ module(
       });
     });
 
-    function _buildTraining({ deliveryMode = 'remote', registrationRequired = true }) {
+    module('when training type is e-learning, hybrid or in-person', function () {
+      test('it displays "formation" information only', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({ type: 'e-learning' }));
+
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+        // then
+        assert.dom(screen.getByText(t('pages.training.type.formation'))).exists();
+      });
+    });
+
+    module('when training type is webinaire, modulix or autoformation', function () {
+      test('it displays the type information', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({ type: 'modulix' }));
+
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+        // then
+        assert.dom(screen.getByText(t('pages.training.type.modulix'))).exists();
+      });
+    });
+
+    function _buildTraining({ deliveryMode = 'remote', registrationRequired = true, type = 'webinaire' }) {
       return {
         title: 'Apprendre à manger un croissant comme les français',
         link: 'https://example.net/',
@@ -108,7 +142,7 @@ module(
           'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
         editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
         locale: 'fr-fr',
-        type: 'webinaire',
+        type,
         deliveryMode,
         objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
         program: 'Heure 1 : Théorie & culture du croissant, Heure 2 : Pratique et technique de dégustation',

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -1,0 +1,36 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import Trainings from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/trainings';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
+module('Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | Trainings', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display the trainings list', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const trainings = [
+      store.createRecord('training', {
+        title: 'Mon super training',
+        link: 'https://exemple.net/',
+        duration: { days: 2 },
+      }),
+      store.createRecord('training', {
+        title: 'Mon autre super training',
+        link: 'https://exemple.net/',
+        duration: { days: 2 },
+      }),
+    ];
+
+    // when
+    const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+
+    // then
+    assert
+      .dom(screen.getByRole('heading', { name: t('pages.skill-review.recommended-engine.trainings.title') }))
+      .isVisible();
+    assert.dom(screen.getByText(t('pages.skill-review.recommended-engine.trainings.description'))).isVisible();
+  });
+});

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2209,6 +2209,12 @@
         "title": "Deine Meinung zählt!"
       },
       "not-finished": "Du kannst deine Ergebnisse noch nicht einsenden, wir haben noch einige Fragen an dich.",
+      "recommended-engine": {
+        "trainings": {
+          "description": "Es wird entsprechend deinen Fortschritten empfohlen, um dir dabei zu helfen, deine Fähigkeiten zu festigen und zum richtigen Zeitpunkt einen Schritt weiter zu gehen.",
+          "title": "Gehen Sie noch einen Schritt weiter – ganz in Ihrem eigenen Tempo."
+        }
+      },
       "reset": {
         "button": "Auf Null stellen und alles noch einmal versuchen",
         "modal": {

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2302,6 +2302,7 @@
       "type": {
         "autoformation": "Selbstständiger Lernpfad",
         "e-learning": "Fernunterricht",
+        "formation": "Ausbildung",
         "hybrid-training": "Hybride Ausbildung",
         "in-person-training": "Präsenzschulungen",
         "modulix": "Pix-Modul (Beta)",

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2210,6 +2210,17 @@
       },
       "not-finished": "Du kannst deine Ergebnisse noch nicht einsenden, wir haben noch einige Fragen an dich.",
       "recommended-engine": {
+        "training-card": {
+          "delivery-mode": {
+            "hybrid": "Hybrid",
+            "on-site": "Vor Ort",
+            "remote": "Fernkurs"
+          },
+          "registration-required": {
+            "no": "Sofortiger freier Zugang",
+            "yes": "Anmeldung erforderlich"
+          }
+        },
         "trainings": {
           "description": "Es wird entsprechend deinen Fortschritten empfohlen, um dir dabei zu helfen, deine Fähigkeiten zu festigen und zum richtigen Zeitpunkt einen Schritt weiter zu gehen.",
           "title": "Gehen Sie noch einen Schritt weiter – ganz in Ihrem eigenen Tempo."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2302,6 +2302,7 @@
       "type": {
         "autoformation": "Autoformation customised test",
         "e-learning": "E-Learning",
+        "formation": "Training",
         "hybrid-training": "Hybrid training",
         "in-person-training": "In person training",
         "modulix": "Pix Module",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2210,6 +2210,17 @@
       },
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
       "recommended-engine": {
+        "training-card": {
+          "delivery-mode": {
+            "hybrid": "Hybrid",
+            "on-site": "On-site",
+            "remote": "Remote"
+          },
+          "registration-required": {
+            "no": "Immediate free access",
+            "yes": "Registration required"
+          }
+        },
         "trainings": {
           "description": "It is recommended based on your progress to help you build your skills and take them to the next level at just the right time.",
           "title": "Go further, at your own pace."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2209,6 +2209,12 @@
         "title": "Your opinion counts!"
       },
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
+      "recommended-engine": {
+        "trainings": {
+          "description": "It is recommended based on your progress to help you build your skills and take them to the next level at just the right time.",
+          "title": "Go further, at your own pace."
+        }
+      },
       "reset": {
         "button": "Reset and restart from the beginning",
         "modal": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -661,7 +661,7 @@
         "paragraphs": {
           "1": "La certificación Pix, reconocida oficialmente, acredita tu dominio de las competencias digitales. Te unirás a una comunidad de millones de usuarios certificados. ¡Enhorabuena por este importante paso en tu carrera profesional!",
           "2": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de puntos que aparece en tu perfil.",
-          "3":"El día de tu certificación, se podía alcanzar el nivel 7 y un máximo de 895 puntos (nivel Experto 1)."
+          "3": "El día de tu certificación, se podía alcanzar el nivel 7 y un máximo de 895 puntos (nivel Experto 1)."
         }
       },
       "competences": {
@@ -2302,6 +2302,7 @@
       "type": {
         "autoformation": "Test de autoformación",
         "e-learning": "Formación a distancia",
+        "formation": "Formación",
         "hybrid-training": "Formación híbrida",
         "in-person-training": "Formación presencial",
         "modulix": "Módulo Pix (Beta)",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2209,6 +2209,12 @@
         "title": "¡Tu opinión cuenta!"
       },
       "not-finished": "Todavía no puedes enviar tus resultados, aún tenemos algunas preguntas para ti.",
+      "recommended-engine": {
+        "trainings": {
+          "description": "Se recomienda en función de tu progreso para ayudarte a reforzar tus habilidades y avanzar más, en el momento adecuado.",
+          "title": "Ve más allá, a tu propio ritmo."
+        }
+      },
       "reset": {
         "button": "Poner a cero y volver a intentarlo todo",
         "modal": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2210,6 +2210,17 @@
       },
       "not-finished": "Todavía no puedes enviar tus resultados, aún tenemos algunas preguntas para ti.",
       "recommended-engine": {
+        "training-card": {
+          "delivery-mode": {
+            "hybrid": "Híbrido",
+            "on-site": "Presencial",
+            "remote": "A distancia"
+          },
+          "registration-required": {
+            "no": "Acceso libre inmediato",
+            "yes": "Inscripción requerida"
+          }
+        },
         "trainings": {
           "description": "Se recomienda en función de tu progreso para ayudarte a reforzar tus habilidades y avanzar más, en el momento adecuado.",
           "title": "Ve más allá, a tu propio ritmo."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2302,6 +2302,7 @@
       "type": {
         "autoformation": "Parcours d'autoformation",
         "e-learning": "Formation à distance",
+        "formation": "Formation",
         "hybrid-training": "Formation hybride",
         "in-person-training": "Formation en présentiel",
         "modulix": "Module Pix",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2209,6 +2209,12 @@
         "title": "Votre avis compte !"
       },
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
+      "recommended-engine": {
+        "trainings": {
+          "description": "Il est recommandé en fonction de votre progression pour vous aider à renforcer vos compétences et aller plus loin, au bon moment.",
+          "title": "Allez plus loin, à votre rythme."
+        }
+      },
       "reset": {
         "button": "Remettre à zéro et tout retenter",
         "modal": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2210,6 +2210,17 @@
       },
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "recommended-engine": {
+        "training-card": {
+          "delivery-mode": {
+            "hybrid": "Hybride",
+            "on-site": "Sur place",
+            "remote": "À distance"
+          },
+          "registration-required": {
+            "no": "Libre accès immédiat",
+            "yes": "Inscription requise"
+          }
+        },
         "trainings": {
           "description": "Il est recommandé en fonction de votre progression pour vous aider à renforcer vos compétences et aller plus loin, au bon moment.",
           "title": "Allez plus loin, à votre rythme."

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2209,6 +2209,12 @@
         "title": "La tua opinione conta!"
       },
       "not-finished": "Non è ancora possibile invia i risultati, quindi abbiamo ancora alcune domande per voi.",
+      "recommended-engine": {
+        "trainings": {
+          "description": "Viene consigliato in base ai tuoi progressi per aiutarti a consolidare le tue competenze e ad andare oltre, al momento giusto.",
+          "title": "Andate oltre, al vostro ritmo."
+        }
+      },
       "reset": {
         "button": "Reimpostare e riprovare",
         "modal": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2210,6 +2210,17 @@
       },
       "not-finished": "Non è ancora possibile invia i risultati, quindi abbiamo ancora alcune domande per voi.",
       "recommended-engine": {
+        "training-card": {
+          "delivery-mode": {
+            "hybrid": "Ibrido",
+            "on-site": "In loco",
+            "remote": "A distanza"
+          },
+          "registration-required": {
+            "no": "Accesso libero immediato",
+            "yes": "Iscrizione richiesta"
+          }
+        },
         "trainings": {
           "description": "Viene consigliato in base ai tuoi progressi per aiutarti a consolidare le tue competenze e ad andare oltre, al momento giusto.",
           "title": "Andate oltre, al vostro ritmo."

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2302,6 +2302,7 @@
       "type": {
         "autoformation": "Corsi di autoformazione",
         "e-learning": "Formazione a distanza",
+        "formation": "Formazione",
         "hybrid-training": "Formazione ibrida",
         "in-person-training": "Formazione faccia a faccia",
         "modulix": "Modulo Pix (Beta)",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2210,6 +2210,17 @@
       },
       "not-finished": "Je kunt je resultaten nog niet opsturen, dus we hebben nog een paar vragen voor je.",
       "recommended-engine": {
+        "training-card": {
+          "delivery-mode": {
+            "hybrid": "Hybride",
+            "on-site": "Ter plaatse",
+            "remote": "Op afstand"
+          },
+          "registration-required": {
+            "no": "Onmiddellijke vrije toegang",
+            "yes": "Inschrijving vereist"
+          }
+        },
         "trainings": {
           "description": "Deze aanbeveling wordt gedaan op basis van je voortgang, om je te helpen je vaardigheden te versterken en op het juiste moment een stap verder te gaan.",
           "title": "Ga verder, op je eigen tempo."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2302,6 +2302,7 @@
       "type": {
         "autoformation": "Zelftrainingscursussen",
         "e-learning": "Afstandsonderwijs",
+        "formation": "Opleiding",
         "hybrid-training": "Hybride training",
         "in-person-training": "Persoonlijke training",
         "modulix": "Modulix",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2209,6 +2209,12 @@
         "title": "Jouw mening telt!"
       },
       "not-finished": "Je kunt je resultaten nog niet opsturen, dus we hebben nog een paar vragen voor je.",
+      "recommended-engine": {
+        "trainings": {
+          "description": "Deze aanbeveling wordt gedaan op basis van je voortgang, om je te helpen je vaardigheden te versterken en op het juiste moment een stap verder te gaan.",
+          "title": "Ga verder, op je eigen tempo."
+        }
+      },
       "reset": {
         "button": "Reset en probeer opnieuw",
         "modal": {


### PR DESCRIPTION
## 💥 Problème

Chantier des CF en fin de parcours avec recommandation. 

## 👩‍🚀 Proposition

Appliquer le nouveau design des cartes de contenu formatifs


## ⚡️ Remarques

J'ajoute une modale vide pour que le bouton n'ai pas une fonction vide.

## ♻️ Pour tester

Se connecter avec perfect-profile-user@example.net (et si vous êtes motivés : dave-comp@example.net )
Utiliser le code campagne EVAL12345

https://app-pr16215.review.pix.fr/campagnes/EVAL12345/evaluation/resultats


- Voir que la carte porte une image avec le logo à gauche (rien à droite pour le moment)
- Voir que la carte porte un titre, un tag (inscription ou non) (tag purple en cours de dev sur Pix UI)
- Voir que la carte porte son type + deliveryMode (hybride, distance..) + durée
- Voir que les 3 cartes sont alignés, même largeur, même hauteur
  - Ouvrir la console et dupliquer le noeud d'une carte existante pour s'en créer 2-3 rapidos
  - Voir que la 4ème carte disparaît, un peu coupé
  - Voir en scrollant que les autres apparaissent (Le carroussel n'est pas implémenté dans ce ticket)
- Voir en mobile que la seconde carte déborde sur la droite et scroller pour accéder aux autres

dernier commit : quand le CF est de type hybrid, e-learning ou in-person-training, on ne veut pas voir le type en entier. Car deliveryMode indique déjà si c'est à distance, en hybride ou en présentiel. Ça fait redondant. On met donc juste "Formation"

<img width="408" height="643" alt="Capture d’écran 2026-05-20 à 15 16 51" src="https://github.com/user-attachments/assets/ec138eb5-2507-4954-b5b8-d6a509951f2c" />
<img width="1278" height="793" alt="Capture d’écran 2026-05-20 à 15 16 13" src="https://github.com/user-attachments/assets/111a0aba-ab52-475f-86d0-3767fbffc552" />

