### PR TITLE
[TECH] Ajouter les dépendances via API dans le linter de dependances

### DIFF
--- a/api/src/maddo/dependencies.json
+++ b/api/src/maddo/dependencies.json
@@ -1,5 +1,6 @@
 {
   "name": "maddo",
-  "dependsOn": ["identity-access-management", "prescription/campaign", "shared"],
+  "dependsOn": ["identity-access-management", "shared"],
+  "dependsOnViaApi": ["prescription/campaign"],
   "circular": "forbidden"
 }

--- a/api/tests/tooling/dependency-cruiser-generator.js
+++ b/api/tests/tooling/dependency-cruiser-generator.js
@@ -16,19 +16,23 @@ export function buildForbiddenRules(contexts = []) {
     });
   }
 
-  // build context dependency rules
-  const dependsOnContexts = contexts
-    .filter((context) => Array.isArray(context.dependsOn))
+  // build dependency violation rules
+  const dependsOnRules = contexts
+    .filter((context) => Array.isArray(context.dependsOn) || Array.isArray(context.dependsOnViaApi))
     .map((context) => {
-      const dependsOn = [context.name, ...context.dependsOn];
+      const dependsOn = [
+        context.name,
+        ...(context.dependsOn || []),
+        ...(context.dependsOnViaApi || []).map((dep) => `${dep}/application/api`),
+      ];
       return {
-        name: `${context.name}-no-context`,
+        name: `${context.name}-dependency-violation`,
         severity: 'error',
         from: { path: `^src/${context.name}/` },
         to: { path: `^src/(?!${dependsOn.join('/|')}/)` },
       };
     });
-  forbiddenRules.push(...dependsOnContexts);
+  forbiddenRules.push(...dependsOnRules);
 
   return forbiddenRules;
 }

--- a/api/tests/unit/tooling/dependency-cruiser-generator_test.js
+++ b/api/tests/unit/tooling/dependency-cruiser-generator_test.js
@@ -3,7 +3,7 @@ import { buildForbiddenRules } from '../../tooling/dependency-cruiser-generator.
 
 describe('Unit | Tooling | Dependency cruiser generator', function () {
   describe('Context dependency rules', function () {
-    it('builds context dependency rule for contexts', function () {
+    it('builds dependency violation rule for contexts', function () {
       const contexts = [
         { name: 'shared', dependsOn: [] },
         { name: 'banner', dependsOn: ['shared'] },
@@ -13,16 +13,31 @@ describe('Unit | Tooling | Dependency cruiser generator', function () {
 
       expect(rules).to.deep.equal([
         {
-          name: 'shared-no-context',
+          name: 'shared-dependency-violation',
           severity: 'error',
           from: { path: '^src/shared/' },
           to: { path: '^src/(?!shared/)' },
         },
         {
-          name: 'banner-no-context',
+          name: 'banner-dependency-violation',
           severity: 'error',
           from: { path: '^src/banner/' },
           to: { path: '^src/(?!banner/|shared/)' },
+        },
+      ]);
+    });
+
+    it('builds dependency violation without api rule for contexts', function () {
+      const contexts = [{ name: 'banner', dependsOn: ['other'], dependsOnViaApi: ['shared'] }];
+
+      const rules = buildForbiddenRules(contexts);
+
+      expect(rules).to.deep.equal([
+        {
+          name: 'banner-dependency-violation',
+          severity: 'error',
+          from: { path: '^src/banner/' },
+          to: { path: '^src/(?!banner/|other/|shared/application/api/)' },
         },
       ]);
     });


### PR DESCRIPTION
## 💥 Problème

Le linter des dépendances entre les contextes ne prends pas en compte les dépendances uniquement via API internes.

## 👩‍🚀 Proposition

Ajouter `dependsOnViaApi` dans `dependencies.json` pour indiquer que la dépendance avec le contexte se fait uniquement via API.

**Exemple pour MADDO :**
```json
{
  "name": "maddo",
  "dependsOn": ["identity-access-management", "shared"],
  "dependsOnViaApi": ["prescription/campaign"],
  "circular": "forbidden"
}
```
- `maddo` dépend de `identity-access-management` et `shared` (import directs)
- `maddo` dépend de `prescription/campaign` uniquement via des API internes

## 👁️ Remarques

N/A

## ♻️ Pour tester

`npm run lint:context-deps`