### PR TITLE
[TECH] Génération des règles dependency cruiser

### DIFF
--- a/api/.dependency-cruiser.mjs
+++ b/api/.dependency-cruiser.mjs
@@ -1,13 +1,25 @@
+import { buildForbiddenRules } from './tests/tooling/dependency-cruiser-generator.js';
+
+const CONTEXTS = [
+  {
+    name: 'shared',
+    // dependsOn: [],
+    circular: 'forbidden',
+  },
+  {
+    name: 'banner',
+    // dependsOn: ['shared'],
+    circular: 'forbidden',
+  },
+  {
+    name: 'learning-content',
+    // dependsOn: ['shared'],
+    circular: 'forbidden',
+  },
+];
+
 export default {
-  forbidden: [
-    {
-      name: 'no-circular',
-      severity: 'error',
-      comment: 'prevent circular dependencies contexts',
-      from: { path: '^src/(banner|learning-content|shared)/' },
-      to: { circular: true },
-    },
-  ],
+  forbidden: buildForbiddenRules(CONTEXTS),
   options: {
     doNotFollow: { path: 'node_modules' },
   },

--- a/api/tests/tooling/dependency-cruiser-generator.js
+++ b/api/tests/tooling/dependency-cruiser-generator.js
@@ -1,0 +1,34 @@
+export function buildForbiddenRules(contexts = []) {
+  const forbiddenRules = [];
+
+  // build forbidden circular rule
+  const forbiddenCirculars = contexts
+    .filter((context) => context.circular === 'forbidden')
+    .map((context) => context.name)
+    .toSorted();
+
+  if (forbiddenCirculars.length > 0) {
+    forbiddenRules.push({
+      name: 'no-circular',
+      severity: 'error',
+      from: { path: `^src/(${forbiddenCirculars.join('|')})/` },
+      to: { circular: true },
+    });
+  }
+
+  // build context dependency rules
+  const dependsOnContexts = contexts
+    .filter((context) => Array.isArray(context.dependsOn))
+    .map((context) => {
+      const dependsOn = [context.name, ...context.dependsOn];
+      return {
+        name: `${context.name}-no-context`,
+        severity: 'error',
+        from: { path: `^src/${context.name}` },
+        to: { path: `^src/(?!${dependsOn.join('|')})` },
+      };
+    });
+  forbiddenRules.push(...dependsOnContexts);
+
+  return forbiddenRules;
+}

--- a/api/tests/unit/tooling/dependency-cruiser-generator_test.js
+++ b/api/tests/unit/tooling/dependency-cruiser-generator_test.js
@@ -1,0 +1,58 @@
+import { expect } from '../../test-helper.js';
+import { buildForbiddenRules } from '../../tooling/dependency-cruiser-generator.js';
+
+describe('Unit | Tooling | Dependency cruiser generator', function () {
+  describe('Context dependency rules', function () {
+    it('builds context dependency rule for contexts', function () {
+      const contexts = [
+        { name: 'shared', dependsOn: [] },
+        { name: 'banner', dependsOn: ['shared'] },
+      ];
+
+      const rules = buildForbiddenRules(contexts);
+
+      expect(rules).to.deep.equal([
+        {
+          name: 'shared-no-context',
+          severity: 'error',
+          from: { path: '^src/shared' },
+          to: { path: '^src/(?!shared)' },
+        },
+        {
+          name: 'banner-no-context',
+          severity: 'error',
+          from: { path: '^src/banner' },
+          to: { path: '^src/(?!banner|shared)' },
+        },
+      ]);
+    });
+  });
+
+  describe('Forbidden circular rule', function () {
+    it('builds forbidden circular rule for contexts', function () {
+      const contexts = [
+        { name: 'shared', circular: 'forbidden' },
+        { name: 'banner', circular: 'forbidden' },
+      ];
+
+      const rules = buildForbiddenRules(contexts);
+
+      expect(rules).to.deep.equal([
+        {
+          name: 'no-circular',
+          severity: 'error',
+          from: { path: '^src/(banner|shared)/' },
+          to: { circular: true },
+        },
+      ]);
+    });
+
+    it('does not builds forbidden circular rule if none defined', function () {
+      const contexts = [{ name: 'shared' }, { name: 'banner' }];
+
+      const rules = buildForbiddenRules(contexts);
+
+      expect(rules).to.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
## 💥 Problème

Dependency cruiser permet la mise en place de règles afin d'assurer la cohérence des dépendance entre les contextes, mais la définition des règles et complexe.

## 👩‍🚀 Proposition

Générer les règles dependency cruiser à partir d'une définition simplifiée : 
```js
const CONTEXTS = [
  {
    name: 'shared',
    dependsOn: [],          // shared ne dépend d'aucun autre contexte
    circular: 'forbidden',  // interdir les dépendances circulaires
  },
  {
    name: 'banner',
    dependsOn: ['shared'],  // banner dépend uniquement de shared
    circular: 'forbidden',  // interdir les dépendances circulaires
  },

]
```

## 👁️ Remarques

La définition des règles sera ajoutée petit à petit.

## ♻️ Pour tester

```
npm run lint:context-deps
```