### PR TITLE
[TECH] Ajouter script migration filterable string->list (PIX-22837)

### DIFF
--- a/api/src/prescription/scripts/migrate-import-format-filterable-to-list.js
+++ b/api/src/prescription/scripts/migrate-import-format-filterable-to-list.js
@@ -1,0 +1,166 @@
+import { commaSeparatedStringParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { ORGANIZATION_FEATURE } from '../../shared/domain/constants.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { CommonOrganizationLearnerFilter } from '../learner-management/domain/models/CommonOrganizationLearnerFilter.js';
+
+export class MigrateImportFormatFilterableToList extends Script {
+  constructor() {
+    super({
+      description:
+        'Migrate organization-learner-import-formats headers with filterable.type === "string" to "list", and backfill organization_learner_filters from existing imported learners.',
+      permanent: false,
+      options: {
+        names: {
+          type: 'string',
+          describe: 'Comma-separated names of organization-learner-import-formats to migrate (e.g. "ONDE")',
+          demandOption: true,
+          coerce: commaSeparatedStringParser(),
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without persisting changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+      logger.info(`BEGIN: Migrate filterable string→list for formats [${options.names.join(', ')}]`);
+
+      try {
+        for (const formatName of options.names) {
+          await migrateFormatByName({ formatName, logger });
+        }
+
+        if (options.dryRun) {
+          await knexConn.rollback();
+          logger.info(`ROLLBACK due to dryRun. Pass --dryRun false to persist changes.`);
+          return;
+        }
+
+        logger.info(`COMMIT: Migration done for formats [${options.names.join(', ')}]`);
+      } catch (error) {
+        await knexConn.rollback();
+        logger.error({ error }, `ROLLBACK: Migration failed`);
+        throw error;
+      }
+    });
+  }
+}
+
+async function migrateFormatByName({ formatName, logger }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const importFormat = await knexConn('organization-learner-import-formats').where({ name: formatName }).first();
+
+  if (!importFormat) {
+    logger.warn(`Format "${formatName}" not found, skipped.`);
+    return;
+  }
+
+  const migratedHeaderNames = [];
+  const newConfig = {
+    ...importFormat.config,
+    headers: importFormat.config.headers.map((header) => {
+      if (header?.config?.displayable?.filterable?.type !== 'string') return header;
+
+      migratedHeaderNames.push(header.name);
+      return {
+        ...header,
+        config: {
+          ...header.config,
+          displayable: {
+            ...header.config.displayable,
+            filterable: { ...header.config.displayable.filterable, type: 'list' },
+          },
+        },
+      };
+    }),
+  };
+
+  if (migratedHeaderNames.length === 0) {
+    logger.info(`Format "${formatName}" has no filterable.type === "string", nothing to migrate.`);
+    return;
+  }
+
+  await knexConn('organization-learner-import-formats')
+    .where({ id: importFormat.id })
+    .update({ config: newConfig, updatedAt: new Date() });
+
+  logger.info(
+    `Format "${formatName}" (id=${importFormat.id}): updated headers [${migratedHeaderNames.join(', ')}] to filterable.type="list"`,
+  );
+
+  const newListHeaders = newConfig.headers.filter(
+    (header) => migratedHeaderNames.includes(header.name) && header.config?.displayable?.filterable?.type === 'list',
+  );
+
+  const organizationIds = await findOrganizationIdsUsingFormat(importFormat.id);
+  logger.info(`Format "${formatName}": ${organizationIds.length} organization(s) to backfill.`);
+
+  for (const organizationId of organizationIds) {
+    await insertFiltersForOrganization({ organizationId, headers: newListHeaders, logger });
+  }
+}
+
+async function findOrganizationIdsUsingFormat(importFormatId) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const rows = await knexConn('organization-features')
+    .select('organization-features.organizationId')
+    .join('features', 'features.id', 'organization-features.featureId')
+    .where('features.key', ORGANIZATION_FEATURE.LEARNER_IMPORT.key)
+    .whereJsonSupersetOf('organization-features.params', { organizationLearnerImportFormatId: importFormatId });
+
+  return rows.map((row) => row.organizationId);
+}
+
+async function insertFiltersForOrganization({ organizationId, headers, logger }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const learners = await knexConn('view-active-organization-learners').select('attributes').where({ organizationId });
+
+  if (learners.length === 0) {
+    logger.info(`Organization ${organizationId}: no learners, skipping filters backfill.`);
+    return;
+  }
+
+  const filters = headers
+    .map((header) => {
+      const key = header.config?.property ?? header.config?.mappingColumn ?? header.name;
+      const isProperty = Boolean(header.config?.property);
+      const attributeName = header.config.displayable.name;
+
+      const values = [
+        ...new Set(
+          learners.map((learner) => (isProperty ? learner[key] : learner.attributes?.[key])).filter((v) => v != null),
+        ),
+      ];
+
+      return new CommonOrganizationLearnerFilter({ organizationId, attributeName, values });
+    })
+    .filter((filter) => filter.values.length > 0);
+
+  await knexConn('organization_learner_filters').where({ organization_id: organizationId }).del();
+
+  if (filters.length === 0) {
+    logger.info(`Organization ${organizationId}: no filter values found, table cleared.`);
+    return;
+  }
+
+  await knexConn.batchInsert(
+    'organization_learner_filters',
+    filters.map((filter) => filter.dataToInsert),
+  );
+
+  logger.info(
+    `Organization ${organizationId}: inserted ${filters.length} filter(s) [${filters.map((f) => f.attributeName).join(', ')}]`,
+  );
+}
+
+await ScriptRunner.execute(import.meta.url, MigrateImportFormatFilterableToList);

--- a/api/tests/prescription/scripts/integration/migrate-import-format-filterable-to-list_test.js
+++ b/api/tests/prescription/scripts/integration/migrate-import-format-filterable-to-list_test.js
@@ -1,0 +1,205 @@
+import sinon from 'sinon';
+
+import { MigrateImportFormatFilterableToList } from '../../../../src/prescription/scripts/migrate-import-format-filterable-to-list.js';
+import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
+import { expect } from '../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../tooling/databases.js';
+
+describe('Script | Prescription | Migrate import format filterable string to list', function () {
+  const FORMAT_NAME = 'TEST_FORMAT';
+
+  function buildFormatWithFilterableString({ name = FORMAT_NAME } = {}) {
+    return databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+      name,
+      fileType: 'csv',
+      config: {
+        unicityColumns: ['INE'],
+        acceptedEncoding: ['utf8'],
+        headers: [
+          {
+            name: 'Nom',
+            required: true,
+            config: { property: 'lastName', validate: { type: 'string', required: true } },
+          },
+          {
+            name: 'Prénom',
+            required: true,
+            config: { property: 'firstName', validate: { type: 'string', required: true } },
+          },
+          {
+            name: 'INE',
+            required: true,
+            config: { validate: { type: 'string', required: true } },
+          },
+          {
+            name: 'Libellé classe',
+            required: true,
+            config: {
+              validate: { type: 'string', required: true },
+              displayable: { position: 1, name: 'division', filterable: { type: 'string' } },
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  function linkOrganizationToFormat({ organizationId, importFormatId }) {
+    const feature = databaseBuilder.factory.buildFeature({ key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key });
+    databaseBuilder.factory.buildOrganizationFeature({
+      organizationId,
+      featureId: feature.id,
+      params: { organizationLearnerImportFormatId: importFormatId },
+    });
+  }
+
+  describe('#handle', function () {
+    it('migrates filterable.type from "string" to "list" in the format config', async function () {
+      const importFormat = buildFormatWithFilterableString();
+      await databaseBuilder.commit();
+
+      const script = new MigrateImportFormatFilterableToList();
+      const logger = { info: sinon.spy(), warn: sinon.spy(), error: sinon.spy() };
+
+      await script.handle({ options: { names: [FORMAT_NAME], dryRun: false }, logger });
+
+      const updatedFormat = await knex('organization-learner-import-formats').where({ id: importFormat.id }).first();
+      const filterableHeader = updatedFormat.config.headers.find((header) => header.name === 'Libellé classe');
+      expect(filterableHeader.config.displayable.filterable).to.deep.equal({ type: 'list' });
+    });
+
+    it('leaves untouched headers without filterable or with filterable.type !== "string"', async function () {
+      const importFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+        name: FORMAT_NAME,
+        config: {
+          unicityColumns: ['INE'],
+          acceptedEncoding: ['utf8'],
+          headers: [
+            {
+              name: 'Nom',
+              required: true,
+              config: { property: 'lastName', validate: { type: 'string', required: true } },
+            },
+            {
+              name: 'Prénom',
+              required: true,
+              config: { property: 'firstName', validate: { type: 'string', required: true } },
+            },
+            {
+              name: 'Classe',
+              required: true,
+              config: {
+                validate: { type: 'string', required: true },
+                displayable: { position: 1, name: 'division', filterable: { type: 'list' } },
+              },
+            },
+          ],
+        },
+      });
+      await databaseBuilder.commit();
+
+      const script = new MigrateImportFormatFilterableToList();
+      const logger = { info: sinon.spy(), warn: sinon.spy(), error: sinon.spy() };
+
+      await script.handle({ options: { names: [FORMAT_NAME], dryRun: false }, logger });
+
+      const updatedFormat = await knex('organization-learner-import-formats').where({ id: importFormat.id }).first();
+      const classeHeader = updatedFormat.config.headers.find((header) => header.name === 'Classe');
+      expect(classeHeader.config.displayable.filterable).to.deep.equal({ type: 'list' });
+      const nomHeader = updatedFormat.config.headers.find((header) => header.name === 'Nom');
+      expect(nomHeader.config.displayable).to.be.undefined;
+    });
+
+    it('backfills organization_learner_filters with unique attribute values from existing learners', async function () {
+      const importFormat = buildFormatWithFilterableString();
+      const organization = databaseBuilder.factory.buildOrganization();
+      linkOrganizationToFormat({ organizationId: organization.id, importFormatId: importFormat.id });
+
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        attributes: { 'Libellé classe': '6A', INE: 'A1' },
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        attributes: { 'Libellé classe': '6B', INE: 'A2' },
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        attributes: { 'Libellé classe': '6A', INE: 'A3' },
+      });
+
+      await databaseBuilder.commit();
+
+      const script = new MigrateImportFormatFilterableToList();
+      const logger = { info: sinon.spy(), warn: sinon.spy(), error: sinon.spy() };
+
+      await script.handle({ options: { names: [FORMAT_NAME], dryRun: false }, logger });
+
+      const filters = await knex('organization_learner_filters').where({ organization_id: organization.id });
+      expect(filters).to.have.lengthOf(1);
+      expect(filters[0].attribute_name).to.equal('division');
+      expect(filters[0].values).to.deep.equal(['6A', '6B']);
+    });
+
+    it('replaces existing organization_learner_filters rows for impacted organizations', async function () {
+      const importFormat = buildFormatWithFilterableString();
+      const organization = databaseBuilder.factory.buildOrganization();
+      linkOrganizationToFormat({ organizationId: organization.id, importFormatId: importFormat.id });
+
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+        organizationId: organization.id,
+        attributeName: 'stale-attribute',
+        values: ['stale'],
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        attributes: { 'Libellé classe': '6A' },
+      });
+      await databaseBuilder.commit();
+
+      const script = new MigrateImportFormatFilterableToList();
+      const logger = { info: sinon.spy(), warn: sinon.spy(), error: sinon.spy() };
+
+      await script.handle({ options: { names: [FORMAT_NAME], dryRun: false }, logger });
+
+      const filters = await knex('organization_learner_filters').where({ organization_id: organization.id });
+      expect(filters).to.have.lengthOf(1);
+      expect(filters[0].attribute_name).to.equal('division');
+    });
+
+    it('does not persist changes when dryRun is true', async function () {
+      const importFormat = buildFormatWithFilterableString();
+      const organization = databaseBuilder.factory.buildOrganization();
+      linkOrganizationToFormat({ organizationId: organization.id, importFormatId: importFormat.id });
+
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        attributes: { 'Libellé classe': '6A' },
+      });
+      await databaseBuilder.commit();
+
+      const script = new MigrateImportFormatFilterableToList();
+      const logger = { info: sinon.spy(), warn: sinon.spy(), error: sinon.spy() };
+
+      await script.handle({ options: { names: [FORMAT_NAME], dryRun: true }, logger });
+
+      const reloadedFormat = await knex('organization-learner-import-formats').where({ id: importFormat.id }).first();
+      const header = reloadedFormat.config.headers.find((h) => h.name === 'Libellé classe');
+      expect(header.config.displayable.filterable).to.deep.equal({ type: 'string' });
+
+      const filters = await knex('organization_learner_filters').where({ organization_id: organization.id });
+      expect(filters).to.be.empty;
+    });
+
+    it('skips unknown format names with a warning', async function () {
+      await databaseBuilder.commit();
+
+      const script = new MigrateImportFormatFilterableToList();
+      const logger = { info: sinon.spy(), warn: sinon.spy(), error: sinon.spy() };
+
+      await script.handle({ options: { names: ['UNKNOWN_FORMAT'], dryRun: false }, logger });
+
+      expect(logger.warn).to.have.been.calledWithMatch('UNKNOWN_FORMAT');
+    });
+  });
+});


### PR DESCRIPTION
## Probleme
Actuellement les import à format permettent de spécifier une colonne filtrable de type `list` qui permet par la suite au front de proposer un champ PixMultiSelect pour filtrer les prescrits. 

## Solution
Modifier les formats d’import et ajouter les CommonLearnerFilter associés. 

## Remarques 
- Ajoute un script `api/src/prescription/scripts/migrate-import-format-filterable-to-list.js` qui :
  - met à jour les headers des `organization-learner-import-formats` où `config.displayable.filterable.type === 'string'` en `'list'` ;
  - rattrape les `organization_learner_filters` à partir des `view-active-organization-learners` pour les organisations utilisant ces formats (delete + insert par organisation, en réutilisant la même logique que `ImportOrganizationLearnerSet.filtersAvailableValues`).
- Options : `--names "ONDE,..."` (obligatoire), `--dryRun` (défaut `true`).
- Toutes les écritures sont enveloppées dans une `DomainTransaction.execute` avec rollback si `dryRun`.

## Comment Tester
- [x] `cd api && npm test -- tests/prescription/scripts/integration/migrate-import-format-filterable-to-list_test.js`
- [x] via le cli scalingo, lancer en dryRun : `node src/prescription/scripts/migrate-import-format-filterable-to-list.js --names ONDE`
- [x] Vérifier dans les logs les organisations rattrapées et les valeurs de filtres
- [x] Rejouer avec `--dryRun false` pour persister
- [x] Aller sur la page d'une orga SCO-1D et voir le filtre de type list

🤖 Generated with [Claude Code](https://claude.com/claude-code)