### PR TITLE
[FEATURE] Lire les données des CGU avec ou sans la nouvelle api (PIX-22580)

### DIFF
--- a/api/src/legal-documents/domain/models/LegalDocumentStatus.js
+++ b/api/src/legal-documents/domain/models/LegalDocumentStatus.js
@@ -1,6 +1,7 @@
 export const STATUS = {
   ACCEPTED: 'accepted',
   REQUESTED: 'requested',
+  NOT_APPLICABLE: 'not-applicable',
   UPDATE_REQUESTED: 'update-requested',
 };
 
@@ -34,6 +35,17 @@ export class LegalDocumentStatus {
     }
 
     return new LegalDocumentStatus({ status: STATUS.UPDATE_REQUESTED, acceptedAt: null, documentPath });
+  }
+
+  static buildForLegacyPixAppCgu({ mustValidateTermsOfService, lastTermsOfServiceValidatedAt }) {
+    if (mustValidateTermsOfService) {
+      return new LegalDocumentStatus({ status: STATUS.UPDATE_REQUESTED, acceptedAt: null, documentPath: null });
+    }
+    return new LegalDocumentStatus({
+      status: STATUS.ACCEPTED,
+      acceptedAt: lastTermsOfServiceValidatedAt,
+      documentPath: null,
+    });
   }
 
   static notFound() {

--- a/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
@@ -1,5 +1,6 @@
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { LegalDocumentService } from '../models/LegalDocumentService.js';
-import { LegalDocumentStatus } from '../models/LegalDocumentStatus.js';
+import { LegalDocumentStatus, STATUS } from '../models/LegalDocumentStatus.js';
 import { LegalDocumentType } from '../models/LegalDocumentType.js';
 
 /**
@@ -12,27 +13,60 @@ import { LegalDocumentType } from '../models/LegalDocumentType.js';
  * @returns {Promise<LegalDocumentStatus>} The legal document status.
  * @throws {Error} If no legal document version is found for the type and service.
  */
+
+const { PIX_APP } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
+
 const getLegalDocumentStatusByUserId = async ({
   userId,
   service,
   type,
   legalDocumentRepository,
+  userRepository,
+  userScoRepository,
   userAcceptanceRepository,
   logger,
 }) => {
   LegalDocumentService.assert(service);
   LegalDocumentType.assert(type);
 
-  const lastLegalDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ service, type });
+  const isPixAppTos = service === PIX_APP && type === TOS;
+  const isNewVersioningEnabled = await featureToggles.get('newPixAppLegalDocumentsVersioning');
 
+  if (!isNewVersioningEnabled && isPixAppTos) {
+    const user = await userRepository.getPixAppLegacyCguByUserId(userId);
+    const legalDocumentStatus = LegalDocumentStatus.buildForLegacyPixAppCgu({
+      mustValidateTermsOfService: user.mustValidateTermsOfService,
+      lastTermsOfServiceValidatedAt: user.lastTermsOfServiceValidatedAt,
+    });
+
+    return legalDocumentStatus;
+  }
+
+  const lastLegalDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ service, type });
   if (!lastLegalDocument) {
     logger.warn(`Unknown legal document version found for ${service} and ${type}`);
     return LegalDocumentStatus.notFound();
   }
 
   const lastUserAcceptance = await userAcceptanceRepository.findLastForLegalDocument({ userId, service, type });
+  const legalDocumentStatus = LegalDocumentStatus.build(lastLegalDocument, lastUserAcceptance);
 
-  return LegalDocumentStatus.build(lastLegalDocument, lastUserAcceptance);
+  if (
+    isPixAppTos &&
+    (legalDocumentStatus.status === STATUS.REQUESTED || legalDocumentStatus.status === STATUS.UPDATE_REQUESTED)
+  ) {
+    const isScoStudent = await userScoRepository.isUserScoStudent(userId);
+    if (isScoStudent) {
+      return new LegalDocumentStatus({
+        status: STATUS.NOT_APPLICABLE,
+        acceptedAt: null,
+        documentPath: null,
+      });
+    }
+  }
+
+  return legalDocumentStatus;
 };
 
 export { getLegalDocumentStatusByUserId };

--- a/api/src/legal-documents/domain/usecases/index.js
+++ b/api/src/legal-documents/domain/usecases/index.js
@@ -1,11 +1,15 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import * as legalDocumentRepository from '../../infrastructure/repositories/legal-document.repository.js';
+import * as userRepository from '../../infrastructure/repositories/user.repository.js';
 import * as userAcceptanceRepository from '../../infrastructure/repositories/user-acceptance.repository.js';
+import * as userScoRepository from '../../infrastructure/repositories/user-sco.repository.js';
 
 const repositories = {
   legalDocumentRepository,
   userAcceptanceRepository,
+  userRepository,
+  userScoRepository,
 };
 
 const dependencies = Object.assign({ logger }, repositories);

--- a/api/src/legal-documents/infrastructure/repositories/user-sco.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user-sco.repository.js
@@ -1,0 +1,31 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+const SIX_YEARS_IN_MS = 6 * 365.25 * 24 * 60 * 60 * 1000;
+
+/**
+ * @deprecated avoid using this function as much as possible because it has performance issues and because it should be obtained from a Prescription internal API when it is available.
+ */
+export const isUserScoStudent = async (userId) => {
+  const knexConnection = DomainTransaction.getConnection();
+
+  const sixYearsAgo = new Date(Date.now() - SIX_YEARS_IN_MS);
+
+  const activeScoLearner = await knexConnection('organization-learners')
+    .join('organizations', 'organization-learners.organizationId', 'organizations.id')
+    .where({
+      'organizations.isManagingStudents': true,
+      'organizations.type': 'SCO',
+      'organization-learners.userId': userId,
+      'organization-learners.deletedAt': null,
+    })
+    .where('organization-learners.createdAt', '>=', sixYearsAgo)
+    .whereNotExists(function () {
+      this.select(1)
+        .from('account-recovery-demands')
+        .where({ userId, used: true })
+        .whereRaw('"organizationLearnerId" = "organization-learners"."id"');
+    })
+    .first();
+
+  return Boolean(activeScoLearner);
+};

--- a/api/src/legal-documents/infrastructure/repositories/user.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user.repository.js
@@ -1,0 +1,14 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { UserNotFoundError } from '../../../shared/domain/errors.js';
+
+const getPixAppLegacyCguByUserId = async (userId) => {
+  const knexConnection = DomainTransaction.getConnection();
+  const user = await knexConnection('users')
+    .select('cgu', 'mustValidateTermsOfService', 'lastTermsOfServiceValidatedAt')
+    .where({ id: userId })
+    .first();
+  if (!user) throw new UserNotFoundError();
+  return user;
+};
+
+export { getPixAppLegacyCguByUserId };

--- a/api/tests/legal-documents/integration/domain/usecases/get-legal-document-status-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/get-legal-document-status-by-user-id.usecase.test.js
@@ -2,13 +2,18 @@ import { LegalDocumentService } from '../../../../../src/legal-documents/domain/
 import { LegalDocumentStatus, STATUS } from '../../../../../src/legal-documents/domain/models/LegalDocumentStatus.js';
 import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 
-const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { PIX_APP, PIX_ORGA } = LegalDocumentService.VALUES;
 const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Legal documents | Domain | Use case | get-legal-document-status-by-user-id', function () {
+  afterEach(async function () {
+    await featureToggles.set('newPixAppLegalDocumentsVersioning', false);
+  });
+
   it('returns the legal document status for a user', async function () {
     // given
     const service = PIX_ORGA;
@@ -52,6 +57,231 @@ describe('Integration | Legal documents | Domain | Use case | get-legal-document
       // then
       expect(legalDocumentStatus).to.be.an.instanceOf(LegalDocumentStatus);
       expect(legalDocumentStatus).to.deep.equal({ status: STATUS.REQUESTED, acceptedAt: null, documentPath: null });
+    });
+  });
+
+  context('when service is pix-app', function () {
+    context('when feature toggle is disabled', function () {
+      beforeEach(async function () {
+        await featureToggles.set('newPixAppLegalDocumentsVersioning', false);
+      });
+
+      context('when when mustValidateTermsOfService=false', function () {
+        it('returns accepted status', async function () {
+          // given
+          const acceptedAt = new Date('2024-06-01');
+          const user = databaseBuilder.factory.buildUser({
+            cgu: true,
+            mustValidateTermsOfService: false,
+            lastTermsOfServiceValidatedAt: acceptedAt,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_APP,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result).to.deep.equal({ status: STATUS.ACCEPTED, acceptedAt, documentPath: null });
+        });
+      });
+
+      context('when mustValidateTermsOfService=true', function () {
+        it('returns update-requested status', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser({
+            cgu: true,
+            mustValidateTermsOfService: true,
+            lastTermsOfServiceValidatedAt: null,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_APP,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result).to.deep.equal({ status: STATUS.UPDATE_REQUESTED, acceptedAt: null, documentPath: null });
+        });
+      });
+    });
+
+    context('when feature toggle is enabled', function () {
+      beforeEach(async function () {
+        await featureToggles.set('newPixAppLegalDocumentsVersioning', true);
+      });
+
+      context('when user has no acceptance and is not an SCO student', function () {
+        it('returns requested status', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser();
+          databaseBuilder.factory.buildLegalDocumentVersion({
+            service: PIX_APP,
+            type: TOS,
+            versionAt: new Date('2024-01-01'),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_APP,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result.status).to.equal(STATUS.REQUESTED);
+        });
+      });
+
+      context('when user has accepted an older version and is not a SCO student', function () {
+        it('returns update-requested status', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser();
+          const oldDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+            service: PIX_APP,
+            type: TOS,
+            versionAt: new Date('2023-01-01'),
+          });
+          databaseBuilder.factory.buildLegalDocumentVersion({
+            service: PIX_APP,
+            type: TOS,
+            versionAt: new Date('2024-01-01'),
+          });
+          databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+            userId: user.id,
+            legalDocumentVersionId: oldDocumentVersion.id,
+            acceptedAt: new Date('2023-06-01'),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_APP,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result.status).to.equal(STATUS.UPDATE_REQUESTED);
+        });
+      });
+
+      context('when user has no acceptance and is a SCO student', function () {
+        it('returns not-applicable status', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser();
+          databaseBuilder.factory.buildLegalDocumentVersion({
+            service: PIX_APP,
+            type: TOS,
+            versionAt: new Date('2024-01-01'),
+          });
+          const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+          databaseBuilder.factory.buildOrganizationLearner({
+            userId: user.id,
+            organizationId: organization.id,
+            createdAt: new Date(),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_APP,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result.status).to.equal(STATUS.NOT_APPLICABLE);
+        });
+      });
+
+      context('when user has an older acceptance and is a SCO student', function () {
+        it('returns not-applicable status', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser();
+          const oldDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+            service: PIX_APP,
+            type: TOS,
+            versionAt: new Date('2023-01-01'),
+          });
+          databaseBuilder.factory.buildLegalDocumentVersion({
+            service: PIX_APP,
+            type: TOS,
+            versionAt: new Date('2024-01-01'),
+          });
+          databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+            userId: user.id,
+            legalDocumentVersionId: oldDocumentVersion.id,
+            acceptedAt: new Date('2023-06-01'),
+          });
+          const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+          databaseBuilder.factory.buildOrganizationLearner({
+            userId: user.id,
+            organizationId: organization.id,
+            createdAt: new Date(),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_APP,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result.status).to.equal(STATUS.NOT_APPLICABLE);
+        });
+      });
+
+      context('when user has accepted the current version even if SCO student', function () {
+        it('returns accepted status', async function () {
+          // given
+          const acceptedAt = new Date('2024-03-01');
+          const user = databaseBuilder.factory.buildUser();
+          const documentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+            service: PIX_APP,
+            type: TOS,
+            versionAt: new Date('2024-01-01'),
+          });
+          databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+            userId: user.id,
+            legalDocumentVersionId: documentVersion.id,
+            acceptedAt,
+          });
+          const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+          databaseBuilder.factory.buildOrganizationLearner({
+            userId: user.id,
+            organizationId: organization.id,
+            createdAt: new Date(),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_APP,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result.status).to.equal(STATUS.ACCEPTED);
+        });
+      });
     });
   });
 });

--- a/api/tests/legal-documents/integration/infrastructure/repositories/user-sco.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/user-sco.repository.test.js
@@ -1,0 +1,183 @@
+import { isUserScoStudent } from '../../../../../src/legal-documents/infrastructure/repositories/user-sco.repository.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Integration | Infrastructure | Repository | UserScoRepository', function () {
+  describe('#isUserScoStudent', function () {
+    context(
+      'when the user has an active SCO learner record created within 6 years and no account recovery demand',
+      function () {
+        it('returns true', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+          databaseBuilder.factory.buildOrganizationLearner({
+            userId,
+            organizationId: organization.id,
+            createdAt: new Date(),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await isUserScoStudent(userId);
+
+          // then
+          expect(result).to.be.true;
+        });
+      },
+    );
+
+    context('when the user has no organization learner', function () {
+      it('returns false', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+
+        // when
+        const result = await isUserScoStudent(userId);
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context('when the user has an organization learner in a non-SCO organization', function () {
+      it('returns false', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'PRO', isManagingStudents: false });
+        databaseBuilder.factory.buildOrganizationLearner({
+          userId,
+          organizationId: organization.id,
+          createdAt: new Date(),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await isUserScoStudent(userId);
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context(
+      'when the user has an organization learner in an SCO organization that does not manage students',
+      function () {
+        it('returns false', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: false });
+          databaseBuilder.factory.buildOrganizationLearner({
+            userId,
+            organizationId: organization.id,
+            createdAt: new Date(),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await isUserScoStudent(userId);
+
+          // then
+          expect(result).to.be.false;
+        });
+      },
+    );
+
+    context('when the user has an SCO learner record created more than 6 years ago', function () {
+      it('returns false', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+        const sevenYearsAgo = new Date();
+        sevenYearsAgo.setFullYear(sevenYearsAgo.getFullYear() - 7);
+        databaseBuilder.factory.buildOrganizationLearner({
+          userId,
+          organizationId: organization.id,
+          createdAt: sevenYearsAgo,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await isUserScoStudent(userId);
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context('when the user has a deleted SCO learner record', function () {
+      it('returns false', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+        databaseBuilder.factory.buildOrganizationLearner({
+          userId,
+          organizationId: organization.id,
+          createdAt: new Date(),
+          deletedAt: new Date(),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await isUserScoStudent(userId);
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context(
+      'when the user has an active SCO learner record but has a used account recovery demand (sortie du SCO)',
+      function () {
+        it('returns false', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+          const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+            userId,
+            organizationId: organization.id,
+            createdAt: new Date(),
+          });
+          databaseBuilder.factory.buildAccountRecoveryDemand({
+            userId,
+            organizationLearnerId: organizationLearner.id,
+            used: true,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await isUserScoStudent(userId);
+
+          // then
+          expect(result).to.be.false;
+        });
+      },
+    );
+
+    context('when the user has a SCO learner record and an unused account recovery demand', function () {
+      it('returns true', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          userId,
+          organizationId: organization.id,
+          createdAt: new Date(),
+        });
+        databaseBuilder.factory.buildAccountRecoveryDemand({
+          userId,
+          organizationLearnerId: organizationLearner.id,
+          used: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await isUserScoStudent(userId);
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+  });
+});

--- a/api/tests/legal-documents/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/user.repository.test.js
@@ -1,0 +1,54 @@
+import * as userRepository from '../../../../../src/legal-documents/infrastructure/repositories/user.repository.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+describe('Integration | Legal documents | Infrastructure | Repository | UserRepository', function () {
+  describe('#getPixAppLegacyCguByUserId', function () {
+    it('returns the legacy CGU data for a user', async function () {
+      // given
+      const lastTermsOfServiceValidatedAt = new Date('2024-03-15');
+      const user = databaseBuilder.factory.buildUser({
+        cgu: true,
+        mustValidateTermsOfService: false,
+        lastTermsOfServiceValidatedAt,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRepository.getPixAppLegacyCguByUserId(user.id);
+
+      // then
+      expect(result.cgu).to.be.true;
+      expect(result.mustValidateTermsOfService).to.be.false;
+      expect(result.lastTermsOfServiceValidatedAt).to.deep.equal(lastTermsOfServiceValidatedAt);
+    });
+
+    it('returns cgu=false and mustValidateTermsOfService=false for a user who has not accepted CGU', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser({
+        cgu: false,
+        mustValidateTermsOfService: false,
+        lastTermsOfServiceValidatedAt: null,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRepository.getPixAppLegacyCguByUserId(user.id);
+
+      // then
+      expect(result.cgu).to.be.false;
+      expect(result.mustValidateTermsOfService).to.be.false;
+      expect(result.lastTermsOfServiceValidatedAt).to.be.null;
+    });
+
+    it('throws UserNotFoundError when user does not exist', async function () {
+      // given / when
+      const error = await catchErr(userRepository.getPixAppLegacyCguByUserId)(999999);
+
+      // then
+      expect(error).to.be.instanceof(UserNotFoundError);
+    });
+  });
+});

--- a/api/tests/legal-documents/unit/domain/models/LegalDocumentStatus.test.js
+++ b/api/tests/legal-documents/unit/domain/models/LegalDocumentStatus.test.js
@@ -84,6 +84,47 @@ describe('Unit | Legal documents | Domain | Model | LegalDocumentStatus', functi
     });
   });
 
+  describe('#LegalDocumentStatus.buildForLegacyPixAppCgu', function () {
+    context('when the user has accepted CGU and must validate terms of service', function () {
+      it('returns an "update-requested" legal document status', function () {
+        // given / when
+        const legalDocumentStatus = LegalDocumentStatus.buildForLegacyPixAppCgu({
+          mustValidateTermsOfService: true,
+          lastTermsOfServiceValidatedAt: new Date('2024-01-01'),
+        });
+
+        // then
+        expect(legalDocumentStatus).to.be.instanceof(LegalDocumentStatus);
+        expect(legalDocumentStatus).to.deep.equal({
+          status: STATUS.UPDATE_REQUESTED,
+          acceptedAt: null,
+          documentPath: null,
+        });
+      });
+    });
+
+    context('when the user has accepted CGU and does not need to revalidate', function () {
+      it('returns an "accepted" legal document status with lastTermsOfServiceValidatedAt as "acceptedAt"', function () {
+        // given
+        const lastTermsOfServiceValidatedAt = new Date('2024-06-15');
+
+        // when
+        const legalDocumentStatus = LegalDocumentStatus.buildForLegacyPixAppCgu({
+          mustValidateTermsOfService: false,
+          lastTermsOfServiceValidatedAt,
+        });
+
+        // then
+        expect(legalDocumentStatus).to.be.instanceof(LegalDocumentStatus);
+        expect(legalDocumentStatus).to.deep.equal({
+          status: STATUS.ACCEPTED,
+          acceptedAt: lastTermsOfServiceValidatedAt,
+          documentPath: null,
+        });
+      });
+    });
+  });
+
   describe('#LegalDocumentStatus.notFound', function () {
     it('returns an legal document status as request when legal document is not found', function () {
       // given / when


### PR DESCRIPTION
## 💥 Problème

Dans le cadre de la nouvelle gestion du versioning des CGUs pour Pix App, nous avons besoin d’une API permettant de récupérer l'état d’acceptation d’un document légal pour un utilisateur.


## 👩‍🚀 Proposition

À faire dans le usecase `getLegalDocumentByUserId` (ajouter la gestion du feature toggle `on` ou `off`) 

CAS 1 : Si le feature toggle `newPixAppLegalDocumentsVersioning` est désactivé et `service=pix-app` et `type=TOS`.

On doit utiliser l’ancien système des CGU (table `users`) pour faire la correspondance avec le nouveau système (`legal document`), selon les règles suivantes :
    Si `cgu=true` et `mustValidateTermsOfService=true`, alors `status=update-requested`
    Si `cgu=true` et `mustValidateTermsOfService=false`, alors `status=accepted`
    Si `cgu=false` alors `status=requested` SAUF POUR LES ELEVES SCO alors `status=skipped`. 

 CAS 2 : Si le feature toggle `newPixAppLegalDocumentsVersioning` est activé.
    Vérifier la table d’acceptation pour l’utilisateur (déjà présent aujourd’hui)
    Si (status=requested ou `update-requested` et `service=pix-app` et `type=TOS`), renvoyer le `status=skipped` si c’est un élève SCO.

Il faudra gérer la nouvelle valeur `skipped` et rajouter une méthode `buildForLegacyPixAppCgu` dans le modèle `legalDocumentStatus`

 **Règles pour définir un élève SCO** 
            tout user ayant au moins un `orga-learner` avec une date de création <= 6 ans
            dans une organisation de type SCO et qui a `isManagingStudents` à `true`
            sans demande de sortie du SCO (table `account-recovery-demands` à `true`)
    `acceptedAt` equivalent à `lastTermsOfServiceValidatedAt`
 
## 👁️ Remarques

- Cas d'un élève qui serait learner de plusieurs organisations et qui aurait fait une demande de récupération de compte (associée à l'un des learners ?) > comment doit se passer le calcul de isStudent dans ce cas ?
- Un ticket "Modifier l'appel Pix App qui récupère le statut des CGU afin de fonctionner avec le nouveau modèle" est prévu prochainement, cette PR sera testable à ce moment là.

## ♻️ Pour tester

Cette PR ne doit pas avoir d'impact sur notre code de production.

Tester la non régression sur Pix App avec le FT activé et non activé : 
* Pour demander la validation pour de nouvelles CGU avec le FT activé : 
   ```shell
   node src/legal-documents/scripts/add-new-legal-document-version.js --type=TOS --service=pix-app --versionAt=2026-05-05
   ```
* Pour demander la validation pour de nouvelles CGU avec le FT non-activé : 
   ```sql
   update "users" set "mustValidateTermsOfService"=true where email='justin.compte@example.net';
   ```
