### PR TITLE
[FEATURE] Laisser la modale d'édition de version ouverte après modification (PIX-22826).

### DIFF
--- a/admin/app/components/certification-frameworks/item/framework/certification-version-detail-modal.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/certification-version-detail-modal.gjs
@@ -99,7 +99,7 @@ export default class CertificationVersionDetailModal extends Component {
 
         <FrameworkContentDetails @areas={{@version.areas}} />
 
-        <VersionComment @version={{@version}} @onSave={{@onClose}} />
+        <VersionComment @version={{@version}} />
       </:content>
     </PixModal>
   </template>

--- a/admin/app/components/certification-frameworks/item/framework/version-comment.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/version-comment.gjs
@@ -26,7 +26,6 @@ export default class VersionComment extends Component {
           'components.complementary-certifications.item.framework.version-detail-modal.comment-save-success',
         ),
       });
-      this.args.onSave();
     } catch {
       this.args.version.rollbackAttributes();
       this.pixToast.sendErrorNotification({

--- a/admin/tests/integration/components/certification-frameworks/item/framework/certification-version-detail-modal-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/certification-version-detail-modal-test.gjs
@@ -1,5 +1,4 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
 import CertificationVersionDetailModal from 'pix-admin/components/certification-frameworks/item/framework/certification-version-detail-modal';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -12,10 +11,8 @@ module(
     setupIntlRenderingTest(hooks);
 
     let store;
-    let pixToast;
     hooks.beforeEach(function () {
       store = this.owner.lookup('service:store');
-      pixToast = this.owner.lookup('service:pix-toast');
     });
 
     function buildVersion(overrides = {}) {
@@ -123,25 +120,6 @@ module(
 
       // then
       assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).exists();
-    });
-
-    test('it closes the modal when comments are saved successfully', async function (assert) {
-      // given
-      const version = buildVersion();
-      const onClose = sinon.stub();
-      sinon.stub(pixToast, 'sendSuccessNotification');
-
-      const screen = await render(
-        <template>
-          <CertificationVersionDetailModal @version={{version}} @status="ACTIVE" @scope="CORE" @onClose={{onClose}} />
-        </template>,
-      );
-
-      // when
-      await click(screen.getByRole('button', { name: t('common.actions.save') }));
-
-      // then
-      assert.ok(onClose.calledOnce);
     });
   },
 );

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -104,7 +104,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     assert.dom(screen.getByRole('dialog')).exists();
   });
 
-  test('it closes the detail modal after saving comments successfully', async function (assert) {
+  test('it leaves detail modal opened after saving comments successfully', async function (assert) {
     // given
     const frameworkHistory = [
       {
@@ -143,6 +143,6 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     await click(screen.getByRole('button', { name: t('common.actions.save') }));
 
     // then
-    assert.dom(screen.queryByRole('dialog')).doesNotExist();
+    assert.dom(screen.queryByRole('dialog')).exists();
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/framework/version-comment-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/version-comment-test.gjs
@@ -66,21 +66,6 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       assert.strictEqual(version.comments, 'Mon nouveau commentaire');
       assert.ok(pixToast.sendSuccessNotification.calledOnce);
     });
-
-    test('it calls onSave after a successful save', async function (assert) {
-      // given
-      const version = { comments: '', save: sinon.stub().resolves() };
-      const onSave = sinon.stub();
-      sinon.stub(pixToast, 'sendSuccessNotification');
-
-      const screen = await render(<template><VersionComment @version={{version}} @onSave={{onSave}} /></template>);
-
-      // when
-      await click(screen.getByRole('button', { name: t('common.actions.save') }));
-
-      // then
-      assert.ok(onSave.calledOnce);
-    });
   });
 
   module('when saving comments fails', function () {


### PR DESCRIPTION
## 💥 Problème

Nous ne voulons pas fermer la modale d'édition de version après enregistrement de commentaires.

## 👩‍🚀 Proposition

Laisser la modale ouverte.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester

- Se connecter à Pix-Admin
- Aller sur `Référentiels de certification`
- Choisir un référentiel parmi la liste de ceux disponibles
- Choisir une version de référentiel et ouvrir la modale d'édition en cliquant sur l'icône 👁️ 
- Ajouter un commentaire et enregistrer
- Vérifier que la modale reste ouverte
