### PR TITLE
[FEATURE] Ajoute la possibilité d'utiliser du markdown dans les descriptions des parcours combinés (Pix-22820)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -151,6 +151,7 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
     questId: combinedCourseQuestId,
     deletedAt: combinedCourseData.deletedAt,
     deletedBy: combinedCourseData.deletedBy,
+    description: combinedCourseData.blueprint.description,
   });
 
   combinedCourseData.participations.forEach((participation) => {
@@ -224,7 +225,7 @@ export const buildCombinedCourseBlueprints = () => {
     internalName: 'Mon schéma de parcours combiné 2',
     illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
     description:
-      "Un parcours pour découvrir l'essentiel sur l'intelligence artificielle : comprendre sa définition, ses domaines d'application, comment elle fonctionne, ainsi que ses enjeux, notamment en matière d'impact environnemental.",
+      "#Un parcours\n pour découvrir l'essentiel sur l'intelligence artificielle : [comprendre sa définition](http://pix.fr), ses domaines d'application, comment elle fonctionne, ainsi que ses enjeux, notamment en matière d'impact environnemental.",
   }).id;
 
   buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId: PRO_ORGANIZATION_ID });

--- a/api/db/seeds/data/team-prescription/fixtures/pro-combined-course.js
+++ b/api/db/seeds/data/team-prescription/fixtures/pro-combined-course.js
@@ -15,6 +15,8 @@ export const PRO_COMBINED_COURSE = {
       { type: 'module', moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' },
       { type: 'module', moduleId: 'f32a2238-4f65-4698-b486-15d51935d335' },
     ],
+    description:
+      "#Un parcours\n pour découvrir l'essentiel sur l'intelligence artificielle : [comprendre sa définition](http://pix.fr), ses domaines d'application, comment elle fonctionne, ainsi que ses enjeux, notamment en matière d'impact environnemental.",
   },
   combinedCourse: {
     code: 'COMBINIX1',

--- a/mon-pix/app/components/markdown-to-html.gjs
+++ b/mon-pix/app/components/markdown-to-html.gjs
@@ -1,5 +1,8 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { renderComponent } from '@ember/renderer';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
+import { modifier } from 'ember-modifier';
 import ENV from 'mon-pix/config/environment';
 import showdown from 'showdown';
 import xss from 'xss';
@@ -21,12 +24,36 @@ function filterAccessibilityClass(value) {
   return value === 'sr-only' ? `class="${value}"` : null;
 }
 
+const replaceLinksFromMarkdown = modifier((element) => {
+  element.querySelectorAll('a').forEach((link) => {
+    const container = document.createElement('span');
+    link.replaceWith(container);
+    renderComponent(PixButtonLink, {
+      into: container,
+      args: { href: link.getAttribute('href'), variant: 'tertiary' },
+    });
+    container.className = 'link-markdown-to-html';
+    const linkInContainer = container.querySelector('a');
+    if (link.hasAttribute('rel')) {
+      linkInContainer.setAttribute('rel', link.getAttribute('rel'));
+    }
+    if (link.hasAttribute('target')) {
+      linkInContainer.setAttribute('target', link.getAttribute('target'));
+    }
+    container.querySelector('a').innerHTML = link.innerHTML;
+  });
+});
+
 export default class MarkdownToHtml extends Component {
   <template>
     {{#if @isInline}}
       {{this.html}}
+    {{else if @mustReplaceLinksFromMarkdown}}
+      <div class="{{@class}}" ...attributes {{replaceLinksFromMarkdown}}>
+        {{this.html}}
+      </div>
     {{else}}
-      <div class={{@class}} ...attributes>
+      <div class="{{@class}}" ...attributes>
         {{this.html}}
       </div>
     {{/if}}

--- a/mon-pix/app/components/routes/combined-courses/presentation.gjs
+++ b/mon-pix/app/components/routes/combined-courses/presentation.gjs
@@ -31,7 +31,7 @@ const Header = <template>
       {{/if}}
 
       <div class={{unless (eq @combinedCourse.status "COMPLETED") "combined-course__description"}}>
-        <MarkdownToHtml @markdown={{@combinedCourse.description}} />
+        <MarkdownToHtml @markdown={{@combinedCourse.description}} @mustReplaceLinksFromMarkdown={{true}} />
       </div>
 
       {{#if (eq @combinedCourse.status "NOT_STARTED")}}

--- a/mon-pix/app/components/routes/combined-courses/presentation.gjs
+++ b/mon-pix/app/components/routes/combined-courses/presentation.gjs
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { and, eq } from 'ember-truth-helpers';
 import CombinedCourseItem from 'mon-pix/components/combined-course/combined-course-item';
+import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
 import ENV from 'mon-pix/config/environment';
 import { CombinedCourseStatuses } from 'mon-pix/models/combined-course';
 
@@ -30,7 +31,7 @@ const Header = <template>
       {{/if}}
 
       <div class={{unless (eq @combinedCourse.status "COMPLETED") "combined-course__description"}}>
-        {{@combinedCourse.description}}
+        <MarkdownToHtml @markdown={{@combinedCourse.description}} />
       </div>
 
       {{#if (eq @combinedCourse.status "NOT_STARTED")}}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -59,6 +59,7 @@
 @use 'components/choice-chip' as *;
 @use 'components/reset-campaign-participation-modal' as *;
 @use 'components/tabs' as *;
+@use 'components/markdown-to-html' as *;
 
 /* we need this to be before competence-card-default because of a mix
 of an adaptative/mobile-first approach — refactoring is welcome here */

--- a/mon-pix/app/styles/components/_markdown-to-html.scss
+++ b/mon-pix/app/styles/components/_markdown-to-html.scss
@@ -1,0 +1,9 @@
+@use 'pix-design-tokens/typography';
+
+.link-markdown-to-html {
+    display: inline-flex;
+
+  a {
+    @extend %pix-body-l;
+  }
+}

--- a/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
@@ -40,14 +40,19 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
         id: 1,
         status: CombinedCourseStatuses.NOT_STARTED,
         code: 'COMBINIX9',
-        description: 'Le but de ma quête',
+        description: 'Le but de ma quête : [plus de détails](http://pix.fr)',
       });
 
       // when
       const screen = await render(
         <template><CombinedCoursesPresentation @combinedCourse={{combinedCourse}} /></template>,
       );
-      assert.ok(screen.getByText('Le but de ma quête'));
+      assert.ok(screen.getByText('Le but de ma quête', { exact: false }));
+      assert.ok(document.getElementsByClassName('link-markdown-to-html'));
+      const expectedLink = screen.getByRole('link', { name: 'plus de détails' });
+      assert.ok(expectedLink.hasAttribute('href', 'http://pix.fr'));
+      assert.ok(expectedLink.hasAttribute('rel', 'noopener noreferrer'));
+      assert.ok(expectedLink.hasAttribute('target', '_blank'));
     });
     test('should display exit button', async function (assert) {
       // given


### PR DESCRIPTION
## 💥 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On veut pouvoir utiliser du markdown pour les descriptions des parcours combinés.

## 👩‍🚀 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Utilisation de MarkdownToHtml pour render du markdown en html dans les descriptions des parcours combinés

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

On a ajouté une description contenant du markdown dans les seeds, pour avoir un cas

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Aller sur Pix App.
Se connecter avec justin-compte@example.net.
"J'ai un code" -> "COMBINIX1"
La description doit s'afficher correctement, avec un titre et un lien venant du markdown.

Autre test : 
Dans pix admin, importer un csv de création de parcours combiné, avec une description qui contient du MD, et vérifier que les parcours associés s'affichent correctement.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
