### PR TITLE
[FEATURE] Importer les traductions italiennes de Pix App (PIX-22764)

### DIFF
--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -604,6 +604,7 @@
           "description": "Du wirst im Internet recherchieren, deine digitale Arbeitsumgebung nutzen, dein Wissen testen usw.",
           "title": "Miss deine digitalen Kompetenzen mit spielerischen und lernenden Herausforderungen, die sich an deinen Kenntnisstand anpassen (über einen adaptiven Algorithmus)."
         },
+        "exam-notice": "Während dieses Tests wird dein Kompetenzprofil weder berücksichtigt noch verändert. Deine Antworten haben keinen Einfluss auf deine Stufen oder deine Gesamt-Pix-Punktzahl.",
         "legal": "Wenn du auf \"Beginnen\" klickst, werden die Informationen über deinen Fortschritt auf dem Pfad an den Organisator der Pfade weitergeleitet, damit er dich begleiten kann. Am Ende des Lernpfads werden deine Ergebnisse automatisch an den Organisator weitergeleitet.",
         "title": "Beginne deinen Pix-Lernpfad",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' bereit, deine digitalen Kompetenzen zu bewerten?"
@@ -640,7 +641,7 @@
           "finished": "Abgeschlossen",
           "started": "In Arbeit"
         },
-        "text-deleted": "Pfad von deiner Organisation deaktiviert.'<br> 'Du kannst nicht mehr auf diesen Pfad einwirken.",
+        "text-deleted": "Pfad von deiner Organisation deaktiviert.'<br>'Du kannst nicht mehr auf diesen Pfad einwirken.",
         "text-disabled": "Pfad von deiner Organisation deaktiviert.'<br>'Du kannst deine Ergebnisse nicht mehr versenden."
       },
       "title": "Pfad"
@@ -735,6 +736,7 @@
         "title": "Ergebnis:"
       },
       "title": "Pix-Zertifikat",
+      "valid-status": "Gültiges Zertifikat",
       "verification-code": {
         "alt": "Kopieren",
         "copied": "Code kopiert!",
@@ -843,7 +845,7 @@
             "3": "'<strong>'Auf ein System mit künstlicher Intelligenz zugreifen'</strong>' oder einen Chatbot.",
             "4": "'<strong>'Ein Forum konsultieren'</strong>', das direkt die Antwort auf eine Frage liefert.",
             "5": "'<strong>'Jedes andere Mittel mobilisieren, das direkt die Antwort auf die Frage liefert '</strong>', ohne die von der Anweisung geforderte Arbeit geleistet zu haben.",
-            "6": "'<strong>'Einen anderen Browser verwenden'</strong>' als den, auf dem du deinen Zertifizierungstest durchführst {certificationName}.",
+            "6": "'<strong>'Einen anderen Browser verwenden'</strong>' als den, auf dem du deinen {certificationName}-Zertifizierungstest durchführst.",
             "7": "'<strong>'Identitätsdiebstahl'</strong>' einer anderen Person."
           },
           "pix-companion": "Der Zugriff auf bestimmte Websites wird im Rahmen des Zertifizierungstests durch eine im Browser installierte Erweiterung unterbunden. Ein nachgewiesener Betrug (Versuch, die Erweiterung zu umgehen oder Nichteinhaltung der oben aufgelisteten Verhaltensweisen) kann zur Ungültigkeit der Zertifizierung führen.",
@@ -957,6 +959,14 @@
         }
       },
       "first-title": "Zertifizierungstest beginnen",
+      "language-selector": {
+        "confirmation-label": "Ich bestätige, dass ich mich in der ausgewählten Sprache wohl fühle, um die Fragen zu beantworten.'<br>'Die Sprachwahl ist '<strong>'endgültig'</strong>'.",
+        "label": "Zertifizierungssprache",
+        "options": {
+          "english": "Englisch - EN",
+          "french": "Französisch - FR"
+        }
+      },
       "link-to-user-certification": "Meine Zertifizierungen ansehen",
       "non-eligible-subscription": "Du bist nicht für {complementarySubscriptionLabel} qualifiziert. Du aknnst dennoch deine Pix-Zertifizierung ablegen.",
       "title": "An einer Zertifizierungstestung teilnehmen"
@@ -1236,7 +1246,7 @@
       },
       "completion-percentage": {
         "caption": "Fortschritt auf dem Pfad",
-        "label": "'<p class=\"sr-only\">'Du hast '</p>'{completionPercentage}%'<p class=\"sr-only\">' deinen Pfad absolviert.'</p>'"
+        "label": "Du hast {completion, number, ::percent} deines Pfades absolviert."
       },
       "sharing-results": {
         "information-banner": "Wenn du auf die Schaltfläche \"Meine Ergebnisse anzeigen\" klickst, werden deine Ergebnisse an den Organisator übermittelt."
@@ -2166,6 +2176,7 @@
         "explanations": {
           "trainings": "Um dich weiterzuentwickeln, entdecke unsere Bildungsempfehlungen und finde heraus, welcher Kurs am besten zu dir passt."
         },
+        "hidden-badges": "{ count, plural, =1 {weiteres erworbenes Badge nicht angezeigt} other {weitere erworbene Badges nicht angezeigt} }",
         "mastery-rate": "Erfolgsquote bei Fragen",
         "retry": {
           "actions": {
@@ -2220,6 +2231,9 @@
       "stage": {
         "caption": "Details zu deinen Ergebnissen in Form von Prozenten und Sternen auf der Grundlage von Kompetenzen",
         "masteryPercentage": "{rate, number, ::percent} des Erfolgs",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired}/{total, plural, =0 {Stern} =1 {# Stern} other {# Sterne}}"
+        },
         "starsAcquired": "{acquired, plural, =0 {kein Stern erworben} =1 {# Stern erworben} other {# Sterne erworben}} auf {total}.",
         "title": "Details zu Kompetenzen"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -72,7 +72,7 @@
       "data-protection-policy": "política de privacidad",
       "error": "Debes aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
       "label": "Acepto las condiciones de uso y la política de privacidad de Pix",
-      "message": "Acepto las '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'condiciones de uso'</a>' y la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'política de privacidad'</a>' de Pix.",
+      "message": "Acepto las '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'condiciones de uso'</a>' y la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'política de privacidad'</a>' de Pix.",
       "read-message": "Lee las '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'condiciones de uso'</a>' y la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'política de privacidad'</a>'."
     },
     "companion": {
@@ -817,7 +817,7 @@
           },
           "paragraphs": {
             "1": {
-              "text": "Para preguntas en '<strong>'modo libre'</strong>', indicado con un icono verde: se le permitirá buscar en la web y utilizar el entorno digital a su disposición.",
+              "text": "Para preguntas en '<strong>'modo libre'</strong>', indicado con un icono verde: se le permitirá buscar en la web y utilizar el entorno digital a su disposición.'<br>'Sin embargo, '<strong>'algunos sitios no serán accesibles durante la certificación'</strong>'.",
               "title": "Modo libre :"
             },
             "2": {
@@ -1211,7 +1211,7 @@
           "aria-label": "Mostrar la indicación en la prueba.",
           "close": "Lo he entendido",
           "focused": {
-            "content": "'<p class=\"tooltip-tag-information__title--focused\">'¡Quédate en esta página para responder!'</p>' No utilices internet ni ninguna aplicación para responder. Se detectará cualquier actividad fuera de la zona.",
+            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'¡Quédate en esta página para responder!'</strong><br/>' No utilices internet ni ninguna aplicación para responder. Se detectará cualquier actividad fuera de la zona.",
             "title": "Modo enfoque"
           },
           "other": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1,11 +1,11 @@
 {
   "api-error-messages": {
     "join-error": {
-      "r11": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentazione - Codice R11).",
-      "r12": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga &gt; Documentazione - Codice R12)",
+      "r11": "Hai già un account Pix con l'indirizzo e-mail '<br>'{value}'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentazione - Codice R11).",
+      "r12": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{value}'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga &gt; Documentazione - Codice R12)",
       "r13": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga &gt; Documentazione - Codice R13)",
-      "r31": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' nella Documentazione di Pix Orga &gt; Codice R31)",
-      "r32": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit di risoluzione dei problemi' in Pix Orga &gt; Documentazione - Codice R32)",
+      "r31": "Hai già un account Pix con l'indirizzo e-mail '<br>'{value}'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' nella Documentazione di Pix Orga &gt; Codice R31)",
+      "r32": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{value}'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit di risoluzione dei problemi' in Pix Orga &gt; Documentazione - Codice R32)",
       "r33": "Hai già un account Pix tramite ENT. Usalo per iscriverti al percorso.",
       "r70": "Si è verificato un errore. Esci e riprova.",
       "r90": {
@@ -23,11 +23,11 @@
     },
     "register-error": {
       "s50": "Questo identificatore esiste già",
-      "s51": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R51).",
-      "s52": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R52)",
+      "s51": "Hai già un account Pix con l'indirizzo e-mail '<br>'{value}'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R51).",
+      "s52": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{value}'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R52)",
       "s53": "Hai già un account Pix tramite ENT.'<br> 'Usalo per iscriverti al percorso.",
-      "s61": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R61).",
-      "s62": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R62)",
+      "s61": "Hai già un account Pix con l'indirizzo e-mail '<br>'{value}'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R61).",
+      "s62": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{value}'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R62)",
       "s63": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentazione - Codice R63)"
     }
   },
@@ -791,7 +791,7 @@
           },
           "paragraphs": {
             "1": "Il test di certificazione è composto da \"<strong>32 domande\"</strong>\".",
-            "2": "Hai un massimo di '<strong>'{durata}'</strong>' per rispondere*.",
+            "2": "Hai un massimo di '<strong>'{duration}'</strong>' per rispondere*.",
             "3": "*escluso il tempo supplementare",
             "4": "Se si completano '<strong>'meno di 20 domande, non sarà possibile assegnare un punteggio'</strong>'."
           },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -111,7 +111,6 @@
       "visible-password": "mostra la password"
     },
     "french-education-ministry": "Ministero dell'Istruzione e della Gioventù. Libertà, uguaglianza, fraternità",
-    "french-republic": "Repubblica francese. Libertà, uguaglianza, fraternità.",
     "languages": {
       "en": "Inglese",
       "fr": "Francese",
@@ -155,7 +154,9 @@
           "min-length": "almeno 8 caratteri"
         }
       }
-    }
+    },
+    "no": "No",
+    "yes": "Sì"
   },
   "components": {
     "attestations": {
@@ -685,13 +686,23 @@
         "CORE": "Certificazione Pix",
         "EDU_1ER_DEGRE": "Certificato Pix+ Edu 1° livello",
         "EDU_2ND_DEGRE": "Certificato Pix+ Edu 2° livello",
-        "EDU_CPE": "Certificato Pix+ Edu CPE"
+        "EDU_CPE": "Certificato Pix+ Edu CPE",
+        "DROIT": "Certificato Pix+ Diritto",
+        "PRO_SANTE": "Certificato Pix+ Professionisti della Salute"
       },
       "frameworks": {
         "EDU": {
           "results-infos": "'<p>'La certificazione si svolge in due fasi:'</p><ol><li>'Prova Pix: appena completata.'</li><li>'Prova orale: organizzata al di fuori di Pix davanti a una giuria.'</li></ol><p>'Al termine dell'orale, verrà assegnato il livello di certificazione definitivo (Esperto, Avanzato, ecc.).'<br/>'Contatta il tuo centro di certificazione per organizzare la prova orale.'</p>'",
           "status": "Certificato valido",
-          "sub-title": "Il candidato è ammesso alla 2ª fase!"
+          "results-sub-title": "Il/la candidato/a è ammissibile al modulo 2 della pratica professionale della certificazione Pix+ Édu!",
+          "steps": {
+            "1": "Volet Pix",
+            "2": "Volet pratica'<br/>'professionale",
+            "3": "Risultato finale"
+          },
+          "sub-title": {
+            "admissible": "Il candidato è ammesso alla 2ª fase!"
+          }
         }
       },
       "global": {
@@ -732,7 +743,9 @@
         "share": "Condividi il tuo certificato",
         "title": "Codice di verifica",
         "tooltip": "Fornite questo codice per consentire a terzi di verificare l'autenticità del tuo certificato."
-      }
+      },
+      "obtained-certification": "Il candidato ha raggiunto il livello {globalLevelLabel} della certificazione {frameworkLabel}.",
+      "valid-status": "Certificato valido"
     },
     "certification-ender": {
       "candidate": {
@@ -948,7 +961,15 @@
       "first-title": "Stai per iniziare il test di certificazione",
       "link-to-user-certification": "Vedi le mie certificazioni",
       "non-eligible-subscription": "Non si ha diritto a {complementarySubscriptionLabel}. È tuttavia possibile ottenere la certificazione Pix.",
-      "title": "Partecipa a una sessione di certificazione"
+      "title": "Partecipa a una sessione di certificazione",
+      "language-selector": {
+        "confirmation-label": "Confermo di essere a mio agio nella lingua selezionata per rispondere alle domande.'<br>'La scelta della lingua è '<strong>'definitiva'</strong>'.",
+        "label": "Lingua di certificazione",
+        "options": {
+          "english": "inglese - EN",
+          "french": "francese - FR"
+        }
+      }
     },
     "certifications-list": {
       "buttons": {
@@ -1268,6 +1289,13 @@
           "select-passages": "Selezione di corsi di formazione adeguati."
         },
         "title": "Calcolo del seguito del percorso in corso."
+      },
+      "errors": {
+        "disabled": {
+          "content": "A causa di un elevato afflusso, l'accesso a questo percorso è temporaneamente sospeso.",
+          "instructions": "Si prega di riprovare più tardi.",
+          "title": "Questo percorso non è disponibile al momento"
+        }
       }
     },
     "comparison-window": {
@@ -1686,7 +1714,6 @@
             "context": "Contesto",
             "did-you-know": "Lo sapevi?",
             "further-information": "Per saperne di più",
-            "key-points": "Punti chiave",
             "tip": "Consiglio"
           }
         }
@@ -1708,7 +1735,8 @@
       },
       "grain": {
         "tag": {
-          "activity": "Attività"
+          "activity": "Attività",
+          "key-points": "Punti chiave"
         },
         "title": {
           "lesson": "Lezione",
@@ -1777,7 +1805,20 @@
       "preview": {
         "showJson": "Visualizza JSON",
         "stepper": "Anteprima: stepper {direction}",
-        "textarea-label": "Contenuto del modulo"
+        "textarea-label": "Contenuto del modulo",
+        "elements-id-button": {
+          "label": "Mostra l'ID degli elementi"
+        },
+        "elements-metadata-panel-label": "Mostra o nascondi i metadati",
+        "grain-select": {
+          "button": "Testa il grain",
+          "grain-label": "Grain {index} : {title}",
+          "label": "Scegli il grain da testare"
+        },
+        "grains-title-button": {
+          "label": "Mostra il titolo dei grain"
+        },
+        "modulix-editor": "Modulix Editor"
       },
       "qab": {
         "correct-answer": "Risposta corretta!",
@@ -2147,7 +2188,12 @@
         },
         "see-trainings": "Vedere i corsi",
         "shared-message": "I risultati sono stati inviati da {date} a {time}.",
-        "thanks": "Grazie {name} per la tua partecipazione!"
+        "thanks": "Grazie {name} per la tua partecipazione!",
+        "hidden-badges": "{ count, plural, =1 {badge aggiuntivo acquisito non visualizzato} other {badge aggiuntivi acquisiti non visualizzati} }",
+        "staged-message": {
+          "show-less": "Comprimi",
+          "show-more": "Mostra di più"
+        }
       },
       "improve": {
         "description": "È possibile riprovare alcune delle domande",
@@ -2186,7 +2232,10 @@
         "caption": "I dettagli dei tuoi risultati sotto forma di percentuali e stelle in base alle competenze",
         "masteryPercentage": "{rate, number, ::percent} di successo",
         "starsAcquired": "{acquired, plural, =0 {nessuna stella acquisita} =1 {# stelle acquisite} other {# stelle acquisite}} su {total}.",
-        "title": "Dettagli sulle competenze"
+        "title": "Dettagli sulle competenze",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired}/{total, plural, =0 {stella} =1 {# stella} other {# stelle}}"
+        }
       },
       "tabs": {
         "aria-label": "3 schede con i dettagli dei risultati",
@@ -2293,56 +2342,12 @@
       "validation": "La password è stata aggiornata."
     },
     "user-account": {
-      "account-update-email": {
-        "email-information": "Questo indirizzo e-mail deve essere valido nel caso in cui si dimentichi la password. Questo sarà il tuo nuovo indirizzo di accesso.",
-        "fields": {
-          "errors": {
-            "empty-password": "La password non può essere vuota.",
-            "invalid-password": "La password inserita non è valida.",
-            "mismatching-email": "I due indirizzi e-mail non sono identici. Si prega di controlla la propria iscrizione.",
-            "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
-            "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
-            "wrong-email-format": "L'indirizzo e-mail non è valido."
-          },
-          "new-email": {
-            "label": "Nuovo indirizzo e-mail"
-          },
-          "new-email-confirmation": {
-            "label": "Conferma dell'indirizzo e-mail"
-          },
-          "password": {
-            "label": "Password"
-          }
-        },
-        "password-information": "Inserisci la password per confermare",
-        "save-button": "Conferma",
-        "title": "Modifica dell'indirizzo e-mail"
-      },
-      "account-update-email-with-validation": {
-        "fields": {
-          "errors": {
-            "empty-password": "La password non può essere vuota.",
-            "invalid-email": "L'indirizzo e-mail non è valido.",
-            "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato",
-            "invalid-password": "La password inserita non è valida.",
-            "new-email-already-exist": "Questo indirizzo e-mail è già in uso."
-          },
-          "new-email": {
-            "label": "Nuovo indirizzo e-mail"
-          },
-          "password": {
-            "label": "Password",
-            "security-information": "La sicurezza dei tuoi dati personali è fondamentale. Per questo motivo verifichiamo che siate l'autore della richiesta. Inserisci la tua password per ricevere un codice di verifica."
-          }
-        },
-        "save-button": "Ricevi un codice di verifica",
-        "title": "Modifica dell'indirizzo e-mail"
-      },
       "connexion-methods": {
         "authentication-methods": {
           "gar": "via ENT/Mediacentre",
           "label": "Connessione esterna",
-          "via": "via {identityProviderOrganizationName}"
+          "connection-via": "Connessione via {identityProviderOrganizationName}",
+          "other-authentication-label": "Altro metodo di connessione"
         },
         "edit-button": "Modificare",
         "email": "Indirizzo e-mail",
@@ -2379,12 +2384,15 @@
           "email-modification-demand-expired": "Questo codice è scaduto. Si prega di rinnovare la richiesta.",
           "incorrect-code": "Il codice inserito non è corretto.",
           "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
-          "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza."
+          "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
+          "no-code": "Inserisci il codice a {numInputs} cifre ricevuto via e-mail."
         },
         "send-back-the-code": "inviami di nuovo il codice",
         "time-code-validation": "Il codice ricevuto è valido per 10 minuti",
         "title": "Verifica dell'indirizzo e-mail",
-        "update-successful": "Il tuo indirizzo e-mail è stato modificato!"
+        "update-successful": "Il tuo indirizzo e-mail è stato modificato!",
+        "add-successful": "Il tuo indirizzo e-mail è stato aggiunto!",
+        "validate-new-email": "Conferma il mio nuovo indirizzo e-mail"
       },
       "language": {
         "lang": "Lingua",
@@ -2396,21 +2404,71 @@
         "last-name": "Cognome",
         "menu-link-title": "I miei dati personali"
       },
-      "title": "Il mio account"
+      "title": "Il mio account",
+      "account-add-or-update-email-with-validation": {
+        "code-reception-information": "Confermando la richiesta di aggiunta dell'indirizzo e-mail, riceverai un codice via e-mail.",
+        "fields": {
+          "email": {
+            "add-email": {
+              "label": "Indirizzo e-mail"
+            },
+            "update-email": {
+              "label": "Nuovo indirizzo e-mail"
+            }
+          },
+          "errors": {
+            "empty-password": "La password non può essere vuota.",
+            "invalid-email": "L'indirizzo e-mail non è valido.",
+            "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato",
+            "invalid-password": "La password inserita non è valida.",
+            "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
+            "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza."
+          },
+          "password": {
+            "label": "Password",
+            "security-information": "La sicurezza dei tuoi dati personali è fondamentale. Per questo motivo verifichiamo che siate l'autore della richiesta. Inserisci la tua password per ricevere un codice di verifica."
+          }
+        },
+        "save-button": "Ricevi un codice di verifica",
+        "title": {
+          "add-email": "Aggiungi un indirizzo e-mail",
+          "update-email": "Modifica dell'indirizzo e-mail"
+        }
+      }
     },
     "user-certifications": {
       "meshes": {
         "EDU_1ER_DEGRE": {
-          "0": "Ammissibile",
-          "BELOW_MINIMUM": "Non ammissibile"
+          "BELOW_MINIMUM": "Non ammissibile",
+          "ADMISSIBLE": "Ammissibile",
+          "ADVANCED": "Avanzato",
+          "EXPERT": "Esperto"
         },
         "EDU_2ND_DEGRE": {
-          "0": "Ammissibile",
-          "BELOW_MINIMUM": "Non ammissibile"
+          "BELOW_MINIMUM": "Non ammissibile",
+          "ADMISSIBLE": "Ammissibile",
+          "ADVANCED": "Avanzato",
+          "EXPERT": "Esperto"
         },
         "EDU_CPE": {
-          "0": "Ammissibile",
-          "BELOW_MINIMUM": "Non ammissibile"
+          "BELOW_MINIMUM": "Non ammissibile",
+          "ADMISSIBLE": "Ammissibile",
+          "ADVANCED": "Avanzato",
+          "EXPERT": "Esperto"
+        },
+        "DROIT": {
+          "ADVANCED": "Avanzato",
+          "BELOW_MINIMUM": "Non ottenuto",
+          "CONFIRMED": "Confermato",
+          "EXPERT": "Esperto",
+          "INDEPENDENT": "Indipendente"
+        },
+        "PRO_SANTE": {
+          "ADVANCED": "Avanzato",
+          "BELOW_MINIMUM": "Non ottenuto",
+          "CONFIRMED": "Confermato",
+          "EXPERT": "Esperto",
+          "INDEPENDENT": "Indipendente"
         }
       }
     },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1,12 +1,12 @@
 {
   "api-error-messages": {
     "join-error": {
-      "r11": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentation - Code R11).",
-      "r12": "Si dispone già di un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga &gt Documentation - Code R12)",
-      "r13": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga &gt Documentazione - Codice R13)",
-      "r31": "Hai già un account Pix con l'indirizzo e-mail'<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' nella Documentazione di Pix Orga &gt - Codice R31)",
-      "r32": "Si dispone già di un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit di risoluzione dei problemi' in Pix Orga &gt Documentation - Code R32)",
-      "r33": "Avete già un account Pix tramite ENT. Utilizzatelo per iscrivervi al corso.",
+      "r11": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentazione - Codice R11).",
+      "r12": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga &gt; Documentazione - Codice R12)",
+      "r13": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga &gt; Documentazione - Codice R13)",
+      "r31": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' nella Documentazione di Pix Orga &gt; Codice R31)",
+      "r32": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit di risoluzione dei problemi' in Pix Orga &gt; Documentazione - Codice R32)",
+      "r33": "Hai già un account Pix tramite ENT. Usalo per iscriverti al percorso.",
       "r70": "Si è verificato un errore. Esci e riprova.",
       "r90": {
         "account-belonging-to-another-user": "Sembra che uno studente stia già utilizzando questo account.",
@@ -17,53 +17,53 @@
             "link-url": "https://support.pix.org/fr/support/tickets/new"
           },
           "disconnect-user": "In caso contrario, effettuare il logout e partecipare alla campagna dal proprio account.",
-          "if-account-belonging-to-user": "Se il conto appartiene a voi,"
+          "if-account-belonging-to-user": "Se il account appartiene a voi,"
         }
       }
     },
     "register-error": {
       "s50": "Questo identificatore esiste già",
-      "s51": "Hai già un account Pix con l'indirizzo e-mail '<br>'{ value }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R51).",
-      "s52": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{ value }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R52)",
-      "s53": "Hai già un account Pix tramite ENT.'<br> 'Usalo per iscriverti al corso.",
-      "s61": "Hai già un account Pix con l'indirizzo e-mail '<br>'{ value }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R61).",
-      "s62": "Si dispone già di un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{ value }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R62)",
+      "s51": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R51).",
+      "s52": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R52)",
+      "s53": "Hai già un account Pix tramite ENT.'<br> 'Usalo per iscriverti al percorso.",
+      "s61": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R61).",
+      "s62": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R62)",
       "s63": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentazione - Codice R63)"
     }
   },
   "application": {
-    "description": "Pix è una piattaforma online per la valutazione e la certificazione delle competenze digitali dei cittadini francofoni (alunni, studenti, diplomati, persone in cerca di lavoro, anziani)."
+    "description": "Pix è una piattaforma online per la valutazione e la certificazione delle competenze digitali."
   },
   "common": {
     "actions": {
-      "back": "Torna a",
-      "cancel": "Annullamento",
-      "close": "Chiudere",
-      "confirm": "Confermare",
+      "back": "Indietro",
+      "cancel": "Annulla",
+      "close": "Chiudi",
+      "confirm": "Conferma",
       "continue": "Continua",
-      "download": "Scaricare",
-      "lets-go": "Si parte!",
-      "login": "Accesso a Pix",
-      "quit": "Lasciare",
+      "download": "Scarica",
+      "lets-go": "Iniziamo!",
+      "login": "Accedi a Pix",
+      "quit": "Esci",
       "refresh-page": "Aggiorna la pagina",
-      "send": "Inviare",
+      "send": "Invia",
       "show-less": "Mostra meno",
-      "show-more": "Vedi di più",
-      "sign-out": "Disconnessione",
-      "stay": "Soggiorno",
-      "validate": "Confermare"
+      "show-more": "Mostra di più",
+      "sign-out": "Disconnetti",
+      "stay": "Rimani",
+      "validate": "Conferma"
     },
     "api-error-messages": {
       "bad-request-error": "I dati inviati non sono nel formato corretto.",
       "gateway-timeout-error": "Il servizio sta subendo dei rallentamenti. Si prega di riprovare più tardi.",
       "internal-server-error": "Si è verificato un errore interno. I nostri team stanno risolvendo il problema. Si prega di riprovare più tardi.",
       "login-unauthorized-error": "L'indirizzo e-mail o il nome utente e/o la password inseriti non sono corretti.",
-      "login-unauthorized-remaining-attempts-error": "Attenzione: avete ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il vostro account Pix venga bloccato definitivamente.",
+      "login-unauthorized-remaining-attempts-error": "Attenzione: hai ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il tuo account Pix venga bloccato definitivamente.",
       "login-unauthorized-remaining-attempts-with-user-name-error": "Attenzione: hai ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il tuo account Pix venga bloccato in modo permanente.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso.",
       "login-unauthorized-with-user-name-error": "Il nome utente e/o la password inseriti non sono corretti.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare il nome utente.",
-      "login-unexpected-error": "Impossibile connettersi. Riprovare tra qualche istante. Se il problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contattateci tramite il centro assistenza'</a>'.",
-      "login-user-blocked-error": "Il suo account è bloccato perché ha effettuato troppi tentativi di connessione. Per sbloccarlo, '<'a href=\"{url}\"'>'contattaci'</a>'.",
-      "login-user-blocked-with-username-error": "Il tuo account è bloccato perché hai effettuato troppi tentativi di accesso. Per sbloccarlo, '<strong>'contatta il tuo insegnante'</strong>' ; se non è disponibile, '<'a href=\"{url}\"'>'contattaci'</a>'.",
+      "login-unexpected-error": "Impossibile accedere. Riprovare tra qualche istante. Se il problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contattateci tramite il centro assistenza'</a>'.",
+      "login-user-blocked-error": "Il suo account è bloccato perché ha effettuato troppi tentativi di accesso. Per sbloccarlo, '<'a href=\"{url}\"'>'contattaci'</a>'.",
+      "login-user-blocked-with-username-error": "Il tuo account è bloccato perché hai effettuato troppi tentativi di accesso. Per sbloccarlo, '<strong>'contatta il tuo insegnante'</strong>'; se non è disponibile, '<'a href=\"{url}\"'>'contattaci'</a>'.",
       "login-user-temporary-blocked-error": "Hai effettuato troppi tentativi di accesso, il tuo account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti. Riprova più tardi o clicca su '<'a href=\"{url}\"'>'password dimenticata'</a>' per resettarla.",
       "login-user-temporary-blocked-with-username-error": "Hai effettuato troppi tentativi di accesso, il tuo account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso."
     },
@@ -88,13 +88,13 @@
       },
       "install-documentation-url": "https://cloud.pix.fr/s/g76RwDwsZmZPZZ6",
       "not-detected": {
-        "description": "L'estensione potrebbe non essere installata o attivata. Consultare il seguente documento per riprendere la sessione di certificazione. Se necessario, contattare il supervisore.",
+        "description": "L'estensione potrebbe non essere installata o attivata. Consulta il seguente documento per riprendere la sessione di certificazione. Se necessario, contattare il sorvegliante.",
         "link": "Accedere alla documentazione",
         "title": "L'estensione Pix Companion<br />non è stata rilevata"
       }
     },
     "data-protection-policy-information-banner": {
-      "title": "La nostra politica sulla privacy è cambiata. Vi invitiamo a leggerla:",
+      "title": "La nostra politica sulla privacy è cambiata. Ti invitiamo a leggerla:",
       "url-label": "Politica di protezione dei dati."
     },
     "display": {
@@ -103,14 +103,15 @@
     "error": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
     "form": {
       "error": "errore",
-      "invisible-password": "nascondere la password",
+      "invisible-password": "nascondi la password",
       "mandatory": "obbligatorio",
       "mandatory-all-fields": "Tutti i campi sono obbligatori.",
       "mandatory-fields": "I campi contrassegnati da '<abbr title=\"mandatory\" class=\"mandatory-mark\">'*'</abbr>' sono obbligatori.",
       "success": "corretto",
-      "visible-password": "Visualizzazione della password"
+      "visible-password": "mostra la password"
     },
-    "french-education-ministry": "Ministero dell'Istruzione e della Gioventù. Libertà uguaglianza fraternità",
+    "french-education-ministry": "Ministero dell'Istruzione e della Gioventù. Libertà, uguaglianza, fraternità",
+    "french-republic": "Repubblica francese. Libertà, uguaglianza, fraternità.",
     "languages": {
       "en": "Inglese",
       "fr": "Francese",
@@ -118,21 +119,20 @@
     },
     "level": "livello",
     "loading": {
-      "default": "Caricamento in corso",
+      "default": "Caricamento in percorso",
       "results": "Preparazione dei risultati",
       "test": "Il test è in fase di caricamento"
     },
     "new-information-banner": {
       "close-label": "Chiudere il banner"
     },
-    "no": "No",
     "no-level": "Nessun livello",
     "or": "o",
     "pagination": {
       "action": {
         "next": "Vai alla pagina successiva",
         "previous": "Vai alla pagina precedente",
-        "select-page-size": "Numero di elementi da visualizzare per pagina"
+        "select-page-size": "Numero di elementi da visualizza per pagina"
       },
       "page-info": "{start, number}-{end, number} su {total, plural, =0 {0 elementi} =1 {1 elemento} other {{total, number} elementi}}",
       "page-number": "Pagina {current, number} / {total, number}",
@@ -143,38 +143,37 @@
     "pix": "pix",
     "skip-links": {
       "skip-to-content": "Vai al contenuto",
-      "skip-to-footer": "Vai a fondo pagina"
+      "skip-to-footer": "Vai al piè di pagina"
     },
     "validation": {
       "password": {
         "error": "È stata inserita una password errata. La password deve essere più lunga di 8 caratteri e contenere almeno un numero, una lettera minuscola e una lettera maiuscola.",
         "rules": {
-          "contains-digit": "una cifra minima",
-          "contains-lowercase": "un minimo",
+          "contains-digit": "almeno una cifra",
+          "contains-lowercase": "almeno una lettera minuscola",
           "contains-uppercase": "almeno una lettera maiuscola",
-          "min-length": "8 caratteri minimo"
+          "min-length": "almeno 8 caratteri"
         }
       }
-    },
-    "yes": "Si"
+    }
   },
   "components": {
     "attestations": {
       "obtainedAt": "Data di emissione: {date}",
       "title": {
-        "numeric-sensivity": "Certificato di consapevolezza digitale"
+        "numeric-sensivity": "Attestato di sensibilizzazione digitale"
       }
     },
     "authentication": {
       "authentication-identity-providers": {
         "login": {
-          "heading": "Altri mezzi di connessione",
-          "login-with-featured-identity-provider-link": "Connettersi con {featuredIdentityProvider}"
+          "heading": "Altri metodi di accesso",
+          "login-with-featured-identity-provider-link": "Accedi con {featuredIdentityProvider}"
         },
-        "select-another-organization-link": "Scegliere un'altra organizzazione",
+        "select-another-organization-link": "Scegli un'altra organizzazione",
         "signup": {
-          "heading": "Altri mezzi di registrazione",
-          "signup-with-featured-identity-provider-link": "Registrazione con {featuredIdentityProvider}"
+          "heading": "Altri metodi di registrazione",
+          "signup-with-featured-identity-provider-link": "Registrati con {featuredIdentityProvider}"
         }
       },
       "login-form": {
@@ -193,16 +192,16 @@
         "label": "Password"
       },
       "oidc-provider-selector": {
-        "label": "Ricerca di un'organizzazione",
-        "placeholder": "Selezionare un'organizzazione",
-        "searchLabel": "Ricerca per parole chiave"
+        "label": "Cerca un'organizzazione",
+        "placeholder": "Seleziona un'organizzazione",
+        "searchLabel": "Cerca per parola chiave"
       },
       "password-reset-demand-form": {
         "actions": {
-          "receive-reset-button": "Ricevere un link di ripristino"
+          "receive-reset-button": "Ricevi un link di reimpostazione"
         },
         "contact-us-link": {
-          "link-text": "Consultare il centro di assistenza"
+          "link-text": "Consulta il centro assistenza"
         },
         "fields": {
           "email": {
@@ -211,19 +210,19 @@
             "placeholder": "Ad esempio, jean.dupont@email.com"
           }
         },
-        "no-email-question": "Problemi di connessione a Pix?",
+        "no-email-question": "Problemi di accesso a Pix?",
         "rule": "Tutti i campi sono obbligatori."
       },
       "password-reset-demand-received-info": {
-        "heading": "Controllare la posta elettronica",
-        "message": "Se il vostro indirizzo è associato a un account Pix, vi sono state inviate per e-mail le istruzioni per reimpostare la password.",
+        "heading": "Controlla la posta elettronica",
+        "message": "Se il tuo indirizzo è associato a un account Pix, ti sono state inviate per e-mail le istruzioni per reimpostare la password.",
         "no-email-received-question": "Non hai ricevuto un'e-mail?",
-        "try-again": "Fare un'altra richiesta"
+        "try-again": "Invia un'altra richiesta"
       },
       "password-reset-form": {
         "actions": {
-          "login": "Voglio connettermi",
-          "submit": "Reimpostare la password"
+          "login": "Voglio accedere",
+          "submit": "Reimposta la password"
         },
         "errors": {
           "expired-demand": "Siamo spiacenti, ma la richiesta di reimpostazione della password è già stata utilizzata o è scaduta. Si prega di riprovare.",
@@ -231,7 +230,7 @@
         },
         "fields": {
           "password": {
-            "label": "Inserire la nuova password"
+            "label": "Inserisci la nuova password"
           }
         },
         "success-info": {
@@ -240,7 +239,7 @@
       },
       "signup-form": {
         "actions": {
-          "submit": "Desidero registrarmi"
+          "submit": "Voglio registrarmi"
         },
         "errors": {
           "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato"
@@ -252,40 +251,40 @@
             "placeholder": "Ad esempio, jean.dupont@email.com"
           },
           "firstname": {
-            "error": "Il nome non è compilato.",
+            "error": "Il nome non è stato inserito.",
             "label": "Nome",
-            "placeholder": "ex: Jean"
+            "placeholder": "es.: Jean"
           },
           "lastname": {
-            "error": "Il vostro nome non è stato inserito.",
-            "label": "Nome",
-            "placeholder": "ad esempio Dupont"
+            "error": "Il cognome non è stato inserito.",
+            "label": "Cognome",
+            "placeholder": "es.: Dupont"
           },
-          "legend": "Informazioni necessarie per la registrazione."
+          "legend": "Informazioni necessarie per la registrazione"
         }
       },
       "sso-selection-form": {
-        "should-display-account-recovery-banner": "Sei uno studente? Se non l'avete ancora fatto, '<'a href=\"{url}\"'>'andate alla pagina per recuperare il vostro account Pix'</a>' e salvate i vostri progressi."
+        "should-display-account-recovery-banner": "Sei uno studente? Se non l'hai ancora fatto, '<'a href=\"{url}\"'>'andate alla pagina per recuperare il tuo account Pix'</a>' e salvate i tuoi progressi."
       }
     },
     "campaigns": {
       "attestation-result": {
-        "computing": "Certificato in corso di calcolo",
-        "computing-description": "Un problema tecnico ci ha impedito di informarvi sui vostri risultati. Vi preghiamo di effettuare nuovamente il login domani su Pix, nella sezione \"Il mio corso\", per controllare i vostri risultati. Ci scusiamo per il disagio causato.",
-        "not-obtained": "Certificato non ottenuto :",
-        "obtained": "Certificato ottenuto",
+        "computing": "Attestato in corso di calcolo",
+        "computing-description": "Un problema tecnico ci ha impedito di informarvi sui tuoi risultati. Ti preghiamo di effettuare nuovamente il login domani su Pix, nella sezione \"Il mio percorso\", per controlla i tuoi risultati. Ci scusiamo per il disagio causato.",
+        "not-obtained": "Attestato non ottenuto:",
+        "obtained": "Attestato ottenuto",
         "title": {
-          "EDUCOLLAB": "Comunicare collaborare",
+          "EDUCOLLAB": "Comunicare e collaborare",
           "EDUCULTURENUM": "Cultura digitale",
           "EDUDOC": "Adattare i documenti",
           "EDUIA": "Dati, algoritmi e IA",
-          "EDUINCONTOURNABLES": "I must-have",
+          "EDUINCONTOURNABLES": "Gli indispensabili",
           "EDURESSOURCES": "Gestione e condivisione delle risorse",
           "EDUSECU": "Sicurezza digitale",
           "EDUSUPPORT": "Creazione di supporti didattici",
-          "EDUVEILLE": "Monitoraggio",
-          "MAIRIEBUREAU": "Mairie de Paris - Ufficio di base",
-          "MINARM": "Base digitale",
+          "EDUVEILLE": "Monitoraggio informativo",
+          "MAIRIEBUREAU": "Comune di Parigi - Ufficio base",
+          "MINARM": "Fondamenti digitali",
           "PARENTHOOD": "Consapevolezza digitale",
           "SIXTH_GRADE": "Consapevolezza digitale"
         }
@@ -296,22 +295,22 @@
           "rewards": "Cerimonia di premiazione",
           "trainings": "Individuare i corsi di formazione utili"
         },
-        "subtitle": "Solo un momento, per favore! Sarò il più veloce possibile.",
-        "title": "Calcolo del punteggio attuale..."
+        "subtitle": "Solo un momento! Faremo il prima possibile.",
+        "title": "Calcolo del punteggio in corso..."
       },
       "start-landing-page": {
         "steps": {
           "step1": {
             "description": "Rispondere a domande adeguate al proprio livello",
-            "title": "Valuta te stesso"
+            "title": "Valutati"
           },
           "step2": {
             "description": "Analizzare i propri punti di forza e le aree di miglioramento",
-            "title": "Scoprite il vostro punteggio"
+            "title": "Scopri il tuo punteggio"
           },
           "step3": {
-            "description": "Accesso a una formazione personalizzata in base ai vostri risultati",
-            "title": "Progredire"
+            "description": "Accesso a una formazione personalizzata in base ai tuoi risultati",
+            "title": "Progredisci"
           }
         }
       }
@@ -320,22 +319,22 @@
       "reconciliation": {
         "error-message": {
           "date-field": "Si prega di utilizzare il formato gg/mm/aaaa quando si inserisce il campo {fieldName}.",
-          "invalid-reconciliation-error": "Controllare le informazioni ({fields}) o contattare un insegnante.",
-          "mandatory-field": "Compilare il campo {fieldName}."
+          "invalid-reconciliation-error": "Controlla le informazioni ({fields}) o contattare un insegnante.",
+          "mandatory-field": "Compila il campo {fieldName}."
         },
         "field": {
           "birthdate": "Data di nascita",
           "firstname": "Nome",
-          "lastname": "Nome",
+          "lastname": "Cognome",
           "sub-label": {
             "date": "In formato (gg/mm/aaaa), ad esempio: {dateFormat}"
           }
         },
-        "title": "Aderire all'organizzazione { organizationName }"
+        "title": "Entra nell'organizzazione { organizationName }"
       }
     },
     "locale-switcher": {
-      "label": "Selezionare una lingua"
+      "label": "Seleziona una lingua"
     }
   },
   "navigation": {
@@ -343,13 +342,13 @@
     "back-to-profile": "Torna alle competenze",
     "copyrights": "©",
     "error": "Errore",
-    "external-link-title": "Aprire in una nuova finestra",
+    "external-link-title": "Apri in una nuova finestra",
     "footer": {
       "a11y": "Accessibilità: parzialmente conforme",
-      "data-protection-policy": "Politica di protezione dei dati",
+      "data-protection-policy": "Informativa sulla protezione dei dati",
       "eula": "Termini e condizioni d'uso",
       "help-center": "Centro assistenza",
-      "label": "Menu a piè di pagina",
+      "label": "Menu del piè di pagina",
       "legal-notice": "Informazioni legali",
       "server-status": "Stato del servizio",
       "sitemap": "Mappa del sito",
@@ -360,7 +359,7 @@
     "main": {
       "attestations": "I miei certificati",
       "code": "Ho un codice",
-      "dashboard": "Casa",
+      "dashboard": "Home",
       "help": "Aiuto",
       "label": "Menu principale",
       "link-help": "https://pix.fr/support",
@@ -369,11 +368,11 @@
       "trainings": "I miei corsi di formazione",
       "tutorials": "I miei tutorial"
     },
-    "mobile-button-title": "Aprire il menu",
+    "mobile-button-title": "Apri il menu",
     "nav-bar": {
-      "aria-label": "navigazione principale",
-      "close": "Chiudere la navigazione",
-      "open": "Aprire la navigazione"
+      "aria-label": "Navigazione principale",
+      "close": "Chiudi la navigazione",
+      "open": "Apri la navigazione"
     },
     "not-logged": {
       "sign-in": "Accedi",
@@ -384,8 +383,8 @@
     "user": {
       "account": "Il mio account",
       "certifications": "Le mie certificazioni",
-      "sign-out": "Disconnessione",
-      "tests": "I miei percorsi di carriera"
+      "sign-out": "Disconnetti",
+      "tests": "I miei percorsi"
     },
     "user-logged-menu": {
       "details": "Visualizza le mie informazioni"
@@ -398,26 +397,26 @@
         "key-expired": "Il link di recupero è scaduto,",
         "key-expired-renew-demand-link": "rinnovare la richiesta qui.",
         "key-invalid": "Il collegamento di recupero non esiste.",
-        "key-used": "Questo conto è già stato recuperato.",
-        "title": "Ops, c'è stato un errore!"
+        "key-used": "Questo account è già stato recuperato.",
+        "title": "Ops, si è verificato un errore!"
       },
       "find-sco-record": {
         "backup-email-confirmation": {
           "ask-for-new-email-message": "o fornirne uno nuovo",
-          "email-already-exist-for-account-message": "L'indirizzo e-mail sotto riportato è già associato al vostro account:",
+          "email-already-exist-for-account-message": "L'indirizzo e-mail sotto riportato è già associato al tuo account:",
           "email-is-needed-message": "{ firstName }, ci serve il suo indirizzo e-mail",
           "email-is-valid-message": "Se valido,",
           "email-reset-message": "reimpostare la password",
-          "email-sent-to-choose-password-message": "Vi invieremo un'e-mail per scegliere la password.",
+          "email-sent-to-choose-password-message": "Ti invieremo un'e-mail per scegli la password.",
           "form": {
             "actions": {
-              "cancel": "Annullamento",
-              "submit": "Ecco a voi"
+              "cancel": "Annulla",
+              "submit": "Conferma"
             },
-            "email": "Il vostro indirizzo e-mail",
+            "email": "Il tuo indirizzo e-mail",
             "error": {
               "email-already-exist": {
-                "existing-email": "Questo indirizzo e-mail è già in vostro possesso. Se è valido,",
+                "existing-email": "Questo indirizzo e-mail è già in tuo possesso. Se è valido,",
                 "init-password": " reimpostare la password",
                 "new-email": "In caso contrario, inserirne uno nuovo."
               },
@@ -431,24 +430,24 @@
         },
         "confirmation-step": {
           "buttons": {
-            "cancel": "Annullamento",
-            "confirm": "Posso confermare"
+            "cancel": "Annulla",
+            "confirm": "Confermo"
           },
-          "certify-account": "Certifico sul mio onore che il conto associato a questi dati mi appartiene.",
-          "contact-support": "Se notate un errore o se questi dati non sono vostri,",
+          "certify-account": "Certifico sul mio onore che il account associato a questi dati mi appartiene.",
+          "contact-support": "Se notate un errore o se questi dati non sono tuoi,",
           "fields": {
-            "first-name": "Il vostro nome di battesimo",
-            "last-name": "Il tuo nome",
-            "latest-organization-name": "Il vostro ultimo stabilimento",
-            "username": "Il tuo login"
+            "first-name": "Il tuo nome",
+            "last-name": "Il tuo cognome",
+            "latest-organization-name": "Il tuo ultimo istituto",
+            "username": "Il tuo identificativo"
           },
-          "found-account": "Abbiamo trovato il suo account:",
-          "good-news": "Buone notizie { firstName }!"
+          "found-account": "Abbiamo trovato il tuo account:",
+          "good-news": "Buone notizie, { firstName }!"
         },
         "conflict": {
           "found-you-but": "{ firstName }, ti abbiamo trovato ma...",
           "title": "Conflitto",
-          "warning": "Per precauzione, dobbiamo verificare insieme i vostri dati."
+          "warning": "Per precauzione, dobbiamo verificare insieme i tuoi dati."
         },
         "contact-support": {
           "link-text": "contattare l'assistenza.",
@@ -457,7 +456,7 @@
         "send-email-confirmation": {
           "check-spam": "Se non vedete questa e-mail, controllate la cartella spam.",
           "return": "Torna a Pix",
-          "send-email": "Le abbiamo appena inviato un'e-mail per consentirle di scegliere una password. Ora può controllare la sua casella di posta elettronica.",
+          "send-email": "Le abbiamo appena inviato un'e-mail per consentirle di scegli una password. Ora può controlla la sua casella di posta elettronica.",
           "title": "Recupero dell'account Pix"
         },
         "student-information": {
@@ -466,7 +465,7 @@
             "empty-ine-ina": "Il campo INE è obbligatorio.",
             "empty-last-name": "Il campo del nome è obbligatorio.",
             "invalid-ine-ina-format": "Il campo INE è nel formato sbagliato.",
-            "not-found": "Pix non riconosce i vostri dati. Verificate che siano corretti, altrimenti"
+            "not-found": "Pix non riconosce i tuoi dati. Verifica che siano corretti, altrimenti"
           },
           "form": {
             "birthdate": "Data di nascita",
@@ -477,13 +476,13 @@
               "birth-month": "mese di nascita",
               "birth-year": "anno di nascita"
             },
-            "last-name": "Nome",
+            "last-name": "Cognome",
             "placeholder": {
-              "birth-day": "JJ",
+              "birth-day": "GG",
               "birth-month": "MM",
               "birth-year": "AAAA"
             },
-            "submit": "Venite a trovarmi!",
+            "submit": "Trova il mio account",
             "tooltip": "<strong>Dove posso trovare il mio INE? </strong> <p>Questo identificatore si trova di solito sulla pagella scolastica, altrimenti la scuola precedente può fornirlo per voi.</p>"
           },
           "mandatory-all-fields": "Tutti i campi sono obbligatori.",
@@ -491,9 +490,9 @@
             "link": "reimpostare la password qui.",
             "text": "Se si dispone di un account con un indirizzo e-mail valido,"
           },
-          "title": "Avete lasciato il sistema scolastico e volete riottenere l'accesso al sistema Pix."
+          "title": "Hai lasciato il sistema scolastico e vuoi recuperare l'accesso al tuo account Pix."
         },
-        "title": "Recuperare il mio account"
+        "title": "Recupera il mio account"
       },
       "support": {
         "recover": " per l'assistenza.",
@@ -501,21 +500,21 @@
         "url-text": "Contatta l'assistenza"
       },
       "update-sco-record": {
-        "fill-password": "Inserisci la tua password e Pix è tuo!",
+        "fill-password": "Inserisci la tua password e Pix sarà tuo!",
         "form": {
-          "authentication-methods-removal-notice": "Dopo questo passaggio, non sarà più possibile connettersi con { connections }.",
-          "choose-password": "Scegliere una password per continuare a godere di Pix.",
+          "authentication-methods-removal-notice": "Dopo questo passaggio, non sarà più possibile accedere con { connections }.",
+          "choose-password": "Scegli una password per continuare a usare Pix.",
           "email-label": "Indirizzo e-mail",
           "errors": {
             "empty-password": "Il campo della password è obbligatorio.",
             "invalid-password": "La password deve essere lunga almeno 8 caratteri e contenere almeno una lettera maiuscola, una lettera minuscola e un numero."
           },
-          "login-button": "Voglio connettermi",
-          "new-connection-info": "Non preoccupatevi, per accedere nuovamente è sufficiente utilizzare il vostro indirizzo e-mail e la password che avete impostato qui.",
+          "login-button": "Voglio accedere",
+          "new-connection-info": "Non preoccupatevi, per accedere nuovamente è sufficiente utilizzare il tuo indirizzo e-mail e la password che hai impostato qui.",
           "password-label": "Password",
           "sco-connections": {
             "gar": "il Mediacentro",
-            "username": "il vostro tesserino scolastico Pix"
+            "username": "il tuo tesserino scolastico Pix"
           }
         },
         "welcome-message": "Bentornato { firstName }!"
@@ -525,13 +524,13 @@
       "modal": {
         "actions": {
           "quit": {
-            "extra-information": "Uscire dalla prova e tornare alla pagina iniziale"
+            "extra-information": "Esci dal test e torna alla pagina iniziale"
           }
         },
-        "content": "Tutti i vostri progressi vengono registrati. Potete riprendere da dove avete lasciato.",
-        "title": "Avete bisogno di una pausa?"
+        "content": "Tutti i tuoi progressi vengono registrati. Puoi riprendere da dove hai lasciato.",
+        "title": "Hai bisogno di una pausa?"
       },
-      "title": "Test di valutazione :"
+      "title": "Test di valutazione:"
     },
     "assessment-results": {
       "actions": {
@@ -539,7 +538,7 @@
         "return-to-homepage": "Torna alla pagina iniziale"
       },
       "answers": {
-        "header": "Le vostre risposte"
+        "header": "Le tue risposte"
       },
       "title": "Fine del test"
     },
@@ -553,15 +552,15 @@
       },
       "sso-selection": {
         "login": {
-          "button": "Voglio connettermi",
+          "button": "Voglio accedere",
           "message": "Verrete reindirizzati alla pagina di login \"{providerName}\" per identificarvi su Pix."
         },
         "signup": {
-          "button": "Desidero registrarmi",
+          "button": "Voglio registrarmi",
           "link": "Registrati su",
-          "title": "Non avete un account?"
+          "title": "Non hai un account?"
         },
-        "title": "Scegliete la vostra organizzazione"
+        "title": "Scegli la tua organizzazione"
       }
     },
     "autonomous-course": {
@@ -569,19 +568,19 @@
         "actions": {
           "sign-in": "Ho già un account, accedo",
           "start-anonymously": "Inizio senza un account Pix",
-          "start-connected": "Inizio"
+          "start-connected": "Inizia"
         },
         "texts": {
-          "first-course": "È il vostro primo tour Pix?",
-          "legal-informations": "Indipendentemente dal fatto che abbiate o meno un account Pix, le informazioni sui vostri progressi ci verranno inviate.'<br>'Queste informazioni vengono utilizzate da Pix per migliorare il servizio.",
-          "title": "Iniziare il corso:"
+          "first-course": "È il tuo primo percorso Pix?",
+          "legal-informations": "Indipendentemente dal fatto che abbiate o meno un account Pix, le informazioni sui tuoi progressi ci verranno inviate.'<br>'Queste informazioni vengono utilizzate da Pix per migliorare il servizio.",
+          "title": "Iniziare il percorso:"
         }
       }
     },
     "campaign": {
       "errors": {
-        "existing-participation": "Il corso non è accessibile a voi.",
-        "existing-participation-info": "Contattate il vostro insegnante per farvi togliere la partecipazione a Pix Orga.",
+        "existing-participation": "Il percorso non è accessibile a voi.",
+        "existing-participation-info": "Contatta il tuo insegnante per farvi togliere la partecipazione a Pix Orga.",
         "existing-participation-user-info": "Esiste già una voce associata al nome {lastName} {firstName}",
         "no-longer-accessible": "Ops, la pagina richiesta non è più accessibile.",
         "not-accessible": "Ops, la pagina richiesta non è accessibile."
@@ -589,83 +588,83 @@
     },
     "campaign-landing": {
       "assessment": {
-        "action": "Inizio",
-        "announcement": "Registratevi o accedete alla piattaforma Pix e iniziate il vostro test.",
+        "action": "Inizia",
+        "announcement": "Registrati o accedi alla piattaforma Pix e iniziate il tuo test.",
         "certify": {
-          "description": "A seconda della vostra situazione e a determinate condizioni, potete accedere alla certificazione Pix, riconosciuta dal mondo professionale e che vi permette di migliorare le vostre competenze digitali. Per ulteriori informazioni, contattare l'organizzatore del corso.",
-          "title": "Le risposte convalidate in questo corso contribuiranno al vostro profilo personale di competenze digitali su Pix."
+          "description": "A seconda della tua situazione e a determinate condizioni, puoi accedere alla certificazione Pix, riconosciuta dal mondo professionale e che ti permette di migliorare le tue competenze digitali. Per ulteriori informazioni, contattare l'organizzatore del percorso.",
+          "title": "Le risposte convalidate in questo percorso contribuiranno al tuo profilo personale di competenze digitali su Pix."
         },
-        "details": "Durante questo corso, avrete l'opportunità di :",
+        "details": "Durante questo percorso, avrete l'opportunità di:",
         "develop": {
           "description": "Ogni 5 domande, si vedono le risposte corrette e si ricevono consigli e raccomandazioni personalizzate di esercitazioni per sviluppare le proprie competenze.",
-          "title": "Scoprite i vostri risultati man mano che il test procede e consultate i suggerimenti su come migliorare."
+          "title": "Scopri i tuoi risultati man mano che il test procede e consulta i suggerimenti su come migliorare."
         },
         "evaluate": {
-          "description": "Dovrete effettuare ricerche su Internet, utilizzare il vostro ambiente di lavoro digitale, testare le vostre conoscenze, ecc.",
-          "title": "Misurate le vostre competenze digitali con sfide di apprendimento divertenti che si adattano al vostro livello di competenza (utilizzando un algoritmo adattivo)."
+          "description": "Dovrai effettuare ricerche su Internet, utilizzare il tuo ambiente di lavoro digitale, testare le tue conoscenze, ecc.",
+          "title": "Misurate le tue competenze digitali con sfide di apprendimento divertenti che si adattano al tuo livello di competenza (utilizzando un algoritmo adattivo)."
         },
-        "exam-notice": "Durante questo percorso, il Suo profilo di competenze non verrà preso in considerazione né modificato. Le Sue risposte non avranno alcun impatto sui Suoi livelli di competenze né sul Suo punteggio globale Pix.",
-        "legal": "Cliccando su \"Sto iniziando\", le informazioni sui vostri progressi nel corso saranno inviate all'organizzatore del corso in modo che possa supportarvi. Al termine del corso, i risultati saranno inviati automaticamente all'organizzatore.",
+        "exam-notice": "Durante questo percorso, il Suo profilo di competenze non verrà preso in considerazione né modificato. Le Sue risposte non avranno alcun impatto sui Suoi livelli di competenze né sul Suo punteggio Pix complessivo.",
+        "legal": "Cliccando su \"Sto iniziando\", le informazioni sui tuoi progressi nel percorso saranno inviate all'organizzatore del percorso in modo che possa supportarvi. Al termine del percorso, i risultati saranno inviati automaticamente all'organizzatore.",
         "title": "Inizia il tuo viaggio Pix",
-        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' pronti a valutare le vostre competenze digitali?"
+        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' pronti a valutare le tue competenze digitali?"
       },
       "profiles-collection": {
-        "action": "Si parte!",
-        "announcement": "Registratevi o accedete alla piattaforma Pix e inviate il vostro profilo all'organizzazione destinataria.",
-        "legal": "Le informazioni relative al vostro profilo PIX saranno inviate all'organizzatore per consentirgli di accompagnarvi. Saranno trasmesse solo con il vostro consenso.",
+        "action": "Iniziamo!",
+        "announcement": "Registrati o accedi alla piattaforma Pix e inviate il tuo profilo all'organizzazione destinataria.",
+        "legal": "Le informazioni relative al tuo profilo Pix saranno inviate all'organizzatore per consentirgli di accompagnarvi. Saranno trasmesse solo con il tuo consenso.",
         "title": "Invia il tuo profilo",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' invia il tuo profilo"
       },
       "title": "Presentazione",
       "warning-message": "Non sei { firstName } { lastName }?",
-      "warning-message-logout": "Disconnessione"
+      "warning-message-logout": "Disconnetti"
     },
     "campaign-participation": {
-      "title": "Corso"
+      "title": "Percorso"
     },
     "campaign-participation-overview": {
       "card": {
-        "finished-at": "Completato su {date}",
+        "finished-at": "Completato il {date}",
         "results": "{result, number, ::percent} di successo",
         "resume": {
           "extra-information": "Riprendere il percorso {campaignTitle}.",
-          "information": "Il curriculum"
+          "information": "Riprendi il percorso"
         },
-        "retry": "Migliorare me stesso",
+        "retry": "Migliorare i miei risultati",
         "see-more": "Vedi dettagli",
         "stages": "{count} { count, plural, =0 {stella} =1 {stella} other {stella} } su {total}",
-        "started-at": "Avviato su {date}",
+        "started-at": "Avviato il {date}",
         "tag": {
           "deleted": "Inattivo",
           "disabled": "Inattivo",
           "finished": "Completato",
-          "started": "In corso"
+          "started": "In percorso"
         },
         "text-deleted": "Percorso disattivato dalla propria organizzazione.'<br> 'Non è più possibile agire su questo percorso.",
-        "text-disabled": "Corso disattivato dalla propria organizzazione.'<br> 'Non è più possibile inviare i risultati."
+        "text-disabled": "Percorso disattivato dalla propria organizzazione.'<br> 'Non è più possibile invia i risultati."
       },
-      "title": "Corso"
+      "title": "Percorso"
     },
     "certificate": {
       "actions": {
         "download-attestation": "Scarica il mio certificato",
         "download-certificate": "Scarica il mio certificato"
       },
-      "back-link": "Torniamo alle mie certificazioni",
-      "candidate": "Candidato :",
+      "back-link": "Torna alle mie certificazioni",
+      "candidate": "Candidato:",
       "candidate-birth": "Nato il {birthdate}",
       "candidate-birth-complete": "Nato su {birthdate} in {birthplace}.",
-      "certification-center": "Centro di certificazione :",
-      "certification-date": "Data della visita :",
+      "certification-center": "Centro di certificazione:",
+      "certification-date": "Data della certificazione:",
       "certification-value": {
         "paragraphs": {
-          "1": "Riconosciuta ufficialmente, la Certificazione Pix attesta la vostra padronanza delle competenze digitali. Entrerete a far parte di una comunità di milioni di utenti certificati. Congratulazioni per questa pietra miliare della vostra carriera!",
-          "2": "Il vostro punteggio certificato è stato calcolato sulla base delle vostre risposte durante il processo di certificazione. Può quindi differire dal numero di pixel indicato nel vostro profilo.",
-          "3": "Il giorno della certificazione è stato possibile raggiungere il livello 7 e un massimo di 895 pix (livello Expert 1)."
+          "1": "Riconosciuta ufficialmente, la Certificazione Pix attesta la tua padronanza delle competenze digitali. Entrerete a far parte di una comunità di milioni di utenti certificati. Congratulazioni per questa pietra miliare della tua carriera!",
+          "2": "Il tuo punteggio certificato è stato calcolato sulla base delle tue risposte durante il processo di certificazione. Può quindi differire dal numero di pix indicato nel tuo profilo.",
+          "3": "Il giorno della certificazione è stato possibile raggiungere il livello 7 e un massimo di 895 pix (livello Esperto 1)."
         }
       },
       "competences": {
-        "information": "Il vostro punteggio certificato è stato calcolato sulla base delle vostre risposte durante il processo di certificazione. Può quindi differire dal numero di Pix visualizzato nel vostro profilo. Il giorno della certificazione era possibile raggiungere il livello {maxReachableLevelOnCertificationDate} di competenze e {maxReachablePixCountOnCertificationDate} pix al massimo."
+        "information": "Il tuo punteggio certificato è stato calcolato sulla base delle tue risposte durante il processo di certificazione. Può quindi differire dal numero di Pix visualizzato nel tuo profilo. Il giorno della certificazione era possibile raggiungere il livello {maxReachableLevelOnCertificationDate} di competenze e {maxReachablePixCountOnCertificationDate} pix al massimo."
       },
       "complementary": {
         "alternative": "Certificazione complementare",
@@ -673,53 +672,43 @@
         "title": "Altre certificazioni ottenute"
       },
       "congratulations": "Congratulazioni!",
-      "delivered-at": "Data di emissione :",
+      "delivered-at": "Data di emissione:",
       "details": {
         "competences": {
-          "description": "Il punteggio Pix fornisce una stima del vostro livello nelle 16 abilità numeriche.",
-          "title": "Il vostro profilo di competenze digitali"
+          "description": "Il punteggio Pix fornisce una stima del tuo livello nelle 16 competenze digitali.",
+          "title": "Il tuo profilo di competenze digitali"
         }
       },
-      "exam-date": "Data della visita :",
+      "exam-date": "Data della certificazione:",
       "framework-title": {
-        "CLEA": "Certificato Pix",
-        "CORE": "Certificato Pix",
-        "DROIT": "Certificato Pix+ Diritto",
+        "CLEA": "Certificazione Pix",
+        "CORE": "Certificazione Pix",
         "EDU_1ER_DEGRE": "Certificato Pix+ Edu 1° livello",
         "EDU_2ND_DEGRE": "Certificato Pix+ Edu 2° livello",
-        "EDU_CPE": "Certificato Pix+ Edu CPE",
-        "PRO_SANTE": "Certificato Pix+ Professionisti della salute"
+        "EDU_CPE": "Certificato Pix+ Edu CPE"
       },
       "frameworks": {
         "EDU": {
-          "results-infos": "'<p>'La certificazione si svolge in due fasi:'</p><ol><li>'Prova Pix: appena completata.'</li><li>'Prova orale: organizzata al di fuori di Pix davanti a una giuria.'</li></ol><p>'Al termine dell'orale, verrà assegnato il livello di certificazione definitivo (Esperto, Avanzato, ecc.).'<br/>'Contattate il vostro centro di certificazione per organizzare la prova orale.'</p>'",
-          "results-sub-title": "Il candidato è ammesso alla 2ª fase della certificazione Pix+ Édu!",
+          "results-infos": "'<p>'La certificazione si svolge in due fasi:'</p><ol><li>'Prova Pix: appena completata.'</li><li>'Prova orale: organizzata al di fuori di Pix davanti a una giuria.'</li></ol><p>'Al termine dell'orale, verrà assegnato il livello di certificazione definitivo (Esperto, Avanzato, ecc.).'<br/>'Contatta il tuo centro di certificazione per organizzare la prova orale.'</p>'",
           "status": "Certificato valido",
-          "steps": {
-            "1": "Sezione Pix",
-            "2": "Sezione pratica'<br/>'professionale",
-            "3": "Risultato finale"
-          },
-          "sub-title": {
-            "admissible": "Il candidato è ammesso alla 2ª fase!"
-          }
+          "sub-title": "Il candidato è ammesso alla 2ª fase!"
         }
       },
       "global": {
         "explanation": {
-          "default": "Avete raggiunto il livello {globalLevelLabel} della Certificazione Pix!",
-          "pre-beginner-level": "Avete completato il test di certificazione Pix, ma i vostri risultati non vi consentono di ottenere il primo livello."
+          "default": "Hai raggiunto il livello {globalLevelLabel} della Certificazione Pix!",
+          "pre-beginner-level": "Hai completato il test di certificazione Pix, ma i tuoi risultati non ti consentono di ottenere il primo livello."
         },
         "labels": {
           "advanced": "Avanzato",
           "beginner": "Novizio",
           "expert": "Esperto",
           "independent": "Indipendente",
-          "level": "Il vostro livello"
+          "level": "Il tuo livello"
         },
         "progress-bar-explanation": {
           "default": "Barra di avanzamento che mostra il livello raggiunto ({level}, o livello {globalLevelLabel}) su un livello massimo raggiungibile di 7 (livello Esperto 1).",
-          "pre-beginner-level": "Barra di avanzamento che indica il livello massimo che può essere raggiunto nella certificazione (ad es. 7 o Expert 1 livello)"
+          "pre-beginner-level": "Barra di avanzamento che indica il livello massimo che può essere raggiunto nella certificazione (ad es. 7 o Esperto 1 livello)"
         }
       },
       "hexagon-score": {
@@ -728,44 +717,42 @@
       "issued-on": "Rilasciato il",
       "jury-info": "Le osservazioni della giuria non vengono condivise nella pagina di verifica del certificato.",
       "jury-title": "Commenti della giuria",
-      "learn-about-certification-results": "Come vanno interpretati i risultati?",
-      "obtained-certification": "Il candidato ha raggiunto il livello {globalLevelLabel} della certificazione {frameworkLabel}.",
+      "learn-about-certification-results": "Come interpretare i risultati?",
       "professionalizing-warning": "Il certificato Pix è riconosciuto come qualifica professionale da France Compétences una volta raggiunto un punteggio minimo di 120 pix.",
       "results": {
         "sub-title": "Il candidato è ammissibile alla certificazione {framework}.",
         "title": "Lettura del risultato:"
       },
       "title": "Certificato Pix",
-      "valid-status": "Certificato valido",
       "verification-code": {
         "alt": "Copia",
         "copied": "Codice copiato!",
-        "copy": "Copiare il codice",
-        "information": "Il vostro codice di verifica univoco",
+        "copy": "Copia il codice",
+        "information": "Il tuo codice di verifica univoco",
         "share": "Condividi il tuo certificato",
         "title": "Codice di verifica",
-        "tooltip": "Fornite questo codice per consentire a terzi di verificare l'autenticità del vostro certificato."
+        "tooltip": "Fornite questo codice per consentire a terzi di verificare l'autenticità del tuo certificato."
       }
     },
     "certification-ender": {
       "candidate": {
         "disconnect": "Esci dal mio account",
-        "disconnect-tip": "Se non si tratta del vostro computer, ricordatevi di disconnettervi.",
+        "disconnect-tip": "Se non si tratta del tuo computer, ricordati di disconnettervi.",
         "ended-by-invigilator": "L'esaminatore ha interrotto il test di certificazione. Non è possibile continuare a rispondere alle domande.",
         "ended-due-to-finalization": "La sessione è stata conclusa dal centro di certificazione. Non è più possibile continuare a rispondere alle domande.",
         "remote-certification": "Se si sta eseguendo la certificazione Pix in remoto, assicurarsi di disconnettersi dallo strumento di monitoraggio una volta completato il test.",
         "title": "Test completato!"
       },
       "results": {
-        "disclaimer": "I risultati, in attesa della convalida da parte dei team Pix, saranno presto disponibili sul vostro account Pix.",
+        "disclaimer": "I risultati, in attesa della convalida da parte dei team Pix, saranno presto disponibili sul tuo account Pix.",
         "step-1": "Accedere al proprio account Pix e trovare i risultati nella sezione \"Le mie certificazioni\" (accessibile cliccando sul proprio nome nell'angolo in alto a destra dello schermo).",
-        "step-2": "Potete scaricare il vostro certificato e condividerlo, oppure inviarci il codice di verifica da utilizzare sul sito web di Pix.",
-        "title": "Come posso visualizzare e condividere i risultati della mia certificazione?"
+        "step-2": "Puoi scaricare il tuo certificato e condividerlo, oppure inviarci il codice di verifica da utilizzare sul sito web di Pix.",
+        "title": "Come posso visualizza e condividere i risultati della mia certificazione?"
       }
     },
     "certification-frameworks": {
       "CLEA": "CLéA Numérique",
-      "CORE": "Pix certification",
+      "CORE": "Certificazione Pix",
       "DROIT": "Pix+ Diritto",
       "EDU_1ER_DEGRE": "Pix+ Édu 1° livello",
       "EDU_2ND_DEGRE": "Pix+ Édu 2° livello",
@@ -775,23 +762,23 @@
     "certification-instructions": {
       "buttons": {
         "continuous": {
-          "aria-label": "Continuare con la schermata successiva",
+          "aria-label": "Continua alla schermata successiva",
           "label": "Continua",
           "last-page": {
             "aria-label": "Proseguire con la pagina di inserimento della certificazione"
           }
         },
         "previous": {
-          "aria-label": "Ritorno alla schermata precedente",
-          "label": "Precedente"
+          "aria-label": "Torna alla schermata precedente",
+          "label": "Indietro"
         }
       },
       "steps": {
         "1": {
           "paragraphs": {
-            "1": "La certificazione {certificationName} è un test \"<strong>adattivo\"</strong> per valutare il vostro livello nel \"<strong>quadro di riferimento delle 16 competenze digitali del Pix\"</strong>.",
+            "1": "La certificazione {certificationName} è un test \"<strong>adattivo\"</strong> per valutare il tuo livello nel \"<strong>quadro di riferimento delle 16 competenze digitali del Pix\"</strong>.",
             "2": "La \"<strong>difficoltà delle domande si adatta in tempo reale\"</strong> in base alle risposte fornite.",
-            "3": "Se alcune domande sembrano difficili, è perché il test di certificazione cerca di misurare il vostro livello massimo. Se non siete in grado di rispondere a una domanda, avete la possibilità di \"saltarla\": non verrà riproposta durante la certificazione e non sarà convalidata.",
+            "3": "Se alcune domande sembrano difficili, è perché il test di certificazione cerca di misurare il tuo livello massimo. Se non sei in grado di rispondere a una domanda, hai la possibilità di \"saltarla\": non verrà riproposta durante la certificazione e non sarà convalidata.",
             "4": "Per ottenere un punteggio il più vicino possibile alle proprie capacità \"<strong>è necessario arrivare alla fine del test\"</strong>.",
             "pix-plus-1": "La certificazione {certificationName} è un '<strong>'test adattivo'</strong>' per valutare il livello del candidato sull’'<strong>'insieme di competenze del quadro di riferimento della certificazione {certificationName}'</strong>'."
           },
@@ -803,8 +790,8 @@
             "strong-text": "32 DOMANDE"
           },
           "paragraphs": {
-            "1": "Il test di certificazione consiste in \"<strong>32 domande\"</strong>\".",
-            "2": "Avete un massimo di '<strong>'{durata}'</strong>' per rispondere*.",
+            "1": "Il test di certificazione è composto da \"<strong>32 domande\"</strong>\".",
+            "2": "Hai un massimo di '<strong>'{durata}'</strong>' per rispondere*.",
             "3": "*escluso il tempo supplementare",
             "4": "Se si completano '<strong>'meno di 20 domande, non sarà possibile assegnare un punteggio'</strong>'."
           },
@@ -812,17 +799,17 @@
         },
         "3": {
           "images": {
-            "focus-challenge": "Modalità di messa a fuoco",
+            "focus-challenge": "Modalità focus",
             "regular-challenge": "Modalità libera"
           },
           "paragraphs": {
             "1": {
               "text": "Per le domande in '<strong>'modalità libera'</strong>' contrassegnate da un'icona verde: sarà possibile effettuare ricerche sul web e utilizzare l'ambiente digitale disponibile.'<br>'Tuttavia, '<strong>'alcuni siti non saranno accessibili nella certificazione'</strong>'.",
-              "title": "Modalità libera :"
+              "title": "Modalità libera:"
             },
             "2": {
               "text": "Per le domande in \"<strong>modalità focus\"</strong>, indicate da un'icona gialla: non sarà possibile lasciare la pagina e cercare.",
-              "title": "Modalità di messa a fuoco :"
+              "title": "Modalità di messa a fuoco:"
             }
           },
           "title": "Due tipi di domande"
@@ -830,11 +817,11 @@
         "4": {
           "list": {
             "1": "Andare in fondo alla pagina",
-            "2": "Selezionare \"Segnala un problema con la domanda\".",
+            "2": "Seleziona \"Segnala un problema con la domanda\".",
             "3": "Fare clic su \"Sì, sono sicuro\".",
-            "4": "Chiamate il supervisore che interverrà per aiutarvi."
+            "4": "Chiamate il sorvegliante, che interverrà per aiutarvi."
           },
-          "text": "'<strong>'In caso di problemi tecnici'</strong> (ad esempio, l'immagine si rifiuta di essere visualizzata), seguire questi passaggi:",
+          "text": "'<strong>'In caso di problemi tecnici'</strong> (ad esempio l'immagine si rifiuta di essere visualizzata), seguire questi passaggi:",
           "title": "Cosa fare in caso di problemi?"
         },
         "5": {
@@ -843,13 +830,13 @@
             "1": "'<strong>'Comunicare con qualcun altro'</strong>', all'interno o all'esterno della stanza, con mezzi fisici o elettronici.",
             "2": "'<strong>'Utilizzare un telefono cellulare o qualsiasi dispositivo elettronico collegato'</strong>' (diverso dal computer su cui si sta prendendo la certificazione).",
             "3": "'<strong>'Utilizzare un sistema di intelligenza artificiale'</strong>' o un chatbot.",
-            "4": "'<strong>'Consultare un forum di auto-aiuto'</strong>' fornendo direttamente la risposta a una domanda.",
+            "4": "'<strong>'Consulta un forum di auto-aiuto'</strong>' fornendo direttamente la risposta a una domanda.",
             "5": "'<strong>'Mobilitare qualsiasi altro mezzo che fornisca direttamente la risposta alla domanda'</strong>', senza aver svolto il lavoro richiesto dall'istruzione.",
             "6": "'<strong>'Usa un browser diverso'</strong>' rispetto a quello su cui si sta eseguendo il test di certificazione {certificationName}.",
             "7": "'<strong>'Impersonare'</strong>' un'altra persona."
           },
           "pix-companion": "L'accesso a determinati siti è vietato nell'ambito del test di certificazione, grazie a un'estensione installata sul browser. Qualsiasi frode accertata (tentativo di aggirare l'estensione o mancato rispetto dei comportamenti sopra elencati) può comportare l'invalidazione della certificazione.",
-          "text": "Nella certificazione è vietato :",
+          "text": "Durante la certificazione è vietato:",
           "title": "Regole da rispettare"
         }
       },
@@ -860,32 +847,32 @@
       "congratulation-banner": {
         "double-certification": {
           "eligible": "È inoltre possibile ottenere una certificazione complementare:",
-          "outdated": "<strong>Non sei più eleggibile per la certificazione {doubleCertificationName} in seguito alla sua evoluzione.</strong><br />Contatta la tua scuola o l'organizzazione che ti ha offerto il corso per riprendere una campagna e tornare così eleggibile. I tuoi progressi sono stati conservati e non devi fare altro che giocare ai nuovi eventi, che dovrebbero essere veloci."
+          "outdated": "<strong>Non sei più eleggibile per la certificazione {doubleCertificationName} in seguito alla sua evoluzione.</strong><br />Contatta la tua scuola o l'organizzazione che ti ha offerto il percorso per riprendere una campagna e tornare così eleggibile. I tuoi progressi sono stati conservati e non devi fare altro che giocare ai nuovi eventi, che dovrebbero essere veloci."
         },
         "link": {
           "text": "Come si ottiene la certificazione?"
         },
-        "message": "Congratulazioni {fullName}, il vostro profilo Pix è certificabile."
+        "message": "Congratulazioni {fullName}, il tuo profilo Pix è certificabile."
       },
       "error-messages": {
         "generic": {
-          "check-personal-info": "Verificare con il supervisore che i propri dati personali corrispondano a quelli riportati sul foglio di registrazione.",
-          "check-session-number": "Controllare il numero della sessione.",
-          "disclaimer": "Le informazioni inserite non corrispondono a nessun candidato iscritto alla sessione."
+          "check-personal-info": "Verificare con il sorvegliante che i propri dati personali corrispondano a quelli riportati sul foglio di registrazione.",
+          "check-session-number": "Controlla il numero della sessione.",
+          "disclaimer": "Le informazioni inserisci non corrispondono a nessun candidato iscritto alla sessione."
         },
-        "language-not-supported": "La certificazione Pix non è ancora disponibile in {userLanguage}. '<br>' Le lingue attualmente disponibili per ottenere la certificazione sono: {availableLanguages}. '<br>' È possibile scegliere un'altra lingua dalla pagina",
+        "language-not-supported": "La certificazione Pix non è ancora disponibile in {userLanguage}. '<br>' Le lingue attualmente disponibili per ottenere la certificazione sono: {availableLanguages}. '<br>' È possibile scegli un'altra lingua dalla pagina",
         "language-not-supported-link": "Il mio account",
         "missing-center-habilitation": "Non è possibile partecipare alla sessione. Il centro di certificazione non è autorizzato a rilasciare questa certificazione.",
         "session-not-accessible": "La sessione a cui si sta cercando di accedere non è più accessibile.",
-        "wrong-account": "Le informazioni inserite corrispondono a un candidato registrato per la sessione e già loggato con un altro account. Verificare di aver effettuato l'accesso con l'account che ha avviato la certificazione.",
-        "wrong-account-sco": "Si sta utilizzando un account non collegato alla propria scuola.\nAccedete all'account con cui avete completato i corsi o chiedete aiuto al vostro supervisore.",
+        "wrong-account": "Le informazioni inserisci corrispondono a un candidato registrato per la sessione e già loggato con un altro account. Verificare di aver effettuato l'accesso con l'account che ha avviato la certificazione.",
+        "wrong-account-sco": "Si sta utilizzando un account non collegato alla propria scuola.\nAccedi all'account con cui hai completato i corsi o chiedete aiuto al tuo sorvegliante.",
         "wrong-account-sco-link": {
-          "label": "Come faccio a trovare il conto collegato allo stabilimento?",
+          "label": "Come faccio a trovare il account collegato allo istituto?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
         },
         "wrong-domain-for-pix-plus": "Poiché al momento le certificazioni Pix+ sono disponibili solo in francese, non sono disponibili su https://pix.org.<br/>Si prega di effettuare il logout e di accedere nuovamente tramite '<a href=\"https://app.pix.fr/connexion\">questo link.</a>'."
       },
-      "first-title": "Partecipare a una sessione",
+      "first-title": "Partecipa a una sessione",
       "form": {
         "actions": {
           "submit": "Continua"
@@ -894,63 +881,63 @@
           "birth-date": "Data di nascita",
           "birth-day": "giorno di nascita (DD)",
           "birth-month": "mese di nascita (MM)",
-          "birth-name": "Nome di nascita",
+          "birth-name": "Cognome di nascita",
           "birth-year": "anno di nascita (YYYY)",
           "first-name": "Nome",
           "session-number": "Numero della sessione",
-          "session-number-information": "Comunicata solo dall'invigilatore all'inizio della sessione."
+          "session-number-information": "Comunicato solo dal sorvegliante all'inizio della sessione."
         },
         "fields-validation": {
           "session-number-error": "Il numero di sessione è composto solo da numeri."
         },
         "placeholders": {
-          "birth-day": "JJ",
+          "birth-day": "GG",
           "birth-month": "MM",
           "birth-name": "ad esempio Dupont",
           "birth-year": "AAAA",
-          "first-name": "ex: Jean",
-          "session-number": "ex: 123456"
+          "first-name": "es.: Jean",
+          "session-number": "es.: 123456"
         }
       },
-      "title": "Partecipare a una sessione di certificazione"
+      "title": "Partecipa a una sessione di certificazione"
     },
     "certification-not-certifiable": {
       "action": {
         "back": "Torna alla pagina iniziale"
       },
       "text": "Per ottenere la certificazione del proprio profilo, è necessario aver raggiunto un livello superiore a 0 in almeno 5 competenze.",
-      "title": "Il vostro profilo non è ancora certificabile."
+      "title": "Il tuo profilo non è ancora certificabile."
     },
     "certification-results": {
       "action": {
-        "confirm": "Posso confermare",
-        "logout": "Disconnessione"
+        "confirm": "Confermo",
+        "logout": "Disconnetti"
       },
       "finished": {
-        "description": "I risultati saranno presto disponibili nel vostro account.",
-        "title": "Bravo, è finita!",
-        "warning-text": "Se non si tratta del vostro computer, ricordatevi di disconnettervi."
+        "description": "I risultati saranno presto disponibili nel tuo account.",
+        "title": "Bravo, hai finito!",
+        "warning-text": "Se non si tratta del tuo computer, ricordati di disconnettervi."
       },
       "flag-alt": "Bandiera",
       "title": "Test completato"
     },
     "certification-start": {
-      "access-code": "Codice di accesso fornito dal supervisore",
+      "access-code": "Codice di accesso fornito dal sorvegliante",
       "actions": {
-        "submit": "Avviare il test"
+        "submit": "Avvia il test"
       },
       "cgu": {
         "contact": {
           "email": "dpo@pix.fr",
-          "info": "Ai sensi della legge francese sulla protezione dei dati, potete esercitare il diritto di accesso e rettifica dei vostri dati personali inviando un'e-mail a"
+          "info": "Ai sensi della legge francese sulla protezione dei dati, puoi esercitare il diritto di accesso e rettifica dei tuoi dati personali inviando un'e-mail a"
         },
-        "info": "Cliccando su \"Inizia il mio test\", accetto che i miei dati di identità, il numero di certificazione e le circostanze del test, così come sono stati inseriti dall'invigilatore, vengano trasmessi a Pix. Pix utilizzerà queste informazioni durante le deliberazioni della giuria per produrre e archiviare i miei risultati e per rilasciare il mio certificato. Se questa certificazione è stata prescritta da un'organizzazione, accetto che Pix possa comunicare i miei risultati a quest'ultima."
+        "info": "Cliccando su \"Inizia il mio test\", accetto che i miei dati di identità, il numero di certificazione e le circostanze del test, così come sono stati inseriti dall'sorvegliante, vengano trasmessi a Pix. Pix utilizzerà queste informazioni durante le deliberazioni della giuria per produrre e archiviare i miei risultati e per rilasciare il mio certificato. Se questa certificazione è stata prescritta da un'organizzazione, accetto che Pix possa comunicare i miei risultati a quest'ultima."
       },
-      "core-and-complementary-subscriptions": "Oltre alla certificazione Pix, siete iscritti alle seguenti certificazioni complementari:",
+      "core-and-complementary-subscriptions": "Oltre alla certificazione Pix, sei iscritti alle seguenti certificazioni complementari:",
       "error-messages": {
         "access-code-error": "Questo codice non esiste o non è più valido.",
-        "candidate-not-authorized-to-resume": "Si prega di contattare il proprio assistente per autorizzare la ripresa della prova.",
-        "candidate-not-authorized-to-start": "L'esaminatore non ha confermato la vostra presenza nell'aula d'esame. Pertanto, non è ancora possibile iniziare il test di certificazione. Si prega di informare l'esaminatore.",
+        "candidate-not-authorized-to-resume": "Contatta il sorvegliante per autorizzare la ripresa della prova.",
+        "candidate-not-authorized-to-start": "Il sorvegliante non ha confermato la tua presenza in aula. Pertanto, non è ancora possibile iniziare il test di certificazione. Informa il sorvegliante.",
         "generic": "Si è appena verificato un errore inatteso del server.",
         "missing-code": "Il codice di accesso non è stato inserito.",
         "session-not-accessible": "La sessione di certificazione non è più accessibile.",
@@ -958,18 +945,10 @@
           "summary-label": "Visualizza altri dettagli:"
         }
       },
-      "first-title": "State per iniziare il test di certificazione",
-      "language-selector": {
-        "confirmation-label": "Confermo di sentirmi a mio agio nella lingua selezionata per rispondere alle domande.'<br>'La scelta della lingua è '<strong>'definitiva'</strong>'.",
-        "label": "Lingua di certificazione",
-        "options": {
-          "english": "Inglese - EN",
-          "french": "Francese - FR"
-        }
-      },
+      "first-title": "Stai per iniziare il test di certificazione",
       "link-to-user-certification": "Vedi le mie certificazioni",
       "non-eligible-subscription": "Non si ha diritto a {complementarySubscriptionLabel}. È tuttavia possibile ottenere la certificazione Pix.",
-      "title": "Partecipare a una sessione di certificazione"
+      "title": "Partecipa a una sessione di certificazione"
     },
     "certifications-list": {
       "buttons": {
@@ -980,11 +959,11 @@
       "comment": "Commento:",
       "description": "Accedi a tutte le tue certificazioni Pix. Visualizza i dettagli e scarica i tuoi certificati.",
       "information": {
-        "certification-center": "Centro di certificazione :",
-        "date": "Data della visita :"
+        "certification-center": "Centro di certificazione:",
+        "date": "Data della visita:"
       },
       "no-certification": {
-        "text": "Non si dispone ancora della certificazione Pix"
+        "text": "Non hai ancora ottenuto la certificazione Pix"
       },
       "statuses": {
         "cancelled": "Annullato",
@@ -997,14 +976,14 @@
     "challenge": {
       "actions": {
         "continue": "Continua",
-        "continue-go-to-next": "Passo alla prossima domanda",
+        "continue-go-to-next": "Passo alla domanda successiva",
         "skip": "Passo",
-        "skip-go-to-next": "Passo alla prossima domanda",
-        "validate": "Convalido",
-        "validate-go-to-next": "Convalido e passo alla domanda successiva",
-        "wait-for-invigilator": "Le azioni sono sospese fino all'arrivo del supervisore."
+        "skip-go-to-next": "Passo alla domanda successiva",
+        "validate": "Confermo",
+        "validate-go-to-next": "Confermo e passo alla domanda successiva",
+        "wait-for-invigilator": "Le azioni sono sospese fino all'arrivo del sorvegliante."
       },
-      "already-answered": "Avete già risposto a questa domanda",
+      "already-answered": "Hai già risposto a questa domanda",
       "answer-input": {
         "numbered-label": "Risposta {number}"
       },
@@ -1017,29 +996,29 @@
       "certification-feedback-panel": {
         "actions": {
           "no-send-feedback": "No, torno al test...",
-          "open-close": "Segnalare un problema con la domanda",
+          "open-close": "Segnala un problema con la domanda",
           "send-feedback": "Sì, sono sicuro"
         },
-        "description": "Siete sicuri di voler segnalare un problema?",
-        "information": "Quando si segnala un problema, la certificazione viene messa in pausa finché il supervisore non interviene per convalidare o invalidare la segnalazione."
+        "description": "Sei sicuri di voler segnalare un problema?",
+        "information": "Quando si segnala un problema, la certificazione viene messa in pausa finché il sorvegliante non interviene per convalidare o invalidare la segnalazione."
       },
       "embed-simulator": {
         "actions": {
-          "launch": "Inizio",
-          "launch-label": "Avvio della simulazione",
-          "reset": "Reset",
-          "reset-label": "Azzeramento della simulazione"
+          "launch": "Inizia",
+          "launch-label": "Avvio del simulatore",
+          "reset": "Reimposta",
+          "reset-label": "Reimpostazione del simulatore"
         },
         "placeholder": "Caricamento dell'applicazione corrente"
       },
       "feedback-panel": {
         "actions": {
-          "open-close": "Segnalare un problema con la domanda"
+          "open-close": "Segnala un problema con la domanda"
         },
-        "description": "Pix è sempre desideroso di ascoltare i vostri commenti su come migliorare i test offerti!",
+        "description": "Pix è sempre desideroso di ascoltare i tuoi commenti su come migliorare i test offerti!",
         "form": {
           "actions": {
-            "submit": "Inviare",
+            "submit": "Invia",
             "submit-aria-label": "Invia il mio messaggio"
           },
           "fields": {
@@ -1060,14 +1039,14 @@
             "detail-selection": {
               "add-comment": "Aggiungi un commento",
               "aria-first": "Ho un problema con",
-              "aria-secondary": "Selezionare un'opzione per specificare il problema",
-              "label": "Selezionare un'opzione per specificare il problema",
+              "aria-secondary": "Seleziona un'opzione per specificare il problema",
+              "label": "Seleziona un'opzione per specificare il problema",
               "options": {
                 "answer-not-accepted": "La mia risposta è corretta, ma non è stata convalidata.",
                 "answer-not-agreed": "Non sono d'accordo con la risposta",
                 "download": {
                   "edit-failure": {
-                    "label": "Non riesco a modificare il",
+                    "label": "Non riesco a modificare il file",
                     "solution": "Il file è probabilmente aperto in \"sola lettura\" o in \"modalità protetta\". '<br>'Fare clic su \"Abilita modifica\" o \"Modifica documento\" nel banner in cima al file, se appare. '<br>'Altrimenti salvare il file con un altro nome e aprire questo nuovo file."
                   },
                   "lost": {
@@ -1075,57 +1054,57 @@
                     "solution": "Per impostazione predefinita, un file scaricato viene salvato nella cartella \"Download\". Può anche essere scaricato nella stessa posizione dell'ultimo download..."
                   },
                   "open-failure": {
-                    "label": "Non riesco ad aprire il file su un computer",
-                    "solution": "Se non si riesce ad aprire un file, consultare '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'la guida situata sotto il pulsante \"Download\"'</a>'. Lì troverete il software o gli strumenti online consigliati."
+                    "label": "Non riesco ad aprire il file sul computer",
+                    "solution": "Se non si riesce ad aprire un file, consulta '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'la guida situata sotto il pulsante \"Download\"'</a>'. Lì troverete il software o gli strumenti online consigliati."
                   },
-                  "other": "Ho un altro problema con il"
+                  "other": "Ho un altro problema con il file"
                 },
                 "embed-displayed-on-desktop-with-problems": {
                   "label": "Su un computer, il simulatore viene visualizzato ma presenta un problema",
-                  "solution": "Facciamo del nostro meglio per garantire che i simulatori funzionino su tutti i dispositivi, tutti i sistemi operativi e tutti i browser, ma è possibile che stiate utilizzando un sistema particolare. Potete fermarvi qui e ricominciare da un computer.'<br>'Specificate il vostro problema indicando il browser e il sistema operativo."
+                  "solution": "Facciamo del nostro meglio per garantire che i simulatori funzionino su tutti i dispositivi, tutti i sistemi operativi e tutti i browser, ma è possibile che stiate utilizzando un sistema particolare. Puoi fermarvi qui e ricominciare da un computer.'<br>'Specificate il tuo problema indicando il browser e il sistema operativo."
                 },
                 "embed-displayed-on-mobile-devices-with-problems": {
                   "label": "Su un telefono o un tablet, il simulatore viene visualizzato ma presenta un problema",
-                  "solution": "Facciamo del nostro meglio per garantire che i simulatori funzionino su tutti i dispositivi, tutti i sistemi operativi e tutti i browser, ma è possibile che stiate utilizzando un sistema particolare.'<br>'Specificate il vostro problema indicando il tipo di dispositivo (smartphone, tablet...), il sistema operativo e il browser."
+                  "solution": "Facciamo del nostro meglio per garantire che i simulatori funzionino su tutti i dispositivi, tutti i sistemi operativi e tutti i browser, ma è possibile che stiate utilizzando un sistema particolare.'<br>'Specificate il tuo problema indicando il tipo di dispositivo (smartphone, tablet...), il sistema operativo e il browser."
                 },
                 "embed-not-displayed": {
                   "label": "Il simulatore/applicazione non viene visualizzato",
-                  "solution": "La connessione Internet potrebbe essere troppo debole.'<br>'Ricaricare la pagina premendo il pulsante di aggiornamento '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' accanto alla barra degli indirizzi. Attendere un attimo e il simulatore potrebbe apparire. '<br><br>'In caso contrario, potete riprovare in un altro momento o da un'altra postazione con una connessione migliore?"
+                  "solution": "La accesso Internet potrebbe essere troppo debole.'<br>'Ricaricare la pagina premendo il pulsante di aggiornamento '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' accanto alla barra degli indirizzi. Attendere un attimo e il simulatore potrebbe apparire. '<br><br>'In caso contrario, puoi riprovare in un altro momento o da un'altra postazione con una accesso migliore?"
                 },
-                "embed-other": "Il simulatore/applicazione presenta un altro problema",
+                "embed-other": "Il simulatore/l'applicazione presenta un altro problema",
                 "link-other": "Il link non funziona o presenta un altro problema",
                 "link-unauthorized": {
                   "label": "Il link è bloccato dalla mia organizzazione/istituzione...",
-                  "solution": "Potreste appartenere a un'organizzazione (scuole, università, aziende, dipartimenti governativi, associazioni, ecc.) che protegge i propri utenti e le proprie apparecchiature limitando le pagine Internet a cui avete accesso.'<br>'"
+                  "solution": "Potreste appartenere a un'organizzazione (scuole, università, aziende, dipartimenti governativi, associazioni, ecc.) che protegge i propri utenti e le proprie apparecchiature limitando le pagine Internet a cui hai accesso.'<br>'"
                 },
-                "other-challenge-proposal": "Ho un'idea (brillante) per un test da suggerire",
+                "other-challenge-proposal": "Ho un'idea brillante per una prova da suggerire",
                 "other-difficulty": "Ho un altro problema",
                 "other-site-improvement": "Ho un suggerimento per migliorare la piattaforma",
                 "picture-not-displayed": {
                   "label": "L'immagine non viene visualizzata",
-                  "solution": "La connessione a Internet potrebbe essere troppo debole.'<br>'Ricaricare la pagina premendo il pulsante di aggiornamento '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' accanto alla barra degli indirizzi. Attendere un attimo e l'immagine potrebbe apparire. '<br><br>'In caso contrario, potete riprovare in un altro momento o da un'altra postazione con una connessione migliore?"
+                  "solution": "La accesso a Internet potrebbe essere troppo debole.'<br>'Ricaricare la pagina premendo il pulsante di aggiornamento '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' accanto alla barra degli indirizzi. Attendere un attimo e l'immagine potrebbe apparire. '<br><br>'In caso contrario, puoi riprovare in un altro momento o da un'altra postazione con una accesso migliore?"
                 },
                 "picture-other": "L'immagine presenta un altro problema",
                 "question-improvement": "Vorrei proporre un miglioramento alla domanda",
                 "question-not-understood": "Non capisco la domanda",
                 "tutorial-link-error": "Il link al tutorial porta a un'altra pagina o a una pagina di errore.",
                 "tutorial-not-accepted": "Il tutorial non è adatto",
-                "tutorial-proposal": "Ho un tutorial per voi"
+                "tutorial-proposal": "Ho un tutorial da suggerire"
               },
-              "problem-suggestion-description": "Descrivete il vostro problema o suggerimento"
+              "problem-suggestion-description": "Descrivi il tuo problema o suggerimento"
             }
           },
           "status": {
             "error": {
-              "empty-message": "È necessario inserire un messaggio.",
+              "empty-message": "È necessario inserisci un messaggio.",
               "max-characters": "Il messaggio è limitato a 10.000 caratteri."
             },
-            "success": "'<p>'Il tuo commento è stato trasmesso al team del progetto Pix.'</p><p>'Mercix!'</p>'"
+            "success": "'<p>'Il tuo commento è stato trasmesso al team del progetto Pix.'</p><p>'Grazie!'</p>'"
           }
         },
         "information": {
-          "data-usage": "'<p>'Pix tratta i dati in quest'area per gestire e analizzare le difficoltà riscontrate e per beneficiare del vostro feedback. Avete dei diritti sui vostri dati che possono essere esercitati contattando: <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Scopri di più sulla protezione dei dati e sui tuoi diritti.'</a></p>'",
-          "guidance": "'<p>'* Fate attenzione a ciò che scrivete in quest'area: rimanete oggettivi e fattuali, a beneficio vostro e degli altri.'</p><p>'In particolare, non inserite informazioni, che riguardino voi stessi o terzi, su salute, religione, opinioni politiche, sindacali o filosofiche, origini etniche, o su sanzioni o condanne.'</p>'"
+          "data-usage": "'<p>'Pix tratta i dati in quest'area per gestire e analizzare le difficoltà riscontrate e per beneficiare del tuo feedback. Hai dei diritti sui tuoi dati che possono essere esercitati contattando: <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Scopri di più sulla protezione dei dati e sui tuoi diritti.'</a></p>'",
+          "guidance": "'<p>'* Fate attenzione a ciò che scrivete in quest'area: rimanete oggettivi e fattuali, a beneficio tuo e degli altri.'</p><p>'In particolare, non inserisci informazioni, che riguardino voi stessi o terzi, su salute, religione, opinioni politiche, sindacali o filosofiche, origini etniche, o su sanzioni o condanne.'</p>'"
         },
         "modal": {
           "content": "'<p><strong>'Sei sicuro di voler segnalare questo problema?'</strong></p><p>'Grazie per la tua segnalazione, che sarà esaminata attentamente dal team Pix. Prendiamo in considerazione tutti i tuoi commenti per migliorare continuamente i nostri servizi e la nostra esperienza utente. Non saremo in grado di fornirle una risposta personalizzata. Grazie per la collaborazione.'</p>'",
@@ -1133,10 +1112,10 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "Abbiamo rilevato un cambio di pagina. La risposta sarà considerata errata. Se siete stati costretti a cambiare pagina, informate il vostro supervisore e rispondete alla domanda in sua presenza.",
+        "certification": "Abbiamo rilevato un cambio di pagina. La risposta sarà considerata errata. Se sei stati costretti a cambiare pagina, informate il tuo sorvegliante e rispondete alla domanda in sua presenza.",
         "default": "Abbiamo rilevato un cambio di pagina. Nella certificazione, la sua risposta non sarebbe stata convalidata.",
         "v3-accessible-certification": "È stato rilevato un cambio di pagina. Se si è dovuto cambiare pagina per utilizzare uno strumento di accessibilità digitale (come uno screen reader o una tastiera virtuale), rispondere comunque alla domanda.",
-        "v3-certification": "Abbiamo rilevato un cambio di pagina. La risposta sarà considerata errata. Se siete stati costretti a cambiare pagina, informate il vostro supervisore in modo che possa vedere la modifica e segnalarla direttamente dall'\"Area del supervisore\"."
+        "v3-certification": "Abbiamo rilevato un cambio di pagina. La risposta sarà considerata errata. Se sei stati costretti a cambiare pagina, informate il tuo sorvegliante in modo che possa vedere la modifica e segnalarla direttamente dall'\"Area del sorvegliante\"."
       },
       "illustration": {
         "placeholder": "Caricamento dell'immagine corrente"
@@ -1150,51 +1129,51 @@
       },
       "live-alerts": {
         "challenge": {
-          "message": "Avvisare il proprio supervisore affinché possa identificare il problema e risolverlo direttamente nell'interfaccia \"Area supervisore\"."
+          "message": "Avvisare il proprio sorvegliante affinché possa identificare il problema e risolverlo direttamente nell'interfaccia \"Area sorvegliante\"."
         },
         "companion": {
-          "message": "Contattare il proprio supervisore per confermare la presenza dell'estensione."
+          "message": "Contattare il proprio sorvegliante per confermare la presenza dell'estensione."
         },
         "refresh": "Aggiorna la pagina",
-        "waiting-information": "In attesa del supervisore..."
+        "waiting-information": "In attesa del sorvegliante..."
       },
       "parts": {
         "answer-input": "La tua risposta",
         "answer-instructions": {
-          "qcm": "Selezionare diverse risposte.",
-          "qcu": "Selezionare una sola risposta."
+          "qcm": "Seleziona diverse risposte.",
+          "qcu": "Seleziona una sola risposta."
         },
         "feedback": "Segnala un problema",
-        "feedback-v3": "Segnalare un problema con la domanda",
-        "instruction": "Istruzioni per il test",
-        "progress": "I vostri progressi",
-        "validation": "Convalidare o superare il test"
+        "feedback-v3": "Segnala un problema con la domanda",
+        "instruction": "Istruzioni per la prova",
+        "progress": "I tuoi progressi",
+        "validation": "Confermare o saltare la prova"
       },
       "progress-bar": {
         "label": "Domanda"
       },
       "skip-error-message": {
-        "qcm": "Per convalidare, selezionare almeno due risposte. In caso contrario, saltare.",
-        "qcu": "Per confermare, selezionare una risposta. Altrimenti, saltare.",
-        "qroc": "Per convalidare, compilare il campo di testo. Altrimenti, saltare.",
+        "qcm": "Per convalidare, seleziona almeno due risposte. In caso contrario, saltare.",
+        "qcu": "Per confermare, seleziona una risposta. Altrimenti, saltare.",
+        "qroc": "Per convalidare, compila il campo di testo. Altrimenti, saltare.",
         "qroc-auto-reply": "Quando il test viene superato, viene visualizzato \"È possibile convalidare\". Riprovare o superare il test.",
-        "qroc-positive-number": "Per convalidare, inserire un numero maggiore o uguale a 0, altrimenti saltare.",
-        "qrocm": "Per convalidare, compilare tutti i campi delle risposte. In caso contrario, saltare."
+        "qroc-positive-number": "Per convalidare, inserisci un numero maggiore o uguale a 0, altrimenti saltare.",
+        "qrocm": "Per convalidare, compila tutti i campi delle risposte. In caso contrario, saltare."
       },
       "statement": {
         "alternative-instruction": {
           "actions": {
-            "display": "Visualizzare l'alternativa di testo",
-            "hide": "Nascondi testo alternativo"
+            "display": "Visualizza il testo alternativo",
+            "hide": "Nascondi il testo alternativo"
           }
         },
         "file-download": {
           "actions": {
-            "choose-type": "Scegliere il tipo di file da utilizzare",
-            "download": "Scaricare"
+            "choose-type": "Scegli il tipo di file da utilizzare",
+            "download": "Scarica"
           },
-          "description": "Pix consente di scegliere il formato di file da scaricare. Se non sapete quale opzione scegliere, mantenete quella predefinita. Questo è il formato di file supportato dal maggior numero di applicazioni software.",
-          "file-type": "file .{fileExtension}",
+          "description": "Pix consente di scegli il formato di file da scaricare. Se non sapete quale opzione scegli, mantenete quella predefinita. Questo è il formato di file supportato dal maggior numero di applicazioni software.",
+          "file-type": "file.{fileExtension}",
           "help": "Hai bisogno di aiuto con '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"apri, modifica o trova questo file (apri in una nuova finestra)\">'apri, modifica o trova questo file'</a>'?"
         },
         "sr-only": {
@@ -1205,29 +1184,29 @@
           "activate": "Attivare la vocalizzazione",
           "deactivate": "Disattivare la vocalizzazione",
           "play": "Leggere le istruzioni ad alta voce",
-          "stop": "Smettere di leggere le istruzioni"
+          "stop": "Interrompi la lettura delle istruzioni"
         },
         "tooltip": {
-          "aria-label": "Visualizzare l'indicazione sulla prova.",
-          "close": "Capisco",
+          "aria-label": "Visualizza l'indicazione sulla prova.",
+          "close": "Ho capito",
           "focused": {
             "content": "'<strong class=\"tooltip-tag-information__title--focused\">'Cerca di rimanere su questa pagina per rispondere!'</strong><br/>' Questa domanda non richiede internet o applicazioni.",
-            "title": "Modalità di messa a fuoco"
+            "title": "Modalità focus"
           },
           "other": {
-            "content": "Siete liberi di utilizzare Internet o le applicazioni per rispondere a questa domanda.",
+            "content": "Sei liberi di utilizzare Internet o le applicazioni per rispondere a questa domanda.",
             "title": "Modalità libera"
           }
         }
       },
       "timed": {
-        "cannot-answer": "Il tempo limite è scaduto. La risposta non sarà convalidata."
+        "cannot-answer": "Il tempo a disposizione è scaduto. La risposta non sarà convalidata."
       },
       "title": {
         "default": "Modalità libera - Domanda {stepNumber} su {totalChallengeNumber}.",
         "focused": "Modalità di messa a fuoco - Domanda {stepNumber} su {totalChallengeNumber}.",
         "focused-out": "Fallito - Modalità di messa a fuoco - Domanda {stepNumber} su {totalChallengeNumber}.",
-        "timed-out": "Tempo trascorso - Domanda {stepNumber} su {totalChallengeNumber}"
+        "timed-out": "Tempo scaduto - Domanda {stepNumber} su {totalChallengeNumber}"
       }
     },
     "checkpoint": {
@@ -1239,17 +1218,17 @@
       },
       "answers": {
         "already-finished": {
-          "explanation": "Avete già risposto a queste domande nei test precedenti: potete accedere direttamente ai vostri risultati.\n\nVolete migliorare il vostro punteggio? Cliccate su \"Vedi i miei risultati\" per ripetere il test.",
+          "explanation": "Hai già risposto a queste domande nei test precedenti: puoi accedere direttamente ai tuoi risultati.\n\nVolete migliorare il tuo punteggio? Cliccate su \"Vedi i miei risultati\" per ripetere il test.",
           "info": "Hai già risposto!"
         },
-        "header": "le vostre risposte"
+        "header": "le tue risposte"
       },
       "completion-percentage": {
         "caption": "progressi lungo il percorso",
         "label": "'<p class=\"sr-only\">'Hai completato '</p>'{completionPercentage}%'<p class=\"sr-only\">' del tuo viaggio.'</p>'"
       },
       "sharing-results": {
-        "information-banner": "Cliccando sul pulsante \"Vedi i miei risultati\", i vostri risultati saranno inviati all'organizzatore."
+        "information-banner": "Cliccando sul pulsante \"Vedi i miei risultati\", i tuoi risultati saranno inviati all'organizzatore."
       },
       "title": {
         "assessment-progress": "Avanzamento",
@@ -1258,23 +1237,16 @@
     },
     "combined-courses": {
       "completed": {
-        "description": "Ben fatto! Avete compiuto un passo importante nella navigazione del mondo digitale.",
-        "retry-text": "Volete ripassare? Siete liberi di rivedere tutti i moduli!",
+        "description": "Ben fatto! Hai compiuto un passo importante nella navigazione del mondo digitale.",
+        "retry-text": "Volete ripassare? Sei liberi di rivedere tutti i moduli!",
         "survey-button": "Rispondere al questionario",
-        "survey-button-description": "Compilate il questionario per dare la vostra opinione sul percorso",
-        "title": "Congratulazioni! Avete finito!"
+        "survey-button-description": "Compila il questionario per dare la tua opinione sul percorso",
+        "title": "Congratulazioni! Hai finito!"
       },
       "content": {
         "resume-button": "Continua il mio viaggio",
-        "start-button": "Iniziare il mio viaggio",
-        "step": "Passo {stepNumber}"
-      },
-      "errors": {
-        "disabled": {
-          "content": "A causa dell'elevato afflusso di visitatori, l'accesso a questo percorso è temporaneamente sospeso.",
-          "instructions": "Ti preghiamo di riprovare più tardi.",
-          "title": "Questo percorso non è disponibile al momento"
-        }
+        "start-button": "Inizia il mio percorso",
+        "step": "Fase {stepNumber}"
       },
       "items": {
         "aria-label-completed-campaign": "Questo elemento viene completato con una percentuale di successo di {value, number, ::percent}.",
@@ -1283,19 +1255,19 @@
         "completed": "Completato!",
         "duration": "≈ {duration} min",
         "formation": {
-          "description": "Completate la vostra diagnosi per sbloccare un programma di moduli su misura per i vostri risultati!",
-          "title": "Programma personalizzato di moduli"
+          "description": "Completate la tua diagnosi per sbloccare un programma di moduli su misura per i tuoi risultati!",
+          "title": "Programma di moduli personalizzato"
         },
-        "tagText": "Ecco dove siete!"
+        "tagText": "Ecco dove sei!"
       },
       "process-custom-passages": {
-        "description": "Analizziamo i vostri risultati e costruiamo il vostro piano di allenamento personalizzato.",
+        "description": "Analizziamo i tuoi risultati e costruiamo il tuo piano di allenamento personalizzato.",
         "list": {
-          "generate-personalize-course": "Generate il vostro percorso personalizzato.",
+          "generate-personalize-course": "Generate il tuo percorso personalizzato.",
           "results-analysis": "Analisi dei risultati.",
           "select-passages": "Selezione di corsi di formazione adeguati."
         },
-        "title": "Calcolo del proseguimento del percorso attuale."
+        "title": "Calcolo del seguito del percorso in corso."
       }
     },
     "comparison-window": {
@@ -1308,11 +1280,11 @@
           "wrong-answer": "La risposta data è sbagliata"
         },
         "aband": {
-          "title": "Non avete dato una risposta",
+          "title": "Non hai dato una risposta",
           "tooltip": "Nessuna risposta"
         },
         "abandAutoReply": {
-          "title": "Avete superato il test",
+          "title": "Hai superato il test",
           "tooltip": "Test passato"
         },
         "default": {
@@ -1321,18 +1293,18 @@
         },
         "feedback": {
           "correct": "Risposta corretta",
-          "wrong": "Risposta errata. '<br>La risposta corretta è :"
+          "wrong": "Risposta errata. '<br>La risposta corretta è:"
         },
         "focusedOut": {
-          "title": "Avete superato la prova",
+          "title": "Hai superato la prova",
           "tooltip": "Test fallito"
         },
         "ko": {
-          "title": "Non avete la risposta giusta",
+          "title": "Non hai la risposta giusta",
           "tooltip": "Risposta errata"
         },
         "koAutoReply": {
-          "title": "Non avete superato il test",
+          "title": "Non hai superato il test",
           "tooltip": "Test non riuscito"
         },
         "ok": {
@@ -1340,29 +1312,29 @@
           "tooltip": "Risposta corretta"
         },
         "okAutoReply": {
-          "title": "Avete superato il test",
+          "title": "Hai superato il test",
           "tooltip": "Test riuscito"
         },
         "solutions": {
-          "end": "o...",
+          "end": "oppure...",
           "or": "o"
         },
         "timedout": {
           "title": "Si è superato il limite di tempo",
-          "tooltip": "Time out"
+          "tooltip": "Tempo scaduto"
         },
         "tips": {
           "other-proposition": "Altra proposta",
           "your-answer": "La tua risposta"
         }
       },
-      "upcoming-tutorials": "Qui troverete presto dei tutorial che vi aiuteranno a superare questo tipo di test."
+      "upcoming-tutorials": "Qui troverete presto dei tutorial che ti aiuteranno a superare questo tipo di test."
     },
     "competence-details": {
       "actions": {
         "continue": {
-          "extra-information": "Abilità del curriculum {competenceName}",
-          "label": "Il curriculum"
+          "extra-information": "Competenze del percorso {competenceName}",
+          "label": "Continua il percorso"
         },
         "improve": {
           "description": {
@@ -1370,33 +1342,33 @@
             "waiting-text": "Provate il livello successivo in"
           },
           "improvingText": "Cercate di raggiungere il livello successivo!",
-          "label": "Ritentore"
+          "label": "Riprova"
         },
         "reset": {
-          "description": "Reset disponibile in { daysBeforeReset, plural, =0 {0 giorni.} =1 { giorno.} other {# giorni.} }",
-          "label": "Azzeramento",
+          "description": "Reimposta disponibile in { daysBeforeReset, plural, =0 {0 giorni.} =1 { giorno.} other {# giorni.} }",
+          "label": "Reimposta",
           "modal": {
-            "important-message": "Il tuo { earnedPix } Pix sarà rimosso dall'abilità: { scoreCardName }.",
-            "important-message-above-level-one": "I livelli { level } e { earnedPix } Pix saranno rimossi dall'abilità: { scoreCardName }.",
-            "title": "Azzeramento delle competenze",
+            "important-message": "Il tuo { earnedPix } Pix sarà rimosso dall'competenze: { scoreCardName }.",
+            "important-message-above-level-one": "I livelli { level } e { earnedPix } Pix saranno rimossi dall'competenze: { scoreCardName }.",
+            "title": "Reimpostazione delle competenze",
             "warning": {
-              "certification": "se desiderate far certificare il vostro profilo e i vostri vari risultati, questo potrebbe influire sulla vostra certificazione.",
+              "certification": "se desiderate far certificare il tuo profilo e i tuoi vari risultati, questo potrebbe influire sulla tua certificazione.",
               "header": "Si prega di notare:",
-              "ongoing-assessment": "se è in corso un corso di valutazione, è possibile che vi vengano riproposte alcune domande."
+              "ongoing-assessment": "se è in percorso un percorso di valutazione, è possibile che ti vengano riproposte alcune domande."
             }
           }
         },
         "start": {
-          "extra-information": "Avviare l'abilità {competenceName}",
-          "label": "Inizio"
+          "extra-information": "Avviare l'competenze {competenceName}",
+          "label": "Inizia"
         }
       },
-      "for-competence": "l'abilità {competence}",
+      "for-competence": "l'competenze {competence}",
       "next-level-info": "{ remainingPixToNextLevel } pix prima del livello { level }",
       "title": "Competenza",
       "tutorials": {
         "description": "Ecco una selezione di tutorial per aiutarvi a guadagnare Pix.",
-        "title": "Coltivare le proprie competenze"
+        "title": "Sviluppa le tue competenze"
       }
     },
     "competence-result": {
@@ -1404,12 +1376,12 @@
         "congratulations": "Congratulazioni!",
         "not-bad": "Non male, ma non eccezionale!",
         "not-bad-subtitle": "Ancora un piccolo sforzo e avrete raggiunto il primo livello.",
-        "too-bad": "Tante foto!",
+        "too-bad": "Peccato!",
         "too-bad-subtitle": "Ovviamente non è la tua giornata, ma la prossima volta farai meglio.",
-        "you-have-earned": "Avete",
-        "you-have-reached-level": "Avete raggiunto"
+        "you-have-earned": "Hai",
+        "you-have-reached-level": "Hai raggiunto"
       },
-      "title": "Risultati della vostra abilità"
+      "title": "Risultati della tua competenza"
     },
     "course": {
       "errors": {
@@ -1420,21 +1392,21 @@
       "campaigns": {
         "resume": {
           "action": "Continua",
-          "text": "<h2>Non dimenticate di completare l'invio del vostro profilo! </h2>"
+          "text": "<h2>Non dimenticate di completare l'invio del tuo profilo! </h2>"
         },
-        "subtitle": "Continuare il test in corso o inviare i risultati",
+        "subtitle": "Continuare il test in percorso o invia i risultati",
         "tests-link": "Tutti i miei percorsi di carriera",
-        "title": "I miei percorsi di carriera"
+        "title": "I miei percorsi"
       },
       "empty-dashboard": {
         "link-to-competences": "Vedi le mie competenze",
-        "message": "<h2>Bravo, hai completato le abilità consigliate! </h2> <p>Per andare avanti continua a esercitarti provando le abilità. </p>"
+        "message": "<h2>Bravo, hai completato le competenze consigliate! </h2> <p>Per andare avanti continua a esercitarti provando le competenze. </p>"
       },
       "improvable-competences": {
-        "extra-information": "Accedere a tutte le abilità per riprovare",
+        "extra-information": "Accedere a tutte le competenze per riprovare",
         "profile-link": "Tutte le competenze",
-        "subtitle": "Siete pronti a passare al livello successivo?",
-        "title": "Riprovare un'abilità"
+        "subtitle": "Sei pronti a passare al livello successivo?",
+        "title": "Riprovare un'competenze"
       },
       "presentation": {
         "link": {
@@ -1453,10 +1425,10 @@
         "profile-link": "Vedi le mie competenze"
       },
       "started-competences": {
-        "subtitle": "Continuate con i vostri test di abilità, trovate gli ultimi qui.",
-        "title": "Riprendere in mano un'abilità"
+        "subtitle": "Continuate con i tuoi test di competenze, trova gli ultimi qui.",
+        "title": "Riprendere in mano un'competenze"
       },
-      "title": "Casa",
+      "title": "Home",
       "welcome": "Ciao { firstName }."
     },
     "download-session-results": {
@@ -1470,86 +1442,86 @@
     },
     "error": {
       "content-text": "'<p>'La invitiamo a ricaricare questa pagina o a tornare alla home page.'</p><p>'Può anche contattarci tramite '<a href=\"https://support.pix.fr/support/tickets/new\">'il modulo del centro assistenza'</a>' specificando il codice di errore sotto nella descrizione.'</p><p>'Ci scusiamo per l'inconveniente.'</p><p>'Il team Pix.'</p>'",
-      "first-title": "Ops, c'è stato un errore!"
+      "first-title": "Ops, si è verificato un errore!"
     },
     "evaluation-results": {
       "quit-results": {
         "leave-without-signup-modal": {
           "actions": {
-            "cancel": "Annullamento",
-            "leave": "Sì, lasciare il corso"
+            "cancel": "Annulla",
+            "leave": "Sì, lascia il corso"
           },
-          "content-information": "Se si abbandona il corso senza registrarsi, non sarà possibile mantenere i propri progressi.",
-          "content-instruction": "Vuole continuare?",
-          "title": "Lasciare e tornare su pix.fr?"
+          "content-information": "Se si abbandona il percorso senza registrarsi, non sarà possibile mantenere i propri progressi.",
+          "content-instruction": "Vuoi continuare?",
+          "title": "Uscire e tornare su pix.fr?"
         }
       }
     },
     "fill-in-campaign-code": {
-      "description": "Questo codice è composto da 9 numeri e/o lettere. Viene inviato dalla vostra scuola/organizzazione e serve per iniziare un corso o inviare il vostro profilo.",
+      "description": "Questo codice è composto da 9 numeri e/o lettere. Viene inviato dalla tua scuola/organizzazione e serve per iniziare un percorso o invia il tuo profilo.",
       "errors": {
-        "forbidden": "Oops! Non riusciamo a trovarti. Si prega di controllare i propri dati per continuare o di informare l'organizzatore.",
-        "missing-code": "Inserire un codice.",
-        "not-found": "Il codice è errato, verificare il formato (ad esempio, ABCDEF234) o contattare l'organizzatore."
+        "forbidden": "Oops! Non riusciamo a trovarti. Controlla i tuoi dati per continuare oppure informa l'organizzatore.",
+        "missing-code": "Inserisci un codice.",
+        "not-found": "Il codice è errato, verificare il formato (ad esempio ABCDEF234) o contattare l'organizzatore."
       },
-      "first-title-connected": "{ firstName }, inserire il codice",
+      "first-title-connected": "{ firstName }, inserisci il codice",
       "first-title-not-connected": "Inserisci il tuo codice",
       "label": "Inserisci il tuo codice per iniziare",
       "mediacentre-start-campaign-modal": {
         "actions": {
           "continue": "Continua",
-          "quit": "Lasciare"
+          "quit": "Esci"
         },
-        "message": "Per accedere al corso :",
-        "message-footer": "Collegatevi a Pix tramite il vostro Mediacentre",
+        "message": "Per accedere al percorso:",
+        "message-footer": "Accedi a Pix tramite il tuo Mediacentre",
         "organised-by": "proposto da",
-        "title": "Accesso al corso tramite Mediacentre"
+        "title": "Accesso al percorso tramite Mediacentre"
       },
-      "start": "Accesso al corso",
+      "start": "Accedi al percorso",
       "title": "Ho un codice",
       "warning-message": "Non sei { firstName } { lastName }?",
-      "warning-message-logout": "Disconnessione"
+      "warning-message-logout": "Disconnetti"
     },
     "fill-in-certificate-verification-code": {
-      "description": "La certificazione Pix attesta un livello di competenza digitale: inserire il \"codice di verifica\" del certificato Pix che si desidera controllare qui sotto.",
+      "description": "La certificazione Pix attesta un livello di competenza digitale: inserisci il \"codice di verifica\" del certificato Pix che si desidera controlla qui sotto.",
       "errors": {
-        "missing-code": "Inserire il codice di verifica.",
+        "missing-code": "Inserisci il codice di verifica.",
         "not-found": "Non esiste un certificato Pix corrispondente.",
-        "unallowed-access": "Inserire il codice di verifica nel formato P-XXXXXXXX nel campo qui sopra.",
-        "wrong-format": "Controllare il formato del codice (P-XXXXXXXX)."
+        "unallowed-access": "Inserisci il codice di verifica nel formato P-XXXXXXXX nel campo qui sopra.",
+        "wrong-format": "Controlla il formato del codice (P-XXXXXXXX)."
       },
       "first-title": "Verifica di un certificato Pix",
       "label": "Codice di verifica",
       "sub-label": "Esempio: P-XXXXXXXX",
       "title": "Verifica di un certificato Pix",
-      "verify": "Controllare il certificato"
+      "verify": "Controlla il certificato"
     },
     "fill-in-participant-external-id": {
       "announcement": "L'organizzatore ha bisogno delle seguenti informazioni per potervi accompagnare:",
       "buttons": {
-        "cancel": "Annullamento",
+        "cancel": "Annulla",
         "continue": "Continua"
       },
       "errors": {
-        "invalid-external-id": "Il vostro { externalIdLabel } non è valido.",
+        "invalid-external-id": "Il tuo { externalIdLabel } non è valido.",
         "invalid-external-id-email": "L'indirizzo e-mail non è valido.",
-        "max-length-external-id": "Il vostro { externalIdLabel } non deve superare i 255 caratteri.",
-        "missing-external-id": "Inserire il proprio { externalIdLabel }."
+        "max-length-external-id": "Il tuo { externalIdLabel } non deve superare i 255 caratteri.",
+        "missing-external-id": "Inserisci il proprio { externalIdLabel }."
       },
       "first-title": "Prima di iniziare",
-      "title": "Inserire il mio login"
+      "title": "Inserisci il mio identificativo"
     },
     "focused-certification-challenge-instructions": {
-      "action": "Sono pronto a partire",
+      "action": "Sono pronto",
       "description": "Per la domanda o le domande successive, non sarà possibile lasciare la pagina.",
-      "title": "Modalità di messa a fuoco"
+      "title": "Modalità focus"
     },
     "join": {
-      "button": "Si parte!",
+      "button": "Iniziamo!",
       "fields": {
         "birthdate": {
           "day-error": "Il giorno di nascita non è valido.",
-          "day-format": "JJ",
+          "day-format": "GG",
           "day-label": "giorno di nascita",
           "label": "Data di nascita",
           "month-error": "Il mese di nascita non è valido.",
@@ -1560,48 +1532,48 @@
           "year-label": "anno di nascita"
         },
         "firstname": {
-          "error": "Il nome non è compilato.",
+          "error": "Il nome non è stato inserito.",
           "label": "Nome"
         },
         "lastname": {
-          "error": "Il vostro nome non è stato inserito.",
+          "error": "Il cognome non è stato inserito.",
           "label": "Nome"
         }
       },
-      "rgpd-legal-notice": "Per sapere come vengono trattati i vostri dati e quali sono i vostri diritti, potete leggere il documento",
+      "rgpd-legal-notice": "Per sapere come vengono trattati i tuoi dati e quali sono i tuoi diritti, puoi leggere il documento",
       "rgpd-legal-notice-link": "Informazioni.",
       "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
       "sco": {
         "associate": "Associato",
         "continue-with-pix": "Continua con il mio account Pix",
-        "error-not-found": "Sei uno studente? '<br>' Controlla i tuoi dati (nome, cognome e data di nascita) o contatta un insegnante.'<br><br>' Sei un insegnante? '<br>' L'accesso a un corso non è al momento disponibile.",
-        "first-title": "Aderire all'organizzazione { organizationName }",
+        "error-not-found": "Sei uno studente? '<br>' Controlla i tuoi dati (nome, cognome e data di nascita) o contatta un insegnante.'<br><br>' Sei un insegnante? '<br>' L'accesso a un percorso non è al momento disponibile.",
+        "first-title": "Entra nell'organizzazione { organizationName }",
         "invalid-reconciliation-error": "Si è verificato un errore. Contattare l'assistenza.",
-        "login-information-message": "L'account Pix '<b>'{ connectionMethod }'</b>' sarà associato allo studente: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Se siete voi, fate clic su \"Associa\", altrimenti uscite.",
-        "login-information-title": "Informazioni sulla connessione",
-        "subtitle": "Compilare le informazioni mancanti"
+        "login-information-message": "L'account Pix '<b>'{ connectionMethod }'</b>' sarà associato allo studente: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Se sei voi, fate clic su \"Associa\", altrimenti uscite.",
+        "login-information-title": "Informazioni sulla accesso",
+        "subtitle": "Compila le informazioni mancanti"
       },
       "sup": {
-        "error": "Controllare le informazioni inserite o, se si dispone già di un account Pix, effettuare il login.",
+        "error": "Controlla le informazioni inserisci o, se hai già un account Pix, effettuare il login.",
         "fields": {
           "student-number": {
-            "error": "Il vostro numero di studente non è stato inserito.",
+            "error": "Il tuo numero di studente non è stato inserito.",
             "label": "Numero dello studente",
             "modify": "Cambiare il numero dello studente",
             "not-existing": "Non ho un numero di matricola"
           }
         },
-        "message": "Per accedere al test e inviare i risultati, immettere le informazioni così come appaiono sulla carta dello studente. Pix se ne ricorderà la prossima volta.",
-        "title": "Registrate il vostro account Pix con {organizationName}."
+        "message": "Per accedere al test e invia i risultati, immettere le informazioni così come appaiono sulla carta dello studente. Pix se ne ricorderà la prossima volta.",
+        "title": "Registra il tuo account Pix presso {organizationName}."
       },
-      "title": "Contatto"
+      "title": "Accesso"
     },
     "learning-more": {
       "info": "Questi link alle esercitazioni sono stati suggeriti dagli utenti di Pix.",
       "title": "Per saperne di più"
     },
     "levelup-notif": {
-      "obtained-level": "Il livello { level } ha vinto!"
+      "obtained-level": "Hai raggiunto il livello { level }!"
     },
     "llm-preview": {
       "iframe-title": "ChatPix",
@@ -1615,13 +1587,13 @@
           "verify": "Controlla la mia risposta"
         },
         "element": {
-          "alternativeText": "Visualizzare l'alternativa di testo",
+          "alternativeText": "Visualizza il testo alternativo",
           "transcription": "Visualizza la trascrizione"
         },
         "embed": {
           "start": {
             "ariaLabel": "Avviare il simulatore",
-            "name": "Inizio"
+            "name": "Inizia"
           }
         },
         "flashcards": {
@@ -1634,18 +1606,18 @@
           "retry": "Riprova",
           "seeAgain": "Rivedere la domanda",
           "seeAnswer": "Vedi la risposta",
-          "start": "Inizio"
+          "start": "Inizia"
         },
         "grain": {
           "continue": "Continua",
-          "skip": "Vai a",
-          "skipActivity": "Saltare l'attività",
-          "terminate": "Finitura"
+          "skip": "Salta",
+          "skipActivity": "Salta l'attività",
+          "terminate": "Termina"
         },
         "interactive-element": {
           "reset": {
-            "ariaLabel": "Resettare il simulatore",
-            "name": "Reset"
+            "ariaLabel": "Reimpostare il simulatore",
+            "name": "Reimposta"
           }
         },
         "stepper": {
@@ -1682,31 +1654,31 @@
         "smallScreenModal": {
           "cancel": "Torna ai dettagli",
           "description": "Alcune attività di questo modulo potrebbero essere difficili da eseguire su uno schermo di piccole dimensioni. Per un'esperienza ottimale, si consiglia di utilizzare un computer.",
-          "startModule": "Inizio",
+          "startModule": "Inizia",
           "title": "Sembra che tu stia usando uno schermo piccolo"
         },
         "startModule": "Avviare il modulo"
       },
       "download": {
-        "button": "Scaricare",
-        "description": "Scegliere il formato in base al software in uso. Se non siete sicuri, scegliete il primo file, che è compatibile con la maggior parte dei software.",
+        "button": "Scarica",
+        "description": "Scegli il formato in base al software in uso. Se non sei sicuri, scegli il primo file, che è compatibile con la maggior parte dei software.",
         "documentationLinkHref": "https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix",
         "documentationLinkLabel": "Come posso aprire, modificare o recuperare questo file?",
         "format": "Formato {format}",
-        "intro": "Scegliere il formato di file che si desidera utilizzare.",
-        "label": "Scaricare il file in formato {format}."
+        "intro": "Scegli il formato di file che si desidera utilizzare.",
+        "label": "Scarica il file in formato {format}."
       },
       "elements": {
         "audio": {
-          "consult-transcription": "Consultare la trascrizione per conoscerne il contenuto.",
+          "consult-transcription": "Consulta la trascrizione per conoscerne il contenuto.",
           "missing-content": "Si è verificato un errore durante la riproduzione dell'audio."
         },
         "image": {
-          "consult-alternative-text": "Consultare il testo alternativo per conoscerne il contenuto.",
+          "consult-alternative-text": "Consulta il testo alternativo per conoscerne il contenuto.",
           "missing-content": "Si è verificato un errore durante la visualizzazione dell'immagine."
         },
         "short-video": {
-          "consult-transcription": "Consultare la trascrizione per conoscerne il contenuto.",
+          "consult-transcription": "Consulta la trascrizione per conoscerne il contenuto.",
           "missing-content": "Si è verificato un errore durante la visualizzazione del video."
         },
         "text": {
@@ -1714,6 +1686,7 @@
             "context": "Contesto",
             "did-you-know": "Lo sapevi?",
             "further-information": "Per saperne di più",
+            "key-points": "Punti chiave",
             "tip": "Consiglio"
           }
         }
@@ -1724,9 +1697,9 @@
         "counters": {
           "almost": "Quasi: {totalAlmost}",
           "no": "Per niente: {totalNo}",
-          "yes": "Sì! : {totalYes}"
+          "yes": "Sì!: {totalYes}"
         },
-        "direction": "Cercare la risposta e girare la carta",
+        "direction": "Cerca la risposta e gira la carta",
         "navigation": {
           "longCurrentStep": "Passare da {current} a {total}.",
           "shortCurrentStep": "{current}/{total}"
@@ -1735,22 +1708,21 @@
       },
       "grain": {
         "tag": {
-          "activity": "Attività",
-          "key-points": "Punti chiave"
+          "activity": "Attività"
         },
         "title": {
           "lesson": "Lezione",
-          "summary": "Sintesi"
+          "summary": "Riepilogo"
         }
       },
       "interactiveElement": {
         "label": "Elemento interattivo"
       },
       "issue-report": {
-        "aria-label": "Invia un problema o un suggerimento",
-        "button": "Rapporto",
+        "aria-label": "Segnala un problema o un suggerimento",
+        "button": "Segnala",
         "error-messages": {
-          "missing-comment": "Inserire un commento."
+          "missing-comment": "Inserisci un commento."
         },
         "modal": {
           "categories": {
@@ -1773,13 +1745,13 @@
               "info": "Si è verificato un errore durante l'invio del commento.",
               "retry": "Riprovare più tardi."
             },
-            "success": "Grazie per il suo commento."
+            "success": "Grazie per il tuo commento."
           },
-          "legend": "Informazioni necessarie per inviare un avviso",
+          "legend": "Informazioni necessarie per invia un avviso",
           "select-label": "Motivo della segnalazione",
           "textarea-label": "Commento",
           "textarea-placeholder": "Ci parli del suo problema o del suo suggerimento",
-          "title": "Rapporto"
+          "title": "Segnalazione"
         }
       },
       "modals": {
@@ -1799,96 +1771,83 @@
           }
         },
         "tooltip": {
-          "disabled": "Da continuare: {sectionTitle}"
+          "disabled": "Da completare: {sectionTitle}"
         }
       },
       "preview": {
-        "elements-id-button": {
-          "label": "Visualizza l'ID degli elementi"
-        },
-        "elements-metadata-panel-label": "Mostra o nascondi i metadati",
-        "grain-select": {
-          "button": "Testare il grain",
-          "grain-label": "Grain {index} : {title}",
-          "label": "Scegli il grain da testare"
-        },
-        "grains-title-button": {
-          "label": "Mostra il nome dei chicchi"
-        },
-        "modulix-editor": "Modulix Editor",
-        "showJson": "Visualizzare JSON",
+        "showJson": "Visualizza JSON",
         "stepper": "Anteprima: stepper {direction}",
         "textarea-label": "Contenuto del modulo"
       },
       "qab": {
-        "correct-answer": "Ottima risposta!",
-        "incorrect-answer": "Risposta sbagliata.",
+        "correct-answer": "Risposta corretta!",
+        "incorrect-answer": "Risposta errata.",
         "retry": "Riprova",
         "score": {
-          "title": "Serie conclusa",
+          "title": "Serie completata",
           "yourScore": "Il tuo punteggio: {score}/{total}"
         }
       },
       "qcm": {
-        "direction": "Selezionare diverse risposte."
+        "direction": "Seleziona diverse risposte."
       },
       "qcu": {
-        "direction": "Selezionare una sola risposta."
+        "direction": "Seleziona una sola risposta."
       },
       "qcuDeclarative": {
         "complementaryInstruction": "Non esiste una risposta giusta o sbagliata.",
-        "direction": "Selezionare una sola risposta."
+        "direction": "Seleziona una sola risposta."
       },
       "qcuDiscovery": {
-        "direction": "Selezionare la risposta che sembra più accurata."
+        "direction": "Seleziona la risposta che sembra più accurata."
       },
       "qrocm": {
-        "direction": "Compilare {count, plural, =1 { il campo} other { i campi}}."
+        "direction": "Compila {count, plural, =1 { il campo} other { i campi}}."
       },
       "recap": {
-        "backToModuleDetails": "Lasciare",
+        "backToModuleDetails": "Esci",
         "goToHomepage": "Continua",
-        "subtitle": "Avete lavorato sui seguenti obiettivi:",
+        "subtitle": "Hai lavorato sui seguenti obiettivi:",
         "title": "Modulo completato!"
       },
       "section": {
         "explore-to-understand": "Esplorare per capire",
         "go-further": "Andare oltre",
-        "practise": "Pratica",
-        "question-yourself": "Fare domande",
-        "retain-the-essentials": "Mantenere l'essenziale"
+        "practise": "Esercitati",
+        "question-yourself": "Interrogarsi",
+        "retain-the-essentials": "Ricorda l'essenziale"
       },
       "sidebar": {
-        "button": "Visualizzare le fasi del modulo"
+        "button": "Visualizza le fasi del modulo"
       },
       "stepper": {
-        "aria-role-description": "sequenza di passi",
+        "aria-role-description": "sequenza di fasi",
         "step": {
           "aria-label": "{currentStep} su {totalSteps}.",
-          "aria-role-description": "palcoscenico"
+          "aria-role-description": "fase"
         }
       },
       "verification-precondition-failed-alert": {
-        "qcm": "Per confermare, selezionare almeno due risposte.",
-        "qcu": "Per confermare, selezionare una risposta.",
-        "qrocm": "Per convalidare, compilare tutti i campi di risposta."
+        "qcm": "Per confermare, seleziona almeno due risposte.",
+        "qcu": "Per confermare, seleziona una risposta.",
+        "qrocm": "Per convalidare, compila tutti i campi di risposta."
       }
     },
     "not-connected": {
-      "message": "Sei proprio fuori dal mondo.'<br>'Grazie, a presto.",
+      "message": "Sei stato disconnesso.'<br>'Grazie, a presto.",
       "title": "Disconnesso"
     },
     "oidc-reconciliation": {
-      "authentication-method-to-add": "Connessione aggiunta :",
+      "authentication-method-to-add": "Connessione aggiunta:",
       "confirm": "Continua",
-      "current-authentication-methods": "I miei metodi di connessione attuali:",
+      "current-authentication-methods": "I miei metodi di accesso attuali:",
       "email": "Indirizzo e-mail",
-      "external-connection": "Collegamento esterno",
+      "external-connection": "Connessione esterna",
       "external-connection-via": "Connessione tramite",
-      "information": "Poiché la valutazione delle competenze è personalizzata, il vostro account deve rimanere strettamente personale.",
+      "information": "Poiché la valutazione delle competenze è personalizzata, il tuo account deve rimanere strettamente personale.",
       "return": "Torna a",
-      "sub-title": "Un nuovo metodo di accesso sta per essere aggiunto al vostro account Pix.",
-      "switch-account": "Cambia conto",
+      "sub-title": "Un nuovo metodo di accesso sta per essere aggiunto al tuo account Pix.",
+      "switch-account": "Cambia account",
       "title": "Attenzione!",
       "username": "Identificatore"
     },
@@ -1900,11 +1859,11 @@
         "expired-authentication-key": "La richiesta di autenticazione è scaduta.",
         "invalid-email": "L'indirizzo e-mail non è valido.",
         "login-unauthorized-error": "L'indirizzo e-mail e/o la password inseriti non sono corretti.",
-        "password-reset-token-invalid-or-expired": "È passato troppo tempo per convalidare la nuova password. Tornare alla pagina di accesso per inserire nuovamente il nome utente e la password temporanea."
+        "password-reset-token-invalid-or-expired": "È passato troppo tempo per convalidare la nuova password. Tornare alla pagina di accesso per inserisci nuovamente il nome utente e la password temporanea."
       },
       "login-form": {
-        "button": "Voglio connettermi",
-        "description": "Effettuate il login per collegare il vostro account esistente e recuperare le competenze precedentemente valutate.",
+        "button": "Voglio accedere",
+        "description": "Effettuate il login per collegare il tuo account esistente e recuperare le competenze precedentemente valutate.",
         "email": "Indirizzo e-mail",
         "password": "Password",
         "title": "Ho già un account Pix"
@@ -1921,7 +1880,7 @@
           "title": "Funzione"
         },
         "description": "Verrà creato un account utilizzando le informazioni fornite dall'organizzazione.",
-        "error": "Non siamo riusciti a recuperare le informazioni sulla vostra identità dal servizio utilizzato. Si prega di contattare l'assistenza informatica dell'organizzazione.",
+        "error": "Non siamo riusciti a recuperare le informazioni sulla tua identità dal servizio utilizzato. Si prega di contattare l'assistenza informatica dell'organizzazione.",
         "first-name-label-and-value": "Nome: {firstName}",
         "last-name-label-and-value": "Nome: {lastName}",
         "title": "Non ho un account Pix"
@@ -1929,25 +1888,25 @@
       "title": "Crea il tuo account Pix"
     },
     "password-reset-demand": {
-      "title": "Avete dimenticato la password?"
+      "title": "Hai dimenticato la password?"
     },
     "profile": {
       "accessibility": {
-        "title": "Il vostro profilo Pix",
-        "user-score": "Il vostro numero di Pix",
-        "user-skills": "Le vostre capacità di Pix"
+        "title": "Il tuo profilo Pix",
+        "user-score": "Il tuo numero di Pix",
+        "user-skills": "Le tue competenze Pix"
       },
       "competence-card": {
         "congrats": "Ben fatto!",
         "details": "dettagli",
         "image-info": {
-          "first-level": "Il primo livello è in corso, completato al {percentageAheadOfNextLevel}%.",
+          "first-level": "Il primo livello è in percorso, completato al {percentageAheadOfNextLevel}%.",
           "level": "Livello attuale: {currentLevel}. Il livello successivo viene completato al {percentageAheadOfNextLevel}%.",
-          "no-level": "Abilità non avviata"
+          "no-level": "Competenza non avviata"
         }
       },
-      "description": "Mettetevi alla prova con il vostro ritmo in 16 abilità digitali. Scegliete una competenza e iniziate a guadagnare pix.",
-      "first-title": "Avete 16 abilità da testare. Concentratevi e partite!",
+      "description": "Mettiti alla prova con i tuoi ritmi in 16 competenze digitali. Scegli una competenza e inizia a guadagnare pix.",
+      "first-title": "Hai 16 competenze da testare. Concentrati e parti!",
       "resume-campaign-banner": {
         "accessibility": {
           "resume": "Continua il tuo viaggio",
@@ -1955,9 +1914,9 @@
         },
         "actions": {
           "continue": "Continua",
-          "resume": "Il curriculum"
+          "resume": "Il percorso"
         },
-        "reminder-continue-campaign": "Non avete completato il corso",
+        "reminder-continue-campaign": "Non hai completato il percorso",
         "reminder-continue-campaign-with-title": "Non è stato completato il percorso \"{title}\".",
         "reminder-send-campaign": "Non dimenticate di finalizzare la spedizione!",
         "reminder-send-campaign-with-title": "Percorso \"{title}\" completato. Non dimenticate di finalizzare la spedizione!"
@@ -1965,16 +1924,16 @@
       "title": "Competenze",
       "total-score-helper": {
         "explanation": "'<p>'Questo è il numero massimo di pix che saremo in grado di raggiungere quando tutti gli 8 livelli del repository Pix saranno disponibili.'</p><p>'Oggi,'<span class=\"hexagon-score-information__--strong\">'il massimo è {maxReachablePixScore} pix'</span>', corrispondente al livello {maxReachableLevel}.'</p>'",
-        "icon": "Informazioni su pix",
-        "label": "Aprire il tooltip",
-        "title": "Perché 1024 pixel?"
+        "icon": "Informazioni sui pix",
+        "label": "Apri il tooltip",
+        "title": "Perché 1024 pix?"
       }
     },
     "profile-already-shared": {
       "actions": {
         "continue": "Continua la tua esperienza Pix"
       },
-      "explanation": "Avete già inviato il profilo sottostante all'organizzazione {organization}'<br>'{date} a {hour,time,hhmm}.",
+      "explanation": "Hai già inviato il profilo sottostante all'organizzazione {organization}'<br>'{date} a {hour,time,hhmm}.",
       "first-title": "Non tutto va secondo i piani",
       "retry": {
         "button": "Invia di nuovo il mio profilo",
@@ -1986,8 +1945,8 @@
       "error": {
         "expired-demand": "Siamo spiacenti, ma la richiesta di reimpostazione della password è già stata utilizzata o è scaduta. Si prega di riprovare."
       },
-      "first-title": "Reimpostare la password",
-      "title": "Cambiare la password"
+      "first-title": "Reimposta la password",
+      "title": "Cambia la password"
     },
     "result-item": {
       "aband": "Nessuna risposta",
@@ -1998,10 +1957,10 @@
       },
       "ko": "Risposta errata",
       "ok": "Risposta corretta",
-      "timedout": "Time out"
+      "timedout": "Tempo scaduto"
     },
     "sco-signup-or-login": {
-      "invitation": "{ organizationName } vi invita ad unirvi a Pix",
+      "invitation": "{ organizationName } ti invita ad unirvi a Pix",
       "login-form": {
         "button": "Accedi",
         "fields": {
@@ -2013,23 +1972,23 @@
           }
         },
         "forgotten-password": {
-          "email": "Un indirizzo e-mail :",
-          "instruction": "Hai dimenticato la password? Avete un account Pix con :",
-          "other-identity": "Un login : Contattare l'insegnante per ripristinarlo",
+          "email": "Un indirizzo e-mail:",
+          "instruction": "Hai dimenticato la password? Hai un account Pix con:",
+          "other-identity": "Un login: Contattare l'insegnante per ripristinarlo",
           "reset-link": "Fare clic qui per ripristinarlo"
         },
         "title": "Ho già un account Pix",
-        "unexpected-user-account-error": "L'indirizzo e-mail o il nome utente non sono corretti. Per continuare, è necessario accedere al proprio account, che si presenta sotto forma di :"
+        "unexpected-user-account-error": "L'indirizzo e-mail o il nome utente non sono corretti. Per continuare, è necessario accedere al proprio account, che si presenta sotto forma di:"
       },
       "signup-form": {
         "button": "Iscriviti",
-        "button-form": "Desidero registrarmi",
+        "button-form": "Voglio registrarmi",
         "fields": {
           "birthdate": {
             "day": {
               "error": "Il giorno di nascita non è valido.",
               "label": "Giorno di nascita",
-              "placeholder": "JJ"
+              "placeholder": "GG"
             },
             "label": "Data di nascita (GG/MM/AAAA)",
             "month": {
@@ -2050,11 +2009,11 @@
             "label": "Indirizzo e-mail"
           },
           "firstname": {
-            "error": "Il nome non è compilato.",
+            "error": "Il nome non è stato inserito.",
             "label": "Nome"
           },
           "lastname": {
-            "error": "Il vostro nome non è stato inserito.",
+            "error": "Il cognome non è stato inserito.",
             "label": "Nome"
           },
           "password": {
@@ -2070,10 +2029,10 @@
         "not-me": "Non sono io",
         "options": {
           "email": "Il mio indirizzo e-mail",
-          "text": "Vorrei registrarmi con :",
+          "text": "Vorrei registrarmi con:",
           "username": "Il mio login"
         },
-        "rgpd-legal-notice": "Per sapere come vengono trattati i vostri dati e quali sono i vostri diritti, potete leggere il documento",
+        "rgpd-legal-notice": "Per sapere come vengono trattati i tuoi dati e quali sono i tuoi diritti, puoi leggere il documento",
         "rgpd-legal-notice-link": "Informazioni.",
         "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
         "title": "Vorrei registrarmi con Pix"
@@ -2081,9 +2040,9 @@
       "title": "Collegarsi a Pix"
     },
     "send-profile": {
-      "disabled-share": "Questo corso è stato disattivato dall'organizzatore. Non è più possibile inviare i risultati.",
+      "disabled-share": "Questo percorso è stato disattivato dall'organizzatore. Non è più possibile invia i risultati.",
       "errors": {
-        "archived": "Non è più possibile inviare il proprio profilo poiché l'organizzatore ha archiviato la raccolta dei profili."
+        "archived": "Non è più possibile invia il proprio profilo poiché l'organizzatore ha archiviato la raccolta dei profili."
       },
       "first-title": "Invio del profilo Pix",
       "form": {
@@ -2092,7 +2051,7 @@
         "send": "Invio il mio profilo",
         "shared": "Grazie, il tuo profilo è stato inviato!"
       },
-      "instructions": "Trasmetterete il punteggio e i livelli di abilità del vostro profilo Pix. Eventuali modifiche al profilo dopo l'invio di queste informazioni non saranno trasmesse. Ricordati di controllare prima di inviare!",
+      "instructions": "Trasmetterete il punteggio e i livelli di competenze del tuo profilo Pix. Eventuali modifiche al profilo dopo l'invio di queste informazioni non saranno trasmesse. Ricordati di controlla prima di invia!",
       "title": "Invia il mio profilo"
     },
     "shared-certification": {
@@ -2101,7 +2060,7 @@
     },
     "sign-in": {
       "actions": {
-        "submit": "Voglio connettermi"
+        "submit": "Voglio accedere"
       },
       "fields": {
         "legend": "Informazioni necessarie per l'accesso.",
@@ -2114,14 +2073,14 @@
         }
       },
       "first-title": "Accedere a",
-      "forgotten-password": "Avete dimenticato la password?",
+      "forgotten-password": "Hai dimenticato la password?",
       "title": "Connessione"
     },
     "signup": {
       "actions": {
         "login": "Accedi",
         "sign-up-on-pix": "Registrati con Pix",
-        "submit": "Desidero registrarmi"
+        "submit": "Voglio registrarmi"
       },
       "fields": {
         "email": {
@@ -2129,7 +2088,7 @@
         }
       },
       "first-title": "Registrati su",
-      "save-progress-message": "Per tenere traccia dei vostri progressi e continuare a valutarvi, registratevi con Pix!",
+      "save-progress-message": "Per tenere traccia dei tuoi progressi e continuare a valutarvi, registrati con Pix!",
       "title": "Registrazione"
     },
     "sitemap": {
@@ -2138,17 +2097,17 @@
         "title": "Accessibilità"
       },
       "cgu": {
-        "policy": "Politica di protezione dei dati",
+        "policy": "Informativa sulla protezione dei dati",
         "subcontractors": "Elenco dei subappaltatori"
       },
       "resources": "Risorse",
       "title": "Mappa del sito"
     },
     "skill-review": {
-      "abstract": "Hai acquisito la padronanza di '<strong>'{rate, number, ::percent}'</strong><br>'delle abilità testate.",
+      "abstract": "Hai acquisito la padronanza di '<strong>'{rate, number, ::percent}'</strong><br>'delle competenze testate.",
       "abstract-title": "Il risultato per questo percorso",
       "actions": {
-        "back-to-pix": "Partenza e ritorno a Pix",
+        "back-to-pix": "Esci e torna a Pix",
         "continue": "Continua la tua esperienza Pix"
       },
       "already-shared": "Grazie, i risultati sono stati inviati!",
@@ -2160,66 +2119,61 @@
         "not-acquired-full": "Distintivo non ottenuto",
         "progress-bar-label": "Percentuale di passaggi di badge"
       },
-      "badges-title": "I vostri badge",
+      "badges-title": "I tuoi badge",
       "details": {
         "caption": "Dettagli sui risultati ottenuti in termini percentuali in base alle competenze",
         "header-result": "Risultati",
         "header-skill": "Competenze testate",
         "percentage": "{rate, number, ::percent}",
-        "progress-bar-label": "Percentuale di successo dell'abilità",
+        "progress-bar-label": "Percentuale di successo dell'competenze",
         "result": "Risultato complessivo",
-        "title": "I risultati per abilità"
+        "title": "I risultati per competenze"
       },
-      "error": "Ops, c'è stato un errore!",
+      "error": "Ops, si è verificato un errore!",
       "hero": {
         "acquired-badges-title": "Premi vinti",
         "explanations": {
-          "trainings": "Per aiutarvi a progredire, date un'occhiata ai nostri corsi di formazione consigliati e trovate quelli più adatti a voi."
+          "trainings": "Per aiutarvi a progredire, date un'occhiata ai nostri corsi di formazione consigliati e trova quelli più adatti a voi."
         },
-        "hidden-badges": "{ count, plural, =1 {badge aggiuntivo ottenuto non visualizzato} other {badge aggiuntivi ottenuti non visualizzati} }",
         "mastery-rate": "di successo nelle domande",
         "retry": {
           "actions": {
-            "reset": "Resettare e riprovare",
-            "retry": "Riproduzione del mio viaggio"
+            "reset": "Reimpostare e riprovare",
+            "retry": "Ripeti il mio percorso"
           },
-          "description": "Il vostro organizzatore vi chiederà di ripetere il corso.",
+          "description": "Il tuo organizzatore ti chiederà di ripetere il percorso.",
           "retryIn": "Non è ancora possibile rigiocare questo percorso, tornare a {duration}.",
           "title": "Migliorare i risultati"
         },
         "see-trainings": "Vedere i corsi",
         "shared-message": "I risultati sono stati inviati da {date} a {time}.",
-        "staged-message": {
-          "show-less": "Riduci",
-          "show-more": "Mostra di più"
-        },
-        "thanks": "Grazie {name}\n per la vostra partecipazione!"
+        "thanks": "Grazie {name} per la tua partecipazione!"
       },
       "improve": {
         "description": "È possibile riprovare alcune delle domande",
-        "title": "Volete migliorare i vostri risultati?"
+        "title": "Volete migliorare i tuoi risultati?"
       },
-      "information": "Se avete già completato un percorso Pix, non vi verranno riproposte le stesse domande. Tuttavia, i risultati qui riportati tengono conto di tutte le vostre risposte.",
+      "information": "Se hai già completato un percorso Pix, non ti verranno riproposte le stesse domande. Tuttavia, i risultati qui riportati tengono account di tutte le tue risposte.",
       "net-promoter-score": {
         "link": {
           "href": "https://pix.fr",
           "label": "Esprimo la mia opinione"
         },
-        "text": "Prendetevi qualche minuto per dirci cosa ne pensate di questo test e aiutarci a migliorarlo.",
-        "title": "La vostra opinione conta!"
+        "text": "Prenditi qualche minuto per dirci cosa ne pensate di questo test e aiutarci a migliorarlo.",
+        "title": "La tua opinione conta!"
       },
-      "not-finished": "Non è ancora possibile inviare i risultati, quindi abbiamo ancora alcune domande per voi.",
+      "not-finished": "Non è ancora possibile invia i risultati, quindi abbiamo ancora alcune domande per voi.",
       "reset": {
-        "button": "Resettare e riprovare",
+        "button": "Reimpostare e riprovare",
         "modal": {
-          "text": "Stai per azzerare il tuo corso <strong>{targetProfileName}</strong>, nel tentativo di migliorare il tuo livello. Alla fine del corso, potrai inviare nuovamente i tuoi risultati.",
-          "warning-text": "I Pix, i livelli e le certificazioni ottenuti durante questo corso saranno cancellati."
+          "text": "Stai per reimpostare il tuo percorso <strong>{targetProfileName}</strong>, nel tentativo di migliorare il tuo livello. Alla fine del percorso, potrai invia nuovamente i tuoi risultati.",
+          "warning-text": "I Pix, i livelli e le certificazioni ottenuti durante questo percorso saranno cancellati."
         },
         "notification": "Azzerare per riprovare. L'organizzatore continuerà ad avere accesso ai risultati inviati in precedenza."
       },
       "retry": {
-        "button": "Riproduzione del mio viaggio",
-        "message": "{organizationName} vi invita a frequentare nuovamente questo corso per migliorare il vostro risultato e continuare a progredire.",
+        "button": "Ripeti il mio percorso",
+        "message": "{organizationName} ti invita a frequentare nuovamente questo percorso per migliorare il tuo risultato e continuare a progredire.",
         "notification": "Ripetere le domande fallite per migliorare il proprio risultato e continuare a progredire. L'organizzatore continuerà ad avere accesso ai risultati precedentemente inviati."
       },
       "retry-and-reset": {
@@ -2229,49 +2183,46 @@
         "in-progress": "Invio"
       },
       "stage": {
-        "caption": "I dettagli dei vostri risultati sotto forma di percentuali e stelle in base alle competenze",
+        "caption": "I dettagli dei tuoi risultati sotto forma di percentuali e stelle in base alle competenze",
         "masteryPercentage": "{rate, number, ::percent} di successo",
-        "recommendedEngine": {
-          "starsAcquired": "{acquired} / {total, plural, =0 {stella} =1 {# stella} other {# stelle}}"
-        },
         "starsAcquired": "{acquired, plural, =0 {nessuna stella acquisita} =1 {# stelle acquisite} other {# stelle acquisite}} su {total}.",
         "title": "Dettagli sulle competenze"
       },
       "tabs": {
         "aria-label": "3 schede con i dettagli dei risultati",
         "results-details": {
-          "description": "Scoprite le vostre competenze in dettaglio, organizzate per aree specifiche, per comprendere meglio i vostri punti di forza e le aree di miglioramento. Identificate i vostri punti di forza e le aree in cui potete concentrare i vostri sforzi per fare ulteriori progressi.",
+          "description": "Scopri le tue competenze in dettaglio, organizzate per aree specifiche, per comprendere meglio i tuoi punti di forza e le aree di miglioramento. Identificate i tuoi punti di forza e le aree in cui puoi concentrare i tuoi sforzi per fare ulteriori progressi.",
           "tab-label": "Dettagli",
           "title": "Dettagli dei risultati"
         },
         "rewards": {
-          "description": "Questa sezione evidenzia i riconoscimenti ricevuti e le aspettative dell'organizzatore del corso. Scoprite come è stata valutata la vostra prestazione e identificate le aree di miglioramento delle vostre competenze.",
+          "description": "Questa sezione evidenzia i riconoscimenti ricevuti e le aspettative dell'organizzatore del percorso. Scopri come è stata valutata la tua prestazione e identificate le aree di miglioramento delle tue competenze.",
           "tab-label": "Premi",
           "title": "Premi e aspettative dell'organizzatore"
         },
         "trainings": {
-          "description": "Ricevete consigli di allenamento personalizzati per continuare a progredire e alimentate la vostra curiosità per aiutarvi a raggiungere il vostro pieno potenziale.",
+          "description": "Ricevi consigli di allenamento personalizzati per continuare a progredire e alimentate la tua curiosità per aiutarvi a raggiungere il tuo pieno potenziale.",
           "tab-label": "Formazione",
           "title": "Volete saperne di più?"
         }
       },
       "title": "Risultati",
       "trainings": {
-        "description": "Scoprite i corsi di formazione consigliati per voi, in base ai vostri risultati, per aiutarvi a progredire!",
+        "description": "Scopri i corsi di formazione consigliati per voi, in base ai tuoi risultati, per aiutarvi a progredire!",
         "title": "Volete saperne di più?"
       }
     },
     "terms-of-service": {
       "cgu": "Accetto i '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'termini e condizioni d'uso di Pix'</a>'.",
       "form": {
-        "button": "Continuo",
+        "button": "Continua",
         "error-message": "È necessario accettare le condizioni d'uso di Pix."
       },
-      "message": "Abbiamo aggiornato le nostre condizioni d'uso. Vi preghiamo di accettarle per continuare la vostra esperienza su Pix.",
+      "message": "Abbiamo aggiornato le nostre condizioni d'uso. Ti preghiamo di accettarle per continuare la tua esperienza su Pix.",
       "title": "Termini e condizioni d'uso"
     },
     "timed-challenge-instructions": {
-      "action": "Inizio",
+      "action": "Inizia",
       "primary": "Avrete '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' per passare alla domanda successiva.",
       "secondary": "È possibile continuare a rispondere anche in seguito, ma la domanda non sarà considerata come riuscita.",
       "time": {
@@ -2287,7 +2238,7 @@
         "e-learning": "Formazione a distanza",
         "hybrid-training": "Formazione ibrida",
         "in-person-training": "Formazione faccia a faccia",
-        "modulix": "Modulo Pix",
+        "modulix": "Modulo Pix (Beta)",
         "webinaire": "Webinar"
       }
     },
@@ -2300,14 +2251,14 @@
       "pages": {
         "page0": {
           "explanation": "Se non conoscete la risposta\nprobabilmente si trova su Internet.",
-          "title": "Potete cercare su Internet ..."
+          "title": "Puoi cercare su Internet..."
         },
         "page1": {
-          "explanation": "Se viene visualizzata questa immagine, utilizzare solo ciò che si conosce!\n Non dovete usare Internet o il vostro software.",
+          "explanation": "Se viene visualizzata questa immagine, utilizzare solo ciò che si conosce!\n Non dovete usare Internet o il tuo software.",
           "title": "... tranne che per alcune domande"
         },
         "page2": {
-          "explanation": "Prendete tutto il tempo necessario per completare il corso.\nSe una domanda è a tempo, ciò sarà indicato.",
+          "explanation": "Prendi tutto il tempo necessario per completare il percorso.\nSe una domanda è a tempo, ciò sarà indicato.",
           "title": "Senza limiti di tempo!"
         },
         "page3": {
@@ -2315,13 +2266,13 @@
           "title": "Tutorial per l'apprendimento"
         },
         "page4": {
-          "explanation": "In base alle vostre risposte,\nPix adatta la difficoltà delle domande.",
+          "explanation": "In base alle tue risposte,\nPix adatta la difficoltà delle domande.",
           "title": "Il giusto livello di difficoltà"
         }
       },
-      "pass": "Ignorare",
-      "pass-title": "Salta il tutorial e inizia il mio viaggio",
-      "start": "Iniziare il mio viaggio",
+      "pass": "Salta",
+      "pass-title": "Salta il tutorial e inizia il mio percorso",
+      "start": "Inizia il mio percorso",
       "title": "Tutorial della campagna"
     },
     "tutorial-panel": {
@@ -2329,179 +2280,170 @@
       "title": "Per avere successo la prossima volta"
     },
     "update-expired-password": {
-      "button": "Reset",
+      "button": "Reimposta",
       "fields": {
         "error": "La password deve essere lunga almeno 8 caratteri e contenere almeno una lettera maiuscola, una lettera minuscola e un numero.",
         "help": "(minimo 8 caratteri, di cui uno maiuscolo, uno minuscolo e un numero)",
         "label": "Password"
       },
-      "first-title": "Reimpostare la password",
-      "go-to-login": "Voglio connettermi",
-      "subtitle": "Scegliere una nuova password per continuare",
-      "title": "Cambiare la password",
+      "first-title": "Reimposta la password",
+      "go-to-login": "Voglio accedere",
+      "subtitle": "Scegli una nuova password per continuare",
+      "title": "Cambia la password",
       "validation": "La password è stata aggiornata."
     },
     "user-account": {
-      "account-add-or-update-email-with-validation": {
-        "code-reception-information": "Confermando la richiesta di aggiunta dell'indirizzo e-mail, riceverai un codice via e-mail.",
+      "account-update-email": {
+        "email-information": "Questo indirizzo e-mail deve essere valido nel caso in cui si dimentichi la password. Questo sarà il tuo nuovo indirizzo di accesso.",
         "fields": {
-          "email": {
-            "add-email": {
-              "label": "Indirizzo e-mail"
-            },
-            "update-email": {
-              "label": "Nuovo indirizzo e-mail"
-            }
+          "errors": {
+            "empty-password": "La password non può essere vuota.",
+            "invalid-password": "La password inserita non è valida.",
+            "mismatching-email": "I due indirizzi e-mail non sono identici. Si prega di controlla la propria iscrizione.",
+            "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
+            "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
+            "wrong-email-format": "L'indirizzo e-mail non è valido."
           },
+          "new-email": {
+            "label": "Nuovo indirizzo e-mail"
+          },
+          "new-email-confirmation": {
+            "label": "Conferma dell'indirizzo e-mail"
+          },
+          "password": {
+            "label": "Password"
+          }
+        },
+        "password-information": "Inserisci la password per confermare",
+        "save-button": "Conferma",
+        "title": "Modifica dell'indirizzo e-mail"
+      },
+      "account-update-email-with-validation": {
+        "fields": {
           "errors": {
             "empty-password": "La password non può essere vuota.",
             "invalid-email": "L'indirizzo e-mail non è valido.",
             "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato",
             "invalid-password": "La password inserita non è valida.",
-            "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
-            "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza."
+            "new-email-already-exist": "Questo indirizzo e-mail è già in uso."
+          },
+          "new-email": {
+            "label": "Nuovo indirizzo e-mail"
           },
           "password": {
             "label": "Password",
-            "security-information": "La sicurezza dei vostri dati personali è fondamentale. Per questo motivo verifichiamo che siate l'autore della richiesta. Inserite la vostra password per ricevere un codice di verifica."
+            "security-information": "La sicurezza dei tuoi dati personali è fondamentale. Per questo motivo verifichiamo che siate l'autore della richiesta. Inserisci la tua password per ricevere un codice di verifica."
           }
         },
-        "save-button": "Ricevere un codice di verifica",
-        "title": {
-          "add-email": "Aggiungi un indirizzo e-mail",
-          "update-email": "Modifica del tuo indirizzo e-mail"
-        }
+        "save-button": "Ricevi un codice di verifica",
+        "title": "Modifica dell'indirizzo e-mail"
       },
       "connexion-methods": {
         "authentication-methods": {
-          "connection-via": "Connessione tramite {identityProviderOrganizationName}",
-          "gar": "Connessione tramite ENT/Mediacentre",
-          "label": "Collegamento esterno",
-          "other-authentication-label": "Un altro metodo di connessione"
+          "gar": "via ENT/Mediacentre",
+          "label": "Connessione esterna",
+          "via": "via {identityProviderOrganizationName}"
         },
         "edit-button": "Modificare",
         "email": "Indirizzo e-mail",
-        "menu-link-title": "I miei metodi di connessione",
+        "menu-link-title": "I miei metodi di accesso",
         "username": "Identificatore"
       },
       "delete-account": {
         "actions": {
-          "delete": "Cancellare il mio account"
+          "delete": "Elimina il mio account"
         },
-        "menu-link-title": "Cancellare il mio account",
+        "menu-link-title": "Elimina il mio account",
         "modal": {
           "error-403": "Non è possibile eliminare il proprio account. Contattare l'assistenza Pix.",
           "question": "Sei sicuro di voler cancellare il tuo account?",
-          "title": "State per cancellare il vostro account",
+          "title": "Stai per eliminare il tuo account",
           "warning-1": "Si noti che l'account non può essere recuperato dopo l'eliminazione.",
-          "warning-2": "Non appena confermate, verrete automaticamente disconnessi e la vostra richiesta verrà immediatamente elaborata."
+          "warning-2": "Non appena confermate, verrete automaticamente disconnessi e la tua richiesta verrà immediatamente elaborata."
         },
         "more-information": "Per ulteriori informazioni,",
         "more-information-contact-support": "è possibile contattare l'assistenza.",
-        "title": "Cancellare definitivamente il mio account",
+        "title": "Elimina definitivamente il mio account",
         "warning-email": "Questa azione è irreversibile. Tutte le competenze, i corsi e i {pixScore} pix ottenuti saranno eliminati definitivamente per l'account PIX che utilizza l'indirizzo e-mail <strong>{email}</strong>.",
         "warning-other": "Questa azione è irreversibile. Tutte le competenze, i corsi e i {pixScore} pix ottenuti saranno eliminati definitivamente per l'account PIX <strong>{firstName} {lastName}</strong>."
       },
       "email-confirmed": "Indirizzo e-mail verificato.",
       "email-verification": {
-        "add-successful": "Il tuo indirizzo e-mail è stato aggiunto!",
-        "code-explanation-of-use": "Per spostarsi da un campo all'altro, utilizzare la tabulazione o le frecce destra e sinistra della tastiera. Per compilare un campo, inserire i numeri da 1 a 9 o utilizzare le frecce su e giù della tastiera.",
+        "code-explanation-of-use": "Per spostarsi da un campo all'altro, utilizzare la tabulazione o le frecce destra e sinistra della tastiera. Per compila un campo, inserisci i numeri da 1 a 9 o utilizzare le frecce su e giù della tastiera.",
         "code-label": "Campo",
-        "code-legend": "Inserire il codice di verifica inviato per e-mail",
+        "code-legend": "Inserisci il codice di verifica inviato per e-mail",
         "confirmation-message": "E-mail inviata!",
-        "description": "Inserire il codice di verifica ricevuto all'indirizzo e-mail :",
+        "description": "Inserisci il codice di verifica ricevuto all'indirizzo e-mail:",
         "did-not-receive": "Non ho ricevuto nulla,",
         "errors": {
           "email-modification-demand-expired": "Questo codice è scaduto. Si prega di rinnovare la richiesta.",
           "incorrect-code": "Il codice inserito non è corretto.",
           "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
-          "no-code": "Inserisci il codice a {numInputs} cifre ricevuto via e-mail.",
           "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza."
         },
-        "send-back-the-code": "inviami il codice",
-        "time-code-validation": "Il codice ricevuto è valido per un'ora",
-        "title": "Controllo dell'indirizzo e-mail",
-        "update-successful": "Il tuo indirizzo e-mail è stato modificato!",
-        "validate-new-email": "Conferma nuovo indirizzo e-mail"
+        "send-back-the-code": "inviami di nuovo il codice",
+        "time-code-validation": "Il codice ricevuto è valido per 10 minuti",
+        "title": "Verifica dell'indirizzo e-mail",
+        "update-successful": "Il tuo indirizzo e-mail è stato modificato!"
       },
       "language": {
         "lang": "Lingua",
-        "menu-link-title": "Scegliete la vostra lingua",
-        "update-successful": "La vostra lingua è stata cambiata!"
+        "menu-link-title": "Scegli la tua lingua",
+        "update-successful": "La tua lingua è stata cambiata!"
       },
       "personal-information": {
         "first-name": "Nome",
-        "last-name": "Nome",
+        "last-name": "Cognome",
         "menu-link-title": "I miei dati personali"
       },
       "title": "Il mio account"
     },
     "user-certifications": {
       "meshes": {
-        "DROIT": {
-          "ADVANCED": "Avanzato",
-          "BELOW_MINIMUM": "Non ottenuto",
-          "CONFIRMED": "Confirmato",
-          "EXPERT": "Esperto",
-          "INDEPENDENT": "Indipendente"
-        },
         "EDU_1ER_DEGRE": {
-          "ADMISSIBLE": "Ammissibile",
-          "ADVANCED": "Avanzato",
-          "BELOW_MINIMUM": "Non ammissibile",
-          "EXPERT": "Esperto"
+          "0": "Ammissibile",
+          "BELOW_MINIMUM": "Non ammissibile"
         },
         "EDU_2ND_DEGRE": {
-          "ADMISSIBLE": "Ammissibile",
-          "ADVANCED": "Avanzato",
-          "BELOW_MINIMUM": "Non ammissibile",
-          "EXPERT": "Esperto"
+          "0": "Ammissibile",
+          "BELOW_MINIMUM": "Non ammissibile"
         },
         "EDU_CPE": {
-          "ADMISSIBLE": "Ammissibile",
-          "ADVANCED": "Avanzato",
-          "BELOW_MINIMUM": "Non ammissibile",
-          "EXPERT": "Esperto"
-        },
-        "PRO_SANTE": {
-          "ADVANCED": "Avanzato",
-          "BELOW_MINIMUM": "Non ottenuto",
-          "CONFIRMED": "Confermato",
-          "EXPERT": "Esperto",
-          "INDEPENDENT": "Indipendente"
+          "0": "Ammissibile",
+          "BELOW_MINIMUM": "Non ammissibile"
         }
       }
     },
     "user-tests": {
       "anonymised-participations": {
-        "course": "Corso",
+        "course": "Percorso",
         "states": {
           "completed": "completato",
           "started": "iniziato"
         },
-        "title": "Corsi per disabili"
+        "title": "Percorsi anonimi"
       },
-      "description": "Trovate i vostri percorsi Pix, seguite i vostri progressi e riprendete semplicemente da dove avete lasciato.",
-      "title": "I miei percorsi di carriera"
+      "description": "Trova i tuoi percorsi Pix, seguite i tuoi progressi e riprendete semplicemente da dove hai lasciato.",
+      "title": "I miei percorsi"
     },
     "user-trainings": {
       "description": "Continuare a progredire grazie ai corsi di formazione consigliati al termine della valutazione.",
       "title": "I miei corsi di formazione"
     },
     "user-tutorials": {
-      "description": "Migliorate le vostre competenze digitali con esercitazioni adatte al vostro livello.",
+      "description": "Migliorate le tue competenze digitali con esercitazioni adatte al tuo livello.",
       "empty-list-info": {
         "description": {
-          "part1": "Durante lo svolgimento dei test, vi verranno suggerite delle esercitazioni: fate clic sull'icona del segnalibro",
+          "part1": "Durante lo svolgimento dei test, ti verranno suggerite delle esercitazioni: fate clic sull'icona del segnalibro",
           "part2": "per registrare quelli che volete trovare qui!"
         },
         "image-link": "images/illustrations/user-tutorials/illustration-en.svg",
-        "title": "Non avete ancora registrato nulla"
+        "title": "Non hai ancora salvato nulla"
       },
-      "filter": "Filtro",
+      "filter": "Filtra",
       "label": "tutorial",
       "list": {
-        "title": "La mia lista",
+        "title": "Il mio elenco",
         "tutorial": {
           "actions": {
             "evaluate": {
@@ -2518,21 +2460,21 @@
           "source": "Da"
         }
       },
-      "recommended": "Consigliato",
+      "recommended": "Consigliati",
       "recommended-empty": {
-        "description": "Per consigliare le esercitazioni adatte al vostro livello, è necessario avviare un test delle competenze.",
-        "link": "Inizio",
-        "title": "{firstName}, trovate i vostri tutorial preferiti qui"
+        "description": "Per consigliare le esercitazioni adatte al tuo livello, è necessario avviare un test delle competenze.",
+        "link": "Inizia",
+        "title": "{firstName}, trova i tuoi tutorial preferiti qui"
       },
-      "saved": "Registrato",
+      "saved": "Salvati",
       "saved-empty": {
         "description": "È necessario registrare un'esercitazione consigliata per farla apparire qui.",
         "title": "Non ci sono ancora esercitazioni registrate"
       },
       "sidebar": {
-        "reset": "Reset",
-        "reset-aria-label": "Azzeramento e deselezione di tutti i filtri",
-        "see-results": "Guarda i risultati"
+        "reset": "Reimposta",
+        "reset-aria-label": "Reimpostazione e deselezione di tutti i filtri",
+        "see-results": "Vedi i risultati"
       },
       "title": "I miei tutorial"
     }

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -25,7 +25,7 @@
       "s50": "Questo identificatore esiste già",
       "s51": "Hai già un account Pix con l'indirizzo e-mail '<br>'{value}'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R51).",
       "s52": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{value}'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R52)",
-      "s53": "Hai già un account Pix tramite ENT.'<br> 'Usalo per iscriverti al percorso.",
+      "s53": "Hai già un account Pix tramite ENT.'<br>'Usalo per iscriverti al percorso.",
       "s61": "Hai già un account Pix con l'indirizzo e-mail '<br>'{value}'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R61).",
       "s62": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{value}'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentazione - Codice R62)",
       "s63": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentazione - Codice R63)"
@@ -106,7 +106,7 @@
       "invisible-password": "nascondi la password",
       "mandatory": "obbligatorio",
       "mandatory-all-fields": "Tutti i campi sono obbligatori.",
-      "mandatory-fields": "I campi contrassegnati da '<abbr title=\"mandatory\" class=\"mandatory-mark\">'*'</abbr>' sono obbligatori.",
+      "mandatory-fields": "I campi contrassegnati da '<abbr title=\"obbligatorio\" class=\"mandatory-mark\">'*'</abbr>' sono obbligatori.",
       "success": "corretto",
       "visible-password": "mostra la password"
     },
@@ -125,6 +125,7 @@
     "new-information-banner": {
       "close-label": "Chiudere il banner"
     },
+    "no": "No",
     "no-level": "Nessun livello",
     "or": "o",
     "pagination": {
@@ -155,7 +156,6 @@
         }
       }
     },
-    "no": "No",
     "yes": "Sì"
   },
   "components": {
@@ -641,8 +641,8 @@
           "finished": "Completato",
           "started": "In percorso"
         },
-        "text-deleted": "Percorso disattivato dalla propria organizzazione.'<br> 'Non è più possibile agire su questo percorso.",
-        "text-disabled": "Percorso disattivato dalla propria organizzazione.'<br> 'Non è più possibile invia i risultati."
+        "text-deleted": "Percorso disattivato dalla propria organizzazione.'<br>'Non è più possibile agire su questo percorso.",
+        "text-disabled": "Percorso disattivato dalla propria organizzazione.'<br>'Non è più possibile inviare i risultati."
       },
       "title": "Percorso"
     },
@@ -684,17 +684,17 @@
       "framework-title": {
         "CLEA": "Certificazione Pix",
         "CORE": "Certificazione Pix",
+        "DROIT": "Certificato Pix+ Diritto",
         "EDU_1ER_DEGRE": "Certificato Pix+ Edu 1° livello",
         "EDU_2ND_DEGRE": "Certificato Pix+ Edu 2° livello",
         "EDU_CPE": "Certificato Pix+ Edu CPE",
-        "DROIT": "Certificato Pix+ Diritto",
         "PRO_SANTE": "Certificato Pix+ Professionisti della Salute"
       },
       "frameworks": {
         "EDU": {
           "results-infos": "'<p>'La certificazione si svolge in due fasi:'</p><ol><li>'Prova Pix: appena completata.'</li><li>'Prova orale: organizzata al di fuori di Pix davanti a una giuria.'</li></ol><p>'Al termine dell'orale, verrà assegnato il livello di certificazione definitivo (Esperto, Avanzato, ecc.).'<br/>'Contatta il tuo centro di certificazione per organizzare la prova orale.'</p>'",
-          "status": "Certificato valido",
           "results-sub-title": "Il/la candidato/a è ammissibile al modulo 2 della pratica professionale della certificazione Pix+ Édu!",
+          "status": "Certificato valido",
           "steps": {
             "1": "Volet Pix",
             "2": "Volet pratica'<br/>'professionale",
@@ -729,12 +729,14 @@
       "jury-info": "Le osservazioni della giuria non vengono condivise nella pagina di verifica del certificato.",
       "jury-title": "Commenti della giuria",
       "learn-about-certification-results": "Come interpretare i risultati?",
+      "obtained-certification": "Il candidato ha raggiunto il livello {globalLevelLabel} della certificazione {frameworkLabel}.",
       "professionalizing-warning": "Il certificato Pix è riconosciuto come qualifica professionale da France Compétences una volta raggiunto un punteggio minimo di 120 pix.",
       "results": {
         "sub-title": "Il candidato è ammissibile alla certificazione {framework}.",
         "title": "Lettura del risultato:"
       },
       "title": "Certificato Pix",
+      "valid-status": "Certificato valido",
       "verification-code": {
         "alt": "Copia",
         "copied": "Codice copiato!",
@@ -743,9 +745,7 @@
         "share": "Condividi il tuo certificato",
         "title": "Codice di verifica",
         "tooltip": "Fornite questo codice per consentire a terzi di verificare l'autenticità del tuo certificato."
-      },
-      "obtained-certification": "Il candidato ha raggiunto il livello {globalLevelLabel} della certificazione {frameworkLabel}.",
-      "valid-status": "Certificato valido"
+      }
     },
     "certification-ender": {
       "candidate": {
@@ -789,10 +789,10 @@
       "steps": {
         "1": {
           "paragraphs": {
-            "1": "La certificazione {certificationName} è un test \"<strong>adattivo\"</strong> per valutare il tuo livello nel \"<strong>quadro di riferimento delle 16 competenze digitali del Pix\"</strong>.",
-            "2": "La \"<strong>difficoltà delle domande si adatta in tempo reale\"</strong> in base alle risposte fornite.",
-            "3": "Se alcune domande sembrano difficili, è perché il test di certificazione cerca di misurare il tuo livello massimo. Se non sei in grado di rispondere a una domanda, hai la possibilità di \"saltarla\": non verrà riproposta durante la certificazione e non sarà convalidata.",
-            "4": "Per ottenere un punteggio il più vicino possibile alle proprie capacità \"<strong>è necessario arrivare alla fine del test\"</strong>.",
+            "1": "La certificazione {certificationName} è un '<strong>'test adattivo'</strong>' per valutare il tuo livello nel '<strong>'quadro di riferimento delle 16 competenze digitali del Pix'</strong>'.",
+            "2": "La '<strong>'difficoltà delle domande si adatta in tempo reale'</strong>' in base alle risposte fornite.",
+            "3": "Se alcune domande sembrano difficili, è perché il test di certificazione cerca di misurare il tuo livello massimo. '<strong>'Se non sei in grado di rispondere a una domanda, hai la possibilità di \"saltarla\"'</strong>': non verrà riproposta durante la certificazione e non sarà convalidata.",
+            "4": "Per ottenere un punteggio il più vicino possibile alle proprie capacità '<strong>'è necessario arrivare alla fine del test'</strong>'.",
             "pix-plus-1": "La certificazione {certificationName} è un '<strong>'test adattivo'</strong>' per valutare il livello del candidato sull’'<strong>'insieme di competenze del quadro di riferimento della certificazione {certificationName}'</strong>'."
           },
           "question": "Come funziona il test?",
@@ -803,7 +803,7 @@
             "strong-text": "32 DOMANDE"
           },
           "paragraphs": {
-            "1": "Il test di certificazione è composto da \"<strong>32 domande\"</strong>\".",
+            "1": "Il test di certificazione è composto da '<strong>'32 domande'</strong>'",
             "2": "Hai un massimo di '<strong>'{duration}'</strong>' per rispondere*.",
             "3": "*escluso il tempo supplementare",
             "4": "Se si completano '<strong>'meno di 20 domande, non sarà possibile assegnare un punteggio'</strong>'."
@@ -821,7 +821,7 @@
               "title": "Modalità libera:"
             },
             "2": {
-              "text": "Per le domande in \"<strong>modalità focus\"</strong>, indicate da un'icona gialla: non sarà possibile lasciare la pagina e cercare.",
+              "text": "Per le domande in '<strong>'modalità focus'</strong>', indicate da un'icona gialla: non sarà possibile lasciare la pagina e cercare.",
               "title": "Modalità di messa a fuoco:"
             }
           },
@@ -834,7 +834,7 @@
             "3": "Fare clic su \"Sì, sono sicuro\".",
             "4": "Chiamate il sorvegliante, che interverrà per aiutarvi."
           },
-          "text": "'<strong>'In caso di problemi tecnici'</strong> (ad esempio l'immagine si rifiuta di essere visualizzata), seguire questi passaggi:",
+          "text": "'<strong>'In caso di problemi tecnici'</strong>' (ad esempio l'immagine si rifiuta di essere visualizzata), seguire questi passaggi:",
           "title": "Cosa fare in caso di problemi?"
         },
         "5": {
@@ -959,9 +959,6 @@
         }
       },
       "first-title": "Stai per iniziare il test di certificazione",
-      "link-to-user-certification": "Vedi le mie certificazioni",
-      "non-eligible-subscription": "Non si ha diritto a {complementarySubscriptionLabel}. È tuttavia possibile ottenere la certificazione Pix.",
-      "title": "Partecipa a una sessione di certificazione",
       "language-selector": {
         "confirmation-label": "Confermo di essere a mio agio nella lingua selezionata per rispondere alle domande.'<br>'La scelta della lingua è '<strong>'definitiva'</strong>'.",
         "label": "Lingua di certificazione",
@@ -969,7 +966,10 @@
           "english": "inglese - EN",
           "french": "francese - FR"
         }
-      }
+      },
+      "link-to-user-certification": "Vedi le mie certificazioni",
+      "non-eligible-subscription": "Non si ha diritto a {complementarySubscriptionLabel}. È tuttavia possibile ottenere la certificazione Pix.",
+      "title": "Partecipa a una sessione di certificazione"
     },
     "certifications-list": {
       "buttons": {
@@ -1246,7 +1246,7 @@
       },
       "completion-percentage": {
         "caption": "progressi lungo il percorso",
-        "label": "'<p class=\"sr-only\">'Hai completato '</p>'{completionPercentage}%'<p class=\"sr-only\">' del tuo viaggio.'</p>'"
+        "label": "Hai completato {completion, number, ::percent} del tuo percorso."
       },
       "sharing-results": {
         "information-banner": "Cliccando sul pulsante \"Vedi i miei risultati\", i tuoi risultati saranno inviati all'organizzatore."
@@ -1269,6 +1269,13 @@
         "start-button": "Inizia il mio percorso",
         "step": "Fase {stepNumber}"
       },
+      "errors": {
+        "disabled": {
+          "content": "A causa di un elevato afflusso, l'accesso a questo percorso è temporaneamente sospeso.",
+          "instructions": "Si prega di riprovare più tardi.",
+          "title": "Questo percorso non è disponibile al momento"
+        }
+      },
       "items": {
         "aria-label-completed-campaign": "Questo elemento viene completato con una percentuale di successo di {value, number, ::percent}.",
         "aria-label-completed-campaign-with-stages": "Hai ottenuto {acquired, plural, =0 {no stelle} =1 {# stelle} other {# stelle}} su {total}.",
@@ -1289,13 +1296,6 @@
           "select-passages": "Selezione di corsi di formazione adeguati."
         },
         "title": "Calcolo del seguito del percorso in corso."
-      },
-      "errors": {
-        "disabled": {
-          "content": "A causa di un elevato afflusso, l'accesso a questo percorso è temporaneamente sospeso.",
-          "instructions": "Si prega di riprovare più tardi.",
-          "title": "Questo percorso non è disponibile al momento"
-        }
       }
     },
     "comparison-window": {
@@ -1321,7 +1321,7 @@
         },
         "feedback": {
           "correct": "Risposta corretta",
-          "wrong": "Risposta errata. '<br>La risposta corretta è:"
+          "wrong": "Risposta errata. '<br>'La risposta corretta è:"
         },
         "focusedOut": {
           "title": "Hai superato la prova",
@@ -1576,7 +1576,7 @@
         "continue-with-pix": "Continua con il mio account Pix",
         "error-not-found": "Sei uno studente? '<br>' Controlla i tuoi dati (nome, cognome e data di nascita) o contatta un insegnante.'<br><br>' Sei un insegnante? '<br>' L'accesso a un percorso non è al momento disponibile.",
         "first-title": "Entra nell'organizzazione { organizationName }",
-        "invalid-reconciliation-error": "Si è verificato un errore. Contattare l'assistenza.",
+        "invalid-reconciliation-error": "Si è verificato un errore. '<br>' Contattare l'assistenza.",
         "login-information-message": "L'account Pix '<b>'{ connectionMethod }'</b>' sarà associato allo studente: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Se sei voi, fate clic su \"Associa\", altrimenti uscite.",
         "login-information-title": "Informazioni sulla accesso",
         "subtitle": "Compila le informazioni mancanti"
@@ -1803,9 +1803,6 @@
         }
       },
       "preview": {
-        "showJson": "Visualizza JSON",
-        "stepper": "Anteprima: stepper {direction}",
-        "textarea-label": "Contenuto del modulo",
         "elements-id-button": {
           "label": "Mostra l'ID degli elementi"
         },
@@ -1818,7 +1815,10 @@
         "grains-title-button": {
           "label": "Mostra il titolo dei grain"
         },
-        "modulix-editor": "Modulix Editor"
+        "modulix-editor": "Modulix Editor",
+        "showJson": "Visualizza JSON",
+        "stepper": "Anteprima: stepper {direction}",
+        "textarea-label": "Contenuto del modulo"
       },
       "qab": {
         "correct-answer": "Risposta corretta!",
@@ -1947,7 +1947,7 @@
         }
       },
       "description": "Mettiti alla prova con i tuoi ritmi in 16 competenze digitali. Scegli una competenza e inizia a guadagnare pix.",
-      "first-title": "Hai 16 competenze da testare. Concentrati e parti!",
+      "first-title": "Hai 16 competenze da testare.'<br>'Concentrati e parti!",
       "resume-campaign-banner": {
         "accessibility": {
           "resume": "Continua il tuo viaggio",
@@ -1964,7 +1964,7 @@
       },
       "title": "Competenze",
       "total-score-helper": {
-        "explanation": "'<p>'Questo è il numero massimo di pix che saremo in grado di raggiungere quando tutti gli 8 livelli del repository Pix saranno disponibili.'</p><p>'Oggi,'<span class=\"hexagon-score-information__--strong\">'il massimo è {maxReachablePixScore} pix'</span>', corrispondente al livello {maxReachableLevel}.'</p>'",
+        "explanation": "'<p>'Questo è il numero massimo di pix che saremo in grado di raggiungere quando tutti gli 8 livelli del repository Pix saranno disponibili.'</p><p>'Oggi,'<span class=\"hexagon-score-information__text--strong\">'il massimo è {maxReachablePixScore} pix'</span>', corrispondente al livello {maxReachableLevel}.'</p>'",
         "icon": "Informazioni sui pix",
         "label": "Apri il tooltip",
         "title": "Perché 1024 pix?"
@@ -2092,7 +2092,7 @@
         "send": "Invio il mio profilo",
         "shared": "Grazie, il tuo profilo è stato inviato!"
       },
-      "instructions": "Trasmetterete il punteggio e i livelli di competenze del tuo profilo Pix. Eventuali modifiche al profilo dopo l'invio di queste informazioni non saranno trasmesse. Ricordati di controlla prima di invia!",
+      "instructions": "Trasmetterete il punteggio e i livelli di competenze del tuo profilo Pix. '<br>' Eventuali modifiche al profilo dopo l'invio di queste informazioni non saranno trasmesse. '<br>' Ricordati di verificarlo prima di inviarlo!",
       "title": "Invia il mio profilo"
     },
     "shared-certification": {
@@ -2176,6 +2176,7 @@
         "explanations": {
           "trainings": "Per aiutarvi a progredire, date un'occhiata ai nostri corsi di formazione consigliati e trova quelli più adatti a voi."
         },
+        "hidden-badges": "{ count, plural, =1 {badge aggiuntivo acquisito non visualizzato} other {badge aggiuntivi acquisiti non visualizzati} }",
         "mastery-rate": "di successo nelle domande",
         "retry": {
           "actions": {
@@ -2188,12 +2189,11 @@
         },
         "see-trainings": "Vedere i corsi",
         "shared-message": "I risultati sono stati inviati da {date} a {time}.",
-        "thanks": "Grazie {name} per la tua partecipazione!",
-        "hidden-badges": "{ count, plural, =1 {badge aggiuntivo acquisito non visualizzato} other {badge aggiuntivi acquisiti non visualizzati} }",
         "staged-message": {
           "show-less": "Comprimi",
           "show-more": "Mostra di più"
-        }
+        },
+        "thanks": "Grazie {name} per la tua partecipazione!"
       },
       "improve": {
         "description": "È possibile riprovare alcune delle domande",
@@ -2231,11 +2231,11 @@
       "stage": {
         "caption": "I dettagli dei tuoi risultati sotto forma di percentuali e stelle in base alle competenze",
         "masteryPercentage": "{rate, number, ::percent} di successo",
-        "starsAcquired": "{acquired, plural, =0 {nessuna stella acquisita} =1 {# stelle acquisite} other {# stelle acquisite}} su {total}.",
-        "title": "Dettagli sulle competenze",
         "recommendedEngine": {
           "starsAcquired": "{acquired}/{total, plural, =0 {stella} =1 {# stella} other {# stelle}}"
-        }
+        },
+        "starsAcquired": "{acquired, plural, =0 {nessuna stella acquisita} =1 {# stelle acquisite} other {# stelle acquisite}} su {total}.",
+        "title": "Dettagli sulle competenze"
       },
       "tabs": {
         "aria-label": "3 schede con i dettagli dei risultati",
@@ -2342,69 +2342,6 @@
       "validation": "La password è stata aggiornata."
     },
     "user-account": {
-      "connexion-methods": {
-        "authentication-methods": {
-          "gar": "via ENT/Mediacentre",
-          "label": "Connessione esterna",
-          "connection-via": "Connessione via {identityProviderOrganizationName}",
-          "other-authentication-label": "Altro metodo di connessione"
-        },
-        "edit-button": "Modificare",
-        "email": "Indirizzo e-mail",
-        "menu-link-title": "I miei metodi di accesso",
-        "username": "Identificatore"
-      },
-      "delete-account": {
-        "actions": {
-          "delete": "Elimina il mio account"
-        },
-        "menu-link-title": "Elimina il mio account",
-        "modal": {
-          "error-403": "Non è possibile eliminare il proprio account. Contattare l'assistenza Pix.",
-          "question": "Sei sicuro di voler cancellare il tuo account?",
-          "title": "Stai per eliminare il tuo account",
-          "warning-1": "Si noti che l'account non può essere recuperato dopo l'eliminazione.",
-          "warning-2": "Non appena confermate, verrete automaticamente disconnessi e la tua richiesta verrà immediatamente elaborata."
-        },
-        "more-information": "Per ulteriori informazioni,",
-        "more-information-contact-support": "è possibile contattare l'assistenza.",
-        "title": "Elimina definitivamente il mio account",
-        "warning-email": "Questa azione è irreversibile. Tutte le competenze, i corsi e i {pixScore} pix ottenuti saranno eliminati definitivamente per l'account PIX che utilizza l'indirizzo e-mail <strong>{email}</strong>.",
-        "warning-other": "Questa azione è irreversibile. Tutte le competenze, i corsi e i {pixScore} pix ottenuti saranno eliminati definitivamente per l'account PIX <strong>{firstName} {lastName}</strong>."
-      },
-      "email-confirmed": "Indirizzo e-mail verificato.",
-      "email-verification": {
-        "code-explanation-of-use": "Per spostarsi da un campo all'altro, utilizzare la tabulazione o le frecce destra e sinistra della tastiera. Per compila un campo, inserisci i numeri da 1 a 9 o utilizzare le frecce su e giù della tastiera.",
-        "code-label": "Campo",
-        "code-legend": "Inserisci il codice di verifica inviato per e-mail",
-        "confirmation-message": "E-mail inviata!",
-        "description": "Inserisci il codice di verifica ricevuto all'indirizzo e-mail:",
-        "did-not-receive": "Non ho ricevuto nulla,",
-        "errors": {
-          "email-modification-demand-expired": "Questo codice è scaduto. Si prega di rinnovare la richiesta.",
-          "incorrect-code": "Il codice inserito non è corretto.",
-          "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
-          "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
-          "no-code": "Inserisci il codice a {numInputs} cifre ricevuto via e-mail."
-        },
-        "send-back-the-code": "inviami di nuovo il codice",
-        "time-code-validation": "Il codice ricevuto è valido per 10 minuti",
-        "title": "Verifica dell'indirizzo e-mail",
-        "update-successful": "Il tuo indirizzo e-mail è stato modificato!",
-        "add-successful": "Il tuo indirizzo e-mail è stato aggiunto!",
-        "validate-new-email": "Conferma il mio nuovo indirizzo e-mail"
-      },
-      "language": {
-        "lang": "Lingua",
-        "menu-link-title": "Scegli la tua lingua",
-        "update-successful": "La tua lingua è stata cambiata!"
-      },
-      "personal-information": {
-        "first-name": "Nome",
-        "last-name": "Cognome",
-        "menu-link-title": "I miei dati personali"
-      },
-      "title": "Il mio account",
       "account-add-or-update-email-with-validation": {
         "code-reception-information": "Confermando la richiesta di aggiunta dell'indirizzo e-mail, riceverai un codice via e-mail.",
         "fields": {
@@ -2434,34 +2371,97 @@
           "add-email": "Aggiungi un indirizzo e-mail",
           "update-email": "Modifica dell'indirizzo e-mail"
         }
-      }
+      },
+      "connexion-methods": {
+        "authentication-methods": {
+          "connection-via": "Connessione via {identityProviderOrganizationName}",
+          "gar": "via ENT/Mediacentre",
+          "label": "Connessione esterna",
+          "other-authentication-label": "Altro metodo di connessione"
+        },
+        "edit-button": "Modificare",
+        "email": "Indirizzo e-mail",
+        "menu-link-title": "I miei metodi di accesso",
+        "username": "Identificatore"
+      },
+      "delete-account": {
+        "actions": {
+          "delete": "Elimina il mio account"
+        },
+        "menu-link-title": "Elimina il mio account",
+        "modal": {
+          "error-403": "Non è possibile eliminare il proprio account. Contattare l'assistenza Pix.",
+          "question": "Sei sicuro di voler cancellare il tuo account?",
+          "title": "Stai per eliminare il tuo account",
+          "warning-1": "Si noti che l'account non può essere recuperato dopo l'eliminazione.",
+          "warning-2": "Non appena confermate, verrete automaticamente disconnessi e la tua richiesta verrà immediatamente elaborata."
+        },
+        "more-information": "Per ulteriori informazioni,",
+        "more-information-contact-support": "è possibile contattare l'assistenza.",
+        "title": "Elimina definitivamente il mio account",
+        "warning-email": "Questa azione è irreversibile. Tutte le competenze, i corsi e i {pixScore} pix ottenuti saranno eliminati definitivamente per l'account PIX che utilizza l'indirizzo e-mail <strong>{email}</strong>.",
+        "warning-other": "Questa azione è irreversibile. Tutte le competenze, i corsi e i {pixScore} pix ottenuti saranno eliminati definitivamente per l'account PIX <strong>{firstName} {lastName}</strong>."
+      },
+      "email-confirmed": "Indirizzo e-mail verificato.",
+      "email-verification": {
+        "add-successful": "Il tuo indirizzo e-mail è stato aggiunto!",
+        "code-explanation-of-use": "Per spostarsi da un campo all'altro, utilizzare la tabulazione o le frecce destra e sinistra della tastiera. Per compila un campo, inserisci i numeri da 1 a 9 o utilizzare le frecce su e giù della tastiera.",
+        "code-label": "Campo",
+        "code-legend": "Inserisci il codice di verifica inviato per e-mail",
+        "confirmation-message": "E-mail inviata!",
+        "description": "Inserisci il codice di verifica ricevuto all'indirizzo e-mail:",
+        "did-not-receive": "Non ho ricevuto nulla,",
+        "errors": {
+          "email-modification-demand-expired": "Questo codice è scaduto. Si prega di rinnovare la richiesta.",
+          "incorrect-code": "Il codice inserito non è corretto.",
+          "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
+          "no-code": "Inserisci il codice a {numInputs} cifre ricevuto via e-mail.",
+          "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza."
+        },
+        "send-back-the-code": "inviami di nuovo il codice",
+        "time-code-validation": "Il codice ricevuto è valido per 10 minuti",
+        "title": "Verifica dell'indirizzo e-mail",
+        "update-successful": "Il tuo indirizzo e-mail è stato modificato!",
+        "validate-new-email": "Conferma il mio nuovo indirizzo e-mail"
+      },
+      "language": {
+        "lang": "Lingua",
+        "menu-link-title": "Scegli la tua lingua",
+        "update-successful": "La tua lingua è stata cambiata!"
+      },
+      "personal-information": {
+        "first-name": "Nome",
+        "last-name": "Cognome",
+        "menu-link-title": "I miei dati personali"
+      },
+      "title": "Il mio account"
     },
     "user-certifications": {
       "meshes": {
-        "EDU_1ER_DEGRE": {
-          "BELOW_MINIMUM": "Non ammissibile",
-          "ADMISSIBLE": "Ammissibile",
-          "ADVANCED": "Avanzato",
-          "EXPERT": "Esperto"
-        },
-        "EDU_2ND_DEGRE": {
-          "BELOW_MINIMUM": "Non ammissibile",
-          "ADMISSIBLE": "Ammissibile",
-          "ADVANCED": "Avanzato",
-          "EXPERT": "Esperto"
-        },
-        "EDU_CPE": {
-          "BELOW_MINIMUM": "Non ammissibile",
-          "ADMISSIBLE": "Ammissibile",
-          "ADVANCED": "Avanzato",
-          "EXPERT": "Esperto"
-        },
         "DROIT": {
           "ADVANCED": "Avanzato",
           "BELOW_MINIMUM": "Non ottenuto",
           "CONFIRMED": "Confermato",
           "EXPERT": "Esperto",
           "INDEPENDENT": "Indipendente"
+        },
+        "EDU_1ER_DEGRE": {
+          "ADMISSIBLE": "Ammissibile",
+          "ADVANCED": "Avanzato",
+          "BELOW_MINIMUM": "Non ammissibile",
+          "EXPERT": "Esperto"
+        },
+        "EDU_2ND_DEGRE": {
+          "ADMISSIBLE": "Ammissibile",
+          "ADVANCED": "Avanzato",
+          "BELOW_MINIMUM": "Non ammissibile",
+          "EXPERT": "Esperto"
+        },
+        "EDU_CPE": {
+          "ADMISSIBLE": "Ammissibile",
+          "ADVANCED": "Avanzato",
+          "BELOW_MINIMUM": "Non ammissibile",
+          "EXPERT": "Esperto"
         },
         "PRO_SANTE": {
           "ADVANCED": "Avanzato",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -72,7 +72,7 @@
       "data-protection-policy": "privacybeleid",
       "error": "Je moet de gebruiksvoorwaarden en het privacybeleid van Pix accepteren om een account aan te maken.",
       "label": "Ik accepteer de gebruiksvoorwaarden en het privacybeleid van Pix",
-      "message": "Ik accepteer de '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'gebruiksvoorwaarden'</a>' en de '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'privacybeleid'</a>' van Pix.",
+      "message": "Ik accepteer de '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'gebruiksvoorwaarden'</a>' en de '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'privacybeleid'</a>' van Pix.",
       "read-message": "Lees de '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'gebruiksvoorwaarden'</a>' en de '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'privacybeleid'</a>'."
     },
     "companion": {
@@ -321,7 +321,7 @@
         "error-message": {
           "date-field": "Gebruik het formaat dd-mm-jjjj bij het invoeren van het veld {fieldName}",
           "invalid-reconciliation-error": "Controleer je gegevens ({fields}) of neem contact op met een docent.",
-          "mandatory-field": "Dit veld is verplicht"
+          "mandatory-field": "Vul het veld {fieldName} in"
         },
         "field": {
           "birthdate": "Geboortedatum",
@@ -651,7 +651,6 @@
         "download-attestation": "Mijn certificaat downloaden",
         "download-certificate": "Mijn certificaat downloaden"
       },
-      "attestation": "Mijn certificaat downloaden",
       "back-link": "Terug naar mijn certificaten",
       "candidate": "Kandidaat :",
       "candidate-birth": "Geboren op {birthdate}",
@@ -717,6 +716,10 @@
           "expert": "Expert",
           "independent": "Onafhankelijk",
           "level": "Jouw niveau"
+        },
+        "progress-bar-explanation": {
+          "default": "Voortgangsbalk die aangeeft welk niveau je hebt bereikt ( {level}, d.w.z. niveau {globalLevelLabel} ) van het maximaal haalbare niveau van 7 (niveau Expert 1)",
+          "pre-beginner-level": "Voortgangsbalk die het maximale niveau aangeeft dat in de certificering bereikt kan worden (d.w.z. 7 of niveau Expert 1)"
         }
       },
       "hexagon-score": {
@@ -728,7 +731,6 @@
       "learn-about-certification-results": "Hoe moeten de resultaten worden geïnterpreteerd?",
       "obtained-certification": "De kandidaat heeft het niveau {globalLevelLabel} van de {frameworkLabel}-certificering bereikt.",
       "professionalizing-warning": "Het Pix-certificaat wordt door France Compétences erkend als een professionele kwalificatie zodra een minimale score van 120 pix is behaald.",
-      "progressbar-explanation": "oortgangsbalk die aangeeft welk niveau je hebt bereikt ( {level}, i.e. level {globalLevelLabel} ) van het maximaal haalbare niveau van 7 (niveau Expert 1)",
       "results": {
         "sub-title": "De kandidaat is toelaatbaar voor de {framework}-certificering.",
         "title": "Resultaat lezen:"
@@ -787,22 +789,22 @@
       "steps": {
         "1": {
           "paragraphs": {
-            "1": "Pix Certification is een '<strong>'adaptieve'</strong>'test om je niveau te beoordelen op de '<strong>'set van 16 digitale vaardigheden in het Pix'</strong>' referentiekader.",
+            "1": "De certificering {certificationName} is een '<strong>'adaptieve test'</strong>' om je niveau te beoordelen op de '<strong>'set van 16 digitale vaardigheden van het Pix-referentiekader'</strong>'.",
             "2": "De '<strong>'moeilijkheidsgraad van de vragen past zich in realtime aan'</strong>' op basis van de gegeven antwoorden.",
             "3": "Als sommige vragen moeilijk lijken, komt dat omdat de certificeringstest je maximale niveau wil meten. '<strong>'Als je een vraag niet kunt beantwoorden, heb je de optie om deze \"over te slaan\"'</strong>': de vraag zal niet opnieuw worden aangeboden tijdens de certificering en zal niet worden gevalideerd.",
-            "4": "Om een score te halen die zo dicht mogelijk bij je capaciteiten ligt '<strong>'is het nodig om naar het einde van de test te gaan'</strong>'."
+            "4": "Om een score te halen die zo dicht mogelijk bij je capaciteiten ligt '<strong>'is het nodig om naar het einde van de test te gaan'</strong>'.",
+            "pix-plus-1": "De certificering {certificationName} is een '<strong>'adaptieve test'</strong>' voor het evalueren van je niveau in '<strong>'alle competenties van het certificeringsreferentiekader {certificationName}'</strong>'."
           },
           "question": "Hoe werkt de certificeringstest?",
-          "title": "Welkom bij Pix-certificering"
+          "title": "Welkom bij de certificering {certificationName}"
         },
         "2": {
           "legend": {
-            "strong-text": "32 VRAGEN",
-            "text": "1 H 45 min"
+            "strong-text": "32 VRAGEN"
           },
           "paragraphs": {
             "1": "De certificeringstest bestaat uit '<strong>'32 vragen'</strong>'.",
-            "2": "Je hebt maximaal '<strong>'1u45'</strong>' om te reageren*.",
+            "2": "Je hebt maximaal '<strong>'{duration}'</strong>' om te reageren*.",
             "3": "*exclusief eventuele extra tijd",
             "4": "Als je '<strong>'minder dan 20 vragen invult, kunnen we je geen score geven'</strong>'."
           },
@@ -815,7 +817,7 @@
           },
           "paragraphs": {
             "1": {
-              "text": "Voor vragen in de '<strong>'vrije modus'</strong>', aangegeven met een groen pictogram: je mag zoeken op het web en gebruik maken van de digitale omgeving die tot je beschikking staat.",
+              "text": "Voor vragen in de '<strong>'vrije modus'</strong>', aangegeven met een groen pictogram: je mag zoeken op het web en gebruik maken van de digitale omgeving die tot je beschikking staat.'<br>'Bepaalde '<strong>'websites zijn echter niet toegankelijk tijdens de certificering'</strong>'.",
               "title": "Vrije modus :"
             },
             "2": {
@@ -843,7 +845,7 @@
             "3": "'<strong>'Gebruik een kunstmatig intelligentiesysteem'</strong>' of een chatbot.",
             "4": "'<strong>'Raadpleeg een zelfhulpforum'</strong>' geeft direct het antwoord op een vraag.",
             "5": "'<strong>'Zet elk ander middel in dat direct het antwoord op de vraag geeft'</strong>', zonder het werk te hebben gedaan dat de instructie vereist.",
-            "6": "'<strong>'Gebruik een andere browser'</strong>' dan de browser waarop je de Pix-certificeringstest uitvoert.",
+            "6": "'<strong>'Gebruik een andere browser'</strong>' dan de browser waarop je de {certificationName}-certificeringstest uitvoert.",
             "7": "'<strong>'Zich voordoen als' een andere persoon."
           },
           "pix-companion": "Toegang tot bepaalde sites is verboden als onderdeel van de certificeringstest, dankzij een extensie die op de browser is geïnstalleerd. Elke bewezen fraude (poging om de extensie te omzeilen of het niet naleven van de hierboven vermelde gedragingen) kan leiden tot het ongeldig verklaren van de certificering.",
@@ -856,7 +858,7 @@
     },
     "certification-joiner": {
       "congratulation-banner": {
-        "complementary-certification": {
+        "double-certification": {
           "eligible": "Je komt ook in aanmerking voor de aanvullende certificering :",
           "outdated": "<strong>Je komt niet langer in aanmerking voor de {doubleCertificationName}-certificering na de evolutie ervan.</strong><br />Neem contact op met je school of de organisatie die je de cursus heeft aangeboden om opnieuw een campagne te doen en zo weer in aanmerking te komen. Je voortgang is bewaard gebleven en je hoeft alleen nog maar de nieuwe evenementen te spelen, wat snel zou moeten gaan."
         },
@@ -866,7 +868,6 @@
         "message": "Gefeliciteerd {fullName}, je Pix-profiel is certificeerbaar."
       },
       "error-messages": {
-        "candidate-not-eligible": "<strong>Het account waarmee u op dit moment bent ingelogd komt niet in aanmerking voor deze certificeringssessie.</strong> '<br>' De ingevoerde informatie komt overeen met een kandidaat die alleen is geregistreerd voor de sessie aanvullende certificering. '<br>' Controleer of u bent ingelogd op het account dat in aanmerking komt om alleen de aanvullende certificering te volgen.",
         "generic": {
           "check-personal-info": "Controleer bij de toezichthouder of je persoonlijke gegevens overeenkomen met die op het inschrijfformulier.",
           "check-session-number": "Controleer het sessienummer.",
@@ -1210,7 +1211,7 @@
           "aria-label": "Geef de indicatie op het bewijs weer.",
           "close": "Ik snap het.",
           "focused": {
-            "content": "'<p class=\"tooltip-tag-information__title--focused\">'Blijf op deze pagina om te reageren!'</p>' Gebruik geen internet of een app. Elke activiteit buiten de zone wordt gedetecteerd.",
+            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'Blijf op deze pagina om te reageren!'</strong><br/>' Gebruik geen internet of een app. Elke activiteit buiten de zone wordt gedetecteerd.",
             "title": "Scherpstelmodus"
           },
           "other": {
@@ -1575,7 +1576,7 @@
         "continue-with-pix": "Doorgaan met mijn Pix-account",
         "error-not-found": "Ben je student? '<br>' Controleer je gegevens (voornaam, achternaam en geboortedatum) of neem contact op met een docent.'<br><br>' Ben je docent? '<br>' Toegang tot een cursus is momenteel niet beschikbaar.",
         "first-title": "Sluit je aan bij de organisatie { organizationName }",
-        "invalid-reconciliation-error": "Er is een fout opgetreden. Neem contact op met ondersteuning.",
+        "invalid-reconciliation-error": "Er is een fout opgetreden. '<br>' Neem contact op met ondersteuning.",
         "login-information-message": "Het Pix-account '<b>'{ connectionMethod }'</b>' wordt gekoppeld aan de leerling: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Als jij dit bent, klik je op \"Koppelen\", anders log je uit.",
         "login-information-title": "Verbindingsinformatie",
         "subtitle": "Vul de ontbrekende informatie in"
@@ -1825,7 +1826,7 @@
         "retry": "Probeer het opnieuw",
         "score": {
           "title": "Serie beëindigd",
-          "yourScore": "Je score : {score}/{totalScore}"
+          "yourScore": "Je score : {score}/{total}"
         }
       },
       "qcm": {
@@ -1910,6 +1911,15 @@
       },
       "signup-form": {
         "button": "Ik maak mijn account aan",
+        "claims": {
+          "FrEduFonctAdm": "Administratieve functie",
+          "FrEduNumenHash": "Technische identificatie",
+          "discipline": "Discipline",
+          "employeeNumber": "Personeelsnummer",
+          "population": "Populatie",
+          "rne": "Aanwijzingsinstelling",
+          "title": "Functie"
+        },
         "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
         "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
         "first-name-label-and-value": "Voornaam: {firstName}",
@@ -1937,7 +1947,7 @@
         }
       },
       "description": "Beoordeel jezelf in je eigen tempo op 16 digitale vaardigheden. Kies een vaardigheid en begin met het verdienen van pix.",
-      "first-title": "Je moet 16 vaardigheden testen. Concentreer je en ga!",
+      "first-title": "Je moet 16 vaardigheden testen. '<br>'Concentreer je en ga!",
       "resume-campaign-banner": {
         "accessibility": {
           "resume": "Vervolg je reis",


### PR DESCRIPTION
## 💥 Problème

Les traductions italiennes ont été revues par une agence de traduction.

## 👩‍🚀 Proposition

Importer ces traductions et les rendre conformes au fichier .fr (nombre de clés et mise en forme)

## 👁️ Remarques

Les fichiers es, nl et de ont été également mis à jour.

## ♻️ Pour tester

Il faut lire le diff mais aussi comparer les fichiers `.fr` et `.it` : clés, balises html, guillemets, variables.
