### PR TITLE
[TECH] Ne plus utiliser la table certification-subscriptions dans les services et usecases (PIX-22920)

### DIFF
--- a/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
+++ b/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
@@ -3,11 +3,11 @@ import dayjs from 'dayjs';
 import { services as enrolmentServices } from '../../../../../src/certification/enrolment/application/services/index.js';
 import { Candidate } from '../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SessionEnrolment } from '../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { Subscription } from '../../../../../src/certification/enrolment/domain/models/Subscription.js';
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { BILLING_MODES } from '../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { usecases as organizationalEntitiesUsecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { usecases as prescriptionTargetProfilesUsecases } from '../../../../../src/prescription/target-profile/domain/usecases/index.js';
 import {
@@ -185,20 +185,14 @@ export class CleaV3Seed {
       isLinked: true,
       hasSeenCertificationInstructions: false,
       accessibilityAdjustmentNeeded: false,
-      subscriptions: [
-        Subscription.buildCore({ certificationCandidateId: null }),
-        Subscription.buildComplementary({
-          certificationCandidateId: null,
-          complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-        }),
-      ],
+      subscription: Frameworks.CLEA,
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
     };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
+      candidate: new Candidate(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 

--- a/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
@@ -3,10 +3,10 @@ import dayjs from 'dayjs';
 import { services as enrolmentServices } from '../../../../../src/certification/enrolment/application/services/index.js';
 import { Candidate } from '../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SessionEnrolment } from '../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { Subscription } from '../../../../../src/certification/enrolment/domain/models/Subscription.js';
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { BILLING_MODES } from '../../../../../src/certification/shared/domain/constants.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { usecases as organizationalEntitiesUsecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import {
   CertificationCenter,
@@ -158,14 +158,14 @@ export class ProSeed {
       isLinked: true,
       hasSeenCertificationInstructions: false,
       accessibilityAdjustmentNeeded: false,
-      subscriptions: [Subscription.buildCore({ certificationCandidateId: null })],
+      subscription: Frameworks.CORE,
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
     };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
+      candidate: new Candidate(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 

--- a/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
@@ -3,9 +3,9 @@ import dayjs from 'dayjs';
 import { services as enrolmentServices } from '../../../../../src/certification/enrolment/application/services/index.js';
 import { Candidate } from '../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SessionEnrolment } from '../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { Subscription } from '../../../../../src/certification/enrolment/domain/models/Subscription.js';
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { usecases as organizationalEntitiesUsecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { usecases as prescriptionLearnerManagementUsecases } from '../../../../../src/prescription/learner-management/domain/usecases/index.js';
 import {
@@ -173,7 +173,7 @@ export class ScoManagingStudent {
   }
 
   async #addCandidateToSession({ organizationLearner, session }) {
-    const candidate = Candidate.create({
+    const candidate = new Candidate({
       firstName: organizationLearner.firstName,
       lastName: organizationLearner.lastName,
       sex: 'F',
@@ -184,7 +184,7 @@ export class ScoManagingStudent {
       isLinked: true,
       hasSeenCertificationInstructions: false,
       accessibilityAdjustmentNeeded: false,
-      subscriptions: [Subscription.buildCore({ certificationCandidateId: null })],
+      subscription: Frameworks.CORE,
       userId: organizationLearner.userId,
       organizationLearnerId: organizationLearner.id,
     });

--- a/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
+++ b/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
@@ -1,11 +1,11 @@
 import { services as enrolmentServices } from '../../../../../src/certification/enrolment/application/services/index.js';
 import { Candidate } from '../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SessionEnrolment } from '../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import { Subscription } from '../../../../../src/certification/enrolment/domain/models/Subscription.js';
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { BILLING_MODES } from '../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { usecases as organizationalEntitiesUsecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import {
   CertificationCenter,
@@ -65,12 +65,7 @@ export class SupWithHabilitationsSeed {
       await this.#addCandidateToSession({
         pixAppUser: certifiableUser,
         session: sessionDroitReadyToStart,
-        subscriptions: [
-          Subscription.buildComplementary({
-            certificationCandidateId: null,
-            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
-          }),
-        ],
+        subscription: Frameworks.EDU_1ER_DEGRE,
       });
     }
 
@@ -89,12 +84,7 @@ export class SupWithHabilitationsSeed {
       await this.#addCandidateToSession({
         pixAppUser: certifiableUser,
         session: sessionEduReadyToStart,
-        subscriptions: [
-          Subscription.buildComplementary({
-            certificationCandidateId: null,
-            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-          }),
-        ],
+        subscription: Frameworks.DROIT,
       });
     }
   }
@@ -177,7 +167,7 @@ export class SupWithHabilitationsSeed {
     });
   }
 
-  async #addCandidateToSession({ pixAppUser, session, subscriptions }) {
+  async #addCandidateToSession({ pixAppUser, session, subscription }) {
     const candidateBirthdate = '2000-10-30';
 
     const candidateDTO = {
@@ -191,14 +181,14 @@ export class SupWithHabilitationsSeed {
       isLinked: true,
       hasSeenCertificationInstructions: false,
       accessibilityAdjustmentNeeded: false,
-      subscriptions,
+      subscription,
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
     };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
+      candidate: new Candidate(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 

--- a/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
+++ b/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
@@ -1,9 +1,9 @@
 /**
  * @typedef {import ('../../domain/models/Candidate.js').Candidate} Candidate
  */
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { WrongDomainExtensionForPixPlusError } from '../../domain/errors.js';
-import { usecases } from '../../domain/usecases/index.js';
+import { withTransaction } from "../../../../shared/domain/DomainTransaction.js";
+import { WrongDomainExtensionForPixPlusError } from "../../domain/errors.js";
+import { usecases } from "../../domain/usecases/index.js";
 
 /**
  * Candidate entry to a certification is a multi step process
@@ -28,7 +28,7 @@ export const registerCandidateParticipation = withTransaction(
       normalizeStringFnc,
     });
 
-    if (candidate.hasNonCoreSubscription() && !isFrenchDomainExtension) {
+    if (!candidate.hasCoreScopeSubscription() && !isFrenchDomainExtension) {
       throw new WrongDomainExtensionForPixPlusError();
     }
 

--- a/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
+++ b/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
@@ -1,9 +1,9 @@
 /**
  * @typedef {import ('../../domain/models/Candidate.js').Candidate} Candidate
  */
-import { withTransaction } from "../../../../shared/domain/DomainTransaction.js";
-import { WrongDomainExtensionForPixPlusError } from "../../domain/errors.js";
-import { usecases } from "../../domain/usecases/index.js";
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { WrongDomainExtensionForPixPlusError } from '../../domain/errors.js';
+import { usecases } from '../../domain/usecases/index.js';
 
 /**
  * Candidate entry to a certification is a multi step process

--- a/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
+++ b/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
@@ -28,7 +28,7 @@ export const registerCandidateParticipation = withTransaction(
       normalizeStringFnc,
     });
 
-    if (candidate.hasComplementarySubscription() && !isFrenchDomainExtension) {
+    if (candidate.hasNonCoreSubscription() && !isFrenchDomainExtension) {
       throw new WrongDomainExtensionForPixPlusError();
     }
 

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -1,10 +1,10 @@
 /**
  * @typedef {import ('./Subscription.js').Subscription} Subscription
  */
-import { CertificationCandidatesError } from "../../../../shared/domain/errors.js";
-import { BILLING_MODES, SUBSCRIPTION_TYPES } from "../../../shared/domain/constants.js";
-import { Frameworks } from "../../../shared/domain/models/Frameworks.js";
-import { validate } from "../validators/candidate-validator.js";
+import { CertificationCandidatesError } from '../../../../shared/domain/errors.js';
+import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
+import { validate } from '../validators/candidate-validator.js';
 
 export class Candidate {
   /**

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -162,6 +162,10 @@ export class Candidate {
     return this.subscriptions.some((subscription) => subscription.isComplementary());
   }
 
+  hasNonCoreSubscription() {
+    return this.subscription !== Frameworks.CORE;
+  }
+
   getComplementarySubscription() {
     return this.subscriptions.find((subscription) => subscription.type === SUBSCRIPTION_TYPES.COMPLEMENTARY);
   }
@@ -172,6 +176,6 @@ export class Candidate {
   }
 
   isRegisteredToDoubleCertification() {
-    return this.subscriptions.length === 2;
+    return this.subscription === Frameworks.CLEA;
   }
 }

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -1,10 +1,10 @@
 /**
  * @typedef {import ('./Subscription.js').Subscription} Subscription
  */
-import { CertificationCandidatesError } from '../../../../shared/domain/errors.js';
-import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
-import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
-import { validate } from '../validators/candidate-validator.js';
+import { CertificationCandidatesError } from "../../../../shared/domain/errors.js";
+import { BILLING_MODES, SUBSCRIPTION_TYPES } from "../../../shared/domain/constants.js";
+import { Frameworks } from "../../../shared/domain/models/Frameworks.js";
+import { validate } from "../validators/candidate-validator.js";
 
 export class Candidate {
   /**
@@ -162,8 +162,12 @@ export class Candidate {
     return this.subscriptions.some((subscription) => subscription.isComplementary());
   }
 
-  hasNonCoreSubscription() {
-    return this.subscription !== Frameworks.CORE;
+  hasCoreFrameworkSubscription() {
+    return this.subscription === Frameworks.CORE;
+  }
+
+  hasCoreScopeSubscription() {
+    return this.subscription === Frameworks.CORE || this.subscription === Frameworks.CLEA;
   }
 
   getComplementarySubscription() {

--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -1,13 +1,11 @@
 import { CertificationCandidatesError } from '../../../../shared/domain/errors.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import * as mailCheckImplementation from '../../../../shared/mail/infrastructure/services/mail-check.js';
-import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
-import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 import { getTransformationStructsForPixCertifCandidatesImport } from '../../infrastructure/candidates-import/candidates-import-transformation-structures.js';
 import * as readOdsUtils from '../../infrastructure/utils/ods/read-ods-utils.js';
 import { Candidate } from '../models/Candidate.js';
-import { Subscription } from '../models/Subscription.js';
 
 export async function extractCertificationCandidatesFromCandidatesImportSheet({
   i18n,
@@ -73,7 +71,7 @@ export async function extractCertificationCandidatesFromCandidatesImportSheet({
       certificationCpfCountryRepository,
     });
 
-    const subscriptions = _buildSubscriptions(candidateData);
+    const subscription = _buildSubscription(candidateData);
 
     if (cpfBirthInformation.hasFailed()) {
       _handleBirthInformationValidationError(cpfBirthInformation, line);
@@ -110,7 +108,7 @@ export async function extractCertificationCandidatesFromCandidatesImportSheet({
       }
     }
 
-    const candidate = Candidate.create({
+    const candidate = new Candidate({
       ...candidateData,
       birthCountry,
       birthINSEECode,
@@ -120,7 +118,7 @@ export async function extractCertificationCandidatesFromCandidatesImportSheet({
       sessionId: session.id,
       billingMode: billingMode ?? null,
       prepaymentCode: candidateData.prepaymentCode ?? null,
-      subscriptions,
+      subscription,
       id: null,
       birthProvinceCode: null,
       createdAt: null,
@@ -195,28 +193,15 @@ function _handleDuplicateCandidate() {
   };
 }
 
-function _buildComplementaryCertification(complementaryCertificationKey) {
-  return Subscription.buildComplementary({
-    certificationCandidateId: null,
-    complementaryCertificationKey,
-  });
-}
-
-function _buildSubscriptions(candidateData) {
-  const subscriptionKeys = Object.values(ComplementaryCertificationKeys).filter((key) => Boolean(candidateData[key]));
-
-  if (subscriptionKeys.includes(ComplementaryCertificationKeys.CLEA) || subscriptionKeys.length === 0) {
-    subscriptionKeys.push(SUBSCRIPTION_TYPES.CORE);
+function _buildSubscription(candidateData) {
+  const selectedFrameworks = Object.values(Frameworks)
+    .filter((key) => key !== Frameworks.CORE)
+    .filter((key) => Boolean(candidateData[key]));
+  if (selectedFrameworks.length > 1) {
+    throw new CertificationCandidatesError({
+      code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
+      message: 'A candidate cannot have more than one complementary certification',
+    });
   }
-
-  const subscriptions = [];
-  for (const subscriptionKey of subscriptionKeys) {
-    if (subscriptionKey === SUBSCRIPTION_TYPES.CORE) {
-      subscriptions.push(Subscription.buildCore({ certificationCandidateId: null }));
-    } else {
-      subscriptions.push(_buildComplementaryCertification(subscriptionKey));
-    }
-  }
-
-  return subscriptions;
+  return selectedFrameworks[0] || Frameworks.CORE;
 }

--- a/api/src/certification/enrolment/domain/services/sessions-import-validation-service.js
+++ b/api/src/certification/enrolment/domain/services/sessions-import-validation-service.js
@@ -4,11 +4,10 @@ import * as mailCheck from '../../../../shared/mail/infrastructure/services/mail
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
 import { CERTIFICATION_SESSIONS_ERRORS } from '../../../shared/domain/constants/sessions-errors.js';
-import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 //  should be injected
 import * as certificationCpfService from '../../../shared/domain/services/certification-cpf-service.js';
 import * as sessionValidator from '../../../shared/domain/validators/session-validator.js';
-import { Subscription } from '../models/Subscription.js';
 
 const validateSession = async function ({
   session,
@@ -130,28 +129,13 @@ const getValidatedSubscriptionsForMassImport = async function ({ subscriptionKey
       codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code],
     });
 
-    return { certificationCandidateComplementaryErrors, subscriptions: [] };
+    return { certificationCandidateComplementaryErrors, subscription: Frameworks.CORE };
   }
 
-  if (subscriptionKeys.includes(ComplementaryCertificationKeys.CLEA) || subscriptionKeys.length === 0) {
-    subscriptionKeys.push(SUBSCRIPTION_TYPES.CORE);
-  }
+  const complementaryKey = subscriptionKeys.find((key) => key !== SUBSCRIPTION_TYPES.CORE);
+  const subscription = complementaryKey ?? Frameworks.CORE;
 
-  const subscriptions = [];
-  for (const subscriptionKey of subscriptionKeys) {
-    if (subscriptionKey === SUBSCRIPTION_TYPES.CORE) {
-      subscriptions.push(Subscription.buildCore({ certificationCandidateId: null }));
-    } else {
-      subscriptions.push(
-        Subscription.buildComplementary({
-          certificationCandidateId: null,
-          complementaryCertificationKey: subscriptionKey,
-        }),
-      );
-    }
-  }
-
-  return { certificationCandidateComplementaryErrors, subscriptions };
+  return { certificationCandidateComplementaryErrors, subscription };
 };
 
 const getValidatedCandidateInformation = async function ({

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -77,7 +77,7 @@ async function _deleteExistingCandidatesInSession({ candidateRepository, session
 
 async function _saveCandidates({ candidates, sessionId, candidateRepository }) {
   const candidatesToSave = candidates.map((candidate) => {
-    return Candidate.create({ ...candidate, sessionId });
+    return new Candidate({ ...candidate, sessionId });
   });
   await candidateRepository.save({ candidates: candidatesToSave });
 }

--- a/api/src/certification/enrolment/domain/usecases/get-candidate-timeline.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate-timeline.js
@@ -9,7 +9,6 @@
  * @typedef {import ('../../infrastructure/repositories/index.js').ComplementaryCertificationBadgeWithOffsetVersionRepository} ComplementaryCertificationBadgeWithOffsetVersionRepository
  * @typedef {import ('../models/timeline/TimelineEvent.js').TimelineEvent} TimelineEvent
  * @typedef {import ('../models/Candidate.js').Candidate} Candidate
- * @typedef {import ('../models/Candidate.js').Subscription} Subscription
  * @typedef {import ('../read-models/UserCertificationEligibility.js').UserCertificationEligibility} UserCertificationEligibility
  * @typedef {import ('../../../shared/domain/models/CertificationCourse.js').CertificationCourse} CertificationCourse
  * @typedef {import ('../../../session-management/domain/models/CertificationAssessment.js').CertificationAssessment} CertificationAssessment

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -125,7 +125,7 @@ async function _createValidCertificationCandidates({
 
     const certificationCandidateErrors = [];
 
-    const { certificationCandidateComplementaryErrors, subscriptions } =
+    const { certificationCandidateComplementaryErrors, subscription } =
       await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
         subscriptionKeys: candidateDTO.subscriptionKeys,
         line: candidateDTO.line,
@@ -133,11 +133,11 @@ async function _createValidCertificationCandidates({
 
     certificationCandidateErrors.push(...certificationCandidateComplementaryErrors);
 
-    const candidate = Candidate.create({
+    const candidate = new Candidate({
       ...candidateDTO,
       sessionId,
+      subscription,
       billingMode: billingMode || candidateDTO.billingMode,
-      subscriptions,
       id: null,
       userId: null,
       reconciledAt: null,

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
@@ -4,8 +4,8 @@
  * @typedef {import ('./index.js').CertificationCenterRepository} CertificationCenterRepository
  */
 
-import { UserNotAuthorizedToCertifyError } from "../../../../shared/domain/errors.js";
-import { CenterHabilitationError } from "../../../shared/domain/errors.js";
+import { UserNotAuthorizedToCertifyError } from '../../../../shared/domain/errors.js';
+import { CenterHabilitationError } from '../../../shared/domain/errors.js';
 
 /**
  * @param {object} params

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
@@ -4,8 +4,8 @@
  * @typedef {import ('./index.js').CertificationCenterRepository} CertificationCenterRepository
  */
 
-import { UserNotAuthorizedToCertifyError } from '../../../../shared/domain/errors.js';
-import { CenterHabilitationError } from '../../../shared/domain/errors.js';
+import { UserNotAuthorizedToCertifyError } from "../../../../shared/domain/errors.js";
+import { CenterHabilitationError } from "../../../shared/domain/errors.js";
 
 /**
  * @param {object} params
@@ -32,7 +32,7 @@ export const verifyCandidateReconciliationRequirements = async ({
     throw new UserNotAuthorizedToCertifyError();
   }
 
-  if (candidate.hasNonCoreSubscription()) {
+  if (!candidate.hasCoreFrameworkSubscription()) {
     const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
 
     if (!certificationCenter.isHabilitated(candidate.subscription)) {

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
@@ -32,11 +32,10 @@ export const verifyCandidateReconciliationRequirements = async ({
     throw new UserNotAuthorizedToCertifyError();
   }
 
-  if (candidate.hasComplementarySubscription()) {
-    const complementarySubscription = candidate.getComplementarySubscription();
+  if (candidate.hasNonCoreSubscription()) {
     const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
 
-    if (!certificationCenter.isHabilitated(complementarySubscription.complementaryCertificationKey)) {
+    if (!certificationCenter.isHabilitated(candidate.subscription)) {
       throw new CenterHabilitationError();
     }
   }

--- a/api/src/certification/enrolment/domain/validators/candidate-validator.js
+++ b/api/src/certification/enrolment/domain/validators/candidate-validator.js
@@ -1,55 +1,9 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
-import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
+import { BILLING_MODES } from '../../../shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
-import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
-
-// eslint-disable-next-line no-unused-vars
-const { CLEA, ...COMPLEMENTARY_CERTIFICATIONS_EXCEPTED_DOUBLE_CERTIFICATION } = ComplementaryCertificationKeys;
-
-const alternativeCoreOnly = Joi.array()
-  .length(1)
-  .items({
-    certificationCandidateId: Joi.number().allow(null),
-    type: SUBSCRIPTION_TYPES.CORE,
-    complementaryCertificationKey: null,
-  })
-  .required();
-const alternativeDoubleCertification = Joi.array()
-  .length(2)
-  .items(
-    Joi.object({
-      certificationCandidateId: Joi.number().allow(null),
-      type: Joi.string()
-        .required()
-        .valid(...Object.values(SUBSCRIPTION_TYPES)),
-      complementaryCertificationKey: Joi.when('type', {
-        is: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-        then: Joi.string().valid(ComplementaryCertificationKeys.CLEA),
-        otherwise: null,
-      }),
-    }),
-  )
-  .unique('type')
-  .required();
-
-const alternativeComplementaryCertification = Joi.array()
-  .length(1)
-  .items(
-    Joi.object({
-      type: Joi.string().required().valid(SUBSCRIPTION_TYPES.COMPLEMENTARY),
-      complementaryCertificationKey: Joi.string().valid(
-        ...Object.values(COMPLEMENTARY_CERTIFICATIONS_EXCEPTED_DOUBLE_CERTIFICATION),
-      ),
-    }),
-  )
-  .unique('type')
-  .required();
-
-const schemaForCompatibilitySubscriptions = Joi.alternatives()
-  .match('one')
-  .try(alternativeCoreOnly, alternativeDoubleCertification, alternativeComplementaryCertification);
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 
 const schema = Joi.object({
   firstName: Joi.string().trim().required().empty(['', null]).messages({
@@ -90,7 +44,7 @@ const schema = Joi.object({
       'number.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SESSION_ID_NOT_A_NUMBER.code,
     }),
   }),
-  subscriptions: schemaForCompatibilitySubscriptions,
+  subscription: Joi.string().valid(...Object.values(Frameworks)),
   billingMode: Joi.when('$isSco', {
     is: false,
     then: Joi.string()

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -8,6 +8,7 @@ import dayjs from 'dayjs';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 import { Candidate } from '../../domain/models/Candidate.js';
 import { Subscription } from '../../domain/models/Subscription.js';
 
@@ -78,31 +79,10 @@ export async function update(candidate) {
   if (!updatedCertificationCandidate) {
     throw new CertificationCandidateNotFoundError();
   }
-
+  // TODO: supprimer lors du drop de certification-subscriptions
+  const complementaryCertificationsData = await knexConn('complementary-certifications').select('id', 'key');
   await knexConn('certification-subscriptions').where({ certificationCandidateId: candidate.id }).del();
-
-  for (const subscription of candidate.subscriptions) {
-    if (subscription.type === SUBSCRIPTION_TYPES.CORE) {
-      await knexConn('certification-subscriptions').insert({
-        certificationCandidateId: candidate.id,
-        type: subscription.type,
-        complementaryCertificationId: null,
-      });
-    } else {
-      const { id: complementaryCertificationId } = await knexConn('complementary-certifications')
-        .select('id')
-        .where({
-          key: subscription.complementaryCertificationKey,
-        })
-        .first();
-
-      await knexConn('certification-subscriptions').insert({
-        certificationCandidateId: candidate.id,
-        type: subscription.type,
-        complementaryCertificationId: complementaryCertificationId,
-      });
-    }
-  }
+  await _writeLegacySubscriptions(knexConn, candidate.id, candidate, complementaryCertificationsData);
 }
 
 /**
@@ -124,15 +104,12 @@ export async function insert(candidate) {
  */
 export async function save({ candidates }) {
   const knexConn = DomainTransaction.getConnection();
-  const complementaryCertificationsData = await knexConn('complementary-certifications').select('id', 'key');
-
   const candidatesData = candidates.map(adaptModelToDb);
 
   const insertedCandidatesData = await knexConn('certification-candidates')
     .insert(candidatesData)
     .returning(['id', 'firstName', 'lastName', 'birthdate']);
 
-  const subscriptionsData = [];
   for (const candidate of candidates) {
     const insertedCandidateId = insertedCandidatesData.find(
       (insertedCandidateData) =>
@@ -140,20 +117,10 @@ export async function save({ candidates }) {
         insertedCandidateData.lastName === candidate.lastName &&
         dayjs(insertedCandidateData.birthdate).format('YYYY-MM-DD') === dayjs(candidate.birthdate).format('YYYY-MM-DD'),
     ).id;
-
-    subscriptionsData.push(
-      ...candidate.subscriptions.map((subscription) => ({
-        certificationCandidateId: insertedCandidateId,
-        type: subscription.type,
-        complementaryCertificationId:
-          complementaryCertificationsData.find(
-            (complementaryCertificationData) =>
-              complementaryCertificationData.key === subscription.complementaryCertificationKey,
-          )?.id ?? null,
-      })),
-    );
+    // TODO: supprimer lors du drop de certification-subscriptions
+    const complementaryCertificationsData = await knexConn('complementary-certifications').select('id', 'key');
+    await _writeLegacySubscriptions(knexConn, insertedCandidateId, candidate, complementaryCertificationsData);
   }
-  await knexConn('certification-subscriptions').insert(subscriptionsData);
 
   return insertedCandidatesData.map(({ id }) => id);
 }
@@ -327,4 +294,32 @@ function toDomain(candidateData) {
     hasStartedTest: Boolean(candidateData.certificationCourseId),
     subscriptions,
   });
+}
+
+async function _writeLegacySubscriptions(knexConn, candidateId, candidate, complementaryCertificationsData) {
+  const subscription = candidate.subscription;
+  const rows = [];
+  if (!subscription || subscription === Frameworks.CORE) {
+    rows.push({
+      certificationCandidateId: candidateId,
+      type: SUBSCRIPTION_TYPES.CORE,
+      complementaryCertificationId: null,
+    });
+  } else {
+    if (subscription === Frameworks.CLEA) {
+      rows.push({
+        certificationCandidateId: candidateId,
+        type: SUBSCRIPTION_TYPES.CORE,
+        complementaryCertificationId: null,
+      });
+    }
+    const complementaryCertificationId =
+      complementaryCertificationsData.find((c) => c.key === subscription)?.id ?? null;
+    rows.push({
+      certificationCandidateId: candidateId,
+      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+      complementaryCertificationId,
+    });
+  }
+  await knexConn('certification-subscriptions').insert(rows);
 }

--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -241,6 +241,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       return domainBuilder.certification.enrolment.buildCandidate({
         ...candidate,
         subscription: candidate.subscriptions[0].complementaryCertificationKey || Frameworks.CORE,
+        subscriptions: [],
       });
     });
     expect(actualCandidates).to.deep.equal(expectedCandidates);
@@ -283,6 +284,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
         return domainBuilder.certification.enrolment.buildCandidate({
           ...candidate,
           subscription: candidate.subscriptions[0].complementaryCertificationKey || Frameworks.CORE,
+          subscriptions: [],
         });
       });
 
@@ -304,7 +306,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       expect(actualCandidates).to.deep.equal(expectedCandidates);
     });
 
-    it('should throw an error if candidate is registered for multiple complementary certifications', async function () {
+    it('should throw an error if candidate is registered for multiple certifications', async function () {
       // given
       mailCheck.assertEmailDomainHasMx.resolves();
 
@@ -362,6 +364,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       return domainBuilder.certification.enrolment.buildCandidate({
         ...candidate,
         subscription: candidate.subscriptions[0].complementaryCertificationKey || Frameworks.CORE,
+        subscriptions: [],
       });
     });
 
@@ -409,6 +412,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       return domainBuilder.certification.enrolment.buildCandidate({
         ...candidate,
         subscription: candidate.subscriptions[0].complementaryCertificationKey || Frameworks.CORE,
+        subscriptions: [],
       });
     });
     expect(actualCandidates).to.deep.equal(expectedCandidates);

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -256,76 +256,31 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         expect(candidate.firstName).to.equal('tutu');
       });
 
-      it('should update its subscriptions', async function () {
-        // when
-        const complementaryCertificationDroit = databaseBuilder.factory.buildComplementaryCertification({
-          id: 555,
-          key: Frameworks.DROIT,
-        });
-        const complementaryCertificationEdu = databaseBuilder.factory.buildComplementaryCertification({
-          id: 666,
-          key: Frameworks.EDU_1ER_DEGRE,
-        });
+      it('should update its subscription', async function () {
+        // given
+        const droitCertification = databaseBuilder.factory.buildComplementaryCertification({ key: Frameworks.DROIT });
+        databaseBuilder.factory.buildComplementaryCertification({ key: Frameworks.EDU_1ER_DEGRE });
         const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-          firstName: 'toto',
+          subscription: Frameworks.DROIT,
         });
+        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
         databaseBuilder.factory.buildComplementaryCertificationSubscription({
           certificationCandidateId: certificationCandidate.id,
-          complementaryCertificationId: complementaryCertificationDroit.id,
+          complementaryCertificationId: droitCertification.id,
         });
-        databaseBuilder.factory.buildCoreSubscription({
-          certificationCandidateId: certificationCandidate.id,
-        });
-
         await databaseBuilder.commit();
 
-        const certificationCandidateToUpdate = domainBuilder.certification.enrolment.buildCandidate({
+        const candidateToUpdate = domainBuilder.certification.enrolment.buildCandidate({
           ...certificationCandidate,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({
-              certificationCandidateId: certificationCandidate.id,
-            }),
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId: certificationCandidate.id,
-              complementaryCertificationKey: complementaryCertificationEdu.key,
-            }),
-          ],
+          subscription: Frameworks.EDU_1ER_DEGRE,
         });
 
         // when
-        const subscriptionsBefore = (
-          await candidateRepository.get({
-            certificationCandidateId: certificationCandidateToUpdate.id,
-          })
-        ).subscriptions;
-
-        await candidateRepository.update(certificationCandidateToUpdate);
-
-        const subscriptionsAfter = (
-          await candidateRepository.get({
-            certificationCandidateId: certificationCandidateToUpdate.id,
-          })
-        ).subscriptions;
+        await candidateRepository.update(candidateToUpdate);
 
         // then
-        expect(subscriptionsBefore).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            certificationCandidateId: certificationCandidate.id,
-            complementaryCertificationKey: complementaryCertificationDroit.key,
-          }),
-          domainBuilder.certification.enrolment.buildCoreSubscription({
-            certificationCandidateId: certificationCandidate.id,
-          }),
-        ]);
-        expect(subscriptionsAfter).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            certificationCandidateId: certificationCandidate.id,
-            complementaryCertificationKey: complementaryCertificationEdu.key,
-          }),
-          domainBuilder.certification.enrolment.buildCoreSubscription({
-            certificationCandidateId: certificationCandidate.id,
-          }),
-        ]);
+        const updated = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
+        expect(updated.subscription).to.equal(Frameworks.EDU_1ER_DEGRE);
       });
     });
 
@@ -350,12 +305,6 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
     let candidateData;
 
     beforeEach(function () {
-      const subscriptionCore = domainBuilder.certification.enrolment.buildCoreSubscription({
-        certificationCandidateId: null,
-      });
-      const subscriptionComplementary = domainBuilder.certification.enrolment.buildComplementarySubscription({
-        certificationCandidateId: null,
-      });
       candidateData = {
         id: null,
         createdAt: new Date('2020-01-01'),
@@ -381,20 +330,15 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: null,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: false,
-        subscriptions: [subscriptionCore, subscriptionComplementary],
         reconciledAt: null,
-        subscription: null,
+        subscription: Frameworks.DROIT,
       };
       databaseBuilder.factory.buildSession({ id: candidateData.sessionId });
-      databaseBuilder.factory.buildComplementaryCertification({
-        id: 22,
-        label: 'Pix+DROIT',
-        key: Frameworks.DROIT,
-      });
+      databaseBuilder.factory.buildComplementaryCertification({ key: Frameworks.DROIT });
       return databaseBuilder.commit();
     });
 
-    it('should insert candidate in DB with subscriptions', async function () {
+    it('should insert candidate in DB with subscription', async function () {
       // given
       const candidateToInsert = domainBuilder.certification.enrolment.buildCandidate(candidateData);
 
@@ -403,34 +347,17 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
 
       // then
       const savedCandidateData = await knex('certification-candidates').select('*').where({ id: candidateId }).first();
+      expect(savedCandidateData.subscription).to.equal(Frameworks.DROIT);
+      expect(parseFloat(savedCandidateData.extraTimePercentage)).to.equal(candidateData.extraTimePercentage);
+
       const savedSubscriptionsData = await knex('certification-subscriptions')
         .select('*')
         .where({ certificationCandidateId: candidateId })
         .orderBy('type');
-      expect(savedCandidateData).to.deepEqualInstanceOmitting(candidateData, [
-        'id',
-        'createdAt',
-        'subscriptions',
-        'complementaryCertificationId',
-        'extraTimePercentage',
-      ]);
-      expect(parseFloat(savedCandidateData.extraTimePercentage)).to.equal(candidateData.extraTimePercentage);
-      expect(savedSubscriptionsData).to.have.lengthOf(2);
+      expect(savedSubscriptionsData).to.have.lengthOf(1);
       expect(savedSubscriptionsData[0]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: candidateId,
-          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-          complementaryCertificationId: 22,
-        },
-        ['createdAt'],
-      );
-      expect(savedSubscriptionsData[1]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: candidateId,
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-        },
-        ['createdAt'],
+        { certificationCandidateId: candidateId, type: SUBSCRIPTION_TYPES.COMPLEMENTARY },
+        ['createdAt', 'complementaryCertificationId'],
       );
     });
   });

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -1,12 +1,16 @@
-import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
-import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
-import { CertificationCandidate } from '../../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
-import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { CertificationCandidatesError } from '../../../../../../src/shared/domain/errors.js';
-import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { expect } from '../../../../../test-helper.js';
-import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr, catchErrSync } from '../../../../../tooling/test-utils/error.js';
+import { Candidate } from "../../../../../../src/certification/enrolment/domain/models/Candidate.js";
+import {
+  CERTIFICATION_CANDIDATES_ERRORS
+} from "../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js";
+import {
+  CertificationCandidate
+} from "../../../../../../src/certification/shared/domain/models/CertificationCandidate.js";
+import { Frameworks } from "../../../../../../src/certification/shared/domain/models/Frameworks.js";
+import { CertificationCandidatesError } from "../../../../../../src/shared/domain/errors.js";
+import { getI18n } from "../../../../../../src/shared/infrastructure/i18n/i18n.js";
+import { expect } from "../../../../../test-helper.js";
+import { domainBuilder } from "../../../../../tooling/domain-builder/domain-builder.js";
+import { catchErr, catchErrSync } from "../../../../../tooling/test-utils/error.js";
 
 const FIRST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code;
 const LAST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code;
@@ -953,15 +957,31 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     });
   });
 
-  describe('hasNonCoreSubscription', function () {
-    it('should return true when subscription is not CORE', function () {
+  describe('hasCoreFrameworkSubscription', function () {
+    it('should return false when subscription is not CORE', function () {
       const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
-      expect(candidate.hasNonCoreSubscription()).to.be.true;
+      expect(candidate.hasCoreFrameworkSubscription()).to.be.false;
     });
 
-    it('should return false when subscription is CORE', function () {
+    it('should return true when subscription is CORE', function () {
       const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CORE });
-      expect(candidate.hasNonCoreSubscription()).to.be.false;
+      expect(candidate.hasCoreFrameworkSubscription()).to.be.true;
+    });
+  });
+
+  describe('hasCoreScopeSubscription', function () {
+    it('should return false when subscription is not CORE or CLEA', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.DROIT });
+      expect(candidate.hasCoreScopeSubscription()).to.be.false;
+    });
+
+    it('should return true when subscription is CORE', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CORE });
+      expect(candidate.hasCoreScopeSubscription()).to.be.true;
+    });
+    it('should return true when subscription is CLEA', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
+      expect(candidate.hasCoreScopeSubscription()).to.be.true;
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -1,14 +1,13 @@
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
-import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
 import { CertificationCandidate } from '../../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CertificationCandidatesError } from '../../../../../../src/shared/domain/errors.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr, catchErrSync } from '../../../../../tooling/test-utils/error.js';
+
 const FIRST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code;
 const LAST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code;
 const BIRTHDATE_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code;
@@ -44,76 +43,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       billingMode: CertificationCandidate.BILLING_MODES.FREE,
       prepaymentCode: null,
       hasSeenCertificationInstructions: false,
-      subscriptions: [
-        {
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-          complementaryCertificationLabel: null,
-          complementaryCertificationKey: null,
-        },
-      ],
     };
-  });
-
-  context('create', function () {
-    context('when the candidate subscription is registered for CORE', function () {
-      it('should create a new Candidate with a CORE subscription attribute', function () {
-        // given
-        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-          subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
-        });
-
-        // when
-        const expectedCandidate = Candidate.create(candidateDTO);
-
-        // then
-        expect(expectedCandidate.subscription).to.equal(Frameworks.CORE);
-      });
-    });
-
-    context('when the candidate is registered for a double certification', function () {
-      it('should create a new Candidate with a CORE subscription attribute', function () {
-        // given
-        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription(),
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId: null,
-              complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-            }),
-          ],
-        });
-
-        // when
-        const expectedCandidate = Candidate.create(candidateDTO);
-
-        // then
-        expect(expectedCandidate.subscription).to.equal(Frameworks.CLEA);
-      });
-    });
-
-    context('when the candidate is registered for a Pix+ certification', function () {
-      it('should create a new Candidate with a PIX+ subscription attribute', function () {
-        // given
-        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId: null,
-              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-            }),
-          ],
-        });
-
-        // when
-        const expectedCandidate = Candidate.create(candidateDTO);
-
-        // then
-        expect(expectedCandidate.subscription).to.equal(Frameworks.DROIT);
-      });
-    });
   });
 
   context('updateBirthInformation', function () {
@@ -453,169 +383,22 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack']);
     });
 
-    context('compatibility core/complementary enable, should use new schema', function () {
+    context('subscription validation', function () {
       context('success cases', function () {
-        it('should validate when there is only one core subscription', function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-            ],
+        Object.values(Frameworks).forEach((subscription) => {
+          it(`should validate when subscription is ${subscription}`, function () {
+            const candidate = domainBuilder.certification.enrolment.buildCandidate({ ...candidateData, subscription });
+            candidate.validate();
           });
-
-          // when, then
-          candidate.validate();
-        });
-
-        it('should validate when there is a double certification', function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-              }),
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: null,
-              }),
-            ],
-          });
-
-          // when, then
-          candidate.validate();
-        });
-        it('should validate when there is only one complementary subscription excluding CLEA', function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-                complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-              }),
-            ],
-          });
-
-          // when, then
-          candidate.validate();
         });
       });
 
       context('ko cases', function () {
-        it('should not validate when there are no subscription at all', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
+        it('should not validate when subscription is an unknown value', async function () {
+          const candidate = domainBuilder.certification.enrolment.buildCandidate({ ...candidateData });
+          candidate.subscription = 'UNKNOWN_FRAMEWORK';
           const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
-        });
-
-        it('should not validate when there are two complementary', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-              }),
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-              }),
-            ],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
-          const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
-        });
-
-        it('should not validate when there are two complementary, one of which is CLEA', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-              }),
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-              }),
-            ],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
-          const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
-        });
-
-        it('should not validate when there are two core', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: null,
-              }),
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: null,
-              }),
-            ],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
-          const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
-        });
-
-        it('should not validate when there are one core and one complementary not clea', async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription({
-                certificationCandidateId: null,
-              }),
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId: null,
-              }),
-            ],
-          });
-          const certificationCandidatesError = new CertificationCandidatesError({
-            code: '"subscriptions" does not match any of the allowed types',
-          });
-
-          // when
-          const error = await catchErr(candidate.validate, candidate)();
-
-          // then
-          expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack', 'meta']);
+          expect(error).to.be.instanceOf(CertificationCandidatesError);
         });
       });
     });
@@ -1170,94 +953,26 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     });
   });
 
-  describe('hasComplementarySubscription', function () {
-    it('should return true', function () {
-      // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildComplementarySubscription({ certificationCandidateId: null }),
-        ],
-      });
-
-      // when
-      const hasCoreSubscription = candidate.hasComplementarySubscription();
-
-      // when / then
-      expect(hasCoreSubscription).to.be.true;
+  describe('hasNonCoreSubscription', function () {
+    it('should return true when subscription is not CORE', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
+      expect(candidate.hasNonCoreSubscription()).to.be.true;
     });
 
-    it('should return false', function () {
-      // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
-      });
-
-      // when
-      const hasCoreSubscription = candidate.hasComplementarySubscription();
-
-      // when / then
-      expect(hasCoreSubscription).to.be.false;
-    });
-  });
-
-  describe('#complementaryCertificationKey', function () {
-    it('should return null when there is no complementary subscription', function () {
-      // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
-      });
-
-      // when
-      const result = candidate.complementaryCertificationKey;
-
-      // then
-      expect(result).to.be.null;
-    });
-
-    it('should return the complementary certification key when there is a complementary subscription', function () {
-      // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            certificationCandidateId: null,
-            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-          }),
-        ],
-      });
-
-      // when
-      const result = candidate.complementaryCertificationKey;
-
-      // then
-      expect(result).to.equal(ComplementaryCertificationKeys.PIX_PLUS_DROIT);
+    it('should return false when subscription is CORE', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CORE });
+      expect(candidate.hasNonCoreSubscription()).to.be.false;
     });
   });
 
   describe('#isRegisteredToDoubleCertification', function () {
-    it('returns true when candidate is registered to double certification', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription(),
-          domainBuilder.certification.enrolment.buildCoreSubscription(),
-        ],
-      });
-
+    it('returns true when candidate subscription is CLEA', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
       expect(candidate.isRegisteredToDoubleCertification()).to.be.true;
     });
 
-    it('returns false when candidate is not registered to double certification', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        subscriptions: [domainBuilder.certification.enrolment.buildComplementarySubscription()],
-      });
-
+    it('returns false when candidate subscription is not CLEA', function () {
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.DROIT });
       expect(candidate.isRegisteredToDoubleCertification()).to.be.false;
     });
   });

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -1,16 +1,12 @@
-import { Candidate } from "../../../../../../src/certification/enrolment/domain/models/Candidate.js";
-import {
-  CERTIFICATION_CANDIDATES_ERRORS
-} from "../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js";
-import {
-  CertificationCandidate
-} from "../../../../../../src/certification/shared/domain/models/CertificationCandidate.js";
-import { Frameworks } from "../../../../../../src/certification/shared/domain/models/Frameworks.js";
-import { CertificationCandidatesError } from "../../../../../../src/shared/domain/errors.js";
-import { getI18n } from "../../../../../../src/shared/infrastructure/i18n/i18n.js";
-import { expect } from "../../../../../test-helper.js";
-import { domainBuilder } from "../../../../../tooling/domain-builder/domain-builder.js";
-import { catchErr, catchErrSync } from "../../../../../tooling/test-utils/error.js";
+import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
+import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
+import { CertificationCandidate } from '../../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { CertificationCandidatesError } from '../../../../../../src/shared/domain/errors.js';
+import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr, catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 const FIRST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code;
 const LAST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code;

--- a/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { registerCandidateParticipation } from '../../../../../../src/certification/enrolment/application/services/register-candidate-participation-service.js';
 import { WrongDomainExtensionForPixPlusError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { usecases } from '../../../../../../src/certification/enrolment/domain/usecases/index.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -64,7 +65,7 @@ describe('Unit | Application | Service | register-candidate-participation', func
       const candidateWithComplementary = domainBuilder.certification.enrolment.buildCandidate({
         ...candidateData,
         sessionId,
-        subscriptions: [domainBuilder.certification.enrolment.buildComplementarySubscription()],
+        subscription: Frameworks.DROIT,
       });
       sinon.stub(usecases, 'verifyCandidateIdentity').resolves(candidateWithComplementary);
 

--- a/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
@@ -5,6 +5,7 @@ import * as sessionsImportValidationService from '../../../../../../src/certific
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CpfBirthInformationValidation } from '../../../../../../src/certification/shared/domain/services/certification-cpf-service.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -461,7 +462,7 @@ describe('Unit | Service | sessions import validation Service', function () {
 
   describe('#getValidatedSubscriptionsForMassImport', function () {
     context('when there are many complementary subscriptions', function () {
-      it('should return an error accordingly and no subscriptions models', async function () {
+      it('should return an error accordingly and a CORE subscription', async function () {
         // given
         const subscriptionKeys = [
           ComplementaryCertificationKeys.PIX_PLUS_DROIT,
@@ -470,7 +471,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         const line = 12;
 
         // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
+        const { certificationCandidateComplementaryErrors, subscription } =
           await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
             subscriptionKeys,
             line,
@@ -484,18 +485,18 @@ describe('Unit | Service | sessions import validation Service', function () {
             isBlocking: true,
           },
         ]);
-        expect(subscriptions).to.be.empty;
+        expect(subscription).to.equal(Frameworks.CORE);
       });
     });
 
     context('when there are no subscriptions at all', function () {
-      it('should add core subscription', async function () {
+      it('should return CORE subscription', async function () {
         // given
         const subscriptionKeys = [];
         const line = 12;
 
         // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
+        const { certificationCandidateComplementaryErrors, subscription } =
           await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
             subscriptionKeys,
             line,
@@ -503,19 +504,17 @@ describe('Unit | Service | sessions import validation Service', function () {
 
         // then
         expect(certificationCandidateComplementaryErrors).to.be.empty;
-        expect(subscriptions).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ]);
+        expect(subscription).to.equal(Frameworks.CORE);
       });
     });
     context('when there is a double certification subscription', function () {
-      it('should add core subscription', async function () {
+      it('should return CLEA subscription', async function () {
         // given
         const subscriptionKeys = [ComplementaryCertificationKeys.CLEA];
         const line = 12;
 
         // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
+        const { certificationCandidateComplementaryErrors, subscription } =
           await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
             subscriptionKeys,
             line,
@@ -523,13 +522,7 @@ describe('Unit | Service | sessions import validation Service', function () {
 
         // then
         expect(certificationCandidateComplementaryErrors).to.be.empty;
-        expect(subscriptions).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            certificationCandidateId: null,
-            complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-          }),
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ]);
+        expect(subscription).to.equal(Frameworks.CLEA);
       });
     });
     context('when there is a complementary certification subscription', function () {
@@ -539,7 +532,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         const line = 12;
 
         // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
+        const { certificationCandidateComplementaryErrors, subscription } =
           await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
             subscriptionKeys,
             line,
@@ -547,12 +540,7 @@ describe('Unit | Service | sessions import validation Service', function () {
 
         // then
         expect(certificationCandidateComplementaryErrors).to.be.empty;
-        expect(subscriptions).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            certificationCandidateId: null,
-            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-          }),
-        ]);
+        expect(subscription).to.equal(Frameworks.DROIT);
       });
     });
   });

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -315,11 +315,6 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
             it('should insert the candidate and return the id', async function () {
               // given
               centerRepository.getById.resolves(domainBuilder.certification.enrolment.buildCenter({}));
-              candidateToEnroll.subscriptions = [
-                domainBuilder.certification.enrolment.buildCoreSubscription({
-                  certificationCandidateId: null,
-                }),
-              ];
               const correctedCandidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
                 ...candidateToEnroll,
                 sessionId,
@@ -327,9 +322,6 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
                 birthINSEECode: 'INSEE_CODE',
                 birthPostalCode: null,
                 birthCity: 'CITY',
-                subscriptions: [
-                  domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-                ],
               });
               candidateRepository.insert.resolves(159);
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
 import { createSessions } from '../../../../../../src/certification/enrolment/domain/usecases/create-sessions.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
@@ -35,13 +35,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
 
     candidateData = {
       sessionId: undefined,
-      subscriptions: [
-        domainBuilder.certification.enrolment.buildCoreSubscription(),
-        domainBuilder.certification.enrolment.buildComplementarySubscription({
-          id: 1,
-          complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-        }),
-      ],
+      subscription: Frameworks.DROIT,
     };
   });
 
@@ -153,7 +147,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
               domainBuilder.certification.enrolment.buildCandidate({
                 ...candidate,
                 sessionId: 1234,
-                subscription: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+                subscription: Frameworks.DROIT,
               }),
             ],
           });
@@ -195,7 +189,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
             domainBuilder.certification.enrolment.buildCandidate({
               ...candidate,
               sessionId: 1234,
-              subscription: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+              subscription: Frameworks.DROIT,
             }),
           ],
         });

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
@@ -10,6 +10,7 @@ import { CertificationStartedEvent } from '../../../../../../src/certification/e
 import { LastAnsweredEvent } from '../../../../../../src/certification/enrolment/domain/models/timeline/LastAnsweredEvent.js';
 import { UserCertificationEligibility } from '../../../../../../src/certification/enrolment/domain/read-models/UserCertificationEligibility.js';
 import { getCandidateTimeline } from '../../../../../../src/certification/enrolment/domain/usecases/get-candidate-timeline.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -186,10 +187,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           const candidate = domainBuilder.certification.enrolment.buildCandidate({
             userId: 222,
             reconciledAt: new Date(),
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription(),
-              domainBuilder.certification.enrolment.buildComplementarySubscription(),
-            ],
+            subscription: Frameworks.CLEA,
           });
           candidateRepository.get.resolves(candidate);
           const placementProfile = domainBuilder.buildPlacementProfile();
@@ -226,10 +224,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           const candidate = domainBuilder.certification.enrolment.buildCandidate({
             userId: 222,
             reconciledAt: new Date(),
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildCoreSubscription(),
-              domainBuilder.certification.enrolment.buildComplementarySubscription(),
-            ],
+            subscription: Frameworks.CLEA,
           });
           candidateRepository.get.resolves(candidate);
           const placementProfile = domainBuilder.buildPlacementProfile();

--- a/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
@@ -7,6 +7,7 @@ import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/d
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
 import { CERTIFICATION_SESSIONS_ERRORS } from '../../../../../../src/certification/shared/domain/constants/sessions-errors.js';
 import { CertificationCandidate } from '../../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CpfBirthInformationValidation } from '../../../../../../src/certification/shared/domain/services/certification-cpf-service.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/domain/constants.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
@@ -133,6 +134,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         userId: null,
         reconciledAt: null,
         billingMode: CertificationCandidate.BILLING_MODES.FREE,
+        subscriptions: [],
       });
       const session1 = { ...firstSession, candidates: [candidateData1] };
       const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
@@ -142,14 +144,13 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         userId: null,
         reconciledAt: null,
         billingMode: CertificationCandidate.BILLING_MODES.FREE,
+        subscriptions: [],
       });
       const session2 = { ...secondSession, candidates: [candidateData2] };
 
       sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
         certificationCandidateComplementaryErrors: [],
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
+        subscription: Frameworks.CORE,
       });
 
       sessionsImportValidationService.getValidatedCandidateInformation.resolves({
@@ -237,6 +238,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           userId: null,
           reconciledAt: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
+          subscriptions: [],
         });
         const session1 = { ...firstSession, candidates: [candidateData1] };
         const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
@@ -246,6 +248,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           userId: null,
           reconciledAt: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
+          subscriptions: [],
         });
         const candidateData3 = { ...candidateData2, lastName: 'Brun', firstName: 'Petit Ours' };
         const candidate3 = domainBuilder.certification.enrolment.buildCandidate({
@@ -255,6 +258,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           userId: null,
           reconciledAt: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
+          subscriptions: [],
         });
         const session2 = { sessionId: 2, candidates: [candidateData2, candidateData3] };
 
@@ -283,9 +287,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
+          subscription: Frameworks.CORE,
         });
 
         temporarySessionsStorageForMassImportService.save.resolves(cachedValidatedSessionsKey);
@@ -359,9 +361,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       // given
       sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
         certificationCandidateComplementaryErrors: [],
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
+        subscription: Frameworks.CORE,
       });
       sessionsImportValidationService.validateSession.resolves([
         { code: 'Veuillez indiquer un nom de site.', isBlocking: true },
@@ -398,9 +398,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
+          subscription: Frameworks.CORE,
         });
         sessionsImportValidationService.validateSession.resolves(['Veuillez indiquer un nom de site.']);
         sessionsImportValidationService.getValidatedCandidateInformation.resolves({
@@ -443,6 +441,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           createdAt: null,
           userId: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
+          subscriptions: [],
         });
         const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
           ...candidateData2,
@@ -450,6 +449,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           createdAt: null,
           userId: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
+          subscriptions: [],
         });
         const sessionsData = [
           {
@@ -460,9 +460,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
+          subscription: Frameworks.CORE,
         });
         sessionsImportValidationService.validateSession.resolves([]);
         sessionsImportValidationService.getValidatedCandidateInformation.resolves({
@@ -529,9 +527,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
+          subscription: Frameworks.CORE,
         });
         sessionsImportValidationService.validateSession.resolves([]);
         sessionsImportValidationService.getValidatedCandidateInformation.resolves({

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-reconciliation-requirements_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-reconciliation-requirements_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { verifyCandidateReconciliationRequirements } from '../../../../../../src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js';
 import { CenterHabilitationError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { UserNotAuthorizedToCertifyError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -85,11 +86,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCases | verify-candidat
         const candidate = domainBuilder.certification.enrolment.buildCandidate({
           userId,
           reconciledAt,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-            }),
-          ],
+          subscription: Frameworks.DROIT,
         });
 
         placementProfileService.getPlacementProfile
@@ -128,11 +125,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCases | verify-candidat
         const candidate = domainBuilder.certification.enrolment.buildCandidate({
           userId,
           reconciledAt,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              complementaryCertificationKey: complementaryCertification.key,
-            }),
-          ],
+          subscription: complementaryCertification.key,
         });
 
         placementProfileService.getPlacementProfile


### PR DESCRIPTION
## 💥 Problème

Suite à l'ajout de la colonne subscription dans certification-candidate, la table certification-subscriptions est devenue obsolète. Ainsi, on peut progressivement retirer son utilisation et la remplacer par la nouvelle colonne.

## 👩‍🚀 Proposition

Utiliser partout dans l'api le nouveau format de subscription uniquement
Mettre une logique provisoire dans le repo candidat pour continuer la double écriture table subscription/colonne subscription

## 👁️ Remarques



## ♻️ Pour tester
E2E

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
