### PR TITLE
[FEATURE] Ajoute un bouton pour supprimer la campagne (PIX-22901)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -51,6 +51,7 @@ const get = async function (id) {
     .leftJoin('badges', 'badges.targetProfileId', 'target-profiles.id')
     .leftJoin('stages', 'stages.targetProfileId', 'target-profiles.id')
     .where('campaigns.id', id)
+    .whereNull('deletedAt')
     .groupBy('campaigns.id', 'users.id', 'target-profiles.id')
     .first();
   if (!result) {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -333,6 +333,20 @@ describe('Integration | Repository | Campaign-Report', function () {
       // then
       expect(error).to.be.instanceOf(NotFoundError);
     });
+
+    it('should throw a NotFoundError if campaign is deleted', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign({
+        deletedAt: new Date(),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(campaignReportRepository.get)(campaign.id);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
   });
 
   describe(findMasteryRates.name, function () {

--- a/orga/app/components/campaign/settings/view.gjs
+++ b/orga/app/components/campaign/settings/view.gjs
@@ -7,8 +7,10 @@ import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { or } from 'ember-truth-helpers';
+import UiDeletionModal from 'pix-orga/components/ui/deletion-modal';
 
 import { ID_PIX_TYPES } from '../../../helpers/id-pix-types';
 import CopyPasteButton from '../../copy-paste-button';
@@ -21,15 +23,19 @@ export default class CampaignView extends Component {
   @service url;
   @service intl;
   @service currentUser;
+  @service router;
+
+  @tracked isDeleteModalOpen = false;
+
+  get canManageCampaign() {
+    const isCurrentUserAdmin = this.currentUser.prescriber.isAdminOfTheCurrentOrganization;
+    const isCurrentUserOwnerOfTheCampaign = parseInt(this.currentUser.prescriber.id) === this.args.campaign.ownerId;
+    return isCurrentUserAdmin || isCurrentUserOwnerOfTheCampaign;
+  }
 
   get displayCampaignActionsButtons() {
     const campaignIsNotArchived = !this.args.campaign.isArchived;
-
-    const isCurrentUserAdmin = this.currentUser.prescriber.isAdminOfTheCurrentOrganization;
-    const isCurrentUserOwnerOfTheCampaign = parseInt(this.currentUser.prescriber.id) === this.args.campaign.ownerId;
-    const isCurrentUserAllowedToUpdateCampaign = isCurrentUserAdmin || isCurrentUserOwnerOfTheCampaign;
-
-    return campaignIsNotArchived && isCurrentUserAllowedToUpdateCampaign;
+    return campaignIsNotArchived && this.canManageCampaign;
   }
 
   get displayCampaignsRootUrl() {
@@ -96,6 +102,28 @@ export default class CampaignView extends Component {
       await campaign.archive();
     } catch {
       this.notifications.sendError(this.intl.t('api-error-messages.global'));
+    }
+  }
+  @action
+  openDeleteModal() {
+    this.isDeleteModalOpen = true;
+  }
+
+  @action
+  closeDeleteModal() {
+    this.isDeleteModalOpen = false;
+  }
+
+  @action
+  async deleteCampaign(campaignId) {
+    this.isDeleteModalOpen = false;
+    try {
+      await this.store.adapterFor('campaign').delete(this.currentUser.organization.id, [campaignId]);
+      this.store.peekRecord('campaign', campaignId)?.unloadRecord();
+      this.notifications.sendSuccess(this.intl.t('pages.campaign-settings.actions.delete-success'));
+      this.router.replaceWith('authenticated.campaigns.list.my-campaigns');
+    } catch {
+      this.notifications.sendError(this.intl.t('pages.campaign-settings.actions.delete-error'));
     }
   }
 
@@ -223,20 +251,37 @@ export default class CampaignView extends Component {
           </div>
         </div>
       </dl>
-
-      {{#if this.displayCampaignActionsButtons}}
+      {{#if this.canManageCampaign}}
         <div class="campaign-settings-buttons">
-          <PixButtonLink @route="authenticated.campaigns.update" @model={{@campaign.id}} @variant="secondary">
-            {{t "pages.campaign-settings.actions.edit"}}
-          </PixButtonLink>
-          <PixButtonLink @route="authenticated.campaigns.new" @query={{this.queryForDuplicate}} @variant="secondary">
-            {{t "pages.campaign-settings.actions.duplicate"}}
-          </PixButtonLink>
-          <PixButton @triggerAction={{fn this.archiveCampaign @campaign.id}} @variant="error">
-            {{t "pages.campaign-settings.actions.archive"}}
+          {{#if this.displayCampaignActionsButtons}}
+            <PixButtonLink @route="authenticated.campaigns.update" @model={{@campaign.id}} @variant="secondary">
+              {{t "pages.campaign-settings.actions.edit"}}
+            </PixButtonLink>
+            <PixButtonLink @route="authenticated.campaigns.new" @query={{this.queryForDuplicate}} @variant="secondary">
+              {{t "pages.campaign-settings.actions.duplicate"}}
+            </PixButtonLink>
+            <PixButton @triggerAction={{fn this.archiveCampaign @campaign.id}} @variant="primary-bis">
+              {{t "pages.campaign-settings.actions.archive"}}
+            </PixButton>
+          {{/if}}
+          <PixButton @triggerAction={{this.openDeleteModal}} @variant="error">
+            {{t "pages.campaign-settings.actions.delete"}}
           </PixButton>
         </div>
       {{/if}}
+      <UiDeletionModal
+        @title={{t "pages.campaign-settings.delete-confirmation-modal.title" htmlSafe=true}}
+        @showModal={{this.isDeleteModalOpen}}
+        @count={{1}}
+        @onTriggerAction={{fn this.deleteCampaign @campaign.id}}
+        @onCloseModal={{this.closeDeleteModal}}
+      >
+        <:content>
+          <p>{{t "pages.campaign-settings.delete-confirmation-modal.content.header"}}</p>
+          <p>{{t "pages.campaign-settings.delete-confirmation-modal.content.main-participation-prevent"}}</p>
+          <p><strong>{{t "pages.campaign-settings.delete-confirmation-modal.content.footer"}}</strong></p>
+        </:content>
+      </UiDeletionModal>
     </PixBlock>
   </template>
 }

--- a/orga/app/components/ui/deletion-modal.gjs
+++ b/orga/app/components/ui/deletion-modal.gjs
@@ -11,17 +11,6 @@ import { not } from 'ember-truth-helpers';
 export default class DeletionModal extends Component {
   @tracked allowDeletion = false;
 
-  get isMultipleDeletion() {
-    return this.args.count > 1;
-  }
-
-  get canDelete() {
-    if (!this.isMultipleDeletion) {
-      return true;
-    }
-    return this.allowDeletion;
-  }
-
   @action
   giveDeletionPermission() {
     this.allowDeletion = !this.allowDeletion;
@@ -30,26 +19,24 @@ export default class DeletionModal extends Component {
     <PixModal @title={{@title}} @showModal={{@showModal}} @onCloseButtonClick={{@onCloseModal}}>
       <:content>
         {{yield to="content"}}
-        {{#if this.isMultipleDeletion}}
-          <PixCheckbox
-            {{on "click" this.giveDeletionPermission}}
-            @size="small"
-            @checked={{this.allowDeletion}}
-            @class="deletion-modal__permission-checkbox"
-          >
-            <:label>
-              <strong>
-                {{t "components.ui.deletion-modal.confirmation-checkbox" count=@count}}
-              </strong>
-            </:label>
-          </PixCheckbox>
-        {{/if}}
+        <PixCheckbox
+          {{on "click" this.giveDeletionPermission}}
+          @size="small"
+          @checked={{this.allowDeletion}}
+          @class="deletion-modal__permission-checkbox"
+        >
+          <:label>
+            <strong>
+              {{t "components.ui.deletion-modal.confirmation-checkbox" count=@count}}
+            </strong>
+          </:label>
+        </PixCheckbox>
       </:content>
       <:footer>
         <PixButton @variant="secondary" @triggerAction={{@onCloseModal}}>
           {{t "common.actions.cancel"}}
         </PixButton>
-        <PixButton @variant="error" @triggerAction={{@onTriggerAction}} @isDisabled={{not this.canDelete}}>
+        <PixButton @variant="error" @triggerAction={{@onTriggerAction}} @isDisabled={{not this.allowDeletion}}>
           {{t "components.ui.deletion-modal.confirm-deletion"}}
         </PixButton>
       </:footer>

--- a/orga/app/routes/authenticated/campaigns/campaign.js
+++ b/orga/app/routes/authenticated/campaigns/campaign.js
@@ -7,11 +7,9 @@ export default class CampaignRoute extends Route {
 
   async model(params) {
     try {
-      const campaign = await this.store.findRecord('campaign', params.campaign_id);
-
-      return campaign;
-    } catch (error) {
-      this.send('error', error, this.router.replaceWith('not-found', params.campaign_id));
+      return await this.store.findRecord('campaign', params.campaign_id);
+    } catch {
+      this.router.replaceWith('not-found', params.campaign_id);
     }
   }
 }

--- a/orga/tests/integration/components/campaign/settings/view-test.gjs
+++ b/orga/tests/integration/components/campaign/settings/view-test.gjs
@@ -1,8 +1,10 @@
 import { render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import View from 'pix-orga/components/campaign/settings/view';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
@@ -16,6 +18,7 @@ module('Integration | Component | Campaign::Settings::View', function (hooks) {
 
   class CurrentUserStub extends Service {
     prescriber = { isAdminOfTheCurrentOrganization: true };
+    organization = { id: 456 };
   }
 
   hooks.beforeEach(function () {
@@ -514,6 +517,151 @@ module('Integration | Component | Campaign::Settings::View', function (hooks) {
     });
   });
 
+  module('Delete campaign Action', function () {
+    module('when the user is a MEMBER and does not own the campaign', function () {
+      test('it should not display the delete button', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { isAdminOfTheCurrentOrganization: false };
+        }
+        this.owner.register('service:currentUser', CurrentUserStub);
+        const campaign = store.createRecord('campaign', { isArchived: false, ownerId: 1 });
+
+        // when
+        const screen = await render(<template><View @campaign={{campaign}} /></template>);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: t('pages.campaign-settings.actions.delete') })).doesNotExist();
+      });
+    });
+    module('when user is ADMIN or owns the campaign', function () {
+      test('it should display the delete button', async function (assert) {
+        // given
+        const campaign = store.createRecord('campaign');
+
+        // when
+        const screen = await render(<template><View @campaign={{campaign}} /></template>);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: t('pages.campaign-settings.actions.delete') })).exists();
+      });
+
+      module('when deleting campaign', function (hooks) {
+        let deleteStub, routerService, replaceWithStub, notificationsService;
+
+        hooks.beforeEach(function () {
+          deleteStub = sinon.stub();
+          notificationsService = this.owner.lookup('service:notifications');
+          routerService = this.owner.lookup('service:router');
+          sinon.stub(store, 'adapterFor').withArgs('campaign').returns({ delete: deleteStub });
+          sinon.stub(store, 'peekRecord');
+          replaceWithStub = sinon.stub(routerService, 'replaceWith');
+        });
+
+        test('it should open the confirmation modal when clicking the delete button', async function (assert) {
+          // given
+          const campaign = store.createRecord('campaign', { isArchived: false });
+
+          // when
+          const screen = await render(<template><View @campaign={{campaign}} /></template>);
+          await click(screen.getByRole('button', { name: t('pages.campaign-settings.actions.delete') }));
+          await screen.findByRole('dialog');
+
+          // then
+          assert
+            .dom(screen.getByRole('heading', { name: t('pages.campaign-settings.delete-confirmation-modal.title') }))
+            .exists();
+          assert.ok(deleteStub.notCalled);
+        });
+
+        test('it should not delete campaign when cancelling the confirmation modal', async function (assert) {
+          // given
+          const campaign = store.createRecord('campaign', { isArchived: false });
+
+          // when
+          const screen = await render(<template><View @campaign={{campaign}} /></template>);
+          await click(screen.getByRole('button', { name: t('pages.campaign-settings.actions.delete') }));
+          await screen.findByRole('dialog');
+          await click(screen.getByRole('button', { name: t('common.actions.cancel') }));
+
+          // then
+          assert.ok(deleteStub.notCalled);
+        });
+
+        test('it should delete campaign after confirmation', async function (assert) {
+          // given
+          const campaign = store.createRecord('campaign', { isArchived: false });
+          deleteStub.resolves(true);
+
+          // when
+          const screen = await render(<template><View @campaign={{campaign}} /></template>);
+          await click(screen.getByRole('button', { name: t('pages.campaign-settings.actions.delete') }));
+          await screen.findByRole('dialog');
+          await click(screen.getByLabelText(t('components.ui.deletion-modal.confirmation-checkbox', { count: 1 })));
+          await click(screen.getByRole('button', { name: t('components.ui.deletion-modal.confirm-deletion') }));
+
+          // then
+          assert.ok(deleteStub.calledOnceWithExactly(456, [campaign.id]));
+        });
+
+        test('it should display a success notification', async function (assert) {
+          // given
+          sinon.stub(notificationsService, 'sendSuccess');
+          const campaign = store.createRecord('campaign', { isArchived: false });
+          deleteStub.resolves();
+
+          // when
+          const screen = await render(<template><View @campaign={{campaign}} /></template>);
+          await click(screen.getByRole('button', { name: t('pages.campaign-settings.actions.delete') }));
+          await screen.findByRole('dialog');
+          await click(screen.getByLabelText(t('components.ui.deletion-modal.confirmation-checkbox', { count: 1 })));
+          await click(screen.getByRole('button', { name: t('components.ui.deletion-modal.confirm-deletion') }));
+
+          // then
+          assert.ok(
+            notificationsService.sendSuccess.calledOnceWithExactly(t('pages.campaign-settings.actions.delete-success')),
+          );
+        });
+
+        test('it should display an error notification when delete fails', async function (assert) {
+          // given
+          sinon.stub(notificationsService, 'sendError');
+          const campaign = store.createRecord('campaign', { isArchived: false });
+          deleteStub.rejects();
+
+          // when
+          const screen = await render(<template><View @campaign={{campaign}} /></template>);
+          await click(screen.getByRole('button', { name: t('pages.campaign-settings.actions.delete') }));
+          await screen.findByRole('dialog');
+          await click(screen.getByLabelText(t('components.ui.deletion-modal.confirmation-checkbox', { count: 1 })));
+          await click(screen.getByRole('button', { name: t('components.ui.deletion-modal.confirm-deletion') }));
+
+          // then
+          assert.ok(
+            notificationsService.sendError.calledOnceWithExactly(t('pages.campaign-settings.actions.delete-error')),
+          );
+        });
+
+        test('it should redirect to index after delete', async function (assert) {
+          // given
+          sinon.stub(notificationsService, 'sendSuccess');
+          const campaign = store.createRecord('campaign', { isArchived: false });
+          deleteStub.resolves();
+
+          // when
+          const screen = await render(<template><View @campaign={{campaign}} /></template>);
+          await click(screen.getByRole('button', { name: t('pages.campaign-settings.actions.delete') }));
+          await screen.findByRole('dialog');
+          await click(screen.getByLabelText(t('components.ui.deletion-modal.confirmation-checkbox', { count: 1 })));
+          await click(screen.getByRole('button', { name: t('components.ui.deletion-modal.confirm-deletion') }));
+
+          // then
+          assert.ok(replaceWithStub.calledOnceWithExactly('authenticated.campaigns.list.my-campaigns'));
+        });
+      });
+    });
+  });
+
   module('on Modify action display', function () {
     module('when the user is a MEMBER and does not own the campaign', function () {
       test('it should not display the button modify', async function (assert) {
@@ -556,11 +704,8 @@ module('Integration | Component | Campaign::Settings::View', function (hooks) {
 
         // when
         const screen = await render(<template><View @campaign={{campaign}} /></template>);
-
         // then
-        assert
-          .dom(screen.queryByText(t('pages.campaign-settings.actions.editpages.campaign-settings.actions.edit')))
-          .doesNotExist();
+        assert.dom(screen.queryByText(t('pages.campaign-settings.actions.edit'))).doesNotExist();
       });
     });
   });

--- a/orga/tests/integration/components/ui/deletion-modal-test.gjs
+++ b/orga/tests/integration/components/ui/deletion-modal-test.gjs
@@ -38,10 +38,11 @@ module('Integration | Component | Ui::DeletionModal', function (hooks) {
       assert.ok(screen.getByRole('button', { name: t('components.ui.deletion-modal.confirm-deletion') }));
     });
 
-    test('it should call onTriggerAction when click on confirm', async function (assert) {
+    test('it should display checkbox for confirmation', async function (assert) {
       //given
       const triggerActionStub = sinon.stub();
       const onCloseModalStub = sinon.stub();
+      const count = 3;
       const title = 'Coucou';
       const content = 'Juste du texte';
 
@@ -51,7 +52,37 @@ module('Integration | Component | Ui::DeletionModal', function (hooks) {
           <UiDeletionModal
             @title={{title}}
             @showModal={{true}}
-            @count={{1}}
+            @count={{count}}
+            @onTriggerAction={{triggerActionStub}}
+            @onCloseModal={{onCloseModalStub}}
+          ><:content>
+              {{content}}</:content></UiDeletionModal>
+        </template>,
+      );
+
+      //then
+      assert.ok(
+        screen.getByRole('checkbox', {
+          name: t('components.ui.deletion-modal.confirmation-checkbox', { count }),
+        }),
+      );
+    });
+
+    test('confirm button should not be clickable if checkbox is not checked', async function (assert) {
+      //given
+      const triggerActionStub = sinon.stub();
+      const onCloseModalStub = sinon.stub();
+      const count = 3;
+      const title = 'Coucou';
+      const content = 'Juste du texte';
+
+      // when
+      const screen = await render(
+        <template>
+          <UiDeletionModal
+            @title={{title}}
+            @showModal={{true}}
+            @count={{count}}
             @onTriggerAction={{triggerActionStub}}
             @onCloseModal={{onCloseModalStub}}
           ><:content>
@@ -63,10 +94,8 @@ module('Integration | Component | Ui::DeletionModal', function (hooks) {
         name: t('components.ui.deletion-modal.confirm-deletion'),
       });
 
-      await click(confirmButton);
-
       // then
-      assert.ok(triggerActionStub.called);
+      assert.dom(confirmButton).hasAttribute('aria-disabled');
     });
 
     test('it should call onTriggerAction after confirmation when click on confirm', async function (assert) {
@@ -136,68 +165,6 @@ module('Integration | Component | Ui::DeletionModal', function (hooks) {
 
       // then
       assert.ok(onCloseModalStub.called);
-    });
-  });
-
-  module('when there is multiple elements', function () {
-    test('it should display checkbox for confirmation', async function (assert) {
-      //given
-      const triggerActionStub = sinon.stub();
-      const onCloseModalStub = sinon.stub();
-      const count = 3;
-      const title = 'Coucou';
-      const content = 'Juste du texte';
-
-      // when
-      const screen = await render(
-        <template>
-          <UiDeletionModal
-            @title={{title}}
-            @showModal={{true}}
-            @count={{count}}
-            @onTriggerAction={{triggerActionStub}}
-            @onCloseModal={{onCloseModalStub}}
-          ><:content>
-              {{content}}</:content></UiDeletionModal>
-        </template>,
-      );
-
-      //then
-      assert.ok(
-        screen.getByRole('checkbox', {
-          name: t('components.ui.deletion-modal.confirmation-checkbox', { count }),
-        }),
-      );
-    });
-
-    test('confirm button should not be clickable if checkbox is not checked', async function (assert) {
-      //given
-      const triggerActionStub = sinon.stub();
-      const onCloseModalStub = sinon.stub();
-      const count = 3;
-      const title = 'Coucou';
-      const content = 'Juste du texte';
-
-      // when
-      const screen = await render(
-        <template>
-          <UiDeletionModal
-            @title={{title}}
-            @showModal={{true}}
-            @count={{count}}
-            @onTriggerAction={{triggerActionStub}}
-            @onCloseModal={{onCloseModalStub}}
-          ><:content>
-              {{content}}</:content></UiDeletionModal>
-        </template>,
-      );
-
-      const confirmButton = screen.getByRole('button', {
-        name: t('components.ui.deletion-modal.confirm-deletion'),
-      });
-
-      // then
-      assert.dom(confirmButton).hasAttribute('aria-disabled');
     });
   });
 });

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -497,7 +497,7 @@
     "ui": {
       "deletion-modal": {
         "confirm-deletion": "Ja, ich streiche",
-        "confirmation-checkbox": "Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe."
+        "confirmation-checkbox": "{count, plural, =1 {Ich bestätige, dass ich die Auswirkungen der Löschung gut verstanden habe.} other {Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe.}}"
       },
       "edit-participant-name-modal": {
         "error-messages": {
@@ -910,6 +910,9 @@
     "campaign-settings": {
       "actions": {
         "archive": "Archivieren",
+        "delete": "Löschen",
+        "delete-error": "Ein Fehler ist aufgetreten, die Kampagne wurde nicht gelöscht.",
+        "delete-success": "Die Kampagne (sowie ihre Ergebnisse) wurde erfolgreich gelöscht.",
         "duplicate": "Duplizieren",
         "edit": "Bearbeiten"
       },
@@ -918,6 +921,14 @@
         "exam": "Test-Kampagne [Beta]",
         "profiles-collection": "Kampagne zum Sammeln von Profilen",
         "title": "Art der Kampagne"
+      },
+      "delete-confirmation-modal": {
+        "content": {
+          "footer": "Achtung, diese Aktion ist unwiderruflich.",
+          "header": "Diese Kampagne wird in Pix Orga nicht mehr sichtbar sein.",
+          "main-participation-prevent": "Alle Teilnahmen an dieser Kampagne und ihre Ergebnisse werden gelöscht."
+        },
+        "title": "Sind Sie sicher, dass Sie die Kampagne löschen möchten?"
       },
       "direct-link": "Direkter Link",
       "external-user-id-label": "Bezeichnung der Kennung",
@@ -971,7 +982,7 @@
         "success-message": "{count, plural, =1 {Die Kampagne (sowie ihre Ergebnisse) wurde tatsächlich aus der Liste entfernt.} other {Die {count}ausgewählten Kampagnen (sowie ihre Ergebnisse) wurden tatsächlich aus der Liste entfernt.}}."
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe.",
+        "confirmation-checkbox": "{count, plural, =1 {Ich bestätige, dass ich die Auswirkungen der Löschung gut verstanden habe.} other {Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe.}}",
         "content": {
           "footer": "Achtung: Diese Aktion kann nicht rückgängig gemacht werden.",
           "header": "{count, plural, =1 {Diese Kampagne wird nicht mehr sichtbar sein} other {Diese Kampagnen werden nicht mehr sichtbar sein}} in Pix Orga.",
@@ -1453,7 +1464,7 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} wurde tatsächlich aus der Teilnehmerliste entfernt.} other {Die {count} ausgewählten Teilnehmer wurden tatsächlich aus der Liste entfernt.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe.",
+        "confirmation-checkbox": "{count, plural, =1 {Ich bestätige, dass ich die Auswirkungen der Löschung gut verstanden habe.} other {Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe.}}",
         "content": {
           "footer": "Achtung: Diese Aktion kann nicht rückgängig gemacht werden.",
           "header": "{count, plural, =1 {Dieser Teilnehmer wird nicht mehr sichtbar sein} other {Diese Teilnehmer werden nicht mehr sichtbar sein}} in Pix Orga.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -495,7 +495,7 @@
     "ui": {
       "deletion-modal": {
         "confirm-deletion": "Yes, I delete",
-        "confirmation-checkbox": "I confirm that I have understood the impacts of the {count} deletions"
+        "confirmation-checkbox": "{count, plural, =1 {I confirm that I have understood the impacts of the deletion} other {I confirm that I have understood the impacts of the {count} deletions}}"
       },
       "edit-participant-name-modal": {
         "error-messages": {
@@ -920,6 +920,9 @@
     "campaign-settings": {
       "actions": {
         "archive": "Archive",
+        "delete": "Delete",
+        "delete-error": "An error occurred, the campaign was not deleted.",
+        "delete-success": "The campaign (and its results) has been successfully deleted.",
         "duplicate": "Duplicate",
         "edit": "Edit"
       },
@@ -928,6 +931,14 @@
         "exam": "Questioning campaign",
         "profiles-collection": "Profiles collection campaign",
         "title": "Type of campaign"
+      },
+      "delete-confirmation-modal": {
+        "content": {
+          "footer": "Warning, this action is irreversible.",
+          "header": "This campaign will no longer be visible in Pix Orga.",
+          "main-participation-prevent": "All participations in this campaign and their results will be deleted."
+        },
+        "title": "Are you sure you want to delete the campaign?"
       },
       "direct-link": "Direct link",
       "external-user-id-label": "External user ID label",
@@ -981,7 +992,7 @@
         "success-message": "{count, plural, =1 {The campaign (and the results) has successfully been deleted from the list.} other {The {count} selected campaigns (and the results) have successfully been deleted from the list.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "I confirm that I have understood the impacts of the {count} deletions",
+        "confirmation-checkbox": "{count, plural, =1 {I confirm that I have understood the impacts of the deletion} other {I confirm that I have understood the impacts of the {count} deletions}}",
         "content": {
           "footer": "Please note that this action is irreversible.",
           "header": "{count, plural, =1 {This campaign} other {These campaigns}} will no longer be visible in Pix Orga.",
@@ -1464,7 +1475,7 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} has successfully been deleted from the participants list.} other {The {count} selected participants have successfully been deleted from the list.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "I confirm that I have understood the impacts of the {count} deletions",
+        "confirmation-checkbox": "{count, plural, =1 {I confirm that I have understood the impacts of the deletion} other {I confirm that I have understood the impacts of the {count} deletions}}",
         "content": {
           "footer": "Please note that this action is irreversible.",
           "header": "{count, plural, =1 {This participant} other {These participants}} will no longer be visible in Pix Orga.",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -501,7 +501,7 @@
     "ui": {
       "deletion-modal": {
         "confirm-deletion": "Sí, estoy borrando",
-        "confirmation-checkbox": "Confirmo que comprendo perfectamente el impacto de las {count} supresiones"
+        "confirmation-checkbox": "{count, plural, =1 {Confirmo que comprendo perfectamente el impacto de la supresión} other {Confirmo que comprendo perfectamente el impacto de las {count} supresiones}}"
       },
       "edit-participant-name-modal": {
         "error-messages": {
@@ -914,6 +914,9 @@
     "campaign-settings": {
       "actions": {
         "archive": "Archivo",
+        "delete": "Eliminar",
+        "delete-error": "Se ha producido un error, la campaña no se ha eliminado.",
+        "delete-success": "La campaña (así como sus resultados) se ha eliminado correctamente.",
         "duplicate": "Duplicar",
         "edit": "Modifique"
       },
@@ -922,6 +925,14 @@
         "exam": "Campaña de concursos",
         "profiles-collection": "Campaña de recogida de perfiles",
         "title": "Tipo de campaña"
+      },
+      "delete-confirmation-modal": {
+        "content": {
+          "footer": "Atención, esta acción es irreversible.",
+          "header": "Esta campaña ya no será visible en Pix Orga.",
+          "main-participation-prevent": "Se eliminarán todas las participaciones en esta campaña y sus resultados."
+        },
+        "title": "¿Está seguro de que desea eliminar la campaña?"
       },
       "direct-link": "Enlace directo",
       "external-user-id-label": "Texto del identificador",
@@ -975,7 +986,7 @@
         "success-message": "{count, plural, =1 {La campaña (junto con sus resultados) ha sido efectivamente eliminada de la lista.} other {Las {count} campañas seleccionadas (junto con sus resultados) han sido efectivamente eliminadas de la lista.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Confirmo que he comprendido perfectamente el impacto de las {count} supresiones",
+        "confirmation-checkbox": "{count, plural, =1 {Confirmo que he comprendido perfectamente el impacto de la supresión} other {Confirmo que he comprendido perfectamente el impacto de las {count} supresiones}}",
         "content": {
           "footer": "Tenga en cuenta que esta acción es irreversible.",
           "header": "{count, plural, =1 {Esta campaña ya no será visible} other {Estas campañas ya no serán visibles}} en Pix Orga.",
@@ -1457,7 +1468,7 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} ha sido efectivamente eliminado de la lista de participantes.} other {Los {count} participantes seleccionados han sido efectivamente eliminados de la lista.}}."
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Confirmo que comprendo perfectamente el impacto de las {count} supresiones",
+        "confirmation-checkbox": "{count, plural, =1 {Confirmo que comprendo perfectamente el impacto de la supresión} other {Confirmo que comprendo perfectamente el impacto de las {count} supresiones}}",
         "content": {
           "footer": "Tenga en cuenta que esta acción es irreversible.",
           "header": "{count, plural, =1 {Este participante ya no será visible} other {Estos participantes ya no serán visibles}} en Pix Orga.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -495,7 +495,7 @@
     "ui": {
       "deletion-modal": {
         "confirm-deletion": "Oui, je supprime",
-        "confirmation-checkbox": "Je confirme avoir bien compris les impacts des {count} suppressions"
+        "confirmation-checkbox": "{count, plural, =1 {Je confirme avoir bien compris les impacts de la suppression} other {Je confirme avoir bien compris les impacts des {count} suppressions}}"
       },
       "edit-participant-name-modal": {
         "error-messages": {
@@ -908,6 +908,9 @@
     "campaign-settings": {
       "actions": {
         "archive": "Archiver",
+        "delete": "Supprimer",
+        "delete-error": "Une erreur est survenue, la campagne n'a pas été supprimée.",
+        "delete-success": "La campagne (ainsi que ses résultats) a bien été supprimée.",
         "duplicate": "Dupliquer",
         "edit": "Modifier"
       },
@@ -916,6 +919,14 @@
         "exam": "Campagne d'interro",
         "profiles-collection": "Campagne de collecte de profils",
         "title": "Type de la campagne"
+      },
+      "delete-confirmation-modal": {
+        "content": {
+          "footer": "Attention, cette action est irréversible.",
+          "header": "Cette campagne ne sera plus visible dans Pix Orga.",
+          "main-participation-prevent": "Toutes les participations à cette campagne et leurs résultats seront supprimés."
+        },
+        "title": "Êtes-vous sûr(e) de vouloir supprimer la campagne ?"
       },
       "direct-link": "Lien direct",
       "external-user-id-label": "Libellé de l'identifiant",
@@ -969,7 +980,7 @@
         "success-message": "{count, plural, =1 {La campagne (ainsi que ses résultats) a bien été supprimée de la liste.} other {Les {count} campagnes sélectionnées (ainsi que leurs résultats) ont bien été supprimés de la liste.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Je confirme avoir bien compris les impacts des {count} suppressions",
+        "confirmation-checkbox": "{count, plural, =1 {Je confirme avoir bien compris les impacts de la suppression} other {Je confirme avoir bien compris les impacts des {count} suppressions}}",
         "content": {
           "footer": "Attention, cette action est irréversible.",
           "header": "{count, plural, =1 {Cette campagne ne sera plus visible} other {Ces campagnes ne seront plus visibles}} dans Pix Orga.",
@@ -1451,7 +1462,7 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} a bien été supprimé de la liste des participants.} other {Les {count} participants sélectionnés ont bien été supprimés de la liste.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Je confirme avoir bien compris les impacts des {count} suppressions",
+        "confirmation-checkbox": "{count, plural, =1 {Je confirme avoir bien compris les impacts de la suppression} other {Je confirme avoir bien compris les impacts des {count} suppressions}}",
         "content": {
           "footer": "Attention, cette action est irréversible.",
           "header": "{count, plural, =1 {Ce participant ne sera plus visible} other {Ces participants ne seront plus visibles}} dans Pix Orga.",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -498,7 +498,7 @@
     "ui": {
       "deletion-modal": {
         "confirm-deletion": "Sì, sto cancellando",
-        "confirmation-checkbox": "Confermo di aver compreso appieno l'impatto delle {count} cancellazioni."
+        "confirmation-checkbox": "{count, plural, =1 {Confermo di aver compreso appieno l'impatto della cancellazione.} other {Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.}}"
       },
       "edit-participant-name-modal": {
         "error-messages": {
@@ -911,6 +911,9 @@
     "campaign-settings": {
       "actions": {
         "archive": "Archivio",
+        "delete": "Eliminare",
+        "delete-error": "Si è verificato un errore, la campagna non è stata eliminata.",
+        "delete-success": "La campagna (e i suoi risultati) è stata eliminata correttamente.",
         "duplicate": "Duplicato",
         "edit": "Modificare"
       },
@@ -919,6 +922,14 @@
         "exam": "Campagna Quiz",
         "profiles-collection": "Campagna di raccolta profili",
         "title": "Tipo di campagna"
+      },
+      "delete-confirmation-modal": {
+        "content": {
+          "footer": "Attenzione, questa azione è irreversibile.",
+          "header": "Questa campagna non sarà più visibile in Pix Orga.",
+          "main-participation-prevent": "Tutte le partecipazioni a questa campagna e i loro risultati saranno eliminati."
+        },
+        "title": "Sei sicuro di voler eliminare la campagna?"
       },
       "direct-link": "Collegamento diretto",
       "external-user-id-label": "Formulazione dell'identificatore",
@@ -972,7 +983,7 @@
         "success-message": "{count, plural, =1 {La campagna (insieme ai suoi risultati) è stata effettivamente rimossa dall'elenco.} other {Le {count} campagne selezionate (insieme ai loro risultati) sono state effettivamente rimosse dall'elenco.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.",
+        "confirmation-checkbox": "{count, plural, =1 {Confermo di aver compreso appieno l'impatto della cancellazione.} other {Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.}}",
         "content": {
           "footer": "Si noti che questa azione è irreversibile.",
           "header": "{count, plural, =1 {Questa campagna non sarà più visibile} other {Queste campagne non saranno più visibili}} in Pix Orga.",
@@ -1454,7 +1465,7 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} è stato rimosso dall'elenco dei partecipanti.} other { I {count} partecipanti selezionati sono stati rimossi dall'elenco.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.",
+        "confirmation-checkbox": "{count, plural, =1 {Confermo di aver compreso appieno l'impatto della cancellazione.} other {Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.}}",
         "content": {
           "footer": "Si noti che questa azione è irreversibile.",
           "header": "{count, plural, =1 {Questo partecipante non sarà più visibile} other {Questi partecipanti non saranno più visibili}} in Pix Orga.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -494,7 +494,7 @@
     "ui": {
       "deletion-modal": {
         "confirm-deletion": "Ja, verwijderen",
-        "confirmation-checkbox": "Ik kan bevestigen dat ik de gevolgen van de {count} verwijderingen volledig begrijp. "
+        "confirmation-checkbox": "{count, plural, =1 {Ik kan bevestigen dat ik de gevolgen van de verwijdering volledig begrijp.} other {Ik kan bevestigen dat ik de gevolgen van de {count} verwijderingen volledig begrijp.}}"
       },
       "edit-participant-name-modal": {
         "error-messages": {
@@ -907,6 +907,9 @@
     "campaign-settings": {
       "actions": {
         "archive": "Archiveren",
+        "delete": "Verwijderen",
+        "delete-error": "Er is een fout opgetreden, de campagne is niet verwijderd.",
+        "delete-success": "De campagne (en de resultaten ervan) is verwijderd.",
         "duplicate": "Dupliceren",
         "edit": "Wijzigen"
       },
@@ -915,6 +918,14 @@
         "exam": "Quiz-campagne",
         "profiles-collection": "Verzamelcampagne profielen",
         "title": "Soort campagne"
+      },
+      "delete-confirmation-modal": {
+        "content": {
+          "footer": "Let op, deze actie is onomkeerbaar.",
+          "header": "Deze campagne is niet langer zichtbaar in Pix Orga.",
+          "main-participation-prevent": "Alle deelnames aan deze campagne en de resultaten ervan worden verwijderd."
+        },
+        "title": "Weet u zeker dat u de campagne wilt verwijderen?"
       },
       "direct-link": "Directe link",
       "external-user-id-label": "Type externe user-ID",
@@ -968,7 +979,7 @@
         "success-message": "{count, plural, =1 {De campagne is verwijderd uit de lijst.} other {De {count} geselecteerde campagnes zijn verwijderd uit de lijst.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Ik kan bevestigen dat ik de gevolgen van de {count} verwijderingen volledig begrijp. ",
+        "confirmation-checkbox": "{count, plural, =1 {Ik kan bevestigen dat ik de gevolgen van de verwijdering volledig begrijp.} other {Ik kan bevestigen dat ik de gevolgen van de {count} verwijderingen volledig begrijp.}}",
         "content": {
           "footer": "Houd er rekening mee dat deze actie onomkeerbaar is.",
           "header": "{count, plural, =1 {Deze campagne zal niet langer zichtbaar zijn} other {Deze campagnes zullen niet langer zichtbaar zijn}} in Pix Orga.",
@@ -1445,7 +1456,7 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} is verwijderd van de lijst met deelnemers.} other {De {count} geselecteerde deelnemers zijn verwijderd van de lijst.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "Ik kan bevestigen dat ik de gevolgen van de {count} verwijderingen volledig begrijp. ",
+        "confirmation-checkbox": "{count, plural, =1 {Ik kan bevestigen dat ik de gevolgen van de verwijdering volledig begrijp.} other {Ik kan bevestigen dat ik de gevolgen van de {count} verwijderingen volledig begrijp.}}",
         "content": {
           "footer": "Houd er rekening mee dat deze actie onomkeerbaar is.",
           "header": "{count, plural, =1 {Deze deelnemer is niet meer zichtbaar} other {Deze deelnemers zijn niet meer zichtbaar}} in Pix Orga.",


### PR DESCRIPTION
## 💥 Problème

Depuis la page de paramètres d'une campagne, il n'était pas possible de supprimer une campagne : seules les actions « Dupliquer », « Modifier » et « Archiver » étaient disponibles.

## 👩‍🚀 Proposition

Ajout d'un bouton « Supprimer » dans les actions de la page de paramètres de campagne (`campaign/settings/view`) :
- Au clic, la campagne (et ses résultats) est supprimée via l'adapter `campaign`.
- En cas de succès, une notification de confirmation s'affiche et l'utilisateur est redirigé vers la page d'accueil (`authenticated.index`).
- En cas d'erreur, une notification d'erreur s'affiche et l'utilisateur reste sur la page.
- Le bouton « Archiver » passe du variant `error` au variant `warning` afin de réserver le rouge à l'action destructrice de suppression.

Les clés de traduction (`delete`, `delete-success`, `delete-error`) ont été ajoutées dans les 6 langues (fr, en, de, es, it, nl).

## 👁️ Remarques

RAS

## ♻️ Pour tester

1. Se rendre sur la page de paramètres d'une campagne.
2. Vérifier la présence du bouton « Supprimer » (en rouge) à côté de « Archiver » (désormais en orange).
3. Cliquer sur « Supprimer » :
   - la campagne est supprimée,
   - une notification de succès s'affiche,
   - on est redirigé vers la liste des campagnes.
