### PR TITLE
[TECH] Déplace le mapping des erreurs Acquisition dans son contexte.

### DIFF
--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -2,6 +2,7 @@ import { HttpErrors } from '../../shared/application/errors/http-errors.js';
 import {
   AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
+  ArchiveOrganizationError,
   ArchiveOrganizationsInBatchError,
   CountryNotFoundError,
   DpoEmailInvalid,
@@ -81,6 +82,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   },
   {
     name: StructureNotFoundError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: ArchiveOrganizationError.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,5 +1,4 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import { UserNotMemberOfOrganizationError } from '../../../team/domain/errors.js';
 import * as SharedDomainErrors from '../../domain/errors.js';
 import { HttpErrors } from './http-errors.js';
 
@@ -99,7 +98,6 @@ const UNPROCESSABLE_ENTITY_ERRORS = [
   SharedDomainErrors.OidcMissingFieldsError,
   SharedDomainErrors.YamlParsingError,
   SharedDomainErrors.UserShouldNotBeReconciledOnAnotherAccountError,
-  UserNotMemberOfOrganizationError,
   SharedDomainErrors.FeatureDisabledError,
 ];
 

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,8 +1,5 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import {
-  ArchiveOrganizationError,
-  UnableToAttachChildOrganizationToParentOrganizationError,
-} from '../../../organizational-entities/domain/errors.js';
+import { UnableToAttachChildOrganizationToParentOrganizationError } from '../../../organizational-entities/domain/errors.js';
 import {
   AlreadyAcceptedOrCancelledInvitationError,
   UserHasNoOrganizationMembershipError,
@@ -111,7 +108,6 @@ const UNPROCESSABLE_ENTITY_ERRORS = [
   SharedDomainErrors.YamlParsingError,
   SharedDomainErrors.UserShouldNotBeReconciledOnAnotherAccountError,
   UserNotMemberOfOrganizationError,
-  ArchiveOrganizationError,
   SharedDomainErrors.FeatureDisabledError,
 ];
 

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,9 +1,5 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import {
-  AlreadyAcceptedOrCancelledInvitationError,
-  UserHasNoOrganizationMembershipError,
-  UserNotMemberOfOrganizationError,
-} from '../../../team/domain/errors.js';
+import { UserHasNoOrganizationMembershipError, UserNotMemberOfOrganizationError } from '../../../team/domain/errors.js';
 import * as SharedDomainErrors from '../../domain/errors.js';
 import { HttpErrors } from './http-errors.js';
 
@@ -48,7 +44,6 @@ const CONFLICT_ERRORS = [
   SharedDomainErrors.DeletedError,
   SharedDomainErrors.CertificationEndedByFinalizationError,
   SharedDomainErrors.MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
-  AlreadyAcceptedOrCancelledInvitationError,
 ];
 
 const PRECONDITION_FAILED_ERRORS = [

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,5 +1,5 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import { UserHasNoOrganizationMembershipError, UserNotMemberOfOrganizationError } from '../../../team/domain/errors.js';
+import { UserNotMemberOfOrganizationError } from '../../../team/domain/errors.js';
 import * as SharedDomainErrors from '../../domain/errors.js';
 import { HttpErrors } from './http-errors.js';
 
@@ -29,7 +29,6 @@ const FORBIDDEN_ERRORS = [
   SharedDomainErrors.CandidateNotAuthorizedToJoinSessionError,
   SharedDomainErrors.CandidateNotAuthorizedToResumeCertificationTestError,
   SharedDomainErrors.CertificationCandidateOnFinalizedSessionError,
-  UserHasNoOrganizationMembershipError,
 ];
 
 const CONFLICT_ERRORS = [

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,5 +1,4 @@
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import { UnableToAttachChildOrganizationToParentOrganizationError } from '../../../organizational-entities/domain/errors.js';
 import {
   AlreadyAcceptedOrCancelledInvitationError,
   UserHasNoOrganizationMembershipError,
@@ -49,7 +48,6 @@ const CONFLICT_ERRORS = [
   SharedDomainErrors.DeletedError,
   SharedDomainErrors.CertificationEndedByFinalizationError,
   SharedDomainErrors.MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
-  UnableToAttachChildOrganizationToParentOrganizationError,
   AlreadyAcceptedOrCancelledInvitationError,
 ];
 

--- a/api/src/team/application/http-error-mapper-configuration.js
+++ b/api/src/team/application/http-error-mapper-configuration.js
@@ -4,6 +4,7 @@ import {
   AlreadyExistingAdminMemberError,
   OrganizationArchivedError,
   UncancellableOrganizationInvitationError,
+  UserHasNoOrganizationMembershipError,
 } from '../domain/errors.js';
 
 const teamDomainErrorMappingConfiguration = [
@@ -22,6 +23,10 @@ const teamDomainErrorMappingConfiguration = [
   {
     name: AlreadyAcceptedOrCancelledInvitationError.name,
     httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: UserHasNoOrganizationMembershipError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/team/application/http-error-mapper-configuration.js
+++ b/api/src/team/application/http-error-mapper-configuration.js
@@ -5,6 +5,7 @@ import {
   OrganizationArchivedError,
   UncancellableOrganizationInvitationError,
   UserHasNoOrganizationMembershipError,
+  UserNotMemberOfOrganizationError,
 } from '../domain/errors.js';
 
 const teamDomainErrorMappingConfiguration = [
@@ -27,6 +28,10 @@ const teamDomainErrorMappingConfiguration = [
   {
     name: UserHasNoOrganizationMembershipError.name,
     httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+  },
+  {
+    name: UserNotMemberOfOrganizationError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/team/application/http-error-mapper-configuration.js
+++ b/api/src/team/application/http-error-mapper-configuration.js
@@ -1,5 +1,6 @@
 import { HttpErrors } from '../../shared/application/errors/http-errors.js';
 import {
+  AlreadyAcceptedOrCancelledInvitationError,
   AlreadyExistingAdminMemberError,
   OrganizationArchivedError,
   UncancellableOrganizationInvitationError,
@@ -17,6 +18,10 @@ const teamDomainErrorMappingConfiguration = [
   {
     name: OrganizationArchivedError.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message),
+  },
+  {
+    name: AlreadyAcceptedOrCancelledInvitationError.name,
+    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -1,5 +1,6 @@
 import { organizationalEntitiesDomainErrorMappingConfiguration } from '../../../../src/organizational-entities/application/http-error-mapper-configuration.js';
 import {
+  ArchiveOrganizationError,
   CountryNotFoundError,
   NetworkAlreadyExistError,
   ParentOrganizationNotInNetworkError,
@@ -140,6 +141,25 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       // then
       expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
       expect(error.message).to.equal('Structure not found');
+      expect(error.meta).to.equal(meta);
+    });
+  });
+
+  context('when mapping "ArchiveOrganizationError"', function () {
+    it('should return a UnprocessableEntityError Http Error', function () {
+      // given
+      const httpErrorMapper = organizationalEntitiesDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === ArchiveOrganizationError.name,
+      );
+
+      const meta = { organizationId: 1234 };
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new ArchiveOrganizationError({ meta }));
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error.message).to.equal('Error during organization archiving');
       expect(error.meta).to.equal(meta);
     });
   });

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -14,7 +14,6 @@ import {
 import { SiecleXmlImportError } from '../../../../src/prescription/learner-management/domain/errors.js';
 import * as DomainErrors from '../../../../src/shared/domain/errors.js';
 import {
-  AlreadyAcceptedOrCancelledInvitationError,
   UserHasNoOrganizationMembershipError,
   UserNotMemberOfOrganizationError,
 } from '../../../../src/team/domain/errors.js';
@@ -236,14 +235,6 @@ describe('Integration | API | Controller Error', function () {
 
       expect(response.statusCode).to.equal(CONFLICT_ERROR);
       expect(responseDetail(response)).to.equal('This user has already a confirmed email.');
-    });
-
-    it('responds Conflict when an AlreadyAcceptedOrCancelledInvitationError occurs', async function () {
-      routeHandler.throws(new AlreadyAcceptedOrCancelledInvitationError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(CONFLICT_ERROR);
-      expect(responseCode(response)).to.equal('INVITATION_ALREADY_ACCEPTED_OR_CANCELLED');
     });
 
     it('responds Conflict when a ChallengeNotAskedError error occurs', async function () {

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -13,7 +13,6 @@ import {
 } from '../../../../src/identity-access-management/domain/errors.js';
 import { SiecleXmlImportError } from '../../../../src/prescription/learner-management/domain/errors.js';
 import * as DomainErrors from '../../../../src/shared/domain/errors.js';
-import { UserNotMemberOfOrganizationError } from '../../../../src/team/domain/errors.js';
 import { expect } from '../../../test-helper.js';
 import { HttpTestServer } from '../../../tooling/server/http-test-server.js';
 
@@ -559,14 +558,6 @@ describe('Integration | API | Controller Error', function () {
 
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
       expect(responseDetail(response)).to.equal('An error occurred, file is invalid');
-    });
-
-    it('responds Unprocessable Entity when a UserNotMemberOfOrganizationError error occurs', async function () {
-      routeHandler.throws(new UserNotMemberOfOrganizationError("L'utilisateur n'est pas membre de l'organisation."));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
-      expect(responseDetail(response)).to.equal("L'utilisateur n'est pas membre de l'organisation.");
     });
 
     it('responds Unprocessable Entity with invalid data attribute', async function () {

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -13,10 +13,7 @@ import {
 } from '../../../../src/identity-access-management/domain/errors.js';
 import { SiecleXmlImportError } from '../../../../src/prescription/learner-management/domain/errors.js';
 import * as DomainErrors from '../../../../src/shared/domain/errors.js';
-import {
-  UserHasNoOrganizationMembershipError,
-  UserNotMemberOfOrganizationError,
-} from '../../../../src/team/domain/errors.js';
+import { UserNotMemberOfOrganizationError } from '../../../../src/team/domain/errors.js';
 import { expect } from '../../../test-helper.js';
 import { HttpTestServer } from '../../../tooling/server/http-test-server.js';
 
@@ -503,16 +500,6 @@ describe('Integration | API | Controller Error', function () {
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal("L'invitation à cette organisation a été annulée.");
-      expect(responseTitle(response)).to.equal('Forbidden');
-    });
-
-    it('responds Forbidden when a UserHasNoOrganizationMembershipError error occurs', async function () {
-      routeHandler.throws(new UserHasNoOrganizationMembershipError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal('User is not member of any organization');
-      expect(responseCode(response)).to.equal('USER_HAS_NO_ORGANIZATION_MEMBERSHIP');
       expect(responseTitle(response)).to.equal('Forbidden');
     });
   });

--- a/api/tests/team/unit/application/http-error-mapper-configuration.test.js
+++ b/api/tests/team/unit/application/http-error-mapper-configuration.test.js
@@ -5,6 +5,7 @@ import {
   AlreadyExistingAdminMemberError,
   OrganizationArchivedError,
   UncancellableOrganizationInvitationError,
+  UserHasNoOrganizationMembershipError,
 } from '../../../../src/team/domain/errors.js';
 import { expect } from '../../../test-helper.js';
 
@@ -61,5 +62,19 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     //then
     expect(error).to.be.instanceOf(HttpErrors.ConflictError);
     expect(error.message).to.equal('The invitation has already been accepted or cancelled');
+  });
+
+  it('instantiates ForbiddenError when UserHasNoOrganizationMembershipError', async function () {
+    //given
+    const httpErrorMapper = teamDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === UserHasNoOrganizationMembershipError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new UserHasNoOrganizationMembershipError());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    expect(error.message).to.equal('User is not member of any organization');
   });
 });

--- a/api/tests/team/unit/application/http-error-mapper-configuration.test.js
+++ b/api/tests/team/unit/application/http-error-mapper-configuration.test.js
@@ -6,6 +6,7 @@ import {
   OrganizationArchivedError,
   UncancellableOrganizationInvitationError,
   UserHasNoOrganizationMembershipError,
+  UserNotMemberOfOrganizationError,
 } from '../../../../src/team/domain/errors.js';
 import { expect } from '../../../test-helper.js';
 
@@ -76,5 +77,19 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     //then
     expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
     expect(error.message).to.equal('User is not member of any organization');
+  });
+
+  it('instantiates UnprocessableEntityError when UserNotMemberOfOrganizationError', async function () {
+    //given
+    const httpErrorMapper = teamDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === UserNotMemberOfOrganizationError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new UserNotMemberOfOrganizationError());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+    expect(error.message).to.equal("L'utilisateur n'est pas membre de l'organisation.");
   });
 });

--- a/api/tests/team/unit/application/http-error-mapper-configuration.test.js
+++ b/api/tests/team/unit/application/http-error-mapper-configuration.test.js
@@ -1,6 +1,7 @@
 import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
 import { teamDomainErrorMappingConfiguration } from '../../../../src/team/application/http-error-mapper-configuration.js';
 import {
+  AlreadyAcceptedOrCancelledInvitationError,
   AlreadyExistingAdminMemberError,
   OrganizationArchivedError,
   UncancellableOrganizationInvitationError,
@@ -46,5 +47,19 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     //then
     expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
     expect(error.message).to.equal("L'organisation est archivée.");
+  });
+
+  it('instantiates ConflictError when AlreadyAcceptedOrCancelledInvitationError', async function () {
+    //given
+    const httpErrorMapper = teamDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === AlreadyAcceptedOrCancelledInvitationError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new AlreadyAcceptedOrCancelledInvitationError());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+    expect(error.message).to.equal('The invitation has already been accepted or cancelled');
   });
 });


### PR DESCRIPTION
## 💥 Problème

Le mapping des erreurs `team` et `organizational-entities` en erreur HTTP est défini dans le fichier `error-manager.js` de `shared`. Or le contexte `shared` ne doit pas importer des modules des autres contextes.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 👩‍🚀 Proposition

Déplacer le mapping des erreurs `team` et `organizational-entities` dans son contexte.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
- La CI doit passer.
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
