### PR TITLE
[TECH] Ne plus utiliser la table certification-subscriptions dans l'inscription du candidat (PIX-22920)

### DIFF
--- a/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
+++ b/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import { services as enrolmentServices } from '../../../../../src/certification/enrolment/application/services/index.js';
 import { Candidate } from '../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SessionEnrolment } from '../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { Subscription } from '../../../../../src/certification/enrolment/domain/models/Subscription.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { BILLING_MODES } from '../../../../../src/certification/shared/domain/constants.js';
@@ -185,20 +185,14 @@ export class CleaV3Seed {
       isLinked: true,
       hasSeenCertificationInstructions: false,
       accessibilityAdjustmentNeeded: false,
-      subscriptions: [
-        Subscription.buildCore({ certificationCandidateId: null }),
-        Subscription.buildComplementary({
-          certificationCandidateId: null,
-          complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-        }),
-      ],
+      subscription: Frameworks.CLEA,
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
     };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
+      candidate: new Candidate(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 

--- a/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import { services as enrolmentServices } from '../../../../../src/certification/enrolment/application/services/index.js';
 import { Candidate } from '../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SessionEnrolment } from '../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { Subscription } from '../../../../../src/certification/enrolment/domain/models/Subscription.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { BILLING_MODES } from '../../../../../src/certification/shared/domain/constants.js';
@@ -158,14 +158,14 @@ export class ProSeed {
       isLinked: true,
       hasSeenCertificationInstructions: false,
       accessibilityAdjustmentNeeded: false,
-      subscriptions: [Subscription.buildCore({ certificationCandidateId: null })],
+      subscription: Frameworks.CORE,
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
     };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
+      candidate: new Candidate(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 

--- a/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import { services as enrolmentServices } from '../../../../../src/certification/enrolment/application/services/index.js';
 import { Candidate } from '../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SessionEnrolment } from '../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { Subscription } from '../../../../../src/certification/enrolment/domain/models/Subscription.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { usecases as organizationalEntitiesUsecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
@@ -173,7 +173,7 @@ export class ScoManagingStudent {
   }
 
   async #addCandidateToSession({ organizationLearner, session }) {
-    const candidate = Candidate.create({
+    const candidate = new Candidate({
       firstName: organizationLearner.firstName,
       lastName: organizationLearner.lastName,
       sex: 'F',
@@ -184,7 +184,7 @@ export class ScoManagingStudent {
       isLinked: true,
       hasSeenCertificationInstructions: false,
       accessibilityAdjustmentNeeded: false,
-      subscriptions: [Subscription.buildCore({ certificationCandidateId: null })],
+      subscription: Frameworks.CORE,
       userId: organizationLearner.userId,
       organizationLearnerId: organizationLearner.id,
     });

--- a/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
+++ b/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
@@ -1,7 +1,7 @@
 import { services as enrolmentServices } from '../../../../../src/certification/enrolment/application/services/index.js';
 import { Candidate } from '../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SessionEnrolment } from '../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { Subscription } from '../../../../../src/certification/enrolment/domain/models/Subscription.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { BILLING_MODES } from '../../../../../src/certification/shared/domain/constants.js';
@@ -65,12 +65,7 @@ export class SupWithHabilitationsSeed {
       await this.#addCandidateToSession({
         pixAppUser: certifiableUser,
         session: sessionDroitReadyToStart,
-        subscriptions: [
-          Subscription.buildComplementary({
-            certificationCandidateId: null,
-            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
-          }),
-        ],
+        subscription: Frameworks.EDU_1ER_DEGRE,
       });
     }
 
@@ -89,12 +84,7 @@ export class SupWithHabilitationsSeed {
       await this.#addCandidateToSession({
         pixAppUser: certifiableUser,
         session: sessionEduReadyToStart,
-        subscriptions: [
-          Subscription.buildComplementary({
-            certificationCandidateId: null,
-            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-          }),
-        ],
+        subscription: Frameworks.DROIT,
       });
     }
   }
@@ -177,7 +167,7 @@ export class SupWithHabilitationsSeed {
     });
   }
 
-  async #addCandidateToSession({ pixAppUser, session, subscriptions }) {
+  async #addCandidateToSession({ pixAppUser, session, subscription }) {
     const candidateBirthdate = '2000-10-30';
 
     const candidateDTO = {
@@ -191,14 +181,14 @@ export class SupWithHabilitationsSeed {
       isLinked: true,
       hasSeenCertificationInstructions: false,
       accessibilityAdjustmentNeeded: false,
-      subscriptions,
+      subscription,
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
     };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
+      candidate: new Candidate(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 

--- a/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
+++ b/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
@@ -28,7 +28,7 @@ export const registerCandidateParticipation = withTransaction(
       normalizeStringFnc,
     });
 
-    if (candidate.hasComplementarySubscription() && !isFrenchDomainExtension) {
+    if (candidate.hasNonCoreSubscription() && !isFrenchDomainExtension) {
       throw new WrongDomainExtensionForPixPlusError();
     }
 

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -2,14 +2,13 @@
  * @typedef {import ('./Subscription.js').Subscription} Subscription
  */
 import { CertificationCandidatesError } from '../../../../shared/domain/errors.js';
-import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
+import { BILLING_MODES } from '../../../shared/domain/constants.js';
 import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 import { validate } from '../validators/candidate-validator.js';
 
 export class Candidate {
   /**
    * @param {object} params
-   * @param {Array<Subscription>} [params.subscriptions=[]]
    */
   constructor({
     id,
@@ -36,7 +35,6 @@ export class Candidate {
     prepaymentCode,
     hasSeenCertificationInstructions = false,
     subscription,
-    subscriptions = [],
     accessibilityAdjustmentNeeded,
     hasStartedTest = false,
   } = {}) {
@@ -63,22 +61,9 @@ export class Candidate {
     this.prepaymentCode = prepaymentCode;
     this.hasSeenCertificationInstructions = hasSeenCertificationInstructions;
     this.subscription = subscription;
-    this.subscriptions = subscriptions;
     this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
     this.reconciledAt = reconciledAt;
     this.hasStartedTest = hasStartedTest;
-  }
-
-  static create(candidateDTO) {
-    const complementaryKey = candidateDTO.subscriptions.find((sub) => {
-      return sub.type === SUBSCRIPTION_TYPES.COMPLEMENTARY;
-    })?.complementaryCertificationKey;
-    const mainSubscription = complementaryKey || Frameworks.CORE;
-
-    return new Candidate({
-      ...candidateDTO,
-      subscription: mainSubscription,
-    });
   }
 
   isReconciled() {
@@ -158,20 +143,11 @@ export class Candidate {
     this.extraTimePercentage = this.extraTimePercentage / 100;
   }
 
-  hasComplementarySubscription() {
-    return this.subscriptions.some((subscription) => subscription.isComplementary());
-  }
-
-  getComplementarySubscription() {
-    return this.subscriptions.find((subscription) => subscription.type === SUBSCRIPTION_TYPES.COMPLEMENTARY);
-  }
-
-  get complementaryCertificationKey() {
-    const complementarySubscription = this.getComplementarySubscription();
-    return complementarySubscription?.complementaryCertificationKey || null;
+  hasNonCoreSubscription() {
+    return this.subscription !== Frameworks.CORE;
   }
 
   isRegisteredToDoubleCertification() {
-    return this.subscriptions.length === 2;
+    return this.subscription === Frameworks.CLEA;
   }
 }

--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -1,13 +1,11 @@
 import { CertificationCandidatesError } from '../../../../shared/domain/errors.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import * as mailCheckImplementation from '../../../../shared/mail/infrastructure/services/mail-check.js';
-import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
-import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 import { getTransformationStructsForPixCertifCandidatesImport } from '../../infrastructure/candidates-import/candidates-import-transformation-structures.js';
 import * as readOdsUtils from '../../infrastructure/utils/ods/read-ods-utils.js';
 import { Candidate } from '../models/Candidate.js';
-import { Subscription } from '../models/Subscription.js';
 
 export async function extractCertificationCandidatesFromCandidatesImportSheet({
   i18n,
@@ -73,7 +71,7 @@ export async function extractCertificationCandidatesFromCandidatesImportSheet({
       certificationCpfCountryRepository,
     });
 
-    const subscriptions = _buildSubscriptions(candidateData);
+    const subscription = _buildSubscription(candidateData);
 
     if (cpfBirthInformation.hasFailed()) {
       _handleBirthInformationValidationError(cpfBirthInformation, line);
@@ -110,7 +108,7 @@ export async function extractCertificationCandidatesFromCandidatesImportSheet({
       }
     }
 
-    const candidate = Candidate.create({
+    const candidate = new Candidate({
       ...candidateData,
       birthCountry,
       birthINSEECode,
@@ -120,7 +118,7 @@ export async function extractCertificationCandidatesFromCandidatesImportSheet({
       sessionId: session.id,
       billingMode: billingMode ?? null,
       prepaymentCode: candidateData.prepaymentCode ?? null,
-      subscriptions,
+      subscription,
       id: null,
       birthProvinceCode: null,
       createdAt: null,
@@ -195,28 +193,15 @@ function _handleDuplicateCandidate() {
   };
 }
 
-function _buildComplementaryCertification(complementaryCertificationKey) {
-  return Subscription.buildComplementary({
-    certificationCandidateId: null,
-    complementaryCertificationKey,
-  });
-}
-
-function _buildSubscriptions(candidateData) {
-  const subscriptionKeys = Object.values(ComplementaryCertificationKeys).filter((key) => Boolean(candidateData[key]));
-
-  if (subscriptionKeys.includes(ComplementaryCertificationKeys.CLEA) || subscriptionKeys.length === 0) {
-    subscriptionKeys.push(SUBSCRIPTION_TYPES.CORE);
+function _buildSubscription(candidateData) {
+  const selectedFrameworks = Object.values(Frameworks)
+    .filter((key) => key !== Frameworks.CORE)
+    .filter((key) => Boolean(candidateData[key]));
+  if (selectedFrameworks.length > 1) {
+    throw new CertificationCandidatesError({
+      code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
+      message: 'A candidate cannot have more than one complementary certification',
+    });
   }
-
-  const subscriptions = [];
-  for (const subscriptionKey of subscriptionKeys) {
-    if (subscriptionKey === SUBSCRIPTION_TYPES.CORE) {
-      subscriptions.push(Subscription.buildCore({ certificationCandidateId: null }));
-    } else {
-      subscriptions.push(_buildComplementaryCertification(subscriptionKey));
-    }
-  }
-
-  return subscriptions;
+  return selectedFrameworks[0] || Frameworks.CORE;
 }

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -77,7 +77,7 @@ async function _deleteExistingCandidatesInSession({ candidateRepository, session
 
 async function _saveCandidates({ candidates, sessionId, candidateRepository }) {
   const candidatesToSave = candidates.map((candidate) => {
-    return Candidate.create({ ...candidate, sessionId });
+    return new Candidate({ ...candidate, sessionId });
   });
   await candidateRepository.save({ candidates: candidatesToSave });
 }

--- a/api/src/certification/enrolment/domain/usecases/get-candidate-timeline.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate-timeline.js
@@ -9,22 +9,25 @@
  * @typedef {import ('../../infrastructure/repositories/index.js').ComplementaryCertificationBadgeWithOffsetVersionRepository} ComplementaryCertificationBadgeWithOffsetVersionRepository
  * @typedef {import ('../models/timeline/TimelineEvent.js').TimelineEvent} TimelineEvent
  * @typedef {import ('../models/Candidate.js').Candidate} Candidate
- * @typedef {import ('../models/Candidate.js').Subscription} Subscription
  * @typedef {import ('../read-models/UserCertificationEligibility.js').UserCertificationEligibility} UserCertificationEligibility
  * @typedef {import ('../../../shared/domain/models/CertificationCourse.js').CertificationCourse} CertificationCourse
  * @typedef {import ('../../../session-management/domain/models/CertificationAssessment.js').CertificationAssessment} CertificationAssessment
  */
 
-import { CandidateCertifiableEvent } from '../models/timeline/CandidateCertifiableEvent.js';
-import { CandidateCreatedEvent } from '../models/timeline/CandidateCreatedEvent.js';
-import { CandidateDoubleCertificationEligibleEvent } from '../models/timeline/CandidateDoubleCertificationEligibleEvent.js';
-import { CandidateEligibleButNotRegisteredToDoubleCertificationEvent } from '../models/timeline/CandidateEligibleButNotRegisteredToDoubleCertificationEvent.js';
-import { CandidateNotCertifiableEvent } from '../models/timeline/CandidateNotCertifiableEvent.js';
-import { CandidateNotEligibleEvent } from '../models/timeline/CandidateNotEligibleEvent.js';
-import { CandidateReconciledEvent } from '../models/timeline/CandidateReconciledEvent.js';
-import { CandidateTimeline } from '../models/timeline/CandidateTimeline.js';
-import { CertificationStartedEvent } from '../models/timeline/CertificationStartedEvent.js';
-import { LastAnsweredEvent } from '../models/timeline/LastAnsweredEvent.js';
+import { CandidateCertifiableEvent } from "../models/timeline/CandidateCertifiableEvent.js";
+import { CandidateCreatedEvent } from "../models/timeline/CandidateCreatedEvent.js";
+import {
+  CandidateDoubleCertificationEligibleEvent
+} from "../models/timeline/CandidateDoubleCertificationEligibleEvent.js";
+import {
+  CandidateEligibleButNotRegisteredToDoubleCertificationEvent
+} from "../models/timeline/CandidateEligibleButNotRegisteredToDoubleCertificationEvent.js";
+import { CandidateNotCertifiableEvent } from "../models/timeline/CandidateNotCertifiableEvent.js";
+import { CandidateNotEligibleEvent } from "../models/timeline/CandidateNotEligibleEvent.js";
+import { CandidateReconciledEvent } from "../models/timeline/CandidateReconciledEvent.js";
+import { CandidateTimeline } from "../models/timeline/CandidateTimeline.js";
+import { CertificationStartedEvent } from "../models/timeline/CertificationStartedEvent.js";
+import { LastAnsweredEvent } from "../models/timeline/LastAnsweredEvent.js";
 
 /**
  * @param {object} params

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -2,10 +2,10 @@
  * @typedef {import ("./index.js").dependencies} deps
  */
 
-import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
-import { Candidate } from '../models/Candidate.js';
-import { SessionEnrolment } from '../models/SessionEnrolment.js';
-import { SessionMassImportReport } from '../models/SessionMassImportReport.js';
+import { PromiseUtils } from "../../../../shared/infrastructure/utils/promise-utils.js";
+import { Candidate } from "../models/Candidate.js";
+import { SessionEnrolment } from "../models/SessionEnrolment.js";
+import { SessionMassImportReport } from "../models/SessionMassImportReport.js";
 
 /**
  * @param {object} params
@@ -125,19 +125,19 @@ async function _createValidCertificationCandidates({
 
     const certificationCandidateErrors = [];
 
-    const { certificationCandidateComplementaryErrors, subscriptions } =
+    const { certificationCandidateComplementaryErrors, subscription } =
       await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
-        subscriptionKeys: candidateDTO.subscriptionKeys,
+        subscriptionKeys: candidateDTO.subscriptionKey,
         line: candidateDTO.line,
       });
 
     certificationCandidateErrors.push(...certificationCandidateComplementaryErrors);
 
-    const candidate = Candidate.create({
+    const candidate = new Candidate({
       ...candidateDTO,
       sessionId,
+      subscription,
       billingMode: billingMode || candidateDTO.billingMode,
-      subscriptions,
       id: null,
       userId: null,
       reconciledAt: null,

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
@@ -32,11 +32,10 @@ export const verifyCandidateReconciliationRequirements = async ({
     throw new UserNotAuthorizedToCertifyError();
   }
 
-  if (candidate.hasComplementarySubscription()) {
-    const complementarySubscription = candidate.getComplementarySubscription();
+  if (candidate.hasNonCoreSubscription()) {
     const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
 
-    if (!certificationCenter.isHabilitated(complementarySubscription.complementaryCertificationKey)) {
+    if (!certificationCenter.isHabilitated(candidate.subscription)) {
       throw new CenterHabilitationError();
     }
   }

--- a/api/src/certification/enrolment/domain/validators/candidate-validator.js
+++ b/api/src/certification/enrolment/domain/validators/candidate-validator.js
@@ -1,55 +1,9 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
-import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
+import { BILLING_MODES } from '../../../shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
-import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
-
-// eslint-disable-next-line no-unused-vars
-const { CLEA, ...COMPLEMENTARY_CERTIFICATIONS_EXCEPTED_DOUBLE_CERTIFICATION } = ComplementaryCertificationKeys;
-
-const alternativeCoreOnly = Joi.array()
-  .length(1)
-  .items({
-    certificationCandidateId: Joi.number().allow(null),
-    type: SUBSCRIPTION_TYPES.CORE,
-    complementaryCertificationKey: null,
-  })
-  .required();
-const alternativeDoubleCertification = Joi.array()
-  .length(2)
-  .items(
-    Joi.object({
-      certificationCandidateId: Joi.number().allow(null),
-      type: Joi.string()
-        .required()
-        .valid(...Object.values(SUBSCRIPTION_TYPES)),
-      complementaryCertificationKey: Joi.when('type', {
-        is: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-        then: Joi.string().valid(ComplementaryCertificationKeys.CLEA),
-        otherwise: null,
-      }),
-    }),
-  )
-  .unique('type')
-  .required();
-
-const alternativeComplementaryCertification = Joi.array()
-  .length(1)
-  .items(
-    Joi.object({
-      type: Joi.string().required().valid(SUBSCRIPTION_TYPES.COMPLEMENTARY),
-      complementaryCertificationKey: Joi.string().valid(
-        ...Object.values(COMPLEMENTARY_CERTIFICATIONS_EXCEPTED_DOUBLE_CERTIFICATION),
-      ),
-    }),
-  )
-  .unique('type')
-  .required();
-
-const schemaForCompatibilitySubscriptions = Joi.alternatives()
-  .match('one')
-  .try(alternativeCoreOnly, alternativeDoubleCertification, alternativeComplementaryCertification);
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 
 const schema = Joi.object({
   firstName: Joi.string().trim().required().empty(['', null]).messages({
@@ -90,7 +44,7 @@ const schema = Joi.object({
       'number.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SESSION_ID_NOT_A_NUMBER.code,
     }),
   }),
-  subscriptions: schemaForCompatibilitySubscriptions,
+  subscription: Joi.string().valid(...Object.values(Frameworks)),
   billingMode: Joi.when('$isSco', {
     is: false,
     then: Joi.string()

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -1,15 +1,7 @@
-/**
- * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
- */
-
 // @ts-check
-import dayjs from 'dayjs';
-
-import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
-import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
-import { Candidate } from '../../domain/models/Candidate.js';
-import { Subscription } from '../../domain/models/Subscription.js';
+import { DomainTransaction } from "../../../../shared/domain/DomainTransaction.js";
+import { CertificationCandidateNotFoundError } from "../../../shared/domain/errors.js";
+import { Candidate } from "../../domain/models/Candidate.js";
 
 /**
  * @function
@@ -78,31 +70,6 @@ export async function update(candidate) {
   if (!updatedCertificationCandidate) {
     throw new CertificationCandidateNotFoundError();
   }
-
-  await knexConn('certification-subscriptions').where({ certificationCandidateId: candidate.id }).del();
-
-  for (const subscription of candidate.subscriptions) {
-    if (subscription.type === SUBSCRIPTION_TYPES.CORE) {
-      await knexConn('certification-subscriptions').insert({
-        certificationCandidateId: candidate.id,
-        type: subscription.type,
-        complementaryCertificationId: null,
-      });
-    } else {
-      const { id: complementaryCertificationId } = await knexConn('complementary-certifications')
-        .select('id')
-        .where({
-          key: subscription.complementaryCertificationKey,
-        })
-        .first();
-
-      await knexConn('certification-subscriptions').insert({
-        certificationCandidateId: candidate.id,
-        type: subscription.type,
-        complementaryCertificationId: complementaryCertificationId,
-      });
-    }
-  }
 }
 
 /**
@@ -124,36 +91,12 @@ export async function insert(candidate) {
  */
 export async function save({ candidates }) {
   const knexConn = DomainTransaction.getConnection();
-  const complementaryCertificationsData = await knexConn('complementary-certifications').select('id', 'key');
 
   const candidatesData = candidates.map(adaptModelToDb);
 
   const insertedCandidatesData = await knexConn('certification-candidates')
     .insert(candidatesData)
     .returning(['id', 'firstName', 'lastName', 'birthdate']);
-
-  const subscriptionsData = [];
-  for (const candidate of candidates) {
-    const insertedCandidateId = insertedCandidatesData.find(
-      (insertedCandidateData) =>
-        insertedCandidateData.firstName === candidate.firstName &&
-        insertedCandidateData.lastName === candidate.lastName &&
-        dayjs(insertedCandidateData.birthdate).format('YYYY-MM-DD') === dayjs(candidate.birthdate).format('YYYY-MM-DD'),
-    ).id;
-
-    subscriptionsData.push(
-      ...candidate.subscriptions.map((subscription) => ({
-        certificationCandidateId: insertedCandidateId,
-        type: subscription.type,
-        complementaryCertificationId:
-          complementaryCertificationsData.find(
-            (complementaryCertificationData) =>
-              complementaryCertificationData.key === subscription.complementaryCertificationKey,
-          )?.id ?? null,
-      })),
-    );
-  }
-  await knexConn('certification-subscriptions').insert(subscriptionsData);
 
   return insertedCandidatesData.map(({ id }) => id);
 }
@@ -166,10 +109,6 @@ export async function save({ candidates }) {
  */
 export async function deleteBySessionId({ sessionId }) {
   const knexConn = DomainTransaction.getConnection();
-  await knexConn('certification-subscriptions')
-    .whereIn('certificationCandidateId', knexConn.select('id').from('certification-candidates').where({ sessionId }))
-    .del();
-
   await knexConn('certification-candidates').where({ sessionId }).del();
 }
 
@@ -181,7 +120,6 @@ export async function deleteBySessionId({ sessionId }) {
  */
 export async function remove({ id }) {
   const knexConn = DomainTransaction.getConnection();
-  await knexConn('certification-subscriptions').where({ certificationCandidateId: id }).del();
   return knexConn('certification-candidates').where({ id }).del();
 }
 
@@ -192,29 +130,8 @@ export async function remove({ id }) {
 function buildBaseReadQuery(knexConn) {
   return knexConn('certification-candidates')
     .select('certification-candidates.*', 'certification-courses.id as certificationCourseId')
-    .select({
-      subscriptions: knexConn.raw(
-        `json_agg(
-          json_build_object(
-            'type', "certification-subscriptions"."type",
-            'complementaryCertificationKey', "complementary-certifications"."key",
-            'certificationCandidateId', "certification-candidates"."id"
-          ) ORDER BY type
-      )`,
-      ),
-    })
     .from('certification-candidates')
     .leftJoin('certification-courses', 'certification-courses.candidateId', 'certification-candidates.id')
-    .join(
-      'certification-subscriptions',
-      'certification-subscriptions.certificationCandidateId',
-      'certification-candidates.id',
-    )
-    .leftJoin(
-      'complementary-certifications',
-      'certification-subscriptions.complementaryCertificationId',
-      'complementary-certifications.id',
-    )
     .groupBy('certification-candidates.id', 'certification-courses.id');
 }
 
@@ -303,16 +220,9 @@ function adaptModelToDb(candidate) {
  * @property {boolean} accessibilityAdjustmentNeeded
  * @property {boolean} hasStartedTest
  * @property {number | null} extraTimePercentage
- * @property {Array<SubscriptionDTO>} subscriptions
+ * @property {String} subscription
  * @property {Date} reconciledAt
  * @property {Date} createdAt
- */
-
-/**
- * @typedef {object} SubscriptionDTO
- * @property {string} type
- * @property {ComplementaryCertificationKeys} complementaryCertificationKey
- * @property {number} certificationCandidateId
  */
 
 /**
@@ -321,10 +231,8 @@ function adaptModelToDb(candidate) {
  * @returns {Candidate}
  */
 function toDomain(candidateData) {
-  const subscriptions = candidateData.subscriptions.map((subscription) => new Subscription(subscription));
   return new Candidate({
     ...candidateData,
     hasStartedTest: Boolean(candidateData.certificationCourseId),
-    subscriptions,
   });
 }

--- a/api/src/certification/enrolment/infrastructure/serializers/candidate-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/candidate-serializer.js
@@ -2,27 +2,15 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Deserializer, Serializer } = jsonapiSerializer;
 
 import { Candidate } from '../../domain/models/Candidate.js';
-import { Subscription } from '../../domain/models/Subscription.js';
 
 export async function deserialize(json) {
   const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
   const deserializedCandidate = await deserializer.deserialize(json);
   deserializedCandidate.birthINSEECode = deserializedCandidate.birthInseeCode;
-  const { attributes } = json.data;
 
-  const subscriptions = attributes['subscriptions'].map(
-    ({ type, complementaryCertificationKey }) =>
-      new Subscription({
-        certificationCandidateId: null,
-        type,
-        complementaryCertificationKey,
-      }),
-  );
-
-  return Candidate.create({
+  return new Candidate({
     ...deserializedCandidate,
     id: deserializedCandidate?.id ? parseInt(deserializedCandidate?.id) : null,
-    subscriptions,
     firstName: deserializedCandidate.firstName.trim(),
     lastName: deserializedCandidate.lastName.trim(),
   });

--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -304,7 +304,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       expect(actualCandidates).to.deep.equal(expectedCandidates);
     });
 
-    it('should throw an error if candidate is registered for multiple complementary certifications', async function () {
+    it('should throw an error if candidate is registered for multiple certifications', async function () {
       // given
       mailCheck.assertEmailDomainHasMx.resolves();
 

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -1,9 +1,7 @@
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import * as candidateRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/candidate-repository.js';
-import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { _ } from '../../../../../../src/shared/infrastructure/utils/lodash-utils.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -14,42 +12,16 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
     context('when the candidate exists', function () {
       it('should return the candidate', async function () {
         // given
-        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
-
-        databaseBuilder.factory.buildCoreSubscription({
-          certificationCandidateId: certificationCandidate.id,
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+          subscription: Frameworks.CLEA,
         });
-
-        const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-          id: 1,
-          key: Frameworks.CLEA,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationSubscription({
-          certificationCandidateId: certificationCandidate.id,
-          complementaryCertificationId: complementaryCertification.id,
-        });
-
         await databaseBuilder.commit();
 
         // when
         const result = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
 
         // then
-        expect(result).to.deepEqualInstance(
-          new Candidate({
-            ...certificationCandidate,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: certificationCandidate.id,
-                complementaryCertificationKey: complementaryCertification.key,
-              }),
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: certificationCandidate.id,
-              }),
-            ],
-          }),
-        );
+        expect(result).to.deepEqualInstance(new Candidate({ ...certificationCandidate, hasStartedTest: false }));
       });
     });
 
@@ -57,35 +29,17 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       it('should return the candidate with information on whether he/she started the test', async function () {
         // given
         const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
-
-        databaseBuilder.factory.buildCoreSubscription({
-          certificationCandidateId: certificationCandidate.id,
-        });
-
         databaseBuilder.factory.buildCertificationCourse({
           userId: certificationCandidate.userId,
           candidateId: certificationCandidate.id,
         });
-
         await databaseBuilder.commit();
 
         // when
-        const result = await candidateRepository.get({
-          certificationCandidateId: certificationCandidate.id,
-        });
+        const result = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
 
         // then
-        expect(result).to.deepEqualInstance(
-          new Candidate({
-            ...certificationCandidate,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: certificationCandidate.id,
-              }),
-            ],
-            hasStartedTest: true,
-          }),
-        );
+        expect(result).to.deepEqualInstance(new Candidate({ ...certificationCandidate, hasStartedTest: true }));
       });
     });
 
@@ -108,28 +62,15 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       it('should return the candidates', async function () {
         // given
         const sessionId = databaseBuilder.factory.buildSession().id;
-        databaseBuilder.factory.buildComplementaryCertification({
-          id: 1,
-          key: Frameworks.CLEA,
-        });
         const certificationCandidate1 = databaseBuilder.factory.buildCertificationCandidate({
           sessionId,
+          subscription: Frameworks.CLEA,
         });
         const certificationCandidate2 = databaseBuilder.factory.buildCertificationCandidate({
           firstName: 'FiFouLaPraline',
           sessionId,
         });
         databaseBuilder.factory.buildCertificationCandidate();
-        databaseBuilder.factory.buildCoreSubscription({
-          certificationCandidateId: certificationCandidate1.id,
-        });
-        databaseBuilder.factory.buildComplementaryCertificationSubscription({
-          certificationCandidateId: certificationCandidate1.id,
-          complementaryCertificationId: 1,
-        });
-        databaseBuilder.factory.buildCoreSubscription({
-          certificationCandidateId: certificationCandidate2.id,
-        });
         await databaseBuilder.commit();
 
         // when
@@ -137,26 +78,8 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
 
         // then
         expect(result).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildCandidate({
-            ...certificationCandidate1,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: certificationCandidate1.id,
-                complementaryCertificationKey: Frameworks.CLEA,
-              }),
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: certificationCandidate1.id,
-              }),
-            ],
-          }),
-          domainBuilder.certification.enrolment.buildCandidate({
-            ...certificationCandidate2,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: certificationCandidate2.id,
-              }),
-            ],
-          }),
+          domainBuilder.certification.enrolment.buildCandidate({ ...certificationCandidate1 }),
+          domainBuilder.certification.enrolment.buildCandidate({ ...certificationCandidate2 }),
         ]);
       });
     });
@@ -166,8 +89,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         // given
         const sessionId = databaseBuilder.factory.buildSession().id;
         const otherSessionId = databaseBuilder.factory.buildSession().id;
-        const candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateId });
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId });
         await databaseBuilder.commit();
 
         //when
@@ -184,14 +106,9 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       it('should return the candidates', async function () {
         // given
         const candidate1 = databaseBuilder.factory.buildCertificationCandidate();
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate1.id });
         const userId = candidate1.userId;
-
         const candidate2 = databaseBuilder.factory.buildCertificationCandidate({ userId });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate2.id });
-
-        const candidate3 = databaseBuilder.factory.buildCertificationCandidate();
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate3.id });
+        databaseBuilder.factory.buildCertificationCandidate();
         await databaseBuilder.commit();
 
         // when
@@ -199,18 +116,8 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
 
         // then
         expect(result).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildCandidate({
-            ...candidate1,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: candidate1.id }),
-            ],
-          }),
-          domainBuilder.certification.enrolment.buildCandidate({
-            ...candidate2,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: candidate2.id }),
-            ],
-          }),
+          domainBuilder.certification.enrolment.buildCandidate({ ...candidate1 }),
+          domainBuilder.certification.enrolment.buildCandidate({ ...candidate2 }),
         ]);
       });
     });
@@ -230,18 +137,10 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
     context('when the candidate exists', function () {
       it('should update the candidate', async function () {
         // when
-        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-          firstName: 'toto',
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({ firstName: 'toto' });
         await databaseBuilder.commit();
         const certificationCandidateToUpdate = domainBuilder.certification.enrolment.buildCandidate({
           ...certificationCandidate,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({
-              certificationCandidateId: certificationCandidate.id,
-            }),
-          ],
         });
         certificationCandidateToUpdate.firstName = 'tutu';
 
@@ -256,76 +155,24 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         expect(candidate.firstName).to.equal('tutu');
       });
 
-      it('should update its subscriptions', async function () {
-        // when
-        const complementaryCertificationDroit = databaseBuilder.factory.buildComplementaryCertification({
-          id: 555,
-          key: Frameworks.DROIT,
-        });
-        const complementaryCertificationEdu = databaseBuilder.factory.buildComplementaryCertification({
-          id: 666,
-          key: Frameworks.EDU_1ER_DEGRE,
-        });
+      it('should update its subscription', async function () {
+        // given
         const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-          firstName: 'toto',
+          subscription: Frameworks.DROIT,
         });
-        databaseBuilder.factory.buildComplementaryCertificationSubscription({
-          certificationCandidateId: certificationCandidate.id,
-          complementaryCertificationId: complementaryCertificationDroit.id,
-        });
-        databaseBuilder.factory.buildCoreSubscription({
-          certificationCandidateId: certificationCandidate.id,
-        });
-
         await databaseBuilder.commit();
 
         const certificationCandidateToUpdate = domainBuilder.certification.enrolment.buildCandidate({
           ...certificationCandidate,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({
-              certificationCandidateId: certificationCandidate.id,
-            }),
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId: certificationCandidate.id,
-              complementaryCertificationKey: complementaryCertificationEdu.key,
-            }),
-          ],
+          subscription: Frameworks.EDU_1ER_DEGRE,
         });
 
         // when
-        const subscriptionsBefore = (
-          await candidateRepository.get({
-            certificationCandidateId: certificationCandidateToUpdate.id,
-          })
-        ).subscriptions;
-
         await candidateRepository.update(certificationCandidateToUpdate);
 
-        const subscriptionsAfter = (
-          await candidateRepository.get({
-            certificationCandidateId: certificationCandidateToUpdate.id,
-          })
-        ).subscriptions;
-
         // then
-        expect(subscriptionsBefore).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            certificationCandidateId: certificationCandidate.id,
-            complementaryCertificationKey: complementaryCertificationDroit.key,
-          }),
-          domainBuilder.certification.enrolment.buildCoreSubscription({
-            certificationCandidateId: certificationCandidate.id,
-          }),
-        ]);
-        expect(subscriptionsAfter).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            certificationCandidateId: certificationCandidate.id,
-            complementaryCertificationKey: complementaryCertificationEdu.key,
-          }),
-          domainBuilder.certification.enrolment.buildCoreSubscription({
-            certificationCandidateId: certificationCandidate.id,
-          }),
-        ]);
+        const updated = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
+        expect(updated.subscription).to.equal(Frameworks.EDU_1ER_DEGRE);
       });
     });
 
@@ -350,12 +197,6 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
     let candidateData;
 
     beforeEach(function () {
-      const subscriptionCore = domainBuilder.certification.enrolment.buildCoreSubscription({
-        certificationCandidateId: null,
-      });
-      const subscriptionComplementary = domainBuilder.certification.enrolment.buildComplementarySubscription({
-        certificationCandidateId: null,
-      });
       candidateData = {
         id: null,
         createdAt: new Date('2020-01-01'),
@@ -381,20 +222,14 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: null,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: false,
-        subscriptions: [subscriptionCore, subscriptionComplementary],
         reconciledAt: null,
-        subscription: null,
+        subscription: Frameworks.DROIT,
       };
       databaseBuilder.factory.buildSession({ id: candidateData.sessionId });
-      databaseBuilder.factory.buildComplementaryCertification({
-        id: 22,
-        label: 'Pix+DROIT',
-        key: Frameworks.DROIT,
-      });
       return databaseBuilder.commit();
     });
 
-    it('should insert candidate in DB with subscriptions', async function () {
+    it('should insert candidate in DB', async function () {
       // given
       const candidateToInsert = domainBuilder.certification.enrolment.buildCandidate(candidateData);
 
@@ -403,43 +238,20 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
 
       // then
       const savedCandidateData = await knex('certification-candidates').select('*').where({ id: candidateId }).first();
-      const savedSubscriptionsData = await knex('certification-subscriptions')
-        .select('*')
-        .where({ certificationCandidateId: candidateId })
-        .orderBy('type');
       expect(savedCandidateData).to.deepEqualInstanceOmitting(candidateData, [
         'id',
         'createdAt',
-        'subscriptions',
         'complementaryCertificationId',
         'extraTimePercentage',
       ]);
       expect(parseFloat(savedCandidateData.extraTimePercentage)).to.equal(candidateData.extraTimePercentage);
-      expect(savedSubscriptionsData).to.have.lengthOf(2);
-      expect(savedSubscriptionsData[0]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: candidateId,
-          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-          complementaryCertificationId: 22,
-        },
-        ['createdAt'],
-      );
-      expect(savedSubscriptionsData[1]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: candidateId,
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-        },
-        ['createdAt'],
-      );
+      expect(savedCandidateData.subscription).to.equal(Frameworks.DROIT);
     });
   });
 
   describe('#save', function () {
     it("should insert session's candidates in DB with their subscriptions", async function () {
       // given
-      const cleaCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
-      const droitCertificationId = databaseBuilder.factory.buildComplementaryCertification.droit({}).id;
       const sessionId = databaseBuilder.factory.buildSession({}).id;
       await databaseBuilder.commit();
       const candidateA = domainBuilder.certification.enrolment.buildCandidate({
@@ -447,12 +259,6 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         lastName: 'Lapraline',
         accessibilityAdjustmentNeeded: true,
         sessionId,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription(),
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            complementaryCertificationKey: Frameworks.CLEA,
-          }),
-        ],
         subscription: Frameworks.CLEA,
       });
       const candidateB = domainBuilder.certification.enrolment.buildCandidate({
@@ -460,18 +266,12 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         lastName: 'Lenougat',
         accessibilityAdjustmentNeeded: true,
         sessionId,
-        subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
       });
       const candidateC = domainBuilder.certification.enrolment.buildCandidate({
         firstName: 'Loulou',
         lastName: 'Lapistache',
         sessionId,
         accessibilityAdjustmentNeeded: false,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            complementaryCertificationKey: Frameworks.DROIT,
-          }),
-        ],
         subscription: Frameworks.DROIT,
       });
 
@@ -479,151 +279,13 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       await candidateRepository.save({ candidates: [candidateA, candidateB, candidateC] });
 
       // then
-      // Candidate A
-      const savedCandidateAData = await knex('certification-candidates')
-        .select('*')
-        .where({ firstName: 'Lolo' })
-        .first();
-      const savedSubscriptionsAData = await knex('certification-subscriptions')
-        .select('*')
-        .where({ certificationCandidateId: savedCandidateAData.id })
-        .orderBy('type');
-      expect(_.omit(savedCandidateAData, ['createdAt', 'extraTimePercentage'])).to.deep.equal({
-        id: savedCandidateAData.id,
-        firstName: candidateA.firstName,
-        reconciledAt: null,
-        lastName: candidateA.lastName,
-        birthCity: candidateA.birthCity,
-        externalId: candidateA.externalId,
-        birthdate: candidateA.birthdate,
-        sessionId: sessionId,
-        birthProvinceCode: candidateA.birthProvinceCode,
-        birthCountry: candidateA.birthCountry,
-        userId: null,
-        email: candidateA.email,
-        resultRecipientEmail: candidateA.resultRecipientEmail,
-        organizationLearnerId: candidateA.organizationLearnerId,
-        birthPostalCode: candidateA.birthPostalCode,
-        birthINSEECode: candidateA.birthINSEECode,
-        sex: candidateA.sex,
-        authorizedToStart: false,
-        billingMode: candidateA.billingMode,
-        prepaymentCode: candidateA.prepaymentCode,
-        hasSeenCertificationInstructions: false,
-        accessibilityAdjustmentNeeded: candidateA.accessibilityAdjustmentNeeded,
-        subscription: Frameworks.CLEA,
-      });
-      expect(savedCandidateAData.createdAt).to.be.instanceOf(Date);
-      expect(parseFloat(savedCandidateAData.extraTimePercentage)).to.equal(candidateA.extraTimePercentage);
-      expect(savedSubscriptionsAData).to.have.lengthOf(2);
-      expect(savedSubscriptionsAData[0]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: savedCandidateAData.id,
-          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-          complementaryCertificationId: cleaCertificationId,
-        },
-        ['createdAt'],
-      );
-      expect(savedSubscriptionsAData[1]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: savedCandidateAData.id,
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-        },
-        ['createdAt'],
-      );
+      const savedA = await knex('certification-candidates').select('*').where({ firstName: 'Lolo' }).first();
+      const savedB = await knex('certification-candidates').select('*').where({ firstName: 'Geogeo' }).first();
+      const savedC = await knex('certification-candidates').select('*').where({ firstName: 'Loulou' }).first();
 
-      // Candidate B
-      const savedCandidateBData = await knex('certification-candidates')
-        .select('*')
-        .where({ firstName: 'Geogeo' })
-        .first();
-      const savedSubscriptionsBData = await knex('certification-subscriptions')
-        .select('*')
-        .where({ certificationCandidateId: savedCandidateBData.id })
-        .orderBy('type');
-      expect(_.omit(savedCandidateBData, ['createdAt', 'extraTimePercentage'])).to.deep.equal({
-        id: savedCandidateBData.id,
-        firstName: candidateB.firstName,
-        reconciledAt: null,
-        lastName: candidateB.lastName,
-        birthCity: candidateB.birthCity,
-        externalId: candidateB.externalId,
-        birthdate: candidateB.birthdate,
-        sessionId: sessionId,
-        birthProvinceCode: candidateB.birthProvinceCode,
-        birthCountry: candidateB.birthCountry,
-        userId: null,
-        email: candidateB.email,
-        resultRecipientEmail: candidateB.resultRecipientEmail,
-        organizationLearnerId: candidateB.organizationLearnerId,
-        birthPostalCode: candidateB.birthPostalCode,
-        birthINSEECode: candidateB.birthINSEECode,
-        sex: candidateB.sex,
-        authorizedToStart: false,
-        billingMode: candidateB.billingMode,
-        prepaymentCode: candidateB.prepaymentCode,
-        hasSeenCertificationInstructions: false,
-        accessibilityAdjustmentNeeded: candidateB.accessibilityAdjustmentNeeded,
-        subscription: Frameworks.CORE,
-      });
-      expect(savedCandidateBData.createdAt).to.be.instanceOf(Date);
-      expect(parseFloat(savedCandidateBData.extraTimePercentage)).to.equal(candidateB.extraTimePercentage);
-      expect(savedSubscriptionsBData).to.have.lengthOf(1);
-      expect(savedSubscriptionsBData[0]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: savedCandidateBData.id,
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-        },
-        ['createdAt'],
-      );
-
-      // Candidate C
-      const savedCandidateCData = await knex('certification-candidates')
-        .select('*')
-        .where({ firstName: 'Loulou' })
-        .first();
-      const savedSubscriptionsCData = await knex('certification-subscriptions')
-        .select('*')
-        .where({ certificationCandidateId: savedCandidateCData.id })
-        .orderBy('type');
-      expect(_.omit(savedCandidateCData, ['createdAt', 'extraTimePercentage'])).to.deep.equal({
-        id: savedCandidateCData.id,
-        firstName: candidateC.firstName,
-        reconciledAt: null,
-        lastName: candidateC.lastName,
-        birthCity: candidateC.birthCity,
-        externalId: candidateC.externalId,
-        birthdate: candidateC.birthdate,
-        sessionId: sessionId,
-        birthProvinceCode: candidateC.birthProvinceCode,
-        birthCountry: candidateC.birthCountry,
-        userId: null,
-        email: candidateC.email,
-        resultRecipientEmail: candidateC.resultRecipientEmail,
-        organizationLearnerId: candidateC.organizationLearnerId,
-        birthPostalCode: candidateC.birthPostalCode,
-        birthINSEECode: candidateC.birthINSEECode,
-        sex: candidateC.sex,
-        authorizedToStart: false,
-        billingMode: candidateC.billingMode,
-        prepaymentCode: candidateC.prepaymentCode,
-        hasSeenCertificationInstructions: false,
-        accessibilityAdjustmentNeeded: candidateC.accessibilityAdjustmentNeeded,
-        subscription: Frameworks.DROIT,
-      });
-      expect(savedCandidateCData.createdAt).to.be.instanceOf(Date);
-      expect(parseFloat(savedCandidateCData.extraTimePercentage)).to.equal(candidateC.extraTimePercentage);
-      expect(savedSubscriptionsCData).to.have.lengthOf(1);
-      expect(savedSubscriptionsCData[0]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: savedCandidateCData.id,
-          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-          complementaryCertificationId: droitCertificationId,
-        },
-        ['createdAt'],
-      );
+      expect(savedA.subscription).to.equal(Frameworks.CLEA);
+      expect(savedB.subscription).to.equal(Frameworks.CORE);
+      expect(savedC.subscription).to.equal(Frameworks.DROIT);
     });
   });
 });

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -1,14 +1,17 @@
-import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
-import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
-import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
-import { CertificationCandidate } from '../../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
-import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { CertificationCandidatesError } from '../../../../../../src/shared/domain/errors.js';
-import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { expect } from '../../../../../test-helper.js';
-import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr, catchErrSync } from '../../../../../tooling/test-utils/error.js';
+import { Candidate } from "../../../../../../src/certification/enrolment/domain/models/Candidate.js";
+import {
+  CERTIFICATION_CANDIDATES_ERRORS
+} from "../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js";
+import {
+  CertificationCandidate
+} from "../../../../../../src/certification/shared/domain/models/CertificationCandidate.js";
+import { Frameworks } from "../../../../../../src/certification/shared/domain/models/Frameworks.js";
+import { CertificationCandidatesError } from "../../../../../../src/shared/domain/errors.js";
+import { getI18n } from "../../../../../../src/shared/infrastructure/i18n/i18n.js";
+import { expect } from "../../../../../test-helper.js";
+import { domainBuilder } from "../../../../../tooling/domain-builder/domain-builder.js";
+import { catchErr, catchErrSync } from "../../../../../tooling/test-utils/error.js";
+
 const FIRST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code;
 const LAST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code;
 const BIRTHDATE_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code;
@@ -44,76 +47,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       billingMode: CertificationCandidate.BILLING_MODES.FREE,
       prepaymentCode: null,
       hasSeenCertificationInstructions: false,
-      subscriptions: [
-        {
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-          complementaryCertificationLabel: null,
-          complementaryCertificationKey: null,
-        },
-      ],
     };
-  });
-
-  context('create', function () {
-    context('when the candidate subscription is registered for CORE', function () {
-      it('should create a new Candidate with a CORE subscription attribute', function () {
-        // given
-        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-          subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
-        });
-
-        // when
-        const expectedCandidate = Candidate.create(candidateDTO);
-
-        // then
-        expect(expectedCandidate.subscription).to.equal(Frameworks.CORE);
-      });
-    });
-
-    context('when the candidate is registered for a double certification', function () {
-      it('should create a new Candidate with a CORE subscription attribute', function () {
-        // given
-        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription(),
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId: null,
-              complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-            }),
-          ],
-        });
-
-        // when
-        const expectedCandidate = Candidate.create(candidateDTO);
-
-        // then
-        expect(expectedCandidate.subscription).to.equal(Frameworks.CLEA);
-      });
-    });
-
-    context('when the candidate is registered for a Pix+ certification', function () {
-      it('should create a new Candidate with a PIX+ subscription attribute', function () {
-        // given
-        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId: null,
-              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-            }),
-          ],
-        });
-
-        // when
-        const expectedCandidate = Candidate.create(candidateDTO);
-
-        // then
-        expect(expectedCandidate.subscription).to.equal(Frameworks.DROIT);
-      });
-    });
   });
 
   context('updateBirthInformation', function () {
@@ -453,169 +387,22 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack']);
     });
 
-    context('compatibility core/complementary enable, should use new schema', function () {
+    context('subscription validation', function () {
       context('success cases', function () {
-        it('should validate when there is only one core subscription', function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-            ],
+        Object.values(Frameworks).forEach((subscription) => {
+          it(`should validate when subscription is ${subscription}`, function () {
+            const candidate = domainBuilder.certification.enrolment.buildCandidate({ ...candidateData, subscription });
+            candidate.validate();
           });
-
-          // when, then
-          candidate.validate();
-        });
-
-        it('should validate when there is a double certification', function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-              }),
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: null,
-              }),
-            ],
-          });
-
-          // when, then
-          candidate.validate();
-        });
-        it('should validate when there is only one complementary subscription excluding CLEA', function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-                complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-              }),
-            ],
-          });
-
-          // when, then
-          candidate.validate();
         });
       });
 
       context('ko cases', function () {
-        it('should not validate when there are no subscription at all', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
+        it('should not validate when subscription is an unknown value', async function () {
+          const candidate = domainBuilder.certification.enrolment.buildCandidate({ ...candidateData });
+          candidate.subscription = 'UNKNOWN_FRAMEWORK';
           const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
-        });
-
-        it('should not validate when there are two complementary', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-              }),
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-              }),
-            ],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
-          const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
-        });
-
-        it('should not validate when there are two complementary, one of which is CLEA', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-              }),
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-              }),
-            ],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
-          const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
-        });
-
-        it('should not validate when there are two core', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: null,
-              }),
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: null,
-              }),
-            ],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
-          const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
-        });
-
-        it('should not validate when there are one core and one complementary not clea', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: null,
-              }),
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-              }),
-            ],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
-          const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
+          expect(error).to.be.instanceOf(CertificationCandidatesError);
         });
       });
     });
@@ -1170,94 +957,26 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     });
   });
 
-  describe('hasComplementarySubscription', function () {
-    it('should return true', function () {
-      // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildComplementarySubscription({ certificationCandidateId: null }),
-        ],
-      });
-
-      // when
-      const hasCoreSubscription = candidate.hasComplementarySubscription();
-
-      // when / then
-      expect(hasCoreSubscription).to.be.true;
+  describe('hasNonCoreSubscription', function () {
+    it('should return true when subscription is not CORE', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
+      expect(candidate.hasNonCoreSubscription()).to.be.true;
     });
 
-    it('should return false', function () {
-      // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
-      });
-
-      // when
-      const hasCoreSubscription = candidate.hasComplementarySubscription();
-
-      // when / then
-      expect(hasCoreSubscription).to.be.false;
-    });
-  });
-
-  describe('#complementaryCertificationKey', function () {
-    it('should return null when there is no complementary subscription', function () {
-      // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
-      });
-
-      // when
-      const result = candidate.complementaryCertificationKey;
-
-      // then
-      expect(result).to.be.null;
-    });
-
-    it('should return the complementary certification key when there is a complementary subscription', function () {
-      // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            certificationCandidateId: null,
-            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-          }),
-        ],
-      });
-
-      // when
-      const result = candidate.complementaryCertificationKey;
-
-      // then
-      expect(result).to.equal(ComplementaryCertificationKeys.PIX_PLUS_DROIT);
+    it('should return false when subscription is CORE', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CORE });
+      expect(candidate.hasNonCoreSubscription()).to.be.false;
     });
   });
 
   describe('#isRegisteredToDoubleCertification', function () {
-    it('returns true when candidate is registered to double certification', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription(),
-          domainBuilder.certification.enrolment.buildCoreSubscription(),
-        ],
-      });
-
+    it('returns true when candidate subscription is CLEA', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
       expect(candidate.isRegisteredToDoubleCertification()).to.be.true;
     });
 
-    it('returns false when candidate is not registered to double certification', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        subscriptions: [domainBuilder.certification.enrolment.buildComplementarySubscription()],
-      });
-
+    it('returns false when candidate subscription is not CLEA', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.DROIT });
       expect(candidate.isRegisteredToDoubleCertification()).to.be.false;
     });
   });

--- a/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { registerCandidateParticipation } from '../../../../../../src/certification/enrolment/application/services/register-candidate-participation-service.js';
 import { WrongDomainExtensionForPixPlusError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { usecases } from '../../../../../../src/certification/enrolment/domain/usecases/index.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -64,7 +65,7 @@ describe('Unit | Application | Service | register-candidate-participation', func
       const candidateWithComplementary = domainBuilder.certification.enrolment.buildCandidate({
         ...candidateData,
         sessionId,
-        subscriptions: [domainBuilder.certification.enrolment.buildComplementarySubscription()],
+        subscription: Frameworks.DROIT,
       });
       sinon.stub(usecases, 'verifyCandidateIdentity').resolves(candidateWithComplementary);
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -315,11 +315,6 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
             it('should insert the candidate and return the id', async function () {
               // given
               centerRepository.getById.resolves(domainBuilder.certification.enrolment.buildCenter({}));
-              candidateToEnroll.subscriptions = [
-                domainBuilder.certification.enrolment.buildCoreSubscription({
-                  certificationCandidateId: null,
-                }),
-              ];
               const correctedCandidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
                 ...candidateToEnroll,
                 sessionId,
@@ -327,9 +322,6 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
                 birthINSEECode: 'INSEE_CODE',
                 birthPostalCode: null,
                 birthCity: 'CITY',
-                subscriptions: [
-                  domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-                ],
               });
               candidateRepository.insert.resolves(159);
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
 import { createSessions } from '../../../../../../src/certification/enrolment/domain/usecases/create-sessions.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
@@ -35,13 +35,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
 
     candidateData = {
       sessionId: undefined,
-      subscriptions: [
-        domainBuilder.certification.enrolment.buildCoreSubscription(),
-        domainBuilder.certification.enrolment.buildComplementarySubscription({
-          id: 1,
-          complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-        }),
-      ],
+      subscription: Frameworks.DROIT,
     };
   });
 
@@ -153,7 +147,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
               domainBuilder.certification.enrolment.buildCandidate({
                 ...candidate,
                 sessionId: 1234,
-                subscription: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+                subscription: Frameworks.DROIT,
               }),
             ],
           });
@@ -195,7 +189,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
             domainBuilder.certification.enrolment.buildCandidate({
               ...candidate,
               sessionId: 1234,
-              subscription: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+              subscription: Frameworks.DROIT,
             }),
           ],
         });

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
@@ -10,6 +10,7 @@ import { CertificationStartedEvent } from '../../../../../../src/certification/e
 import { LastAnsweredEvent } from '../../../../../../src/certification/enrolment/domain/models/timeline/LastAnsweredEvent.js';
 import { UserCertificationEligibility } from '../../../../../../src/certification/enrolment/domain/read-models/UserCertificationEligibility.js';
 import { getCandidateTimeline } from '../../../../../../src/certification/enrolment/domain/usecases/get-candidate-timeline.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -186,10 +187,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           const candidate = domainBuilder.certification.enrolment.buildCandidate({
             userId: 222,
             reconciledAt: new Date(),
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription(),
-              domainBuilder.certification.enrolment.buildComplementarySubscription(),
-            ],
+            subscription: Frameworks.CLEA,
           });
           candidateRepository.get.resolves(candidate);
           const placementProfile = domainBuilder.buildPlacementProfile();
@@ -226,10 +224,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           const candidate = domainBuilder.certification.enrolment.buildCandidate({
             userId: 222,
             reconciledAt: new Date(),
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription(),
-              domainBuilder.certification.enrolment.buildComplementarySubscription(),
-            ],
+            subscription: Frameworks.CLEA,
           });
           candidateRepository.get.resolves(candidate);
           const placementProfile = domainBuilder.buildPlacementProfile();

--- a/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
@@ -1,17 +1,28 @@
-import sinon from 'sinon';
+import sinon from "sinon";
 
-import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { SessionMassImportReport } from '../../../../../../src/certification/enrolment/domain/models/SessionMassImportReport.js';
-import { validateSessions } from '../../../../../../src/certification/enrolment/domain/usecases/validate-sessions.js';
-import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
-import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
-import { CERTIFICATION_SESSIONS_ERRORS } from '../../../../../../src/certification/shared/domain/constants/sessions-errors.js';
-import { CertificationCandidate } from '../../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
-import { CpfBirthInformationValidation } from '../../../../../../src/certification/shared/domain/services/certification-cpf-service.js';
-import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/domain/constants.js';
-import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { expect } from '../../../../../test-helper.js';
-import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { SessionEnrolment } from "../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js";
+import {
+  SessionMassImportReport
+} from "../../../../../../src/certification/enrolment/domain/models/SessionMassImportReport.js";
+import { validateSessions } from "../../../../../../src/certification/enrolment/domain/usecases/validate-sessions.js";
+import { SUBSCRIPTION_TYPES } from "../../../../../../src/certification/shared/domain/constants.js";
+import {
+  CERTIFICATION_CANDIDATES_ERRORS
+} from "../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js";
+import {
+  CERTIFICATION_SESSIONS_ERRORS
+} from "../../../../../../src/certification/shared/domain/constants/sessions-errors.js";
+import {
+  CertificationCandidate
+} from "../../../../../../src/certification/shared/domain/models/CertificationCandidate.js";
+import {
+  CpfBirthInformationValidation
+} from "../../../../../../src/certification/shared/domain/services/certification-cpf-service.js";
+import { CERTIFICATION_CENTER_TYPES } from "../../../../../../src/shared/domain/constants.js";
+import { getI18n } from "../../../../../../src/shared/infrastructure/i18n/i18n.js";
+import { expect } from "../../../../../test-helper.js";
+import { domainBuilder } from "../../../../../tooling/domain-builder/domain-builder.js";
+import { Frameworks } from "../../../../../../src/certification/shared/domain/models/Frameworks.js";
 
 const userId = 1234;
 const cachedValidatedSessionsKey = 'uuid';
@@ -147,9 +158,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
       sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
         certificationCandidateComplementaryErrors: [],
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
+        subscription: Frameworks.CORE,
       });
 
       sessionsImportValidationService.getValidatedCandidateInformation.resolves({
@@ -283,9 +292,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
+          subscription: Frameworks.CORE,
         });
 
         temporarySessionsStorageForMassImportService.save.resolves(cachedValidatedSessionsKey);
@@ -359,9 +366,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       // given
       sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
         certificationCandidateComplementaryErrors: [],
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
+        subscription: Frameworks.CORE,
       });
       sessionsImportValidationService.validateSession.resolves([
         { code: 'Veuillez indiquer un nom de site.', isBlocking: true },
@@ -398,9 +403,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
+          subscription: Frameworks.CORE,
         });
         sessionsImportValidationService.validateSession.resolves(['Veuillez indiquer un nom de site.']);
         sessionsImportValidationService.getValidatedCandidateInformation.resolves({
@@ -460,9 +463,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
+          subscription: Frameworks.CORE,
         });
         sessionsImportValidationService.validateSession.resolves([]);
         sessionsImportValidationService.getValidatedCandidateInformation.resolves({
@@ -529,9 +530,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
+          subscription: Frameworks.CORE,
         });
         sessionsImportValidationService.validateSession.resolves([]);
         sessionsImportValidationService.getValidatedCandidateInformation.resolves({

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-reconciliation-requirements_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-reconciliation-requirements_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { verifyCandidateReconciliationRequirements } from '../../../../../../src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js';
 import { CenterHabilitationError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { UserNotAuthorizedToCertifyError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -85,11 +86,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCases | verify-candidat
         const candidate = domainBuilder.certification.enrolment.buildCandidate({
           userId,
           reconciledAt,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-            }),
-          ],
+          subscription: Frameworks.DROIT,
         });
 
         placementProfileService.getPlacementProfile
@@ -128,11 +125,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCases | verify-candidat
         const candidate = domainBuilder.certification.enrolment.buildCandidate({
           userId,
           reconciledAt,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              complementaryCertificationKey: complementaryCertification.key,
-            }),
-          ],
+          subscription: complementaryCertification.key,
         });
 
         placementProfileService.getPlacementProfile

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
@@ -1,7 +1,5 @@
 import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/candidate-serializer.js';
-import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CertificationCandidate } from '../../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -58,7 +56,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
       };
     });
 
-    it('should deserialize correctly candidate with subscriptions', async function () {
+    it('should deserialize correctly candidate with subscription', async function () {
       // given
       const candidateJsonApiData = {
         data: {
@@ -86,16 +84,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
             'billing-mode': candidateData.billingMode,
             'prepayment-code': candidateData.prepaymentCode,
             'has-seen-certification-instructions': candidateData.hasSeenCertificationInstructions,
-            subscriptions: [
-              {
-                complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_PRO_SANTE,
-                type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-              },
-              {
-                complementaryCertificationKey: null,
-                type: SUBSCRIPTION_TYPES.CORE,
-              },
-            ],
+            subscription: Frameworks.PRO_SANTE,
           },
         },
       };
@@ -107,15 +96,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
       expect(deserializedCandidate).to.deepEqualInstance(
         domainBuilder.certification.enrolment.buildCandidate({
           ...candidateData,
-          complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_PRO_SANTE,
           subscription: Frameworks.PRO_SANTE,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId: null,
-              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_PRO_SANTE,
-            }),
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         }),
       );
     });

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
@@ -1,6 +1,5 @@
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { domainBuilder } from '../../../domain-builder.js';
 
 const buildCandidate = function ({
   id = 123,
@@ -26,7 +25,6 @@ const buildCandidate = function ({
   billingMode = null,
   prepaymentCode = null,
   hasSeenCertificationInstructions = false,
-  subscriptions = [domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null })],
   accessibilityAdjustmentNeeded,
   subscription = Frameworks.CORE,
 } = {}) {
@@ -54,7 +52,6 @@ const buildCandidate = function ({
     billingMode,
     prepaymentCode,
     hasSeenCertificationInstructions,
-    subscriptions,
     accessibilityAdjustmentNeeded,
     subscription,
   });


### PR DESCRIPTION
## 💥 Problème

Suite à l'ajout de la colonne subscription dans certification-candidate, la table certification-subscriptions est devenue obsolète. Ainsi, on peut progressivement retirer son utilisation et la remplacer par la nouvelle colonne.

## 👩‍🚀 Proposition

Dans le contexte Enrolment/Candidate, ne plus solliciter la table certification-subscriptions

## 👁️ Remarques

En attente du feu vert de team data

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
