### PR TITLE
[TECH] Extrait la logique de parsing du model OrganizationFeature

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationFeature.js
+++ b/api/src/organizational-entities/domain/models/OrganizationFeature.js
@@ -47,22 +47,19 @@ class OrganizationFeature {
             ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key,
             ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
           ),
-          then: Joi.valid(null, '').optional(),
+          then: Joi.valid(null).optional(),
         },
       ],
     }),
     deleteLearner: Joi.when('featureName', {
       is: Joi.string().required().valid(ORGANIZATION_FEATURE.LEARNER_IMPORT.key),
-      then: Joi.valid('Y', 'N').allow(null).optional(),
-      otherwise: Joi.valid(null, '').optional(),
+      then: Joi.boolean().allow(null).optional(),
+      otherwise: Joi.valid(null, false).optional(),
     }),
     organizationId: Joi.number().integer().required(),
   });
 
-  #deleteLearner;
   constructor({ featureName, organizationId, params, deleteLearner, features }) {
-    const parsedParams = params ? JSON.parse(params) : null;
-    const parsedOrganizationId = parseInt(organizationId, 10);
     const selectedFeature = features.find(({ key }) => key === featureName);
 
     if (!selectedFeature) {
@@ -74,17 +71,12 @@ class OrganizationFeature {
       );
     }
 
-    this.#validate({ featureName, params: parsedParams, deleteLearner, organizationId });
+    this.#validate({ featureName, params, deleteLearner, organizationId });
 
     this.featureId = selectedFeature.id;
-    this.organizationId = parsedOrganizationId;
-    this.params = parsedParams;
-
-    this.#deleteLearner = deleteLearner === 'Y';
-  }
-
-  get deleteLearner() {
-    return this.#deleteLearner;
+    this.organizationId = organizationId;
+    this.params = params ?? null;
+    this.deleteLearner = deleteLearner ?? false;
   }
 
   #validate(data) {

--- a/api/src/organizational-entities/domain/usecases/add-organization-feature-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/add-organization-feature-in-batch.usecase.js
@@ -30,7 +30,13 @@ export const addOrganizationFeatureInBatch = withTransaction(
     const csvData = csvParser.parse();
     const data = csvData.map(({ featureName, organizationId, params, deleteLearner }) => {
       try {
-        return new OrganizationFeature({ featureName, organizationId, params, deleteLearner, features });
+        return new OrganizationFeature({
+          featureName,
+          organizationId: parseInt(organizationId, 10),
+          params: params ? JSON.parse(params) : null,
+          deleteLearner: deleteLearner === 'Y',
+          features,
+        });
       } catch (error) {
         if (error instanceof EntityValidationError) throw error;
         throw new FeatureParamsNotProcessable();

--- a/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
@@ -22,9 +22,10 @@ async function saveInBatch(organizationFeatures) {
     const knexConn = DomainTransaction.getConnection();
     await knexConn('organization-features')
       .insert(
-        organizationFeatures.map((organizationFeature) => ({
-          ...organizationFeature,
-          params: JSON.stringify(organizationFeature.params),
+        organizationFeatures.map(({ featureId, organizationId, params }) => ({
+          featureId,
+          organizationId,
+          params: JSON.stringify(params),
         })),
       )
       .onConflict(['featureId', 'organizationId'])

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationFeature_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationFeature_test.js
@@ -11,8 +11,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
     beforeEach(function () {
       // given
       featureName = 'TOTO';
-      organizationId = '2';
-      params = `{"id": 3}`;
+      organizationId = 2;
+      params = { id: 3 };
       features = [
         {
           key: 'TATA',
@@ -34,8 +34,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
     beforeEach(function () {
       // given
       featureName = ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key;
-      organizationId = '2';
-      params = `["RIRI","FIFI","LOULOU"]`;
+      organizationId = 2;
+      params = ['RIRI', 'FIFI', 'LOULOU'];
       features = [
         {
           key: ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
@@ -52,6 +52,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
         featureId: 1,
         organizationId: 2,
         params: ['RIRI', 'FIFI', 'LOULOU'],
+        deleteLearner: false,
       });
     });
 
@@ -66,7 +67,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
     it('should throw EntityErrorValidation on deleteLearner', function () {
       //when
       const error = catchErrSync(
-        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Y', features }),
+        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: true, features }),
       )();
 
       // then
@@ -78,8 +79,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
     beforeEach(function () {
       // given
       featureName = ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key;
-      organizationId = '2';
-      params = `{"id": 3}`;
+      organizationId = 2;
+      params = { id: 3 };
       features = [
         {
           key: ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key,
@@ -96,6 +97,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
         featureId: 1,
         organizationId: 2,
         params: { id: 3 },
+        deleteLearner: false,
       });
     });
 
@@ -108,13 +110,14 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
         featureId: 1,
         organizationId: 2,
         params: null,
+        deleteLearner: false,
       });
     });
 
     it('should throw EntityErrorValidation on deleteLearner', function () {
       //when
       const error = catchErrSync(
-        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Y', features }),
+        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: true, features }),
       )();
 
       // then
@@ -126,8 +129,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
     beforeEach(function () {
       // given
       featureName = ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key;
-      organizationId = '2';
-      params = `{"id": 3}`;
+      organizationId = 2;
+      params = { id: 3 };
       features = [
         {
           key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
@@ -144,6 +147,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
         featureId: 1,
         organizationId: 2,
         params: { id: 3 },
+        deleteLearner: false,
       });
     });
 
@@ -156,13 +160,14 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
         featureId: 1,
         organizationId: 2,
         params: null,
+        deleteLearner: false,
       });
     });
 
     it('should throw EntityErrorValidation on deleteLearner', function () {
       //when
       const error = catchErrSync(
-        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Y', features }),
+        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: true, features }),
       )();
 
       // then
@@ -174,8 +179,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
     beforeEach(function () {
       // given
       featureName = ORGANIZATION_FEATURE.LEARNER_IMPORT.key;
-      organizationId = '2';
-      params = `{"id": 3}`;
+      organizationId = 2;
+      params = { id: 3 };
       features = [
         {
           key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
@@ -192,6 +197,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
         featureId: 1,
         organizationId: 2,
         params: { id: 3 },
+        deleteLearner: false,
       });
     });
 
@@ -206,7 +212,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
     it('should throw EntityErrorValidation on non object params', function () {
       //when
       const error = catchErrSync(
-        () => new OrganizationFeature({ featureName, organizationId, features, params: '[]' }),
+        () => new OrganizationFeature({ featureName, organizationId, features, params: [] }),
       )();
 
       // then
@@ -220,7 +226,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
           featureName,
           organizationId,
           params,
-          deleteLearner: 'Y',
+          deleteLearner: true,
           features,
         });
         // then
@@ -233,7 +239,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
           featureName,
           organizationId,
           params,
-          deleteLearner: 'N',
+          deleteLearner: false,
           features,
         });
         // then
@@ -271,8 +277,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
     describe(`#${featureName}`, function () {
       beforeEach(function () {
         // given
-        organizationId = '2';
-        params = `{"id": 3}`;
+        organizationId = 2;
+        params = { id: 3 };
         features = [
           {
             key: featureName,
@@ -289,6 +295,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
           featureId: 1,
           organizationId: 2,
           params: null,
+          deleteLearner: false,
         });
       });
 
@@ -303,7 +310,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
       it('should throw EntityErrorValidation on deleteLearner', function () {
         //when
         const error = catchErrSync(
-          () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Y', features }),
+          () => new OrganizationFeature({ featureName, organizationId, deleteLearner: true, features }),
         )();
 
         // then


### PR DESCRIPTION
## 💥 Problème

En travaillant sur la validation des parametres de la fonctionnalité des gestions des attestations on s'est rendu compte que le model OrganizationForAdmin utilise des objets à plat pour gérer les fonctionnalités. Cependant il existe un model OrganizationFeature avec déjà la couche de validation. Le problème c'est que ce model est fortement lié à l'ajout en masse de fonctionnalité via l'onglet Administration.

## 👩‍🚀 Proposition

Extraire la logique de parsing lié au CSV du model et la rapatrier dans le usecase.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester

La CI est verte 🍏 
