### PR TITLE
[FEATURE] Met à jour les labels de certaines attestations

### DIFF
--- a/api/db/migrations/20260529155253_update-labels-of-attestations.js
+++ b/api/db/migrations/20260529155253_update-labels-of-attestations.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'attestations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex(TABLE_NAME).where({ id: 1 }).update({ label: 'Sensibilisation au numérique' });
+  await knex(TABLE_NAME).where({ id: 2 }).update({ label: 'Sensibilisation au numérique (Parentalité)' });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex(TABLE_NAME).where({ id: 1 }).update({ label: 'Attestation de sensibilisation au numérique' });
+  await knex(TABLE_NAME)
+    .where({ id: 2 })
+    .update({ label: 'Attestation de sensibilisation au numérique (Parentalité)' });
+};
+
+export { down, up };


### PR DESCRIPTION
## 💥 Problème
Suite à une demande concernant l'affichage des attestations, on doit changer leurs labels en base de données.

## 👩‍🚀 Proposition
On retire "Attestation" du label de deux attestations.

## ♻️ Pour tester
Tester que la migration fonctionne bien et que le rollback est possible.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
