### PR TITLE
[BUGFIX] - Répare le rattachement d'une attestation aux parcours combinés dans PixAdmin (PIX-22779)

### DIFF
--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -6,6 +6,7 @@ export default class CombinedCourseBlueprint extends Model {
   @attr('string') illustration;
   @attr('string') description;
   @attr('string') attestationLabel;
+  @attr('string') attestationKey;
   @attr({ type: 'date', defaultValue: () => undefined }) createdAt;
   @attr({ defaultValue: () => [] }) content;
 }

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
@@ -15,6 +15,12 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('country', { code: '99100', name: 'France' });
+    server.create('attestation', {
+      templateName: 'parentalite',
+      key: 'PARENTHOOD',
+      file: 'parentalite.pdf',
+      label: 'Parentalite',
+    });
 
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
@@ -46,6 +52,14 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
     );
 
     await fillIn(screen.getByLabelText(t('components.combined-course-blueprints.labels.description')), 'description');
+
+    await click(
+      screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+    );
+
+    await screen.findByRole('listbox');
+
+    await click(screen.getByRole('option', { name: 'Parentalite' }));
 
     await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 

--- a/admin/tests/mirage/factories/attestation.js
+++ b/admin/tests/mirage/factories/attestation.js
@@ -1,0 +1,3 @@
+import { Factory } from 'miragejs';
+
+export default Factory.extend({});

--- a/admin/tests/unit/serializers/combined-course-blueprint-test.js
+++ b/admin/tests/unit/serializers/combined-course-blueprint-test.js
@@ -17,6 +17,7 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
         },
       ],
       attestationLabel: 'Label attestation',
+      attestationKey: 'ATTESTATION_KEY',
     });
 
     const serializedRecord = record.serialize();
@@ -38,6 +39,7 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
               },
             ],
             'attestation-label': 'Label attestation',
+            'attestation-key': 'ATTESTATION_KEY',
           },
         },
       },


### PR DESCRIPTION
## 💥 Problème
On a vu que l'attestationKey n'était pas passée du front au back lors de la création d'un parcours combiné avec attestation.

## 👩‍🚀 Proposition
On ajoute attestationKey au model combined-course-blueprint côté front parce qu'il est attendu dans la désérialisation côté back.

## 👁️ Remarques
On en profite pour enrichir les tests d'acceptance du front.

## ♻️ Pour tester
Aller sur PixAdmin -> Schémas de parcours
Créer un schéma de parcours avec attestation
Vérifier que l'attestationKey est bien désérialisée et que la rewardId est bien présente dans la quête sur le blueprint.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
