### PR TITLE
[BUMP] Mettre à jour le package @1024pix/epreuves-components.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@1024pix/epreuves-components": "^4.6.0",
+        "@1024pix/epreuves-components": "^4.6.1",
         "@1024pix/oppsy": "^1.0.2",
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.0.tgz",
-      "integrity": "sha512-j/rvZ8NL4LccoI8er+aMeXOUXh+lP7LpTa6/X1MYMY5dGmgw82xdAEgAVTXy0l7bBqAI+4pv0E7iM9JeUzJBfg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.1.tgz",
+      "integrity": "sha512-ic1HZ3vRgQz7skHC5XdHSU7tK4Vy27QGn2z/0v0TqQXycm2sEgXn3YZbCFuoHfdtXPSrtD3LNCyU7Ae6ikJxJQ==",
       "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -92,7 +92,7 @@
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/unit/infrastructure/repositories/module-repository_test.js'"
   },
   "dependencies": {
-    "@1024pix/epreuves-components": "^4.6.0",
+    "@1024pix/epreuves-components": "^4.6.1",
     "@1024pix/oppsy": "^1.0.2",
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^4.6.0",
+        "@1024pix/epreuves-components": "^4.6.1",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^60.10.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.0.tgz",
-      "integrity": "sha512-j/rvZ8NL4LccoI8er+aMeXOUXh+lP7LpTa6/X1MYMY5dGmgw82xdAEgAVTXy0l7bBqAI+4pv0E7iM9JeUzJBfg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.1.tgz",
+      "integrity": "sha512-ic1HZ3vRgQz7skHC5XdHSU7tK4Vy27QGn2z/0v0TqQXycm2sEgXn3YZbCFuoHfdtXPSrtD3LNCyU7Ae6ikJxJQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^4.6.0",
+    "@1024pix/epreuves-components": "^4.6.1",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^60.10.1",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^4.6.0",
+        "@1024pix/epreuves-components": "^4.6.1",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^60.11.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.0.tgz",
-      "integrity": "sha512-j/rvZ8NL4LccoI8er+aMeXOUXh+lP7LpTa6/X1MYMY5dGmgw82xdAEgAVTXy0l7bBqAI+4pv0E7iM9JeUzJBfg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.1.tgz",
+      "integrity": "sha512-ic1HZ3vRgQz7skHC5XdHSU7tK4Vy27QGn2z/0v0TqQXycm2sEgXn3YZbCFuoHfdtXPSrtD3LNCyU7Ae6ikJxJQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^4.6.0",
+    "@1024pix/epreuves-components": "^4.6.1",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^60.11.0",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 💥 Problème

Une nouvelle version `patch` du package epreuves component est disponible.

## 👩‍🚀 Proposition

Mettre à jour le package @1024pix/epreuves-components vers la version 4.6.1.

## 👁️ Remarques

Cette mise à jour contient uniquement des refactos du code, ainsi que des améliorations d'accessibilité.

## ♻️ Pour tester

Se rendre sur [la page de démo des modules](https://app-pr16284.review.pix.fr/modules/0aefd71f/demo-epreuves-components/passage) et vérifier que tout semble conforme.