### PR TITLE
[FEATURE] Ne pas afficher la vocalisation par défaut hors certif (PIX-22890).

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -24,7 +24,15 @@ export default class ChallengeController extends Controller {
   @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOutOfChallenge = false;
   @tracked hasUserConfirmedTimedChallengeWarning = false;
-  @tracked isTextToSpeechActivated = true;
+  @tracked userEnabledTextToSpeech = false;
+
+  get isTextToSpeechActivated() {
+    const certificationCourse = this.model.assessment.belongsTo('certificationCourse').value();
+    if (certificationCourse) {
+      return certificationCourse?.isAdjustedForAccessibility;
+    }
+    return this.userEnabledTextToSpeech;
+  }
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;
@@ -241,7 +249,7 @@ export default class ChallengeController extends Controller {
   }
 
   @action toggleTextToSpeech() {
-    this.isTextToSpeechActivated = !this.isTextToSpeechActivated;
+    this.userEnabledTextToSpeech = !this.userEnabledTextToSpeech;
     if (!this.isTextToSpeechActivated) {
       speechSynthesis.cancel();
     }

--- a/mon-pix/tests/acceptance/challenge-page-banner-test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner-test.js
@@ -76,7 +76,24 @@ module('Acceptance | Challenge page banner', function (hooks) {
         });
       });
 
-      test("should display text-to-speech button in challenge instruction when it's been activated in the banner", async function (assert) {
+      test('displays deactivated text-to-speech button in challenge instruction', async function (assert) {
+        // given
+        class MetricsStubService extends Service {
+          trackPage = sinon.stub();
+          trackEvent = sinon.stub();
+          context = {};
+        }
+        this.owner.register('service:pix-metrics', MetricsStubService);
+
+        // when
+        const screen = await visit(`/assessments/${assessment.id}/challenges/${challenge.id}`);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Activer la vocalisation' })).exists();
+        assert.dom(screen.queryByRole('button', { name: 'Lire la consigne à haute voix' })).doesNotExist();
+      });
+
+      test("displays text-to-speech button in challenge instruction when it's been activated in the banner", async function (assert) {
         // given
         class MetricsStubService extends Service {
           trackPage = sinon.stub();
@@ -86,24 +103,12 @@ module('Acceptance | Challenge page banner', function (hooks) {
         this.owner.register('service:pix-metrics', MetricsStubService);
 
         const screen = await visit(`/assessments/${assessment.id}/challenges/${challenge.id}`);
-        await click(screen.getByRole('button', { name: 'Désactiver la vocalisation' }));
 
         // when
         await click(screen.getByRole('button', { name: 'Activer la vocalisation' }));
 
         // then
         assert.dom(screen.getByRole('button', { name: 'Lire la consigne à haute voix' })).exists();
-      });
-
-      test("should hide text-to-speech button in challenge instruction when it's been deactivated in the banner", async function (assert) {
-        // given
-        const screen = await visit(`/assessments/${assessment.id}/challenges/${challenge.id}`);
-
-        // when
-        await click(screen.getByRole('button', { name: 'Désactiver la vocalisation' }));
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Lire la consigne à haute voix' })).doesNotExist();
       });
     });
   });


### PR DESCRIPTION
## 💥 Problème

Lors de l'épix MVP oralisation de la certification, nous avons permis à un candidat dont le besoin de test aménagé avait été signalé lors de son inscription dans Pix Certif d’utiliser l’oralisation de la consigne pendant sa certification.
Cette modification a eu des impacts non cantonnés à la certification…
Désormais, le bouton “Lire la consigne à haute voix” est visible par défaut dans l’encart de la consigne pour tout utilisateur Pix App, y compris ceux qui ne passent pas une certification mais qui sont en parcours ou même en entraînement libre.

Cette affichage systématique nuit à la lisibilité de la consigne par l’utilisateur Pix App à moins qu'il ne pense à désactiver la lecture en cliquant en haut à droite sur le haut parleur.

## 👩‍🚀 Proposition

Par défaut, la vocalisation ne doit pas être active pour tous les utilisateurs Pix App.
Elle ne doit être active que : 
- si l’utilisateur Pix App a cliqué sur le bouton pour “Activer la vocalisation”
- si le candidat inscrit en certification a eu un besoin de test aménagé de déclaré.

## ♻️ Pour tester

- En positionnement, vérifier que le bouton d'activation vocale est désactivé par défaut
- Créer une session de certif avec deux candidats (un avec un besoin d'a11y, l'autre non) et vérifier que :
-> le bouton est activé par défaut pour le candidat avec besoin 
-> Le bouton est non visible pour le candidat sans besoin. 