### PR TITLE
[TECH] corrige la rechargement des fichiers de trad sur Orga (PIX-22745)

### DIFF
--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -4,6 +4,8 @@ import { service } from '@ember/service';
 import ENV from 'pix-orga/config/environment';
 import { formats } from 'pix-orga/ember-intl';
 
+const translations = import.meta.glob('/translations/*.json');
+
 export default class ApplicationRoute extends Route {
   @service store;
   @service featureToggles;
@@ -39,6 +41,13 @@ export default class ApplicationRoute extends Route {
     await this.oidcIdentityProviders.load().catch();
 
     await this.dayjsLocaleLoader.load(this.locale.currentLanguage);
+    const loader = translations[`/translations/${this.locale.currentLanguage}.json`];
+    if (!loader) {
+      throw new Error(`Missing locale: ${this.locale.currentLanguage}`);
+    }
+    const mod = await loader();
+    this.intl.addTranslations(this.locale.currentLanguage, mod.default);
+    this.intl.setLocale([this.locale.currentLanguage]);
   }
 
   async model() {


### PR DESCRIPTION
## 💥 Problème

Depuis le passage à vite, les fichier de traductions ne se recharge lorsqu'on on les modifie

## 👩‍🚀 Proposition

Faire que les modifications des traductions s'affiche en développement

## 👁️ Remarques

Cette solution est tirée d'une réponse d'[Ember Assistant ](https://chatgpt.com/g/g-NlX2z2g6H-ember-assistant)
L'explication du [import.glob](https://chatgpt.com/share/6a0d76f7-ff18-83eb-a27b-905332778758)
## ♻️ Pour tester
en local, 
- lancer `npm start`
- modifier un fichier de traduction
- voir la mise a jour 

 
