### PR TITLE
[FEATURE] Ajouter la colonne description à la table trainings (PIX-22852)

### DIFF
--- a/api/db/migrations/20260521150049_add-column-description-for-trainings.js
+++ b/api/db/migrations/20260521150049_add-column-description-for-trainings.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'trainings';
+const COLUMN_NAME = 'description';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.text(COLUMN_NAME).comment('Training description');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 💥 Problème

Il manque un moyen de stocker les descriptions des CF qui seront proposés par le moteur de reco.

## 👩‍🚀 Proposition

Ajouter une colonne "description" dans la table `trainings`, en utilisant un fichier de migration.

## 👁️ Remarques

Faut-il prévenir les capt'ains quand c'est mergé et en prod ?

## ♻️ Pour tester

- Récupérer la branche localement
- Lancer la commande `npm run db:migrate`
- Vérifier que la table `trainings` possède la colonne `description`
