### PR TITLE
[TECH] Corriger le titre du module Vous avez reçu un mail

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_NOV.json
@@ -2,7 +2,7 @@
   "id": "0d8e8473-96d2-4a7a-bfa5-8cbf14a6e7e7",
   "shortId": "e2a291d1",
   "slug": "repondre-mail-nov",
-  "title": " Vous avez reçu un mail",
+  "title": "Vous avez reçu un mail",
   "isBeta": true,
   "visibility": "public",
   "details": {


### PR DESCRIPTION
## 💥 Problème

Il y a un espace en trop sur le titre du module `Vous avez reçu un mail`

## 👩‍🚀 Proposition

Le corriger

## 👁️ Remarques

RAS

## ♻️ Pour tester
CI au vert ✅ 