### PR TITLE
[TECH] Déplacer LearningContentConversionService dans prescription/shared

### DIFF
--- a/api/src/prescription/shared/domain/services/learning-content-conversion-service.js
+++ b/api/src/prescription/shared/domain/services/learning-content-conversion-service.js
@@ -1,4 +1,4 @@
-import * as skillRepository from '../../../../src/shared/infrastructure/repositories/skill-repository.js';
+import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 
 async function findActiveSkillsForCappedTubes(cappedTubes, dependencies = { skillRepository }) {
   const skills = [];

--- a/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
 import * as frameworksAPI from '../../../../learning-content/application/api/frameworks-api.js';
 import * as campaignRepository from '../../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import { PIX_ORIGIN } from '../../../../shared/domain/constants.js';
@@ -14,6 +13,7 @@ import * as competenceRepository from '../../../../shared/infrastructure/reposit
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import * as thematicRepository from '../../../../shared/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
+import * as learningContentConversionService from '../../domain/services/learning-content-conversion-service.js';
 
 export const findBySkillIds = async (skillIds, locale) => {
   const skills = await skillRepository.findByRecordIds(skillIds);

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -1,6 +1,6 @@
-import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import * as learningContentConversionService from '../../../shared/domain/services/learning-content-conversion-service.js';
 import * as learningContentRepository from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as organizationsToAttachToTargetProfileRepository from '../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js';
@@ -11,8 +11,7 @@ import * as targetProfileForUpdateRepository from '../../infrastructure/reposito
 import * as targetProfileSummaryForAdminRepository from '../../infrastructure/repositories/target-profile-summary-for-admin-repository.js';
 
 /**
- * @typedef {import('../../infrastructure/repositories/')} AdminMemberRepository
- * @typedef {import('../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js')} LearningContentConversionService
+ * @typedef {import('../../../shared/domain/services/learning-content-conversion-service.js')} LearningContentConversionService
  * @typedef {import('../../../../../lib/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
  * @typedef {import('../../../../shared/infrastructure/repositories/organization-repository.js')} OrganizationRepository
  * @typedef {import('../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js')} OrganizationsToAttachToTargetProfileRepository

--- a/api/tests/prescription/shared/unit/domain/services/learning-content-conversion-service_test.js
+++ b/api/tests/prescription/shared/unit/domain/services/learning-content-conversion-service_test.js
@@ -1,10 +1,10 @@
 import sinon from 'sinon';
 
-import { findActiveSkillsForCappedTubes } from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
-import { expect } from '../../../../test-helper.js';
-import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { findActiveSkillsForCappedTubes } from '../../../../../../src/prescription/shared/domain/services/learning-content-conversion-service.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
-describe('Unit | Service | learning-content-conversion-service', function () {
+describe('Prescription | Shared | Unit | Service | learning-content-conversion-service', function () {
   describe('#findActiveSkillsForCappedTubes', function () {
     it('should find all skills of provided tubes capped by difficulty', async function () {
       // given


### PR DESCRIPTION
## 💥 Problème

Il reste uniquement le fichier `learning-content-conversion-service.js` dans la dossier `lib` 🔥

## 👩‍🚀 Proposition

Ce service est utilisé dans les contextes : `prescription/shared` et `prescription/target-profile`.

Donc l'endroit le plus approprié semble `prescription/shared`

## 👁️ Remarques

N/A

## ♻️ Pour tester

Test CI ok
