### PR TITLE
[TECH] Déplace le mapping des erreurs evaluation dans son contexte.

### DIFF
--- a/api/src/certification/evaluation/domain/usecases/evaluate-and-save-answer.js
+++ b/api/src/certification/evaluation/domain/usecases/evaluate-and-save-answer.js
@@ -1,10 +1,10 @@
-import { EmptyAnswerError } from '../../../../evaluation/domain/errors.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
   CertificationEndedByInvigilatorError,
   ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,
+  EmptyAnswerError,
   ForbiddenAccess,
   NotFoundError,
 } from '../../../../shared/domain/errors.js';

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -1,6 +1,7 @@
 import { HttpErrors } from '../../shared/application/errors/http-errors.js';
 import {
   AcquiredBadgeForbiddenUpdateError,
+  AlreadyRatedAssessmentError,
   AnswerEvaluationError,
   CompetenceResetError,
   EmptyAnswerError,
@@ -36,6 +37,12 @@ const evaluationDomainErrorMappingConfiguration = [
     name: AnswerEvaluationError.name,
     httpErrorFn: (error) => {
       return new HttpErrors.InternalServerError(error.message);
+    },
+  },
+  {
+    name: AlreadyRatedAssessmentError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.PreconditionFailedError(error.message);
     },
   },
 ];

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -4,17 +4,10 @@ import {
   AlreadyRatedAssessmentError,
   AnswerEvaluationError,
   CompetenceResetError,
-  EmptyAnswerError,
   ImproveCompetenceEvaluationForbiddenError,
 } from '../domain/errors.js';
 
 const evaluationDomainErrorMappingConfiguration = [
-  {
-    name: EmptyAnswerError.name,
-    httpErrorFn: (error) => {
-      return new HttpErrors.BadRequestError(error.message, error.code);
-    },
-  },
   {
     name: ImproveCompetenceEvaluationForbiddenError.name,
     httpErrorFn: (error) => {

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -32,7 +32,7 @@ class AnswerEvaluationError extends DomainError {
 }
 
 class AlreadyRatedAssessmentError extends DomainError {
-  constructor(message = 'Cette évaluation a déjà été évaluée.') {
+  constructor(message = 'Assessment is already rated.') {
     super(message);
   }
 }

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -1,11 +1,5 @@
 import { DomainError } from '../../shared/domain/errors.js';
 
-class EmptyAnswerError extends DomainError {
-  constructor(message = 'The answer value cannot be empty', code = 'ANSWER_CANNOT_BE_EMPTY') {
-    super(message, code);
-  }
-}
-
 class ImproveCompetenceEvaluationForbiddenError extends DomainError {
   constructor(message = 'Le niveau maximum est déjà atteint pour cette compétence.') {
     super(message);
@@ -42,6 +36,5 @@ export {
   AlreadyRatedAssessmentError,
   AnswerEvaluationError,
   CompetenceResetError,
-  EmptyAnswerError,
   ImproveCompetenceEvaluationForbiddenError,
 };

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -1,9 +1,8 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { ChallengeAlreadyAnsweredError, ForbiddenAccess } from '../../../shared/domain/errors.js';
+import { ChallengeAlreadyAnsweredError, EmptyAnswerError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
-import { EmptyAnswerError } from '../errors.js';
 
 export async function saveAndCorrectAnswerForCampaign({
   answer,

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -1,9 +1,8 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { ChallengeAlreadyAnsweredError, ForbiddenAccess } from '../../../shared/domain/errors.js';
+import { ChallengeAlreadyAnsweredError, EmptyAnswerError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
-import { EmptyAnswerError } from '../errors.js';
 
 export async function saveAndCorrectAnswerForCompetenceEvaluation({
   answer,

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
@@ -1,5 +1,8 @@
-import { ChallengeAlreadyAnsweredError, ChallengeNotAskedError } from '../../../shared/domain/errors.js';
-import { EmptyAnswerError } from '../errors.js';
+import {
+  ChallengeAlreadyAnsweredError,
+  ChallengeNotAskedError,
+  EmptyAnswerError,
+} from '../../../shared/domain/errors.js';
 
 export async function saveAndCorrectAnswerForDemoAndPreview({
   answer,

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,5 +1,4 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import { EmptyAnswerError } from '../../../evaluation/domain/errors.js';
 import {
   ArchiveOrganizationError,
   UnableToAttachChildOrganizationToParentOrganizationError,
@@ -97,7 +96,6 @@ const BAD_REQUEST_ERRORS = [
   SharedDomainErrors.UserOrgaSettingsCreationError,
   SharedDomainErrors.AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
   SharedDomainErrors.TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
-  EmptyAnswerError,
 ];
 
 const UNPROCESSABLE_ENTITY_ERRORS = [

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,5 +1,5 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import { AlreadyRatedAssessmentError, EmptyAnswerError } from '../../../evaluation/domain/errors.js';
+import { EmptyAnswerError } from '../../../evaluation/domain/errors.js';
 import {
   ArchiveOrganizationError,
   UnableToAttachChildOrganizationToParentOrganizationError,
@@ -140,9 +140,7 @@ export function mapToHttpError(error) {
   if (error instanceof SharedDomainErrors.ApplicationWithInvalidCredentialsError) {
     return new HttpErrors.UnauthorizedError('The client ID and/or secret are invalid.');
   }
-  if (error instanceof AlreadyRatedAssessmentError) {
-    return new HttpErrors.PreconditionFailedError('Assessment is already rated.');
-  }
+
   if (error instanceof SharedDomainErrors.ChallengeNotAskedError) {
     return new HttpErrors.ConflictError('This challenge has not been asked to the user.');
   }

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -1059,6 +1059,12 @@ class FeatureDisabledError extends DomainError {
   }
 }
 
+class EmptyAnswerError extends DomainError {
+  constructor(message = 'The answer value cannot be empty', code = 'ANSWER_CANNOT_BE_EMPTY') {
+    super(message, code);
+  }
+}
+
 export {
   AccountRecoveryDemandExpired,
   AccountRecoveryUserAlreadyConfirmEmail,
@@ -1114,6 +1120,7 @@ export {
   DeprecatedCertificationIssueReportSubcategoryError,
   DomainError,
   EmailModificationDemandNotFoundOrExpiredError,
+  EmptyAnswerError,
   EntityValidationError,
   FeatureDisabledError,
   FileValidationError,

--- a/api/tests/certification/evaluation/integration/domain/usecases/evaluate-and-save-answer_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/evaluate-and-save-answer_test.js
@@ -1,11 +1,11 @@
 import { usecases } from '../../../../../../src/certification/evaluation/domain/usecases/index.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
-import { EmptyAnswerError } from '../../../../../../src/evaluation/domain/errors.js';
 import {
   CertificationEndedByFinalizationError,
   CertificationEndedByInvigilatorError,
   ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,
+  EmptyAnswerError,
   ForbiddenAccess,
   NotFoundError,
 } from '../../../../../../src/shared/domain/errors.js';

--- a/api/tests/evaluation/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/evaluation/unit/application/http-error-mapper-configuration_test.js
@@ -1,0 +1,21 @@
+import { evaluationDomainErrorMappingConfiguration } from '../../../../src/evaluation/application/http-error-mapper-configuration.js';
+import { AlreadyRatedAssessmentError } from '../../../../src/evaluation/domain/errors.js';
+import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
+import { expect } from '../../../test-helper.js';
+
+describe('Unit | Evaluation | Application | HttpErrorMapperConfiguration', function () {
+  context('when mapping "AlreadyRatedAssessmentError"', function () {
+    it('returns an PreconditionFailedError Http Error', function () {
+      // given
+      const httpErrorMapper = evaluationDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === AlreadyRatedAssessmentError.name,
+      );
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new AlreadyRatedAssessmentError());
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -1,11 +1,14 @@
 import sinon from 'sinon';
 
-import { EmptyAnswerError } from '../../../../../src/evaluation/domain/errors.js';
 import * as correctionService from '../../../../../src/evaluation/domain/services/correction-service.js';
 import { saveAndCorrectAnswerForCampaign } from '../../../../../src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js';
 import { AnswerJob } from '../../../../../src/quest/domain/models/AnwserJob.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { ChallengeAlreadyAnsweredError, ChallengeNotAskedError } from '../../../../../src/shared/domain/errors.js';
+import {
+  ChallengeAlreadyAnsweredError,
+  ChallengeNotAskedError,
+  EmptyAnswerError,
+} from '../../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
@@ -1,11 +1,14 @@
 import sinon from 'sinon';
 
-import { EmptyAnswerError } from '../../../../../src/evaluation/domain/errors.js';
 import * as correctionService from '../../../../../src/evaluation/domain/services/correction-service.js';
 import { saveAndCorrectAnswerForCompetenceEvaluation } from '../../../../../src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js';
 import { AnswerJob } from '../../../../../src/quest/domain/models/AnwserJob.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { ChallengeAlreadyAnsweredError, ChallengeNotAskedError } from '../../../../../src/shared/domain/errors.js';
+import {
+  ChallengeAlreadyAnsweredError,
+  ChallengeNotAskedError,
+  EmptyAnswerError,
+} from '../../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-demo-and-preview_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-demo-and-preview_test.js
@@ -1,10 +1,13 @@
 import sinon from 'sinon';
 
-import { EmptyAnswerError } from '../../../../../src/evaluation/domain/errors.js';
 import * as correctionService from '../../../../../src/evaluation/domain/services/correction-service.js';
 import { saveAndCorrectAnswerForDemoAndPreview } from '../../../../../src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { ChallengeAlreadyAnsweredError, ChallengeNotAskedError } from '../../../../../src/shared/domain/errors.js';
+import {
+  ChallengeAlreadyAnsweredError,
+  ChallengeNotAskedError,
+  EmptyAnswerError,
+} from '../../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../test-helper.js';

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -81,14 +81,6 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('L\u2019entité existe déjà.');
     });
 
-    it('responds Precondition Failed when a AlreadyRatedAssessmentError error occurs', async function () {
-      routeHandler.throws(new EvaluationDomainErrors.AlreadyRatedAssessmentError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(PRECONDITION_FAILED);
-      expect(responseDetail(response)).to.equal('Assessment is already rated.');
-    });
-
     it('responds Precondition Failed when a CompetenceResetError error occurs', async function () {
       routeHandler.throws(new CompetenceResetError(2));
       const response = await server.requestObject(request);


### PR DESCRIPTION
## 💥 Problème

Le mapping des erreurs evaluation en erreur HTTP est défini dans le fichier `error-manager.js` de `shared`. Or le contexte `shared` ne doit pas importer des modules des autres contextes.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 👩‍🚀 Proposition

Déplacer le mapping des erreurs evaluation dans son contexte.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
- La CI doit passer.
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
