### PR TITLE
[BUGFIX] Changement d'une clé de traduction (PIX-22782)

### DIFF
--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1329,7 +1329,7 @@
         "CandidateNotEligibleEvent": "Candidat non éligible à la double certification",
         "CandidateReconciledEvent": "Candidat réconcilié à un compte utilisateur",
         "CertificationStartedEvent": "Entrée en certification",
-        "LastAnswerEvent": "Dernière réponse le"
+        "LastAnsweredEvent": "Dernière réponse le"
       },
       "metadata": "Metadata",
       "title": "Journal d'évènements",


### PR DESCRIPTION
## 💥 Problème

la clé d'une  traduction est mal nommé

## 👩‍🚀 Proposition

fix it !

## 👁️ Remarques

RAS

## ♻️ Pour tester

Aller sur la timeline d'un candidat et observer que toute les trad sont ok
[timeline](https://admin-pr16252.review.pix.fr/candidates/11/timeline)