### PR TITLE
[FEATURE] Créer une api interne pour remonter les stats de participation d'une organisation (PIX-22894)

### DIFF
--- a/api/src/prescription/campaign/application/api/campaign-stats-api.js
+++ b/api/src/prescription/campaign/application/api/campaign-stats-api.js
@@ -1,0 +1,18 @@
+import { usecases } from '../../domain/usecases/index.js';
+import { OrganizationStatistics } from './models/OrganizationStatistics.js';
+
+/**
+ * @module CampaignStatsApi
+ */
+
+/**
+ * @function
+ * @name getOrganizationParticipantsStatistics
+ *
+ * @param {number} organizationId
+ * @returns {Promise<OrganizationStatistics>}
+ */
+export const getOrganizationParticipantsStatistics = async (organizationId) => {
+  const statistics = await usecases.getOrganizationParticipantsStatistics({ organizationId });
+  return new OrganizationStatistics(statistics);
+};

--- a/api/src/prescription/campaign/application/api/models/OrganizationStatistics.js
+++ b/api/src/prescription/campaign/application/api/models/OrganizationStatistics.js
@@ -1,0 +1,5 @@
+export class OrganizationStatistics {
+  constructor({ totalParticipantsCount }) {
+    this.totalParticipantsCount = totalParticipantsCount;
+  }
+}

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -117,6 +117,7 @@ import { getBadgeAcquisitionsStatistics } from './statistics/get-badge-acquisiti
 import { getCampaignParticipationsActivityByDay } from './statistics/get-campaign-participations-activity-by-day.js';
 import { getCampaignParticipationsCountByStage } from './statistics/get-campaign-participations-counts-by-stage.js';
 import { getCampaignParticipationsCountsByStatus } from './statistics/get-campaign-participations-counts-by-status.js';
+import { getOrganizationParticipantsStatistics } from './statistics/get-organization-participants-statistics.js';
 import { getParticipationsCountByMasteryRate } from './statistics/get-participations-count-by-mastery-rate.js';
 import { swapCampaignCodes } from './swap-campaign-code.js';
 import { unarchiveCampaign } from './unarchive-campaign.js';
@@ -159,6 +160,7 @@ const usecasesWithoutInjectedDependencies = {
   getCampaignParticipationsActivityByDay,
   getCampaignParticipationsCountByStage,
   getCampaignParticipationsCountsByStatus,
+  getOrganizationParticipantsStatistics,
   getParticipationsCountByMasteryRate,
 };
 

--- a/api/src/prescription/campaign/domain/usecases/statistics/get-organization-participants-statistics.js
+++ b/api/src/prescription/campaign/domain/usecases/statistics/get-organization-participants-statistics.js
@@ -1,0 +1,10 @@
+const getOrganizationParticipantsStatistics = async function ({
+  organizationId,
+  campaignParticipationsStatsRepository,
+}) {
+  const totalParticipantsCount =
+    await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(organizationId);
+  return { totalParticipantsCount };
+};
+
+export { getOrganizationParticipantsStatistics };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -80,7 +80,24 @@ const countParticipationsByStatus = async (campaignId) => {
   };
 };
 
+const countParticipantsByOrganizationId = async (organizationId) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const [{ count }] = await knexConn
+    .count('* as count')
+    .from(
+      knexConn('campaign-participations')
+        .select('campaign-participations.organizationLearnerId')
+        .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+        .where('campaigns.organizationId', organizationId)
+        .groupBy('campaign-participations.organizationLearnerId'),
+    );
+
+  return count;
+};
+
 export {
+  countParticipantsByOrganizationId,
   countParticipationsByMasteryRate,
   countParticipationsByStatus,
   getAllParticipationsByCampaignId,

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -502,4 +502,98 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
       });
     });
   });
+
+  describe('#countParticipantsByOrganizationId', function () {
+    it('returns 0 when the organization has no campaigns', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
+
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(organizationId);
+
+      expect(result).to.equal(0);
+    });
+
+    it('returns 0 when the organization has campaigns but no participations', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildCampaign({ organizationId });
+      await databaseBuilder.commit();
+
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(organizationId);
+
+      expect(result).to.equal(0);
+    });
+
+    it('returns the count of distinct organizationLearnerIds across all campaigns of the organization', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const { id: campaignId1 } = databaseBuilder.factory.buildCampaign({ organizationId });
+      const { id: campaignId2 } = databaseBuilder.factory.buildCampaign({ organizationId });
+      const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      const { id: organizationLearnerId2 } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaignId1,
+        organizationLearnerId: organizationLearnerId1,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaignId2,
+        organizationLearnerId: organizationLearnerId2,
+      });
+      await databaseBuilder.commit();
+
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(organizationId);
+
+      expect(result).to.equal(2);
+    });
+
+    it('counts a learner only once even if they participated in multiple campaigns', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const { id: campaignId1 } = databaseBuilder.factory.buildCampaign({ organizationId });
+      const { id: campaignId2 } = databaseBuilder.factory.buildCampaign({ organizationId });
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignId1, organizationLearnerId });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignId2, organizationLearnerId });
+      await databaseBuilder.commit();
+
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(organizationId);
+
+      expect(result).to.equal(1);
+    });
+
+    it('does not count participations from other organizations', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const { id: otherOrganizationId } = databaseBuilder.factory.buildOrganization();
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ organizationId });
+      const { id: otherCampaignId } = databaseBuilder.factory.buildCampaign({ organizationId: otherOrganizationId });
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      const { id: otherOrganizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: otherOrganizationId,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: otherCampaignId,
+        organizationLearnerId: otherOrganizationLearnerId,
+      });
+      await databaseBuilder.commit();
+
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(organizationId);
+
+      expect(result).to.equal(1);
+    });
+
+    it('counts deleted participations and disabled learners regardless of their status', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ organizationId });
+      const { id: disabledLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        isDisabled: true,
+      });
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, deletedAt: new Date() });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId: disabledLearnerId });
+      await databaseBuilder.commit();
+
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(organizationId);
+
+      expect(result).to.equal(2);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/application/api/campaign-stats-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaign-stats-api_test.js
@@ -1,0 +1,24 @@
+import sinon from 'sinon';
+
+import * as campaignStatsApi from '../../../../../../src/prescription/campaign/application/api/campaign-stats-api.js';
+import { OrganizationStatistics } from '../../../../../../src/prescription/campaign/application/api/models/OrganizationStatistics.js';
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | API | CampaignStats', function () {
+  describe('#getOrganizationParticipantsStatistics', function () {
+    it('returns the statistics for the given organization', async function () {
+      const organizationId = 1;
+      const expectedStats = { totalParticipantsCount: 42 };
+      sinon
+        .stub(usecases, 'getOrganizationParticipantsStatistics')
+        .withArgs({ organizationId })
+        .resolves(expectedStats);
+
+      const result = await campaignStatsApi.getOrganizationParticipantsStatistics(organizationId);
+
+      expect(result).to.be.an.instanceOf(OrganizationStatistics);
+      expect(result).to.deep.equal(expectedStats);
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/domain/usecases/statistics/get-organization-participants-statistics_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/statistics/get-organization-participants-statistics_test.js
@@ -1,0 +1,32 @@
+import sinon from 'sinon';
+
+import { getOrganizationParticipantsStatistics } from '../../../../../../../src/prescription/campaign/domain/usecases/statistics/get-organization-participants-statistics.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | UseCase | getOrganizationParticipantsStatistics', function () {
+  it('returns the total participants count for the given organization', async function () {
+    const organizationId = 1;
+    const campaignParticipationsStatsRepository = { countParticipantsByOrganizationId: sinon.stub() };
+    campaignParticipationsStatsRepository.countParticipantsByOrganizationId.withArgs(organizationId).resolves(42);
+
+    const result = await getOrganizationParticipantsStatistics({
+      organizationId,
+      campaignParticipationsStatsRepository,
+    });
+
+    expect(result).to.deep.equal({ totalParticipantsCount: 42 });
+  });
+
+  it('returns 0 when the organization has no participants', async function () {
+    const organizationId = 1;
+    const campaignParticipationsStatsRepository = { countParticipantsByOrganizationId: sinon.stub() };
+    campaignParticipationsStatsRepository.countParticipantsByOrganizationId.withArgs(organizationId).resolves(0);
+
+    const result = await getOrganizationParticipantsStatistics({
+      organizationId,
+      campaignParticipationsStatsRepository,
+    });
+
+    expect(result).to.deep.equal({ totalParticipantsCount: 0 });
+  });
+});


### PR DESCRIPTION
## 💥 Problème
On a besoin pour une prochaine feature, de remonter l'information du nombre de participation a des campagnes au grain d'une organisation.
Ce sont des sujets côté contexte prescription

## 👩‍🚀 Proposition
Créer une api interne qui fait remonter ces stats qu'on pourra utiliser dans un autre contexte dans les prochains dev.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
Review tech + CI Verte

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
