### PR TITLE
[TECH] Déplacement de la récupération des donnée du composant vers la route parente (pix-22889)

### DIFF
--- a/admin/app/components/certification-frameworks/item/framework/new-version-form.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/new-version-form.gjs
@@ -14,27 +14,7 @@ export default class NewVersionForm extends Component {
   @service router;
   @service store;
 
-  @tracked frameworks = [];
   @tracked selectedTubes = [];
-
-  constructor() {
-    super(...arguments);
-
-    this.#onMount();
-  }
-
-  get scope() {
-    return this.router.currentRoute.parent.parent.params.certification_framework_key;
-  }
-
-  get frameworkLabel() {
-    return this.store.peekRecord('certification-framework', this.scope)?.name;
-  }
-
-  async #onMount() {
-    const foundFrameworks = await this.store.findAll('framework');
-    this.frameworks = foundFrameworks.map((framework) => framework);
-  }
 
   @action
   onTubesSelectionChange(selectedTubes) {
@@ -44,7 +24,7 @@ export default class NewVersionForm extends Component {
   @action
   async onSubmit() {
     const consolidatedFramework = this.store.createRecord('certification-consolidated-framework', {
-      scope: this.scope,
+      scope: this.args.scope,
       tubes: this.selectedTubes,
     });
 
@@ -69,9 +49,9 @@ export default class NewVersionForm extends Component {
 
     <form>
       <section>
-        {{#if this.frameworks.length}}
+        {{#if @frameworks.length}}
           <TubesSelection
-            @frameworks={{this.frameworks}}
+            @frameworks={{@frameworks}}
             @onChange={{this.onTubesSelectionChange}}
             @displaySkillDifficultyAvailability={{true}}
             @displaySkillDifficultySelection={{false}}

--- a/admin/app/routes/authenticated/certification-frameworks/item/framework/new-version.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/framework/new-version.js
@@ -1,0 +1,16 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import RSVP from 'rsvp';
+
+export default class FrameworkRoute extends Route {
+  @service store;
+
+  async model() {
+    const frameworks = await this.store.findAll('framework');
+    const item = await this.modelFor('authenticated.certification-frameworks.item');
+    return RSVP.hash({
+      frameworks,
+      scope: item.frameworkKey,
+    });
+  }
+}

--- a/admin/app/templates/authenticated/certification-frameworks/item/framework/new-version.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item/framework/new-version.gjs
@@ -1,3 +1,3 @@
 import NewVersionForm from 'pix-admin/components/certification-frameworks/item/framework/new-version-form';
 
-<template><NewVersionForm /></template>
+<template><NewVersionForm @frameworks={{@model.frameworks}} @scope={{@model.scope}} /></template>

--- a/admin/tests/integration/components/certification-frameworks/item/framework/new-version-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/new-version-form-test.gjs
@@ -2,7 +2,6 @@ import { render, within } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import NewVersionForm from 'pix-admin/components/certification-frameworks/item/framework/new-version-form';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
 
@@ -14,20 +13,14 @@ module('Integration | Component | complementary-certifications/item/framework/ne
     const store = this.owner.lookup('service:store');
 
     const frameworks = _createFrameworks(store);
-    sinon.stub(store, 'findAll').withArgs('framework').resolves(frameworks);
 
     store.createRecord('certification-framework', {
       id: 'DROIT',
       name: 'Pix+Droit',
     });
 
-    const serviceRouter = this.owner.lookup('service:router');
-    sinon
-      .stub(serviceRouter, 'currentRoute')
-      .value({ parent: { parent: { params: { certification_framework_key: 'DROIT' } } } });
-
     // when
-    const screen = await render(<template><NewVersionForm /></template>);
+    const screen = await render(<template><NewVersionForm @frameworks={{frameworks}} @scope="DROIT" /></template>);
 
     assert
       .dom(


### PR DESCRIPTION
## 💥 Problème

Le composant devait connaitre l'archi des templates parents

## 👩‍🚀 Proposition

Gérer ça coté route.

## 👁️ Remarques

RAS

## ♻️ Pour tester
