### PR TITLE
[TECH] Corriger les bugs d'affichage des dates sur PixAdmin (PIX-22828)

### DIFF
--- a/admin/app/components/sessions/certifications/list.gjs
+++ b/admin/app/components/sessions/certifications/list.gjs
@@ -102,7 +102,7 @@ export default class CertificationsHeader extends Component {
               {{t "pages.certifications.table.headers.finished-certification-date"}}
             </:header>
             <:cell>
-              {{certification.lastAnswerDate}}
+              {{if @session.isFinalized certification.lastAnswerDate}}
             </:cell>
           </PixTableColumn>
         </:columns>

--- a/admin/app/ember-intl.js
+++ b/admin/app/ember-intl.js
@@ -7,7 +7,6 @@ export const formats = {
       day: 'numeric',
       hour: 'numeric',
       minute: 'numeric',
-      timeZone: 'UTC',
     },
     // DD/MM/YYYY HH:mm:ss
     long: {
@@ -17,7 +16,6 @@ export const formats = {
       hour: 'numeric',
       minute: 'numeric',
       second: 'numeric',
-      timeZone: 'UTC',
     },
   },
   formatTime: {
@@ -26,7 +24,6 @@ export const formats = {
       hour: 'numeric',
       minute: 'numeric',
       second: 'numeric',
-      timeZone: 'UTC',
     },
   },
 };

--- a/admin/app/templates/authenticated/sessions/session/certifications.gjs
+++ b/admin/app/templates/authenticated/sessions/session/certifications.gjs
@@ -14,6 +14,7 @@ import List from 'pix-admin/components/sessions/certifications/list';
     />
 
     <List
+      @session={{@controller.model.session}}
       @juryCertificationSummaries={{@controller.model.juryCertificationSummaries}}
       @pagination={{@controller.model.juryCertificationSummaries.meta}}
     />

--- a/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
@@ -89,9 +89,11 @@ const answers = [
 module('Integration | Component | Certifications | certification > details v3', function (hooks) {
   setupIntlRenderingTest(hooks);
   let store;
+  let intl;
 
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
+    intl = this.owner.lookup('service:intl');
   });
 
   module('#display', function () {
@@ -140,7 +142,7 @@ module('Integration | Component | Certifications | certification > details v3', 
           )
           .exists();
         assert.dom(screen.getByLabelText(`${pixScoreLabel} :`)).exists();
-        assert.strictEqual(creationDate, '13/01/2023 08:00:00');
+        assert.strictEqual(creationDate, intl.formatDate(model.createdAt, { format: 'long' }));
       });
 
       module('when the certification is valid', function () {
@@ -171,7 +173,9 @@ module('Integration | Component | Certifications | certification > details v3', 
           const lastAnswerAtLabel = t(
             'pages.certifications.certification.details.v3.general-informations.labels.last-answer-at',
           );
-          assert.dom(screen.getByLabelText(`${lastAnswerAtLabel} :`)).containsText('13/01/2023 09:05:00');
+          assert
+            .dom(screen.getByLabelText(`${lastAnswerAtLabel} :`))
+            .containsText(intl.formatDate(new Date('2023-01-13T09:05:00Z'), { format: 'long' }));
         });
 
         test('should display the certification duration', async function (assert) {
@@ -301,7 +305,9 @@ module('Integration | Component | Certifications | certification > details v3', 
 
             // then
             assert.dom(screen.getByText('Dernière réponse le :')).exists();
-            assert.dom(screen.getByText('13/01/2023 08:05:00')).exists();
+            assert
+              .dom(screen.getByText(intl.formatDate(new Date('2023-01-13T08:05:00Z'), { format: 'long' })))
+              .exists();
           });
           test('should display the session finalized tooltip', async function (assert) {
             // given
@@ -325,7 +331,9 @@ module('Integration | Component | Certifications | certification > details v3', 
             const screen = await render(<template><DetailsV3 @details={{model}} /></template>);
 
             // then
-            const tooltipTrigger = screen.getByText('13/01/2023 08:05:00');
+            const tooltipTrigger = screen.getByText(
+              intl.formatDate(new Date('2023-01-13T08:05:00Z'), { format: 'long' }),
+            );
 
             fireEvent.mouseOver(tooltipTrigger);
 
@@ -359,7 +367,9 @@ module('Integration | Component | Certifications | certification > details v3', 
 
             // then
             assert.dom(screen.getByText('Dernière réponse le :')).exists();
-            assert.dom(screen.getByText('13/01/2023 08:05:00')).exists();
+            assert
+              .dom(screen.getByText(intl.formatDate(new Date('2023-01-13T08:05:00Z'), { format: 'long' })))
+              .exists();
           });
           test('should display the ended by invigilator tooltip', async function (assert) {
             // given
@@ -381,7 +391,9 @@ module('Integration | Component | Certifications | certification > details v3', 
 
             // when
             const screen = await render(<template><DetailsV3 @details={{model}} /></template>);
-            fireEvent.mouseOver(screen.getByText('13/01/2023 08:05:00'));
+            fireEvent.mouseOver(
+              screen.getByText(intl.formatDate(new Date('2023-01-13T08:05:00Z'), { format: 'long' })),
+            );
 
             // then
             assert
@@ -488,7 +500,7 @@ module('Integration | Component | Certifications | certification > details v3', 
 
         const expected = answers.map((answer) => [
           answer.questionNumber,
-          `${answer.answeredAt.getUTCHours()}:${answer.answeredAt.getUTCMinutes()}:00`,
+          intl.formatTime(answer.answeredAt, { format: 'long' }),
           answer.answerStatusName,
           `${answer.competenceIndex} ${answer.competenceName}`,
           answer.skillName,

--- a/admin/tests/integration/components/sessions/certifications/list-test.gjs
+++ b/admin/tests/integration/components/sessions/certifications/list-test.gjs
@@ -8,9 +8,11 @@ module('Integration | Component | certifications/list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let store;
+  let intl;
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
+    intl = this.owner.lookup('service:intl');
   });
 
   test('should display number of certification issue reports with required action', async function (assert) {
@@ -61,6 +63,58 @@ module('Integration | Component | certifications/list', function (hooks) {
 
     // then
     assert.dom(screen.getByText('Pix+ Droit', { exact: false })).exists();
+  });
+
+  module('lastAnswerAt" column', function () {
+    test('should display the last answer date when session is finalized', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+
+      const lastAnswerAt = new Date('2023-01-13T08:00:00Z');
+      const session = store.createRecord('session', { status: 'finalized' });
+      const juryCertificationSummaries = [store.createRecord('jury-certification-summary', { lastAnswerAt })];
+      const pagination = {};
+
+      // when
+      const screen = await render(
+        <template>
+          <List
+            @session={{session}}
+            @juryCertificationSummaries={{juryCertificationSummaries}}
+            @pagination={{pagination}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(intl.formatDate(lastAnswerAt, { format: 'long' }))).exists();
+    });
+
+    test('should not display the last answer date when session is not finalized', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+
+      const lastAnswerAt = new Date('2023-01-13T08:00:00Z');
+      const session = store.createRecord('session', { status: 'created' });
+      const juryCertificationSummaries = [store.createRecord('jury-certification-summary', { lastAnswerAt })];
+      const pagination = {};
+
+      // when
+      const screen = await render(
+        <template>
+          <List
+            @session={{session}}
+            @juryCertificationSummaries={{juryCertificationSummaries}}
+            @pagination={{pagination}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.queryByText(intl.formatDate(lastAnswerAt, { format: 'long' }))).doesNotExist();
+    });
   });
 
   module('when user has a SuperAdmin, Certif or Support role', function () {


### PR DESCRIPTION
## 💥 Problème

- dates UTC au lieu d'être recalées à la timezone d’affichage sur Pix Admin
- partout où l’info de “fin de certif” est affichée, possibilité de constater une date qui bouge au fur et à mesure que la certification avance (date et heure de la dernière réponse du candidat, "en live")
- en fait, plein d’affichages de dates côté admin sont KO (tous ceux utilisant EmberIntl.formatDate

## 👩‍🚀 Proposition

- ne plus forcer la timezone UTC de façon à ce qu'intl traduisent les dates au fuseau horaire de l'utilisateur. 
- ne pas afficher la date de "fin" dans le tableau récapitulatif des certifs d'une session tant que la sessions n'est pas finalisée

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
Créer une session et passer une certif.
Dans admin, sur la page /sessions/XXXX/certifications, vérifier que la date de début est correcte, et que la date de fin est vide
finaliser la session, vérifier dans admin que la date de fin est correcte.
On peut, avec une extension, jouer sur les fuseaux horaire et vérifier que les deux horaires changent bien selon le fuseau appliqué

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
