### PR TITLE
[TECH] Ajoute l'équipe responsable du code dans les logs (PIX-22545)

### DIFF
--- a/api/db/knex-extensions.js
+++ b/api/db/knex-extensions.js
@@ -2,8 +2,10 @@ import Knex from 'knex';
 import QueryBuilder from 'knex/lib/query/querybuilder.js';
 import pg from 'pg';
 
+import { config } from '../src/shared/config.js';
 import { getInContext, getRequestId } from '../src/shared/infrastructure/execution-context-manager.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
+import { routeDomainToOwnerTeam } from '../src/shared/infrastructure/utils/route-domain-to-owner-team.js';
 
 const types = pg.types;
 
@@ -31,8 +33,12 @@ export function configureGlobalExtensions() {
   QueryBuilder.prototype.toSQL = function () {
     const ret = originalToSQL.apply(this);
     const request = getInContext('request');
+    const teamsToContact = routeDomainToOwnerTeam(
+      config.routeDomainToOwnerTeamMapping,
+      request?.route?.realm?.plugin,
+    ).join(',');
     ret.sql =
-      `/* path:${request?.route?.path} | routeDomain:${request?.route?.realm?.plugin} | request_id:${getRequestId()} */ `.concat(
+      `/* path:${request?.route?.path} | routeDomain:${request?.route?.realm?.plugin} | request_id:${getRequestId()} | teamsToContact:${teamsToContact} */ `.concat(
         ret.sql,
       );
     return ret;

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -184,6 +184,7 @@ const schema = Joi.object({
   APIM_URL: Joi.string().optional(),
   PIX_ASSETS_MANAGER_URL: Joi.string().uri().optional(),
   HTTP_SERVER_RESPONSE_TIMEOUT_MS: Joi.number().integer().min(0).optional(),
+  ROUTE_DOMAIN_TO_OWNER_TEAM_MAPPING: Joi.string().optional(),
 }).options({ allowUnknown: true });
 
 const configuration = (function () {
@@ -556,6 +557,7 @@ const configuration = (function () {
     autonomousCourse: {
       autonomousCoursesOrganizationId: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
     },
+    routeDomainToOwnerTeamMapping: parseJSONEnv('ROUTE_DOMAIN_TO_OWNER_TEAM_MAPPING'),
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -5,6 +5,7 @@ import { getForwardedOrigin } from '../../../identity-access-management/infrastr
 import { config } from '../../config.js';
 import { getCorrelationInfo, getInContext, setInContext } from '../execution-context-manager.js';
 import { loggerPino } from '../utils/logger.js';
+import { routeDomainToOwnerTeam } from '../utils/route-domain-to-owner-team.js';
 
 const serializersSym = Symbol.for('pino.serializers');
 
@@ -40,6 +41,9 @@ function requestSerializer(req) {
     metrics,
     route: request?.route?.path,
     routeDomain: request?.route?.realm?.plugin,
+    teamsToContact: routeDomainToOwnerTeam(config.routeDomainToOwnerTeamMapping, request?.route?.realm?.plugin).join(
+      ',',
+    ),
   };
 }
 

--- a/api/src/shared/infrastructure/utils/route-domain-to-owner-team.js
+++ b/api/src/shared/infrastructure/utils/route-domain-to-owner-team.js
@@ -1,0 +1,29 @@
+/**
+ * Determines the owner team(s) for a given route domain based on a mapping configuration.
+ * It selects the team(s) associated with the longest prefix of the route domain present in the map.
+ *
+ * @param {Object.<string, string[]>} routeDomainToOwnerTeamMap - A map where keys are route domain prefixes and values are arrays of owner team ids.
+ * @param {string} routeDomain - The route domain to find the owner team for.
+ * @returns {string[]} An array of owner team ids. Returns an empty array if no match is found or if the map is not provided.
+ *
+ * @example
+ * const map = {
+ *   'users': ['team-identity'],
+ *   'users/billing': ['team-billing'],
+ *   'organizations': ['team-org', 'team-admin']
+ * };
+ * routeDomainToOwnerTeam(map, 'users/profile'); // returns ['team-identity']
+ * routeDomainToOwnerTeam(map, 'users/billing/invoice'); // returns ['team-billing']
+ */
+export function routeDomainToOwnerTeam(routeDomainToOwnerTeamMap, routeDomain) {
+  if (!routeDomainToOwnerTeamMap) {
+    return [];
+  }
+  const matchingKeys = Object.entries(routeDomainToOwnerTeamMap)
+    .filter(([routeDomainPattern, _value]) => routeDomain.startsWith(routeDomainPattern))
+    .map(([key, _value]) => key);
+
+  const longestMatchingKey = matchingKeys.sort((a, b) => b.length - a.length)[0];
+
+  return routeDomainToOwnerTeamMap[longestMatchingKey] ?? [];
+}

--- a/api/tests/shared/unit/infrastructure/utils/route-domain-to-owner-team_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/route-domain-to-owner-team_test.js
@@ -1,0 +1,74 @@
+import { routeDomainToOwnerTeam } from '../../../../../src/shared/infrastructure/utils/route-domain-to-owner-team.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Shared | infrastructure | Utils | route-domain-to-owner-team', function () {
+  it('should return an empty array if config is empty', function () {
+    const config = {};
+    const route = 'announcements';
+    const team = routeDomainToOwnerTeam(config, route);
+    expect(team).to.be.empty;
+  });
+
+  it('should return an empty array if config is undefined', function () {
+    const config = undefined;
+    const route = 'announcements';
+    const team = routeDomainToOwnerTeam(config, route);
+    expect(team).to.be.empty;
+  });
+
+  it('should match a team from a route domain', function () {
+    const config = {
+      announcements: ['team-1'],
+      banner: ['team-2'],
+    };
+
+    const route = 'announcements';
+    const team = routeDomainToOwnerTeam(config, route);
+    expect(team).to.have.members(['team-1']);
+  });
+
+  it('should match multiple teams from a route domain', function () {
+    const config = {
+      announcements: ['team-1', 'team-2'],
+      banner: ['team-3'],
+    };
+
+    const route = 'announcements';
+    const team = routeDomainToOwnerTeam(config, route);
+    expect(team).to.have.members(['team-2', 'team-1']);
+  });
+
+  it('should match a start a of route domain', function () {
+    const config = {
+      announcements: ['team-1', 'team-2'],
+      banner: ['team-3'],
+    };
+
+    const route = 'announcements/parts';
+    const team = routeDomainToOwnerTeam(config, route);
+    expect(team).to.have.members(['team-1', 'team-2']);
+  });
+
+  it('should match only the more specific route domain', function () {
+    const config = {
+      announcements: ['team-1', 'team-2'],
+      'announcements/parts': ['team-1', 'team-4'],
+      banner: ['team-3'],
+    };
+
+    const route = 'announcements/parts';
+    const team = routeDomainToOwnerTeam(config, route);
+    expect(team).to.have.members(['team-1', 'team-4']);
+  });
+
+  it('should return an empty array if no team is found', function () {
+    const config = {
+      announcements: ['team-1', 'team-2'],
+      banner: ['team-3'],
+    };
+
+    const route = 'not-found';
+    const team = routeDomainToOwnerTeam(config, route);
+    expect(team).to.be.empty;
+  });
+});


### PR DESCRIPTION
## 💥 Problème

Il peut être compliqué pour l'équipe Captain de rediriger les logs aux bonnes équipes, et il n'y a pas beaucoup de plus value à faire le passe-plat.

## 👩‍🚀 Proposition

On ajoute dans les logs un champ `teamsToContact`. Pour calculer la valeur de ce champ, on se base sur une map passée dans les variables d'environement.

Le mapping se fait entre le `route domain` et les identifiants des équipes dans slack.

