### PR TITLE
[FEATURE] Rendre le bouton "supprimer une version" fonctionnel (PIX-22696)

### DIFF
--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -1,10 +1,9 @@
-import { action } from '@ember/object';
-import { service } from '@ember/service';
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { service } from "@ember/service";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 
-import FrameworkHistory from './framework/framework-history';
-import History from './target-profile/history';
+import FrameworkHistory from "./framework/framework-history";
+import History from "./target-profile/history";
 
 export default class CertificationFramework extends Component {
   @service store;
@@ -24,28 +23,12 @@ export default class CertificationFramework extends Component {
       await certificationFramework.reload();
       this.targetProfilesHistory = certificationFramework.targetProfilesHistory;
     }
-
-    await this.#loadFrameworkHistory();
-  }
-
-  async #loadFrameworkHistory() {
-    const frameworkHistory = await this.store.queryRecord('framework-history', this.args.frameworkKey);
-    this.frameworkHistory = frameworkHistory?.history;
-  }
-
-  @action
-  async reloadHistory() {
-    await this.#loadFrameworkHistory();
   }
 
   <template>
-    {{#if this.frameworkHistory}}
       <FrameworkHistory
-        @history={{this.frameworkHistory}}
-        @scope={{@frameworkKey}}
-        @onVersionDeleted={{this.reloadHistory}}
+        @frameworkKey={{@frameworkKey}}
       />
-    {{/if}}
 
     {{#if this.targetProfilesHistory}}
       <History @targetProfilesHistory={{this.targetProfilesHistory}} />

--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -1,9 +1,9 @@
-import { service } from "@ember/service";
-import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
-import FrameworkHistory from "./framework/framework-history";
-import History from "./target-profile/history";
+import FrameworkHistory from './framework/framework-history';
+import History from './target-profile/history';
 
 export default class CertificationFramework extends Component {
   @service store;
@@ -26,9 +26,7 @@ export default class CertificationFramework extends Component {
   }
 
   <template>
-      <FrameworkHistory
-        @frameworkKey={{@frameworkKey}}
-      />
+    <FrameworkHistory @frameworkKey={{@frameworkKey}} />
 
     {{#if this.targetProfilesHistory}}
       <History @targetProfilesHistory={{this.targetProfilesHistory}} />

--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -24,13 +25,26 @@ export default class CertificationFramework extends Component {
       this.targetProfilesHistory = certificationFramework.targetProfilesHistory;
     }
 
+    await this.#loadFrameworkHistory();
+  }
+
+  async #loadFrameworkHistory() {
     const frameworkHistory = await this.store.queryRecord('framework-history', this.args.frameworkKey);
     this.frameworkHistory = frameworkHistory?.history;
   }
 
+  @action
+  async reloadHistory() {
+    await this.#loadFrameworkHistory();
+  }
+
   <template>
     {{#if this.frameworkHistory}}
-      <FrameworkHistory @history={{this.frameworkHistory}} @scope={{@frameworkKey}} />
+      <FrameworkHistory
+        @history={{this.frameworkHistory}}
+        @scope={{@frameworkKey}}
+        @onVersionDeleted={{this.reloadHistory}}
+      />
     {{/if}}
 
     {{#if this.targetProfilesHistory}}

--- a/admin/app/components/certification-frameworks/item/framework/certification-version-detail-modal.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/certification-version-detail-modal.gjs
@@ -37,7 +37,7 @@ export default class CertificationVersionDetailModal extends Component {
     <PixModal
       class="certification-version-detail-modal"
       @title={{this.frameworkLabel}}
-      @showModal={{true}}
+      @showModal={{@showModal}}
       @onCloseButtonClick={{@onClose}}
     >
       <:content>

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -1,5 +1,7 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
@@ -19,10 +21,14 @@ const STATUS_COLORS = { ACTIVE: 'success', DRAFT: 'tertiary', ARCHIVED: 'seconda
 
 export default class FrameworkHistory extends Component {
   @service store;
+  @service intl;
+  @service pixToast;
 
   @tracked frameworkHistory = [];
   @tracked selectedVersion = null;
   @tracked selectedVersionStatus = null;
+  @tracked showDeletionConfirmationModal = false;
+  @tracked showVersionDetailModal = false;
 
   constructor() {
     super(...arguments);
@@ -39,24 +45,42 @@ export default class FrameworkHistory extends Component {
   async viewVersion(id, status) {
     this.selectedVersionStatus = status;
     this.selectedVersion = await this.store.findRecord('certification-version', id);
+    this.showVersionDetailModal = true;
   }
 
   @action
-  closeModal() {
+  closeModalVersionDetail() {
     this.selectedVersion = null;
     this.selectedVersionStatus = null;
+    this.showVersionDetailModal = false;
   }
 
   @action
-  async deleteVersion(idToDelete) {
-    const selectedVersion = await this.store.findRecord('certification-version', idToDelete);
+  async showDeleteVersionModal(selectedVersionId) {
+    this.selectedVersion = await this.store.findRecord('certification-version', selectedVersionId);
+    this.showDeletionConfirmationModal = true;
+  }
+
+  @action
+  closeDeleteVersionModal() {
+    this.showDeletionConfirmationModal = false;
+  }
+
+  @action
+  async deleteVersion() {
+    const selectionVersionId = parseInt(this.selectedVersion.id);
     try {
-      await selectedVersion.destroyRecord();
-      this.frameworkHistory = this.frameworkHistory.filter(({ id }) => {
-        return id !== idToDelete;
+      await this.selectedVersion.destroyRecord();
+      this.frameworkHistory = this.frameworkHistory.filter(({ id }) => id !== selectionVersionId);
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.certification-frameworks.deletion-modal.success-message'),
       });
     } catch {
-      selectedVersion.rollbackAttributes();
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.certification-frameworks.deletion-modal.error-message'),
+      });
+    } finally {
+      this.closeDeleteVersionModal();
     }
   }
 
@@ -143,7 +167,7 @@ export default class FrameworkHistory extends Component {
                   @isDisabled={{not (eq version.status "DRAFT")}}
                 />
                 <PixIconButton
-                  @triggerAction={{fn this.deleteVersion version.id}}
+                  @triggerAction={{fn this.showDeleteVersionModal version.id}}
                   @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.delete"}}
                   @iconName="delete"
                   @isDisabled={{not (eq version.status "DRAFT")}}
@@ -160,8 +184,26 @@ export default class FrameworkHistory extends Component {
         @version={{this.selectedVersion}}
         @status={{this.selectedVersionStatus}}
         @scope={{@scope}}
-        @onClose={{this.closeModal}}
+        @onClose={{this.closeModalVersionDetail}}
+        @showModal={{this.showVersionDetailModal}}
       />
     {{/if}}
+
+    <PixModal
+      @title={{t "components.certification-frameworks.deletion-modal.title"}}
+      @onCloseButtonClick={{this.closeDeleteVersionModal}}
+      @showModal={{this.showDeletionConfirmationModal}}
+    >
+      <:content>
+        <p>
+          {{t "components.certification-frameworks.deletion-modal.content"}}
+        </p>
+      </:content>
+      <:footer>
+        <PixButton @triggerAction={{this.deleteVersion}}>
+          {{t "components.certification-frameworks.deletion-modal.action-button"}}
+        </PixButton>
+      </:footer>
+    </PixModal>
   </template>
 }

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -20,8 +20,20 @@ const STATUS_COLORS = { ACTIVE: 'success', DRAFT: 'tertiary', ARCHIVED: 'seconda
 export default class FrameworkHistory extends Component {
   @service store;
 
+  @tracked frameworkHistory = [];
   @tracked selectedVersion = null;
   @tracked selectedVersionStatus = null;
+
+  constructor() {
+    super(...arguments);
+
+    this.#onMount();
+  }
+
+  async #onMount() {
+    const frameworkHistory = await this.store.queryRecord('framework-history', this.args.frameworkKey);
+    this.frameworkHistory = frameworkHistory?.history;
+  }
 
   @action
   async viewVersion(id, status) {
@@ -36,102 +48,112 @@ export default class FrameworkHistory extends Component {
   }
 
   @action
-  async deleteVersion(id) {
-    const selectedVersion = await this.store.findRecord('certification-version', id);
-    await selectedVersion.destroyRecord();
-    await this.args.onVersionDeleted();
+  async deleteVersion(idToDelete) {
+    const selectedVersion = await this.store.findRecord('certification-version', idToDelete);
+    try {
+      await selectedVersion.destroyRecord();
+      this.frameworkHistory = this.frameworkHistory.filter(({ id }) => {
+        return id !== idToDelete;
+      });
+    } catch {
+      selectedVersion.rollbackAttributes();
+    }
   }
 
   <template>
-    <section class="framework-versions">
-      <PixTable
-        @variant="admin"
-        @caption={{t "components.complementary-certifications.item.framework.history.table.caption"}}
-        @data={{@history}}
-      >
-        <:columns as |version context|>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t "components.complementary-certifications.item.framework.history.table.columns.version-id"}}
-            </:header>
-            <:cell>
-              {{version.id}}
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t
-                "components.complementary-certifications.item.framework.history.table.columns.maximum-assessment-length"
-              }}
-            </:header>
-            <:cell>
-              {{version.maximumAssessmentLength}}
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              <PixIcon @name="time" @ariaHidden={{true}} />
-              {{t "components.complementary-certifications.item.framework.history.table.columns.assessment-duration"}}
-            </:header>
-            <:cell>
-              {{formatMinutes version.assessmentDuration}}
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              <PixIcon @name="calendar" @ariaHidden={{true}} />
-              {{t "components.complementary-certifications.item.framework.history.table.columns.start-date"}}
-            </:header>
-            <:cell>
-              <strong>{{if version.startDate (formatDate version.startDate) "-"}}</strong>
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              <PixIcon @name="calendar" @ariaHidden={{true}} />
-              {{t "components.complementary-certifications.item.framework.history.table.columns.expiration-date"}}
-            </:header>
-            <:cell>
-              <strong>{{if version.expirationDate (formatDate version.expirationDate) "-"}}</strong>
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t "components.complementary-certifications.item.framework.history.table.columns.status"}}
-            </:header>
-            <:cell>
-              <PixTag @color={{get STATUS_COLORS version.status}}>
-                {{t (concat "components.complementary-certifications.item.framework.history.statuses." version.status)}}
-              </PixTag>
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t "components.complementary-certifications.item.framework.history.table.columns.actions"}}
-            </:header>
-            <:cell>
-              <PixIconButton
-                @triggerAction={{fn this.viewVersion version.id version.status}}
-                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.view"}}
-                @iconName="eye"
-              />
-              <PixIconButton
-                @triggerAction={{this.editVersion}}
-                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.edit"}}
-                @iconName="edit"
-                @isDisabled={{not (eq version.status "DRAFT")}}
-              />
-              <PixIconButton
-                @triggerAction={{this.deleteVersion}}
-                @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.delete"}}
-                @iconName="delete"
-                @isDisabled={{not (eq version.status "DRAFT")}}
-              />
-            </:cell>
-          </PixTableColumn>
-        </:columns>
-      </PixTable>
-    </section>
+    {{#if this.frameworkHistory}}
+      <section class="framework-versions">
+        <PixTable
+          @variant="admin"
+          @caption={{t "components.complementary-certifications.item.framework.history.table.caption"}}
+          @data={{this.frameworkHistory}}
+        >
+          <:columns as |version context|>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                {{t "components.complementary-certifications.item.framework.history.table.columns.version-id"}}
+              </:header>
+              <:cell>
+                {{version.id}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                {{t
+                  "components.complementary-certifications.item.framework.history.table.columns.maximum-assessment-length"
+                }}
+              </:header>
+              <:cell>
+                {{version.maximumAssessmentLength}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                <PixIcon @name="time" @ariaHidden={{true}} />
+                {{t "components.complementary-certifications.item.framework.history.table.columns.assessment-duration"}}
+              </:header>
+              <:cell>
+                {{formatMinutes version.assessmentDuration}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                <PixIcon @name="calendar" @ariaHidden={{true}} />
+                {{t "components.complementary-certifications.item.framework.history.table.columns.start-date"}}
+              </:header>
+              <:cell>
+                <strong>{{if version.startDate (formatDate version.startDate) "-"}}</strong>
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                <PixIcon @name="calendar" @ariaHidden={{true}} />
+                {{t "components.complementary-certifications.item.framework.history.table.columns.expiration-date"}}
+              </:header>
+              <:cell>
+                <strong>{{if version.expirationDate (formatDate version.expirationDate) "-"}}</strong>
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                {{t "components.complementary-certifications.item.framework.history.table.columns.status"}}
+              </:header>
+              <:cell>
+                <PixTag @color={{get STATUS_COLORS version.status}}>
+                  {{t
+                    (concat "components.complementary-certifications.item.framework.history.statuses." version.status)
+                  }}
+                </PixTag>
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                {{t "components.complementary-certifications.item.framework.history.table.columns.actions"}}
+              </:header>
+              <:cell>
+                <PixIconButton
+                  @triggerAction={{fn this.viewVersion version.id version.status}}
+                  @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.view"}}
+                  @iconName="eye"
+                />
+                <PixIconButton
+                  @triggerAction={{this.editVersion}}
+                  @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.edit"}}
+                  @iconName="edit"
+                  @isDisabled={{not (eq version.status "DRAFT")}}
+                />
+                <PixIconButton
+                  @triggerAction={{fn this.deleteVersion version.id}}
+                  @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.delete"}}
+                  @iconName="delete"
+                  @isDisabled={{not (eq version.status "DRAFT")}}
+                />
+              </:cell>
+            </PixTableColumn>
+          </:columns>
+        </PixTable>
+      </section>
+    {{/if}}
 
     {{#if this.selectedVersion}}
       <CertificationVersionDetailModal

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -38,7 +38,8 @@ export default class FrameworkHistory extends Component {
   @action
   async deleteVersion(id) {
     const selectedVersion = await this.store.findRecord('certification-version', id);
-    selectedVersion.destroyRecord()
+    await selectedVersion.destroyRecord();
+    await this.args.onVersionDeleted();
   }
 
   <template>

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -36,10 +36,10 @@ export default class FrameworkHistory extends Component {
   }
 
   @action
-  editVersion() {}
-
-  @action
-  deleteVersion() {}
+  async deleteVersion(id) {
+    const selectedVersion = await this.store.findRecord('certification-version', id);
+    selectedVersion.destroyRecord()
+  }
 
   <template>
     <section class="framework-versions">

--- a/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
@@ -32,23 +32,6 @@ module('Integration | Component | certification-frameworks/item/framework', func
         )
         .exists();
     });
-
-    test('it should not display the framework history when there is no history', async function (assert) {
-      // given
-      store.queryRecord = sinon.stub().resolves({ history: [] });
-
-      // when
-      const screen = await render(<template><Framework @frameworkKey="DROIT" /></template>);
-
-      // then
-      assert
-        .dom(
-          screen.queryByRole('table', {
-            name: t('components.complementary-certifications.item.framework.history.table.caption'),
-          }),
-        )
-        .doesNotExist();
-    });
   });
 
   module('when the framework is CORE', function () {

--- a/admin/tests/integration/components/certification-frameworks/item/framework/certification-version-detail-modal-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/certification-version-detail-modal-test.gjs
@@ -37,7 +37,13 @@ module(
       // when
       const screen = await render(
         <template>
-          <CertificationVersionDetailModal @version={{version}} @status="ACTIVE" @scope="CORE" @onClose={{onClose}} />
+          <CertificationVersionDetailModal
+            @version={{version}}
+            @status="ACTIVE"
+            @scope="CORE"
+            @onClose={{onClose}}
+            @showModal={{true}}
+          />
         </template>,
       );
 
@@ -53,7 +59,13 @@ module(
       // when
       const screen = await render(
         <template>
-          <CertificationVersionDetailModal @version={{version}} @status="ACTIVE" @scope="CORE" @onClose={{onClose}} />
+          <CertificationVersionDetailModal
+            @version={{version}}
+            @status="ACTIVE"
+            @scope="CORE"
+            @onClose={{onClose}}
+            @showModal={{true}}
+          />
         </template>,
       );
 
@@ -71,7 +83,13 @@ module(
       // when
       const screen = await render(
         <template>
-          <CertificationVersionDetailModal @version={{version}} @status="ACTIVE" @scope="CORE" @onClose={{onClose}} />
+          <CertificationVersionDetailModal
+            @version={{version}}
+            @status="ACTIVE"
+            @scope="CORE"
+            @onClose={{onClose}}
+            @showModal={{true}}
+          />
         </template>,
       );
 
@@ -98,7 +116,13 @@ module(
       // when
       const screen = await render(
         <template>
-          <CertificationVersionDetailModal @version={{version}} @status="ACTIVE" @scope="CORE" @onClose={{onClose}} />
+          <CertificationVersionDetailModal
+            @version={{version}}
+            @status="ACTIVE"
+            @scope="CORE"
+            @onClose={{onClose}}
+            @showModal={{true}}
+          />
         </template>,
       );
 
@@ -114,12 +138,46 @@ module(
       // when
       const screen = await render(
         <template>
-          <CertificationVersionDetailModal @version={{version}} @status="ACTIVE" @scope="CORE" @onClose={{onClose}} />
+          <CertificationVersionDetailModal
+            @version={{version}}
+            @status="ACTIVE"
+            @scope="CORE"
+            @onClose={{onClose}}
+            @showModal={{true}}
+          />
         </template>,
       );
 
       // then
       assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).exists();
+    });
+
+    test('if sould be hidden when showModal is false', async function (assert) {
+      //given
+      const area = store.createRecord('area', {
+        id: 'area1',
+        title: 'Domaine test',
+        code: '1',
+        color: 'red',
+        frameworkId: 'fw1',
+      });
+      const version = buildVersion({ areas: [area] });
+      const onClose = sinon.stub();
+
+      //when
+      const screen = await render(
+        <template>
+          <CertificationVersionDetailModal
+            @version={{version}}
+            @status="ACTIVE"
+            @scope="CORE"
+            @onClose={{onClose}}
+            @showModal={{false}}
+          />
+        </template>,
+      );
+
+      assert.dom(screen.queryByRole('dialog')).doesNotExist();
     });
   },
 );

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -9,41 +9,48 @@ import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-ren
 module('Integration | Component | Complementary certifications/Item/Framework | Framework history', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let intl;
-
-  let store;
-
-  let pixToast;
+  let intl, store, pixToast, frameworkItem1, frameworkItem2, frameworkItem3;
 
   hooks.beforeEach(function () {
     intl = this.owner.lookup('service:intl');
     store = this.owner.lookup('service:store');
     pixToast = this.owner.lookup('service:pix-toast');
+
+    frameworkItem1 = {
+      id: 456,
+      startDate: new Date('2023-10-10'),
+      expirationDate: null,
+      assessmentDuration: 90,
+      maximumAssessmentLength: 32,
+      status: 'ACTIVE',
+    };
+    frameworkItem2 = {
+      id: 123,
+      startDate: new Date('2020-01-01'),
+      expirationDate: new Date('2021-06-15'),
+      assessmentDuration: 105,
+      maximumAssessmentLength: 32,
+      status: 'ARCHIVED',
+    };
+    frameworkItem3 = {
+      id: 999,
+      startDate: null,
+      expirationDate: null,
+      assessmentDuration: 90,
+      maximumAssessmentLength: 32,
+      status: 'DRAFT',
+    };
+
+    sinon.stub(store, 'queryRecord').resolves(
+      store.createRecord('framework-history', {
+        history: [frameworkItem1, frameworkItem2, frameworkItem3],
+      }),
+    );
   });
 
   test('it should display the framework history', async function (assert) {
-    // given
-    const frameworkHistory = [
-      {
-        id: 456,
-        startDate: new Date('2023-10-10'),
-        expirationDate: null,
-        assessmentDuration: 90,
-        maximumAssessmentLength: 32,
-        status: 'ACTIVE',
-      },
-      {
-        id: 123,
-        startDate: new Date('2020-01-01'),
-        expirationDate: new Date('2021-06-15'),
-        assessmentDuration: 105,
-        maximumAssessmentLength: 32,
-        status: 'ARCHIVED',
-      },
-    ];
-
     // when
-    const screen = await render(<template><FrameworkHistory @history={{frameworkHistory}} /></template>);
+    const screen = await render(<template><FrameworkHistory @frameworkKey="DROIT" /></template>);
 
     // then
     assert
@@ -54,16 +61,16 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       )
       .exists();
 
-    assert.strictEqual(screen.getAllByRole('row').length, frameworkHistory.length + 1);
+    assert.strictEqual(screen.getAllByRole('row').length, 4);
 
-    assert.dom(screen.getByRole('cell', { name: `${frameworkHistory[0].id}` })).exists();
-    assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkHistory[0].startDate) })).exists();
+    assert.dom(screen.getByRole('cell', { name: `${frameworkItem1.id}` })).exists();
+    assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkItem1.startDate) })).exists();
     assert
       .dom(screen.getByText(t('components.complementary-certifications.item.framework.history.statuses.ACTIVE')))
       .hasClass('pix-tag--success');
 
-    assert.dom(screen.getByRole('cell', { name: `${frameworkHistory[1].id}` })).exists();
-    assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkHistory[1].startDate) })).exists();
+    assert.dom(screen.getByRole('cell', { name: `${frameworkItem2.id}` })).exists();
+    assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkItem2.startDate) })).exists();
     assert
       .dom(screen.getByText(t('components.complementary-certifications.item.framework.history.statuses.ARCHIVED')))
       .hasClass('pix-tag--secondary');
@@ -71,52 +78,24 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
   test('it opens the detail modal when clicking the view button', async function (assert) {
     // given
-    const frameworkHistory = [
-      {
-        id: 456,
-        startDate: new Date('2023-10-10'),
-        expirationDate: null,
-        assessmentDuration: 90,
-        maximumAssessmentLength: 32,
-        status: 'ACTIVE',
-      },
-    ];
-
-    const certificationVersion = store.createRecord('certification-version', {
-      id: '456',
-      startDate: new Date('2023-10-10'),
-      assessmentDuration: 90,
-      areas: [],
-    });
-    sinon.stub(store, 'findRecord').resolves(certificationVersion);
+    sinon.stub(store, 'findRecord').resolves(store.createRecord('certification-version'));
 
     // when
-    const screen = await render(<template><FrameworkHistory @history={{frameworkHistory}} @scope="CORE" /></template>);
+    const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
 
     await click(
-      screen.getByRole('button', {
+      screen.getAllByRole('button', {
         name: t('components.complementary-certifications.item.framework.history.table.actions.view'),
-      }),
+      })[0],
     );
 
     // then
-    sinon.assert.calledOnceWithExactly(store.findRecord, 'certification-version', 456);
+    sinon.assert.calledOnceWithExactly(store.findRecord, 'certification-version', frameworkItem1.id);
     assert.dom(screen.getByRole('dialog')).exists();
   });
 
   test('it leaves detail modal opened after saving comments successfully', async function (assert) {
     // given
-    const frameworkHistory = [
-      {
-        id: 456,
-        startDate: new Date('2023-10-10'),
-        expirationDate: null,
-        assessmentDuration: 90,
-        maximumAssessmentLength: 32,
-        status: 'ACTIVE',
-      },
-    ];
-
     const certificationVersion = store.createRecord('certification-version', {
       id: '456',
       startDate: new Date('2023-10-10'),
@@ -130,12 +109,12 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     sinon.stub(store, 'findRecord').resolves(certificationVersion);
     sinon.stub(pixToast, 'sendSuccessNotification');
 
-    const screen = await render(<template><FrameworkHistory @history={{frameworkHistory}} @scope="CORE" /></template>);
+    const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
 
     await click(
-      screen.getByRole('button', {
+      screen.getAllByRole('button', {
         name: t('components.complementary-certifications.item.framework.history.table.actions.view'),
-      }),
+      })[0],
     );
     assert.dom(screen.getByRole('dialog')).exists();
 
@@ -144,5 +123,37 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
     // then
     assert.dom(screen.queryByRole('dialog')).exists();
+  });
+
+  module('deletion', function () {
+    const deleteButtonName = t('components.complementary-certifications.item.framework.history.table.actions.delete');
+
+    test('it should not be possible to delete an ACTIVE or ARCHIVED version', async function (assert) {
+      // when
+      const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+
+      // then
+      assert.strictEqual(screen.getAllByRole('button', { name: deleteButtonName }).length, 3);
+
+      assert.dom(screen.getAllByRole('button', { name: deleteButtonName })[0]).hasAttribute('aria-disabled');
+      assert.dom(screen.getAllByRole('button', { name: deleteButtonName })[1]).hasAttribute('aria-disabled');
+      assert.dom(screen.getAllByRole('button', { name: deleteButtonName })[2]).doesNotHaveAttribute('aria-disabled');
+    });
+
+    test('it should be possible to delete a DRAFT version', async function (assert) {
+      // given
+      const certificationVersion = store.createRecord('certification-version', { id: frameworkItem3.id });
+      sinon.stub(store, 'findRecord').resolves(certificationVersion);
+      sinon.stub(certificationVersion, 'destroyRecord').resolves();
+
+      const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+
+      // when
+      await click(screen.getAllByRole('button', { name: deleteButtonName })[2]);
+
+      // then
+      assert.strictEqual(screen.getAllByRole('row').length, 3);
+      assert.dom(screen.queryByRole('cell', { name: `${frameworkItem3.id}` })).doesNotExist();
+    });
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -14,7 +14,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
   hooks.beforeEach(function () {
     intl = this.owner.lookup('service:intl');
     store = this.owner.lookup('service:store');
-    pixToast = this.owner.lookup('service:pix-toast');
+    pixToast = this.owner.lookup('service:pixToast');
 
     frameworkItem1 = {
       id: 456,
@@ -125,8 +125,11 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     assert.dom(screen.queryByRole('dialog')).exists();
   });
 
-  module('deletion', function () {
-    const deleteButtonName = t('components.complementary-certifications.item.framework.history.table.actions.delete');
+  module('deletion', function (hooks) {
+    let deleteButtonName;
+    hooks.beforeEach(() => {
+      deleteButtonName = t('components.complementary-certifications.item.framework.history.table.actions.delete');
+    });
 
     test('it should not be possible to delete an ACTIVE or ARCHIVED version', async function (assert) {
       // when
@@ -150,10 +153,48 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
       // when
       await click(screen.getAllByRole('button', { name: deleteButtonName })[2]);
+      await click(screen.getByText('Confirmer la suppression'));
 
       // then
       assert.strictEqual(screen.getAllByRole('row').length, 3);
       assert.dom(screen.queryByRole('cell', { name: `${frameworkItem3.id}` })).doesNotExist();
+    });
+
+    module('when deletion is a success', function () {
+      test('it should send a toast for feedback ', async function (assert) {
+        sinon.stub(pixToast, 'sendSuccessNotification');
+        const certificationVersion = store.createRecord('certification-version', { id: frameworkItem3.id });
+        sinon.stub(store, 'findRecord').resolves(certificationVersion);
+        sinon.stub(certificationVersion, 'destroyRecord').resolves();
+
+        const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+
+        // when
+        await click(screen.getAllByRole('button', { name: deleteButtonName })[2]);
+        await click(screen.getByText('Confirmer la suppression'));
+
+        // then
+        assert.ok(pixToast.sendSuccessNotification.called);
+      });
+    });
+
+    module('when deletion is a error', function () {
+      test('it should send a toast for feedback ', async function (assert) {
+        sinon.stub(pixToast, 'sendErrorNotification');
+
+        const certificationVersion = store.createRecord('certification-version', { id: frameworkItem3.id });
+        sinon.stub(store, 'findRecord').resolves(certificationVersion);
+        sinon.stub(certificationVersion, 'destroyRecord').rejects();
+
+        const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+
+        // when
+        await click(screen.getAllByRole('button', { name: deleteButtonName })[2]);
+        await click(screen.getByText('Confirmer la suppression'));
+
+        // then
+        assert.ok(pixToast.sendErrorNotification.called);
+      });
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -479,6 +479,13 @@
       }
     },
     "certification-frameworks": {
+      "deletion-modal": {
+        "action-button": "Confirm deletion",
+        "content": "You are about to delete a certification version !!!!",
+        "error-message": "An error has occured",
+        "success-message": "That version has indeed been removed",
+        "title": "Confirmation of version deletion"
+      },
       "item": {
         "framework": {
           "new-version-form": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -486,6 +486,13 @@
       }
     },
     "certification-frameworks": {
+      "deletion-modal": {
+        "action-button": "Confirmer la suppression",
+        "content": "Vous vous apprêtez à supprimer une version.",
+        "error-message": "Une erreur s'est produite",
+        "success-message": "La version à bien été supprimée",
+        "title": "Confirmation de suppression d'une version"
+      },
       "item": {
         "framework": {
           "new-version-form": {

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -1,6 +1,5 @@
-import { usecases } from "../domain/usecases/index.js";
-import * as certificationVersionDetailSerializer
-  from "../infrastructure/serializers/certification-version-detail-serializer.js";
+import { usecases } from '../domain/usecases/index.js';
+import * as certificationVersionDetailSerializer from '../infrastructure/serializers/certification-version-detail-serializer.js';
 
 const getVersionById = async function (request) {
   const certificationVersionId = request.params.certificationVersionId;

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -1,5 +1,6 @@
-import { usecases } from '../domain/usecases/index.js';
-import * as certificationVersionDetailSerializer from '../infrastructure/serializers/certification-version-detail-serializer.js';
+import { usecases } from "../domain/usecases/index.js";
+import * as certificationVersionDetailSerializer
+  from "../infrastructure/serializers/certification-version-detail-serializer.js";
 
 const getVersionById = async function (request) {
   const certificationVersionId = request.params.certificationVersionId;
@@ -26,7 +27,7 @@ const update = async function (request, h) {
 const deleteCertificationVersion = async function (request) {
   const versionId = request.params.certificationVersionId;
 
-  await usecases.deleteCertificationVersion({ versionId });
+  await usecases.deleteCertificationVersion({ certificationVersionId });
 
   return h.response().code(204);
 };

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -23,8 +23,8 @@ const update = async function (request, h) {
   return h.response().code(204);
 };
 
-const deleteCertificationVersion = async function (request) {
-  const versionId = request.params.certificationVersionId;
+const deleteCertificationVersion = async function (request, h) {
+  const certificationVersionId = request.params.certificationVersionId;
 
   await usecases.deleteCertificationVersion({ certificationVersionId });
 

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -23,8 +23,17 @@ const update = async function (request, h) {
   return h.response().code(204);
 };
 
+const deleteCertificationVersion = async function (request) {
+  const versionId = request.params.certificationVersionId;
+
+  await usecases.deleteCertificationVersion({ versionId });
+
+  return h.response().code(204);
+};
+
 const certificationVersionController = {
   getVersionById,
+  deleteCertificationVersion,
   update,
 };
 

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -82,6 +82,33 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'DELETE',
+      path: '/api/admin/certification-versions/{certificationVersionId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationVersionId: identifiersType.certificationVersionId,
+          }),
+        },
+        handler: certificationVersionController.deleteCertificationVersion,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin',
+          "Elle supprime une version de référentiel de certification en cours d'édition.",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/certification/configuration/domain/errors.js
+++ b/api/src/certification/configuration/domain/errors.js
@@ -1,4 +1,4 @@
-import { DomainError } from "../../../shared/domain/errors.js";
+import { DomainError } from '../../../shared/domain/errors.js';
 
 export class InvalidScoWhitelistError extends DomainError {
   constructor(meta) {

--- a/api/src/certification/configuration/domain/errors.js
+++ b/api/src/certification/configuration/domain/errors.js
@@ -1,4 +1,4 @@
-import { DomainError } from '../../../shared/domain/errors.js';
+import { DomainError } from "../../../shared/domain/errors.js";
 
 export class InvalidScoWhitelistError extends DomainError {
   constructor(meta) {
@@ -10,5 +10,11 @@ export class InvalidBadgeLevelError extends DomainError {
   constructor(message = 'Badge level inconsistency') {
     super(message);
     this.code = 'INVALID_BADGE_LEVEL';
+  }
+}
+
+export class CertificationVersionForbiddenDeletionError extends DomainError {
+  constructor() {
+    super('Il est interdit de supprimer une version de référentiel de certification qui a déjà été activé.');
   }
 }

--- a/api/src/certification/configuration/domain/errors.js
+++ b/api/src/certification/configuration/domain/errors.js
@@ -15,6 +15,6 @@ export class InvalidBadgeLevelError extends DomainError {
 
 export class CertificationVersionForbiddenDeletionError extends DomainError {
   constructor() {
-    super('Il est interdit de supprimer une version de référentiel de certification qui a déjà été activé.');
+    super('Il est interdit de supprimer une version de référentiel de certification qui a déjà été activée.');
   }
 }

--- a/api/src/certification/configuration/domain/usecases/delete-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/delete-certification-version.js
@@ -2,7 +2,7 @@
  * @typedef {import ('./index.js').VersionRepository} VersionRepository
  */
 
-import { CertificationVersionForbiddenDeletionError } from "../errors.js";
+import { CertificationVersionForbiddenDeletionError } from '../errors.js';
 
 /**
  * @param {object} params

--- a/api/src/certification/configuration/domain/usecases/delete-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/delete-certification-version.js
@@ -1,0 +1,19 @@
+/**
+ * @typedef {import ('./index.js').VersionRepository} VersionRepository
+ */
+
+import { CertificationVersionForbiddenDeletionError } from "../errors.js";
+
+/**
+ * @param {object} params
+ * @param {number} params.certificationVersionId
+ * @param {VersionRepository} params.versionRepository
+ */
+
+export async function deleteCertificationVersion({ certificationVersionId, versionRepository }) {
+  if (await versionRepository.isDraft(certificationVersionId)) {
+    await versionRepository.deleteDraft(certificationVersionId);
+    return;
+  }
+  throw new CertificationVersionForbiddenDeletionError();
+}

--- a/api/src/certification/configuration/domain/usecases/delete-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/delete-certification-version.js
@@ -11,9 +11,9 @@ import { CertificationVersionForbiddenDeletionError } from '../errors.js';
  */
 
 export async function deleteCertificationVersion({ certificationVersionId, versionRepository }) {
-  if (await versionRepository.isDraft(certificationVersionId)) {
-    await versionRepository.deleteDraft(certificationVersionId);
-    return;
+  const version = await versionRepository.getById({ id: certificationVersionId });
+  if (version.startDate) {
+    throw new CertificationVersionForbiddenDeletionError();
   }
-  throw new CertificationVersionForbiddenDeletionError();
+  await versionRepository.deleteVersion(certificationVersionId);
 }

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -31,6 +31,7 @@ import { searchAttachableTargetProfiles } from './search-attachable-target-profi
 import { sendTargetProfileNotifications } from './send-target-profile-notifications.js';
 import { updateScoBlockedAccessDate } from './update-sco-blocked-access-date.js';
 import { updateVersion } from './update-version.js';
+import { deleteCertificationVersion } from "./delete-certification-version.js";
 
 /**
  *
@@ -77,6 +78,7 @@ const usecasesWithoutInjectedDependencies = {
   attachBadges,
   calibrateFrameworkVersion,
   createCertificationVersion,
+  deleteCertificationVersion,
   exportScoWhitelist,
   findCertificationFrameworks,
   findComplementaryCertifications,

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -18,6 +18,7 @@ import * as versionRepository from '../../infrastructure/repositories/version-re
 import { attachBadges } from './attach-badges.js';
 import { calibrateFrameworkVersion } from './calibrate-framework-version.js';
 import { createCertificationVersion } from './create-certification-version.js';
+import { deleteCertificationVersion } from './delete-certification-version.js';
 import { exportScoWhitelist } from './export-sco-whitelist.js';
 import { findCertificationFrameworks } from './find-certification-frameworks.js';
 import { findComplementaryCertifications } from './find-complementary-certifications.js';
@@ -31,7 +32,6 @@ import { searchAttachableTargetProfiles } from './search-attachable-target-profi
 import { sendTargetProfileNotifications } from './send-target-profile-notifications.js';
 import { updateScoBlockedAccessDate } from './update-sco-blocked-access-date.js';
 import { updateVersion } from './update-version.js';
-import { deleteCertificationVersion } from "./delete-certification-version.js";
 
 /**
  *

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -3,13 +3,11 @@
  * @typedef {import("../../../shared/domain/models/Scopes.js").SCOPES} SCOPES
  * @typedef {import("../../../../shared/domain/models/Challenge.js").Challenge} Challenge
  */
-import { DomainTransaction } from "../../../../shared/domain/DomainTransaction.js";
-import { NotFoundError } from "../../../../shared/domain/errors.js";
-import {
-  FlashAssessmentAlgorithmConfiguration
-} from "../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js";
-import { Version } from "../../domain/models/Version.js";
-import { FrameworkHistoryEntry } from "../../domain/read-models/FrameworkHistoryEntry.js";
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
+import { Version } from '../../domain/models/Version.js';
+import { FrameworkHistoryEntry } from '../../domain/read-models/FrameworkHistoryEntry.js';
 
 /**
  * @returns {Promise<Version[]>}

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -128,13 +128,7 @@ export async function getFrameworkHistory({ scope }) {
   return rows.map(_toFrameworkHistoryEntry);
 }
 
-export async function isDraft(id) {
-  const knexConn = DomainTransaction.getConnection();
-  const version = await knexConn('certification_versions').select('startDate').where({ id }).first();
-  return version?.startDate === null;
-}
-
-export async function deleteDraft(id) {
+export async function deleteVersion(id) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('certification-frameworks-challenges').where({ versionId: id }).del();
   await knexConn('certification_versions').where({ id }).del();

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -3,11 +3,13 @@
  * @typedef {import("../../../shared/domain/models/Scopes.js").SCOPES} SCOPES
  * @typedef {import("../../../../shared/domain/models/Challenge.js").Challenge} Challenge
  */
-import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
-import { Version } from '../../domain/models/Version.js';
-import { FrameworkHistoryEntry } from '../../domain/read-models/FrameworkHistoryEntry.js';
+import { DomainTransaction } from "../../../../shared/domain/DomainTransaction.js";
+import { NotFoundError } from "../../../../shared/domain/errors.js";
+import {
+  FlashAssessmentAlgorithmConfiguration
+} from "../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js";
+import { Version } from "../../domain/models/Version.js";
+import { FrameworkHistoryEntry } from "../../domain/read-models/FrameworkHistoryEntry.js";
 
 /**
  * @returns {Promise<Version[]>}
@@ -126,6 +128,18 @@ export async function getFrameworkHistory({ scope }) {
     .orderBy('startDate', 'desc');
 
   return rows.map(_toFrameworkHistoryEntry);
+}
+
+export async function isDraft(id) {
+  const knexConn = DomainTransaction.getConnection();
+  const version = await knexConn('certification_versions').select('startDate').where({ id }).first();
+  return version?.startDate === null;
+}
+
+export async function deleteDraft(id) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('certification-frameworks-challenges').where({ versionId: id }).del();
+  await knexConn('certification_versions').where({ id }).del();
 }
 
 const _toFrameworkHistoryEntry = ({ id, startDate, expirationDate, assessmentDuration, challengesConfiguration }) => {

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -1,8 +1,7 @@
-import { expect } from 'chai';
-
 import { createServer } from '../../../../../server.js';
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
-import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Acceptance | Certification | Configuration | API | certification-version-route', function () {
@@ -124,6 +123,31 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       expect(response.statusCode).to.equal(204);
       const [updatedVersion] = await knex('certification_versions').where({ id: version.id });
       expect(updatedVersion.comments).to.equal('Newly updated comments');
+    });
+  });
+
+  describe('DELETE /api/admin/certification-frameworks/{id}', function () {
+    it('should return 204 HTTP status code', async function () {
+      // given
+      const versionId = databaseBuilder.factory.buildCertificationVersion({
+        scope: SCOPES.CORE,
+        startDate: null,
+        expirationDate: null,
+      }).id;
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'DELETE',
+        url: `/api/admin/certification-frameworks/${versionId}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -139,7 +139,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       const options = {
         method: 'DELETE',
-        url: `/api/admin/certification-frameworks/${versionId}`,
+        url: `/api/admin/certification-versions/${versionId}`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -1,7 +1,7 @@
 import { createServer } from '../../../../../server.js';
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../test-helper.js';
-import { databaseBuilder } from '../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Acceptance | Certification | Configuration | API | certification-version-route', function () {
@@ -126,7 +126,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
     });
   });
 
-  describe('DELETE /api/admin/certification-frameworks/{id}', function () {
+  describe('DELETE /api/admin/certification-versions/{id}', function () {
     it('should return 204 HTTP status code', async function () {
       // given
       const versionId = databaseBuilder.factory.buildCertificationVersion({

--- a/api/tests/certification/configuration/integration/domain/usecases/delete-certification-version_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/delete-certification-version_test.js
@@ -1,11 +1,9 @@
-import { usecases } from "../../../../../../src/certification/configuration/domain/usecases/index.js";
-import { SCOPES } from "../../../../../../src/certification/shared/domain/models/Scopes.js";
-import { expect } from "../../../../../test-helper.js";
-import { databaseBuilder, knex } from "../../../../../tooling/databases.js";
-import { catchErr } from "../../../../../tooling/test-utils/error.js";
-import {
-  CertificationVersionForbiddenDeletionError
-} from "../../../../../../src/certification/configuration/domain/errors.js";
+import { CertificationVersionForbiddenDeletionError } from '../../../../../../src/certification/configuration/domain/errors.js';
+import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Integration | Domain | UseCase | delete-certification-version', function () {
   it('should throw CertificationVersionForbiddenDeletionError certification-version is not draft', async function () {

--- a/api/tests/certification/configuration/integration/domain/usecases/delete-certification-version_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/delete-certification-version_test.js
@@ -1,0 +1,48 @@
+import { usecases } from "../../../../../../src/certification/configuration/domain/usecases/index.js";
+import { SCOPES } from "../../../../../../src/certification/shared/domain/models/Scopes.js";
+import { expect } from "../../../../../test-helper.js";
+import { databaseBuilder, knex } from "../../../../../tooling/databases.js";
+import { catchErr } from "../../../../../tooling/test-utils/error.js";
+import {
+  CertificationVersionForbiddenDeletionError
+} from "../../../../../../src/certification/configuration/domain/errors.js";
+
+describe('Certification | Configuration | Integration | Domain | UseCase | delete-certification-version', function () {
+  it('should throw CertificationVersionForbiddenDeletionError certification-version is not draft', async function () {
+    // given
+    const certificationVersion = databaseBuilder.factory.buildCertificationVersion({
+      scope: SCOPES.CORE,
+      startDate: new Date(),
+      expirationDate: null,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const error = await catchErr(usecases.deleteCertificationVersion)({
+      certificationVersionId: certificationVersion.id,
+    });
+    // then
+    expect(error).to.be.instanceOf(CertificationVersionForbiddenDeletionError);
+  });
+
+  it('should delete given certification version', async function () {
+    // given
+    const certificationVersion = databaseBuilder.factory.buildCertificationVersion({
+      scope: SCOPES.CORE,
+      startDate: null,
+      expirationDate: null,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.deleteCertificationVersion({ certificationVersionId: certificationVersion.id });
+
+    // then
+    const matchingCertificationVersions = await knex
+      .from('certification_versions')
+      .where({ id: certificationVersion.id });
+    expect(matchingCertificationVersions).to.be.empty;
+  });
+});

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -1,13 +1,14 @@
-import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
-import * as versionRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/version-repository.js';
-import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../../src/certification/shared/domain/constants.js';
-import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { expect } from '../../../../../test-helper.js';
-import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
-import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
+import { Version } from "../../../../../../src/certification/configuration/domain/models/Version.js";
+import * as versionRepository
+  from "../../../../../../src/certification/configuration/infrastructure/repositories/version-repository.js";
+import { DEFAULT_SESSION_DURATION_MINUTES } from "../../../../../../src/certification/shared/domain/constants.js";
+import { Frameworks } from "../../../../../../src/certification/shared/domain/models/Frameworks.js";
+import { SCOPES } from "../../../../../../src/certification/shared/domain/models/Scopes.js";
+import { NotFoundError } from "../../../../../../src/shared/domain/errors.js";
+import { expect } from "../../../../../test-helper.js";
+import { databaseBuilder, knex } from "../../../../../tooling/databases.js";
+import { domainBuilder } from "../../../../../tooling/domain-builder/domain-builder.js";
+import { catchErr } from "../../../../../tooling/test-utils/error.js";
 
 describe('Certification | Configuration | Integration | Repository | Version', function () {
   describe('#create', function () {
@@ -535,6 +536,48 @@ describe('Certification | Configuration | Integration | Repository | Version', f
           comments: 'versionDroit',
         }),
       ]);
+    });
+  });
+
+  describe('#isDraft', function () {
+    it('should return true when certificationVersion does not have a start date', async function () {
+      const certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
+        startDate: null,
+        expirationDate: null,
+      }).id;
+      await databaseBuilder.commit();
+
+      const result = await versionRepository.isDraft(certificationVersionId);
+
+      expect(result).to.be.true;
+    });
+    it('should return false when certification version have a start date', async function () {
+      const certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
+        startDate: new Date('2025-06-01'),
+        expirationDate: null,
+      }).id;
+      await databaseBuilder.commit();
+
+      const result = await versionRepository.isDraft(certificationVersionId);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('#deleteDraft', function () {
+    it('should return delete a draft certification version ', async function () {
+      const certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
+        startDate: null,
+        expirationDate: null,
+      }).id;
+      await databaseBuilder.commit();
+
+      await versionRepository.deleteDraft(certificationVersionId);
+
+      const matchingCertificationVersions = await knex
+        .from('certification_versions')
+        .where({ id: certificationVersionId });
+      expect(matchingCertificationVersions).to.be.empty;
     });
   });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -538,32 +538,7 @@ describe('Certification | Configuration | Integration | Repository | Version', f
     });
   });
 
-  describe('#isDraft', function () {
-    it('should return true when certificationVersion does not have a start date', async function () {
-      const certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
-        startDate: null,
-        expirationDate: null,
-      }).id;
-      await databaseBuilder.commit();
-
-      const result = await versionRepository.isDraft(certificationVersionId);
-
-      expect(result).to.be.true;
-    });
-    it('should return false when certification version have a start date', async function () {
-      const certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
-        startDate: new Date('2025-06-01'),
-        expirationDate: null,
-      }).id;
-      await databaseBuilder.commit();
-
-      const result = await versionRepository.isDraft(certificationVersionId);
-
-      expect(result).to.be.false;
-    });
-  });
-
-  describe('#deleteDraft', function () {
+  describe('#deleteVersion', function () {
     it('should return delete a draft certification version ', async function () {
       const certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
         startDate: null,
@@ -571,7 +546,7 @@ describe('Certification | Configuration | Integration | Repository | Version', f
       }).id;
       await databaseBuilder.commit();
 
-      await versionRepository.deleteDraft(certificationVersionId);
+      await versionRepository.deleteVersion(certificationVersionId);
 
       const matchingCertificationVersions = await knex
         .from('certification_versions')

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -1,14 +1,13 @@
-import { Version } from "../../../../../../src/certification/configuration/domain/models/Version.js";
-import * as versionRepository
-  from "../../../../../../src/certification/configuration/infrastructure/repositories/version-repository.js";
-import { DEFAULT_SESSION_DURATION_MINUTES } from "../../../../../../src/certification/shared/domain/constants.js";
-import { Frameworks } from "../../../../../../src/certification/shared/domain/models/Frameworks.js";
-import { SCOPES } from "../../../../../../src/certification/shared/domain/models/Scopes.js";
-import { NotFoundError } from "../../../../../../src/shared/domain/errors.js";
-import { expect } from "../../../../../test-helper.js";
-import { databaseBuilder, knex } from "../../../../../tooling/databases.js";
-import { domainBuilder } from "../../../../../tooling/domain-builder/domain-builder.js";
-import { catchErr } from "../../../../../tooling/test-utils/error.js";
+import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
+import * as versionRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/version-repository.js';
+import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../../src/certification/shared/domain/constants.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Integration | Repository | Version', function () {
   describe('#create', function () {

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -48,8 +48,8 @@ describe('Unit | Certification | Configuration | Application | Router | certific
       });
     });
 
-    describe('when the scope parameter is invalid', function () {
-      it('should return 400 HTTP status code when scope is not a valid id', async function () {
+    describe('when the id parameter is invalid', function () {
+      it('should return 400 HTTP status code when id is not valid', async function () {
         sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
         sinon.stub(certificationVersionController, 'getVersionById').returns('ok');
         const httpTestServer = new HttpTestServer();
@@ -138,6 +138,26 @@ describe('Unit | Certification | Configuration | Application | Router | certific
         expect(response.statusCode).to.equal(400);
         sinon.assert.notCalled(certificationVersionController.update);
       });
+    });
+  });
+
+  describe('DELETE /api/admin/certification-frameworks/{id}', function () {
+    it('should return 204 HTTP status code', async function () {
+      // given
+      sinon.stub(securityPreHandlers, `checkAdminMemberHasRoleSuperAdmin`).returns(true);
+      sinon
+        .stub(certificationVersionController, 'deleteCertificationVersion')
+        .callsFake((request, h) => h.response().code(204));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/admin/certification-versions/1');
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      sinon.assert.calledOnce(certificationVersionController.deleteCertificationVersion);
     });
   });
 });

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -1,10 +1,13 @@
-import sinon from 'sinon';
+import sinon from "sinon";
 
-import { certificationVersionController } from '../../../../../src/certification/configuration/application/certification-version-controller.js';
-import * as moduleUnderTest from '../../../../../src/certification/configuration/application/certification-version-route.js';
-import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
-import { expect } from '../../../../test-helper.js';
-import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
+import {
+  certificationVersionController
+} from "../../../../../src/certification/configuration/application/certification-version-controller.js";
+import * as moduleUnderTest
+  from "../../../../../src/certification/configuration/application/certification-version-route.js";
+import { securityPreHandlers } from "../../../../../src/shared/application/security-pre-handlers.js";
+import { expect } from "../../../../test-helper.js";
+import { HttpTestServer } from "../../../../tooling/server/http-test-server.js";
 
 describe('Unit | Certification | Configuration | Application | Router | certification-version-route', function () {
   describe('GET /api/admin/certification-versions/{certificationVersionId}', function () {
@@ -141,7 +144,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
     });
   });
 
-  describe('DELETE /api/admin/certification-frameworks/{id}', function () {
+  describe('DELETE /api/admin/certification-version/{id}', function () {
     it('should return 204 HTTP status code', async function () {
       // given
       sinon.stub(securityPreHandlers, `checkAdminMemberHasRoleSuperAdmin`).returns(true);
@@ -158,6 +161,40 @@ describe('Unit | Certification | Configuration | Application | Router | certific
       // then
       expect(response.statusCode).to.equal(204);
       sinon.assert.calledOnce(certificationVersionController.deleteCertificationVersion);
+    });
+
+    it('should return 403 HTTP status code when user is not SuperAdmin', async function () {
+      // given
+      sinon
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+        .returns((request, h) => h.response().code(403).takeover());
+      sinon.stub(certificationVersionController, 'deleteCertificationVersion').returns('ok');
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/admin/certification-versions/1');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(certificationVersionController.deleteCertificationVersion);
+    });
+
+    it('should return 400 HTTP status code when id is not valid', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+      sinon.stub(certificationVersionController, 'deleteCertificationVersion').returns('ok');
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/admin/certification-versions/NOT_AN_ID');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      sinon.assert.notCalled(certificationVersionController.deleteCertificationVersion);
     });
   });
 });

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -1,13 +1,10 @@
-import sinon from "sinon";
+import sinon from 'sinon';
 
-import {
-  certificationVersionController
-} from "../../../../../src/certification/configuration/application/certification-version-controller.js";
-import * as moduleUnderTest
-  from "../../../../../src/certification/configuration/application/certification-version-route.js";
-import { securityPreHandlers } from "../../../../../src/shared/application/security-pre-handlers.js";
-import { expect } from "../../../../test-helper.js";
-import { HttpTestServer } from "../../../../tooling/server/http-test-server.js";
+import { certificationVersionController } from '../../../../../src/certification/configuration/application/certification-version-controller.js';
+import * as moduleUnderTest from '../../../../../src/certification/configuration/application/certification-version-route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect } from '../../../../test-helper.js';
+import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 
 describe('Unit | Certification | Configuration | Application | Router | certification-version-route', function () {
   describe('GET /api/admin/certification-versions/{certificationVersionId}', function () {


### PR DESCRIPTION
## 💥 Problème

Le bouton "supprimer la version" a été ajouté dans la pr #16065 sans être fonctionnel. Les PRs #16170 et #16199 ont permis de rendre la date d'activation d'une version optionnelle, permettant ainsi l'existence de version "en cours d'édition".

## 👩‍🚀 Proposition

On peut maintenant ajouter une route supprimant une version brouillon (sans date d'activation) et déclencher son appel lors d'un clic sur le bouton.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
Modifier manuellement les données pour ajouter une version brouillon
la supprimer avec le bouton

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
