### PR TITLE
[TECH] Permettre de correctement fermer Maddo lorsqu'on fait Ctrl+C dans le terminal

### DIFF
--- a/api/index.maddo.js
+++ b/api/index.maddo.js
@@ -3,7 +3,11 @@ import { createMaddoServer } from './server.maddo.js';
 import { JobGroup } from './src/shared/application/jobs/job-controller.js';
 import { config, schema as configSchema } from './src/shared/config.js';
 import { JobClient } from './src/shared/infrastructure/jobs/JobClient.js';
+import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
+import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
+import { close as closePubSub } from './src/shared/infrastructure/pubsub.js';
 import { logger } from './src/shared/infrastructure/utils/logger.js';
+import { redisMonitor } from './src/shared/infrastructure/utils/redis-monitor.js';
 import { validateEnvironmentVariables } from './src/shared/infrastructure/validate-environment-variables.js';
 
 validateEnvironmentVariables(configSchema);
@@ -33,14 +37,22 @@ async function _exitOnSignal(signal) {
   await JobClient.instance.stop();
   logger.info('Closing connections to databases...');
   await databaseConnections.disconnect();
+  logger.info('Closing connections to pubsub...');
+  await closePubSub();
+  logger.info('Closing connections to storages...');
+  await quitAllStorages();
+  logger.info('Closing connections to redis mutex...');
+  await quitMutex();
+  logger.info('Closing connections to redis monitor...');
+  await redisMonitor.quit();
   logger.info('Exiting process...');
 }
 
-process.on('SIGTERM', () => {
-  _exitOnSignal('SIGTERM');
+process.on('SIGTERM', async () => {
+  await _exitOnSignal('SIGTERM');
 });
-process.on('SIGINT', () => {
-  _exitOnSignal('SIGINT');
+process.on('SIGINT', async () => {
+  await _exitOnSignal('SIGINT');
 });
 
 (async () => {


### PR DESCRIPTION
## 💥 Problème

Le spam Ctrl+c n'a pas l'air de fermer Maddo correctement lorsqu'on le lance en local.

Extrait du terminal d'un collègue :
```sh
^C[14:43:23] INFO: Received signal: SIGINT. {"user_id":null,"request_id":null,"scriptId":null,"jobId":null,"pix-metadata":null}
[14:43:23] INFO: Stopping HAPI server... {"user_id":null,"request_id":null,"scriptId":null,"jobId":null,"pix-metadata":null}
[14:43:23] INFO: server stopped {"host":"pixodrome","port":5000,"protocol":"http"}
[14:43:23] INFO: {} {"user_id":null,"request_id":null,"scriptId":null,"jobId":null,"pix-metadata":null}
[14:43:23] INFO: Stopping PG Boss client... {"user_id":null,"request_id":null,"scriptId":null,"jobId":null,"pix-metadata":null}
[14:43:23] INFO: Closing connections to databases... {"user_id":null,"request_id":null,"scriptId":null,"jobId":null,"pix-metadata":null}
[14:43:23] INFO: Closing connections to live {"user_id":null,"request_id":null,"scriptId":null,"jobId":null,"pix-metadata":null}
[14:43:23] INFO: Closing connections to datamart {"user_id":null,"request_id":null,"scriptId":null,"jobId":null,"pix-metadata":null}
[14:43:23] INFO: Exiting process... {"user_id":null,"request_id":null,"scriptId":null,"jobId":null,"pix-metadata":null}
^[[A^C^C^C^C^C^C^C^C^C
```

## 👩‍🚀 Proposition

Fermer tous les clients Redis ouverts

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
Lancer Maddo en local et spam Ctrl+c 🎉 
