### PR TITLE
[TECH] Déplacer le mapping des erreurs LLM dans son contexte

### DIFF
--- a/api/config/server-setup-error-handling.js
+++ b/api/config/server-setup-error-handling.js
@@ -3,6 +3,7 @@ import { devcompDomainErrorMappingConfiguration } from '../src/devcomp/applicati
 import { evaluationDomainErrorMappingConfiguration } from '../src/evaluation/application/http-error-mapper-configuration.js';
 import { authenticationDomainErrorMappingConfiguration } from '../src/identity-access-management/application/http-error-mapper-configuration.js';
 import { legalDocumentsDomainErrorMappingConfiguration } from '../src/legal-documents/application/http-error-mapper-configuration.js';
+import { llmDomainErrorMappingConfiguration } from '../src/llm/application/http-error-mapper-configuration.js';
 import { organizationalEntitiesDomainErrorMappingConfiguration } from '../src/organizational-entities/application/http-error-mapper-configuration.js';
 import { prescriptionDomainErrorMappingConfiguration } from '../src/prescription/shared/application/http-error-mapper-configuration.js';
 import { stagesDomainErrorMappingConfiguration } from '../src/prescription/stages/application/http-error-mapper-configuration.js';
@@ -22,6 +23,7 @@ const setupErrorHandling = function (server) {
     ...evaluationDomainErrorMappingConfiguration,
     ...stagesDomainErrorMappingConfiguration,
     ...legalDocumentsDomainErrorMappingConfiguration,
+    ...llmDomainErrorMappingConfiguration,
     ...prescriptionDomainErrorMappingConfiguration,
     ...schoolDomainErrorMappingConfiguration,
     ...profileDomainErrorMappingConfiguration,

--- a/api/src/llm/application/http-error-mapper-configuration.js
+++ b/api/src/llm/application/http-error-mapper-configuration.js
@@ -1,0 +1,61 @@
+import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import {
+  ChatForbiddenError,
+  ChatNotFoundError,
+  ConfigurationNotFoundError,
+  IncorrectMessagesOrderingError,
+  LLMApiError,
+  MaxPromptsReachedError,
+  NoAttachmentNeededError,
+  NoAttachmentNorMessageProvidedError,
+  NoUserIdProvidedError,
+  PromptAlreadyOngoingError,
+  TooLargeMessageInputError,
+} from '../domain/errors.js';
+
+export const llmDomainErrorMappingConfiguration = [
+  {
+    name: ChatNotFoundError.name,
+    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code, error.meta),
+  },
+  {
+    name: MaxPromptsReachedError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+  },
+  {
+    name: ChatForbiddenError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+  },
+  {
+    name: PromptAlreadyOngoingError.name,
+    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: ConfigurationNotFoundError.name,
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+  },
+  {
+    name: NoUserIdProvidedError.name,
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+  },
+  {
+    name: NoAttachmentNeededError.name,
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+  },
+  {
+    name: NoAttachmentNorMessageProvidedError.name,
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+  },
+  {
+    name: LLMApiError.name,
+    httpErrorFn: (error) => new HttpErrors.ServiceUnavailableError(error.message),
+  },
+  {
+    name: IncorrectMessagesOrderingError.name,
+    httpErrorFn: (error) => new HttpErrors.InternalServerError(error.message),
+  },
+  {
+    name: TooLargeMessageInputError.name,
+    httpErrorFn: (error) => new HttpErrors.PayloadTooLargeError(error.message, error.code, error.meta),
+  },
+];

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,6 +1,5 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
 import { AlreadyRatedAssessmentError, EmptyAnswerError } from '../../../evaluation/domain/errors.js';
-import * as LLMDomainErrors from '../../../llm/domain/errors.js';
 import {
   ArchiveOrganizationError,
   UnableToAttachChildOrganizationToParentOrganizationError,
@@ -18,7 +17,6 @@ const NOT_FOUND_ERRORS = [
   SharedDomainErrors.UserNotFoundError,
   SharedDomainErrors.OrganizationNotFoundError,
   SharedDomainErrors.CampaignCodeError,
-  LLMDomainErrors.ChatNotFoundError,
 ];
 
 const FORBIDDEN_ERRORS = [
@@ -41,8 +39,6 @@ const FORBIDDEN_ERRORS = [
   SharedDomainErrors.CandidateNotAuthorizedToResumeCertificationTestError,
   SharedDomainErrors.CertificationCandidateOnFinalizedSessionError,
   UserHasNoOrganizationMembershipError,
-  LLMDomainErrors.MaxPromptsReachedError,
-  LLMDomainErrors.ChatForbiddenError,
 ];
 
 const CONFLICT_ERRORS = [
@@ -59,7 +55,6 @@ const CONFLICT_ERRORS = [
   SharedDomainErrors.MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
   UnableToAttachChildOrganizationToParentOrganizationError,
   AlreadyAcceptedOrCancelledInvitationError,
-  LLMDomainErrors.PromptAlreadyOngoingError,
 ];
 
 const PRECONDITION_FAILED_ERRORS = [
@@ -103,10 +98,6 @@ const BAD_REQUEST_ERRORS = [
   SharedDomainErrors.AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
   SharedDomainErrors.TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
   EmptyAnswerError,
-  LLMDomainErrors.ConfigurationNotFoundError,
-  LLMDomainErrors.NoUserIdProvidedError,
-  LLMDomainErrors.NoAttachmentNeededError,
-  LLMDomainErrors.NoAttachmentNorMessageProvidedError,
 ];
 
 const UNPROCESSABLE_ENTITY_ERRORS = [
@@ -136,12 +127,7 @@ const UNAUTHORIZED_ERRORS = [
 const SERVICE_UNAVAILABLE_ERRORS = [
   SharedDomainErrors.SendingEmailError,
   SharedDomainErrors.InvalidExternalAPIResponseError,
-  LLMDomainErrors.LLMApiError,
 ];
-
-const INTERNAL_SERVER_ERRORS = [LLMDomainErrors.IncorrectMessagesOrderingError];
-
-const PAYLOAD_TOO_LARGE_ERRORS = [LLMDomainErrors.TooLargeMessageInputError];
 
 export function mapToHttpError(error) {
   // Special cases: hardcoded messages or non-standard patterns
@@ -212,9 +198,6 @@ export function mapToHttpError(error) {
     return new HttpErrors.UnauthorizedError(error.message, error.code, error.meta);
   if (SERVICE_UNAVAILABLE_ERRORS.some((E) => error instanceof E))
     return new HttpErrors.ServiceUnavailableError(error.message);
-  if (INTERNAL_SERVER_ERRORS.some((E) => error instanceof E)) return new HttpErrors.InternalServerError(error.message);
-  if (PAYLOAD_TOO_LARGE_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.PayloadTooLargeError(error.message, error.code, error.meta);
 
   return new HttpErrors.BaseHttpError(error.message);
 }

--- a/api/tests/llm/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/llm/unit/application/http-error-mapper-configuration_test.js
@@ -1,0 +1,183 @@
+import { llmDomainErrorMappingConfiguration } from '../../../../src/llm/application/http-error-mapper-configuration.js';
+import {
+  ChatForbiddenError,
+  ChatNotFoundError,
+  ConfigurationNotFoundError,
+  IncorrectMessagesOrderingError,
+  LLMApiError,
+  MaxPromptsReachedError,
+  NoAttachmentNeededError,
+  NoAttachmentNorMessageProvidedError,
+  NoUserIdProvidedError,
+  PromptAlreadyOngoingError,
+  TooLargeMessageInputError,
+} from '../../../../src/llm/domain/errors.js';
+import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
+import { expect } from '../../../test-helper.js';
+
+describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () {
+  context('when mapping "ChatNotFoundError"', function () {
+    it('returns an NotFoundError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === ChatNotFoundError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new ChatNotFoundError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+    });
+  });
+
+  context('when mapping "MaxPromptsReachedError"', function () {
+    it('returns an ForbiddenError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === MaxPromptsReachedError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new MaxPromptsReachedError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    });
+  });
+
+  context('when mapping "ChatForbiddenError"', function () {
+    it('returns an ForbiddenError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === ChatForbiddenError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new ChatForbiddenError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    });
+  });
+
+  context('when mapping "PromptAlreadyOngoingError"', function () {
+    it('returns an ConflictError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === PromptAlreadyOngoingError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new PromptAlreadyOngoingError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+    });
+  });
+
+  context('when mapping "ConfigurationNotFoundError"', function () {
+    it('returns an BadRequestError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === ConfigurationNotFoundError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new ConfigurationNotFoundError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+    });
+  });
+
+  context('when mapping "NoUserIdProvidedError"', function () {
+    it('returns an BadRequestError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === NoUserIdProvidedError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new NoUserIdProvidedError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+    });
+  });
+
+  context('when mapping "NoAttachmentNeededError"', function () {
+    it('returns an BadRequestError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === NoAttachmentNeededError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new NoAttachmentNeededError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+    });
+  });
+
+  context('when mapping "NoAttachmentNorMessageProvidedError"', function () {
+    it('returns an BadRequestError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === NoAttachmentNorMessageProvidedError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new NoAttachmentNorMessageProvidedError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+    });
+  });
+
+  context('when mapping "LLMApiError"', function () {
+    it('returns an ServiceUnavailableError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === LLMApiError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new LLMApiError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.ServiceUnavailableError);
+    });
+  });
+
+  context('when mapping "IncorrectMessagesOrderingError"', function () {
+    it('returns an InternalServerError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === IncorrectMessagesOrderingError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new IncorrectMessagesOrderingError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.InternalServerError);
+    });
+  });
+
+  context('when mapping "TooLargeMessageInputError"', function () {
+    it('returns an PayloadTooLargeError Http Error', function () {
+      // given
+      const httpErrorMapper = llmDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === TooLargeMessageInputError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new TooLargeMessageInputError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.PayloadTooLargeError);
+    });
+  });
+});

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -11,7 +11,6 @@ import {
   MissingOrInvalidCredentialsError,
   UserShouldChangePasswordError,
 } from '../../../../src/identity-access-management/domain/errors.js';
-import * as LLMDomainErrors from '../../../../src/llm/domain/errors.js';
 import { SiecleXmlImportError } from '../../../../src/prescription/learner-management/domain/errors.js';
 import * as DomainErrors from '../../../../src/shared/domain/errors.js';
 import {
@@ -201,14 +200,6 @@ describe('Integration | API | Controller Error', function () {
       expect(responseCode(response)).to.equal('SESSION_ALREADY_FINALIZED');
     });
 
-    it('responds Conflict when a PromptAlreadyOngoingError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.PromptAlreadyOngoingError('chatId'));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(CONFLICT_ERROR);
-      expect(responseDetail(response)).to.equal('A prompt is already ongoing for chat with id chatId');
-    });
-
     it('responds Conflict when a CertificationCandidateByPersonalInfoTooManyMatchesError error occurs', async function () {
       routeHandler.throws(new DomainErrors.CertificationCandidateByPersonalInfoTooManyMatchesError());
       const response = await server.requestObject(request);
@@ -295,40 +286,6 @@ describe('Integration | API | Controller Error', function () {
         'The token used to retrieve the results of the certification session is invalid.',
       );
       expect(responseCode(response)).to.equal('INVALID_SESSION_RESULT_TOKEN');
-    });
-
-    it('responds Bad Request when a LLMDomainErrors.ConfigurationNotFoundError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.ConfigurationNotFoundError('someConfigId'));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
-      expect(responseDetail(response)).to.equal('The configuration of id "someConfigId" does not exist');
-    });
-
-    it('responds Bad Request when a LLMDomainErrors.NoUserIdProvidedError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.NoUserIdProvidedError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
-      expect(responseDetail(response)).to.equal('Must provide a user ID to use LLM API');
-    });
-
-    it('responds Bad Request when a LLMDomainErrors.NoAttachmentNeededError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.NoAttachmentNeededError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
-      expect(responseDetail(response)).to.equal(
-        'Attachment has been provided but is not expected for the given configuration',
-      );
-    });
-
-    it('responds Bad Request when a LLMDomainErrors.NoAttachmentNorMessageProvidedError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.NoAttachmentNorMessageProvidedError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
-      expect(responseDetail(response)).to.equal('At least a message or an attachment, if applicable, must be provided');
     });
 
     it('responds Bad Request when a CertificationCandidatePersonalInfoFieldMissingError error occurs', async function () {
@@ -467,22 +424,6 @@ describe('Integration | API | Controller Error', function () {
       );
     });
 
-    it('responds Forbidden when a LLMDomainErrors.MaxPromptsReachedError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.MaxPromptsReachedError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal("You've reached the max prompts authorized");
-    });
-
-    it('responds Forbidden when a LLMDomainErrors.ChatForbiddenError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.ChatForbiddenError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal('User has not the right to use this chat');
-    });
-
     it('responds Forbidden when a UserNotAuthorizedToUpdateResourceError error occurs', async function () {
       routeHandler.throws(
         new DomainErrors.UserNotAuthorizedToUpdateResourceError(
@@ -595,14 +536,6 @@ describe('Integration | API | Controller Error', function () {
 
   context('404 Not found', function () {
     const NOT_FOUND_ERROR = 404;
-
-    it('responds Not Found when a LLMDomainErrors.ChatNotFoundError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.ChatNotFoundError('someChatId'));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
-      expect(responseDetail(response)).to.equal('The chat of id "someChatId" does not exist');
-    });
 
     it('responds Not Found when a DomainError.NotFoundError error occurs', async function () {
       routeHandler.throws(new DomainErrors.NotFoundError('Entity Not Found'));
@@ -907,26 +840,10 @@ describe('Integration | API | Controller Error', function () {
       expect(response.statusCode).to.equal(INTERNAL_SERVER_ERROR);
       expect(responseDetail(response)).to.equal('Problème lors de l\'évaluation de la réponse du challenge: "123456"');
     });
-
-    it('responds Internal server error when a LLMDomainErrors.IncorrectMessagesOrderingError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.IncorrectMessagesOrderingError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(INTERNAL_SERVER_ERROR);
-      expect(responseDetail(response)).to.equal('Messages must respect the ordering enforced by LLM providers');
-    });
   });
 
   context('503 Service Unavailable', function () {
     const SERVICE_UNAVAILABLE_ERROR = 503;
-
-    it('responds Service Unavailable when a LLMDomainErrors.LLMApiError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.LLMApiError('some error message'));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
-      expect(responseDetail(response)).to.equal('Something went wrong when reaching the LLM Api : some error message');
-    });
 
     it('responds ServiceUnavailable when a SendingEmailError error occurs', async function () {
       routeHandler.throws(new DomainErrors.SendingEmailError('toto@pix.fr'));
@@ -934,18 +851,6 @@ describe('Integration | API | Controller Error', function () {
 
       expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
       expect(responseDetail(response)).to.equal('Failed to send email to "toto@pix.fr" for some unknown reason.');
-    });
-  });
-
-  context('413 Payload Too Large', function () {
-    const PAYLOAD_TOO_LARGE_ERROR = 413;
-
-    it('responds Payload too large when a LLMDomainErrors.TooLargeMessageInputError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.TooLargeMessageInputError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(PAYLOAD_TOO_LARGE_ERROR);
-      expect(responseDetail(response)).to.equal("You've reached the max characters input");
     });
   });
 });


### PR DESCRIPTION
## 💥 Problème

Le mapping des erreurs LLM en erreur HTTP est défini dans le fichier `error-manager.js` de `shared`. Or le contexte `shared` ne doit pas importer des modules des autres contextes.

## 👩‍🚀 Proposition

Déplacer le mapping des erreurs LLM en erreur HTTP dans le contexte `llm`.

## 👁️ Remarques

N/A

## ♻️ Pour tester

- La CI doit passer.
- Faire un petit tour du llm