### PR TITLE
[FEATURE] Contenus formatifs - Ajouter le format “Service externe” (PIX-22791)

### DIFF
--- a/admin/app/components/trainings/training-details-card.gjs
+++ b/admin/app/components/trainings/training-details-card.gjs
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 
-import { localeCategories } from '../../models/training';
+import { localeCategories, typeCategories } from '../../models/training';
 import StateTag from './state-tag';
 
 export default class TrainingDetailsCard extends Component {
@@ -24,6 +24,10 @@ export default class TrainingDetailsCard extends Component {
     return this.args.training.type === 'modulix'
       ? `${this.url.pixAppUrl}${this.args.training.link}`
       : this.args.training.link;
+  }
+
+  get typeLabel() {
+    return typeCategories[this.args.training.type];
   }
 
   <template>
@@ -48,7 +52,7 @@ export default class TrainingDetailsCard extends Component {
         </DescriptionList.Item>
 
         <DescriptionList.Item @label={{t "pages.trainings.training.details.contentType"}}>
-          {{@training.type}}
+          {{this.typeLabel}}
         </DescriptionList.Item>
 
         <DescriptionList.Item @label={{t "pages.trainings.training.details.duration"}}>

--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -10,6 +10,7 @@ export const typeCategories = {
   'hybrid-training': 'Formation hybride',
   'in-person-training': 'Formation en présentiel',
   modulix: 'Module Pix',
+  'external-service': 'Service externe',
 };
 
 export const optionsTypeList = formatList(typeCategories);

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -31,7 +31,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     assert.dom(screen.getByRole('heading', { level: 1, name: training.internalTitle })).exists();
     assert.dom(screen.getByText(training.title)).exists();
     assert.dom(screen.getByText('https://un-contenu-formatif')).exists();
-    assert.dom(screen.getByText('webinaire')).exists();
+    assert.dom(screen.getByText('Webinaire')).exists();
     assert.dom(screen.getByText('2j')).exists();
     assert.dom(screen.getByText('Franco-français (fr-fr)')).exists();
     assert.dom(screen.getByText('Un éditeur de contenu formatif')).exists();

--- a/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
+++ b/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
@@ -22,7 +22,7 @@ module('Integration | Component | Trainings | Training', function (hooks) {
       title: 'title',
       internalTitle: 'internalTitle',
       link: 'my-training-link',
-      type: 'type',
+      type: 'webinaire',
       locales: ['fr-fr'],
       editorName: 'Albert',
       editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
@@ -46,7 +46,7 @@ module('Integration | Component | Trainings | Training', function (hooks) {
     assert.ok(screen.getByText('internalTitle'));
     assert.ok(screen.getByText('internalTitle'));
     assert.ok(screen.getByRole('link', { name: 'my-training-link (nouvelle fenêtre)' }));
-    assert.ok(screen.getByText('type'));
+    assert.ok(screen.getByText('Webinaire'));
     assert.ok(screen.getByText('Franco-français (fr-fr)'));
     assert.ok(screen.getByText('Albert'));
   });

--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -138,7 +138,15 @@ const register = async function (server) {
                   minutes: Joi.number().min(0).max(59).default(0),
                 }).required(),
                 type: Joi.string()
-                  .valid('autoformation', 'e-learning', 'hybrid-training', 'in-person-training', 'modulix', 'webinaire')
+                  .valid(
+                    'autoformation',
+                    'e-learning',
+                    'hybrid-training',
+                    'in-person-training',
+                    'modulix',
+                    'webinaire',
+                    'external-service',
+                  )
                   .required(),
                 locales: Joi.array()
                   .items(Joi.string().valid(...lowerCaseSupportedLocales))
@@ -210,7 +218,15 @@ const register = async function (server) {
                   minutes: Joi.number().min(0).max(59).required(),
                 }).allow(null),
                 type: Joi.string()
-                  .valid('autoformation', 'e-learning', 'hybrid-training', 'in-person-training', 'modulix', 'webinaire')
+                  .valid(
+                    'autoformation',
+                    'e-learning',
+                    'hybrid-training',
+                    'in-person-training',
+                    'modulix',
+                    'webinaire',
+                    'external-service',
+                  )
                   .allow(null),
                 locales: Joi.array().items(Joi.string().valid(...lowerCaseSupportedLocales)),
                 'editor-name': Joi.string().allow(null),


### PR DESCRIPTION
## 👩‍🚀 Proposition

Permettre d'ajouter le type de format "Service externe" pour un CF.

## 👁️ Remarques

J'en ai profité pour améliorer l'affichage du type de CF dans la vue du CF en détails.

## ♻️ Pour tester

- Se connecter dans [PixAdmin](https://admin-pr16261.review.pix.fr/login)
- Ouvrir le menu des contenus formatifs
- Modifier n'importe quel contenu
- Dans la vue de modification, vérifier qu'on peut sélectionner le format "Service externe" dans la liste, et enregistrer la modification
- Dans la vue de détails, vérifier qu'on voit bien "type de contenu: service externe"
- Créer un nouveau CF
- Vérifier qu'on peut sélectionner le format "Service externe" dans la liste, et enregistrer la création
- Dans la vue de détails, vérifier qu'on voit bien "type de contenu: service externe"