### PR TITLE
[TECH] Ajout d'une commande pour start l'environnement local de certif

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lint:yaml": "eslint --fix .circleci/*.yml .github/**/*.yaml",
     "lint:docs": "find ./docs -type f -name '*.md' | xargs -L1 markdown-link-check --quiet --config ./docs/link--check-config.json ",
     "preinstall": "npx check-engine",
+    "dev:team-certif": "run-p --print-label dev:api dev:mon-pix dev:certif dev:admin",
     "dev:admin": "cd admin && npm run dev",
     "dev:api": "cd api && npm run dev",
     "dev:certif": "cd certif && npm run dev",


### PR DESCRIPTION
## 💥 Problème

C'est un peu relou de lancer tout les fronts pour start son environnement locale

## 👩‍🚀 Proposition

Ajout d'une commande pour lancer les front pour l'environnement de certif + l'API en local

## 👁️ Remarques

Les autres utilisateurs qui ont consulté cette PR ont aussi consulté #16250

## ♻️ Pour tester
Lancer la command `npm run dev:team-certif` et avoir les 3 front admin/certif/mon-pix de lancé avec l'api