### PR TITLE
[FEATURE] Suppression du stepper sur le certificat Pix+ Edu avec niveau (PIX-22888).

### DIFF
--- a/mon-pix/app/components/certifications/shareable-certificate/v3-pix-plus-certificate.gjs
+++ b/mon-pix/app/components/certifications/shareable-certificate/v3-pix-plus-certificate.gjs
@@ -23,12 +23,8 @@ export default class PixPlusCertificate extends Component {
 
   @tracked eduCurrentStep = this.isCandidateEduAdmissible ? EDU_STEPS.ADMISSIBLE : EDU_STEPS.FINAL;
 
-  get isEduCertification() {
-    return this.args.certificate.certificationFramework.includes('EDU');
-  }
-
   get isCandidateEduAdmissible() {
-    return this.isEduCertification && this.args.certificate.level === 'ADMISSIBLE';
+    return this.args.certificate.certificationFramework.includes('EDU') && this.args.certificate.level === 'ADMISSIBLE';
   }
 
   get isUserCertificate() {
@@ -97,7 +93,7 @@ export default class PixPlusCertificate extends Component {
               </h2>
             {{/if}}
 
-            {{#if this.isEduCertification}}
+            {{#if this.isCandidateEduAdmissible}}
               <PixStepper
                 class="v3-pix-plus-certificate__stepper"
                 @steps={{this.steps}}

--- a/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-pix-plus-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-pix-plus-certificate-test.gjs
@@ -90,139 +90,143 @@ module('Integration | Component | Certifications | Shareable certificate | v3-pi
       });
     });
 
-    test('it displays the results block when the candidate is admissible', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certification = store.createRecord('certification', {
-        birthdate: '2000-01-22',
-        birthplace: 'Paris',
-        firstName: 'Jean',
-        lastName: 'Doe',
-        certificationDate: new Date('2026-02-15T10:00:00Z'),
-        deliveredAt: new Date('2026-02-20T10:00:00Z'),
-        certificationCenter: 'Université de Lyon',
-        certificationFramework: 'EDU_1ER_DEGRE',
-        level: 'ADMISSIBLE',
-      });
-      this.set('certification', certification);
+    module('results block', function () {
+      test('it displays the results block when the candidate is admissible', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'ADMISSIBLE',
+        });
+        this.set('certification', certification);
 
-      // when
-      const screen = await render(hbs`
+        // when
+        const screen = await render(hbs`
+            <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
+
+        // then
+        assert.dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') })).exists();
+      });
+
+      test('it does not display the results block when the candidate is not admissible and has no global labels', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'EXPERT',
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await render(hbs`
+            <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
+
+        // then
+        assert
+          .dom(screen.queryByRole('heading', { level: 3, name: t('pages.certificate.results.title') }))
+          .doesNotExist();
+      });
+
+      test('it displays the results block when the candidate is not admissible but has global labels', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'EXPERT',
+          globalSummaryLabel: 'Summary label',
+          globalDescriptionLabel: 'Description label',
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await render(hbs`
           <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
 
-      // then
-      assert.dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') })).exists();
+        // then
+        assert.dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') })).exists();
+        assert.dom(screen.getByText('Summary label')).exists();
+        assert.dom(screen.getByText('Description label')).exists();
+      });
     });
 
-    test('it does not display the results block when the candidate is not admissible and has no global labels', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certification = store.createRecord('certification', {
-        birthdate: '2000-01-22',
-        birthplace: 'Paris',
-        firstName: 'Jean',
-        lastName: 'Doe',
-        certificationDate: new Date('2026-02-15T10:00:00Z'),
-        deliveredAt: new Date('2026-02-20T10:00:00Z'),
-        certificationCenter: 'Université de Lyon',
-        certificationFramework: 'EDU_1ER_DEGRE',
-        level: 'EXPERT',
-      });
-      this.set('certification', certification);
+    module('sub-title', function () {
+      test('it displays the admissible sub-title when the candidate is admissible', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'ADMISSIBLE',
+        });
+        this.set('certification', certification);
 
-      // when
-      const screen = await render(hbs`
+        // when
+        const screen = await render(hbs`
           <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
 
-      // then
-      assert
-        .dom(screen.queryByRole('heading', { level: 3, name: t('pages.certificate.results.title') }))
-        .doesNotExist();
-    });
-
-    test('it displays the results block when the candidate is not admissible but has global labels', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certification = store.createRecord('certification', {
-        birthdate: '2000-01-22',
-        birthplace: 'Paris',
-        firstName: 'Jean',
-        lastName: 'Doe',
-        certificationDate: new Date('2026-02-15T10:00:00Z'),
-        deliveredAt: new Date('2026-02-20T10:00:00Z'),
-        certificationCenter: 'Université de Lyon',
-        certificationFramework: 'EDU_1ER_DEGRE',
-        level: 'EXPERT',
-        globalSummaryLabel: 'Summary label',
-        globalDescriptionLabel: 'Description label',
+        // then
+        const subTitle = t('pages.certificate.frameworks.EDU.sub-title.admissible.candidate').replace(/ /g, ' ');
+        assert
+          .dom(screen.getByRole('heading', { level: 2, name: (name) => name.replace(/ /g, ' ').includes(subTitle) }))
+          .exists();
       });
-      this.set('certification', certification);
 
-      // when
-      const screen = await render(hbs`
+      test('it displays the default sub-title when the candidate is not admissible', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'EXPERT',
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await render(hbs`
           <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
 
-      // then
-      assert.dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') })).exists();
-      assert.dom(screen.getByText('Summary label')).exists();
-      assert.dom(screen.getByText('Description label')).exists();
-    });
-
-    test('it displays the admissible sub-title when the candidate is admissible', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certification = store.createRecord('certification', {
-        birthdate: '2000-01-22',
-        birthplace: 'Paris',
-        firstName: 'Jean',
-        lastName: 'Doe',
-        certificationDate: new Date('2026-02-15T10:00:00Z'),
-        deliveredAt: new Date('2026-02-20T10:00:00Z'),
-        certificationCenter: 'Université de Lyon',
-        certificationFramework: 'EDU_1ER_DEGRE',
-        level: 'ADMISSIBLE',
+        // then
+        const subTitle = t('pages.certificate.obtained-certification.candidate', {
+          globalLevelLabel: t('pages.user-certifications.meshes.EDU_1ER_DEGRE.EXPERT'),
+          frameworkLabel: t('pages.certification-frameworks.EDU_1ER_DEGRE'),
+        }).replace(/ /g, ' ');
+        assert
+          .dom(screen.getByRole('heading', { level: 2, name: (name) => name.replace(/ /g, ' ').includes(subTitle) }))
+          .exists();
       });
-      this.set('certification', certification);
-
-      // when
-      const screen = await render(hbs`
-          <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
-
-      // then
-      const subTitle = t('pages.certificate.frameworks.EDU.sub-title.admissible.candidate').replace(/ /g, ' ');
-      assert
-        .dom(screen.getByRole('heading', { level: 2, name: (name) => name.replace(/ /g, ' ').includes(subTitle) }))
-        .exists();
-    });
-
-    test('it displays the default sub-title when the candidate is not admissible', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certification = store.createRecord('certification', {
-        birthdate: '2000-01-22',
-        birthplace: 'Paris',
-        firstName: 'Jean',
-        lastName: 'Doe',
-        certificationDate: new Date('2026-02-15T10:00:00Z'),
-        deliveredAt: new Date('2026-02-20T10:00:00Z'),
-        certificationCenter: 'Université de Lyon',
-        certificationFramework: 'EDU_1ER_DEGRE',
-        level: 'EXPERT',
-      });
-      this.set('certification', certification);
-
-      // when
-      const screen = await render(hbs`
-          <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
-
-      // then
-      const subTitle = t('pages.certificate.obtained-certification.candidate', {
-        globalLevelLabel: t('pages.user-certifications.meshes.EDU_1ER_DEGRE.EXPERT'),
-        frameworkLabel: t('pages.certification-frameworks.EDU_1ER_DEGRE'),
-      }).replace(/ /g, ' ');
-      assert
-        .dom(screen.getByRole('heading', { level: 2, name: (name) => name.replace(/ /g, ' ').includes(subTitle) }))
-        .exists();
     });
 
     module('level tag', function () {

--- a/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-pix-plus-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-pix-plus-certificate-test.gjs
@@ -40,27 +40,54 @@ module('Integration | Component | Certifications | Shareable certificate | v3-pi
   });
 
   module('for an EDU framework', function () {
-    test('it displays the stepper', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certification = store.createRecord('certification', {
-        birthdate: '2000-01-22',
-        birthplace: 'Paris',
-        firstName: 'Jean',
-        lastName: 'Doe',
-        certificationDate: new Date('2026-02-15T10:00:00Z'),
-        deliveredAt: new Date('2026-02-20T10:00:00Z'),
-        certificationCenter: 'Université de Lyon',
-        certificationFramework: 'EDU_1ER_DEGRE',
-      });
-      this.set('certification', certification);
+    module('stepper', function () {
+      test('it displays the stepper when candidate is admissible', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'ADMISSIBLE',
+        });
+        this.set('certification', certification);
 
-      // when
-      const screen = await render(hbs`
+        // when
+        const screen = await render(hbs`
           <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
 
-      // then
-      assert.dom(screen.getByText(t('pages.certificate.frameworks.EDU.steps.1'))).exists();
+        // then
+        assert.dom(screen.getByText(t('pages.certificate.frameworks.EDU.steps.1'))).exists();
+      });
+
+      test('it does not display the stepper when candidate is received', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Doe',
+          certificationDate: new Date('2026-02-15T10:00:00Z'),
+          deliveredAt: new Date('2026-02-20T10:00:00Z'),
+          certificationCenter: 'Université de Lyon',
+          certificationFramework: 'EDU_1ER_DEGRE',
+          level: 'EXPERT',
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await render(hbs`
+          <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
+
+        // then
+        assert.dom(screen.queryByText(t('pages.certificate.frameworks.EDU.steps.1'))).doesNotExist();
+      });
     });
 
     test('it displays the results block when the candidate is admissible', async function (assert) {


### PR DESCRIPTION
## 💥 Problème

Pix+ Edu est la seule certification actuellement qui comporte deux volets :
- un premier volet qui est passé sur la plateforme Pix qui donne un résultat “Admissible” ou “Non Admissible”
- un deuxième volet, accessible uniquement si le volet 1 est “Admissible” qui se passe devant un jury externe. Au terme de cette 2e épreuve, le candidat se voit attribuer par le jury externe un niveau “Avancé” ou “Expert”.

On affiche toujours le fil d’Ariane pour guider le candidat ou le vérificateur alors que le résultat final de la certification a été obtenu (volet 2/2). Cela créé une distraction qui détourne l’attention de l'élément principal de ce certificat : le badge du niveau atteint.

## 👩‍🚀 Proposition

Harmonisation avec l’affichage du certificat Pix+ Droit et Pix+ Pro Santé via la suppression du fil d’Ariane sur le certificat en ligne (vue candidat) et le certificat partagé (vue vérificateur) lorsque le candidat a obtenu son 2e volet Pix+ Edu

## ♻️ Pour tester

- Passer sur une certification Pix+ Edu
- Modifier le résultat sur PixAdmin pour accorder un niveau jury
- Vérifier dans les certificats obtenus (en ligne et vue vérificateur) que le stepper n'apparait plus avec un niveau
