### PR TITLE
[TECH] Réparer un test flaky sur la mise à jour du logo d'une organisation (PIX-22794)

### DIFF
--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -189,7 +189,7 @@ module('Integration | Component | organizations/header-information', function (h
         });
 
         sinon.stub(organization, 'save').rejects({ errors: [{ status: '413', meta: { maxSizeInMegaBytes: '2.5' } }] });
-        sinon.stub(organization, 'rollbackAttributes').resolves();
+        sinon.stub(organization, 'rollbackAttributes').returns();
 
         const file = new Blob([''], { type: `new-logo-file` });
 
@@ -219,7 +219,7 @@ module('Integration | Component | organizations/header-information', function (h
         });
 
         sinon.stub(organization, 'save').rejects();
-        sinon.stub(organization, 'rollbackAttributes').resolves();
+        sinon.stub(organization, 'rollbackAttributes').returns();
 
         const file = new Blob([''], { type: `new-logo-file` });
 


### PR DESCRIPTION
## 💥 Problème
On a un test flaky sur la mise à jour du logo d'une orga. C'est probablement dû au stub de la méthode `rollbackAttributes` du model `organization`. Dans le test on resolve ce stub alors qu'il ne renvoie pas une promesse.

## 👩‍🚀 Proposition
Faire plutôt un returns() sur ce stub.

## 👁️ Remarques
RAS

## ♻️ Pour tester
Voir si le flacky a disparu.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
