### PR TITLE
[TECH] Déplacer metrics.js dans shared

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -23,7 +23,6 @@ import { identityAccessManagementRoutes } from './src/identity-access-management
 import * as serverAuthentication from './src/identity-access-management/infrastructure/server-authentication.js';
 import { learningContentRoutes } from './src/learning-content/routes.js';
 import { llmRoutes } from './src/llm/routes.js';
-import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import { organizationalEntitiesRoutes } from './src/organizational-entities/application/routes.js';
 import { campaignRoutes } from './src/prescription/campaign/routes.js';
 import { campaignParticipationsRoutes } from './src/prescription/campaign-participation/routes.js';
@@ -38,6 +37,7 @@ import { questRoutes } from './src/quest/routes.js';
 import { schoolRoutes } from './src/school/routes.js';
 import { config } from './src/shared/config.js';
 import { installHapiHook } from './src/shared/infrastructure/execution-context-manager.js';
+import { DatadogMetrics } from './src/shared/infrastructure/metrics/datadog-metrics.js';
 import { plugins } from './src/shared/infrastructure/plugins/index.js';
 import { deserializer } from './src/shared/infrastructure/serializers/jsonapi/deserializer.js';
 // bounded context migration
@@ -74,7 +74,7 @@ const createServer = async () => {
   const server = await createBareServer();
 
   // initialisation of Datadog link for metrics publication
-  const metrics = new Metrics({ config });
+  const metrics = new DatadogMetrics({ config });
   server.directMetrics = metrics;
 
   if (logOpsMetrics) {

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -12,11 +12,11 @@ import * as serverAuthentication from './src/identity-access-management/infrastr
 import * as campaignsRoutes from './src/maddo/application/campaigns-routes.js';
 import * as organizationsRoutes from './src/maddo/application/organizations-routes.js';
 import * as replicationsRoutes from './src/maddo/application/replications-routes.js';
-import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import * as franceTravailRoutes from './src/prescription/campaign-participation/application/pole-emploi-route.js';
 import * as healthcheckRoutes from './src/shared/application/healthcheck/index.js';
 import { config } from './src/shared/config.js';
 import { installHapiHook } from './src/shared/infrastructure/execution-context-manager.js';
+import { DatadogMetrics } from './src/shared/infrastructure/metrics/datadog-metrics.js';
 import { plugins } from './src/shared/infrastructure/plugins/index.js';
 import { deserializer } from './src/shared/infrastructure/serializers/jsonapi/deserializer.js';
 import { maddoSwaggers } from './src/shared/swaggers.js';
@@ -29,7 +29,7 @@ const createMaddoServer = async () => {
   const server = createBareServer();
 
   // initialisation of Datadog link for metrics publication
-  const metrics = new Metrics({ config });
+  const metrics = new DatadogMetrics({ config });
   server.directMetrics = metrics;
 
   if (logOpsMetrics) {

--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -4,16 +4,16 @@ import { fileURLToPath } from 'node:url';
 
 import { PgBoss } from 'pg-boss';
 
-import { Metrics } from '../../../monitoring/infrastructure/metrics.js';
 import { config } from '../../config.js';
 import { executeInContext, EXECUTORS } from '../execution-context-manager.js';
+import { DatadogMetrics } from '../metrics/datadog-metrics.js';
 import { importNamedExportFromFile } from '../utils/import-named-exports-from-directory.js';
 import { child } from '../utils/logger.js';
 import { MonitoredJobHandler } from './MonitoredJobHandler.js';
 
 const workerDirPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 const logger = child('worker', { event: 'worker' });
-const metrics = new Metrics({ config });
+const metrics = new DatadogMetrics({ config });
 
 export class JobClient {
   /** @type JobClient */

--- a/api/src/shared/infrastructure/metrics/datadog-metrics.js
+++ b/api/src/shared/infrastructure/metrics/datadog-metrics.js
@@ -1,10 +1,10 @@
 import metrics from 'datadog-metrics';
 
-import { child } from '../../shared/infrastructure/utils/logger.js';
+import { child } from '../utils/logger.js';
 
 const logger = child('metrics', { event: 'metrics' });
 
-export class Metrics {
+export class DatadogMetrics {
   static intervals = [];
   static metricDefinitions = {};
 
@@ -56,7 +56,7 @@ export class Metrics {
         }
       });
     };
-    Metrics.intervals.push(setInterval(f(valueProducer), intervalInSeconds));
+    DatadogMetrics.intervals.push(setInterval(f(valueProducer), intervalInSeconds));
     metricDefinitionsArray.forEach(({ type, name, tags }) => {
       this.#registerMetric({ type, name, tags });
     });
@@ -64,16 +64,16 @@ export class Metrics {
 
   #registerMetric({ type, name, tags }) {
     const metricSignature = `${type}|${name}|${tags}`;
-    if (!Metrics.metricDefinitions[metricSignature]) {
+    if (!DatadogMetrics.metricDefinitions[metricSignature]) {
       logger.info(`Metric registered with : ${type}, ${name}, ${tags}`);
-      Metrics.metricDefinitions[metricSignature] = { type, name, tags };
+      DatadogMetrics.metricDefinitions[metricSignature] = { type, name, tags };
     }
   }
 
   async clearMetrics() {
-    Metrics.intervals.forEach(clearInterval);
-    logger.info(JSON.stringify(Metrics.metricDefinitions));
-    Object.values(Metrics.metricDefinitions).forEach((v) => {
+    DatadogMetrics.intervals.forEach(clearInterval);
+    logger.info(JSON.stringify(DatadogMetrics.metricDefinitions));
+    Object.values(DatadogMetrics.metricDefinitions).forEach((v) => {
       const zero = v;
       zero.value = 0;
       this.#addMetricPointWithoutRegistration(zero);

--- a/api/tests/shared/integration/infrastructure/metrics/datadog-metrics_test.js
+++ b/api/tests/shared/integration/infrastructure/metrics/datadog-metrics_test.js
@@ -1,10 +1,10 @@
 import metrics from 'datadog-metrics';
 import nock from 'nock';
 
-import { Metrics } from '../../../../src/monitoring/infrastructure/metrics.js';
-import { expect } from '../../../test-helper.js';
+import { DatadogMetrics } from '../../../../../src/shared/infrastructure/metrics/datadog-metrics.js';
+import { expect } from '../../../../test-helper.js';
 
-describe('Integration | Monitoring | Infrastructure | metrics', function () {
+describe('Integration | Monitoring | Infrastructure | Datadog metrics', function () {
   describe('constructor', function () {
     describe('when isDirectMetricsEnabled is false', function () {
       it('should not send metrics to Datadog', async function () {
@@ -17,7 +17,7 @@ describe('Integration | Monitoring | Infrastructure | metrics', function () {
         nock('https://api.datadog_fake.com').post('/api/v1/series').reply(200);
 
         // when
-        const m = new Metrics({ config });
+        const m = new DatadogMetrics({ config });
         m.addMetricPoint({ type: 'histogram', name: 'test', value: 1 });
         await metrics.flush();
 
@@ -37,7 +37,7 @@ describe('Integration | Monitoring | Infrastructure | metrics', function () {
         nock('https://api.datadog_fake.com').post('/api/v1/series').reply(200);
 
         // when
-        const m = new Metrics({ config });
+        const m = new DatadogMetrics({ config });
         m.addMetricPoint({ type: 'histogram', name: 'test', value: 1 });
         await metrics.flush();
 

--- a/api/worker.js
+++ b/api/worker.js
@@ -1,9 +1,9 @@
 import { databaseConnections } from './db/database-connections.js';
-import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import { checkJobGroups, JobGroup } from './src/shared/application/jobs/job-controller.js';
 import { config, schema as configSchema } from './src/shared/config.js';
 import { JobClient } from './src/shared/infrastructure/jobs/JobClient.js';
 import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
+import { DatadogMetrics } from './src/shared/infrastructure/metrics/datadog-metrics.js';
 import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
 import { close as closePubsub } from './src/shared/infrastructure/pubsub.js';
 import { child } from './src/shared/infrastructure/utils/logger.js';
@@ -11,7 +11,7 @@ import { validateEnvironmentVariables } from './src/shared/infrastructure/valida
 
 const logger = child('worker', { event: 'worker' });
 
-const metrics = new Metrics({ config });
+const metrics = new DatadogMetrics({ config });
 
 const isRunningFromCli = import.meta.filename === process.argv[1];
 


### PR DESCRIPTION
## 💥 Problème

Le contexte `shared` importe le fichier `metrics.js` depuis le contexte `monitoring` (pour le `Job Client`. Et `metrics.js` est le seul fichier dans le contexte `monitoring`.

## 👩‍🚀 Proposition

1. Déplacer `metrics.js` dans `shared/infrastructure/metrics`
2. Renommer `metrics.js` en `datadog-metrics.js` et la classe en `DatadogMetrics`. Ce qui permet de différencier des métriques prometeus.
3. Suppression du contexte `monitoring`

## 👁️ Remarques

À voir plus tard pour supprimer tout le code lié aux métriques Datadog car elles ne sont pas utilisées il me semble.

## ♻️ Pour tester

Tests ok