### PR TITLE
[BUGFIX] Réparer le titre de la modale de détail d'une version de certification (PIX-22916)

### DIFF
--- a/admin/app/components/certification-frameworks/item/framework/certification-version-detail-modal.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/certification-version-detail-modal.gjs
@@ -18,11 +18,11 @@ export default class CertificationVersionDetailModal extends Component {
   @service intl;
 
   get frameworkLabel() {
-    return this.intl.t(`components.certification-frameworks.labels.${this.args.scope}`);
+    return this.intl.t(`components.certification-frameworks.labels.${this.args.frameworkKey}`);
   }
 
   get locales() {
-    if (this.args.scope === 'CORE') {
+    if (this.args.frameworkKey === 'CORE') {
       return [
         { flag: '🇫🇷', label: 'fr-FR' },
         { flag: '🇫🇷', label: 'fr' },

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -181,7 +181,7 @@ export default class FrameworkHistory extends Component {
       <CertificationVersionDetailModal
         @version={{this.selectedVersion}}
         @status={{this.selectedVersionStatus}}
-        @scope={{@scope}}
+        @frameworkKey={{@frameworkKey}}
         @onClose={{this.closeModalVersionDetail}}
         @showModal={{this.showVersionDetailModal}}
       />

--- a/admin/tests/integration/components/certification-frameworks/item/framework/certification-version-detail-modal-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/certification-version-detail-modal-test.gjs
@@ -40,7 +40,7 @@ module(
           <CertificationVersionDetailModal
             @version={{version}}
             @status="ACTIVE"
-            @scope="CORE"
+            @frameworkKey="CORE"
             @onClose={{onClose}}
             @showModal={{true}}
           />
@@ -62,7 +62,7 @@ module(
           <CertificationVersionDetailModal
             @version={{version}}
             @status="ACTIVE"
-            @scope="CORE"
+            @frameworkKey="CORE"
             @onClose={{onClose}}
             @showModal={{true}}
           />
@@ -86,7 +86,7 @@ module(
           <CertificationVersionDetailModal
             @version={{version}}
             @status="ACTIVE"
-            @scope="CORE"
+            @frameworkKey="CORE"
             @onClose={{onClose}}
             @showModal={{true}}
           />
@@ -117,7 +117,7 @@ module(
           <CertificationVersionDetailModal
             @version={{version}}
             @status="ACTIVE"
-            @scope="CORE"
+            @frameworkKey="CORE"
             @onClose={{onClose}}
             @showModal={{true}}
           />
@@ -139,7 +139,7 @@ module(
           <CertificationVersionDetailModal
             @version={{version}}
             @status="ACTIVE"
-            @scope="CORE"
+            @frameworkKey="CORE"
             @onClose={{onClose}}
             @showModal={{true}}
           />
@@ -168,7 +168,7 @@ module(
           <CertificationVersionDetailModal
             @version={{version}}
             @status="ACTIVE"
-            @scope="CORE"
+            @frameworkKey="CORE"
             @onClose={{onClose}}
             @showModal={{false}}
           />

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -103,7 +103,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
     await click(
       screen.getAllByRole('button', {
-        name: t('components.complementary-certifications.item.framework.history.table.actions.view'),
+        name: t('components.certification-frameworks.item.framework.history.table.actions.view'),
       })[0],
     );
 

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -94,6 +94,23 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     assert.dom(screen.getByRole('dialog')).exists();
   });
 
+  test('it displays the framework label as the modal title', async function (assert) {
+    // given
+    sinon.stub(store, 'findRecord').resolves(store.createRecord('certification-version'));
+
+    // when
+    const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+
+    await click(
+      screen.getAllByRole('button', {
+        name: t('components.complementary-certifications.item.framework.history.table.actions.view'),
+      })[0],
+    );
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: t('components.certification-frameworks.labels.CORE') })).exists();
+  });
+
   test('it leaves detail modal opened after saving comments successfully', async function (assert) {
     // given
     const certificationVersion = store.createRecord('certification-version', {


### PR DESCRIPTION
## 💥 Problème

Une PR précédente a cassé le titre de la modale
<img width="979" height="106" alt="image" src="https://github.com/user-attachments/assets/1db53dd9-3139-4542-a377-4afaaf917cb2" />

## 👩‍🚀 Proposition

Réparer le passage de la clé du framework à la modale pour que le titre s'affiche correctement*
Ajouter un test sur le titre de la modale 

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
Ouvrir (avec le bouton "œil") le détail d'une version de certification

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
