### PR TITLE
[FEATURE] Autoriser France Travail à voir le questionnaire de fin de parcours combiné dans tous les cas

### DIFF
--- a/mon-pix/app/components/routes/combined-courses/presentation.gjs
+++ b/mon-pix/app/components/routes/combined-courses/presentation.gjs
@@ -134,6 +134,10 @@ export default class CombinedCoursePresentation extends Component {
   get isSurveyEnabled() {
     const surveyEnabledForCombinedCourses = this.featureToggles.featureToggles?.isSurveyEnabledForCombinedCourses;
 
+    if (this.args.combinedCourse.organizationId === ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID) {
+      return true;
+    }
+
     if (!ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST) return surveyEnabledForCombinedCourses;
 
     const organizationsToExclude = ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST.split(',');

--- a/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
@@ -450,12 +450,12 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
       assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
     });
 
-    test('should display France Travail survey cta', async function (assert) {
+    test('should display France Travail survey cta in all cases', async function (assert) {
       // given
       const FRANCE_TRAVAIL_ORGANIZATION_ID = 456;
       const store = this.owner.lookup('service:store');
       const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: true });
+      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: false });
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
         status: CombinedCourseStatuses.COMPLETED,


### PR DESCRIPTION
## 💥 Problème
On veut autoriser France Travail à avoir accès au questionnaire de fin de parcours combiné même quand le feature toggle est désactivé pour les autres organisations.

## 👩‍🚀 Proposition
On passe la valeur de "isSurveyEnabled" à true dans tous les cas dans le front.

## 👁️ Remarques
C'est cracra mais c'est urgent.
On repassera sur le code de toute façon au moment du rattachement questionnaire / schéma de parcours combiné.

## ♻️ Pour tester
Changer la variable FRANCE_TRAVAIL_ORGANIZATION_ID dans l'environnement front, la passer à 1005.
Tester qu'à la fin de Combinix1, on a le questionnaire FranceTravail.

Puis se connecter avec attestation-blank@example.net
Et passer MAXICOMBI
vérifier qu'on a plus le questionnaire

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
