### PR TITLE
[FEATURE] Ne pas autoriser l'ajout de la feature Attestation Management sans paramètres (PIX-22821).

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -3,6 +3,7 @@ import differenceBy from 'lodash/differenceBy.js';
 import isEmpty from 'lodash/isEmpty.js';
 
 import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
+import { FeatureParamsNotProcessable } from '../errors.js';
 import { DataProtectionOfficer } from './DataProtectionOfficer.js';
 import { Network } from './Network.js';
 
@@ -166,6 +167,12 @@ class OrganizationForAdmin {
   }
 
   #validate() {
+    if (
+      this.features[ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key]?.active &&
+      this.features[ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key].params === null
+    ) {
+      throw new FeatureParamsNotProcessable();
+    }
     const { error } = schema.validate(this);
 
     if (error) {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -188,7 +188,6 @@ const get = async function ({ organizationId }) {
     });
 
   const importFormats = await knexConn('organization-learner-import-formats');
-
   organization.features = availableFeatures.reduce((features, { key, enabled, params }) => {
     switch (key) {
       case ORGANIZATION_FEATURE.LEARNER_IMPORT.key:

--- a/api/src/quest/application/attestation-controller.js
+++ b/api/src/quest/application/attestation-controller.js
@@ -22,12 +22,12 @@ const save = async (request, h) => {
   return h.response().code(204);
 };
 
-const findAllByOrganizationId = async (request, _, dependencies = { attestationSerializer }) => {
+const getAllByOrganizationId = async (request, _, dependencies = { attestationSerializer }) => {
   const organizationId = request.params['organizationId'];
-  const attestations = await usecases.findOrganizationAttestations({ organizationId });
+  const attestations = await usecases.getOrganizationAttestations({ organizationId });
   return dependencies.attestationSerializer.serialize(attestations);
 };
 
-const attestationController = { save, findAllByOrganizationId };
+const attestationController = { save, getAllByOrganizationId };
 
 export { attestationController };

--- a/api/src/quest/application/attestation-route.js
+++ b/api/src/quest/application/attestation-route.js
@@ -59,7 +59,7 @@ const register = async function (server) {
             assign: 'makeCheckOrganizationHasFeature',
           },
         ],
-        handler: attestationController.findAllByOrganizationId,
+        handler: attestationController.getAllByOrganizationId,
         tags: ['api', 'organizations'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',

--- a/api/src/quest/domain/usecases/find-organization-attestations.js
+++ b/api/src/quest/domain/usecases/find-organization-attestations.js
@@ -1,3 +1,0 @@
-export const findOrganizationAttestations = async ({ organizationId, attestationRepository }) => {
-  return attestationRepository.findAllByOrganizationId({ organizationId });
-};

--- a/api/src/quest/domain/usecases/get-organization-attestations.js
+++ b/api/src/quest/domain/usecases/get-organization-attestations.js
@@ -1,0 +1,3 @@
+export const getOrganizationAttestations = async ({ organizationId, attestationRepository }) => {
+  return attestationRepository.getAllByOrganizationId({ organizationId });
+};

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -62,7 +62,6 @@ import { findCombinedCourseBlueprints } from './find-combined-course-blueprints.
 import { findCombinedCourseByCampaignId } from './find-combined-course-by-campaign-id.js';
 import { findCombinedCourseByModuleIdAndUserId } from './find-combined-course-by-moduleId-and-user-id.js';
 import { findCombinedCourseParticipations } from './find-combined-course-participations.js';
-import { findOrganizationAttestations } from './find-organization-attestations.js';
 import { getCombinedCourseBlueprintById } from './get-combined-course-blueprint-by-id.js';
 import { getCombinedCourseByCode } from './get-combined-course-by-code.js';
 import getCombinedCourseById from './get-combined-course-by-id.js';
@@ -70,6 +69,7 @@ import { getCombinedCourseParticipationById } from './get-combined-course-partic
 import { getCombinedCourseStatistics } from './get-combined-course-statistics.js';
 import getCombinedCoursesByOrganizationId from './get-combined-courses-by-organization-id.js';
 import { getCourseByOrganizationId } from './get-course-by-organization-id.js';
+import { getOrganizationAttestations } from './get-organization-attestations.js';
 import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
 import { getVerifiedCode } from './get-verified-code.js';
 import { rewardUser } from './reward-user.js';
@@ -105,7 +105,7 @@ const usecasesWithoutInjectedDependencies = {
   findByOrganizationId,
   deleteAndAnonymizeParticipationsForALearnerId,
   updateCombinedCourses,
-  findOrganizationAttestations,
+  getOrganizationAttestations,
   getCourseByOrganizationId,
 };
 

--- a/api/src/quest/infrastructure/repositories/attestation-repository.js
+++ b/api/src/quest/infrastructure/repositories/attestation-repository.js
@@ -24,7 +24,7 @@ export const save = async ({ templateName, templateKey, templateFile, label, att
   });
 };
 
-export const findAllByOrganizationId = async ({ organizationId }) => {
+export const getAllByOrganizationId = async ({ organizationId }) => {
   const knexConn = DomainTransaction.getConnection();
 
   const organizationAttestationManagementFeature = await knexConn('organization-features')

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -1,9 +1,11 @@
 import { OrganizationBatchUpdateDTO } from '../../../../../src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js';
+import { FeatureParamsNotProcessable } from '../../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin', function () {
   describe('constructor', function () {
@@ -45,6 +47,22 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       }).to.throw();
     });
 
+    context('attestation management feature', function () {
+      it('should throw if params are not in the expected format', function () {
+        const error = catchErrSync(() => {
+          new OrganizationForAdmin({
+            features: { [ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key]: { active: true, params: null } },
+          });
+        })();
+        expect(error).to.be.instanceOf(FeatureParamsNotProcessable);
+      });
+      it('should not throw if feature is not active while params are not in the expected format', function () {
+        const organization = new OrganizationForAdmin({
+          features: { [ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key]: { active: false, params: null } },
+        });
+        expect(organization).to.be.instanceOf(OrganizationForAdmin);
+      });
+    });
     context('legacy features', function () {
       it('put legacy features to new feature format', function () {
         // given

--- a/api/tests/quest/integration/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/attestation-repository_test.js
@@ -89,7 +89,7 @@ describe('Quest | Integration | Repository | attestation', function () {
       expect(error).to.be.instanceOf(AlreadyExistingEntityError);
     });
   });
-  describe('#findAllByOrganizationId', function () {
+  describe('#getAllByOrganizationId', function () {
     it('should retrieve attestations by organization id', async function () {
       const attestation1 = databaseBuilder.factory.buildAttestation({
         key: 'key',
@@ -118,7 +118,7 @@ describe('Quest | Integration | Repository | attestation', function () {
       await databaseBuilder.commit();
 
       //when
-      const results = await attestationRepository.findAllByOrganizationId({
+      const results = await attestationRepository.getAllByOrganizationId({
         organizationId: organization.id,
       });
 


### PR DESCRIPTION
## 💥 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Certaines organisations ont des params de feature à null. 
Sur les routes qui rattachent des features à une organisation, on doit vérifier que les params de la feature ne soient pas à null si ceux-ci sont requis (c'est le cas pour `ATTESTATION_MANAGEMENT`et que leurs keys correspondent à des clés existantes (voir les constants contenues dans l’objet ORGANIZATION_FEATURE de constants.js dans api/src/shared/domain/constants.js). 

## 👩‍🚀 Proposition

Pour répondre au besoin de manière immédiate, on ajoute une condition dans la fonction `#validate` de `OrganizationForAdmin` pour lever une exception si la feature ajoutée est `ATTESTATION_MANAGEMENT` mais que les params ne sont pas spécifiés.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 👁️ Remarques

On a spotté des refacto à faire sur toute la gestion des organization features mais ces refacto ne sont pas triviaux.
Ils feront l'objet de PRs dédiées.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester

Se connecter à Pix Admin.
Consulter la page de l'organisation `Attestations` : https://admin-pr16317.review.pix.fr/organizations/107485/features
Vérifier que l'on peut afficher la page et que la feature `attestation` est bien disponible.


<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
