### PR TITLE
[BUGFIX] Remplacer l'apostrophe dans le tag “L’info en +” (PIX-22790)

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1713,7 +1713,7 @@
           "tag": {
             "context": "Contexte",
             "did-you-know": "Le saviez-vous ?",
-            "further-information": "L'info en plus",
+            "further-information": "L’info en plus",
             "tip": "Astuce"
           }
         }


### PR DESCRIPTION
## 💥 Problème

Dans le tag “L’info en +”, il faudrait remplacer l’apostrophe droite (') est utilisée.

## 👩‍🚀 Proposition

Remplacer par une apostrophe courbe (’).

## ♻️ Pour tester

- Ouvrir le module résultats-recherche : http://app-pr16257.review.pix.fr/modules/5c1088d0/liste-resultats-recherche
- Dans la deuxième leçon, il existe un element `text`qui possède le taf "L'info en +". Vérifier que l'apostrophe affichée est la bonne
