### PR TITLE
[TECH] Renommer la clé de traduction obsolète "complementary-certification' dans Pix Admin (PIX-22698)

### DIFF
--- a/admin/app/components/certification-frameworks/item/framework/certification-version-detail-modal.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/certification-version-detail-modal.gjs
@@ -42,34 +42,32 @@ export default class CertificationVersionDetailModal extends Component {
     >
       <:content>
         <h2 class="certification-version-detail-modal__subtitle">{{t
-            "components.complementary-certifications.item.framework.version-detail-modal.parameters"
+            "components.certification-frameworks.item.framework.version-detail-modal.parameters"
           }}</h2>
         <PixBlock class="certification-version-detail-modal__parameters">
           <dl>
             <PixIcon @name="star" @ariaHidden={{true}} />
-            <dt>{{t "components.complementary-certifications.item.framework.version-detail-modal.status"}}</dt>
+            <dt>{{t "components.certification-frameworks.item.framework.version-detail-modal.status"}}</dt>
             <dd>
               <PixTag @color={{get STATUS_COLORS @status}}>
-                {{t (concat "components.complementary-certifications.item.framework.history.statuses." @status)}}
+                {{t (concat "components.certification-frameworks.item.framework.history.statuses." @status)}}
               </PixTag>
             </dd>
 
             {{#if @version.startDate}}
               <PixIcon @name="calendar" @ariaHidden={{true}} />
-              <dt>{{t "components.complementary-certifications.item.framework.version-detail-modal.start-date"}}</dt>
+              <dt>{{t "components.certification-frameworks.item.framework.version-detail-modal.start-date"}}</dt>
               <dd>{{formatDate @version.startDate}}</dd>
             {{/if}}
 
             {{#if @version.expirationDate}}
               <PixIcon @name="calendar" @ariaHidden={{true}} />
-              <dt>{{t
-                  "components.complementary-certifications.item.framework.version-detail-modal.expiration-date"
-                }}</dt>
+              <dt>{{t "components.certification-frameworks.item.framework.version-detail-modal.expiration-date"}}</dt>
               <dd>{{formatDate @version.expirationDate}}</dd>
             {{/if}}
 
             <PixIcon @name="flag" @ariaHidden={{true}} />
-            <dt>{{t "components.complementary-certifications.item.framework.version-detail-modal.locales"}}</dt>
+            <dt>{{t "components.certification-frameworks.item.framework.version-detail-modal.locales"}}</dt>
             <dd>
               {{#each this.locales as |locale|}}
                 {{locale.flag}}
@@ -78,20 +76,18 @@ export default class CertificationVersionDetailModal extends Component {
             </dd>
 
             <PixIcon @name="time" @ariaHidden={{true}} />
-            <dt>{{t
-                "components.complementary-certifications.item.framework.version-detail-modal.assessment-duration"
-              }}</dt>
+            <dt>{{t "components.certification-frameworks.item.framework.version-detail-modal.assessment-duration"}}</dt>
             <dd>{{formatMinutes @version.assessmentDuration}}</dd>
 
             <PixIcon @name="helpSimple" @ariaHidden={{true}} />
             <dt>{{t
-                "components.complementary-certifications.item.framework.version-detail-modal.maximum-assessment-length"
+                "components.certification-frameworks.item.framework.version-detail-modal.maximum-assessment-length"
               }}</dt>
             <dd>{{@version.maximumAssessmentLength}}</dd>
 
             <PixIcon @name="helpSimple" @ariaHidden={{true}} />
             <dt>{{t
-                "components.complementary-certifications.item.framework.version-detail-modal.minimum-answers-required"
+                "components.certification-frameworks.item.framework.version-detail-modal.minimum-answers-required"
               }}</dt>
             <dd>{{@version.minimumAnswersRequiredForValidation}}</dd>
           </dl>

--- a/admin/app/components/certification-frameworks/item/framework/framework-content-details.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-content-details.gjs
@@ -58,7 +58,7 @@ export default class FrameworkContentDetails extends Component {
 
   <template>
     <h2 class="certification-version-detail-modal__subtitle">{{t
-        "components.complementary-certifications.item.framework.version-detail-modal.content"
+        "components.certification-frameworks.item.framework.version-detail-modal.content"
       }}</h2>
     <PixBlock class="certification-version-detail-modal__content">
       {{#each this.areas as |area|}}

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -89,13 +89,13 @@ export default class FrameworkHistory extends Component {
       <section class="framework-versions">
         <PixTable
           @variant="admin"
-          @caption={{t "components.complementary-certifications.item.framework.history.table.caption"}}
+          @caption={{t "components.certification-frameworks.item.framework.history.table.caption"}}
           @data={{this.frameworkHistory}}
         >
           <:columns as |version context|>
             <PixTableColumn @context={{context}}>
               <:header>
-                {{t "components.complementary-certifications.item.framework.history.table.columns.version-id"}}
+                {{t "components.certification-frameworks.item.framework.history.table.columns.version-id"}}
               </:header>
               <:cell>
                 {{version.id}}
@@ -104,7 +104,7 @@ export default class FrameworkHistory extends Component {
             <PixTableColumn @context={{context}}>
               <:header>
                 {{t
-                  "components.complementary-certifications.item.framework.history.table.columns.maximum-assessment-length"
+                  "components.certification-frameworks.item.framework.history.table.columns.maximum-assessment-length"
                 }}
               </:header>
               <:cell>
@@ -114,7 +114,7 @@ export default class FrameworkHistory extends Component {
             <PixTableColumn @context={{context}}>
               <:header>
                 <PixIcon @name="time" @ariaHidden={{true}} />
-                {{t "components.complementary-certifications.item.framework.history.table.columns.assessment-duration"}}
+                {{t "components.certification-frameworks.item.framework.history.table.columns.assessment-duration"}}
               </:header>
               <:cell>
                 {{formatMinutes version.assessmentDuration}}
@@ -123,7 +123,7 @@ export default class FrameworkHistory extends Component {
             <PixTableColumn @context={{context}}>
               <:header>
                 <PixIcon @name="calendar" @ariaHidden={{true}} />
-                {{t "components.complementary-certifications.item.framework.history.table.columns.start-date"}}
+                {{t "components.certification-frameworks.item.framework.history.table.columns.start-date"}}
               </:header>
               <:cell>
                 <strong>{{if version.startDate (formatDate version.startDate) "-"}}</strong>
@@ -132,7 +132,7 @@ export default class FrameworkHistory extends Component {
             <PixTableColumn @context={{context}}>
               <:header>
                 <PixIcon @name="calendar" @ariaHidden={{true}} />
-                {{t "components.complementary-certifications.item.framework.history.table.columns.expiration-date"}}
+                {{t "components.certification-frameworks.item.framework.history.table.columns.expiration-date"}}
               </:header>
               <:cell>
                 <strong>{{if version.expirationDate (formatDate version.expirationDate) "-"}}</strong>
@@ -140,35 +140,33 @@ export default class FrameworkHistory extends Component {
             </PixTableColumn>
             <PixTableColumn @context={{context}}>
               <:header>
-                {{t "components.complementary-certifications.item.framework.history.table.columns.status"}}
+                {{t "components.certification-frameworks.item.framework.history.table.columns.status"}}
               </:header>
               <:cell>
                 <PixTag @color={{get STATUS_COLORS version.status}}>
-                  {{t
-                    (concat "components.complementary-certifications.item.framework.history.statuses." version.status)
-                  }}
+                  {{t (concat "components.certification-frameworks.item.framework.history.statuses." version.status)}}
                 </PixTag>
               </:cell>
             </PixTableColumn>
             <PixTableColumn @context={{context}}>
               <:header>
-                {{t "components.complementary-certifications.item.framework.history.table.columns.actions"}}
+                {{t "components.certification-frameworks.item.framework.history.table.columns.actions"}}
               </:header>
               <:cell>
                 <PixIconButton
                   @triggerAction={{fn this.viewVersion version.id version.status}}
-                  @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.view"}}
+                  @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.view"}}
                   @iconName="eye"
                 />
                 <PixIconButton
                   @triggerAction={{this.editVersion}}
-                  @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.edit"}}
+                  @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.edit"}}
                   @iconName="edit"
                   @isDisabled={{not (eq version.status "DRAFT")}}
                 />
                 <PixIconButton
                   @triggerAction={{fn this.showDeleteVersionModal version.id}}
-                  @ariaLabel={{t "components.complementary-certifications.item.framework.history.table.actions.delete"}}
+                  @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.delete"}}
                   @iconName="delete"
                   @isDisabled={{not (eq version.status "DRAFT")}}
                 />

--- a/admin/app/components/certification-frameworks/item/framework/version-comment.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/version-comment.gjs
@@ -23,14 +23,14 @@ export default class VersionComment extends Component {
       await this.args.version.save();
       this.pixToast.sendSuccessNotification({
         message: this.intl.t(
-          'components.complementary-certifications.item.framework.version-detail-modal.comment-save-success',
+          'components.certification-frameworks.item.framework.version-detail-modal.comment-save-success',
         ),
       });
     } catch {
       this.args.version.rollbackAttributes();
       this.pixToast.sendErrorNotification({
         message: this.intl.t(
-          'components.complementary-certifications.item.framework.version-detail-modal.comment-save-error',
+          'components.certification-frameworks.item.framework.version-detail-modal.comment-save-error',
         ),
       });
     }
@@ -43,7 +43,7 @@ export default class VersionComment extends Component {
 
   <template>
     <h2 class="certification-version-detail-modal__subtitle">{{t
-        "components.complementary-certifications.item.framework.version-detail-modal.comment"
+        "components.certification-frameworks.item.framework.version-detail-modal.comment"
       }}</h2>
     <PixBlock class="certification-version-detail-modal__comment">
       <PixTextarea

--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -46,7 +46,7 @@ export default class Header extends Component {
           @route="authenticated.certification-frameworks.item.framework.new-version"
           @iconBefore="add"
         >
-          {{t "components.complementary-certifications.item.framework.create-button"}}
+          {{t "components.certification-frameworks.item.framework.create-button"}}
         </PixButtonLink>
       {{/if}}
     </div>

--- a/admin/app/components/certification-frameworks/item/target-profile/badges-list.gjs
+++ b/admin/app/components/certification-frameworks/item/target-profile/badges-list.gjs
@@ -17,17 +17,17 @@ export default class BadgesList extends Component {
   <template>
     <section class="page-section">
       <h2 class="certification-framework-details__badges-title page-section__header">
-        {{t "components.complementary-certifications.target-profiles.badges-list.title"}}
+        {{t "components.certification-frameworks.target-profiles.badges-list.title"}}
       </h2>
       <PixTable
         @variant="admin"
         @data={{this.currentTargetProfileBadges}}
-        @caption={{t "components.complementary-certifications.target-profiles.badges-list.caption"}}
+        @caption={{t "components.certification-frameworks.target-profiles.badges-list.caption"}}
       >
         <:columns as |row currentTargetProfileBadge|>
           <PixTableColumn @context={{currentTargetProfileBadge}}>
             <:header>
-              {{t "components.complementary-certifications.target-profiles.badges-list.header.image-url"}}
+              {{t "components.certification-frameworks.target-profiles.badges-list.header.image-url"}}
             </:header>
             <:cell>
               <img
@@ -39,7 +39,7 @@ export default class BadgesList extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{currentTargetProfileBadge}} class="table__column--wide">
             <:header>
-              {{t "components.complementary-certifications.target-profiles.badges-list.header.name"}}
+              {{t "components.certification-frameworks.target-profiles.badges-list.header.name"}}
             </:header>
             <:cell>
               {{row.label}}
@@ -47,7 +47,7 @@ export default class BadgesList extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{currentTargetProfileBadge}}>
             <:header>
-              {{t "components.complementary-certifications.target-profiles.badges-list.header.level"}}
+              {{t "components.certification-frameworks.target-profiles.badges-list.header.level"}}
             </:header>
             <:cell>
               {{row.level}}
@@ -55,7 +55,7 @@ export default class BadgesList extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{currentTargetProfileBadge}}>
             <:header>
-              {{t "components.complementary-certifications.target-profiles.badges-list.header.minimum-earned-pix"}}
+              {{t "components.certification-frameworks.target-profiles.badges-list.header.minimum-earned-pix"}}
             </:header>
             <:cell>
               {{this.getMinimumEarnedPixValue row.minimumEarnedPix}}
@@ -63,7 +63,7 @@ export default class BadgesList extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{currentTargetProfileBadge}}>
             <:header>
-              {{t "components.complementary-certifications.target-profiles.badges-list.header.id"}}
+              {{t "components.certification-frameworks.target-profiles.badges-list.header.id"}}
             </:header>
             <:cell>
               <LinkTo

--- a/admin/app/components/certification-frameworks/item/target-profile/history.gjs
+++ b/admin/app/components/certification-frameworks/item/target-profile/history.gjs
@@ -22,18 +22,18 @@ export default class TargetProfilesHistory extends Component {
     <section class="page-section framework-target-profiles-history">
       <PixAccordions>
         <:title>
-          {{t "components.complementary-certifications.target-profiles.history-list.title"}}
+          {{t "components.certification-frameworks.target-profiles.history-list.title"}}
         </:title>
         <:content>
           <PixTable
             @variant="admin"
             @data={{@targetProfilesHistory}}
-            @caption={{t "components.complementary-certifications.target-profiles.history-list.caption"}}
+            @caption={{t "components.certification-frameworks.target-profiles.history-list.caption"}}
           >
             <:columns as |row targetProfileHistory|>
               <PixTableColumn @context={{targetProfileHistory}}>
                 <:header>
-                  {{t "components.complementary-certifications.target-profiles.history-list.headers.name"}}
+                  {{t "components.certification-frameworks.target-profiles.history-list.headers.name"}}
                 </:header>
                 <:cell>
                   {{row.name}}
@@ -42,7 +42,7 @@ export default class TargetProfilesHistory extends Component {
               <PixTableColumn @context={{targetProfileHistory}}>
                 <:header>
                   <PixIcon @name="calendar" @ariaHidden={{true}} />
-                  {{t "components.complementary-certifications.target-profiles.history-list.headers.attached-at"}}
+                  {{t "components.certification-frameworks.target-profiles.history-list.headers.attached-at"}}
                 </:header>
                 <:cell>
                   <strong>{{formatDate row.attachedAt}}</strong>
@@ -51,7 +51,7 @@ export default class TargetProfilesHistory extends Component {
               <PixTableColumn @context={{targetProfileHistory}}>
                 <:header>
                   <PixIcon @name="calendar" @ariaHidden={{true}} />
-                  {{t "components.complementary-certifications.target-profiles.history-list.headers.detached-at"}}
+                  {{t "components.certification-frameworks.target-profiles.history-list.headers.detached-at"}}
                 </:header>
                 <:cell>
                   <strong>{{if row.detachedAt (formatDate row.detachedAt) "-"}}</strong>
@@ -59,12 +59,12 @@ export default class TargetProfilesHistory extends Component {
               </PixTableColumn>
               <PixTableColumn @context={{targetProfileHistory}}>
                 <:header>
-                  {{t "components.complementary-certifications.target-profiles.history-list.headers.actions"}}
+                  {{t "components.certification-frameworks.target-profiles.history-list.headers.actions"}}
                 </:header>
                 <:cell>
                   <PixIconButton
                     @triggerAction={{fn this.viewTargetProfile row.id}}
-                    @ariaLabel={{t "components.complementary-certifications.target-profiles.history-list.actions.view"}}
+                    @ariaLabel={{t "components.certification-frameworks.target-profiles.history-list.actions.view"}}
                     @iconName="eye"
                   />
                 </:cell>

--- a/admin/app/components/layout/menu-bar/index.gjs
+++ b/admin/app/components/layout/menu-bar/index.gjs
@@ -53,7 +53,7 @@ export default class MenuBar extends Component {
         <MenuBarEntry
           @path="authenticated.certification-frameworks"
           @icon="extension"
-          @title={{t "components.layout.menu-bar.entries.complementary-certifications"}}
+          @title={{t "components.layout.menu-bar.entries.certification-frameworks"}}
           @inline={{true}}
         />
         {{#if this.accessControl.hasAccessToTargetProfilesActionsScope}}

--- a/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
@@ -27,7 +27,7 @@ module('Integration | Component | certification-frameworks/item/framework', func
       assert
         .dom(
           screen.getByRole('table', {
-            name: t('components.complementary-certifications.item.framework.history.table.caption'),
+            name: t('components.certification-frameworks.item.framework.history.table.caption'),
           }),
         )
         .exists();
@@ -45,7 +45,7 @@ module('Integration | Component | certification-frameworks/item/framework', func
       assert
         .dom(
           screen.queryByRole('button', {
-            name: t('components.complementary-certifications.target-profiles.history-list.title'),
+            name: t('components.certification-frameworks.target-profiles.history-list.title'),
           }),
         )
         .doesNotExist();
@@ -76,7 +76,7 @@ module('Integration | Component | certification-frameworks/item/framework', func
       assert
         .dom(
           screen.getByRole('button', {
-            name: t('components.complementary-certifications.target-profiles.history-list.title'),
+            name: t('components.certification-frameworks.target-profiles.history-list.title'),
           }),
         )
         .exists();

--- a/admin/tests/integration/components/certification-frameworks/item/framework/certification-version-detail-modal-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/certification-version-detail-modal-test.gjs
@@ -71,7 +71,7 @@ module(
 
       // then
       assert
-        .dom(screen.getByText(t('components.complementary-certifications.item.framework.history.statuses.ACTIVE')))
+        .dom(screen.getByText(t('components.certification-frameworks.item.framework.history.statuses.ACTIVE')))
         .exists();
     });
 
@@ -95,9 +95,7 @@ module(
 
       // then
       assert
-        .dom(
-          screen.getByText(t('components.complementary-certifications.item.framework.version-detail-modal.start-date')),
-        )
+        .dom(screen.getByText(t('components.certification-frameworks.item.framework.version-detail-modal.start-date')))
         .exists();
     });
 

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -56,7 +56,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     assert
       .dom(
         screen.getByRole('table', {
-          name: t('components.complementary-certifications.item.framework.history.table.caption'),
+          name: t('components.certification-frameworks.item.framework.history.table.caption'),
         }),
       )
       .exists();
@@ -66,13 +66,13 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     assert.dom(screen.getByRole('cell', { name: `${frameworkItem1.id}` })).exists();
     assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkItem1.startDate) })).exists();
     assert
-      .dom(screen.getByText(t('components.complementary-certifications.item.framework.history.statuses.ACTIVE')))
+      .dom(screen.getByText(t('components.certification-frameworks.item.framework.history.statuses.ACTIVE')))
       .hasClass('pix-tag--success');
 
     assert.dom(screen.getByRole('cell', { name: `${frameworkItem2.id}` })).exists();
     assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkItem2.startDate) })).exists();
     assert
-      .dom(screen.getByText(t('components.complementary-certifications.item.framework.history.statuses.ARCHIVED')))
+      .dom(screen.getByText(t('components.certification-frameworks.item.framework.history.statuses.ARCHIVED')))
       .hasClass('pix-tag--secondary');
   });
 
@@ -85,7 +85,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
     await click(
       screen.getAllByRole('button', {
-        name: t('components.complementary-certifications.item.framework.history.table.actions.view'),
+        name: t('components.certification-frameworks.item.framework.history.table.actions.view'),
       })[0],
     );
 
@@ -113,7 +113,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
     await click(
       screen.getAllByRole('button', {
-        name: t('components.complementary-certifications.item.framework.history.table.actions.view'),
+        name: t('components.certification-frameworks.item.framework.history.table.actions.view'),
       })[0],
     );
     assert.dom(screen.getByRole('dialog')).exists();
@@ -128,7 +128,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
   module('deletion', function (hooks) {
     let deleteButtonName;
     hooks.beforeEach(() => {
-      deleteButtonName = t('components.complementary-certifications.item.framework.history.table.actions.delete');
+      deleteButtonName = t('components.certification-frameworks.item.framework.history.table.actions.delete');
     });
 
     test('it should not be possible to delete an ACTIVE or ARCHIVED version', async function (assert) {

--- a/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
@@ -37,7 +37,7 @@ module('Integration | Component | certification-frameworks/item/header', functio
       const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
 
       // then
-      assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
+      assert.dom(screen.getByText(t('components.certification-frameworks.item.framework.create-button'))).exists();
     });
 
     test('it should not display the create button when user is not super admin', async function (assert) {
@@ -51,7 +51,7 @@ module('Integration | Component | certification-frameworks/item/header', functio
 
       // then
       assert
-        .dom(screen.queryByText(t('components.complementary-certifications.item.framework.create-button')))
+        .dom(screen.queryByText(t('components.certification-frameworks.item.framework.create-button')))
         .doesNotExist();
     });
 
@@ -66,7 +66,7 @@ module('Integration | Component | certification-frameworks/item/header', functio
 
       // then
       assert
-        .dom(screen.queryByText(t('components.complementary-certifications.item.framework.create-button')))
+        .dom(screen.queryByText(t('components.certification-frameworks.item.framework.create-button')))
         .doesNotExist();
     });
   });

--- a/admin/tests/integration/components/certification-frameworks/item/target-profile-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/target-profile-test.gjs
@@ -41,7 +41,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       assert
         .dom(
           screen.getByRole('heading', {
-            name: t('components.complementary-certifications.target-profiles.badges-list.title'),
+            name: t('components.certification-frameworks.target-profiles.badges-list.title'),
           }),
         )
         .exists();
@@ -51,7 +51,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       assert
         .dom(
           screen.getByRole('button', {
-            name: t('components.complementary-certifications.target-profiles.history-list.title'),
+            name: t('components.certification-frameworks.target-profiles.history-list.title'),
           }),
         )
         .exists();
@@ -92,7 +92,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       assert
         .dom(
           screen.queryByRole('heading', {
-            name: t('components.complementary-certifications.target-profiles.badges-list.title'),
+            name: t('components.certification-frameworks.target-profiles.badges-list.title'),
           }),
         )
         .doesNotExist();
@@ -100,7 +100,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       assert.dom(screen.queryByText('Badge Volcan')).doesNotExist();
 
       assert
-        .dom(screen.getByText(t('components.complementary-certifications.target-profiles.history-list.title')))
+        .dom(screen.getByText(t('components.certification-frameworks.target-profiles.history-list.title')))
         .exists();
     });
   });

--- a/admin/tests/integration/components/certification-frameworks/item/target-profile/badges-list-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/target-profile/badges-list-test.gjs
@@ -31,7 +31,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
 
     // then
     const table = screen.getByRole('table', {
-      name: t('components.complementary-certifications.target-profiles.badges-list.caption'),
+      name: t('components.certification-frameworks.target-profiles.badges-list.caption'),
     });
     assert.dom(within(table).getByRole('columnheader', { name: 'Image du badge certifié' })).exists();
     assert.dom(within(table).getByRole('columnheader', { name: 'Nom du badge certifié' })).exists();

--- a/admin/tests/integration/components/certification-frameworks/item/target-profile/history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/target-profile/history-test.gjs
@@ -24,32 +24,32 @@ module('Integration | Component | certification-frameworks/item/target-profile/h
     const screen = await render(<template><History @targetProfilesHistory={{targetProfilesHistory}} /></template>);
     await click(
       screen.getByRole('button', {
-        name: t('components.complementary-certifications.target-profiles.history-list.title'),
+        name: t('components.certification-frameworks.target-profiles.history-list.title'),
       }),
     );
 
     // then
     const table = screen.getByRole('table', {
-      name: t('components.complementary-certifications.target-profiles.history-list.caption'),
+      name: t('components.certification-frameworks.target-profiles.history-list.caption'),
     });
     assert
       .dom(
         within(table).getByRole('columnheader', {
-          name: t('components.complementary-certifications.target-profiles.history-list.headers.name'),
+          name: t('components.certification-frameworks.target-profiles.history-list.headers.name'),
         }),
       )
       .exists();
     assert
       .dom(
         within(table).getByRole('columnheader', {
-          name: t('components.complementary-certifications.target-profiles.history-list.headers.attached-at'),
+          name: t('components.certification-frameworks.target-profiles.history-list.headers.attached-at'),
         }),
       )
       .exists();
     assert
       .dom(
         within(table).getByRole('columnheader', {
-          name: t('components.complementary-certifications.target-profiles.history-list.headers.detached-at'),
+          name: t('components.certification-frameworks.target-profiles.history-list.headers.detached-at'),
         }),
       )
       .exists();
@@ -57,7 +57,7 @@ module('Integration | Component | certification-frameworks/item/target-profile/h
     assert.dom(within(table).getByRole('cell', { name: 'Target Volcan' })).exists();
     assert.strictEqual(
       within(table).getAllByRole('button', {
-        name: t('components.complementary-certifications.target-profiles.history-list.actions.view'),
+        name: t('components.certification-frameworks.target-profiles.history-list.actions.view'),
       }).length,
       2,
     );

--- a/admin/tests/integration/components/menu-bar-test.gjs
+++ b/admin/tests/integration/components/menu-bar-test.gjs
@@ -200,8 +200,8 @@ module('Integration | Component | menu-bar', function (hooks) {
     assert.dom(screen.getByRole('link', { name: 'Sessions de certifications' })).exists();
   });
 
-  module('Complementary certifications tab', function () {
-    test('should contain link to "complementary certifications" management page', async function (assert) {
+  module('Certification framework tab', function () {
+    test('should contain link to "certification frameworks" management page', async function (assert) {
       // given
       class AccessControlStub extends Service {
         hasAccessToComplementaryCertificationsScope = true;
@@ -212,7 +212,7 @@ module('Integration | Component | menu-bar', function (hooks) {
       const screen = await render(<template><MenuBar /></template>);
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Certifications complémentaires' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Référentiels de certification' })).exists();
     });
   });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -487,13 +487,64 @@
         "title": "Confirmation of version deletion"
       },
       "item": {
+        "certification-framework": "Certification framework",
         "framework": {
+          "create-button": "Create a new version of the certification framework",
+          "details": {
+            "title": "Current certification framework details"
+          },
+          "history": {
+            "label": "Versions",
+            "statuses": {
+              "ACTIVE": "Active",
+              "ARCHIVED": "Archived",
+              "DRAFT": "Draft"
+            },
+            "table": {
+              "actions": {
+                "delete": "Delete version",
+                "edit": "Edit version",
+                "view": "View version details"
+              },
+              "caption": "Versions list in descending order",
+              "columns": {
+                "actions": "Actions",
+                "assessment-duration": "Duration (min)",
+                "expiration-date": "Expiration date",
+                "maximum-assessment-length": "Nb of questions",
+                "start-date": "Start date",
+                "status": "Status",
+                "version-id": "Version ID"
+              }
+            },
+            "title": "Framework versions history"
+          },
           "new-version-form": {
             "submit-button": "Submit the new version of the certification framework ",
             "success-notification": "The new version of the certification framework  has been successfully created.",
             "title": "Creating a new version of the certification framework for {frameworkLabel}"
+          },
+          "no-current-framework": "No certification framework is currently used.",
+          "tab": "Certification framework",
+          "version-detail-modal": {
+            "assessment-duration": "Duration:",
+            "comment": "Comment:",
+            "comment-save-error": "An error occurred while saving the comment.",
+            "comment-save-success": "The comment has been saved.",
+            "content": "Framework content:",
+            "expiration-date": "Expiration date:",
+            "locales": "Languages:",
+            "maximum-assessment-length": "Max nb of questions:",
+            "minimum-answers-required": "Min nb of answers:",
+            "parameters": "Framework parameters:",
+            "start-date": "Start date:",
+            "status": "Status:"
           }
-        }
+        },
+        "navigation": {
+          "aria-label": "Navigation of the complementary certification section"
+        },
+        "target-profile": "Target profile"
       },
       "labels": {
         "CLEA": "CléA Numérique",
@@ -509,7 +560,34 @@
         "caption": "List of certification frameworks, including name and active version start date",
         "name": "Name"
       },
-      "page-title": "Certification Frameworks"
+      "page-title": "Certification Frameworks",
+      "target-profiles": {
+        "badges-list": {
+          "caption": "Liste des badges certifiants liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
+          "header": {
+            "id": "ID du badge certifiant",
+            "image-url": "Image du badge certifié",
+            "level": "Niveau du badge certifié",
+            "minimum-earned-pix": "Nombre de pix minimum",
+            "name": "Nom du badge certifié"
+          },
+          "title": "Badges certifiés du profil cible actuel"
+        },
+        "history-list": {
+          "actions": {
+            "view": "View target profile"
+          },
+          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
+          "headers": {
+            "actions": "Actions",
+            "attached-at": "Attachment date",
+            "detached-at": "Detachment date",
+            "name": "Internal name"
+          },
+          "title": "Historique des profils cibles rattachés"
+        }
+      },
+      "title": "All certification frameworks"
     },
     "certifications": {
       "edu-results": {
@@ -628,98 +706,14 @@
         "detach-organization-success": "Blueprint is not shared with organization {name} anymore."
       }
     },
-    "complementary-certifications": {
-      "item": {
-        "certification-framework": "Complementary certification",
-        "framework": {
-          "create-button": "Create a new version of the certification framework",
-          "details": {
-            "title": "Current certification framework details"
-          },
-          "history": {
-            "label": "Versions",
-            "statuses": {
-              "ACTIVE": "Active",
-              "ARCHIVED": "Archived",
-              "DRAFT": "Draft"
-            },
-            "table": {
-              "actions": {
-                "delete": "Delete version",
-                "edit": "Edit version",
-                "view": "View version details"
-              },
-              "caption": "Versions list in descending order",
-              "columns": {
-                "actions": "Actions",
-                "assessment-duration": "Duration (min)",
-                "expiration-date": "Expiration date",
-                "maximum-assessment-length": "Nb of questions",
-                "start-date": "Start date",
-                "status": "Status",
-                "version-id": "Version ID"
-              }
-            },
-            "title": "Framework versions history"
-          },
-          "no-current-framework": "No certification framework is currently used.",
-          "tab": "Certification framework",
-          "version-detail-modal": {
-            "assessment-duration": "Duration:",
-            "comment": "Comment:",
-            "comment-save-error": "An error occurred while saving the comment.",
-            "comment-save-success": "The comment has been saved.",
-            "content": "Framework content:",
-            "expiration-date": "Expiration date:",
-            "locales": "Languages:",
-            "maximum-assessment-length": "Max nb of questions:",
-            "minimum-answers-required": "Min nb of answers:",
-            "parameters": "Framework parameters:",
-            "start-date": "Start date:",
-            "status": "Status:"
-          }
-        },
-        "navigation": {
-          "aria-label": "Navigation of the complementary certification section"
-        },
-        "target-profile": "Target profile"
-      },
-      "target-profiles": {
-        "badges-list": {
-          "caption": "Liste des badges certifiants liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
-          "header": {
-            "id": "ID du badge certifiant",
-            "image-url": "Image du badge certifié",
-            "level": "Niveau du badge certifié",
-            "minimum-earned-pix": "Nombre de pix minimum",
-            "name": "Nom du badge certifié"
-          },
-          "title": "Badges certifiés du profil cible actuel"
-        },
-        "history-list": {
-          "actions": {
-            "view": "View target profile"
-          },
-          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
-          "headers": {
-            "actions": "Actions",
-            "attached-at": "Attachment date",
-            "detached-at": "Detachment date",
-            "name": "Internal name"
-          },
-          "title": "Historique des profils cibles rattachés"
-        }
-      },
-      "title": "All certification frameworks"
-    },
     "layout": {
       "menu-bar": {
         "entries": {
           "administration": "Administration",
           "autonomous-courses": "Parcours autonomes",
           "certification-centers": "Centres de certification",
+          "certification-frameworks": "Certification frameworks",
           "certifications": "Certifications",
-          "complementary-certifications": "Certifications complémentaires",
           "logout": "Se déconnecter",
           "organizations": "Organisations",
           "sessions": "Sessions de certifications",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -494,13 +494,65 @@
         "title": "Confirmation de suppression d'une version"
       },
       "item": {
+        "certification-framework": "Référentiel de certification",
         "framework": {
+          "create-button": "Créer une nouvelle version du référentiel",
+          "details": {
+            "empty-current-framework": "Le référentiel de certification actuel est vide.",
+            "title": "Détails du référentiel de certification actuel"
+          },
+          "history": {
+            "label": "Versions",
+            "statuses": {
+              "ACTIVE": "Actif",
+              "ARCHIVED": "Archivé",
+              "DRAFT": "En cours d'édition"
+            },
+            "table": {
+              "actions": {
+                "delete": "Supprimer la version",
+                "edit": "Éditer la version",
+                "view": "Voir les détails de la version"
+              },
+              "caption": "Liste des versions par ordre décroissant",
+              "columns": {
+                "actions": "Actions",
+                "assessment-duration": "Durée (min)",
+                "expiration-date": "Date d'expiration",
+                "maximum-assessment-length": "Nombre de questions",
+                "start-date": "Date d'activation",
+                "status": "Statut",
+                "version-id": "ID de version"
+              }
+            },
+            "title": "Historique des versions du référentiel"
+          },
           "new-version-form": {
             "submit-button": "Créer la nouvelle version du référentiel de certification",
             "success-notification": "La nouvelle version du référentiel de certification a été créé avec succès",
             "title": "Création d'une nouvelle version du référentiel de certification"
+          },
+          "no-current-framework": "Aucun référentiel de certification n'est utilisé actuellement.",
+          "tab": "Référentiel de certification",
+          "version-detail-modal": {
+            "assessment-duration": "Durée (min) :",
+            "comment": "Commentaire :",
+            "comment-save-error": "Une erreur est survenue lors de la sauvegarde du commentaire.",
+            "comment-save-success": "Le commentaire a bien été sauvegardé.",
+            "content": "Contenu du référentiel :",
+            "expiration-date": "Date d'expiration :",
+            "locales": "Locale :",
+            "maximum-assessment-length": "Nombre max de questions :",
+            "minimum-answers-required": "Nombre min de réponses :",
+            "parameters": "Paramètres du référentiel :",
+            "start-date": "Date d'activation :",
+            "status": "Statut :"
           }
-        }
+        },
+        "navigation": {
+          "aria-label": "Navigation de la section certification complémentaire"
+        },
+        "target-profile": "Profil cible"
       },
       "labels": {
         "CLEA": "CléA Numérique",
@@ -516,7 +568,34 @@
         "caption": "Liste des référentiels de certification, comprenant le nom et la date de début de la dernière version active",
         "name": "Nom"
       },
-      "page-title": "Référentiels de certification"
+      "page-title": "Référentiels de certification",
+      "target-profiles": {
+        "badges-list": {
+          "caption": "Liste des badges certifiants liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
+          "header": {
+            "id": "ID du badge certifiant",
+            "image-url": "Image du badge certifié",
+            "level": "Niveau du badge certifié",
+            "minimum-earned-pix": "Nombre de pix minimum",
+            "name": "Nom du badge certifié"
+          },
+          "title": "Badges certifiés du profil cible actuel"
+        },
+        "history-list": {
+          "actions": {
+            "view": "Voir le profil cible"
+          },
+          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
+          "headers": {
+            "actions": "Actions",
+            "attached-at": "Date de rattachement",
+            "detached-at": "Date de détachement",
+            "name": "Nom interne"
+          },
+          "title": "Historique des profils cibles"
+        }
+      },
+      "title": "Tous les référentiels de certification"
     },
     "certifications": {
       "edu-results": {
@@ -635,99 +714,14 @@
         "detach-organization-success": "Le schéma de parcours n'est plus partagé avec l'organisation {name}."
       }
     },
-    "complementary-certifications": {
-      "item": {
-        "certification-framework": "Référentiel de certification",
-        "framework": {
-          "create-button": "Créer une nouvelle version du référentiel",
-          "details": {
-            "empty-current-framework": "Le référentiel de certification actuel est vide.",
-            "title": "Détails du référentiel de certification actuel"
-          },
-          "history": {
-            "label": "Versions",
-            "statuses": {
-              "ACTIVE": "Actif",
-              "ARCHIVED": "Archivé",
-              "DRAFT": "En cours d'édition"
-            },
-            "table": {
-              "actions": {
-                "delete": "Supprimer la version",
-                "edit": "Éditer la version",
-                "view": "Voir les détails de la version"
-              },
-              "caption": "Liste des versions par ordre décroissant",
-              "columns": {
-                "actions": "Actions",
-                "assessment-duration": "Durée (min)",
-                "expiration-date": "Date d'expiration",
-                "maximum-assessment-length": "Nombre de questions",
-                "start-date": "Date d'activation",
-                "status": "Statut",
-                "version-id": "ID de version"
-              }
-            },
-            "title": "Historique des versions du référentiel"
-          },
-          "no-current-framework": "Aucun référentiel de certification n'est utilisé actuellement.",
-          "tab": "Référentiel de certification",
-          "version-detail-modal": {
-            "assessment-duration": "Durée (min) :",
-            "comment": "Commentaire :",
-            "comment-save-error": "Une erreur est survenue lors de la sauvegarde du commentaire.",
-            "comment-save-success": "Le commentaire a bien été sauvegardé.",
-            "content": "Contenu du référentiel :",
-            "expiration-date": "Date d'expiration :",
-            "locales": "Locale :",
-            "maximum-assessment-length": "Nombre max de questions :",
-            "minimum-answers-required": "Nombre min de réponses :",
-            "parameters": "Paramètres du référentiel :",
-            "start-date": "Date d'activation :",
-            "status": "Statut :"
-          }
-        },
-        "navigation": {
-          "aria-label": "Navigation de la section certification complémentaire"
-        },
-        "target-profile": "Profil cible"
-      },
-      "target-profiles": {
-        "badges-list": {
-          "caption": "Liste des badges certifiants liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
-          "header": {
-            "id": "ID du badge certifiant",
-            "image-url": "Image du badge certifié",
-            "level": "Niveau du badge certifié",
-            "minimum-earned-pix": "Nombre de pix minimum",
-            "name": "Nom du badge certifié"
-          },
-          "title": "Badges certifiés du profil cible actuel"
-        },
-        "history-list": {
-          "actions": {
-            "view": "Voir le profil cible"
-          },
-          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
-          "headers": {
-            "actions": "Actions",
-            "attached-at": "Date de rattachement",
-            "detached-at": "Date de détachement",
-            "name": "Nom interne"
-          },
-          "title": "Historique des profils cibles"
-        }
-      },
-      "title": "Tous les référentiels de certification"
-    },
     "layout": {
       "menu-bar": {
         "entries": {
           "administration": "Administration",
           "autonomous-courses": "Parcours autonomes",
           "certification-centers": "Centres de certification",
+          "certification-frameworks": "Référentiels de certification",
           "certifications": "Certifications",
-          "complementary-certifications": "Certifications complémentaires",
           "logout": "Se déconnecter",
           "organizations": "Organisations",
           "sessions": "Sessions de certifications",


### PR DESCRIPTION
## 💥 Problème

L'ancienne section "Certifications complémentaires" de Pix Admin a été renommée il y a quelques mois, mais ce changement n'avait pas était répercuté dans les clés de traduction

## 👩‍🚀 Proposition

Renommer la clé de traduction 'complementary-certification' en 'certification-framework' pour être cohérent avec le nom de la section dans Pix Admin

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
Verifier que les traductions ne sont pas cassées dans pix Admin, section "Référentiels de certification"

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
