### PR TITLE
[TECH] Suppression de restes de language inclusif (PIX-22798).

### DIFF
--- a/mon-pix/tests/integration/components/certification-joiner-test.js
+++ b/mon-pix/tests/integration/components/certification-joiner-test.js
@@ -173,7 +173,7 @@ module('Integration | Component | certification-joiner', function (hooks) {
       // then
       assert.ok(
         screen.getByText(
-          'Les informations saisies correspondent à un.e candidat.e inscrit.e à la session et déjà connecté.e avec un autre compte. Vérifiez que vous êtes connecté.e au compte qui a démarré la certification.',
+          'Les informations saisies correspondent à un(e) candidat(e) inscrit(e) à la session et déjà connecté(e) avec un autre compte. Vérifiez que vous êtes connecté(e) au compte qui a démarré la certification.',
         ),
       );
     });

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -877,7 +877,7 @@
         "language-not-supported-link": "Mon compte",
         "missing-center-habilitation": "Vous ne pouvez pas rejoindre la session. Le centre de certification n'est pas habilité à vous faire passer cette certification.",
         "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
-        "wrong-account": "Les informations saisies correspondent à un.e candidat.e inscrit.e à la session et déjà connecté.e avec un autre compte. Vérifiez que vous êtes connecté.e au compte qui a démarré la certification.",
+        "wrong-account": "Les informations saisies correspondent à un(e) candidat(e) inscrit(e) à la session et déjà connecté(e) avec un autre compte. Vérifiez que vous êtes connecté(e) au compte qui a démarré la certification.",
         "wrong-account-sco": "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement.\nConnectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant.",
         "wrong-account-sco-link": {
           "label": "Comment trouver le compte lié à l'établissement ?",


### PR DESCRIPTION
## 💥 Problème

L'écriture inclusive ne correspond pas à la ligne édito de Pix et il en reste dans l'application.

## 👩‍🚀 Proposition

Suppression de ces restes

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester

Se connecter à une certification avec les informations d'un candidat déjà rentré en session sous un autre compte.
