### PR TITLE
[TECH] Utilise les ids directement dans la création de schéma de parcours combinés.

### DIFF
--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -73,7 +73,7 @@ export default class Details extends Component {
             </DescriptionList>
             <div class="combined-course-blueprint__content">
               {{#each @model.content as |requirement|}}
-                <RequirementTag @type={{requirement.type}} @value={{requirement.value}} @label={{requirement.label}} />
+                <RequirementTag @requirement={{requirement}} />
               {{/each}}
             </div>
           </div>

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -115,8 +115,9 @@ export default class CombineCourseBluePrintForm extends Component {
   }
 
   @action
-  setAttestationKey(value) {
-    this.blueprint.attestationKey = value;
+  setAttestation(rewardId) {
+    this.blueprint.rewardId = rewardId;
+    this.blueprint.rewardType = 'ATTESTATION';
   }
 
   @action
@@ -245,8 +246,8 @@ export default class CombineCourseBluePrintForm extends Component {
 
         <SelectAttestation
           @attestations={{@attestations}}
-          @value={{this.blueprint.attestationKey}}
-          @onChange={{this.setAttestationKey}}
+          @value={{this.blueprint.rewardId}}
+          @onChange={{this.setAttestation}}
         />
 
       </form>

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -71,7 +71,8 @@ export default class CombineCourseBluePrintForm extends Component {
       ...this.blueprint.content,
       {
         type: 'module',
-        value: this.itemValue,
+        value: module.id,
+        shortId: module.shortId,
         label: module.title,
       },
     ];
@@ -259,12 +260,8 @@ export default class CombineCourseBluePrintForm extends Component {
         {{#if (gt this.blueprint.content.length 0)}}
           <ul class="combined-course-page__list">
             {{#each this.blueprint.content as |item|}}
-              <li><RequirementTag
-                  @type={{item.type}}
-                  @value={{item.value}}
-                  @label={{item.label}}
-                  @onRemove={{this.removeRequirement}}
-                />
+              <li>
+                <RequirementTag @requirement={{item}} @onRemove={{this.removeRequirement}} />
               </li>
             {{/each}}
           </ul>

--- a/admin/app/components/combined-course-blueprints/select-attestation.gjs
+++ b/admin/app/components/combined-course-blueprints/select-attestation.gjs
@@ -4,7 +4,7 @@ import { t } from 'ember-intl';
 
 export default class SelectAttestation extends Component {
   get attestationsOptions() {
-    return this.args.attestations?.map((attestation) => ({ value: attestation.key, label: attestation.label })) ?? [];
+    return this.args.attestations?.map((attestation) => ({ value: attestation.id, label: attestation.label })) ?? [];
   }
 
   <template>

--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -14,7 +14,7 @@ const getItemType = (type) =>
 export default class RequirementTag extends Component {
   @action
   onRemove() {
-    this.args.onRemove?.({ type: this.args.type, value: this.args.value });
+    this.args.onRemove?.({ type: this.args.requirement.type, value: this.args.requirement.value });
   }
 
   get displayRemoveButton() {
@@ -22,26 +22,34 @@ export default class RequirementTag extends Component {
   }
 
   <template>
-    <PixTag @color={{getItemColor @type}} @displayRemoveButton={{this.displayRemoveButton}} @onRemove={{this.onRemove}}>
-      {{#if (eq @type "evaluation")}}
+    <PixTag
+      @color={{getItemColor @requirement.type}}
+      @displayRemoveButton={{this.displayRemoveButton}}
+      @onRemove={{this.onRemove}}
+    >
+      {{#if (eq @requirement.type "evaluation")}}
         <LinkTo
           @route="authenticated.target-profiles.target-profile.details"
-          @model={{@value}}
+          @model={{@requirement.value}}
           target="_blank"
           rel="noopener noreferrer"
         >
-          {{t (getItemType @type)}}
+          {{t (getItemType @requirement.type)}}
           -
-          {{@value}}
+          {{@requirement.value}}
           -
-          {{@label}}</LinkTo>
+          {{@requirement.label}}</LinkTo>
       {{else}}
-        <a target="_blank" rel="noopener noreferrer" href="https://app.recette.pix.fr/modules/{{@value}}/slug/details">
-          {{t (getItemType @type)}}
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://app.recette.pix.fr/modules/{{@requirement.shortId}}/slug/details"
+        >
+          {{t (getItemType @requirement.type)}}
           -
-          {{@value}}
+          {{@requirement.shortId}}
           -
-          {{@label}}
+          {{@requirement.label}}
         </a>
       {{/if}}
     </PixTag>

--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -6,7 +6,8 @@ export default class CombinedCourseBlueprint extends Model {
   @attr('string') illustration;
   @attr('string') description;
   @attr('string') attestationLabel;
-  @attr('string') attestationKey;
+  @attr() rewardId;
+  @attr('string') rewardType;
   @attr({ type: 'date', defaultValue: () => undefined }) createdAt;
   @attr({ defaultValue: () => [] }) content;
 }

--- a/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
@@ -23,7 +23,7 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
       illustration: 'http://pix.fr/mon-illu.png',
       attestationLabel: '6ème',
       content: [
-        { type: 'module', value: 'abc-123' },
+        { type: 'module', value: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a', shortId: 'abc-123' },
         { type: 'evaluation', value: 123 },
       ],
     };

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -28,10 +28,12 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
     sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
     const findRecordStub = sinon.stub(store, 'findRecord');
     const attestations = [
-      { key: 'PARENTHOOD', label: 'Parentalite' },
-      { key: 'SIXTH_GRADE', label: '6eme' },
+      { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+      { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
     ];
-    findRecordStub.withArgs('module', 'module-123').resolves({ title: 'module 123' });
+    findRecordStub
+      .withArgs('module', 'module-123')
+      .resolves({ id: 'full-id-module-123', shortId: 'module-123', title: 'module 123' });
     findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
 
     //when
@@ -78,11 +80,12 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
     assert.strictEqual(blueprintStub.internalName, 'internalName');
     assert.deepEqual(blueprintStub.content, [
       { type: 'evaluation', value: 1, label: 'super pc' },
-      { type: 'module', value: 'module-123', label: 'module 123' },
+      { type: 'module', value: 'full-id-module-123', shortId: 'module-123', label: 'module 123' },
     ]);
     assert.strictEqual(blueprintStub.illustration, 'illustrations/hello.svg');
     assert.strictEqual(blueprintStub.description, 'description');
-    assert.strictEqual(blueprintStub.attestationKey, 'PARENTHOOD');
+    assert.strictEqual(blueprintStub.rewardId, 5);
+    assert.strictEqual(blueprintStub.rewardType, 'ATTESTATION');
     assert.ok(
       pixToastSuccessStub.calledOnceWith({
         message: t('components.combined-course-blueprints.create.notifications.success'),
@@ -287,7 +290,9 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       // given
       const store = this.owner.lookup('service:store');
       const findRecordStub = sinon.stub(store, 'findRecord');
-      findRecordStub.withArgs('module', 'module123').resolves({ title: 'module 123' });
+      findRecordStub
+        .withArgs('module', 'module123')
+        .resolves({ id: 'full-id-module123', shortId: 'module123', title: 'module 123' });
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
       //when
       const screen = await render(<template><CombinedCourseBlueprintForm /></template>);

--- a/admin/tests/integration/components/combined-course-blueprints/select-attestation-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/select-attestation-test.gjs
@@ -32,8 +32,8 @@ module('Integration | Component | CombinedCourseBlueprints::SelectAttestation', 
   test('it should select an attestation', async function (assert) {
     const onChangeStub = sinon.stub();
     const attestations = [
-      { key: 'KEY_1', label: 'Attestation 1' },
-      { key: 'KEY_2', label: 'Attestation 2' },
+      { id: 1, key: 'KEY_1', label: 'Attestation 1' },
+      { id: 2, key: 'KEY_2', label: 'Attestation 2' },
     ];
     const screen = await render(
       <template><SelectAttestation @attestations={{attestations}} @onChange={{onChangeStub}} /></template>,
@@ -45,6 +45,6 @@ module('Integration | Component | CombinedCourseBlueprints::SelectAttestation', 
 
     await click(screen.getByRole('option', { name: 'Attestation 1' }));
 
-    assert.ok(onChangeStub.calledWithExactly('KEY_1'));
+    assert.ok(onChangeStub.calledWithExactly(1));
   });
 });

--- a/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
+++ b/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
@@ -12,27 +12,25 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
   test('should display a module item when type is not evaluation', async function (assert) {
     const item = {
       type: 'module',
-      value: 'abc-123',
+      value: 'full-id-abc-123',
+      shortId: 'abc-123',
       label: 'Mon module',
     };
-    const screen = await renderScreen(
-      <template><RequirementTag @type={{item.type}} @value={{item.value}} @label={{item.label}} /></template>,
-    );
+    const screen = await renderScreen(<template><RequirementTag @requirement={{item}} /></template>);
     assert.ok(screen.getByText(t('components.combined-course-blueprints.items.module'), { exact: false }));
-    assert.ok(screen.getByText(item.value, { exact: false }));
+    assert.ok(screen.getByText(item.shortId, { exact: false }));
     assert.ok(screen.getByText(item.label, { exact: false }));
     const link = screen.getByRole('link');
     assert.ok(link.getAttribute('href').endsWith('modules/abc-123/slug/details'));
   });
+
   test('should display a target profile item when type is evaluation', async function (assert) {
     const item = {
       type: 'evaluation',
       value: 1,
       label: 'Ma campagne',
     };
-    const screen = await renderScreen(
-      <template><RequirementTag @type={{item.type}} @value={{item.value}} @label={{item.label}} /></template>,
-    );
+    const screen = await renderScreen(<template><RequirementTag @requirement={{item}} /></template>);
     const link = screen.getByRole('link');
     assert.ok(screen.getByText(t('components.combined-course-blueprints.items.targetProfile'), { exact: false }));
     assert.ok(screen.getByText(item.value, { exact: false }));
@@ -43,28 +41,28 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
   test('should call onRemove with value and type when remove button is clicked', async function (assert) {
     const item = {
       type: 'module',
-      value: 'abc-123',
+      value: 'full-id-abc-123',
+      shortId: 'abc-123',
     };
     const removeStub = sinon.stub();
 
     const screen = await renderScreen(
-      <template><RequirementTag @type={{item.type}} @value={{item.value}} @onRemove={{removeStub}} /></template>,
+      <template><RequirementTag @requirement={{item}} @onRemove={{removeStub}} /></template>,
     );
 
     await screen.getByRole('button').click();
 
-    assert.ok(removeStub.calledOnceWith(item));
+    assert.ok(removeStub.calledOnceWith({ type: item.type, value: item.value }));
   });
 
   test('should hide remove button when onRemove is not provided', async function (assert) {
     const item = {
       type: 'module',
-      value: 'abc-123',
+      value: 'full-id-abc-123',
+      shortId: 'abc-123',
     };
 
-    const screen = await renderScreen(
-      <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
-    );
+    const screen = await renderScreen(<template><RequirementTag @requirement={{item}} /></template>);
 
     assert.notOk(screen.queryByRole('button'));
   });

--- a/admin/tests/unit/serializers/combined-course-blueprint-test.js
+++ b/admin/tests/unit/serializers/combined-course-blueprint-test.js
@@ -17,7 +17,8 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
         },
       ],
       attestationLabel: 'Label attestation',
-      attestationKey: 'ATTESTATION_KEY',
+      rewardId: 5,
+      rewardType: 'ATTESTATION',
     });
 
     const serializedRecord = record.serialize();
@@ -39,7 +40,8 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
               },
             ],
             'attestation-label': 'Label attestation',
-            'attestation-key': 'ATTESTATION_KEY',
+            'reward-id': 5,
+            'reward-type': 'ATTESTATION',
           },
         },
       },

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -1,4 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
+import * as adminCombinedCourseBlueprintDetailsSerializer from '../infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js';
 import * as adminCombinedCourseBlueprintSerializer from '../infrastructure/serializers/admin-combined-course-blueprint-serializer.js';
 import * as combinedCourseBlueprintOrganizationSerializer from '../infrastructure/serializers/combined-course-blueprint-organization-serializer.js';
 import * as combinedCourseBlueprintSerializer from '../infrastructure/serializers/combined-course-blueprint-serializer.js';
@@ -18,9 +19,9 @@ const save = async (request, h, dependencies = { adminCombinedCourseBlueprintSer
   return h.response(dependencies.adminCombinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint)).created();
 };
 
-const getById = async (request, _, dependencies = { adminCombinedCourseBlueprintSerializer }) => {
+const getById = async (request, _, dependencies = { adminCombinedCourseBlueprintDetailsSerializer }) => {
   const combinedCourseBlueprint = await usecases.getCombinedCourseBlueprintById({ id: request.params.blueprintId });
-  return dependencies.adminCombinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
+  return dependencies.adminCombinedCourseBlueprintDetailsSerializer.serialize(combinedCourseBlueprint);
 };
 
 const detachOrganization = async (request, h) => {

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -2,7 +2,6 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
-import { contentSchema } from '../domain/models/AdminCombinedCourseBlueprint.js';
 import { combinedCourseBlueprintController } from './combined-course-blueprint-controller.js';
 
 const register = async function (server) {
@@ -53,8 +52,9 @@ const register = async function (server) {
                 'internal-name': Joi.string().required(),
                 illustration: Joi.string().allow(null),
                 description: Joi.string().allow(null),
-                'attestation-key': Joi.string().allow(null),
-                content: contentSchema,
+                'reward-id': Joi.number().integer().allow(null),
+                'reward-type': Joi.string().allow(null),
+                content: Joi.array(),
                 createdAt: Joi.date(),
               },
             },

--- a/api/src/quest/domain/constants.js
+++ b/api/src/quest/domain/constants.js
@@ -2,6 +2,11 @@ import { ATTESTATIONS_TABLE_NAME } from '../../../db/migrations/20240820101115_a
 import { CsvColumn } from '../../shared/infrastructure/serializers/csv/csv-column.js';
 
 export const REWARD_TYPES = { ATTESTATION: ATTESTATIONS_TABLE_NAME };
+
+export const COMBINED_COURSE_ITEM_TYPES = {
+  MODULE: 'module',
+  EVALUATION: 'evaluation',
+};
 export const QUEST_HEADER = {
   columns: [
     new CsvColumn({

--- a/api/src/quest/domain/models/AdminCombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/AdminCombinedCourseBlueprint.js
@@ -1,5 +1,4 @@
-import Joi from 'joi';
-
+import { ObjectValidationError } from '../../../shared/domain/errors.js';
 import { REQUIREMENT_TYPES } from './Quest.js';
 
 export class AdminCombinedCourseBlueprint {
@@ -9,9 +8,10 @@ export class AdminCombinedCourseBlueprint {
     internalName,
     description,
     illustration,
-    content,
-    attestationKey,
     attestationLabel,
+    rewardId = null,
+    rewardType = null,
+    quest,
     createdAt,
     updatedAt,
     organizationIds = [],
@@ -22,63 +22,23 @@ export class AdminCombinedCourseBlueprint {
     this.description = description;
     this.illustration = illustration;
     this.organizationIds = organizationIds;
-    this.content = content;
-    this.attestationKey = attestationKey;
     this.attestationLabel = attestationLabel;
+    this.rewardId = rewardId;
+    this.rewardType = rewardType;
+    this.quest = quest;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+
+    this.validate();
   }
 
-  static buildContentItems(items) {
-    const data = items.map(({ moduleShortId, targetProfileId }) => {
-      return moduleShortId
-        ? { type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: moduleShortId }
-        : { type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfileId };
-    });
-    return Joi.attempt(data, contentSchema);
+  get targetProfileIds() {
+    return this.quest.successRequirements
+      .filter((item) => item.requirement_type === REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS)
+      .map(({ data }) => parseInt(data.targetProfileId.data));
   }
 
-  static buildFromBlueprint({ combinedCourseBlueprint, modulesById, attestationLabel }) {
-    const items = combinedCourseBlueprint.quest.successRequirements.map((requirement) => {
-      if (requirement.requirement_type === REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
-        return { targetProfileId: requirement.data.targetProfileId.data };
-      } else if (requirement.requirement_type === REQUIREMENT_TYPES.OBJECT.PASSAGES) {
-        const module = modulesById[requirement.data.moduleId.data];
-        return { moduleShortId: module?.[0].shortId };
-      }
-    });
-
-    const content = AdminCombinedCourseBlueprint.buildContentItems(items);
-    return new AdminCombinedCourseBlueprint({ ...combinedCourseBlueprint, content, attestationLabel });
+  validate() {
+    if (!this.quest) throw new ObjectValidationError('Quest is required');
   }
 }
-
-export const ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS = {
-  MODULE: 'module',
-  EVALUATION: 'evaluation',
-};
-
-export const contentSchema = Joi.array()
-  .items(
-    Joi.object({
-      type: Joi.string()
-        .valid(ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
-        .required(),
-      value: Joi.alternatives()
-        .conditional('type', {
-          switch: [
-            {
-              is: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
-              then: Joi.number().integer(),
-            },
-            {
-              is: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-              then: Joi.string(),
-            },
-          ],
-        })
-        .required(),
-    }),
-  )
-  .required()
-  .strict();

--- a/api/src/quest/domain/models/AdminCombinedCourseBlueprintDetails.js
+++ b/api/src/quest/domain/models/AdminCombinedCourseBlueprintDetails.js
@@ -1,0 +1,14 @@
+import { AdminCombinedCourseBlueprint } from './AdminCombinedCourseBlueprint.js';
+import { QuestInput } from './QuestInput.js';
+
+export class AdminCombinedCourseBlueprintDetails extends AdminCombinedCourseBlueprint {
+  constructor({ content, ...rest }) {
+    super(rest);
+    this.content = content;
+  }
+
+  static buildFromBlueprint({ combinedCourseBlueprint, modulesById, attestationLabel }) {
+    const items = QuestInput.itemsFromQuest({ quest: combinedCourseBlueprint.quest, modulesById });
+    return new AdminCombinedCourseBlueprintDetails({ ...combinedCourseBlueprint, content: items, attestationLabel });
+  }
+}

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -1,5 +1,4 @@
 import { CampaignParticipationStatuses } from '../../../prescription/shared/domain/constants.js';
-import { ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS } from './AdminCombinedCourseBlueprint.js';
 import { CombinedCourse } from './CombinedCourse.js';
 import { CRITERION_COMPARISONS, Quest, REQUIREMENT_COMPARISONS, REQUIREMENT_TYPES } from './Quest.js';
 import { buildRequirement } from './Requirement.js';
@@ -78,36 +77,6 @@ export class CombinedCourseBlueprint {
       },
       quest,
     );
-  }
-
-  static buildWithQuest({ adminCombinedCourseBlueprint, modulesByShortId, rewardId, rewardType }) {
-    const successRequirements = adminCombinedCourseBlueprint.content.map((requirement) => {
-      if (requirement.type === ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION) {
-        const requirementTargetProfileId = requirement.value;
-        return CombinedCourseBlueprint.buildRequirementForCombinedCourse({
-          targetProfileId: requirementTargetProfileId,
-        });
-      } else if (requirement.type === ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE) {
-        const [module] = modulesByShortId[requirement.value];
-        return CombinedCourseBlueprint.buildRequirementForCombinedCourse({
-          moduleId: module.id,
-        });
-      } else {
-        return requirement;
-      }
-    });
-
-    const quest = new Quest({
-      rewardType,
-      rewardId,
-      eligibilityRequirements: [],
-      successRequirements,
-    });
-
-    return new CombinedCourseBlueprint({
-      ...adminCombinedCourseBlueprint,
-      quest,
-    });
   }
 
   static buildRequirementForCombinedCourse({ campaignId, moduleId, targetProfileId }) {

--- a/api/src/quest/domain/models/QuestInput.js
+++ b/api/src/quest/domain/models/QuestInput.js
@@ -1,0 +1,73 @@
+import Joi from 'joi';
+
+import { EntityValidationError } from '../../../shared/domain/errors.js';
+import { COMBINED_COURSE_ITEM_TYPES } from '../constants.js';
+import { CombinedCourseBlueprint } from './CombinedCourseBlueprint.js';
+import { Quest, REQUIREMENT_TYPES } from './Quest.js';
+
+const itemsSchema = Joi.array()
+  .items(
+    Joi.object({
+      type: Joi.string().valid(COMBINED_COURSE_ITEM_TYPES.EVALUATION, COMBINED_COURSE_ITEM_TYPES.MODULE).required(),
+      value: Joi.alternatives()
+        .conditional('type', {
+          switch: [
+            {
+              is: COMBINED_COURSE_ITEM_TYPES.EVALUATION,
+              then: Joi.number().integer(),
+            },
+            {
+              is: COMBINED_COURSE_ITEM_TYPES.MODULE,
+              then: Joi.string(),
+            },
+          ],
+        })
+        .required(),
+      shortId: Joi.string().optional(),
+    }),
+  )
+  .required()
+  .strict();
+
+export class QuestInput {
+  constructor({ items, rewardId, rewardType } = {}) {
+    this.items = items;
+    this.rewardId = rewardId;
+    this.rewardType = rewardType;
+    this.#validate();
+  }
+
+  #validate() {
+    const { error } = itemsSchema.validate(this.items);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: this.items });
+    }
+  }
+
+  toQuest() {
+    const successRequirements = this.items.map((item) => {
+      if (item.type === COMBINED_COURSE_ITEM_TYPES.MODULE) {
+        return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: item.value });
+      }
+      return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: item.value });
+    });
+
+    return new Quest({
+      eligibilityRequirements: [],
+      successRequirements,
+      rewardId: this.rewardId,
+      rewardType: this.rewardType,
+    });
+  }
+
+  static itemsFromQuest({ quest, modulesById }) {
+    return quest.successRequirements.map((requirement) => {
+      if (requirement.requirement_type === REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
+        return { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: requirement.data.targetProfileId.data };
+      }
+      const moduleId = requirement.data.moduleId.data;
+      const shortId = modulesById[moduleId][0].shortId;
+      return { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: moduleId, shortId };
+    });
+  }
+}

--- a/api/src/quest/domain/usecases/create-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/create-combined-course-blueprint.js
@@ -1,36 +1,13 @@
-import _ from 'lodash';
-
-import { ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS } from '../models/AdminCombinedCourseBlueprint.js';
 import { CombinedCourseBlueprint } from '../models/CombinedCourseBlueprint.js';
 
 export const createCombinedCourseBlueprint = async ({
   adminCombinedCourseBlueprint,
   combinedCourseBlueprintRepository,
   targetProfileRepository,
-  moduleRepository,
-  rewardRepository,
 }) => {
-  const targetProfileIds = adminCombinedCourseBlueprint.content
-    .filter((item) => item.type === ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION)
-    .map(({ value }) => value);
-  await targetProfileRepository.findByIds({ ids: targetProfileIds });
-
-  const moduleShortIds = adminCombinedCourseBlueprint.content
-    .filter((item) => item.type === ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
-    .map(({ value }) => value);
-  const modules = await moduleRepository.getByShortIds({ moduleShortIds });
-  const modulesByShortId = _.groupBy(modules, 'shortId');
-
-  const reward = adminCombinedCourseBlueprint.attestationKey
-    ? await rewardRepository.getByAttestationKey({ key: adminCombinedCourseBlueprint.attestationKey })
-    : null;
+  await targetProfileRepository.findByIds({ ids: adminCombinedCourseBlueprint.targetProfileIds });
 
   return combinedCourseBlueprintRepository.save({
-    combinedCourseBlueprint: CombinedCourseBlueprint.buildWithQuest({
-      adminCombinedCourseBlueprint,
-      modulesByShortId,
-      rewardId: reward?.id,
-      rewardType: reward?.type,
-    }),
+    combinedCourseBlueprint: new CombinedCourseBlueprint({ ...adminCombinedCourseBlueprint }),
   });
 };

--- a/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
@@ -1,5 +1,5 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
-import { AdminCombinedCourseBlueprint } from '../models/AdminCombinedCourseBlueprint.js';
+import { AdminCombinedCourseBlueprintDetails } from '../models/AdminCombinedCourseBlueprintDetails.js';
 import { REQUIREMENT_TYPES } from '../models/Quest.js';
 
 export const getCombinedCourseBlueprintById = async ({
@@ -22,7 +22,7 @@ export const getCombinedCourseBlueprintById = async ({
 
   const attestation = await attestationRepository.getByRewardId({ rewardId: combinedCourseBlueprint.quest.rewardId });
 
-  return AdminCombinedCourseBlueprint.buildFromBlueprint({
+  return AdminCombinedCourseBlueprintDetails.buildFromBlueprint({
     combinedCourseBlueprint,
     modulesById,
     attestationLabel: attestation.label,

--- a/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js
@@ -1,0 +1,20 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (adminCombinedCourseBlueprintDetails) {
+  return new Serializer('combined-course-blueprints', {
+    attributes: [
+      'name',
+      'internalName',
+      'description',
+      'illustration',
+      'content',
+      'createdAt',
+      'updatedAt',
+      'attestationLabel',
+    ],
+  }).serialize(adminCombinedCourseBlueprintDetails);
+};
+
+export { serialize };

--- a/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js
@@ -1,29 +1,30 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
+import { REWARD_TYPES } from '../../domain/constants.js';
 import { AdminCombinedCourseBlueprint } from '../../domain/models/AdminCombinedCourseBlueprint.js';
+import { QuestInput } from '../../domain/models/QuestInput.js';
 
 const { Deserializer, Serializer } = jsonapiSerializer;
 
-const serialize = function (adminCombinedCourseBlueprint) {
+const serialize = function (combinedCourseBlueprint) {
   return new Serializer('combined-course-blueprints', {
-    attributes: [
-      'name',
-      'internalName',
-      'description',
-      'illustration',
-      'content',
-      'createdAt',
-      'updatedAt',
-      'attestationLabel',
-    ],
-  }).serialize(adminCombinedCourseBlueprint);
+    attributes: ['name', 'internalName', 'description', 'illustration', 'createdAt', 'updatedAt'],
+  }).serialize(combinedCourseBlueprint);
 };
 
 const deserialize = async function (payload) {
   const deserializedData = await new Deserializer({
     keyForAttribute: 'camelCase',
   }).deserialize(payload);
-  return new AdminCombinedCourseBlueprint(deserializedData);
+  const questInput = new QuestInput({
+    items: deserializedData.content ?? [],
+    rewardId: deserializedData.rewardId,
+    rewardType: REWARD_TYPES[deserializedData.rewardType] ?? null,
+  });
+  return new AdminCombinedCourseBlueprint({
+    ...deserializedData,
+    quest: questInput.toQuest(),
+  });
 };
 
 export { deserialize, serialize };

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -1,6 +1,5 @@
 import { createServer } from '../../../../server.js';
 import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
-import { AdminCombinedCourseBlueprint } from '../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { expect } from '../../../test-helper.js';
 import { databaseBuilder } from '../../../tooling/databases.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../tooling/test-utils/http-server.js';
@@ -41,7 +40,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     context('when user is admin ', function () {
       it('should create a combined course blueprint', async function () {
         // given
-        databaseBuilder.factory.buildAttestation({ key: ATTESTATIONS.SIXTH_GRADE });
+        const attestation = databaseBuilder.factory.buildAttestation({ key: ATTESTATIONS.SIXTH_GRADE });
         const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         await databaseBuilder.commit();
 
@@ -53,8 +52,9 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               'internal-name': 'Mon schéma de parcours combiné',
               description: 'La description combinix',
               illustration: 'illustration.svg',
-              'attestation-key': ATTESTATIONS.SIXTH_GRADE,
-              content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
+              'reward-id': attestation.id,
+              'reward-type': 'ATTESTATION',
+              content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
             },
           },
         };

--- a/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
@@ -1,6 +1,7 @@
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { QuestInput } from '../../../../../src/quest/domain/models/QuestInput.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
@@ -10,30 +11,30 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 describe('Integration | Combined course | Domain | UseCases | create-combined-course-blueprint', function () {
   it('should create a combined course blueprint with quest', async function () {
     // given
-    const moduleShortId = '6a68bf32';
     const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
-    const modulesByShortId = { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] };
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     const attestation = databaseBuilder.factory.buildAttestation();
     await databaseBuilder.commit();
 
+    const content = [
+      { type: 'module', value: moduleId, shortId: '6a68bf32' },
+      { type: 'evaluation', value: targetProfileId },
+    ];
+    const questInput = new QuestInput({
+      items: content,
+      rewardId: attestation.id,
+      rewardType: REWARD_TYPES.ATTESTATION,
+    });
     const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId }, { targetProfileId }]),
-      attestationKey: attestation.key,
+      content,
+      quest: questInput.toQuest(),
     });
 
-    const expectedCombinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
-      adminCombinedCourseBlueprint,
-      modulesByShortId,
-      rewardId: attestation.id,
-      rewardType: REWARD_TYPES.ATTESTATION,
-    });
-
-    const expectedQuest = expectedCombinedCourseBlueprint.quest.toDTO();
+    const expectedQuest = adminCombinedCourseBlueprint.quest.toDTO();
 
     await usecases.createCombinedCourseBlueprint({ adminCombinedCourseBlueprint });
 
@@ -67,13 +68,17 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     await databaseBuilder.commit();
 
+    const content = [
+      { type: 'module', value: '6282925d-4775-4bca-b513-4c3009ec5886', shortId: '6a68bf32' },
+      { type: 'evaluation', value: targetProfileId },
+    ];
     const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }, { targetProfileId }]),
-      attestationKey: undefined,
+      content,
+      quest: new QuestInput({ items: content }).toQuest(),
     });
 
     await usecases.createCombinedCourseBlueprint({ adminCombinedCourseBlueprint });
@@ -98,29 +103,17 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     await databaseBuilder.commit();
 
+    const content = [
+      { type: 'evaluation', value: targetProfileId },
+      { type: 'evaluation', value: 123 },
+    ];
     const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { targetProfileId: 123 }]),
-    });
-
-    const error = await catchErr(usecases.createCombinedCourseBlueprint)({ adminCombinedCourseBlueprint });
-    expect(error).to.be.instanceOf(NotFoundError);
-  });
-
-  it('should return error if one of the modules in content is not found', async function () {
-    // given
-    const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
-      name: 'Mon épure',
-      internalName: 'Une épure pour tel niveau',
-      illustration: 'illustrations/mon-epure.png',
-      description: 'Description',
-      content: AdminCombinedCourseBlueprint.buildContentItems([
-        { moduleShortId: '6a68bf32' },
-        { moduleShortId: 'abc-123' },
-      ]),
+      content,
+      quest: new QuestInput({ items: content }).toQuest(),
     });
 
     const error = await catchErr(usecases.createCombinedCourseBlueprint)({ adminCombinedCourseBlueprint });

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 
-import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { COMBINED_COURSE_ITEM_TYPES, REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
@@ -62,9 +62,10 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
       organizationIds: [],
       attestationLabel,
     });
-    expect(adminCombinedCourseBlueprint.content).to.deep.equal(
-      AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: 'e074af34' }]),
-    );
+    expect(adminCombinedCourseBlueprint.content).to.deep.equal([
+      { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: targetProfileId },
+      { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: '9beb922f-4d8e-495d-9c85-0e7265ca78d6', shortId: 'e074af34' },
+    ]);
   });
 
   it('should throw when no combined course blueprint is found for a given id', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -6,6 +6,7 @@ import {
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../../src/quest/domain/models/Quest.js';
+import { QuestInput } from '../../../../../src/quest/domain/models/QuestInput.js';
 import * as combinedCourseBluePrintRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprint-repository.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
@@ -16,16 +17,20 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
     it('should create a combined course blueprint with its quest', async function () {
       // given
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
-        adminCombinedCourseBlueprint: new AdminCombinedCourseBlueprint({
+      const content = [
+        { type: 'evaluation', value: targetProfileId },
+        { type: 'module', value: '6282925d-4775-4bca-b513-4c3009ec5886', shortId: '6a68bf32' },
+      ];
+      const combinedCourseBlueprint = new CombinedCourseBlueprint({
+        ...new AdminCombinedCourseBlueprint({
           name: 'Combined course IA',
           internalName: 'Ia combined course blueprint',
           description: "L'ia c'est magique",
           illustration: 'illustration/ia.svg',
-          content: AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: '6a68bf32' }]),
+          content,
           organizationIds: [],
+          quest: new QuestInput({ items: content }).toQuest(),
         }),
-        modulesByShortId: { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] },
       });
 
       // when
@@ -131,17 +136,18 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
 
       await databaseBuilder.commit();
 
-      const combinedCourseBlueprintWithoutTargetProfile = CombinedCourseBlueprint.buildWithQuest({
-        adminCombinedCourseBlueprint: new AdminCombinedCourseBlueprint({
+      const updatedContent = [{ type: 'module', value: '6282925d-4775-4bca-b513-4c3009ec5886', shortId: '6a68bf32' }];
+      const combinedCourseBlueprintWithoutTargetProfile = new CombinedCourseBlueprint({
+        ...new AdminCombinedCourseBlueprint({
           id: combinedCourseBlueprintInDb.id,
           name: 'Updated Combined course IA',
           internalName: 'Ia combined course blueprint',
           description: "L'ia c'est magique",
           illustration: 'illustration/ia.svg',
-          content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
+          content: updatedContent,
           organizationIds: [],
+          quest: new QuestInput({ items: updatedContent }).toQuest(),
         }),
-        modulesByShortId: { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] },
       });
 
       // when

--- a/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
 import { combinedCourseBlueprintController } from '../../../../src/quest/application/combined-course-blueprint-controller.js';
 import * as combinedCourseBlueprintRoute from '../../../../src/quest/application/combined-course-blueprint-route.js';
-import { AdminCombinedCourseBlueprint } from '../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect } from '../../../test-helper.js';
 import { HttpTestServer } from '../../../tooling/server/http-test-server.js';
@@ -54,7 +53,7 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
             description: 'La description combinix',
             illustration: 'illustration.svg',
             'attestation-key': ATTESTATIONS.SIXTH_GRADE,
-            content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
+            content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
           },
         },
       };

--- a/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprintDetails_test.js
+++ b/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprintDetails_test.js
@@ -1,0 +1,47 @@
+import { COMBINED_COURSE_ITEM_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { AdminCombinedCourseBlueprintDetails } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprintDetails.js';
+import { QuestInput } from '../../../../../src/quest/domain/models/QuestInput.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprintDetails ', function () {
+  describe('#constructor', function () {
+    it('should set content alongside inherited properties', function () {
+      const items = [{ type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: 12 }];
+      const quest = new QuestInput({ items }).toQuest();
+      const content = [{ type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: 12 }];
+
+      const details = new AdminCombinedCourseBlueprintDetails({ quest, content });
+
+      expect(details.content).to.deep.equal(content);
+      expect(details.quest).to.equal(quest);
+    });
+  });
+
+  describe('.buildFromBlueprint', function () {
+    it('should build details with content derived from quest', function () {
+      const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
+      const shortId = 'abc123';
+      const targetProfileId = 42;
+      const items = [
+        { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: moduleId },
+        { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: targetProfileId },
+      ];
+      const quest = new QuestInput({ items }).toQuest();
+      const combinedCourseBlueprint = { id: 1, name: 'test', quest };
+      const modulesById = { [moduleId]: [{ shortId }] };
+
+      const details = AdminCombinedCourseBlueprintDetails.buildFromBlueprint({
+        combinedCourseBlueprint,
+        modulesById,
+        attestationLabel: 'Mon attestation',
+      });
+
+      expect(details).to.be.instanceOf(AdminCombinedCourseBlueprintDetails);
+      expect(details.attestationLabel).to.equal('Mon attestation');
+      expect(details.content).to.deep.equal([
+        { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: moduleId, shortId },
+        { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: targetProfileId },
+      ]);
+    });
+  });
+});

--- a/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprint_test.js
@@ -1,15 +1,15 @@
-import { ATTESTATIONS } from '../../../../../src/profile/domain/constants.js';
-import {
-  ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS,
-  AdminCombinedCourseBlueprint,
-} from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
-import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { COMBINED_COURSE_ITEM_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
+import { QuestInput } from '../../../../../src/quest/domain/models/QuestInput.js';
+import { ObjectValidationError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprint ', function () {
   describe('#constructor', function () {
     it('should construct object', function () {
+      const quest = domainBuilder.buildQuest();
       // given
       const values = {
         id: 1,
@@ -17,9 +17,10 @@ describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprint ', funct
         internalName: 'internalName',
         description: 'description',
         illustration: 'illustration',
-        content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '123' }]),
-        attestationKey: ATTESTATIONS.PARENTHOOD,
         attestationLabel: 'Parentalité',
+        rewardId: 1,
+        rewardType: 'attestations',
+        quest,
         createdAt: new Date(),
         updatedAt: new Date(),
         organizationIds: [],
@@ -30,60 +31,27 @@ describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprint ', funct
       // then
       expect(blueprint).deep.equal(values);
     });
-  });
 
-  describe('#buildContentItems', function () {
-    it('should build blueprint content items for targetProfileId and moduleId', function () {
-      const requirements = AdminCombinedCourseBlueprint.buildContentItems([
-        { targetProfileId: 123 },
-        { moduleShortId: 'az-123' },
-      ]);
+    it('should throw if quest is not provided', function () {
+      const error = catchErrSync(() => new AdminCombinedCourseBlueprint({ name: 'test' }))();
 
-      expect(requirements).deep.equal([
-        {
-          type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
-          value: 123,
-        },
-        {
-          type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-          value: 'az-123',
-        },
-      ]);
+      expect(error).to.be.an.instanceOf(ObjectValidationError);
+      expect(error.message).to.equal('Quest is required');
     });
   });
 
-  describe('#buildFromBlueprint', function () {
-    it('should return an object containing combined course blueprint, content and attestation key', function () {
-      // given
-      const combinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
-        quest: domainBuilder.buildQuest({
-          successRequirements: [
-            CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: 123 }),
-            CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: 'completeId-az-123' }),
-          ],
-        }),
+  describe('#targetProfileIds', function () {
+    it('should return target profile ids from quest success requirements', function () {
+      const items = [
+        { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: 12 },
+        { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: '6282925d-4775-4bca-b513-4c3009ec5886' },
+        { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: 34 },
+      ];
+      const blueprint = new AdminCombinedCourseBlueprint({
+        quest: new QuestInput({ items }).toQuest(),
       });
 
-      const expectedContent = AdminCombinedCourseBlueprint.buildContentItems([
-        { targetProfileId: 123 },
-        { moduleShortId: 'az-123' },
-      ]);
-
-      // when
-      const readyToSerialize = AdminCombinedCourseBlueprint.buildFromBlueprint({
-        combinedCourseBlueprint,
-        modulesById: { 'completeId-az-123': [{ shortId: 'az-123' }] },
-        attestationLabel: 'Parentalité',
-      });
-
-      // then
-      expect(readyToSerialize).deep.equal(
-        new AdminCombinedCourseBlueprint({
-          ...combinedCourseBlueprint,
-          content: expectedContent,
-          attestationLabel: 'Parentalité',
-        }),
-      );
+      expect(blueprint.targetProfileIds).to.deep.equal([12, 34]);
     });
   });
 });

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -1,9 +1,6 @@
-import { ATTESTATIONS } from '../../../../../src/profile/domain/constants.js';
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
-import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
-import { Module } from '../../../../../src/quest/domain/models/Module.js';
 import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
 import { expect } from '../../../../test-helper.js';
 
@@ -174,60 +171,6 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       expect(combinedCourse.illustration).to.equal(illustration);
       expect(combinedCourse.code).to.equal(code);
       expect(combinedCourse.organizationId).to.equal(organizationId);
-    });
-  });
-
-  describe('#buildWithQuest', function () {
-    it('should return combined course blueprint with quest', async function () {
-      // given
-      const targetProfileId = 1;
-      const moduleShortId = 'ecc13f55';
-      const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
-      const modulesByShortId = {
-        ecc13f55: [new Module({ id: moduleId })],
-      };
-      const content = AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId, moduleShortId }]);
-      const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
-        id: 1,
-        name: 'Combinix',
-        internalName: 'Combinix',
-        description: 'bla bla bla',
-        illustration: 'illu.svg',
-        content,
-        attestationKey: ATTESTATIONS.PARENTHOOD,
-        organizationIds: [1, 2],
-        createdAt: new Date(),
-      });
-
-      const expectedBlueprintQuest = new Quest({
-        rewardId: 1,
-        rewardType: REWARD_TYPES.ATTESTATION,
-        eligibilityRequirements: [],
-        successRequirements: [
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: targetProfileId }),
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }),
-        ],
-      });
-
-      // when
-      const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
-        adminCombinedCourseBlueprint,
-        modulesByShortId,
-        rewardId: 1,
-        rewardType: REWARD_TYPES.ATTESTATION,
-      });
-
-      // then
-      expect(combinedCourseBlueprint).to.be.instanceOf(CombinedCourseBlueprint);
-      expect(combinedCourseBlueprint.name).to.equal(adminCombinedCourseBlueprint.name);
-      expect(combinedCourseBlueprint.internalName).to.equal(adminCombinedCourseBlueprint.internalName);
-      expect(combinedCourseBlueprint.description).to.equal(adminCombinedCourseBlueprint.description);
-      expect(combinedCourseBlueprint.illustration).to.equal(adminCombinedCourseBlueprint.illustration);
-      expect(combinedCourseBlueprint.createdAt).to.equal(adminCombinedCourseBlueprint.createdAt);
-      expect(combinedCourseBlueprint.organizationIds).to.deep.equal([1, 2]);
-
-      expect(combinedCourseBlueprint.quest).to.be.instanceOf(Quest);
-      expect(combinedCourseBlueprint.quest).to.deep.equal(expectedBlueprintQuest);
     });
   });
 

--- a/api/tests/quest/unit/domain/models/QuestInput_test.js
+++ b/api/tests/quest/unit/domain/models/QuestInput_test.js
@@ -1,0 +1,155 @@
+import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import {
+  CRITERION_COMPARISONS,
+  Quest,
+  REQUIREMENT_COMPARISONS,
+  REQUIREMENT_TYPES,
+} from '../../../../../src/quest/domain/models/Quest.js';
+import { QuestInput } from '../../../../../src/quest/domain/models/QuestInput.js';
+import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Models | QuestInput', function () {
+  describe('#constructor', function () {
+    it('should throw if an item has an invalid type', function () {
+      expect(() => new QuestInput({ items: [{ type: 'invalid', value: 'x' }] })).to.throw(EntityValidationError);
+    });
+
+    it('should throw if an evaluation item has a non-integer value', function () {
+      expect(() => new QuestInput({ items: [{ type: 'evaluation', value: 'not-an-int' }] })).to.throw(
+        EntityValidationError,
+      );
+    });
+  });
+
+  describe('#toQuest', function () {
+    it('should build a quest from a module item', function () {
+      const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+      const questInput = new QuestInput({ items: [{ type: 'module', value: moduleId }] });
+
+      const quest = questInput.toQuest();
+
+      expect(quest).to.be.instanceOf(Quest);
+      expect(quest.eligibilityRequirements).to.deep.equal([]);
+      expect(quest.successRequirements.map((r) => r.toDTO())).to.deep.equal([
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          data: {
+            moduleId: { data: moduleId, comparison: CRITERION_COMPARISONS.EQUAL },
+            isTerminated: { data: true, comparison: CRITERION_COMPARISONS.EQUAL },
+          },
+        },
+      ]);
+    });
+
+    it('should build a quest from an evaluation item', function () {
+      const targetProfileId = 42;
+      const questInput = new QuestInput({ items: [{ type: 'evaluation', value: targetProfileId }] });
+
+      const quest = questInput.toQuest();
+
+      expect(quest).to.be.instanceOf(Quest);
+      expect(quest.eligibilityRequirements).to.deep.equal([]);
+      expect(quest.successRequirements.map((r) => r.toDTO())).to.deep.equal([
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          data: {
+            targetProfileId: { data: targetProfileId, comparison: CRITERION_COMPARISONS.EQUAL },
+            status: { data: CampaignParticipationStatuses.SHARED, comparison: CRITERION_COMPARISONS.EQUAL },
+          },
+        },
+      ]);
+    });
+
+    it('should build a quest from mixed items', function () {
+      const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+      const targetProfileId = 42;
+      const questInput = new QuestInput({
+        items: [
+          { type: 'module', value: moduleId },
+          { type: 'evaluation', value: targetProfileId },
+        ],
+      });
+
+      const quest = questInput.toQuest();
+
+      expect(quest.successRequirements.map((r) => r.toDTO())).to.deep.equal([
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          data: {
+            moduleId: { data: moduleId, comparison: CRITERION_COMPARISONS.EQUAL },
+            isTerminated: { data: true, comparison: CRITERION_COMPARISONS.EQUAL },
+          },
+        },
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          data: {
+            targetProfileId: { data: targetProfileId, comparison: CRITERION_COMPARISONS.EQUAL },
+            status: { data: CampaignParticipationStatuses.SHARED, comparison: CRITERION_COMPARISONS.EQUAL },
+          },
+        },
+      ]);
+    });
+
+    it('should include rewardId and rewardType in the quest', function () {
+      const questInput = new QuestInput({ items: [], rewardId: 7, rewardType: REWARD_TYPES.ATTESTATION });
+
+      const quest = questInput.toQuest();
+
+      expect(quest.rewardId).to.equal(7);
+      expect(quest.rewardType).to.equal(REWARD_TYPES.ATTESTATION);
+    });
+
+    it('should build a quest without reward', function () {
+      const questInput = new QuestInput({ items: [] });
+
+      const quest = questInput.toQuest();
+
+      expect(quest.rewardId).to.be.undefined;
+      expect(quest.rewardType).to.be.undefined;
+    });
+  });
+
+  describe('#itemsFromQuest', function () {
+    it('should rebuild items from a quest with mixed requirements', function () {
+      const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+      const shortId = 'az-123';
+      const targetProfileId = 42;
+      const quest = new QuestInput({
+        items: [
+          { type: 'module', value: moduleId, shortId },
+          { type: 'evaluation', value: targetProfileId },
+        ],
+      }).toQuest();
+      const modulesById = { [moduleId]: [{ shortId }] };
+
+      const items = QuestInput.itemsFromQuest({ quest, modulesById });
+
+      expect(items).to.deep.equal([
+        { type: 'module', value: moduleId, shortId },
+        { type: 'evaluation', value: targetProfileId },
+      ]);
+    });
+
+    it('should produce items that round-trip through buildContentItems', function () {
+      const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+      const shortId = 'az-123';
+      const targetProfileId = 42;
+      const originalContent = [
+        { type: 'module', value: moduleId, shortId },
+        { type: 'evaluation', value: targetProfileId },
+      ];
+      const quest = new QuestInput({ items: originalContent }).toQuest();
+      const modulesById = { [moduleId]: [{ shortId }] };
+
+      const rebuiltContent = QuestInput.itemsFromQuest({ quest, modulesById });
+
+      expect(rebuiltContent).to.deep.equal(originalContent);
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-details-serializer_test.js
@@ -1,0 +1,49 @@
+import { COMBINED_COURSE_ITEM_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { AdminCombinedCourseBlueprintDetails } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprintDetails.js';
+import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
+import * as adminCombinedCourseBlueprintDetailsSerializer from '../../../../../src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-blueprint-details', function () {
+  it('#serialize', function () {
+    // given
+    const adminCombinedCourseBlueprintDetails = new AdminCombinedCourseBlueprintDetails({
+      id: 1,
+      name: 'Mon parcours',
+      internalName: 'Mon modèle de parcours',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      illustration: '/illustrations/image.svg',
+      content: [
+        { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: 'mon-module', shortId: 'short-mon-module' },
+        { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: 123 },
+      ],
+      attestationLabel: '6ème',
+      organizationIds: [],
+      quest: new Quest({ eligibilityRequirements: [], successRequirements: [], rewardId: null, rewardType: null }),
+    });
+
+    // when
+    const serialized = adminCombinedCourseBlueprintDetailsSerializer.serialize(adminCombinedCourseBlueprintDetails);
+
+    // then
+    expect(serialized).to.deep.equal({
+      data: {
+        attributes: {
+          name: 'Mon parcours',
+          'internal-name': 'Mon modèle de parcours',
+          illustration: '/illustrations/image.svg',
+          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          content: [
+            { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: 'mon-module', shortId: 'short-mon-module' },
+            { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: 123 },
+          ],
+          'created-at': adminCombinedCourseBlueprintDetails.createdAt,
+          'updated-at': adminCombinedCourseBlueprintDetails.updatedAt,
+          'attestation-label': '6ème',
+        },
+        type: 'combined-course-blueprints',
+        id: '1',
+      },
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-serializer_test.js
@@ -1,62 +1,18 @@
-import {
-  ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS,
-  AdminCombinedCourseBlueprint,
-} from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
+import { COMBINED_COURSE_ITEM_TYPES, REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
 import * as adminCombinedCourseBlueprintSerializer from '../../../../../src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-blueprint', function () {
-  it('#serialize', function () {
-    // given
-    const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
-      id: 1,
-      name: 'Mon parcours',
-      internalName: 'Mon modèle de parcours',
-      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-      illustration: '/illustrations/image.svg',
-      content: AdminCombinedCourseBlueprint.buildContentItems([
-        { moduleShortId: 'mon-module' },
-        { targetProfileId: 123 },
-      ]),
-      attestationKey: 'SIXTH_GRADE',
-      attestationLabel: '6ème',
-      organizationIds: [],
-    });
-
-    // when
-    const serializedCombinedCourseBlueprint =
-      adminCombinedCourseBlueprintSerializer.serialize(adminCombinedCourseBlueprint);
-
-    // then
-    expect(serializedCombinedCourseBlueprint).to.deep.equal({
-      data: {
-        attributes: {
-          name: 'Mon parcours',
-          'internal-name': 'Mon modèle de parcours',
-          illustration: '/illustrations/image.svg',
-          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-          content: [
-            {
-              type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-              value: 'mon-module',
-            },
-            {
-              type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
-              value: 123,
-            },
-          ],
-          'created-at': adminCombinedCourseBlueprint.createdAt,
-          'updated-at': adminCombinedCourseBlueprint.updatedAt,
-          'attestation-label': '6ème',
-        },
-        type: 'combined-course-blueprints',
-        id: '1',
-      },
-    });
-  });
-
   it('#deserialize', async function () {
     const date = new Date();
+    const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+    const items = [
+      { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: moduleId },
+      { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: 123 },
+    ];
     // given
     const serializedBlueprint = {
       data: {
@@ -65,17 +21,9 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
           'internal-name': 'Mon modèle de parcours',
           illustration: '/illustrations/image.svg',
           description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-          'attestation-key': 'SIXTH_GRADE',
-          content: [
-            {
-              type: 'passages',
-              value: 'mon-module',
-            },
-            {
-              type: 'campaignParticipations',
-              value: 123,
-            },
-          ],
+          'reward-id': 5,
+          'reward-type': 'ATTESTATION',
+          content: items,
           'created-at': date,
           'updated-at': date,
         },
@@ -85,30 +33,30 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
     };
 
     // when
-    const deserialize = await adminCombinedCourseBlueprintSerializer.deserialize(serializedBlueprint);
+    const result = await adminCombinedCourseBlueprintSerializer.deserialize(serializedBlueprint);
 
     // then
-    expect(deserialize).deep.equal({
-      id: '1',
-      name: 'Mon parcours',
-      internalName: 'Mon modèle de parcours',
-      illustration: '/illustrations/image.svg',
-      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-      content: [
-        {
-          type: 'passages',
-          value: 'mon-module',
-        },
-        {
-          type: 'campaignParticipations',
-          value: 123,
-        },
-      ],
-      attestationKey: 'SIXTH_GRADE',
-      attestationLabel: undefined,
-      organizationIds: [],
-      createdAt: date,
-      updatedAt: date,
-    });
+    expect(result).to.deep.equal(
+      new AdminCombinedCourseBlueprint({
+        id: '1',
+        name: 'Mon parcours',
+        internalName: 'Mon modèle de parcours',
+        illustration: '/illustrations/image.svg',
+        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        rewardId: 5,
+        rewardType: 'ATTESTATION',
+        createdAt: date,
+        updatedAt: date,
+        quest: new Quest({
+          eligibilityRequirements: [],
+          successRequirements: [
+            CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }),
+            CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: 123 }),
+          ],
+          rewardId: 5,
+          rewardType: REWARD_TYPES.ATTESTATION,
+        }),
+      }),
+    );
   });
 });


### PR DESCRIPTION
## 💥 Problème

Aujourd'hui, on utilise les shortIds pour les modules et les keys pour les attestations. Le problème c'est que ça oblige à aller chercher des données en plus alors qu'on a déjà les ids côté PixAdmin et qu'on pourrait les envoyer au backend directement. 

## 👩‍🚀 Proposition

Front : 
- Remplacer attestationKey par rewardId/rewardType (attestations en dur) 
- Remplacer moduleShortId par moduleId
- Refacto de RequirementTag qui vient cacher le comportement spécifique par type

Back: 
- Centralisation la conversion en quest des données envoyées par le front dans un nouveau model QuestInput
- Séparation en deux models de la logique de création (AdminCombinedCourseBlueprint) et de la logique d'affichage (AdminCombinedCourseBlueprintDetails)

## 👁️ Remarques

Cela permet de bien séparer la responsabilité de chaque objet et de supprimer deux requêtes à la base de données.

## ♻️ Pour tester

- Se connecter en super admin sur PixAdmin
- Créer un schéma de parcours combiné avec en récompense une attestation et en contenu au moins une campagne et un module
- Vérifier que la création se passe bien
- Vérifier dans les détails du parcours combiné qu'on retrouve bien tous les éléments