### PR TITLE
[BUGFIX] Ajout de la gestion des certification-version en draft  dans la méthode findActiveByScope (pix22874)

### DIFF
--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -50,6 +50,7 @@ export async function findActiveByScope({ scope }) {
     .select('*')
     .where({ scope })
     .whereNull('expirationDate')
+    .whereNotNull('startDate')
     .first();
 
   if (!versionData) {

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -167,7 +167,7 @@ describe('Certification | Configuration | Integration | Repository | Version', f
   });
 
   describe('#findActiveByScope', function () {
-    it('should return the current version for the given scope', async function () {
+    it('should return the current active version for the given scope', async function () {
       // given
       const scope = SCOPES.PIX_PLUS_DROIT;
 
@@ -218,6 +218,17 @@ describe('Certification | Configuration | Integration | Repository | Version', f
         defaultCandidateCapacity: -3,
         defaultProbabilityToPickChallenge: 30,
       };
+
+      databaseBuilder.factory.buildCertificationVersion({
+        scope,
+        startDate: null,
+        expirationDate: null,
+        assessmentDuration: 120,
+        globalScoringConfiguration: [{ config: 'latest' }],
+        competencesScoringConfiguration: [{ config: 'latest' }],
+        challengesConfiguration: expectedConfig,
+      });
+
       const expectedVersionId = databaseBuilder.factory.buildCertificationVersion({
         scope,
         startDate: new Date('2025-06-01'),


### PR DESCRIPTION
## 💥 Problème

Les version au status draft peuvent resortir car on ne check pas la value de `startedDate`

## 👩‍🚀 Proposition

Ajouter un check sur startedDate

## 👁️ Remarques

RAS

## ♻️ Pour tester

CI ok