### PR TITLE
[FEATURE] Affichage d'une modale pour les détails d'un contenu formatif recommandé (PIX-22730).

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -7,8 +7,11 @@ export function buildTrainings(databaseBuilder) {
     id: trainingId++,
     title: 'Apprendre à manger un croissant comme les français',
     internalTitle: 'Apprendre à manger un croissant comme les français',
+    duration: { days: 0, hours: 0, minutes: 0 },
     locales: ['fr'],
     objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
+    description:
+      "Aujourd'hui, manger un croissant est tout un art en France. De nombreux touristes viennent en France et font le tour des meilleures boulangeries pour en manger, mais sans connaître les différentes manières de le savourer pleinement.",
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({
@@ -43,6 +46,8 @@ export function buildTrainings(databaseBuilder) {
       'Savoir rédiger un prompt qui n’inclut pas d’informations personnelles',
     ],
     registrationRequired: true,
+    description:
+      'Quand vous discutez avec un logiciel d’intelligence artificielle (IA) générative, la conversation n’est pas privée. Tout ce que vous écrivez peut être enregistré et parfois réutilisé pour améliorer l’IA. Dans ce module, vous allez comprendre pourquoi les échanges avec une IA générative ne sont pas totalement privés et quelles informations il vaut mieux éviter d’écrire dans vos instructions (prompts).',
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({
@@ -67,13 +72,15 @@ export function buildTrainings(databaseBuilder) {
     title: 'Des mots de passe solides',
     internalTitle: 'Des mots de passe solides',
     link: '/modules/3e5fa7fc/mots-de-passe-securises',
-    duration: '00:12:00',
+    duration: '2days 00:12:00',
     editorName: 'Pix',
     editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
     type: 'modulix',
     locales: ['fr'],
     objectives: ['Connaître les principaux risques liés aux mots de passe', 'Savoir créer un mot de passe solide'],
     deliveryMode: Training.modes.ONSITE,
+    description:
+      "Aujourd'hui, on utilise des mots de passe pour tout : son téléphone, son adresse mail, ses réseaux sociaux. Dans ce module, vous allez découvrir pourquoi et comment créer des mots de passe solides.",
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -1,0 +1,104 @@
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { t } from 'ember-intl';
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
+
+import RegistrationCardTag from './registration-card-tag';
+
+<template>
+  <PixModal
+    @title={{@training.title}}
+    @showModal={{@isOpen}}
+    @onCloseButtonClick={{@onClose}}
+    class="results-recommendation-engine-training-card-modal"
+  >
+    <:content>
+      <div class="results-recommendation-engine-training-card-modal__section">
+        <dl class="results-recommendation-engine-training-card-modal-section__description">
+          <RegistrationCardTag @registrationRequired={{@training.registrationRequired}} />
+          <dt>{{t "pages.skill-review.recommended-engine.modal.editor-name"}}<span>{{@training.editorName}}</span></dt>
+          <dd>{{htmlUnsafe @training.description}}</dd>
+        </dl>
+        <div class="results-recommendation-engine-training-card-modal-section__information">
+          {{#if @training.hasDuration}}
+            <dl class="results-recommendation-engine-training-card-modal-section__time-information">
+              <PixIcon @name="time" @ariaHidden={{true}} />
+              <dt>{{t "pages.skill-review.recommended-engine.modal.duration"}}</dt>
+              <dd class="results-recommendation-engine-training-card-modal-section__time-information--bold">
+                <span>{{@training.formattedDays}}</span>
+                <span>{{@training.formattedTime}}</span>
+              </dd>
+            </dl>
+          {{/if}}
+          <dl class="results-recommendation-engine-training-card-modal-section__localisation-information">
+            <PixIcon @name="mapPin" @ariaHidden={{true}} />
+            <dt>{{t "pages.skill-review.recommended-engine.modal.localisation"}}</dt>
+            <dd
+              class="results-recommendation-engine-training-card-modal-section__time-information results-recommendation-engine-training-card-modal-section__localisation-information--bold"
+            >{{@deliveryMode}}</dd>
+          </dl>
+        </div>
+      </div>
+
+      <PixAccordions>
+        <:title>
+          <h2>{{t "pages.skill-review.recommended-engine.modal.objectives"}}</h2>
+        </:title>
+        <:content>
+          <ul class="results-recommendation-engine-training-card-modal__objectives">
+            {{#each @training.objectives as |objective|}}
+              <li>
+                <PixIcon
+                  @name="checkCircle"
+                  @plainIcon={{true}}
+                  class="results-recommendation-engine-training-card-modal-objectives__icon"
+                  @ariaHidden={{true}}
+                />
+                {{htmlUnsafe objective}}
+              </li>
+            {{/each}}
+          </ul>
+        </:content>
+      </PixAccordions>
+      <PixAccordions>
+        <:title>
+          <h2>{{t "pages.skill-review.recommended-engine.modal.program"}}</h2>
+        </:title>
+        <:content>
+          <p class="results-recommendation-engine-training-card-modal__program">{{@training.program}}</p>
+        </:content>
+      </PixAccordions>
+    </:content>
+    <:footer>
+      <ul class="results-recommendation-engine-training-card-modal-footer">
+        <li>
+          <PixButton
+            @triggerAction={{@onClose}}
+            @variant="secondary"
+            class="results-recommendation-engine-training-card-modal-footer__cancel-button"
+          >
+            {{t "common.actions.close"}}
+          </PixButton>
+        </li>
+        <li>
+          <PixButtonLink
+            @href={{@training.link}}
+            target="_blank"
+            rel="noreferrer"
+            class="results-recommendation-engine-training-card-modal-footer__link-button"
+          >
+            {{#if @training.isModulix}}
+              {{t "pages.skill-review.recommended-engine.modal.actions.discover-module"}}
+            {{else}}
+              {{t "pages.skill-review.recommended-engine.modal.actions.discover-program"}}
+              <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
+            {{/if}}
+          </PixButtonLink>
+        </li>
+      </ul>
+    </:footer>
+  </PixModal>
+</template>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -3,7 +3,6 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -11,27 +10,12 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
+import CardTag from './card-tag';
+
 export default class Card extends Component {
   @service intl;
 
   @tracked modalIsOpen = false;
-
-  get tagProperties() {
-    const registrationRequired = this.args.training.registrationRequired;
-
-    const color = registrationRequired ? 'blue-light' : 'purple';
-    const iconName = registrationRequired ? 'lock' : 'acute';
-    const translationKey = registrationRequired ? 'yes' : 'no';
-    const text = this.intl.t(
-      `pages.skill-review.recommended-engine.training-card.registration-required.${translationKey}`,
-    );
-
-    return {
-      color,
-      iconName,
-      text,
-    };
-  }
 
   get deliveryMode() {
     const deliveryMode = this.args.training.deliveryMode === 'onSite' ? 'on-site' : this.args.training.deliveryMode;
@@ -70,14 +54,7 @@ export default class Card extends Component {
           alt=""
         />
       </div>
-      <PixTag @color={{this.tagProperties.color}} class="results-recommendation-engine-training-card__tag">
-        <PixIcon
-          class="results-recommendation-engine-training-card__tag-icon"
-          @name={{this.tagProperties.iconName}}
-          @ariaHidden={{true}}
-        />
-        {{this.tagProperties.text}}
-      </PixTag>
+      <RegistrationCardTag @registrationRequired={{@training.registrationRequired}} />
       <section class="results-recommendation-engine-training-card-content">
         <p class="results-recommendation-engine-training-card-content__title">{{@training.title}}</p>
         <ul class="results-recommendation-engine-training-card-content__details"><li>{{this.type}}</li>
@@ -97,14 +74,7 @@ export default class Card extends Component {
       <:content>
         <section class="results-recommendation-engine-training-card-modal__section">
           <div class="results-recommendation-engine-training-card-modal-section__description">
-            <PixTag @color={{this.tagProperties.color}} class="results-recommendation-engine-training-card__tag">
-              <PixIcon
-                class="results-recommendation-engine-training-card__tag-icon"
-                @name={{this.tagProperties.iconName}}
-                @ariaHidden={{true}}
-              />
-              {{this.tagProperties.text}}
-            </PixTag>
+            <CardTag @registrationRequired={{@training.registrationRequired}} />
             <p>{{t "pages.skill-review.recommended-engine.modal.editor-name"}}<span>{{@training.editorName}}</span></p>
             <p>{{@training.description}}</p>
           </div>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -57,7 +57,12 @@ export default class Card extends Component {
   }
 
   <template>
-    <button class="results-recommendation-engine-training-card" type="button" {{on "click" this.showModal}}>
+    <button
+      class="results-recommendation-engine-training-card"
+      type="button"
+      aria-label={{t "pages.skill-review.recommended-engine.training-card.aria-label"}}
+      {{on "click" this.showModal}}
+    >
       <div class="results-recommendation-engine-training-card-image-hero">
         <img
           class="results-recommendation-engine-training-card-image-hero__editor-logo"

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -1,4 +1,6 @@
 import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
@@ -152,6 +154,31 @@ export default class Card extends Component {
         </PixAccordions>
       </:content>
       <:footer>
+        <ul class="results-recommendation-engine-training-card-modal-footer">
+          <li>
+            <PixButton
+              @triggerAction={{this.closeModal}}
+              @variant="secondary"
+              class="results-recommendation-engine-training-card-modal-footer__cancel-button"
+            >
+              {{t "common.actions.cancel"}}
+            </PixButton>
+          </li>
+          <li>
+            <PixButtonLink
+              @href={{@training.link}}
+              target="_blank"
+              class="results-recommendation-engine-training-card-modal-footer__link-button"
+            >
+              {{#if @training.isModulix}}
+                {{t "pages.skill-review.recommended-engine.modal.actions.discover-module"}}
+              {{else}}
+                {{t "pages.skill-review.recommended-engine.modal.actions.discover-program"}}
+                <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
+              {{/if}}
+            </PixButtonLink>
+          </li>
+        </ul>
       </:footer>
     </PixModal>
   </template>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 export default class Card extends Component {
   @service intl;
@@ -79,9 +80,49 @@ export default class Card extends Component {
         </ul>
       </section>
     </button>
-    <PixModal @title={{@training.title}} @showModal={{this.modalIsOpen}} @onCloseButtonClick={{this.closeModal}}>
+    <PixModal
+      @title={{@training.title}}
+      @showModal={{this.modalIsOpen}}
+      @onCloseButtonClick={{this.closeModal}}
+      class="results-recommendation-engine-training-card-modal"
+    >
       <:content>
+        <section class="results-recommendation-engine-training-card-modal__section">
+          <div class="results-recommendation-engine-training-card-modal-section__description">
+            <PixTag @color={{this.tagProperties.color}} class="results-recommendation-engine-training-card__tag">
+              <PixIcon
+                class="results-recommendation-engine-training-card__tag-icon"
+                @name={{this.tagProperties.iconName}}
+                @ariaHidden={{true}}
+              />
+              {{this.tagProperties.text}}
+            </PixTag>
+            <p>{{t "pages.skill-review.recommended-engine.modal.editor-name"}}<span>{{@training.editorName}}</span></p>
+            <p>{{@training.description}}</p>
+          </div>
+          <div class="results-recommendation-engine-training-card-modal-section__information">
+            {{#if @training.hasDuration}}
+              <div class="results-recommendation-engine-training-card-modal-section__time-information">
+                <PixIcon @name="time" @ariaHidden={{true}} />
+                <p>{{t "pages.skill-review.recommended-engine.modal.duration"}}</p>
+                <p class="results-recommendation-engine-training-card-modal-section__time-information--bold">
+                  <span>{{this.formattedDays}}</span>
+                  <span>{{this.formattedTime}}</span>
+                </p>
+              </div>
+            {{/if}}
+            <div class="results-recommendation-engine-training-card-modal-section__localisation-information">
+              <PixIcon @name="mapPin" @ariaHidden={{true}} />
+              <p>{{t "pages.skill-review.recommended-engine.modal.localisation"}}</p>
+              <p
+                class="results-recommendation-engine-training-card-modal-section__localisation-information--bold"
+              >{{this.deliveryMode}}</p>
+            </div>
+          </div>
+        </section>
       </:content>
+      <:footer>
+      </:footer>
     </PixModal>
   </template>
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -35,13 +35,6 @@ export default class Card extends Component {
     return this.intl.t(`pages.skill-review.recommended-engine.training-card.delivery-mode.${deliveryMode}`);
   }
 
-  get formattedDuration() {
-    const days = this.args.training.duration.days ? `${this.args.training.duration.days}j ` : '';
-    const hours = this.args.training.duration.hours ? `${this.args.training.duration.hours}h ` : '';
-    const minutes = this.args.training.duration.minutes ? `${this.args.training.duration.minutes}min` : '';
-    return `${days}${hours}${minutes}`.trim();
-  }
-
   get type() {
     if (this.args.training.isTypeLinkedToALocation) {
       return this.intl.t('pages.training.type.formation');
@@ -78,8 +71,12 @@ export default class Card extends Component {
       </PixTag>
       <section class="results-recommendation-engine-training-card-content">
         <p class="results-recommendation-engine-training-card-content__title">{{@training.title}}</p>
-        <ul class="results-recommendation-engine-training-card-content__details"><li>{{this.type}}</li><li
-          >{{this.deliveryMode}}</li><li>{{this.formattedDuration}}</li></ul>
+        <ul class="results-recommendation-engine-training-card-content__details"><li>{{this.type}}</li>
+          <li>{{this.deliveryMode}}</li>
+          {{#if @training.hasDuration}}
+            <li>{{@training.formattedDuration}}</li>
+          {{/if}}
+        </ul>
       </section>
     </button>
     <PixModal @title={{@training.title}} @showModal={{this.modalIsOpen}} @onCloseButtonClick={{this.closeModal}}>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -1,3 +1,4 @@
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
@@ -120,6 +121,35 @@ export default class Card extends Component {
             </div>
           </div>
         </section>
+
+        <PixAccordions>
+          <:title>
+            <h2>{{t "pages.skill-review.recommended-engine.modal.objectives"}}</h2>
+          </:title>
+          <:content>
+            <ol class="results-recommendation-engine-training-card-modal__objectives">
+              {{#each @training.objectives as |objective|}}
+                <li>
+                  <PixIcon
+                    @name="checkCircle"
+                    @plainIcon={{true}}
+                    class="results-recommendation-engine-training-card-modal-objectives__icon"
+                    @ariaHidden={{true}}
+                  />
+                  {{objective}}
+                </li>
+              {{/each}}
+            </ol>
+          </:content>
+        </PixAccordions>
+        <PixAccordions>
+          <:title>
+            <h2>{{t "pages.skill-review.recommended-engine.modal.program"}}</h2>
+          </:title>
+          <:content>
+            <p class="results-recommendation-engine-training-card-modal__program">{{@training.program}}</p>
+          </:content>
+        </PixAccordions>
       </:content>
       <:footer>
       </:footer>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -1,8 +1,3 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -10,7 +5,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
-import CardTag from './card-tag';
+import CardModal from './card-modal';
+import RegistrationCardTag from './registration-card-tag';
 
 export default class Card extends Component {
   @service intl;
@@ -65,96 +61,13 @@ export default class Card extends Component {
         </ul>
       </section>
     </button>
-    <PixModal
-      @title={{@training.title}}
-      @showModal={{this.modalIsOpen}}
-      @onCloseButtonClick={{this.closeModal}}
-      class="results-recommendation-engine-training-card-modal"
-    >
-      <:content>
-        <section class="results-recommendation-engine-training-card-modal__section">
-          <div class="results-recommendation-engine-training-card-modal-section__description">
-            <CardTag @registrationRequired={{@training.registrationRequired}} />
-            <p>{{t "pages.skill-review.recommended-engine.modal.editor-name"}}<span>{{@training.editorName}}</span></p>
-            <p>{{@training.description}}</p>
-          </div>
-          <div class="results-recommendation-engine-training-card-modal-section__information">
-            {{#if @training.hasDuration}}
-              <div class="results-recommendation-engine-training-card-modal-section__time-information">
-                <PixIcon @name="time" @ariaHidden={{true}} />
-                <p>{{t "pages.skill-review.recommended-engine.modal.duration"}}</p>
-                <p class="results-recommendation-engine-training-card-modal-section__time-information--bold">
-                  <span>{{this.formattedDays}}</span>
-                  <span>{{this.formattedTime}}</span>
-                </p>
-              </div>
-            {{/if}}
-            <div class="results-recommendation-engine-training-card-modal-section__localisation-information">
-              <PixIcon @name="mapPin" @ariaHidden={{true}} />
-              <p>{{t "pages.skill-review.recommended-engine.modal.localisation"}}</p>
-              <p
-                class="results-recommendation-engine-training-card-modal-section__localisation-information--bold"
-              >{{this.deliveryMode}}</p>
-            </div>
-          </div>
-        </section>
-
-        <PixAccordions>
-          <:title>
-            <h2>{{t "pages.skill-review.recommended-engine.modal.objectives"}}</h2>
-          </:title>
-          <:content>
-            <ol class="results-recommendation-engine-training-card-modal__objectives">
-              {{#each @training.objectives as |objective|}}
-                <li>
-                  <PixIcon
-                    @name="checkCircle"
-                    @plainIcon={{true}}
-                    class="results-recommendation-engine-training-card-modal-objectives__icon"
-                    @ariaHidden={{true}}
-                  />
-                  {{objective}}
-                </li>
-              {{/each}}
-            </ol>
-          </:content>
-        </PixAccordions>
-        <PixAccordions>
-          <:title>
-            <h2>{{t "pages.skill-review.recommended-engine.modal.program"}}</h2>
-          </:title>
-          <:content>
-            <p class="results-recommendation-engine-training-card-modal__program">{{@training.program}}</p>
-          </:content>
-        </PixAccordions>
-      </:content>
-      <:footer>
-        <ul class="results-recommendation-engine-training-card-modal-footer">
-          <li>
-            <PixButton
-              @triggerAction={{this.closeModal}}
-              @variant="secondary"
-              class="results-recommendation-engine-training-card-modal-footer__cancel-button"
-            >
-              {{t "common.actions.cancel"}}
-            </PixButton>
-          </li>
-          <li>
-            <PixButtonLink
-              @href={{@training.link}}
-              target="_blank"
-              class="results-recommendation-engine-training-card-modal-footer__link-button"
-            >
-              {{#if @training.isModulix}}
-                {{t "pages.skill-review.recommended-engine.modal.actions.discover-module"}}
-              {{else}}
-                {{t "pages.skill-review.recommended-engine.modal.actions.discover-program"}}
-                <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
-              {{/if}}
-            </PixButtonLink>
-          </li>
-        </ul>
-      </:footer>
-    </PixModal>
+    <CardModal
+      @training={{@training}}
+      @deliveryMode={{this.deliveryMode}}
+      @formattedDays={{@training.formattedDays}}
+      @formattedTime={{@training.formattedTime}}
+      @isOpen={{this.modalIsOpen}}
+      @onClose={{this.closeModal}}
+    />
   </template>
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -15,7 +15,7 @@ export default class Card extends Component {
   get tagProperties() {
     const registrationRequired = this.args.training.registrationRequired;
 
-    const color = registrationRequired ? 'blue-light' : 'primary';
+    const color = registrationRequired ? 'blue-light' : 'purple';
     const iconName = registrationRequired ? 'lock' : 'acute';
     const translationKey = registrationRequired ? 'yes' : 'no';
     const text = this.intl.t(

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/registration-card-tag.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/registration-card-tag.gjs
@@ -1,0 +1,36 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class RegistrationCardTag extends Component {
+  @service intl;
+
+  get tagProperties() {
+    const registrationRequired = this.args.registrationRequired;
+
+    const color = registrationRequired ? 'blue-light' : 'purple';
+    const iconName = registrationRequired ? 'lock' : 'acute';
+    const translationKey = registrationRequired ? 'yes' : 'no';
+    const text = this.intl.t(
+      `pages.skill-review.recommended-engine.training-card.registration-required.${translationKey}`,
+    );
+
+    return {
+      color,
+      iconName,
+      text,
+    };
+  }
+
+  <template>
+    <PixTag @color={{this.tagProperties.color}} class="results-recommendation-engine-training-card__tag">
+      <PixIcon
+        class="results-recommendation-engine-training-card__tag-icon"
+        @name={{this.tagProperties.iconName}}
+        @ariaHidden={{true}}
+      />
+      {{this.tagProperties.text}}
+    </PixTag>
+  </template>
+}

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -16,6 +16,7 @@ export default class Training extends Model {
   @attr() objectives;
   @attr('string') program;
   @attr('boolean') registrationRequired;
+  @attr('string') description;
 
   @belongsTo('campaign-participation', { async: true, inverse: 'trainings' }) campaignParticipation;
 

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -42,4 +42,8 @@ export default class Training extends Model {
   get isTypeLinkedToALocation() {
     return this.isElearning || this.isHybrid || this.isInPerson;
   }
+
+  get hasDuration() {
+    return this.duration.days || this.duration.hours || this.duration.minutes;
+  }
 }

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -1,3 +1,4 @@
+import { service } from '@ember/service';
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Training extends Model {
@@ -47,4 +48,35 @@ export default class Training extends Model {
   get hasDuration() {
     return this.duration.days || this.duration.hours || this.duration.minutes;
   }
+
+  get formattedDuration() {
+    const daysPart = this.formattedDays;
+    const timePart = this.formattedTime;
+
+    if (daysPart && timePart)
+      return `${daysPart} ${this.intl.t('pages.skill-review.recommended-engine.training-card.duration.and')} ${timePart}`;
+    return daysPart || timePart;
+  }
+
+  get formattedDays() {
+    const { days } = this.duration;
+
+    return days
+      ? `${days} ${this.intl.t('pages.skill-review.recommended-engine.training-card.duration.days', { count: days })}`
+      : '';
+  }
+
+  get formattedTime() {
+    const { hours, minutes } = this.duration;
+
+    const formattedHours = hours
+      ? `${hours}${this.intl.t('pages.skill-review.recommended-engine.training-card.duration.hours')}`
+      : '';
+    const formattedMinutes = minutes
+      ? `${minutes}${this.intl.t('pages.skill-review.recommended-engine.training-card.duration.minutes')}`
+      : '';
+    return [formattedHours, formattedMinutes].filter(Boolean).join('');
+  }
+
+  @service intl;
 }

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -197,3 +197,25 @@
     color: var(--pix-primary-300);
   }
 }
+
+.results-recommendation-engine-training-card-modal-footer {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  justify-content: flex-end;
+
+  @include breakpoints.device-is('mobile') {
+    flex-direction: column;
+    justify-content: center;
+    width: 100%
+  }
+
+  &__link-button {
+    display: flex;
+    gap: var(--pix-spacing-1x);
+    justify-content: center;
+  }
+
+  &__cancel-button {
+    width: 100%;
+  }
+}

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -105,3 +105,70 @@
 
 }
 
+.results-recommendation-engine-training-card-modal {
+  @include breakpoints.device-is('tablet') {
+    width: 742px;
+  }
+
+  h2 {
+    @extend %pix-title-xs;
+  }
+
+  &__section {
+    @extend %pix-body-m;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-6x);
+    justify-content: space-between;
+    margin-bottom: var(--pix-spacing-6x);
+
+    @include breakpoints.device-is('tablet') {
+      flex-direction: row;
+      gap: var(--pix-spacing-2x);
+    }
+  }
+}
+
+.results-recommendation-engine-training-card-modal-section {
+  &__description {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+
+    span {
+      font-weight: var(--pix-font-bold);
+    }
+  }
+
+  &__information {
+    display: flex;
+    gap: var(--pix-spacing-6x);
+    align-items: center;
+    justify-content: space-around;
+    padding: var(--pix-spacing-6x) var(--pix-spacing-10x);
+    background-color: var(--pix-primary-10);
+    border: 1px solid var(--pix-primary-100);
+    border-radius: 12px;
+
+    @include breakpoints.device-is('tablet') {
+      flex-direction: column;
+      gap: var(--pix-spacing-8x);
+      justify-content: center;
+    }
+  }
+
+  &__time-information, &__localisation-information {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-1x);
+    align-items: center;
+    justify-content: center;
+
+    &--bold {
+      display: flex;
+      flex-direction: column;
+      font-weight: var(--pix-font-bold);
+    }
+  }
+}

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -128,6 +128,25 @@
       gap: var(--pix-spacing-2x);
     }
   }
+
+  &__objectives {
+    @extend %pix-body-m;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+
+    li {
+      display: flex;
+      gap: var(--pix-spacing-3x);
+      align-items: center;
+      color: var(--pix-neutral-800);
+    }
+  }
+
+  &__program {
+    color: var(--pix-neutral-800);
+  }
 }
 
 .results-recommendation-engine-training-card-modal-section {
@@ -170,5 +189,11 @@
       flex-direction: column;
       font-weight: var(--pix-font-bold);
     }
+  }
+}
+
+.results-recommendation-engine-training-card-modal-objectives {
+  &__icon {
+    color: var(--pix-primary-300);
   }
 }

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -223,10 +223,8 @@ module(
         assert.dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.objectives'))).exists();
         assert.dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.program'))).exists();
 
-        const objectives = within(modal).getByRole('list');
-        assert.strictEqual(objectives.children.length, 2);
-
-        assert.dom(within(modal).getByRole('button', { name: t('common.actions.cancel') })).exists();
+        const actionButtons = within(modal).getByRole('list');
+        assert.dom(within(actionButtons).getByRole('button', { name: t('common.actions.close') })).exists();
       });
 
       module('when training is modulix type', function () {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -22,7 +22,7 @@ module(
       const trainingTitle = screen.getAllByText(training.title);
       assert.strictEqual(trainingTitle.length, 2);
       assert.dom(screen.getByText('Webinaire')).exists();
-      assert.dom(screen.getByText('2h')).exists();
+      assert.dom(screen.getByText('1 jour et 2h')).exists();
     });
 
     module('when delivery mode is hybrid', function () {
@@ -133,11 +133,87 @@ module(
       });
     });
 
-    function _buildTraining({ deliveryMode = 'remote', registrationRequired = true, type = 'webinaire' }) {
+    module('handle duration', function () {
+      module('when training has no duration', function () {
+        test('it displays nothing', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord(
+            'training',
+            _buildTraining({ type: 'modulix', duration: { days: 0, hours: 0, minutes: 0 } }),
+          );
+
+          // when
+          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+          // then
+          const list = screen.getByRole('list');
+          assert.strictEqual(list.children.length, 2);
+        });
+      });
+
+      module('when training has only days duration', function () {
+        test('it displays days only', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord(
+            'training',
+            _buildTraining({ type: 'modulix', duration: { days: 3, hours: 0, minutes: 0 } }),
+          );
+
+          // when
+          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+          // then
+          assert.dom(screen.getByText('3 jours')).exists();
+        });
+      });
+
+      module('when training has days and hours duration', function () {
+        test('it displays complete duration', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord(
+            'training',
+            _buildTraining({ type: 'modulix', duration: { days: 3, hours: 1, minutes: 0 } }),
+          );
+
+          // when
+          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+          // then
+          assert.dom(screen.getByText('3 jours et 1h')).exists();
+        });
+      });
+
+      module('when training has minutes and hours duration', function () {
+        test('it displays complete duration', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord(
+            'training',
+            _buildTraining({ type: 'modulix', duration: { days: 0, hours: 1, minutes: 30 } }),
+          );
+
+          // when
+          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+
+          // then
+          assert.dom(screen.getByText('1h30min')).exists();
+        });
+      });
+    });
+
+    function _buildTraining({
+      deliveryMode = 'remote',
+      registrationRequired = true,
+      type = 'webinaire',
+      duration = { days: 1, hours: 2, minutes: 0 },
+    }) {
       return {
         title: 'Apprendre à manger un croissant comme les français',
         link: 'https://example.net/',
-        duration: { hours: 2 },
+        duration,
         editorLogoUrl:
           'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
         editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -199,7 +199,9 @@ module(
 
         // when
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
-        await click(screen.getByRole('button', { name: /Apprendre à manger un croissant comme les français / }));
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
+        );
 
         // then
         const modal = await screen.findByRole('dialog');
@@ -235,7 +237,9 @@ module(
 
           // when
           const screen = await render(<template><TrainingCard @training={{training}} /></template>);
-          await click(screen.getByRole('button', { name: /Apprendre à manger un croissant comme les français / }));
+          await click(
+            screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
+          );
 
           // then
           const modal = await screen.findByRole('dialog');
@@ -257,7 +261,9 @@ module(
 
           // when
           const screen = await render(<template><TrainingCard @training={{training}} /></template>);
-          await click(screen.getByRole('button', { name: /Apprendre à manger un croissant comme les français / }));
+          await click(
+            screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
+          );
 
           // then
           const modal = await screen.findByRole('dialog');

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -1,4 +1,5 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import TrainingCard from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/training/card';
 import { module, test } from 'qunit';
@@ -35,8 +36,13 @@ module(
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
 
         // then
+        const trainingCardList = screen.getByRole('list');
         assert
-          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.delivery-mode.hybrid')))
+          .dom(
+            within(trainingCardList).getByText(
+              t('pages.skill-review.recommended-engine.training-card.delivery-mode.hybrid'),
+            ),
+          )
           .exists();
       });
     });
@@ -51,8 +57,13 @@ module(
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
 
         // then
+        const trainingCardList = screen.getByRole('list');
         assert
-          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.delivery-mode.on-site')))
+          .dom(
+            within(trainingCardList).getByText(
+              t('pages.skill-review.recommended-engine.training-card.delivery-mode.on-site'),
+            ),
+          )
           .exists();
       });
     });
@@ -67,8 +78,13 @@ module(
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
 
         // then
+        const trainingCardList = screen.getByRole('list');
         assert
-          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.delivery-mode.remote')))
+          .dom(
+            within(trainingCardList).getByText(
+              t('pages.skill-review.recommended-engine.training-card.delivery-mode.remote'),
+            ),
+          )
           .exists();
       });
     });
@@ -83,9 +99,10 @@ module(
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
 
         // then
-        assert
-          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.registration-required.yes')))
-          .exists();
+        const tag = screen.getAllByText(
+          t('pages.skill-review.recommended-engine.training-card.registration-required.yes'),
+        );
+        assert.strictEqual(tag.length, 2);
       });
     });
 
@@ -99,9 +116,10 @@ module(
         const screen = await render(<template><TrainingCard @training={{training}} /></template>);
 
         // then
-        assert
-          .dom(screen.getByText(t('pages.skill-review.recommended-engine.training-card.registration-required.no')))
-          .exists();
+        const tag = screen.getAllByText(
+          t('pages.skill-review.recommended-engine.training-card.registration-required.no'),
+        );
+        assert.strictEqual(tag.length, 2);
       });
     });
 
@@ -152,25 +170,8 @@ module(
         });
       });
 
-      module('when training has only days duration', function () {
-        test('it displays days only', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const training = store.createRecord(
-            'training',
-            _buildTraining({ type: 'modulix', duration: { days: 3, hours: 0, minutes: 0 } }),
-          );
-
-          // when
-          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
-
-          // then
-          assert.dom(screen.getByText('3 jours')).exists();
-        });
-      });
-
-      module('when training has days and hours duration', function () {
-        test('it displays complete duration', async function (assert) {
+      module('when training has duration', function () {
+        test('it displays duration', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
           const training = store.createRecord(
@@ -185,22 +186,38 @@ module(
           assert.dom(screen.getByText('3 jours et 1h')).exists();
         });
       });
+    });
 
-      module('when training has minutes and hours duration', function () {
-        test('it displays complete duration', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const training = store.createRecord(
-            'training',
-            _buildTraining({ type: 'modulix', duration: { days: 0, hours: 1, minutes: 30 } }),
-          );
+    module('when user clicks on a training card', function () {
+      test('should display a modal with training information', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord(
+          'training',
+          _buildTraining({ type: 'modulix', duration: { days: 1, hours: 2, minutes: 10 } }),
+        );
 
-          // when
-          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+        await click(screen.getByRole('button', { name: /Apprendre à manger un croissant comme les français / }));
 
-          // then
-          assert.dom(screen.getByText('1h30min')).exists();
-        });
+        // then
+        const modal = await screen.findByRole('dialog');
+        assert
+          .dom(within(modal).getByRole('heading', { name: 'Apprendre à manger un croissant comme les français' }))
+          .exists();
+        assert
+          .dom(
+            within(modal).getByText(t('pages.skill-review.recommended-engine.training-card.registration-required.yes')),
+          )
+          .exists();
+        assert.dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.duration'))).exists();
+        assert.dom(within(modal).getByText(training.editorName)).exists();
+        assert.dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.localisation'))).exists();
+        assert
+          .dom(within(modal).getByText(t('pages.skill-review.recommended-engine.training-card.delivery-mode.remote')))
+          .exists();
+        assert.dom(within(modal).getByText(training.description)).exists();
       });
     });
 
@@ -222,6 +239,8 @@ module(
         deliveryMode,
         objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
         program: 'Heure 1 : Théorie & culture du croissant, Heure 2 : Pratique et technique de dégustation',
+        description:
+          "Aujourd'hui, manger un croissant est tout un art en France. De nombreux touristes viennent en France et font le tour des meilleures boulangeries pour en manger, mais sans connaître les différentes manières de le savourer pleinement.",
         registrationRequired,
       };
     }

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -218,6 +218,10 @@ module(
           .dom(within(modal).getByText(t('pages.skill-review.recommended-engine.training-card.delivery-mode.remote')))
           .exists();
         assert.dom(within(modal).getByText(training.description)).exists();
+        assert.dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.objectives'))).exists();
+        assert.dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.program'))).exists();
+        const objectives = within(modal).getByRole('list');
+        assert.strictEqual(objectives.children.length, 2);
       });
     });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -220,8 +220,55 @@ module(
         assert.dom(within(modal).getByText(training.description)).exists();
         assert.dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.objectives'))).exists();
         assert.dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.program'))).exists();
+
         const objectives = within(modal).getByRole('list');
         assert.strictEqual(objectives.children.length, 2);
+
+        assert.dom(within(modal).getByRole('button', { name: t('common.actions.cancel') })).exists();
+      });
+
+      module('when training is modulix type', function () {
+        test('it displays a link button to redirect to a module', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord('training', _buildTraining({ type: 'modulix' }));
+
+          // when
+          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+          await click(screen.getByRole('button', { name: /Apprendre à manger un croissant comme les français / }));
+
+          // then
+          const modal = await screen.findByRole('dialog');
+          assert
+            .dom(
+              within(modal).getByRole('link', {
+                name: t('pages.skill-review.recommended-engine.modal.actions.discover-module'),
+              }),
+            )
+            .exists();
+        });
+      });
+
+      module('when training is a other type than modulix', function () {
+        test('it displays a link button to redirect to an external website', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord('training', _buildTraining({ type: 'webinaire' }));
+
+          // when
+          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+          await click(screen.getByRole('button', { name: /Apprendre à manger un croissant comme les français / }));
+
+          // then
+          const modal = await screen.findByRole('dialog');
+          assert
+            .dom(
+              within(modal).getByRole('link', {
+                name: `${t('pages.skill-review.recommended-engine.modal.actions.discover-program')} ${t('navigation.external-link-title')}`,
+              }),
+            )
+            .exists();
+        });
       });
     });
 

--- a/mon-pix/tests/unit/models/training-test.js
+++ b/mon-pix/tests/unit/models/training-test.js
@@ -1,0 +1,64 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../helpers/setup-intl';
+
+module('Unit | Model | training', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('#formattedDuration', function () {
+    module('when training has only days duration', function () {
+      test('it returns days only', async function (assert) {
+        // given
+        const training = store.createRecord('training', {
+          type: 'modulix',
+          duration: {
+            days: 3,
+          },
+        });
+
+        // when
+        const displayedDuration = training.formattedDuration;
+
+        // then
+        assert.strictEqual(displayedDuration, '3 jours');
+      });
+    });
+  });
+
+  module('when training has days and hours duration', function () {
+    test('it displays complete duration', async function (assert) {
+      // given
+      const training = store.createRecord('training', { type: 'modulix', duration: { days: 3, hours: 1, minutes: 0 } });
+
+      // when
+      const displayedDuration = training.formattedDuration;
+
+      // then
+      assert.strictEqual(displayedDuration, '3 jours et 1h');
+    });
+  });
+
+  module('when training has minutes and hours duration', function () {
+    test('it displays complete duration', async function (assert) {
+      // given
+      const training = store.createRecord('training', {
+        type: 'modulix',
+        duration: { days: 0, hours: 1, minutes: 30 },
+      });
+
+      // when
+      const displayedDuration = training.formattedDuration;
+
+      // then
+      assert.strictEqual(displayedDuration, '1h30min');
+    });
+  });
+});

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2234,6 +2234,7 @@
           "program": "Programm"
         },
         "training-card": {
+          "aria-label": "Trainingsdetails öffnen",
           "delivery-mode": {
             "hybrid": "Hybrid",
             "on-site": "Vor Ort",

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2222,6 +2222,11 @@
       },
       "not-finished": "Du kannst deine Ergebnisse noch nicht einsenden, wir haben noch einige Fragen an dich.",
       "recommended-engine": {
+        "modal": {
+          "duration": "Dauer",
+          "editor-name": "Vorgeschlagen von : ",
+          "localisation": "Standort"
+        },
         "training-card": {
           "delivery-mode": {
             "hybrid": "Hybrid",

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2223,6 +2223,10 @@
       "not-finished": "Du kannst deine Ergebnisse noch nicht einsenden, wir haben noch einige Fragen an dich.",
       "recommended-engine": {
         "modal": {
+          "actions": {
+            "discover-module": "Modul starten",
+            "discover-program": "Dieses Programm entdecken"
+          },
           "duration": "Dauer",
           "editor-name": "Vorgeschlagen von : ",
           "localisation": "Standort",

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2228,6 +2228,12 @@
             "on-site": "Vor Ort",
             "remote": "Fernkurs"
           },
+          "duration": {
+            "and": "und",
+            "days": "{ count, plural, =1 {Tag} other {Tage} }",
+            "hours": "Std",
+            "minutes": "Min"
+          },
           "registration-required": {
             "no": "Sofortiger freier Zugang",
             "yes": "Anmeldung erforderlich"

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2225,7 +2225,9 @@
         "modal": {
           "duration": "Dauer",
           "editor-name": "Vorgeschlagen von : ",
-          "localisation": "Standort"
+          "localisation": "Standort",
+          "objectives": "Ziele",
+          "program": "Programm"
         },
         "training-card": {
           "delivery-mode": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2222,6 +2222,11 @@
       },
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
       "recommended-engine": {
+        "modal": {
+          "duration": "Duration",
+          "editor-name": "Proposed by: ",
+          "localisation": "Location"
+        },
         "training-card": {
           "delivery-mode": {
             "hybrid": "Hybrid",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2223,6 +2223,10 @@
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
       "recommended-engine": {
         "modal": {
+          "actions": {
+            "discover-module": "Start the module",
+            "discover-program": "Discover this programme"
+          },
           "duration": "Duration",
           "editor-name": "Proposed by: ",
           "localisation": "Location",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2234,6 +2234,7 @@
           "program": "Programme"
         },
         "training-card": {
+          "aria-label": "Open the training details",
           "delivery-mode": {
             "hybrid": "Hybrid",
             "on-site": "On-site",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2228,6 +2228,12 @@
             "on-site": "On-site",
             "remote": "Remote"
           },
+          "duration": {
+            "and": "and",
+            "days": "{ count, plural, =1 {day} other {days} }",
+            "hours": "h",
+            "minutes": "min"
+          },
           "registration-required": {
             "no": "Immediate free access",
             "yes": "Registration required"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2225,7 +2225,9 @@
         "modal": {
           "duration": "Duration",
           "editor-name": "Proposed by: ",
-          "localisation": "Location"
+          "localisation": "Location",
+          "objectives": "Objectives",
+          "program": "Programme"
         },
         "training-card": {
           "delivery-mode": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2222,6 +2222,11 @@
       },
       "not-finished": "Todavía no puedes enviar tus resultados, aún tenemos algunas preguntas para ti.",
       "recommended-engine": {
+        "modal": {
+          "duration": "Duración",
+          "editor-name": "Propuesto por: ",
+          "localisation": "Localización"
+        },
         "training-card": {
           "delivery-mode": {
             "hybrid": "Híbrido",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2225,7 +2225,9 @@
         "modal": {
           "duration": "Duración",
           "editor-name": "Propuesto por: ",
-          "localisation": "Localización"
+          "localisation": "Localización",
+          "objectives": "Objetivos",
+          "program": "Programa"
         },
         "training-card": {
           "delivery-mode": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2228,6 +2228,12 @@
             "on-site": "Presencial",
             "remote": "A distancia"
           },
+          "duration": {
+            "and": "y",
+            "days": "{ count, plural, =1 {día} other {días} }",
+            "hours": "h",
+            "minutes": "min"
+          },
           "registration-required": {
             "no": "Acceso libre inmediato",
             "yes": "Inscripción requerida"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2234,6 +2234,7 @@
           "program": "Programa"
         },
         "training-card": {
+          "aria-label": "Abrir los detalles de la formación",
           "delivery-mode": {
             "hybrid": "Híbrido",
             "on-site": "Presencial",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2223,6 +2223,10 @@
       "not-finished": "Todavía no puedes enviar tus resultados, aún tenemos algunas preguntas para ti.",
       "recommended-engine": {
         "modal": {
+          "actions": {
+            "discover-module": "Iniciar el módulo",
+            "discover-program": "Descubrir este programa"
+          },
           "duration": "Duración",
           "editor-name": "Propuesto por: ",
           "localisation": "Localización",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2234,6 +2234,7 @@
           "program": "Programme"
         },
         "training-card": {
+          "aria-label": "Ouvrir les détails de la formation",
           "delivery-mode": {
             "hybrid": "Hybride",
             "on-site": "Sur place",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2222,6 +2222,11 @@
       },
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "recommended-engine": {
+        "modal": {
+          "duration": "Durée",
+          "editor-name": "Proposé par : ",
+          "localisation": "Localisation"
+        },
         "training-card": {
           "delivery-mode": {
             "hybrid": "Hybride",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2225,7 +2225,9 @@
         "modal": {
           "duration": "Durée",
           "editor-name": "Proposé par : ",
-          "localisation": "Localisation"
+          "localisation": "Localisation",
+          "objectives": "Objectifs",
+          "program": "Programme"
         },
         "training-card": {
           "delivery-mode": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2223,6 +2223,10 @@
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "recommended-engine": {
         "modal": {
+          "actions": {
+            "discover-module": "Découvrir le module",
+            "discover-program": "Découvrir ce programme"
+          },
           "duration": "Durée",
           "editor-name": "Proposé par : ",
           "localisation": "Localisation",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2228,6 +2228,12 @@
             "on-site": "Sur place",
             "remote": "À distance"
           },
+          "duration": {
+            "and": "et",
+            "days": "{ count, plural, =1 {jour} other {jours} }",
+            "hours": "h",
+            "minutes": "min"
+          },
           "registration-required": {
             "no": "Libre accès immédiat",
             "yes": "Inscription requise"

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2222,6 +2222,11 @@
       },
       "not-finished": "Non è ancora possibile invia i risultati, quindi abbiamo ancora alcune domande per voi.",
       "recommended-engine": {
+        "modal": {
+          "duration": "Durata",
+          "editor-name": "Proposto da : ",
+          "localisation": "Localizzazione"
+        },
         "training-card": {
           "delivery-mode": {
             "hybrid": "Ibrido",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2234,6 +2234,7 @@
           "program": "Programma"
         },
         "training-card": {
+          "aria-label": "Apri i dettagli della formazione",
           "delivery-mode": {
             "hybrid": "Ibrido",
             "on-site": "In loco",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2223,6 +2223,10 @@
       "not-finished": "Non è ancora possibile invia i risultati, quindi abbiamo ancora alcune domande per voi.",
       "recommended-engine": {
         "modal": {
+          "actions": {
+            "discover-module": "Avvia il modulo",
+            "discover-program": "Scopri questo programma"
+          },
           "duration": "Durata",
           "editor-name": "Proposto da : ",
           "localisation": "Localizzazione",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2228,6 +2228,12 @@
             "on-site": "In loco",
             "remote": "A distanza"
           },
+          "duration": {
+            "and": "e",
+            "days": "{ count, plural, =1 {giorno} other {giorni} }",
+            "hours": "h",
+            "minutes": "min"
+          },
           "registration-required": {
             "no": "Accesso libero immediato",
             "yes": "Iscrizione richiesta"

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2225,7 +2225,9 @@
         "modal": {
           "duration": "Durata",
           "editor-name": "Proposto da : ",
-          "localisation": "Localizzazione"
+          "localisation": "Localizzazione",
+          "objectives": "Obiettivi",
+          "program": "Programma"
         },
         "training-card": {
           "delivery-mode": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2228,6 +2228,12 @@
             "on-site": "Ter plaatse",
             "remote": "Op afstand"
           },
+          "duration": {
+            "and": "en",
+            "days": "{ count, plural, =1 {dag} other {dagen} }",
+            "hours": "u",
+            "minutes": "min"
+          },
           "registration-required": {
             "no": "Onmiddellijke vrije toegang",
             "yes": "Inschrijving vereist"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2225,7 +2225,9 @@
         "modal": {
           "duration": "Duur",
           "editor-name": "Voorgesteld door : ",
-          "localisation": "Locatie"
+          "localisation": "Locatie",
+          "objectives": "Doelstellingen",
+          "program": "Programma"
         },
         "training-card": {
           "delivery-mode": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2223,6 +2223,10 @@
       "not-finished": "Je kunt je resultaten nog niet opsturen, dus we hebben nog een paar vragen voor je.",
       "recommended-engine": {
         "modal": {
+          "actions": {
+            "discover-module": "Module starten",
+            "discover-program": "Dit programma ontdekken"
+          },
           "duration": "Duur",
           "editor-name": "Voorgesteld door : ",
           "localisation": "Locatie",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2222,6 +2222,11 @@
       },
       "not-finished": "Je kunt je resultaten nog niet opsturen, dus we hebben nog een paar vragen voor je.",
       "recommended-engine": {
+        "modal": {
+          "duration": "Duur",
+          "editor-name": "Voorgesteld door : ",
+          "localisation": "Locatie"
+        },
         "training-card": {
           "delivery-mode": {
             "hybrid": "Hybride",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2234,6 +2234,7 @@
           "program": "Programma"
         },
         "training-card": {
+          "aria-label": "Trainingsdetails openen",
           "delivery-mode": {
             "hybrid": "Hybride",
             "on-site": "Ter plaatse",


### PR DESCRIPTION
## 💥 Problème

Chantier des parcours avec contenu formatifs recommandés. On souhaite pouvoir cliquer sur un contenu F et voir tous les détails de ce dernier : 
- description
- programme
- objectifs
- durée
- localisation
- proposé par 
- etc...

## 👩‍🚀 Proposition

Ajouter la modale

## 👁️ Remarques

Ce qui n'a pas été fait ici : 
- L'icône à coté du titre de la modale, on a pas les illus encore
- Le `PixAccordions` n'a pas été mis à jour coté design ici
- Pas de carroussels de trainings ici

## ♻️ Pour tester

- dave-comp@example.net > Poursuivre le parcours EDUMULTIP > Accéder à la nouvelle page
- Première carte: N'a pas de duration donc on ne voit pas l'heure, sur les autre si
- Cliquer sur cette carte sans duration => Accéder à une modale avec titre du training, le tag de la registration, l'editorName, la description, la localisation.
- Voir 2 accordéons avec Objectifs et Programme
- Dans cette carte là pas de durée, rien ne s'affiche
- Cette carte n'étant pas un module, voir le bouton "Accéder au programme" 
- Quitter cette modale et cliquer sur une autre training card
- Constater qu'ici on à la durée et un bouton pour accéder au module
- Mettre en mobile et constater que ça suit les maquettes Figma.

