### PR TITLE
[TECH] Logger le user_id pour les connexions réussies (PIX-22741)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -221,7 +221,7 @@ TEST_JOBS_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # type: Boolean
 # default: `false`
 # sample: START_JOB_IN_WEB_PROCESS=true
-START_JOB_IN_WEB_PROCESS=
+# START_JOB_IN_WEB_PROCESS=
 
 
 
@@ -1257,7 +1257,7 @@ DAY_BEFORE_RETRYING=
 # presence: optional
 # type: Integer
 # default: 0
-HTTP_SERVER_RESPONSE_TIMEOUT_MS=
+# HTTP_SERVER_RESPONSE_TIMEOUT_MS=
 
 # Response timeout in milliseconds. Sets the maximum time allowed before a statement in query will time out.
 # Put 0 to set no timeout at all.
@@ -1265,7 +1265,7 @@ HTTP_SERVER_RESPONSE_TIMEOUT_MS=
 # presence: optional
 # type: Integer
 # default: 0
-DATABASE_STATEMENT_TIMEOUT_MS=
+# DATABASE_STATEMENT_TIMEOUT_MS=
 
 # Response timeout in milliseconds. Sets the maximum time allowed before a query will time out.
 # Put 0 to set no timeout at all.
@@ -1273,7 +1273,7 @@ DATABASE_STATEMENT_TIMEOUT_MS=
 # presence: optional
 # type: Integer
 # default: 0
-DATABASE_QUERY_TIMEOUT_MS=
+# DATABASE_QUERY_TIMEOUT_MS=
 
 # Response timeout in milliseconds. Sets the maximum time allowed before terminating any session with an open idle transaction.
 # Put 0 to set no timeout at all.
@@ -1281,7 +1281,7 @@ DATABASE_QUERY_TIMEOUT_MS=
 # presence: optional
 # type: Integer
 # default: 0
-DATABASE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_MS=
+# DATABASE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_MS=
 
 # Response timeout in milliseconds. Sets the maximum time allowed to wait for a connection before timeout.
 # Put 0 to set no timeout at all.
@@ -1289,7 +1289,7 @@ DATABASE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_MS=
 # presence: optional
 # type: Integer
 # default: 0
-DATABASE_CONNECTION_TIMEOUT_MS=
+# DATABASE_CONNECTION_TIMEOUT_MS=
 
 # Response timeout in milliseconds. Help me Benjamin I am not sure about this one.
 # Put 0 to set no timeout at all.
@@ -1297,7 +1297,7 @@ DATABASE_CONNECTION_TIMEOUT_MS=
 # presence: optional
 # type: Integer
 # default: 10000
-DATABASE_IDLE_TIMEOUT_MS=
+# DATABASE_IDLE_TIMEOUT_MS=
 
 # ========
 # TRANSLATIONS

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -3,7 +3,7 @@ import { stdSerializers } from 'pino';
 import { generateHash } from '../../../identity-access-management/infrastructure/utils/crypto.js';
 import { getForwardedOrigin } from '../../../identity-access-management/infrastructure/utils/network.js';
 import { config } from '../../config.js';
-import { getCorrelationInfo, getInContext } from '../execution-context-manager.js';
+import { getCorrelationInfo, getInContext, setInContext } from '../execution-context-manager.js';
 import { loggerPino } from '../utils/logger.js';
 
 const serializersSym = Symbol.for('pino.serializers');
@@ -30,13 +30,14 @@ function requestSerializer(req) {
     enhancedReq.grantType = grant_type || '-';
     enhancedReq.usernameHash = generateHash(username) || '-';
     enhancedReq.refreshTokenHash = generateHash(refresh_token) || '-';
+    setInContext('user_id', request?.response?.source?.user_id);
   }
 
   const metrics = getInContext('metrics', null);
   return {
     ...enhancedReq,
     ...getCorrelationInfo(),
-    metrics: metrics,
+    metrics,
     route: request?.route?.path,
     routeDomain: request?.route?.realm?.plugin,
   };

--- a/api/tests/integration/infrastructure/plugins/pino_test.js
+++ b/api/tests/integration/infrastructure/plugins/pino_test.js
@@ -2,7 +2,10 @@ import { Writable } from 'node:stream';
 
 import pino from 'pino';
 
-import { incrementInContext } from '../../../../src/shared/infrastructure/execution-context-manager.js';
+import {
+  incrementInContext,
+  installHapiHook,
+} from '../../../../src/shared/infrastructure/execution-context-manager.js';
 import * as pinoPlugin from '../../../../src/shared/infrastructure/plugins/pino.js';
 import { expect } from '../../../test-helper.js';
 import { HttpTestServer } from '../../../tooling/server/http-test-server.js';
@@ -31,7 +34,7 @@ describe('Integration | Infrastructure | plugins | pino', function () {
             path: '/api/token',
             config: {
               handler: () => {
-                return {};
+                return { user_id: '1234' };
               },
             },
           },
@@ -48,6 +51,7 @@ describe('Integration | Infrastructure | plugins | pino', function () {
       },
       name: 'test-api',
     });
+    installHapiHook();
   });
 
   async function registerWithPlugin(cb) {
@@ -137,7 +141,7 @@ describe('Integration | Infrastructure | plugins | pino', function () {
           expect(messages).to.have.lengthOf(1);
           expect(messages[0].msg).to.equal('request completed');
           expect(messages[0].req.version).to.equal('development');
-          expect(messages[0].req.user_id).to.equal(null);
+          expect(messages[0].req.user_id).to.equal('1234');
           expect(messages[0].req.route).to.equal('/api/token');
           expect(messages[0].req.usernameHash).to.equal(
             '31f7a65e315586ac198bd798b6629ce4903d0899476d5741a9f32e2e521b6a66', // echo -n 'toto'| shasum -a 256
@@ -164,7 +168,7 @@ describe('Integration | Infrastructure | plugins | pino', function () {
           expect(messages).to.have.lengthOf(1);
           expect(messages[0].msg).to.equal('request completed');
           expect(messages[0].req.version).to.equal('development');
-          expect(messages[0].req.user_id).to.equal(null);
+          expect(messages[0].req.user_id).to.equal('1234');
           expect(messages[0].req.route).to.equal('/api/token');
           expect(messages[0].req.usernameHash).to.equal('-');
         });


### PR DESCRIPTION
## 💥 Problème

Quand un utilisateur se connecte via la route `/api/token`, on ne sait pas quel est l'utilisateur au niveau des logs.

## 👩‍🚀 Proposition

Pour la route `/api/token` ajouter dans le log le `user_id` retourné dans la réponse.

## 👁️ Remarques

**Scout:** Dans le `sample.env`, commenter certaines variables d'environnement qui ont une valeur par défaut.

## ♻️ Pour tester

Se connecter à Pix App, voir le `user_id` dans la log de la requête `POST /api/token`
