### PR TITLE
[FEATURE] Créer une route pour remonter les statistiques d'une organisation (PIX-22895)

### DIFF
--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -14,6 +14,7 @@ import {
 import * as organizationSerializer from '../../infrastructure/serializers/jsonapi/organization-serializer.js';
 import { organizationForAdminSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js';
 import * as organizationPlacesStatisticsSerializer from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js';
+import * as organizationStatisticsSerializer from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js';
 
 const ADD_TAGS_TO_ORGANIZATIONS_HEADER = organizationTagCsvParser.CSV_HEADER;
 
@@ -190,6 +191,11 @@ const findChildrenOrganizations = async function (request, h, dependencies = { o
   return dependencies.organizationForAdminSerializer.serialize(childOrganizations);
 };
 
+const getOrganizationStatistics = async function (request, h, dependencies = { organizationStatisticsSerializer }) {
+  const organizationId = request.params.organizationId;
+  const statistics = await usecases.getOrganizationStatistics({ organizationId });
+  return dependencies.organizationStatisticsSerializer.serialize(statistics);
+};
 const organizationAdminController = {
   getTemplateForAddTagsToOrganizations,
   addTagsToOrganizations,
@@ -210,6 +216,7 @@ const organizationAdminController = {
   updateOrganizationInformation,
   findPaginatedFilteredOrganizations,
   findChildrenOrganizations,
+  getOrganizationStatistics,
 };
 
 export { organizationAdminController };

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -527,6 +527,35 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/organizations/{organizationId}/statistics',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: (request, h) => organizationAdminController.getOrganizationStatistics(request, h),
+        tags: ['api', 'organizations'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, CERTIF, SUPPORT ou METIER permettant un accès à l'application d'administration de Pix**\n" +
+            "- Elle permet la récuperation des statistiques de l'organisation",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/organizational-entities/domain/usecases/get-organization-statistics.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/get-organization-statistics.usecase.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {import('./index.js').OrganizationForAdminRepository} OrganizationForAdminRepository
+ */
+
+import { OrganizationNotFound } from '../errors.js';
+
+/**
+ *
+ * @param {Object} params
+ * @param {Number} params.organizationId
+ * @param {OrganizationForAdminRepository} params.organizationForAdminRepository
+ * @returns {Promise<{totalParticipantsCount: Number; id: string}>}
+ */
+export async function getOrganizationStatistics({ organizationId, organizationForAdminRepository }) {
+  const organization = await organizationForAdminRepository.exist({ organizationId });
+  if (!organization) {
+    throw new OrganizationNotFound({ meta: { organizationId } });
+  }
+
+  const statistics = await organizationForAdminRepository.getOrganizationParticipantsStatistics({ organizationId });
+  return { ...statistics, id: `${organizationId}_organization_statistics` };
+}

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -107,6 +107,7 @@ import { getNetworkDetails } from './get-network-details.usecase.js';
 import { getOrganizationById } from './get-organization-by-id.js';
 import { getOrganizationDetails } from './get-organization-details.usecase.js';
 import { getOrganizationPlacesStatistics } from './get-organization-places-statistics.usecase.js';
+import { getOrganizationStatistics } from './get-organization-statistics.usecase.js';
 import { getRecentlyUsedTags } from './get-recently-used-tags.usecase.js';
 import { updateCertificationCenter } from './update-certification-center.usecase.js';
 import { updateCertificationCenterDataProtectionOfficerInformation } from './update-certification-center-data-protection-officer-information.usecase.js';
@@ -141,6 +142,7 @@ const usecasesWithoutInjectedDependencies = {
   getOrganizationById,
   getOrganizationDetails,
   getOrganizationPlacesStatistics,
+  getOrganizationStatistics,
   getRecentlyUsedTags,
   updateCertificationCenterDataProtectionOfficerInformation,
   updateCertificationCenter,
@@ -157,6 +159,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {detachParentOrganizationFromOrganization} detachParentOrganizationFromOrganization
  * @property {findPaginatedFilteredCertificationCenters} findPaginatedFilteredCertificationCenters
  * @property {getOrganizationDetails} getOrganizationDetails
+ * @property {getOrganizationStatistics} getOrganizationStatistics
  * @property {getNetworkDetails} getNetworkDetails
  * @property {updateOrganizationsInBatch} updateOrganizationsInBatch
  * @property {updateOrganizationInformation} updateOrganizationInformation

--- a/api/src/organizational-entities/infrastructure/repositories/index.js
+++ b/api/src/organizational-entities/infrastructure/repositories/index.js
@@ -1,3 +1,4 @@
+import * as campaignStatsApi from '../../../prescription/campaign/application/api/campaign-stats-api.js';
 import * as campaignApi from '../../../prescription/campaign/application/api/campaigns-api.js';
 import * as learnerApi from '../../../prescription/learner-management/application/api/learners-api.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -13,6 +14,7 @@ const dependencies = {
   organizationApi,
   learnerApi,
   campaignApi,
+  campaignStatsApi,
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -377,6 +377,15 @@ const createProOrganizationInvitation = async function ({
   });
 };
 
+/**
+ * @type {function}
+ * @param {number} organizationId
+ * @return {Promise<{totalParticipantsCount: number}>}
+ */
+const getOrganizationParticipantsStatistics = async ({ campaignStatsApi, organizationId }) => {
+  return campaignStatsApi.getOrganizationParticipantsStatistics(organizationId);
+};
+
 async function _addOrUpdateDataProtectionOfficer(knexConn, dataProtectionOfficer) {
   await knexConn(DATA_PROTECTION_OFFICERS_TABLE_NAME)
     .insert(dataProtectionOfficer)
@@ -560,6 +569,7 @@ export const organizationForAdminRepository = {
   findPaginatedFiltered,
   findChildrenByParentOrganizationId,
   get,
+  getOrganizationParticipantsStatistics,
   save,
   update,
 };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (statistics) {
+  return new Serializer('organization-statistics', {
+    attributes: ['totalParticipantsCount'],
+  }).serialize(statistics);
+};
+
+export { serialize };

--- a/api/src/prescription/campaign/domain/usecases/statistics/get-organization-participants-statistics.js
+++ b/api/src/prescription/campaign/domain/usecases/statistics/get-organization-participants-statistics.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {import('../../../infrastructure/repositories/campaign-participations-stats-repository.js')} CampaignParticipationsStatsRepository
+ * @param {Object} params
+ * @param {Number} params.organizationId
+ * @param {CampaignParticipationsStatsRepository} params.campaignParticipationsStatsRepository
+ * @returns {Promise<{totalParticipantsCount: Number}>}
+ */
+
 const getOrganizationParticipantsStatistics = async function ({
   organizationId,
   campaignParticipationsStatsRepository,

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1615,6 +1615,32 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       expect(response.result.data.type).to.equal('organization-places-statistics');
     });
   });
+
+  describe('GET /api/organizations/{id}/statistics', function () {
+    it('should return statistics of a given organization and http code 200', async function () {
+      // given
+      const server = await createServer();
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/organizations/${organizationId}/statistics`,
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.type).to.equal('organization-statistics');
+      expect(response.result.data.id).to.equal(`${organizationId}_organization_statistics`);
+    });
+  });
 });
 
 function _createMultipartPayload({ boundary, filename, fieldName, contentType, content }) {

--- a/api/tests/organizational-entities/integration/domain/usecases/get-organization-statistics.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/get-organization-statistics.usecase.test.js
@@ -1,0 +1,36 @@
+import { OrganizationNotFound } from '../../../../../src/organizational-entities/domain/errors.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+describe('Integration | UseCases | get-organization-statistics', function () {
+  it('should return statistics for a given organization id', async function () {
+    // given
+    const { organizationId, id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();
+    const { id: otherOrganizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+    const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+    databaseBuilder.factory.buildCampaignParticipation({ organizationLearnerId, campaignId });
+    databaseBuilder.factory.buildCampaignParticipation({
+      organizationLearnerId: otherOrganizationLearnerId,
+      campaignId,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.getOrganizationStatistics({ organizationId });
+
+    // then
+    expect(result).to.deep.equal({ totalParticipantsCount: 2, id: `${organizationId}_organization_statistics` });
+  });
+
+  it('should throw an OrganizationNotFoundError when organization does not exist', async function () {
+    // when
+    const error = await catchErr(usecases.getOrganizationStatistics)({ organizationId: 99 });
+
+    // then
+    expect(error).to.be.instanceOf(OrganizationNotFound);
+    expect(error.meta).to.deep.equal({ organizationId: 99 });
+  });
+});

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
@@ -229,4 +229,33 @@ describe('Unit | Organizational Entities | Application | Controller | Admin | or
       expect(result).to.equal(organizationPlacesStatisticsSerialized);
     });
   });
+
+  describe('#getOrganizationStatistics', function () {
+    it('should call the usecase and serialize the response', async function () {
+      // given
+      const organizationId = 1234;
+      const request = { params: { organizationId } };
+
+      const organizationStatistics = Symbol('statistics');
+      const organizationStatisticsSerialized = Symbol('serializedStatistics');
+      sinon.stub(usecases, 'getOrganizationStatistics').withArgs({ organizationId }).resolves(organizationStatistics);
+      const organizationStatisticsSerializerStub = {
+        serialize: sinon.stub(),
+      };
+
+      organizationStatisticsSerializerStub.serialize
+        .withArgs(organizationStatistics)
+        .returns(organizationStatisticsSerialized);
+
+      const dependencies = {
+        organizationStatisticsSerializer: organizationStatisticsSerializerStub,
+      };
+
+      // when
+      const result = await organizationAdminController.getOrganizationStatistics(request, hFake, dependencies);
+
+      // then
+      expect(result).to.equal(organizationStatisticsSerialized);
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
@@ -107,4 +107,53 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
       });
     });
   });
+
+  describe('GET /api/admin/organizations/{id}/statistics', function () {
+    describe('when the user authenticated has no role', function () {
+      it('returns a 403 HTTP status code', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) =>
+          h
+            .response({ errors: new Error('forbidden') })
+            .code(403)
+            .takeover(),
+        );
+        sinon.stub(organizationAdminController, 'getOrganizationStatistics');
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/organizations/1/statistics');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(organizationAdminController.getOrganizationStatistics);
+      });
+    });
+
+    const authorizedRoles = [
+      { role: 'SuperAdmin', stub: 'checkAdminMemberHasRoleSuperAdmin' },
+      { role: 'Support', stub: 'checkAdminMemberHasRoleSupport' },
+      { role: 'Certif', stub: 'checkAdminMemberHasRoleCertif' },
+      { role: 'Metier', stub: 'checkAdminMemberHasRoleMetier' },
+    ];
+
+    authorizedRoles.forEach(({ role, stub }) => {
+      describe(`when the user has ${role} role`, function () {
+        it('returns a 200 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, stub).callsFake((request, h) => h.response(true));
+          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').callsFake((_handlers) => {
+            return () => true;
+          });
+          sinon.stub(organizationAdminController, 'getOrganizationStatistics').returns('ok');
+
+          // when
+          const response = await httpTestServer.request('GET', '/api/admin/organizations/1/statistics');
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          sinon.assert.calledOnce(organizationAdminController.getOrganizationStatistics);
+        });
+      });
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1,0 +1,34 @@
+import sinon from 'sinon';
+
+import { organizationForAdminRepository } from '../../../../../src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Organizational-Entities | Unit | Infrastructure | repositories | organization-for-admin', function () {
+  describe('#getOrganizationParticipantsStatistics', function () {
+    let campaignStatsApiStub;
+
+    beforeEach(function () {
+      campaignStatsApiStub = {
+        getOrganizationParticipantsStatistics: sinon.stub(),
+      };
+    });
+
+    it('should return statistics for given organization id', async function () {
+      //given
+      const organizationId = Symbol('organizationId');
+      const expectedCount = {
+        totalParticipantsCount: Symbol('totalParticipantsCount'),
+      };
+      campaignStatsApiStub.getOrganizationParticipantsStatistics.withArgs(organizationId).resolves(expectedCount);
+
+      //when
+      const result = await organizationForAdminRepository.getOrganizationParticipantsStatistics({
+        organizationId,
+        campaignStatsApi: campaignStatsApiStub,
+      });
+
+      //then
+      expect(result).to.equal(expectedCount);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.test.js
@@ -1,0 +1,27 @@
+import * as organizationStatisticsSerializer from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Infrastructure | Serializers | JSONAPI | Organizations-Administrations | organization-statistics', function () {
+  describe('#serialize', function () {
+    it('should convert a statistics object into JSON API data', function () {
+      // given
+      const statistics = { totalParticipantsCount: 42, id: '1_organization_statistics' };
+
+      const expectedJSON = {
+        data: {
+          type: 'organization-statistics',
+          id: '1_organization_statistics',
+          attributes: {
+            'total-participants-count': 42,
+          },
+        },
+      };
+
+      // when
+      const json = organizationStatisticsSerializer.serialize(statistics);
+
+      // then
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/application/api/campaign-stats-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaign-stats-api_test.js
@@ -8,6 +8,7 @@ import { expect } from '../../../../../test-helper.js';
 describe('Unit | API | CampaignStats', function () {
   describe('#getOrganizationParticipantsStatistics', function () {
     it('returns the statistics for the given organization', async function () {
+      // given
       const organizationId = 1;
       const expectedStats = { totalParticipantsCount: 42 };
       sinon
@@ -15,8 +16,10 @@ describe('Unit | API | CampaignStats', function () {
         .withArgs({ organizationId })
         .resolves(expectedStats);
 
+      // when
       const result = await campaignStatsApi.getOrganizationParticipantsStatistics(organizationId);
 
+      // then
       expect(result).to.be.an.instanceOf(OrganizationStatistics);
       expect(result).to.deep.equal(expectedStats);
     });

--- a/api/tests/prescription/campaign/unit/domain/usecases/statistics/get-organization-participants-statistics_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/statistics/get-organization-participants-statistics_test.js
@@ -5,28 +5,34 @@ import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | UseCase | getOrganizationParticipantsStatistics', function () {
   it('returns the total participants count for the given organization', async function () {
+    // given
     const organizationId = 1;
     const campaignParticipationsStatsRepository = { countParticipantsByOrganizationId: sinon.stub() };
     campaignParticipationsStatsRepository.countParticipantsByOrganizationId.withArgs(organizationId).resolves(42);
 
+    // when
     const result = await getOrganizationParticipantsStatistics({
       organizationId,
       campaignParticipationsStatsRepository,
     });
 
+    // then
     expect(result).to.deep.equal({ totalParticipantsCount: 42 });
   });
 
   it('returns 0 when the organization has no participants', async function () {
+    // given
     const organizationId = 1;
     const campaignParticipationsStatsRepository = { countParticipantsByOrganizationId: sinon.stub() };
     campaignParticipationsStatsRepository.countParticipantsByOrganizationId.withArgs(organizationId).resolves(0);
 
+    // when
     const result = await getOrganizationParticipantsStatistics({
       organizationId,
       campaignParticipationsStatsRepository,
     });
 
+    // then
     expect(result).to.deep.equal({ totalParticipantsCount: 0 });
   });
 });


### PR DESCRIPTION
## 💥 Problème

On a besoin d'afficher dans Pix Admin, des statistiques sur la page d'une organisation. Pour l'instant on veut remonter le nombre de participants uniques depuis la création de l'orga.

## 👩‍🚀 Proposition
Créer une nouvelle route API en passant l'id de l'orga en paramètres d'URL, qui remontera ce nombre.

## 👁️ Remarques

- On utilise l'API interne côté prescription pour remonter ce compte.
- Cette route est accessible pour tous les rôles Pix admin

## ♻️ Pour tester
- faire un appel HTTP GET vers le endpoint `/api/admin/organizations/{organizationId}/statistics`
- constater que les statistiques qui nous intéressent sont remontées.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
