### PR TITLE
[FEATURE] Activer la locale « es » sur Pix Orga (PIX-22847)

### DIFF
--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
       SUPPORTED_LOCALES: [
         { value: 'de-AT', nativeName: 'Deutsch (Österreich)', displayedInSwitcher: true },
         { value: 'en', nativeName: 'English', displayedInSwitcher: true },
-        // { value: 'es', nativeName: 'Español', displayedInSwitcher: true },
+        { value: 'es', nativeName: 'Español', displayedInSwitcher: true },
         { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },
         { value: 'fr-BE', nativeName: 'Français (Belgique)', displayedInSwitcher: true },
         { value: 'fr-FR', nativeName: 'Français (France)', displayedInSwitcher: false },

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -274,6 +274,10 @@ module('Unit | Services | locale', function (hooks) {
           value: 'en',
         },
         {
+          label: 'Español',
+          value: 'es',
+        },
+        {
           label: 'Français',
           value: 'fr',
         },


### PR DESCRIPTION
## 💥 Problème

Nous avons besoin de restaurer la locale `es` sur Pix Orga

## 👩‍🚀 Proposition

Rajouter la locale qui avait été désactivée temporairement ici https://github.com/1024pix/pix/pull/15695

## 👁️ Remarques

Les autres locales à activer `it`, `de-AT` ne nécessitaient pas de développement supplémentaire.

## ♻️ Pour tester

- Se connecter sur Pix Orga : https://orga-pr16288.review.pix.org/
- Vérifier que l'espagnol est dans le locale switcher.
- Vérifier que si le cookie locale est `es`, le site s'affiche en espagnol automatiquement.