### PR TITLE
[FEATURE] Ajouter une route permettant de récupérer un détail de profil cible (PIX-22674)

### DIFF
--- a/api/src/prescription/target-profile/application/pre-handlers.js
+++ b/api/src/prescription/target-profile/application/pre-handlers.js
@@ -1,0 +1,21 @@
+import boom from '@hapi/boom';
+
+import { usecases } from '../domain/usecases/index.js';
+
+async function checkTargetProfileBelongsToOrganization(
+  request,
+  h,
+  dependencies = { checkTargetProfileBelongsToOrganizationUsecase: usecases.checkTargetProfileBelongsToOrganization },
+) {
+  const targetProfileId = parseInt(request.params.targetProfileId);
+  const organizationId = parseInt(request.params.organizationId);
+
+  const belongsToOrganization = await dependencies.checkTargetProfileBelongsToOrganizationUsecase({
+    targetProfileId,
+    organizationId,
+  });
+
+  return belongsToOrganization ? h.continue : boom.forbidden();
+}
+
+export const targetProfilePreHandlers = { checkTargetProfileBelongsToOrganization };

--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -2,6 +2,7 @@ import { getChallengeLocale } from '../../../shared/infrastructure/utils/request
 import { usecases } from '../domain/usecases/index.js';
 import * as frameworkWithSkillsSerializer from '../infrastructure/serializers/jsonapi/framework-with-skills-serializer.js';
 import * as targetProfileForSpecifierSerializer from '../infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js';
+import * as targetProfileOverviewSerializer from '../infrastructure/serializers/jsonapi/target-profile-overview-serializer.js';
 
 const findTargetProfiles = async function (request, h, dependencies = { targetProfileForSpecifierSerializer }) {
   const organizationId = request.params.organizationId;
@@ -20,9 +21,16 @@ const findLearningContentsByOrganizationId = async function (
   return dependencies.frameworkWithSkillsSerializer.serialize(learningContents);
 };
 
+const getTargetProfileOverview = async function (request, _, dependencies = { targetProfileOverviewSerializer }) {
+  const targetProfileId = request.params.targetProfileId;
+  const targetProfile = await usecases.getTargetProfileOverview({ targetProfileId });
+  return dependencies.targetProfileOverviewSerializer.serialize(targetProfile);
+};
+
 const targetProfileController = {
   findLearningContentsByOrganizationId,
   findTargetProfiles,
+  getTargetProfileOverview,
 };
 
 export { targetProfileController };

--- a/api/src/prescription/target-profile/application/target-profile-route.js
+++ b/api/src/prescription/target-profile/application/target-profile-route.js
@@ -26,7 +26,35 @@ const register = async function (server) {
         tags: ['api', 'target-profile'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            '- Récupération des profiles cibles utilisables par l‘organisation\n',
+            '- Récupération des profils cibles utilisables par l‘organisation\n',
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/target-profiles/{targetProfileId}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserBelongsToOrganization,
+            assign: 'checkUserBelongsToOrganization',
+          },
+          {
+            method: targetProfilePreHandlers.checkTargetProfileBelongsToOrganization,
+            assign: 'checkTargetProfileBelongsToOrganization',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+            targetProfileId: identifiersType.targetProfileId,
+          }),
+        },
+        handler: targetProfileController.getTargetProfileOverview,
+        tags: ['api', 'target-profile'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Récupération du détail d'un profil cible via l‘organisation\n",
         ],
       },
     },

--- a/api/src/prescription/target-profile/application/target-profile-route.js
+++ b/api/src/prescription/target-profile/application/target-profile-route.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { targetProfilePreHandlers } from './pre-handlers.js';
 import { targetProfileController } from './target-profile-controller.js';
 
 const register = async function (server) {

--- a/api/src/prescription/target-profile/domain/models/TargetProfileOverview.js
+++ b/api/src/prescription/target-profile/domain/models/TargetProfileOverview.js
@@ -1,0 +1,42 @@
+class TargetProfileOverview {
+  constructor({
+    id,
+    name,
+    internalName,
+    imageUrl,
+    category,
+    isSimplifiedAccess,
+    outdated,
+    badges,
+    frameworks,
+    description,
+  } = {}) {
+    this.id = id;
+    this.name = name;
+    this.internalName = internalName;
+    this.imageUrl = imageUrl;
+    this.category = category;
+    this.isSimplifiedAccess = isSimplifiedAccess;
+    this.outdated = outdated;
+    this.badges = badges;
+    this.frameworks = frameworks;
+    this.description = description;
+  }
+
+  get level() {
+    if (this.frameworks?.length > 0) {
+      const areas = this.frameworks.flatMap((framework) => framework.areas ?? []);
+      const competences = areas.flatMap((area) => area.competences ?? []);
+      const tubes = competences.flatMap((competence) => competence.tubes ?? []);
+
+      const maxTubes = tubes.map((tube) => tube.getHardestSkill()?.difficulty ?? 0);
+      if (maxTubes.length === 0) {
+        return 0;
+      }
+      return maxTubes.reduce((total, value) => total + value, 0) / maxTubes.length;
+    }
+    return 0;
+  }
+}
+
+export { TargetProfileOverview };

--- a/api/src/prescription/target-profile/domain/usecases/check-target-profile-belongs-to-organization.js
+++ b/api/src/prescription/target-profile/domain/usecases/check-target-profile-belongs-to-organization.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {import('../../infrastructure/repositories/target-profile-repository.js')} TargetProfileRepository
+ */
+
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+
+/**
+ * @param {object} params
+ * @param {number} params.targetProfileId
+ * @param {number} params.organizationId
+ * @param {TargetProfileRepository} params.targetProfileRepository
+ * @returns {Promise<Boolean>}
+ */
+export async function checkTargetProfileBelongsToOrganization({
+  targetProfileId,
+  organizationId,
+  targetProfileRepository,
+}) {
+  try {
+    const organizationIds = await targetProfileRepository.findOrganizationIds(targetProfileId);
+    return organizationIds.includes(organizationId);
+  } catch (error) {
+    logger.error(error, 'checkTargetProfileBelongsToOrganization');
+  }
+  return false;
+}

--- a/api/src/prescription/target-profile/domain/usecases/get-target-profile-overview.js
+++ b/api/src/prescription/target-profile/domain/usecases/get-target-profile-overview.js
@@ -1,0 +1,21 @@
+import { TargetProfileOverview } from '../models/TargetProfileOverview.js';
+
+/** @param {import('./index.js').Dependencies & {
+ *   locale: string
+ *   targetProfileId: number
+ * }}
+ */
+const getTargetProfileOverview = async function ({
+  locale,
+  targetProfileId,
+  targetProfileRepository,
+  learningContentRepository,
+}) {
+  const targetProfile = await targetProfileRepository.get(targetProfileId);
+
+  const { frameworks } = await learningContentRepository.findByTargetProfileId(targetProfileId, locale);
+
+  return new TargetProfileOverview({ ...targetProfile, frameworks });
+};
+
+export { getTargetProfileOverview };

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -10,18 +10,7 @@ import * as targetProfileForSpecifierRepository from '../../infrastructure/repos
 import * as targetProfileForUpdateRepository from '../../infrastructure/repositories/target-profile-for-update-repository.js';
 import * as targetProfileSummaryForAdminRepository from '../../infrastructure/repositories/target-profile-summary-for-admin-repository.js';
 
-/**
- * @typedef {import('../../../shared/domain/services/learning-content-conversion-service.js')} LearningContentConversionService
- * @typedef {import('../../../../../lib/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
- * @typedef {import('../../../../shared/infrastructure/repositories/organization-repository.js')} OrganizationRepository
- * @typedef {import('../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js')} OrganizationsToAttachToTargetProfileRepository
- * @typedef {import('../../infrastructure/repositories/target-profile-administration-repository.js')} TargetProfileAdministrationRepository
- * @typedef {import('../../infrastructure/repositories/target-profile-bond-repository.js')} TargetProfileBondRepository
- * @typedef {import('../../infrastructure/repositories/target-profile-for-specifier-repository.js')} TargetProfileForSpecifierRepository
- * @typedef {import('../../infrastructure/repositories/target-profile-for-update-repository.js')} TargetProfileForUpdateRepository
- * @typedef {import('../../../../../lib/infrastructure/repositories/target-profile-repository.js')} TargetProfileRepository
- * @typedef {import('../../infrastructure/repositories/target-profile-summary-for-admin-repository.js')} TargetProfileSummaryForAdminRepository
- */
+/** @typedef {typeof dependencies} Dependencies */
 
 const dependencies = {
   learningContentConversionService,
@@ -51,6 +40,7 @@ import { getLearningContentByTargetProfile } from './get-learning-content-by-tar
 import { getTargetProfile } from './get-target-profile.js';
 import { getTargetProfileContentAsJson } from './get-target-profile-content-as-json.js';
 import { getTargetProfileForAdmin } from './get-target-profile-for-admin.js';
+import { getTargetProfileOverview } from './get-target-profile-overview.js';
 import { markTargetProfileAsSimplifiedAccess } from './mark-target-profile-as-simplified-access.js';
 import { outdateTargetProfile } from './outdate-target-profile.js';
 import { updateTargetProfile } from './update-target-profile.js';
@@ -71,6 +61,7 @@ const usecasesWithoutInjectedDependencies = {
   getTargetProfileContentAsJson,
   getTargetProfileForAdmin,
   getTargetProfile,
+  getTargetProfileOverview,
   markTargetProfileAsSimplifiedAccess,
   outdateTargetProfile,
   updateTargetProfile,

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -28,6 +28,7 @@ const dependencies = {
 import { attachOrganizationsFromExistingTargetProfile } from './attach-organizations-from-existing-target-profile.js';
 import { attachOrganizationsToTargetProfile } from './attach-organizations-to-target-profile.js';
 import { attachTargetProfilesToOrganization } from './attach-target-profiles-to-organization.js';
+import { checkTargetProfileBelongsToOrganization } from './check-target-profile-belongs-to-organization.js';
 import { copyTargetProfile } from './copy-target-profile.js';
 import { createTargetProfile } from './create-target-profile.js';
 import { detachOrganizationsFromTargetProfile } from './detach-organizations-from-target-profile.js';
@@ -49,6 +50,7 @@ const usecasesWithoutInjectedDependencies = {
   attachOrganizationsFromExistingTargetProfile,
   attachOrganizationsToTargetProfile,
   attachTargetProfilesToOrganization,
+  checkTargetProfileBelongsToOrganization,
   copyTargetProfile,
   createTargetProfile,
   detachOrganizationsFromTargetProfile,

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-overview-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-overview-serializer.js
@@ -1,0 +1,46 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (targetProfiles) {
+  return new Serializer('target-profile-overview', {
+    ref: 'id',
+    attributes: ['name', 'isSimplifiedAccess', 'description', 'imageUrl', 'category', 'level', 'badges', 'frameworks'],
+    badges: {
+      ref: 'id',
+      included: true,
+      attributes: ['altMessage', 'imageUrl', 'message', 'title', 'key', 'isCertifiable', 'isAlwaysVisible', 'criteria'],
+    },
+    frameworks: {
+      ref: 'id',
+      included: true,
+      attributes: ['name', 'areas'],
+
+      areas: {
+        include: true,
+        ref: 'id',
+        attributes: ['code', 'title', 'color', 'competences'],
+
+        competences: {
+          include: true,
+          ref: 'id',
+          attributes: ['name', 'index', 'thematics'],
+
+          thematics: {
+            include: true,
+            ref: 'id',
+            attributes: ['name', 'index', 'tubes'],
+
+            tubes: {
+              include: true,
+              ref: 'id',
+              attributes: ['name', 'practicalTitle', 'practicalDescription', 'isMobileCompliant', 'isTabletCompliant'],
+            },
+          },
+        },
+      },
+    },
+  }).serialize(targetProfiles);
+};
+
+export { serialize };

--- a/api/src/shared/domain/models/Competence.js
+++ b/api/src/shared/domain/models/Competence.js
@@ -1,5 +1,16 @@
 class Competence {
-  constructor({ id, name, index, description, origin, areaId, skillIds = [], thematicIds = [], tubes = [] }) {
+  constructor({
+    id,
+    name,
+    index,
+    description,
+    origin,
+    areaId,
+    skillIds = [],
+    thematicIds = [],
+    thematics = [],
+    tubes = [],
+  }) {
     this.id = id;
     this.name = name;
     this.index = index;
@@ -9,6 +20,7 @@ class Competence {
     this.level = -1;
     this.skillIds = skillIds;
     this.thematicIds = thematicIds;
+    this.thematics = thematics;
     this.tubes = tubes;
   }
 

--- a/api/src/shared/domain/models/TargetProfile.js
+++ b/api/src/shared/domain/models/TargetProfile.js
@@ -33,15 +33,10 @@ class TargetProfile {
     this.stages = stages;
     this.badges = badges;
     this.description = description;
-    this.organizationsAttached = [];
   }
 
   get hasBadges() {
     return !!this.badges && this.badges.length > 0;
-  }
-
-  get organizations() {
-    return this.organizationsAttached;
   }
 }
 

--- a/api/src/shared/domain/models/TargetProfile.js
+++ b/api/src/shared/domain/models/TargetProfile.js
@@ -22,12 +22,14 @@ class TargetProfile {
     stages,
     badges,
     description,
+    estimatedTime,
   } = {}) {
     this.id = id;
     this.name = name;
     this.internalName = internalName;
     this.imageUrl = imageUrl;
     this.category = category;
+    this.estimatedTime = estimatedTime;
     this.isSimplifiedAccess = isSimplifiedAccess;
     this.outdated = outdated;
     this.stages = stages;

--- a/api/src/shared/domain/models/Thematic.js
+++ b/api/src/shared/domain/models/Thematic.js
@@ -1,10 +1,11 @@
 class Thematic {
-  constructor({ id, name, index, competenceId, tubeIds = [] } = {}) {
+  constructor({ id, name, index, competenceId, tubeIds = [], tubes = [] } = {}) {
     this.id = id;
     this.name = name;
     this.index = index;
     this.competenceId = competenceId;
     this.tubeIds = tubeIds;
+    this.tubes = tubes;
   }
 }
 

--- a/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
@@ -5,10 +5,189 @@ import { buildLearningContent as learningContentBuilder } from '../../../../tool
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Acceptance | Route | target-profile', function () {
-  let server;
+  let server, learningContent;
 
   beforeEach(async function () {
     server = await createServer();
+    learningContent = {
+      frameworks: [
+        {
+          id: 'frameworkPix',
+          name: 'Pix',
+        },
+        {
+          id: 'frameworkFrance',
+          name: 'France',
+        },
+        {
+          id: 'frameworkCuisine',
+          name: 'Cuisine',
+        },
+      ],
+      areas: [
+        {
+          id: 'areaPix1',
+          code: '1',
+          title_i18n: {
+            fr: 'areaPix1 title fr',
+          },
+          color: 'areaPix1 color',
+          competenceIds: ['competencePix1_1'],
+          frameworkId: 'frameworkPix',
+        },
+        {
+          id: 'areaFrance1',
+          code: '1',
+          title_i18n: {
+            fr: 'areaFrance1 title fr',
+          },
+          color: 'areaFrance1 color',
+          competenceIds: ['competenceFrance1_1'],
+          frameworkId: 'frameworkFrance',
+        },
+        {
+          id: 'areaCuisine1',
+          code: '1',
+          title_i18n: {
+            fr: 'areaCuisine1 title fr',
+          },
+          color: 'areaCuisine1 color',
+          competenceIds: ['competenceCuisine1_1'],
+          frameworkId: 'frameworkCuisine',
+        },
+      ],
+      competences: [
+        {
+          id: 'competencePix1_1',
+          name_i18n: {
+            fr: 'competencePix1_1 name fr',
+            en: 'competencePix1_1 name en',
+          },
+          areaId: 'areaPix1',
+          index: '0',
+          origin: 'Pix',
+          thematicIds: ['thematicPix1_1_1'],
+        },
+        {
+          id: 'competenceFrance1_1',
+          name_i18n: {
+            fr: 'competenceFrance1_1 name fr',
+            en: 'competenceFrance1_1 name en',
+          },
+          areaId: 'areaFrance1',
+          index: '0',
+          origin: 'France',
+          thematicIds: ['thematicFrance1_1_1'],
+        },
+        {
+          id: 'competenceCuisine1_1',
+          name_i18n: {
+            fr: 'competenceCuisine1_1 name fr',
+            en: 'competenceCuisine1_1 name en',
+          },
+          areaId: 'areaCuisine1',
+          index: '0',
+          origin: 'Cuisine',
+          thematicIds: ['thematicCuisine1_1_1'],
+        },
+      ],
+      thematics: [
+        {
+          id: 'thematicPix1_1_1',
+          name_i18n: {
+            fr: 'thematicPix1_1_1 name fr',
+          },
+          index: 0,
+          tubeIds: ['tubePix1_1_1_1'],
+          competenceId: 'competencePix1_1',
+        },
+        {
+          id: 'thematicFrance1_1_1',
+          name_i18n: {
+            fr: 'thematicFrance1_1_1 name fr',
+          },
+          index: 0,
+          tubeIds: ['tubeFrance1_1_1_1'],
+          competenceId: 'competenceFrance1_1',
+        },
+        {
+          id: 'thematicCuisine1_1_1',
+          name_i18n: {
+            fr: 'thematicCuisine1_1_1 name fr',
+          },
+          index: 0,
+          tubeIds: ['tubeCuisine1_1_1_1'],
+          competenceId: 'competenceCuisine1_1',
+        },
+      ],
+      tubes: [
+        {
+          id: 'tubePix1_1_1_1',
+          name: '@tubePix1_1_1_1',
+          practicalTitle_i18n: {
+            fr: 'tubePix1_1_1_1 practicalTitle fr',
+          },
+          practicalDescription_i18n: {
+            fr: 'tubePix1_1_1_1 practicalDescription fr',
+          },
+          competenceId: 'competencePix1_1',
+          isMobileCompliant: true,
+          isTabletCompliant: true,
+          skillIds: ['skillPix1_1_1_1_1'],
+          thematicId: 'thematicPix1_1_1',
+        },
+        {
+          id: 'tubeFrance1_1_1_1',
+          name: '@tubeFrance1_1_1_1',
+          practicalTitle_i18n: {
+            fr: 'tubeFrance1_1_1_1 practicalTitle fr',
+          },
+          practicalDescription_i18n: {
+            fr: 'tubeFrance1_1_1_1 practicalDescription fr',
+          },
+          competenceId: 'competenceFrance1_1',
+          isMobileCompliant: true,
+          isTabletCompliant: false,
+          skillIds: ['skillFrance1_1_1_1_1'],
+          thematicId: 'thematicFrance1_1_1',
+        },
+        {
+          id: 'tubeCuisine1_1_1_1',
+          name: '@tubeCuisine1_1_1_1',
+          practicalTitle_i18n: {
+            fr: 'tubeCuisine1_1_1_1 practicalTitle fr',
+          },
+          practicalDescription_i18n: {
+            fr: 'tubeCuisine1_1_1_1 practicalDescription fr',
+          },
+          competenceId: 'competenceCuisine1_1',
+          isMobileCompliant: false,
+          isTabletCompliant: true,
+          skillIds: ['skillCuisine1_1_1_1_1'],
+          thematicId: 'thematicCuisine1_1_1',
+        },
+      ],
+      skills: [
+        {
+          id: 'skillPix1_1_1_1_1',
+          status: 'actif',
+          tubeId: 'tubePix1_1_1_1',
+          level: 1,
+        },
+        {
+          id: 'skillFrance1_1_1_1_1',
+          status: 'actif',
+          tubeId: 'tubeFrance1_1_1_1',
+          level: 1,
+        },
+        {
+          id: 'skillCuisine1_1_1_1_1',
+          status: 'actif',
+          tubeId: 'tubeCuisine1_1_1_1',
+          level: 1,
+        },
+      ],
+    };
   });
 
   describe('GET /api/organizations/{organizationId}/target-profiles', function () {
@@ -17,7 +196,7 @@ describe('Acceptance | Route | target-profile', function () {
       let linkedOrganization;
 
       beforeEach(async function () {
-        const learningContent = [
+        const learningContentAreas = [
           {
             id: 'recArea0',
             competences: [
@@ -29,7 +208,7 @@ describe('Acceptance | Route | target-profile', function () {
             ],
           },
         ];
-        const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+        const learningContentObjects = learningContentBuilder.fromAreas(learningContentAreas);
         databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         user = databaseBuilder.factory.buildUser({});
@@ -78,186 +257,6 @@ describe('Acceptance | Route | target-profile', function () {
     let userId, organizationId;
 
     beforeEach(async function () {
-      const learningContent = {
-        frameworks: [
-          {
-            id: 'frameworkPix',
-            name: 'Pix',
-          },
-          {
-            id: 'frameworkFrance',
-            name: 'France',
-          },
-          {
-            id: 'frameworkCuisine',
-            name: 'Cuisine',
-          },
-        ],
-        areas: [
-          {
-            id: 'areaPix1',
-            code: '1',
-            title_i18n: {
-              fr: 'areaPix1 title fr',
-            },
-            color: 'areaPix1 color',
-            competenceIds: ['competencePix1_1'],
-            frameworkId: 'frameworkPix',
-          },
-          {
-            id: 'areaFrance1',
-            code: '1',
-            title_i18n: {
-              fr: 'areaFrance1 title fr',
-            },
-            color: 'areaFrance1 color',
-            competenceIds: ['competenceFrance1_1'],
-            frameworkId: 'frameworkFrance',
-          },
-          {
-            id: 'areaCuisine1',
-            code: '1',
-            title_i18n: {
-              fr: 'areaCuisine1 title fr',
-            },
-            color: 'areaCuisine1 color',
-            competenceIds: ['competenceCuisine1_1'],
-            frameworkId: 'frameworkCuisine',
-          },
-        ],
-        competences: [
-          {
-            id: 'competencePix1_1',
-            name_i18n: {
-              fr: 'competencePix1_1 name fr',
-              en: 'competencePix1_1 name en',
-            },
-            areaId: 'areaPix1',
-            index: '0',
-            origin: 'Pix',
-            thematicIds: ['thematicPix1_1_1'],
-          },
-          {
-            id: 'competenceFrance1_1',
-            name_i18n: {
-              fr: 'competenceFrance1_1 name fr',
-              en: 'competenceFrance1_1 name en',
-            },
-            areaId: 'areaFrance1',
-            index: '0',
-            origin: 'France',
-            thematicIds: ['thematicFrance1_1_1'],
-          },
-          {
-            id: 'competenceCuisine1_1',
-            name_i18n: {
-              fr: 'competenceCuisine1_1 name fr',
-              en: 'competenceCuisine1_1 name en',
-            },
-            areaId: 'areaCuisine1',
-            index: '0',
-            origin: 'Cuisine',
-            thematicIds: ['thematicCuisine1_1_1'],
-          },
-        ],
-        thematics: [
-          {
-            id: 'thematicPix1_1_1',
-            name_i18n: {
-              fr: 'thematicPix1_1_1 name fr',
-            },
-            index: 0,
-            tubeIds: ['tubePix1_1_1_1'],
-            competenceId: 'competencePix1_1',
-          },
-          {
-            id: 'thematicFrance1_1_1',
-            name_i18n: {
-              fr: 'thematicFrance1_1_1 name fr',
-            },
-            index: 0,
-            tubeIds: ['tubeFrance1_1_1_1'],
-            competenceId: 'competenceFrance1_1',
-          },
-          {
-            id: 'thematicCuisine1_1_1',
-            name_i18n: {
-              fr: 'thematicCuisine1_1_1 name fr',
-            },
-            index: 0,
-            tubeIds: ['tubeCuisine1_1_1_1'],
-            competenceId: 'competenceCuisine1_1',
-          },
-        ],
-        tubes: [
-          {
-            id: 'tubePix1_1_1_1',
-            name: '@tubePix1_1_1_1',
-            practicalTitle_i18n: {
-              fr: 'tubePix1_1_1_1 practicalTitle fr',
-            },
-            practicalDescription_i18n: {
-              fr: 'tubePix1_1_1_1 practicalDescription fr',
-            },
-            competenceId: 'competencePix1_1',
-            isMobileCompliant: true,
-            isTabletCompliant: true,
-            skillIds: ['skillPix1_1_1_1_1'],
-            thematicId: 'thematicPix1_1_1',
-          },
-          {
-            id: 'tubeFrance1_1_1_1',
-            name: '@tubeFrance1_1_1_1',
-            practicalTitle_i18n: {
-              fr: 'tubeFrance1_1_1_1 practicalTitle fr',
-            },
-            practicalDescription_i18n: {
-              fr: 'tubeFrance1_1_1_1 practicalDescription fr',
-            },
-            competenceId: 'competenceFrance1_1',
-            isMobileCompliant: true,
-            isTabletCompliant: false,
-            skillIds: ['skillFrance1_1_1_1_1'],
-            thematicId: 'thematicFrance1_1_1',
-          },
-          {
-            id: 'tubeCuisine1_1_1_1',
-            name: '@tubeCuisine1_1_1_1',
-            practicalTitle_i18n: {
-              fr: 'tubeCuisine1_1_1_1 practicalTitle fr',
-            },
-            practicalDescription_i18n: {
-              fr: 'tubeCuisine1_1_1_1 practicalDescription fr',
-            },
-            competenceId: 'competenceCuisine1_1',
-            isMobileCompliant: false,
-            isTabletCompliant: true,
-            skillIds: ['skillCuisine1_1_1_1_1'],
-            thematicId: 'thematicCuisine1_1_1',
-          },
-        ],
-        skills: [
-          {
-            id: 'skillPix1_1_1_1_1',
-            status: 'actif',
-            tubeId: 'tubePix1_1_1_1',
-            level: 1,
-          },
-          {
-            id: 'skillFrance1_1_1_1_1',
-            status: 'actif',
-            tubeId: 'tubeFrance1_1_1_1',
-            level: 1,
-          },
-          {
-            id: 'skillCuisine1_1_1_1_1',
-            status: 'actif',
-            tubeId: 'tubeCuisine1_1_1_1',
-            level: 1,
-          },
-        ],
-      };
-
       organizationId = databaseBuilder.factory.buildOrganization().id;
       userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildMembership({ userId, organizationId });
@@ -291,6 +290,43 @@ describe('Acceptance | Route | target-profile', function () {
       // when
       const response = await server.inject(options);
 
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('GET /api/organizations/{organizationId}/target-profiles/{targetProfileId}', function () {
+    let userId, organizationId, targetProfilePixId;
+
+    beforeEach(async function () {
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ userId, organizationId });
+
+      targetProfilePixId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfilePixId, organizationId });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: targetProfilePixId,
+        tubeId: 'tubePix1_1_1_1',
+      });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: targetProfilePixId,
+        tubeId: 'tubeFrance1_1_1_1',
+      });
+
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
+    });
+
+    it('should return response code 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/target-profiles/${targetProfilePixId}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
       expect(response.statusCode).to.equal(200);
     });
   });

--- a/api/tests/prescription/target-profile/integration/application/pre-handlers_test.js
+++ b/api/tests/prescription/target-profile/integration/application/pre-handlers_test.js
@@ -1,0 +1,77 @@
+import { targetProfilePreHandlers } from '../../../../../src/prescription/target-profile/application/pre-handlers.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
+
+describe('#checkTargetProfileBelongsToOrganization', function () {
+  let httpServerTest;
+  let organizationId, targetProfileId;
+
+  beforeEach(async function () {
+    targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
+
+    await databaseBuilder.commit();
+    const moduleUnderTest = {
+      name: 'security-test',
+      register: async function (server) {
+        server.route([
+          {
+            method: 'GET',
+            path: '/organizations/{organizationId}/target-profiles/{targetProfileId}',
+            handler: (r, h) => h.response().code(200),
+            config: {
+              pre: [
+                {
+                  method: targetProfilePreHandlers.checkTargetProfileBelongsToOrganization,
+                },
+              ],
+            },
+          },
+        ]);
+      },
+    };
+    httpServerTest = new HttpTestServer();
+    await httpServerTest.register(moduleUnderTest);
+  });
+
+  it('returns 403 when target profile is not in the organization', async function () {
+    const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+    await databaseBuilder.commit();
+
+    const options = {
+      method: 'GET',
+      url: `/organizations/${otherOrganizationId}/target-profiles/${targetProfileId}`,
+    };
+
+    const response = await httpServerTest.requestObject(options);
+
+    expect(response.statusCode).to.equal(403);
+  });
+
+  it('returns 403 when target profile does not exist', async function () {
+    const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+    await databaseBuilder.commit();
+
+    const options = {
+      method: 'GET',
+      url: `/organizations/${otherOrganizationId}/target-profiles/123`,
+    };
+
+    const response = await httpServerTest.requestObject(options);
+
+    expect(response.statusCode).to.equal(403);
+  });
+
+  it('returns 200 when the targetProfile belongs to the organization', async function () {
+    const options = {
+      method: 'GET',
+      url: `/organizations/${organizationId}/target-profiles/${targetProfileId}`,
+    };
+
+    const response = await httpServerTest.requestObject(options);
+
+    expect(response.statusCode).to.equal(200);
+  });
+});

--- a/api/tests/prescription/target-profile/integration/domain/usecases/check-target-profile-belongs-to-organization-test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/check-target-profile-belongs-to-organization-test.js
@@ -1,0 +1,56 @@
+import { usecases } from '../../../../../../src/prescription/target-profile/domain/usecases/index.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | UseCase | check-target-profile-belongs-to-organization', function () {
+  it('should return true when the target profile belongs to the organization', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization();
+    const targetProfile = databaseBuilder.factory.buildTargetProfile();
+    databaseBuilder.factory.buildTargetProfileShare({
+      organizationId: organization.id,
+      targetProfileId: targetProfile.id,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.checkTargetProfileBelongsToOrganization({
+      targetProfileId: targetProfile.id,
+      organizationId: organization.id,
+    });
+
+    // then
+    expect(result).to.be.true;
+  });
+
+  it('should return false when the target profile does not belong to the organization', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization();
+    const targetProfile = databaseBuilder.factory.buildTargetProfile();
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.checkTargetProfileBelongsToOrganization({
+      targetProfileId: targetProfile.id,
+      organizationId: organization.id,
+    });
+
+    // then
+    expect(result).to.be.false;
+  });
+
+  it('should return false when the target profile does exists', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization();
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.checkTargetProfileBelongsToOrganization({
+      targetProfileId: 123,
+      organizationId: organization.id,
+    });
+
+    // then
+    expect(result).to.be.false;
+  });
+});

--- a/api/tests/prescription/target-profile/integration/domain/usecases/get-target-profile-overview_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/get-target-profile-overview_test.js
@@ -1,0 +1,200 @@
+import { usecases } from '../../../../../../src/prescription/target-profile/domain/usecases/index.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Unit | Prescription | Domain | Models | TargetProfileOverview', function () {
+  it('should return a targetProfilOverview', async function () {
+    //given
+    const framework = {
+      frameworks: [
+        {
+          id: 'fmk1',
+        },
+      ],
+      areas: [
+        {
+          id: 'recAreaA',
+          title_i18n: {
+            fr: 'titleFRA',
+            en: 'titleENA',
+          },
+          color: 'colorA',
+          code: 'codeA',
+          frameworkId: 'fmk1',
+          competenceIds: ['recCompA', 'recCompB'],
+        },
+      ],
+      competences: [
+        {
+          id: 'recCompA',
+          name_i18n: {
+            fr: 'nameFRA',
+            en: 'nameENA',
+          },
+          index: '1',
+          areaId: 'recAreaA',
+          origin: 'Pix',
+          thematicIds: ['recThemA', 'recThemB'],
+        },
+      ],
+      thematics: [
+        {
+          id: 'recThemA',
+          name_i18n: {
+            fr: 'nameFRA',
+            en: 'nameENA',
+          },
+          index: '1',
+          competenceId: 'recCompA',
+          tubeIds: ['recTube1'],
+        },
+      ],
+      tubes: [
+        {
+          id: 'recTube1',
+          competenceId: 'recCompA',
+          thematicId: 'recThemA',
+          name: 'tubeName1',
+          practicalTitle_i18n: {
+            fr: 'practicalTitleFR1',
+            en: 'practicalTitleEN1',
+          },
+          isMobileCompliant: false,
+          isTabletCompliant: true,
+          skillIds: ['recSkillTube1'],
+        },
+      ],
+      skills: [
+        {
+          id: 'recSkillTube1',
+          tubeId: 'recTube1',
+          status: 'actif',
+          level: 1,
+        },
+      ],
+    };
+    databaseBuilder.factory.learningContent.build(framework);
+
+    const targetProfile = databaseBuilder.factory.buildTargetProfile({
+      description: 'description',
+    });
+    databaseBuilder.factory.buildTargetProfileTube({
+      targetProfileId: targetProfile.id,
+      tubeId: 'recTube1',
+    });
+
+    await databaseBuilder.commit();
+
+    //when
+    const result = await usecases.getTargetProfileOverview({ targetProfileId: targetProfile.id, locale: 'fr-FR' });
+
+    //then
+    expect(result).to.deep.equal({
+      id: targetProfile.id,
+      imageUrl: 'https://images.pix.fr/profil-cible/Illu_GEN.svg',
+      internalName: 'Remplir un tableur',
+      isSimplifiedAccess: false,
+      description: 'description',
+      name: 'Remplir un tableur',
+      outdated: false,
+      category: targetProfile.category,
+      badges: [],
+      frameworks: [
+        {
+          id: 'fmk1',
+          name: 'Pix',
+          areas: [
+            {
+              id: 'recAreaA',
+              name: 'name Domaine A',
+              title: 'titleFRA',
+              code: 'codeA',
+              color: 'colorA',
+              frameworkId: 'fmk1',
+              competences: [
+                {
+                  id: 'recCompA',
+                  name: 'nameFRA',
+                  description: 'description FR Compétence A',
+                  index: '1',
+                  level: -1,
+                  origin: 'Pix',
+                  areaId: 'recAreaA',
+                  skillIds: [],
+                  thematicIds: ['recThemA', 'recThemB'],
+                  tubes: [
+                    {
+                      id: 'recTube1',
+                      isMobileCompliant: false,
+                      isTabletCompliant: true,
+                      name: 'tubeName1',
+                      practicalDescription: 'practicalDescription FR Tube A',
+                      practicalTitle: 'practicalTitleFR1',
+                      competenceId: 'recCompA',
+                      skillIds: ['recSkillTube1'],
+                      skills: [
+                        {
+                          competenceId: null,
+                          difficulty: 1,
+                          hint: 'Un indice',
+                          hintStatus: 'hintStatus Acquis A',
+                          id: 'recSkillTube1',
+                          learningMoreTutorialIds: [],
+                          name: 'name Acquis A',
+                          pixValue: 2.9,
+                          status: 'actif',
+                          tubeId: 'recTube1',
+                          tutorialIds: [],
+                          version: 5,
+                        },
+                      ],
+                      thematicId: 'recThemA',
+                    },
+                  ],
+                  thematics: [
+                    {
+                      id: 'recThemA',
+                      index: 1,
+                      name: 'nameFRA',
+                      tubeIds: ['recTube1'],
+                      competenceId: 'recCompA',
+                      tubes: [
+                        {
+                          id: 'recTube1',
+                          isMobileCompliant: false,
+                          isTabletCompliant: true,
+                          name: 'tubeName1',
+                          practicalDescription: 'practicalDescription FR Tube A',
+                          practicalTitle: 'practicalTitleFR1',
+                          competenceId: 'recCompA',
+                          skillIds: ['recSkillTube1'],
+                          skills: [
+                            {
+                              competenceId: null,
+                              difficulty: 1,
+                              hint: 'Un indice',
+                              hintStatus: 'hintStatus Acquis A',
+                              id: 'recSkillTube1',
+                              learningMoreTutorialIds: [],
+                              name: 'name Acquis A',
+                              pixValue: 2.9,
+                              status: 'actif',
+                              tubeId: 'recTube1',
+                              tutorialIds: [],
+                              version: 5,
+                            },
+                          ],
+                          thematicId: 'recThemA',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/api/tests/prescription/target-profile/integration/domain/usecases/get-target-profile-overview_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/get-target-profile-overview_test.js
@@ -2,7 +2,7 @@ import { usecases } from '../../../../../../src/prescription/target-profile/doma
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 
-describe('Unit | Prescription | Domain | Models | TargetProfileOverview', function () {
+describe('Integration | Prescription | Domain | Models | TargetProfileOverview', function () {
   it('should return a targetProfilOverview', async function () {
     //given
     const framework = {

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import sinon from 'sinon';
 
+import { Badge } from '../../../../../../src/evaluation/domain/models/Badge.js';
 import * as targetProfileRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { TargetProfile } from '../../../../../../src/shared/domain/models/TargetProfile.js';
@@ -28,6 +29,28 @@ describe('Integration | Repository | Target-profile', function () {
       // then
       expect(foundTargetProfile).to.be.an.instanceOf(TargetProfile);
       expect(foundTargetProfile.id).to.be.equal(targetProfile.id);
+    });
+
+    it('should return targetProfile badges', async function () {
+      //given
+      const badge1 = databaseBuilder.factory.buildBadge({
+        targetProfileId: targetProfile.id,
+      });
+      const badge2 = databaseBuilder.factory.buildBadge({
+        targetProfileId: targetProfile.id,
+      });
+      databaseBuilder.factory.buildBadge();
+      await databaseBuilder.commit();
+
+      //when
+      const result = await targetProfileRepository.get(targetProfile.id);
+
+      //then
+      expect(result.badges.length).to.be.equal(2);
+      expect(result.badges[0]).to.be.an.instanceOf(Badge);
+      expect(result.badges[1]).to.be.an.instanceOf(Badge);
+      expect(result.badges[0].id).to.be.equal(badge1.id);
+      expect(result.badges[1].id).to.be.equal(badge2.id);
     });
 
     context('when the targetProfile does not exist', function () {

--- a/api/tests/prescription/target-profile/unit/application/target-profiles-route_test.js
+++ b/api/tests/prescription/target-profile/unit/application/target-profiles-route_test.js
@@ -76,6 +76,12 @@ describe('Unit | Target Profiles | Application | Routes', function () {
     const url = '/api/organizations/123/frameworks';
     const payload = null;
 
+    beforeEach(function () {
+      sinon
+        .stub(targetProfileController, 'findLearningContentsByOrganizationId')
+        .callsFake((request, h) => h.response('ok'));
+    });
+
     it('should called controller findLearningContentsByOrganizationId', async function () {
       // given
       securityPreHandlers.checkUserBelongsToOrganization.callsFake(() => (request, h) => h.response(true));

--- a/api/tests/prescription/target-profile/unit/application/target-profiles-route_test.js
+++ b/api/tests/prescription/target-profile/unit/application/target-profiles-route_test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import { targetProfilePreHandlers } from '../../../../../src/prescription/target-profile/application/pre-handlers.js';
 import { targetProfileController } from '../../../../../src/prescription/target-profile/application/target-profile-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/target-profile/application/target-profile-route.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
@@ -9,9 +10,65 @@ import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 describe('Unit | Target Profiles | Application | Routes', function () {
   beforeEach(function () {
     sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization');
-    sinon
-      .stub(targetProfileController, 'findLearningContentsByOrganizationId')
-      .callsFake((request, h) => h.response('ok'));
+  });
+
+  describe('GET /api/organizations/{organizationId}/target-profiles/{targetProfileId}', function () {
+    const method = 'GET';
+    const url = '/api/organizations/123/target-profiles/456';
+    const payload = null;
+
+    beforeEach(function () {
+      sinon.stub(targetProfileController, 'getTargetProfileOverview').callsFake((request, h) => h.response('ok'));
+    });
+
+    it('should call getTargetProfileOverview in controller if prehandlers are ok', async function () {
+      // given
+      securityPreHandlers.checkUserBelongsToOrganization.callsFake(() => (request, h) => h.response(true));
+      sinon
+        .stub(targetProfilePreHandlers, 'checkTargetProfileBelongsToOrganization')
+        .callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      //  when
+      await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(targetProfileController.getTargetProfileOverview.calledOnce).to.be.true;
+    });
+
+    context('when user does not belong to organization', function () {
+      it('should return 403', async function () {
+        // given
+        securityPreHandlers.checkUserBelongsToOrganization.callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        //  when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).equal(403);
+      });
+    });
+
+    context('when targetProfile does not belong to organization', function () {
+      it('should return 403', async function () {
+        // given
+        securityPreHandlers.checkUserBelongsToOrganization.callsFake(() => (request, h) => h.response(true));
+        sinon
+          .stub(targetProfilePreHandlers, 'checkTargetProfileBelongsToOrganization')
+          .callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        //  when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).equal(403);
+      });
+    });
   });
 
   describe('GET /api/organizations/{organizationId}/frameworks', function () {

--- a/api/tests/prescription/target-profile/unit/domain/models/TargetProfileOverview_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/models/TargetProfileOverview_test.js
@@ -1,0 +1,104 @@
+import { TargetProfileOverview } from '../../../../../../src/prescription/target-profile/domain/models/TargetProfileOverview.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Prescription | Domain | Models | TargetProfileOverview', function () {
+  let framework;
+
+  beforeEach(function () {
+    framework = domainBuilder.buildFramework({
+      id: 'framework1',
+      areas: [
+        domainBuilder.buildArea({
+          id: 'area1',
+          competences: [
+            domainBuilder.buildCompetence({
+              id: 'comp1',
+              tubes: [
+                domainBuilder.buildTube({
+                  id: 'tube1.1',
+                  skills: [domainBuilder.buildSkill({ difficulty: 2 }), domainBuilder.buildSkill({ difficulty: 1 })],
+                }),
+              ],
+            }),
+            domainBuilder.buildCompetence({
+              id: 'comp2',
+              tubes: [
+                domainBuilder.buildTube({
+                  id: 'tube2.1',
+                  skills: [domainBuilder.buildSkill({ difficulty: 2 }), domainBuilder.buildSkill({ difficulty: 4 })],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+  });
+
+  describe('#constructor', function () {
+    it('initializes targetProfile overview properties', function () {
+      // given & when
+      const badge = domainBuilder.buildBadge();
+      const targetProfile = new TargetProfileOverview({
+        id: 'id',
+        badges: [badge],
+        category: 'category',
+        description: 'description',
+        imageUrl: 'imageUrl',
+        internalName: 'internalName',
+        isSimplifiedAccess: 'isSimplifiedAccess',
+        name: 'name',
+        outdated: 'outdated',
+        frameworks: [framework],
+      });
+
+      // then
+      expect(targetProfile).deep.equal({
+        id: 'id',
+        badges: [badge],
+        category: 'category',
+        description: 'description',
+        imageUrl: 'imageUrl',
+        internalName: 'internalName',
+        isSimplifiedAccess: 'isSimplifiedAccess',
+        name: 'name',
+        outdated: 'outdated',
+        frameworks: [framework],
+      });
+    });
+  });
+
+  describe('#level', function () {
+    it('returns 0 if no tubes', function () {
+      const targetProfile = new TargetProfileOverview({
+        id: 'id',
+        category: 'category',
+        description: 'description',
+        estimatedTime: 4,
+        imageUrl: 'imageUrl',
+        internalName: 'internalName',
+        isSimplifiedAccess: 'isSimplifiedAccess',
+        name: 'name',
+        outdated: 'outdated',
+      });
+      expect(targetProfile.level).equal(0);
+    });
+
+    it('returns average tubes level', function () {
+      const targetProfile = new TargetProfileOverview({
+        id: 'id',
+        category: 'category',
+        description: 'description',
+        estimatedTime: 4,
+        imageUrl: 'imageUrl',
+        internalName: 'internalName',
+        isSimplifiedAccess: 'isSimplifiedAccess',
+        name: 'name',
+        outdated: 'outdated',
+        frameworks: [framework],
+      });
+      expect(targetProfile.level).equal(3);
+    });
+  });
+});

--- a/api/tests/prescription/target-profile/unit/domain/models/TargetProfile_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/models/TargetProfile_test.js
@@ -1,8 +1,7 @@
 import { TargetProfile } from '../../../../../../src/prescription/target-profile/domain/models/TargetProfile.js';
 import { expect } from '../../../../../test-helper.js';
-import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
-describe('Unit | Domain | Models | TargetProfile', function () {
+describe('Unit | Prescription | Domain | Models | TargetProfile', function () {
   describe('#detach', function () {
     it('should detach organizations', function () {
       const targetProfile = new TargetProfile({ id: 123 });
@@ -18,25 +17,6 @@ describe('Unit | Domain | Models | TargetProfile', function () {
       targetProfile.detach([3, 3]);
 
       expect(targetProfile.organizationIdsToDetach).deep.equal([3]);
-    });
-  });
-
-  describe('#hasBadges', function () {
-    it('should return true when target profile has badges', function () {
-      // given
-      const badge = domainBuilder.buildBadge();
-      const targetProfile = domainBuilder.buildTargetProfile({ badges: [badge] });
-
-      // then
-      expect(targetProfile.hasBadges).to.be.true;
-    });
-
-    it("should return false when target profile doesn't have badges", function () {
-      // given
-      const targetProfile = domainBuilder.buildTargetProfile();
-
-      // then
-      expect(targetProfile.hasBadges).to.be.false;
     });
   });
 });

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-overview-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-overview-serializer_test.js
@@ -1,0 +1,245 @@
+import { TargetProfileOverview } from '../../../../../../../src/prescription/target-profile/domain/models/TargetProfileOverview.js';
+import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-overview-serializer.js';
+import { expect } from '../../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
+import { buildThematic } from '../../../../../../tooling/domain-builder/factory/build-thematic.js';
+
+describe('Unit | Serializer | JSONAPI | targetProfileOverview', function () {
+  describe('#serialize', function () {
+    let framework;
+    beforeEach(function () {
+      const tubesComp1 = [
+        domainBuilder.buildTube({
+          id: 'tube1.1',
+          skills: [domainBuilder.buildSkill({ difficulty: 2 }), domainBuilder.buildSkill({ difficulty: 1 })],
+        }),
+      ];
+      const tubesComp2 = [
+        domainBuilder.buildTube({
+          id: 'tube2.1',
+          skills: [domainBuilder.buildSkill({ difficulty: 4 }), domainBuilder.buildSkill({ difficulty: 1 })],
+        }),
+      ];
+      framework = domainBuilder.buildFramework({
+        id: 'framework1',
+        name: 'pix',
+        areas: [
+          domainBuilder.buildArea({
+            id: 'area1',
+            competences: [
+              domainBuilder.buildCompetence({
+                id: 'comp1',
+                thematics: [
+                  buildThematic({
+                    id: 'thematic1',
+                    name: 'Ma thématique 1',
+                    tubes: tubesComp1,
+                  }),
+                ],
+                tubes: tubesComp1,
+              }),
+              domainBuilder.buildCompetence({
+                id: 'comp2',
+                thematics: [
+                  buildThematic({
+                    id: 'thematic2',
+                    name: 'Ma thématique 2',
+                    tubes: tubesComp2,
+                  }),
+                ],
+                tubes: tubesComp2,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+
+    it('should serialize a target profile overview to JSONAPI', function () {
+      // given
+      const badge = domainBuilder.buildBadge();
+      const targetProfile = domainBuilder.buildTargetProfile({
+        id: 1,
+        name: 'name',
+        imageUrl: 'imageUrl',
+        category: 'category',
+        isSimplifiedAccess: true,
+        description: 'description',
+        badges: [badge],
+      });
+
+      // when
+      const serializedTargetProfile = serializer.serialize(
+        new TargetProfileOverview({ ...targetProfile, frameworks: [framework] }),
+      );
+
+      //then
+      expect(serializedTargetProfile).deep.equal({
+        data: {
+          id: '1',
+          type: 'target-profile-overviews',
+          attributes: {
+            description: 'description',
+            name: 'name',
+            'image-url': 'imageUrl',
+            category: 'category',
+            'is-simplified-access': true,
+            level: 3,
+          },
+          relationships: {
+            badges: {
+              data: [
+                {
+                  id: '1',
+                  type: 'badges',
+                },
+              ],
+            },
+            frameworks: {
+              data: [{ id: 'framework1', type: 'frameworks' }],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              'alt-message': 'altMessage',
+              'image-url': '/img/banana',
+              'is-always-visible': false,
+              'is-certifiable': false,
+              key: 'key',
+              message: 'message',
+              title: 'title',
+            },
+            id: '1',
+            type: 'badges',
+          },
+          {
+            attributes: {
+              name: '@tubeName',
+              'practical-title': 'titre pratique',
+              'practical-description': 'description pratique',
+              'is-mobile-compliant': false,
+              'is-tablet-compliant': false,
+            },
+            id: 'tube1.1',
+            type: 'tubes',
+          },
+          {
+            attributes: {
+              name: 'Ma thématique 1',
+              index: 0,
+            },
+            id: 'thematic1',
+            type: 'thematics',
+            relationships: {
+              tubes: {
+                data: [{ id: 'tube1.1', type: 'tubes' }],
+              },
+            },
+          },
+          {
+            attributes: {
+              index: '1.1',
+              name: 'Manger des fruits',
+            },
+            id: 'comp1',
+            type: 'competences',
+            relationships: {
+              thematics: {
+                data: [
+                  {
+                    id: 'thematic1',
+                    type: 'thematics',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            attributes: {
+              name: '@tubeName',
+              'practical-title': 'titre pratique',
+              'practical-description': 'description pratique',
+              'is-mobile-compliant': false,
+              'is-tablet-compliant': false,
+            },
+            id: 'tube2.1',
+            type: 'tubes',
+          },
+          {
+            attributes: {
+              name: 'Ma thématique 2',
+              index: 0,
+            },
+            id: 'thematic2',
+            type: 'thematics',
+            relationships: {
+              tubes: {
+                data: [{ id: 'tube2.1', type: 'tubes' }],
+              },
+            },
+          },
+          {
+            attributes: {
+              index: '1.1',
+              name: 'Manger des fruits',
+            },
+            id: 'comp2',
+            type: 'competences',
+            relationships: {
+              thematics: {
+                data: [
+                  {
+                    id: 'thematic2',
+                    type: 'thematics',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            attributes: {
+              code: '5',
+              color: 'red',
+              title: 'Super domaine',
+            },
+            id: 'area1',
+            relationships: {
+              competences: {
+                data: [
+                  {
+                    id: 'comp1',
+                    type: 'competences',
+                  },
+                  {
+                    id: 'comp2',
+                    type: 'competences',
+                  },
+                ],
+              },
+            },
+            type: 'areas',
+          },
+          {
+            attributes: {
+              name: 'pix',
+            },
+            id: 'framework1',
+            relationships: {
+              areas: {
+                data: [
+                  {
+                    id: 'area1',
+                    type: 'areas',
+                  },
+                ],
+              },
+            },
+            type: 'frameworks',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/domain/models/TargetProfile_test.js
+++ b/api/tests/shared/unit/domain/models/TargetProfile_test.js
@@ -1,0 +1,60 @@
+import { TargetProfile } from '../../../../../src/shared/domain/models/TargetProfile.js';
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Shared | Domain | Models | TargetProfile', function () {
+  describe('#constructor', function () {
+    it('initializes targetProfile properties', function () {
+      // given & when
+      const stage = domainBuilder.buildStage();
+      const badge = domainBuilder.buildBadge();
+      const targetProfile = new TargetProfile({
+        id: 'id',
+        badges: [badge],
+        category: 'category',
+        description: 'description',
+        estimatedTime: 4,
+        imageUrl: 'imageUrl',
+        internalName: 'internalName',
+        isSimplifiedAccess: 'isSimplifiedAccess',
+        name: 'name',
+        outdated: 'outdated',
+        stages: [stage],
+      });
+
+      // then
+      expect(targetProfile).deep.equal({
+        id: 'id',
+        badges: [badge],
+        category: 'category',
+        description: 'description',
+        estimatedTime: 4,
+        imageUrl: 'imageUrl',
+        internalName: 'internalName',
+        isSimplifiedAccess: 'isSimplifiedAccess',
+        name: 'name',
+        outdated: 'outdated',
+        stages: [stage],
+      });
+    });
+  });
+
+  describe('#hasBadges', function () {
+    it('should return true when target profile has badges', function () {
+      // given
+      const badge = domainBuilder.buildBadge();
+      const targetProfile = domainBuilder.buildTargetProfile({ badges: [badge] });
+
+      // then
+      expect(targetProfile.hasBadges).to.be.true;
+    });
+
+    it("should return false when target profile doesn't have badges", function () {
+      // given
+      const targetProfile = domainBuilder.buildTargetProfile();
+
+      // then
+      expect(targetProfile.hasBadges).to.be.false;
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence.js
@@ -8,6 +8,7 @@ const buildCompetence = function ({
   areaId = 'area123',
   skillIds = [],
   thematicIds = [],
+  thematics = [],
   tubes = [],
   origin = 'Pix',
 } = {}) {
@@ -20,6 +21,7 @@ const buildCompetence = function ({
     areaId,
     skillIds,
     thematicIds,
+    thematics,
     tubes,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-target-profile.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile.js
@@ -3,20 +3,30 @@ import { TargetProfile } from '../../../../src/shared/domain/models/TargetProfil
 const buildTargetProfile = function ({
   id = 123,
   name = 'Profil cible super cool',
+  category = 'category',
+  internalName = 'Profil cible super cool (interne)',
   imageUrl = 'ImageURL',
   isSimplifiedAccess = false,
+  estimatedTime,
   outdated = false,
   stages = [],
   badges = [],
+  frameworks = [],
+  description = 'La description du profil cible',
 } = {}) {
   return new TargetProfile({
     id,
+    category,
+    description,
     name,
+    estimatedTime,
+    internalName,
     imageUrl,
     isSimplifiedAccess,
     outdated,
     stages,
     badges,
+    frameworks,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-thematic.js
+++ b/api/tests/tooling/domain-builder/factory/build-thematic.js
@@ -6,6 +6,7 @@ const buildThematic = function buildThematic({
   index = 0,
   competenceId = 'recComp1',
   tubeIds = [],
+  tubes = [],
 } = {}) {
   return new Thematic({
     id,
@@ -13,6 +14,7 @@ const buildThematic = function buildThematic({
     index,
     competenceId,
     tubeIds,
+    tubes,
   });
 };
 


### PR DESCRIPTION
## 🥇 Problème
Actuellement, il n'existe pas de route permettant de récupérer un profil cible avec ses badges et les compétences qu'il contient. Or, nous avons besoin d'un tel endpoint pour afficher le détail d'un profil cible dans le catalogue depuis Pix Orga.

## 🥈 Proposition
Ajouter une route permettant de récupérer un détail de profil cible.

## 🥉 Comment tester
```bash
ACCESS_TOKEN=$(curl -s https://orga-pr16326.review.pix.fr/api/token --data-raw 'grant_type=password&username=admin-orga@example.net&password=pix123' | jq -r '.access_token')
```
```bash
curl -s https://orga-pr16326.review.pix.fr/api/organizations/1005/target-profiles/6001  -H "Authorization: Bearer ${ACCESS_TOKEN}" | jq .