### PR TITLE
[TECH] Déplacer AggregateImportError dans le contexte prescription

### DIFF
--- a/api/src/prescription/learner-management/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/learner-management/application/http-error-mapper-configuration.js
@@ -4,7 +4,12 @@ import { AggregateImportError, CouldNotDeleteLearnersError, SiecleXmlImportError
 const learnerManagementDomainErrorMappingConfiguration = [
   {
     name: AggregateImportError.name,
-    httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
+    httpErrorFn: (aggregateError) => {
+      // For AggregateImportError, all errors are aggregated in error.meta
+      return aggregateError.meta.map(
+        (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
+      );
+    },
   },
   {
     name: CouldNotDeleteLearnersError.name,

--- a/api/src/shared/application/errors/hapi-error-mapper.js
+++ b/api/src/shared/application/errors/hapi-error-mapper.js
@@ -1,6 +1,5 @@
 import kebabCase from 'lodash/kebabCase.js';
 
-import { AggregateImportError } from '../../../prescription/learner-management/domain/errors.js';
 import { DomainError, EntityValidationError } from '../../domain/errors.js';
 import { getBaseLocale } from '../../domain/services/locale-service.js';
 import { getI18n } from '../../infrastructure/i18n/i18n.js';
@@ -35,13 +34,6 @@ export class HapiErrorMapper {
 
     if (response instanceof DomainError) {
       const httpError = this.#registry.mapToError(response) ?? mapToHttpError(response);
-
-      if (response instanceof AggregateImportError) {
-        httpError.meta.forEach((error) => {
-          error.status = httpError.status;
-        });
-        return HttpErrors.sendJsonApiError(httpError.meta, h);
-      }
       return HttpErrors.sendJsonApiError(httpError, h);
     }
     return h.continue;

--- a/api/src/shared/application/errors/http-errors.js
+++ b/api/src/shared/application/errors/http-errors.js
@@ -170,8 +170,8 @@ class TooManyRequestsError extends BaseHttpError {
 }
 
 /**
- *
- * @param {import('../../infrastructure/serializers/jsonapi/error-serializer.js').HttpError} httpError
+ * @typedef {import('../../infrastructure/serializers/jsonapi/error-serializer.js').HttpError} HttpError
+ * @param {Array<HttpError>|HttpError} httpError
  * @param {Object} h
  * @returns {Promise}
  */

--- a/api/tests/prescription/learner-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/prescription/learner-management/unit/application/http-error-mapper-configuration_test.js
@@ -5,20 +5,26 @@ import {
   SiecleXmlImportError,
 } from '../../../../../src/prescription/learner-management/domain/errors.js';
 import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { CsvImportError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Prescription | Learner Management | Unit | Application | HttpErrorMapperConfiguration', function () {
-  it('instantiates PreconditionFailedError when AggregateImportError', async function () {
+  it('instantiates multiple PreconditionFailedError when AggregateImportError', async function () {
     //given
     const httpErrorMapper = learnerManagementDomainErrorMappingConfiguration.find(
       (httpErrorMapper) => httpErrorMapper.name === AggregateImportError.name,
     );
 
     //when
-    const error = httpErrorMapper.httpErrorFn(new AggregateImportError());
+    const error1 = new CsvImportError('ERROR_1');
+    const error2 = new CsvImportError('ERROR_2');
+    const error = httpErrorMapper.httpErrorFn(new AggregateImportError([error1, error2]));
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+    expect(error).to.be.deep.equal([
+      new HttpErrors.PreconditionFailedError(error1.message, error1.code),
+      new HttpErrors.PreconditionFailedError(error2.message, error2.code),
+    ]);
   });
 
   it('instantiates PreconditionFailedError when CouldNotDeleteLearnersError', async function () {


### PR DESCRIPTION
## 💥 Problème

Le contexte `shared` importe l'erreur `AggregateImportError` du contexte prescription pour réaliser un mapping spécifique. Or les fichiers de mapping http des contextes sont fait pour ça (`http-error-mapper-configuration.js`)

## 👩‍🚀 Proposition

Déplacer le mapping de `AggregateImportError` dans le fichier de mapping du contexte de prescription : `api/src/prescription/learner-management/application/http-error-mapper-configuration.js`

La particularité est qu'il mappe cette erreur en plusieurs `HttpErrors`

## 👁️ Remarques

N/A

## ♻️ Pour tester

Vérifier si les erreurs des imports sont correctement remontées au front.
