### PR TITLE
[FEATURE] Renvoyer la description sur la route de récupération de CF (PIX-22853)

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -19,6 +19,7 @@ import { databaseBuffer } from '../database-buffer.js';
  *   registrationRequired: boolean,
  *   program: string,
  *   objectives: string[],
+ *   description: string,
  * }} Training
  */
 
@@ -39,6 +40,7 @@ function buildTraining({
   registrationRequired = false,
   program = 'Programme du contenu formatif',
   objectives = [],
+  description = "<p>Voici la description d'un contenu formatif</p>",
 } = {}) {
   const values = {
     id,
@@ -57,6 +59,7 @@ function buildTraining({
     registrationRequired,
     program,
     objectives,
+    description,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'trainings',

--- a/api/src/devcomp/domain/models/Training.js
+++ b/api/src/devcomp/domain/models/Training.js
@@ -21,6 +21,7 @@ class Training {
     registrationRequired,
     program,
     objectives,
+    description,
   } = {}) {
     this.id = id;
     this.title = title;
@@ -37,6 +38,7 @@ class Training {
     this.registrationRequired = registrationRequired;
     this.program = program;
     this.objectives = objectives;
+    this.description = description;
   }
 
   shouldBeObtained(knowledgeElements, skills) {

--- a/api/src/devcomp/domain/read-models/UserRecommendedTraining.js
+++ b/api/src/devcomp/domain/read-models/UserRecommendedTraining.js
@@ -12,6 +12,7 @@ class UserRecommendedTraining {
     registrationRequired,
     program,
     objectives,
+    description,
   } = {}) {
     this.id = id;
     this.title = title;
@@ -25,6 +26,7 @@ class UserRecommendedTraining {
     this.registrationRequired = registrationRequired;
     this.program = program;
     this.objectives = objectives;
+    this.description = description;
   }
 }
 

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -98,6 +98,7 @@ const serialize = function (training = {}, meta) {
       'registrationRequired',
       'program',
       'objectives',
+      'description',
     ],
     targetProfileSummaries: {
       ref: 'id',

--- a/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -49,6 +49,7 @@ describe('Acceptance | API | Campaign Participations', function () {
         'registration-required': false,
         program: 'Programme du contenu formatif',
         objectives: [],
+        description: "<p>Voici la description d'un contenu formatif</p>",
       });
     });
   });

--- a/api/tests/devcomp/acceptance/application/user-trainings/users-trainings-route_test.js
+++ b/api/tests/devcomp/acceptance/application/user-trainings/users-trainings-route_test.js
@@ -52,6 +52,7 @@ describe('Acceptance | Routes | UserTrainingsRoute', function () {
             'editor-name': "Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité",
             'editor-logo-url':
               'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+            description: "<p>Voici la description d'un contenu formatif</p>",
           },
           relationships: {
             'target-profile-summaries': {

--- a/api/tests/devcomp/unit/domain/models/Training_test.js
+++ b/api/tests/devcomp/unit/domain/models/Training_test.js
@@ -28,6 +28,7 @@ describe('Unit | Devcomp | Domain | Models | Training', function () {
         editorName: 'Example',
         editorLogoUrl: 'https://example.net/logo.svg',
         trainingTriggers,
+        description: 'Voici la description de mon contenu formatif',
       });
 
       // then
@@ -49,6 +50,7 @@ describe('Unit | Devcomp | Domain | Models | Training', function () {
         title: 'Training 1',
         trainingTriggers,
         type: 'webinar',
+        description: 'Voici la description de mon contenu formatif',
       });
     });
   });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -350,6 +350,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             objectives: ['objective 1', 'objective 2'],
             program: 'training program',
             'registration-required': false,
+            description: "<p>Voici la description d'un contenu formatif</p>",
           },
           relationships: {
             'target-profile-summaries': {
@@ -400,6 +401,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             objectives: ['objective 1', 'objective 2'],
             program: 'training program',
             'registration-required': false,
+            description: "<p>Voici la description d'un contenu formatif</p>",
           },
           relationships: {
             'target-profile-summaries': {
@@ -436,6 +438,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/editor_logo_url.svg',
             'is-disabled': true,
+            description: "<p>Voici la description d'un contenu formatif pour le ministère</p>",
           },
         },
       };
@@ -452,6 +455,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
         editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/editor_logo_url.svg',
         editorName: 'Ministère education nationale',
         isDisabled: true,
+        description: "<p>Voici la description d'un contenu formatif pour le ministère</p>",
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-training.js
+++ b/api/tests/tooling/domain-builder/factory/build-training.js
@@ -18,6 +18,7 @@ const buildTraining = function ({
   registrationRequired = false,
   program = 'training program',
   objectives = ['objective 1', 'objective 2'],
+  description = "<p>Voici la description d'un contenu formatif</p>",
 } = {}) {
   return new Training({
     id,
@@ -35,6 +36,7 @@ const buildTraining = function ({
     registrationRequired,
     program,
     objectives,
+    description,
   });
 };
 


### PR DESCRIPTION
## 💥 Problème

Dans la page de résultats avec Moteur de reco, il manque la description du training dans le retour API.

## 👩‍🚀 Proposition

Ajouter le champ `description` dans le retour API.

## 👁️ Remarques

RAS

## ♻️ Pour tester

- Ouvrir [PixApp](https://app-pr16300.review.pix.fr/)
- Se connecter avec dave-comp@example.net
- Saisir le code "EDUMULTIP" et faire le parcours
- Dans la page de résultats, regarder le retour API de la route des trainings, et vérifier qu'on a bien le champ `description`

En local:
<img width="977" height="393" alt="image" src="https://github.com/user-attachments/assets/0e4166ff-43a0-407f-a5a9-1f5e7fecb2bc" />


<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
