### PR TITLE
[TECH] Déplacer les erreurs certification définies dans shared

### DIFF
--- a/api/src/certification/enrolment/application/http-error-mapper-configuration.js
+++ b/api/src/certification/enrolment/application/http-error-mapper-configuration.js
@@ -1,7 +1,6 @@
 import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
 import {
   CertificationCandidateForbiddenDeletionError,
-  CertificationCandidateNotFoundError,
   InvalidCertificationCandidate,
   SessionStartedDeletionError,
   UnknownCountryForStudentEnrolmentError,
@@ -12,10 +11,6 @@ const enrolmentDomainErrorMappingConfiguration = [
   {
     name: CertificationCandidateForbiddenDeletionError.name,
     httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
-  },
-  {
-    name: CertificationCandidateNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code),
   },
   { name: SessionStartedDeletionError.name, httpErrorFn: (error) => new HttpErrors.ConflictError(error.message) },
   {

--- a/api/src/certification/enrolment/domain/errors.js
+++ b/api/src/certification/enrolment/domain/errors.js
@@ -13,12 +13,6 @@ class SessionStartedDeletionError extends DomainError {
   }
 }
 
-class CertificationCandidateNotFoundError extends DomainError {
-  constructor(message = 'Certification candidate not found') {
-    super(message);
-  }
-}
-
 class UnknownCountryForStudentEnrolmentError extends DomainError {
   constructor(
     { firstName, lastName },
@@ -99,7 +93,6 @@ class WrongDomainExtensionForPixPlusError extends DomainError {
 
 export {
   CertificationCandidateForbiddenDeletionError,
-  CertificationCandidateNotFoundError,
   InvalidCertificationCandidate,
   SessionStartedDeletionError,
   UnknownCountryForStudentEnrolmentError,

--- a/api/src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js
+++ b/api/src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js
@@ -2,7 +2,7 @@
  * @typedef {import ('./index.js').CandidateRepository} CandidateRepository
  * @typedef {import ('../models/Candidate.js').Candidate} Candidate
  */
-import { CertificationCandidateNotFoundError } from '../errors.js';
+import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
 
 /**
  * @param {object} params

--- a/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
@@ -3,10 +3,8 @@
  */
 
 import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import {
-  CandidateAlreadyLinkedToUserError,
-  CertificationCandidateNotFoundError,
-} from '../../../../shared/domain/errors.js';
+import { CandidateAlreadyLinkedToUserError } from '../../../../shared/domain/errors.js';
+import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
 
 /**
  * @param {object} params

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
-import { CertificationCandidateNotFoundError } from '../../domain/errors.js';
+import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
 import { Candidate } from '../../domain/models/Candidate.js';
 import { Subscription } from '../../domain/models/Subscription.js';
 

--- a/api/src/certification/evaluation/domain/errors.js
+++ b/api/src/certification/evaluation/domain/errors.js
@@ -1,15 +1,9 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 
-class ChallengeAlreadyAnsweredError extends DomainError {
-  constructor() {
-    super('La question a déjà été répondue.', 'ALREADY_ANSWERED_ERROR');
-  }
-}
-
 class CertificationComputeError extends DomainError {
   constructor(message = 'Erreur lors du calcul de la certification.') {
     super(message);
   }
 }
 
-export { CertificationComputeError, ChallengeAlreadyAnsweredError };
+export { CertificationComputeError };

--- a/api/src/certification/evaluation/domain/usecases/create-live-alert.js
+++ b/api/src/certification/evaluation/domain/usecases/create-live-alert.js
@@ -1,5 +1,5 @@
+import { ChallengeAlreadyAnsweredError } from '../../../../shared/domain/errors.js';
 import { CertificationChallengeLiveAlert } from '../../../shared/domain/models/CertificationChallengeLiveAlert.js'; // todo me déplacer
-import { ChallengeAlreadyAnsweredError } from '../errors.js';
 
 export async function createLiveAlert({
   assessmentId,

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
+import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
 import { Candidate } from '../../domain/models/Candidate.js';
 
 /**

--- a/api/src/certification/results/application/http-error-mapper-configuration.js
+++ b/api/src/certification/results/application/http-error-mapper-configuration.js
@@ -1,5 +1,9 @@
 import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
-import { MoreThanOneMatchingCertificationError, NoCertificationResultForDivision } from '../domain/errors.js';
+import {
+  CertificateGenerationError,
+  MoreThanOneMatchingCertificationError,
+  NoCertificationResultForDivision,
+} from '../domain/errors.js';
 
 const parcoursupDomainErrorMappingConfiguration = [
   {
@@ -12,6 +16,10 @@ const resultsDomainErrorMappingConfiguration = [
   {
     name: NoCertificationResultForDivision.name,
     httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code, error.meta),
+  },
+  {
+    name: CertificateGenerationError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/certification/session-management/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session-management/application/http-error-mapper-configuration.js
@@ -5,6 +5,7 @@ import {
   ChallengeToBeNeutralizedNotFoundError,
   InvalidSessionSupervisingLoginError,
   SendingEmailToRefererError,
+  SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionNotAccessible,
@@ -51,6 +52,10 @@ const sessionDomainErrorMappingConfiguration = [
   },
   {
     name: SendingEmailToRefererError.name,
+    httpErrorFn: (error) => new HttpErrors.ServiceUnavailableError(error.message),
+  },
+  {
+    name: SendingEmailToResultRecipientError.name,
     httpErrorFn: (error) => new HttpErrors.ServiceUnavailableError(error.message),
   },
 ];

--- a/api/src/certification/session-management/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session-management/application/http-error-mapper-configuration.js
@@ -4,6 +4,7 @@ import {
   ChallengeToBeDeneutralizedNotFoundError,
   ChallengeToBeNeutralizedNotFoundError,
   InvalidSessionSupervisingLoginError,
+  SendingEmailToRefererError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionNotAccessible,
@@ -47,6 +48,10 @@ const sessionDomainErrorMappingConfiguration = [
   {
     name: CertificationCenterIsArchivedError.name,
     httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+  },
+  {
+    name: SendingEmailToRefererError.name,
+    httpErrorFn: (error) => new HttpErrors.ServiceUnavailableError(error.message),
   },
 ];
 

--- a/api/src/certification/session-management/domain/errors.js
+++ b/api/src/certification/session-management/domain/errors.js
@@ -47,13 +47,6 @@ class SessionWithMissingAbortReasonError extends DomainError {
   }
 }
 
-class CsvWithNoSessionDataError extends DomainError {
-  constructor(message = 'No session data in csv') {
-    super(message);
-    this.code = 'CSV_DATA_REQUIRED';
-  }
-}
-
 class ChallengeToBeNeutralizedNotFoundError extends DomainError {
   constructor() {
     super("La question à neutraliser n'a pas été posée lors du test de certification");
@@ -107,7 +100,6 @@ export {
   CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually,
   ChallengeToBeDeneutralizedNotFoundError,
   ChallengeToBeNeutralizedNotFoundError,
-  CsvWithNoSessionDataError,
   InvalidSessionSupervisingLoginError,
   SendingEmailToRefererError,
   SendingEmailToResultRecipientError,

--- a/api/src/certification/session-management/domain/usecases/validate-live-alert.js
+++ b/api/src/certification/session-management/domain/usecases/validate-live-alert.js
@@ -5,8 +5,7 @@
  * @typedef {import('./index.js').CertificationIssueReportRepository} CertificationIssueReportRepository
  */
 
-import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { ChallengeAlreadyAnsweredError } from '../../../evaluation/domain/errors.js';
+import { ChallengeAlreadyAnsweredError, NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationIssueReport } from '../../../shared/domain/models/CertificationIssueReport.js';
 import { CertificationIssueReportCategory } from '../../../shared/domain/models/CertificationIssueReportCategory.js';
 

--- a/api/src/certification/session-management/infrastructure/repositories/certification-candidate-for-supervising-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-candidate-for-supervising-repository.js
@@ -1,5 +1,5 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
+import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
 import { CertificationCandidateForSupervising } from '../../domain/models/CertificationCandidateForSupervising.js';
 
 const get = async function ({ certificationCandidateId }) {

--- a/api/src/certification/shared/application/helpers/csvHelpers.js
+++ b/api/src/certification/shared/application/helpers/csvHelpers.js
@@ -6,7 +6,7 @@ const { readFile, access } = promises;
 import papa from 'papaparse';
 
 import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { CsvWithNoSessionDataError } from '../../../session-management/domain/errors.js';
+import { CsvWithNoSessionDataError } from '../../domain/errors.js';
 
 const optionsWithHeader = {
   skipEmptyLines: true,

--- a/api/src/certification/shared/application/http-error-mapper-configuration.js
+++ b/api/src/certification/shared/application/http-error-mapper-configuration.js
@@ -8,6 +8,7 @@ import {
 import { sessionDomainErrorMappingConfiguration } from '../../session-management/application/http-error-mapper-configuration.js';
 import {
   CenterHabilitationError,
+  CertificationCandidateNotFoundError,
   CertificationCourseUpdateError,
   InvalidCertificationReportForFinalization,
 } from '../domain/errors.js';
@@ -26,6 +27,10 @@ const certificationDomainErrorMappingConfiguration = [
   {
     name: CenterHabilitationError.name,
     httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
+  },
+  {
+    name: CertificationCandidateNotFoundError.name,
+    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code),
   },
 ];
 

--- a/api/src/certification/shared/application/http-error-mapper-configuration.js
+++ b/api/src/certification/shared/application/http-error-mapper-configuration.js
@@ -10,15 +10,14 @@ import {
   CenterHabilitationError,
   CertificationCandidateNotFoundError,
   CertificationCourseUpdateError,
+  CsvWithNoSessionDataError,
   InvalidCertificationReportForFinalization,
 } from '../domain/errors.js';
 
 const certificationDomainErrorMappingConfiguration = [
   {
     name: InvalidCertificationReportForFinalization.name,
-    httpErrorFn: (error) => {
-      return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
-    },
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
   },
   {
     name: CertificationCourseUpdateError.name,
@@ -31,6 +30,10 @@ const certificationDomainErrorMappingConfiguration = [
   {
     name: CertificationCandidateNotFoundError.name,
     httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code),
+  },
+  {
+    name: CsvWithNoSessionDataError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/certification/shared/domain/errors.js
+++ b/api/src/certification/shared/domain/errors.js
@@ -1,5 +1,12 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 
+class CertificationCandidateNotFoundError extends DomainError {
+  constructor(message = 'No candidate found') {
+    super(message);
+    this.code = 'CANDIDATE_NOT_FOUND';
+  }
+}
+
 class CertificationCourseUpdateError extends DomainError {
   constructor(message = 'Échec lors la création ou de la mise à jour du test de certification.') {
     super(message);
@@ -18,4 +25,9 @@ class CenterHabilitationError extends DomainError {
   }
 }
 
-export { CenterHabilitationError, CertificationCourseUpdateError, InvalidCertificationReportForFinalization };
+export {
+  CenterHabilitationError,
+  CertificationCandidateNotFoundError,
+  CertificationCourseUpdateError,
+  InvalidCertificationReportForFinalization,
+};

--- a/api/src/certification/shared/domain/errors.js
+++ b/api/src/certification/shared/domain/errors.js
@@ -25,9 +25,17 @@ class CenterHabilitationError extends DomainError {
   }
 }
 
+class CsvWithNoSessionDataError extends DomainError {
+  constructor(message = 'No session data in csv') {
+    super(message);
+    this.code = 'CSV_DATA_REQUIRED';
+  }
+}
+
 export {
   CenterHabilitationError,
   CertificationCandidateNotFoundError,
   CertificationCourseUpdateError,
+  CsvWithNoSessionDataError,
   InvalidCertificationReportForFinalization,
 };

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,5 +1,4 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import { ChallengeAlreadyAnsweredError } from '../../../certification/evaluation/domain/errors.js';
 import { AlreadyRatedAssessmentError, EmptyAnswerError } from '../../../evaluation/domain/errors.js';
 import * as LLMDomainErrors from '../../../llm/domain/errors.js';
 import {
@@ -51,6 +50,7 @@ const FORBIDDEN_ERRORS = [
 ];
 
 const CONFLICT_ERRORS = [
+  SharedDomainErrors.ChallengeAlreadyAnsweredError,
   SharedDomainErrors.UserAlreadyExistsWithAuthenticationMethodError,
   SharedDomainErrors.UnexpectedUserAccountError,
   SharedDomainErrors.AccountRecoveryUserAlreadyConfirmEmail,
@@ -120,7 +120,6 @@ const BAD_REQUEST_ERRORS = [
 const UNPROCESSABLE_ENTITY_ERRORS = [
   SharedDomainErrors.UserCouldNotBeReconciledError,
   AdminMemberError,
-  ChallengeAlreadyAnsweredError,
   SharedDomainErrors.OidcError,
   SharedDomainErrors.AuthenticationMethodAlreadyExistsError,
   SharedDomainErrors.MissingAttributesError,
@@ -165,9 +164,6 @@ export function mapToHttpError(error) {
   }
   if (error instanceof AlreadyRatedAssessmentError) {
     return new HttpErrors.PreconditionFailedError('Assessment is already rated.');
-  }
-  if (error instanceof SharedDomainErrors.ChallengeAlreadyAnsweredError) {
-    return new HttpErrors.ConflictError('This challenge has already been answered.');
   }
   if (error instanceof SharedDomainErrors.ChallengeNotAskedError) {
     return new HttpErrors.ConflictError('This challenge has not been asked to the user.');

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,6 +1,5 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
 import { ChallengeAlreadyAnsweredError } from '../../../certification/evaluation/domain/errors.js';
-import { SendingEmailToResultRecipientError } from '../../../certification/session-management/domain/errors.js';
 import { AlreadyRatedAssessmentError, EmptyAnswerError } from '../../../evaluation/domain/errors.js';
 import * as LLMDomainErrors from '../../../llm/domain/errors.js';
 import {
@@ -145,7 +144,6 @@ const UNAUTHORIZED_ERRORS = [
 
 const SERVICE_UNAVAILABLE_ERRORS = [
   SharedDomainErrors.SendingEmailError,
-  SendingEmailToResultRecipientError,
   SharedDomainErrors.InvalidExternalAPIResponseError,
   LLMDomainErrors.LLMApiError,
 ];

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,9 +1,6 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
 import { ChallengeAlreadyAnsweredError } from '../../../certification/evaluation/domain/errors.js';
-import {
-  SendingEmailToRefererError,
-  SendingEmailToResultRecipientError,
-} from '../../../certification/session-management/domain/errors.js';
+import { SendingEmailToResultRecipientError } from '../../../certification/session-management/domain/errors.js';
 import { AlreadyRatedAssessmentError, EmptyAnswerError } from '../../../evaluation/domain/errors.js';
 import * as LLMDomainErrors from '../../../llm/domain/errors.js';
 import {
@@ -147,7 +144,6 @@ const UNAUTHORIZED_ERRORS = [
 ];
 
 const SERVICE_UNAVAILABLE_ERRORS = [
-  SendingEmailToRefererError,
   SharedDomainErrors.SendingEmailError,
   SendingEmailToResultRecipientError,
   SharedDomainErrors.InvalidExternalAPIResponseError,

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,7 +1,6 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
 import { ChallengeAlreadyAnsweredError } from '../../../certification/evaluation/domain/errors.js';
 import {
-  CsvWithNoSessionDataError,
   SendingEmailToRefererError,
   SendingEmailToResultRecipientError,
 } from '../../../certification/session-management/domain/errors.js';
@@ -126,7 +125,6 @@ const UNPROCESSABLE_ENTITY_ERRORS = [
   SharedDomainErrors.UserCouldNotBeReconciledError,
   AdminMemberError,
   ChallengeAlreadyAnsweredError,
-  CsvWithNoSessionDataError,
   SharedDomainErrors.OidcError,
   SharedDomainErrors.AuthenticationMethodAlreadyExistsError,
   SharedDomainErrors.MissingAttributesError,

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,6 +1,5 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
 import { ChallengeAlreadyAnsweredError } from '../../../certification/evaluation/domain/errors.js';
-import { CertificateGenerationError } from '../../../certification/results/domain/errors.js';
 import {
   CsvWithNoSessionDataError,
   SendingEmailToRefererError,
@@ -124,7 +123,6 @@ const BAD_REQUEST_ERRORS = [
 ];
 
 const UNPROCESSABLE_ENTITY_ERRORS = [
-  CertificateGenerationError,
   SharedDomainErrors.UserCouldNotBeReconciledError,
   AdminMemberError,
   ChallengeAlreadyAnsweredError,

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -25,7 +25,6 @@ import * as SharedDomainErrors from '../../domain/errors.js';
 import { HttpErrors } from './http-errors.js';
 
 const NOT_FOUND_ERRORS = [
-  SharedDomainErrors.CertificationCandidateNotFoundError,
   SharedDomainErrors.NotFoundError,
   SharedDomainErrors.UserNotFoundError,
   SharedDomainErrors.OrganizationNotFoundError,

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -111,13 +111,6 @@ class CertificationCandidateByPersonalInfoNotFoundError extends DomainError {
   }
 }
 
-class CertificationCandidateNotFoundError extends DomainError {
-  constructor(message = 'No candidate found') {
-    super(message);
-    this.code = 'CANDIDATE_NOT_FOUND';
-  }
-}
-
 class CsvImportError extends DomainError {
   constructor(code, meta) {
     super('An error occurred during CSV import');
@@ -1095,7 +1088,6 @@ export {
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidateDeletionError,
-  CertificationCandidateNotFoundError,
   CertificationCandidateOnFinalizedSessionError,
   CertificationCandidatePersonalInfoFieldMissingError,
   CertificationCandidatePersonalInfoWrongFormat,

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -171,8 +171,8 @@ class CertificationAlgorithmVersionError extends DomainError {
 }
 
 class ChallengeAlreadyAnsweredError extends DomainError {
-  constructor(message = 'La question a déjà été répondue.') {
-    super(message);
+  constructor() {
+    super('This challenge has already been answered.', 'ALREADY_ANSWERED_ERROR');
   }
 }
 

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -1,7 +1,7 @@
-import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import * as candidateRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/candidate-repository.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
+import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { _ } from '../../../../../../src/shared/infrastructure/utils/lodash-utils.js';
 import { expect } from '../../../../../test-helper.js';

--- a/api/tests/certification/enrolment/unit/domain/usecases/candidate-has-seen-certification-instructions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/candidate-has-seen-certification-instructions_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
-import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { candidateHasSeenCertificationInstructions } from '../../../../../../src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js';
+import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
@@ -1,11 +1,9 @@
 import sinon from 'sinon';
 
 import { updateEnrolledCandidate } from '../../../../../../src/certification/enrolment/domain/usecases/update-enrolled-candidate.js';
+import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
-import {
-  CandidateAlreadyLinkedToUserError,
-  CertificationCandidateNotFoundError,
-} from '../../../../../../src/shared/domain/errors.js';
+import { CandidateAlreadyLinkedToUserError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -1,6 +1,6 @@
 import * as certificationCandidateRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js';
+import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { CertificationCandidateNotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';

--- a/api/tests/certification/evaluation/unit/domain/usecases/create-live-alert_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/create-live-alert_test.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import sinon from 'sinon';
 
-import { ChallengeAlreadyAnsweredError } from '../../../../../../src/certification/evaluation/domain/errors.js';
 import { createLiveAlert } from '../../../../../../src/certification/evaluation/domain/usecases/create-live-alert.js';
+import { ChallengeAlreadyAnsweredError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';

--- a/api/tests/certification/results/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/results/unit/application/http-error-mapper-configuration_test.js
@@ -1,0 +1,61 @@
+import {
+  parcoursupDomainErrorMappingConfiguration,
+  resultsDomainErrorMappingConfiguration,
+} from '../../../../../src/certification/results/application/http-error-mapper-configuration.js';
+import {
+  CertificateGenerationError,
+  MoreThanOneMatchingCertificationError,
+  NoCertificationResultForDivision,
+} from '../../../../../src/certification/results/domain/errors.js';
+import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Certification | Results | Application | HttpErrorMapperConfiguration', function () {
+  context('when mapping "MoreThanOneMatchingCertificationError"', function () {
+    it('returns an ConflictError Http Error', function () {
+      //given
+      const httpErrorMapper = parcoursupDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === MoreThanOneMatchingCertificationError.name,
+      );
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new MoreThanOneMatchingCertificationError());
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+      expect(error.message).to.equal('More than one candidate found for current search parameters');
+    });
+  });
+
+  context('when mapping "NoCertificationResultForDivision"', function () {
+    it('returns an NotFoundError Http Error', function () {
+      //given
+      const httpErrorMapper = resultsDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === NoCertificationResultForDivision.name,
+      );
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new NoCertificationResultForDivision());
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error.message).to.equal('Aucun résultat de certification pour cette classe.');
+    });
+  });
+
+  context('when mapping "CertificateGenerationError"', function () {
+    it('returns an UnprocessableEntityError Http Error', function () {
+      //given
+      const httpErrorMapper = resultsDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === CertificateGenerationError.name,
+      );
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new CertificateGenerationError());
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error.message).to.equal('An error has occurred during PDF generation');
+    });
+  });
+});

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
@@ -1,5 +1,5 @@
 import * as certificationCandidateForSupervisingRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/certification-candidate-for-supervising-repository.js';
-import { CertificationCandidateNotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';

--- a/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
@@ -4,6 +4,7 @@ import {
   CertificationCenterIsArchivedError,
   InvalidSessionSupervisingLoginError,
   SendingEmailToRefererError,
+  SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionWithoutStartedCertificationError,
@@ -111,12 +112,32 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       );
 
       // when
-      const error = httpErrorMapper.httpErrorFn(new SendingEmailToRefererError(['test@email.com']));
+      const error = httpErrorMapper.httpErrorFn(new SendingEmailToRefererError(['test1@email.com', 'test2@email.com']));
 
       // then
       expect(error).to.be.instanceOf(HttpErrors.ServiceUnavailableError);
       expect(error.message).to.equal(
-        "Échec lors de l'envoi du mail au(x) référent(s) du centre de certification : test@email.com",
+        "Échec lors de l'envoi du mail au(x) référent(s) du centre de certification : test1@email.com, test2@email.com",
+      );
+    });
+  });
+
+  context('when mapping "SendingEmailToResultRecipientError"', function () {
+    it('returns an ServiceUnavailableError Http Error', async function () {
+      // given
+      const httpErrorMapper = sessionDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === SendingEmailToResultRecipientError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(
+        new SendingEmailToResultRecipientError(['test1@email.com', 'test2@email.com']),
+      );
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.ServiceUnavailableError);
+      expect(error.message).to.equal(
+        "Échec lors de l'envoi des résultats au(x) destinataire(s) : test1@email.com, test2@email.com",
       );
     });
   });

--- a/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
@@ -3,6 +3,7 @@ import { SESSION_SUPERVISING } from '../../../../../src/certification/session-ma
 import {
   CertificationCenterIsArchivedError,
   InvalidSessionSupervisingLoginError,
+  SendingEmailToRefererError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionWithoutStartedCertificationError,
@@ -85,18 +86,38 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
     });
   });
 
-  it('should instantiate ForbiddenError when InvalidSessionSupervisingLoginError', async function () {
-    // given
-    const httpErrorMapper = sessionDomainErrorMappingConfiguration.find(
-      (httpErrorMapper) => httpErrorMapper.name === InvalidSessionSupervisingLoginError.name,
-    );
+  context('when mapping "InvalidSessionSupervisingLoginError"', function () {
+    it('returns an UnauthorizedError Http Error', async function () {
+      // given
+      const httpErrorMapper = sessionDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === InvalidSessionSupervisingLoginError.name,
+      );
 
-    // when
-    const error = httpErrorMapper.httpErrorFn(new InvalidSessionSupervisingLoginError());
+      // when
+      const error = httpErrorMapper.httpErrorFn(new InvalidSessionSupervisingLoginError());
 
-    // then
-    expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
-    expect(error.message).to.equal(SESSION_SUPERVISING.INCORRECT_DATA.getMessage());
-    expect(error.code).to.equal(SESSION_SUPERVISING.INCORRECT_DATA.code);
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+      expect(error.message).to.equal(SESSION_SUPERVISING.INCORRECT_DATA.getMessage());
+      expect(error.code).to.equal(SESSION_SUPERVISING.INCORRECT_DATA.code);
+    });
+  });
+
+  context('when mapping "SendingEmailToRefererError"', function () {
+    it('returns an ServiceUnavailableError Http Error', async function () {
+      // given
+      const httpErrorMapper = sessionDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === SendingEmailToRefererError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new SendingEmailToRefererError(['test@email.com']));
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.ServiceUnavailableError);
+      expect(error.message).to.equal(
+        "Échec lors de l'envoi du mail au(x) référent(s) du centre de certification : test@email.com",
+      );
+    });
   });
 });

--- a/api/tests/certification/session-management/unit/domain/errors_test.js
+++ b/api/tests/certification/session-management/unit/domain/errors_test.js
@@ -14,10 +14,6 @@ describe('Certification | session-management | Unit | Domain | Errors', function
     expect(errors.SessionWithMissingAbortReasonError).to.exist;
   });
 
-  it('should export a CsvWithNoSessionDataError', function () {
-    expect(errors.CsvWithNoSessionDataError).to.exist;
-  });
-
   it('should export a ChallengeToBeDeneutralizedNotFoundError', function () {
     expect(errors.ChallengeToBeDeneutralizedNotFoundError).to.exist;
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/validate-live-alert_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/validate-live-alert_test.js
@@ -1,13 +1,12 @@
 import sinon from 'sinon';
 
-import { ChallengeAlreadyAnsweredError } from '../../../../../../src/certification/evaluation/domain/errors.js';
 import { validateLiveAlert } from '../../../../../../src/certification/session-management/domain/usecases/validate-live-alert.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
 import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { ChallengeAlreadyAnsweredError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';

--- a/api/tests/certification/shared/integration/application/helpers/csvHelpers_test.js
+++ b/api/tests/certification/shared/integration/application/helpers/csvHelpers_test.js
@@ -1,11 +1,11 @@
 import * as url from 'node:url';
 
-import { CsvWithNoSessionDataError } from '../../../../../../src/certification/session-management/domain/errors.js';
 import {
   parseCsv,
   parseCsvWithHeader,
   readCsvFile,
 } from '../../../../../../src/certification/shared/application/helpers/csvHelpers.js';
+import { CsvWithNoSessionDataError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';

--- a/api/tests/certification/shared/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/shared/unit/application/http-error-mapper-configuration_test.js
@@ -1,6 +1,7 @@
 import { certificationDomainErrorMappingConfiguration } from '../../../../../src/certification/shared/application/http-error-mapper-configuration.js';
 import {
   CenterHabilitationError,
+  CertificationCandidateNotFoundError,
   CertificationCourseUpdateError,
   InvalidCertificationReportForFinalization,
 } from '../../../../../src/certification/shared/domain/errors.js';
@@ -58,6 +59,23 @@ describe('Unit | Certification | Shared | Application | HttpErrorMapperConfigura
         'This certification center has no habilitation for the given complementary certification.',
       );
       expect(error.code).to.equal('CENTER_HABILITATION_ERROR');
+    });
+  });
+
+  context('when mapping "CertificationCandidateNotFoundError"', function () {
+    it('returns a NotFoundError Http Error', function () {
+      //given
+      const httpErrorMapper = certificationDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === CertificationCandidateNotFoundError.name,
+      );
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new CertificationCandidateNotFoundError());
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error.message).to.equal('No candidate found');
+      expect(error.code).to.equal('CANDIDATE_NOT_FOUND');
     });
   });
 });

--- a/api/tests/certification/shared/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/shared/unit/application/http-error-mapper-configuration_test.js
@@ -3,6 +3,7 @@ import {
   CenterHabilitationError,
   CertificationCandidateNotFoundError,
   CertificationCourseUpdateError,
+  CsvWithNoSessionDataError,
   InvalidCertificationReportForFinalization,
 } from '../../../../../src/certification/shared/domain/errors.js';
 import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
@@ -76,6 +77,23 @@ describe('Unit | Certification | Shared | Application | HttpErrorMapperConfigura
       expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
       expect(error.message).to.equal('No candidate found');
       expect(error.code).to.equal('CANDIDATE_NOT_FOUND');
+    });
+  });
+
+  context('when mapping "CsvWithNoSessionDataError"', function () {
+    it('returns a UnprocessableEntityError Http Error', function () {
+      //given
+      const httpErrorMapper = certificationDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === CsvWithNoSessionDataError.name,
+      );
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new CsvWithNoSessionDataError());
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error.message).to.equal('No session data in csv');
+      expect(error.code).to.equal('CSV_DATA_REQUIRED');
     });
   });
 });

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -1,7 +1,6 @@
 import sinon from 'sinon';
 
 import {
-  SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionWithoutStartedCertificationError,
 } from '../../../../src/certification/session-management/domain/errors.js';
@@ -936,16 +935,6 @@ describe('Integration | API | Controller Error', function () {
 
       expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
       expect(responseDetail(response)).to.equal('Failed to send email to "toto@pix.fr" for some unknown reason.');
-    });
-
-    it('responds ServiceUnavailable when a SendingEmailToResultRecipientError error occurs', async function () {
-      routeHandler.throws(new SendingEmailToResultRecipientError(['toto@pix.fr', 'titi@pix.fr']));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
-      expect(responseDetail(response)).to.equal(
-        "Échec lors de l'envoi des résultats au(x) destinataire(s) : toto@pix.fr, titi@pix.fr",
-      );
     });
   });
 

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -640,15 +640,6 @@ describe('Integration | API | Controller Error', function () {
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('Ce compte est introuvable.');
     });
-
-    it('responds NotFoundError when a CertificationCandidateNotFoundError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.CertificationCandidateNotFoundError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
-      expect(responseDetail(response)).to.equal('No candidate found');
-      expect(responseCode(response)).to.equal('CANDIDATE_NOT_FOUND');
-    });
   });
 
   context('422 Unprocessable Entity', function () {

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -1,7 +1,6 @@
 import sinon from 'sinon';
 
 import {
-  SendingEmailToRefererError,
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionWithoutStartedCertificationError,
@@ -946,16 +945,6 @@ describe('Integration | API | Controller Error', function () {
       expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
       expect(responseDetail(response)).to.equal(
         "Échec lors de l'envoi des résultats au(x) destinataire(s) : toto@pix.fr, titi@pix.fr",
-      );
-    });
-
-    it('responds ServiceUnavailable when a SendingEmailToRefererError error occurs', async function () {
-      routeHandler.throws(new SendingEmailToRefererError(['toto@pix.fr', 'titi@pix.fr']));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
-      expect(responseDetail(response)).to.equal(
-        "Échec lors de l'envoi du mail au(x) référent(s) du centre de certification : toto@pix.fr, titi@pix.fr",
       );
     });
   });


### PR DESCRIPTION
## 💥 Problème

Des classes d'erreurs de `certification` (définies dans les contextes certifications) ont leur mapping de déclarer dans `src/shared` (`api/src/shared/application/errors/error-manager.js`). Or, `shared` ne doit jamais importer des modules depuis d'autres contextes.

## 👩‍🚀 Proposition

Peut se lire facilement commit par commit :
- Déplacer `CertificationCandidateNotFoundError` dans `certification/shared`
- Déplacer `CertificateGenerationError` dans `certification/results`
- Déplacer `CsvWithNoSessionDataError` dans `certification/shared`
- Déplacer `SendingEmailToRefererError` dans `certification/session-management`
- Déplacer `ChallengeAlreadyAnsweredError` dans `shared` car utilisé dans `certification` et `evaluation`

## 👁️ Remarques

Des tests ont été ajoutés dans chaque contexte sur le mapping des erreurs.

## ♻️ Pour tester

- Les tests CI ok.
- J'aimerais faire un test fonctionnel de `ChallengeAlreadyAnsweredError`, notamment sur les live-alerts, mais je ne sais pas comment le faire
