### PR TITLE
[TECH] Simplifier le mapping de error-manager dans shared

### DIFF
--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -7,6 +7,7 @@ const NOT_FOUND_ERRORS = [
   SharedDomainErrors.UserNotFoundError,
   SharedDomainErrors.OrganizationNotFoundError,
   SharedDomainErrors.CampaignCodeError,
+  SharedDomainErrors.CertificationCandidateByPersonalInfoNotFoundError,
 ];
 
 const FORBIDDEN_ERRORS = [
@@ -28,6 +29,10 @@ const FORBIDDEN_ERRORS = [
   SharedDomainErrors.CandidateNotAuthorizedToJoinSessionError,
   SharedDomainErrors.CandidateNotAuthorizedToResumeCertificationTestError,
   SharedDomainErrors.CertificationCandidateOnFinalizedSessionError,
+  SharedDomainErrors.UserNotAuthorizedToAccessEntityError,
+  SharedDomainErrors.UserAlreadyLinkedToCandidateInSessionError,
+  SharedDomainErrors.UserNotAuthorizedToCertifyError,
+  SharedDomainErrors.ApplicationScopeNotAllowedError,
 ];
 
 const CONFLICT_ERRORS = [
@@ -42,6 +47,8 @@ const CONFLICT_ERRORS = [
   SharedDomainErrors.DeletedError,
   SharedDomainErrors.CertificationEndedByFinalizationError,
   SharedDomainErrors.MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
+  SharedDomainErrors.ChallengeNotAskedError,
+  SharedDomainErrors.CertificationCandidateByPersonalInfoTooManyMatchesError,
 ];
 
 const PRECONDITION_FAILED_ERRORS = [
@@ -84,6 +91,12 @@ const BAD_REQUEST_ERRORS = [
   SharedDomainErrors.UserOrgaSettingsCreationError,
   SharedDomainErrors.AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
   SharedDomainErrors.TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
+  SharedDomainErrors.CertificationCandidatePersonalInfoFieldMissingError,
+  SharedDomainErrors.CertificationCandidatePersonalInfoWrongFormat,
+  SharedDomainErrors.CertificationCenterMembershipCreationError,
+  SharedDomainErrors.SendingEmailToInvalidDomainError,
+  SharedDomainErrors.SendingEmailToInvalidEmailAddressError,
+  SharedDomainErrors.AssessmentEndedError,
 ];
 
 const UNPROCESSABLE_ENTITY_ERRORS = [
@@ -106,6 +119,7 @@ const UNAUTHORIZED_ERRORS = [
   SharedDomainErrors.InvalidResultRecipientTokenError,
   SharedDomainErrors.InvalidTemporaryKeyError,
   SharedDomainErrors.AccountRecoveryDemandExpired,
+  SharedDomainErrors.ApplicationWithInvalidCredentialsError,
 ];
 
 const SERVICE_UNAVAILABLE_ERRORS = [
@@ -114,56 +128,6 @@ const SERVICE_UNAVAILABLE_ERRORS = [
 ];
 
 export function mapToHttpError(error) {
-  // Special cases: hardcoded messages or non-standard patterns
-  if (error instanceof SharedDomainErrors.UserNotAuthorizedToAccessEntityError) {
-    return new HttpErrors.ForbiddenError('Utilisateur non autorisé à accéder à la ressource');
-  }
-  if (error instanceof SharedDomainErrors.UserAlreadyLinkedToCandidateInSessionError) {
-    return new HttpErrors.ForbiddenError("L'utilisateur est déjà lié à un candidat dans cette session.");
-  }
-  if (error instanceof SharedDomainErrors.ApplicationWithInvalidCredentialsError) {
-    return new HttpErrors.UnauthorizedError('The client ID and/or secret are invalid.');
-  }
-
-  if (error instanceof SharedDomainErrors.ChallengeNotAskedError) {
-    return new HttpErrors.ConflictError('This challenge has not been asked to the user.');
-  }
-  if (error instanceof SharedDomainErrors.CertificationCandidateByPersonalInfoNotFoundError) {
-    return new HttpErrors.NotFoundError(
-      "Aucun candidat de certification ne correspond aux informations d'identité fournies.",
-    );
-  }
-  if (error instanceof SharedDomainErrors.CertificationCandidateByPersonalInfoTooManyMatchesError) {
-    return new HttpErrors.ConflictError(
-      "Plus d'un candidat de certification correspondent aux informations d'identité fournies.",
-    );
-  }
-  if (error instanceof SharedDomainErrors.CertificationCandidatePersonalInfoFieldMissingError) {
-    return new HttpErrors.BadRequestError("Un ou plusieurs champs d'informations d'identité sont manquants.");
-  }
-  if (error instanceof SharedDomainErrors.CertificationCandidatePersonalInfoWrongFormat) {
-    return new HttpErrors.BadRequestError("Un ou plusieurs champs d'informations d'identité sont au mauvais format.");
-  }
-  if (error instanceof SharedDomainErrors.CertificationCenterMembershipCreationError) {
-    return new HttpErrors.BadRequestError("Le membre ou le centre de certification n'existe pas.");
-  }
-  if (error instanceof SharedDomainErrors.UserNotAuthorizedToCertifyError) {
-    return new HttpErrors.ForbiddenError('The user cannot be certified.');
-  }
-  if (error instanceof SharedDomainErrors.ApplicationScopeNotAllowedError) {
-    return new HttpErrors.ForbiddenError('The scope is not allowed.');
-  }
-  if (error instanceof SharedDomainErrors.AssessmentEndedError) {
-    return new HttpErrors.BaseHttpError(error.message);
-  }
-  if (error instanceof SharedDomainErrors.SendingEmailToInvalidDomainError) {
-    return new HttpErrors.BadRequestError(error.message, 'SENDING_EMAIL_TO_INVALID_DOMAIN');
-  }
-  if (error instanceof SharedDomainErrors.SendingEmailToInvalidEmailAddressError) {
-    return new HttpErrors.BadRequestError(error.message, 'SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS', error.meta);
-  }
-
-  // Standard mapping by HTTP error type
   if (NOT_FOUND_ERRORS.some((E) => error instanceof E))
     return new HttpErrors.NotFoundError(error.message, error.code, error.meta);
   if (FORBIDDEN_ERRORS.some((E) => error instanceof E))

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -112,7 +112,7 @@ class CandidateAlreadyLinkedToUserError extends DomainError {
 }
 
 class CertificationCandidateByPersonalInfoNotFoundError extends DomainError {
-  constructor(message = "Aucun candidat de certification n'a été trouvé avec ces informations.") {
+  constructor(message = "Aucun candidat de certification ne correspond aux informations d'identité fournies.") {
     super(message);
   }
 }
@@ -126,7 +126,7 @@ class CsvImportError extends DomainError {
 }
 
 class CertificationCandidateByPersonalInfoTooManyMatchesError extends DomainError {
-  constructor(message = "Plus d'un candidat de certification a été trouvé avec ces informations.") {
+  constructor(message = "Plus d'un candidat de certification correspondent aux informations d'identité fournies.") {
     super(message);
   }
 }
@@ -138,13 +138,13 @@ class CertificationCandidateDeletionError extends DomainError {
 }
 
 class CertificationCandidatePersonalInfoFieldMissingError extends DomainError {
-  constructor(message = 'Information obligatoire manquante du candidat de certification.') {
+  constructor(message = "Un ou plusieurs champs d'informations d'identité sont manquants.") {
     super(message);
   }
 }
 
 class CertificationCandidatePersonalInfoWrongFormat extends DomainError {
-  constructor(message = 'Information transmise par le candidat de certification au mauvais format.') {
+  constructor(message = "Un ou plusieurs champs d'informations d'identité sont au mauvais format.") {
     super(message);
   }
 }
@@ -183,7 +183,7 @@ class ChallengeAlreadyAnsweredError extends DomainError {
 }
 
 class ChallengeNotAskedError extends DomainError {
-  constructor(message = 'La question à laquelle vous essayez de répondre ne vous a pas été proposée.') {
+  constructor(message = 'This challenge has not been asked to the user.') {
     super(message);
   }
 }
@@ -588,7 +588,7 @@ class ApplicationWithInvalidCredentialsError extends DomainError {
 }
 
 class ApplicationScopeNotAllowedError extends DomainError {
-  constructor(message = 'The scope is invalid.') {
+  constructor(message = 'The scope is not allowed.') {
     super(message);
   }
 }
@@ -767,14 +767,14 @@ class SendingEmailError extends DomainError {
 class SendingEmailToInvalidDomainError extends DomainError {
   constructor(emailAddress) {
     super(`Failed to send email to "${emailAddress}" because domain seems to be invalid.`);
-    this.code = 'INVALID_EMAIL_DOMAIN';
+    this.code = 'SENDING_EMAIL_TO_INVALID_DOMAIN';
   }
 }
 
 class SendingEmailToInvalidEmailAddressError extends DomainError {
   constructor(emailAddress, errorMessage) {
     super(`Failed to send email to "${emailAddress}" because email address seems to be invalid.`);
-    this.code = 'INVALID_EMAIL_ADDRESS_FORMAT';
+    this.code = 'SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS';
     this.meta = {
       emailAddress,
       errorMessage,

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -592,7 +592,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       // then
       expect(response.result.errors[0]).to.deep.equal({
         title: 'Unauthorized',
-        detail: 'The client ID and/or secret are invalid.',
+        detail: 'The client ID or secret are invalid.',
         status: '401',
       });
     });
@@ -612,7 +612,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       // then
       expect(response.result.errors[0]).to.deep.equal({
         title: 'Unauthorized',
-        detail: 'The client ID and/or secret are invalid.',
+        detail: 'The client ID or secret are invalid.',
         status: '401',
       });
     });

--- a/api/tests/school/integration/domain/services/correct-answer_test.js
+++ b/api/tests/school/integration/domain/services/correct-answer_test.js
@@ -131,7 +131,6 @@ describe('Integration | UseCases | correct-answer', function () {
       });
 
       expect(error).to.be.instanceOf(ChallengeNotAskedError);
-      expect(error.message).to.equal('La question à laquelle vous essayez de répondre ne vous a pas été proposée.');
     });
 
     it('should return error when lastChallengeId is missing', async function () {
@@ -157,7 +156,6 @@ describe('Integration | UseCases | correct-answer', function () {
       });
 
       expect(error).to.be.instanceOf(ChallengeNotAskedError);
-      expect(error.message).to.equal('La question à laquelle vous essayez de répondre ne vous a pas été proposée.');
     });
 
     it('should return error when assessment is finished', async function () {

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -290,7 +290,7 @@ describe('Integration | API | Controller Error', function () {
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
-      expect(responseDetail(response)).to.equal("Le membre ou le centre de certification n'existe pas.");
+      expect(responseDetail(response)).to.equal('Erreur lors de la création du membership de centre de certification.');
     });
 
     it('responds Bad Request when a InvalidCertificationReportForFinalization error occurs', async function () {
@@ -386,7 +386,7 @@ describe('Integration | API | Controller Error', function () {
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal('Utilisateur non autorisé à accéder à la ressource');
+      expect(responseDetail(response)).to.equal('User is not authorized to access ressource');
     });
 
     it('responds Forbidden when a UserNotAuthorizedToUpdatePasswordError error occurs', async function () {
@@ -437,7 +437,9 @@ describe('Integration | API | Controller Error', function () {
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal("L'utilisateur est déjà lié à un candidat dans cette session.");
+      expect(responseDetail(response)).to.equal(
+        'Cet utilisateur est déjà lié à un candidat de certification au sein de cette session.',
+      );
     });
 
     it('responds Forbidden when a UserNotAuthorizedToCertifyError error occurs', async function () {
@@ -445,7 +447,7 @@ describe('Integration | API | Controller Error', function () {
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal('The user cannot be certified.');
+      expect(responseDetail(response)).to.equal('User is not certifiable');
     });
 
     it('responds Forbidden when a UserNotAuthorizedToGetCampaignResultsError error occurs', async function () {
@@ -770,7 +772,7 @@ describe('Integration | API | Controller Error', function () {
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
-      expect(responseDetail(response)).to.equal('The client ID and/or secret are invalid.');
+      expect(responseDetail(response)).to.equal('The client ID or secret are invalid.');
     });
   });
 


### PR DESCRIPTION
## 💥 Problème

Il y a des mappings particulier dans le `error-manager.js` dans shared.

## 👩‍🚀 Proposition

Standardiser le mapping de ces erreurs.

## 👁️ Remarques

N/A

## ♻️ Pour tester

La CI doit passer.