### PR TITLE
[TECH] Migration pour ajouter le liens des questionnaires aux blueprints (PIX-22938)

### DIFF
--- a/api/db/migrations/20260529094825_add-survey-url-in-combined-course-blueprints.js
+++ b/api/db/migrations/20260529094825_add-survey-url-in-combined-course-blueprints.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'combined_course_blueprints';
+const COLUMN_NAME = 'surveyUrl';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .string(COLUMN_NAME)
+      .defaultTo(null)
+      .comment("Url for the blueprint's survey displayed at the end of related combined courses");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 💥 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On veut enregistrer au niveau des blueprints les liens des questionnaires à afficher à la fin des parcours combinés associés.

## 👩‍🚀 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Ajout d'une colonne dans la table combined-course-blueprints pour stocker cette donnée

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
npm run db:migrate
npm run db:rollback:latest

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
