### PR TITLE
[BUGFIX] Retourner null quand il n'y a plus d'épreuve disponible dans une activité

### DIFF
--- a/api/src/school/domain/usecases/get-next-challenge.js
+++ b/api/src/school/domain/usecases/get-next-challenge.js
@@ -30,6 +30,10 @@ export async function getNextChallenge({
     alternativeVersion: activity.alternativeVersion,
   });
 
+  if (!challengeId) {
+    return null;
+  }
+
   await assessmentRepository.updateWhenNewChallengeIsAsked({ id: assessmentId, lastChallengeId: challengeId });
   return challengeToPlayApi.get(challengeId);
 }

--- a/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
@@ -87,6 +87,42 @@ describe('Integration | School | Usecase | get-next-challenge', function () {
       });
     });
 
+    context('when last activity is started but all challenges have been answered', function () {
+      it('should return null', async function () {
+        const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
+
+        const { id: activityId } = databaseBuilder.factory.buildActivity({
+          assessmentId,
+          level: Activity.levels.VALIDATION,
+          status: Activity.status.STARTED,
+          stepIndex: 0,
+        });
+        databaseBuilder.factory.buildActivityAnswer({ activityId, challengeId: 'only_va_challenge_id' });
+
+        databaseBuilder.factory.learningContent.build({
+          challenges: [],
+          skills: [],
+          missions: [
+            learningContentBuilder.buildMission({
+              id: missionId,
+              content: {
+                steps: [
+                  {
+                    validationChallenges: [['only_va_challenge_id']],
+                  },
+                ],
+              },
+            }),
+          ],
+        });
+        await databaseBuilder.commit();
+
+        const challenge = await usecases.getNextChallenge({ assessmentId });
+
+        expect(challenge).to.be.null;
+      });
+    });
+
     context('when last activity is started but has answer duplicate', function () {
       it('should return next challenge and update assessment', async function () {
         const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();


### PR DESCRIPTION
## 🌱 Problème

Lorsqu'une activité est en statut `STARTED` mais que toutes ses épreuves ont déjà été répondues, `mission.getChallengeId()` retourne `undefined` (index hors limites). Cet `undefined` est ensuite passé à `challengeToPlayApi.get()` `DataLoader.load(undefined)`, provoquant une `TypeError`.

Cela peut probablement arriver dans une fenêtre temporelle entre la sauvegarde de la dernière réponse et la mise à jour du statut de l'activité vers `SUCCEEDED`.

## 🐣 Proposition

Vérification de `challengeId` dans `getNextChallenge` avant d'appeler l'API : si `undefined`, on retourne `null` (cohérent avec le cas activité non démarrée).

Ajout d'un test d'intégration couvrant ce cas.

## 🐝 Pour tester

🟢 