### PR TITLE
[FEATURE] Modification de l'affichage des boutons d'actions de certification (PIX-22922).

### DIFF
--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -19,33 +19,39 @@ export default class CertificationInformationGlobalActions extends Component {
   @tracked displayConfirm = false;
   @tracked modalTitle = null;
 
-  get canPerformCertificationActions() {
-    return Boolean(
-      !this.args.certification.isPublished &&
-      this.args.session.finalizedAt &&
-      (this.args.certification.status === 'validated' ||
-        this.args.certification.status === 'error' ||
-        !this.args.certification.status),
-    );
+  get basicActionsRequirements() {
+    return this.args.session.finalizedAt && !this.args.certification.isPublished;
   }
 
   get displayCancelCertificationButton() {
-    return this.canPerformCertificationActions;
+    return (
+      this.basicActionsRequirements &&
+      !this.args.certification.isCertificationCancelled &&
+      !this.isCertificationRejected
+    );
   }
 
   get displayUncancelCertificationButton() {
-    return Boolean(
-      this.args.certification.isCertificationCancelled &&
-      !this.args.certification.isPublished &&
-      this.args.session.finalizedAt,
+    return (
+      this.basicActionsRequirements && this.args.certification.isCertificationCancelled && !this.isCertificationRejected
     );
   }
 
   get displayRejectCertificationButton() {
-    return this.canPerformCertificationActions;
+    return (
+      this.basicActionsRequirements &&
+      !this.isCertificationRejected &&
+      !this.args.certification.isCertificationCancelled
+    );
   }
 
   get displayUnrejectCertificationButton() {
+    return (
+      this.basicActionsRequirements && this.isCertificationRejected && !this.args.certification.isCertificationCancelled
+    );
+  }
+
+  get isCertificationRejected() {
     return this.args.certification.status === 'rejected' && this.args.certification.isRejectedForFraud;
   }
 

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -58,9 +58,9 @@ module('Integration | Component | Certifications | Certification | Information |
   });
 
   module('cancel button', function () {
-    module('when should display', function () {
-      module('when certification is validated, session is finalized and not published', function () {
-        test('should display a cancel button', async function (assert) {
+    module('when session is finalized and not published', function () {
+      module('when certification is not rejected for fraud', function () {
+        test('displays a cancel button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
             userId: 1,
@@ -79,73 +79,13 @@ module('Integration | Component | Certifications | Certification | Information |
         });
       });
 
-      module('when certification has error status, session is finalized and not published', function () {
-        test('should display a cancel button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: assessmentResultStatus.ERROR,
-            isPublished: false,
-          });
-          const session = createFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
-            .exists();
-        });
-      });
-      module('when certification has no status, session is finalized and not published', function () {
-        test('should display a cancel button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: null,
-            isPublished: false,
-          });
-          const session = createFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
-            .exists();
-        });
-      });
-    });
-
-    module('when should not display', function () {
-      module('when certification status is cancelled', function () {
-        test('should not display a cancel button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: assessmentResultStatus.CANCELLED,
-            isPublished: false,
-          });
-          const session = createFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
-            .doesNotExist();
-        });
-      });
-
-      module('when certification status is rejected', function () {
-        test('should not display a cancel button', async function (assert) {
+      module('when certification is rejected for fraud', function () {
+        test('does not display a cancel button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
             userId: 1,
             status: assessmentResultStatus.REJECTED,
+            isRejectedForFraud: true,
             isPublished: false,
           });
           const session = createFinalizedSession();
@@ -159,45 +99,45 @@ module('Integration | Component | Certifications | Certification | Information |
             .doesNotExist();
         });
       });
+    });
 
-      module('when session is not finalized', function () {
-        test('should not display a cancel button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: assessmentResultStatus.VALIDATED,
-            isPublished: false,
-          });
-          const session = createNonFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
-            .doesNotExist();
+    module('when session is not finalized', function () {
+      test('does not display a cancel button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: false,
         });
+        const session = createNonFinalizedSession();
+
+        // when
+        const screen = await renderGlobalActions(certification, session);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+          .doesNotExist();
       });
+    });
 
-      module('when certification is published', function () {
-        test('should not display a cancel button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: assessmentResultStatus.VALIDATED,
-            isPublished: true,
-          });
-          const session = createFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
-            .doesNotExist();
+    module('when certification is published', function () {
+      test('does not display a cancel button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: true,
         });
+        const session = createFinalizedSession();
+
+        // when
+        const screen = await renderGlobalActions(certification, session);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+          .doesNotExist();
       });
     });
 
@@ -223,7 +163,7 @@ module('Integration | Component | Certifications | Certification | Information |
         screen = await renderGlobalActions(certification, session);
       });
 
-      test('should display confirmation modal on click', async function (assert) {
+      test('displays confirmation modal on click', async function (assert) {
         // when
         await fireEvent.click(
           screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }),
@@ -238,7 +178,7 @@ module('Integration | Component | Certifications | Certification | Information |
       });
 
       module('when modal is confirmed', function () {
-        test('should perform action and close modal on success', async function (assert) {
+        test('performs action and close modal on success', async function (assert) {
           // given
           const currentCertification = store.peekRecord('certification', 1);
 
@@ -258,7 +198,7 @@ module('Integration | Component | Certifications | Certification | Information |
           assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
 
-        test('should display notification and close modal on error', async function (assert) {
+        test('displays notification and close modal on error', async function (assert) {
           // given
           const notificationStub = setupNotificationStub(this.owner);
           const currentCertification = store.peekRecord('certification', 1);
@@ -280,7 +220,7 @@ module('Integration | Component | Certifications | Certification | Information |
         });
       });
 
-      test('should close modal on cancellation', async function (assert) {
+      test('closes modal on cancellation', async function (assert) {
         // given
         const currentCertification = store.peekRecord('certification', 1);
 
@@ -301,19 +241,129 @@ module('Integration | Component | Certifications | Certification | Information |
   });
 
   module('uncancel button', function () {
-    module('when the certification is cancelled, not published and the session is finalized', function (hooks) {
+    module('when session is finalized and not published', function () {
       let screen;
 
-      const modalTitle = 'Confirmer la désannulation de la certification';
-      const modalMessage =
-        'Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.';
+      module('when certification is cancelled', function (hooks) {
+        const modalTitle = 'Confirmer la désannulation de la certification';
+        const modalMessage =
+          'Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.';
 
-      hooks.beforeEach(async function () {
+        hooks.beforeEach(async function () {
+          // given
+          const certification = store.createRecord('certification', {
+            id: '2',
+            userId: 1,
+            status: assessmentResultStatus.CANCELLED,
+            isPublished: false,
+            save: sinon.stub(),
+            reload: sinon.stub(),
+          });
+          const session = createFinalizedSession();
+
+          // when
+          screen = await renderGlobalActions(certification, session);
+        });
+
+        test('displays an uncancel button', async function (assert) {
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }))
+            .exists();
+        });
+
+        test('on cancel button click, displays a confirmation modal', async function (assert) {
+          // when
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
+          );
+
+          await screen.findByRole('dialog');
+
+          // then
+          assert.dom(screen.getByText(modalTitle)).exists();
+          assert.dom(screen.getByText(modalMessage)).exists();
+          assert.dom(screen.getByRole('button', { name: t('common.actions.confirm') })).exists();
+          assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+        });
+
+        module('on modal confirmation', function () {
+          test('uncancels the certification and closes the modal', async function (assert) {
+            // given
+            const currentCertification = store.peekRecord('certification', 2);
+
+            // when
+            await fireEvent.click(
+              screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
+            );
+
+            await screen.findByRole('dialog');
+
+            await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+
+            await waitForDialogClose();
+
+            // then
+            sinon.assert.calledWith(currentCertification.save, {
+              adapterOptions: { isCertificationUncancel: true },
+            });
+            assert.ok(currentCertification.reload.calledOnce);
+            assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
+          });
+
+          test('on error, displays a notification and closes the modal', async function (assert) {
+            // given
+            const notificationStub = setupNotificationStub(this.owner);
+
+            const currentCertification = store.peekRecord('certification', 2);
+            currentCertification.save.rejects();
+
+            // when
+            await fireEvent.click(
+              screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
+            );
+            await screen.findByRole('dialog');
+            await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+            await waitForDialogClose();
+
+            // then
+            sinon.assert.calledWith(notificationStub, {
+              message: t('components.certifications.global-actions.uncancel.error-message'),
+            });
+            assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
+          });
+        });
+
+        test('on modal cancellation, closes the modal', async function (assert) {
+          // given
+          const currentCertification = store.peekRecord('certification', 2);
+
+          // when
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
+          );
+
+          await screen.findByRole('dialog');
+
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.cancel') }));
+
+          await waitForDialogClose();
+
+          // then
+          assert.ok(currentCertification.save.notCalled);
+          assert.ok(currentCertification.reload.notCalled);
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
+        });
+      });
+    });
+
+    module('when certification is not cancelled', function () {
+      test('does not display an uncancel button', async function (assert) {
         // given
         const certification = store.createRecord('certification', {
           id: '1',
           userId: 1,
-          status: assessmentResultStatus.CANCELLED,
+          status: assessmentResultStatus.VALIDATED,
           isPublished: false,
           save: sinon.stub(),
           reload: sinon.stub(),
@@ -321,105 +371,60 @@ module('Integration | Component | Certifications | Certification | Information |
         const session = createFinalizedSession();
 
         // when
-        screen = await renderGlobalActions(certification, session);
-      });
+        const screen = await renderGlobalActions(certification, session);
 
-      test('should display an uncancel button', async function (assert) {
         // then
         assert
-          .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }))
-          .exists();
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }))
+          .doesNotExist();
       });
+    });
 
-      test('on cancel button click, should display a confirmation modal', async function (assert) {
-        // when
-        await fireEvent.click(
-          screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
-        );
-
-        await screen.findByRole('dialog');
-
-        // then
-        assert.dom(screen.getByText(modalTitle)).exists();
-        assert.dom(screen.getByText(modalMessage)).exists();
-        assert.dom(screen.getByRole('button', { name: t('common.actions.confirm') })).exists();
-        assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
-      });
-
-      module('on modal confirmation', function () {
-        test('should uncancel the certification and close the modal', async function (assert) {
-          // given
-          const currentCertification = store.peekRecord('certification', 1);
-
-          // when
-          await fireEvent.click(
-            screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
-          );
-
-          await screen.findByRole('dialog');
-
-          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
-
-          await waitForDialogClose();
-
-          // then
-          sinon.assert.calledWith(currentCertification.save, {
-            adapterOptions: { isCertificationUncancel: true },
-          });
-          assert.ok(currentCertification.reload.calledOnce);
-          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
-        });
-
-        test('on error, should display a notification and close the modal', async function (assert) {
-          // given
-          const notificationStub = setupNotificationStub(this.owner);
-
-          const currentCertification = store.peekRecord('certification', 1);
-          currentCertification.save.rejects();
-
-          // when
-          await fireEvent.click(
-            screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
-          );
-          await screen.findByRole('dialog');
-          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
-          await waitForDialogClose();
-
-          // then
-          sinon.assert.calledWith(notificationStub, {
-            message: t('components.certifications.global-actions.uncancel.error-message'),
-          });
-          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
-        });
-      });
-
-      test('on modal cancellation, should close the modal', async function (assert) {
+    module('when session is not finalized', function () {
+      test('does not display an uncancel button', async function (assert) {
         // given
-        const currentCertification = store.peekRecord('certification', 1);
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: false,
+        });
+        const session = createNonFinalizedSession();
 
         // when
-        await fireEvent.click(
-          screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
-        );
-
-        await screen.findByRole('dialog');
-
-        await fireEvent.click(screen.getByRole('button', { name: t('common.actions.cancel') }));
-
-        await waitForDialogClose();
+        const screen = await renderGlobalActions(certification, session);
 
         // then
-        assert.ok(currentCertification.save.notCalled);
-        assert.ok(currentCertification.reload.notCalled);
-        assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when certification is published', function () {
+      test('does not display a uncancel button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: true,
+        });
+        const session = createFinalizedSession();
+
+        // when
+        const screen = await renderGlobalActions(certification, session);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }))
+          .doesNotExist();
       });
     });
   });
 
   module('reject button', function () {
-    module('when should display', function () {
-      module('when certification is validated, session is finalized and not published', function () {
-        test('should display a reject button', async function (assert) {
+    module('when session is finalized and not published', function () {
+      module('when certification is validated', function () {
+        test('displays a reject button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
             userId: 1,
@@ -438,69 +443,8 @@ module('Integration | Component | Certifications | Certification | Information |
         });
       });
 
-      module('when certification has error status, session is finalized and not published', function () {
-        test('should display a reject button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: assessmentResultStatus.ERROR,
-            isPublished: false,
-          });
-          const session = createFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
-            .exists();
-        });
-      });
-      module('when certification has no status, session is finalized and not published', function () {
-        test('should display a cancel button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: null,
-            isPublished: false,
-          });
-          const session = createFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
-            .exists();
-        });
-      });
-    });
-
-    module('when should not display', function () {
-      module('when certification status is cancelled', function () {
-        test('should not display a reject button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: assessmentResultStatus.CANCELLED,
-            isPublished: false,
-          });
-          const session = createFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
-            .doesNotExist();
-        });
-      });
-
-      module('when certification status is rejected', function () {
-        test('should not display a reject button', async function (assert) {
+      module('when certification is rejected due to lack of answers', function () {
+        test('displays a reject button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
             userId: 1,
@@ -515,52 +459,72 @@ module('Integration | Component | Certifications | Certification | Information |
           // then
           assert
             .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
-            .doesNotExist();
-        });
-      });
-
-      module('when session is not finalized', function () {
-        test('should not display a reject button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: assessmentResultStatus.VALIDATED,
-            isPublished: false,
-          });
-          const session = createNonFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
-            .doesNotExist();
-        });
-      });
-
-      module('when certification is published', function () {
-        test('should not display a reject button', async function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            userId: 1,
-            status: assessmentResultStatus.VALIDATED,
-            isPublished: true,
-          });
-          const session = createFinalizedSession();
-
-          // when
-          const screen = await renderGlobalActions(certification, session);
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
-            .doesNotExist();
+            .exists();
         });
       });
     });
 
-    module('when button is displayed', function (hooks) {
+    module('when certification status is cancelled', function () {
+      test('does not display a reject button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.CANCELLED,
+          isPublished: false,
+        });
+        const session = createFinalizedSession();
+
+        // when
+        const screen = await renderGlobalActions(certification, session);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when session is not finalized', function () {
+      test('does not display a reject button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: false,
+        });
+        const session = createNonFinalizedSession();
+
+        // when
+        const screen = await renderGlobalActions(certification, session);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when certification is published', function () {
+      test('does not display a reject button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: true,
+        });
+        const session = createFinalizedSession();
+
+        // when
+        const screen = await renderGlobalActions(certification, session);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when reject button is displayed', function (hooks) {
       let screen;
       const modalTitle = 'Confirmer le rejet de la certification';
       const modalMessage =
@@ -582,7 +546,7 @@ module('Integration | Component | Certifications | Certification | Information |
         screen = await renderGlobalActions(certification, session);
       });
 
-      test('should display confirmation modal on click', async function (assert) {
+      test('displays confirmation modal on click', async function (assert) {
         // when
         await fireEvent.click(
           screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }),
@@ -597,7 +561,7 @@ module('Integration | Component | Certifications | Certification | Information |
       });
 
       module('when modal is confirmed', function () {
-        test('should perform action and close modal on success', async function (assert) {
+        test('performs action and closes modal on success', async function (assert) {
           // given
           const currentCertification = store.peekRecord('certification', 1);
 
@@ -617,7 +581,7 @@ module('Integration | Component | Certifications | Certification | Information |
           assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
 
-        test('should display notification and close modal on error', async function (assert) {
+        test('displays notification and closes modal on error', async function (assert) {
           // given
           const notificationStub = setupNotificationStub(this.owner);
           const currentCertification = store.peekRecord('certification', 1);
@@ -639,7 +603,7 @@ module('Integration | Component | Certifications | Certification | Information |
         });
       });
 
-      test('should close modal on cancellation', async function (assert) {
+      test('closes modal on cancellation', async function (assert) {
         // given
         const currentCertification = store.peekRecord('certification', 1);
 
@@ -677,20 +641,20 @@ module('Integration | Component | Certifications | Certification | Information |
           save: sinon.stub(),
           reload: sinon.stub(),
         });
-        const session = store.createRecord('session', {});
+        const session = createFinalizedSession();
 
         // when
         screen = await renderGlobalActions(certification, session);
       });
 
-      test('should display an uncancel button', async function (assert) {
+      test('displays an unreject button', async function (assert) {
         // then
         assert
           .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.unreject.button') }))
           .exists();
       });
 
-      test('on cancel button click, should display a confirmation modal', async function (assert) {
+      test('on unreject button click, displays a confirmation modal', async function (assert) {
         // when
         await fireEvent.click(
           screen.getByRole('button', { name: t('components.certifications.global-actions.unreject.button') }),
@@ -706,7 +670,7 @@ module('Integration | Component | Certifications | Certification | Information |
       });
 
       module('on modal confirmation', function () {
-        test('should unreject the certification and close the modal', async function (assert) {
+        test('unrejects the certification and closes the modal', async function (assert) {
           // given
           const currentCertification = store.peekRecord('certification', 1);
 
@@ -729,7 +693,7 @@ module('Integration | Component | Certifications | Certification | Information |
           assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
 
-        test('on error, should display a notification and close the modal', async function (assert) {
+        test('on error, displays a notification and closes the modal', async function (assert) {
           // given
           const notificationStub = setupNotificationStub(this.owner);
 
@@ -752,7 +716,7 @@ module('Integration | Component | Certifications | Certification | Information |
         });
       });
 
-      test('on modal cancellation, should close the modal', async function (assert) {
+      test('on modal cancellation, closes the modal', async function (assert) {
         // given
         const currentCertification = store.peekRecord('certification', 1);
 
@@ -771,6 +735,46 @@ module('Integration | Component | Certifications | Certification | Information |
         assert.ok(currentCertification.save.notCalled);
         assert.ok(currentCertification.reload.notCalled);
         assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
+      });
+    });
+
+    module('when session is not finalized', function () {
+      test('does not display an unreject button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: false,
+        });
+        const session = createNonFinalizedSession();
+
+        // when
+        const screen = await renderGlobalActions(certification, session);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.unreject.button') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when certification is published', function () {
+      test('does not display an unreject button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: true,
+        });
+        const session = createFinalizedSession();
+
+        // when
+        const screen = await renderGlobalActions(certification, session);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.unreject.button') }))
+          .doesNotExist();
       });
     });
   });

--- a/api/src/certification/session-management/domain/usecases/cancel.js
+++ b/api/src/certification/session-management/domain/usecases/cancel.js
@@ -6,7 +6,7 @@
  */
 
 import CertificationCancelled from '../../../../../src/shared/domain/events/CertificationCancelled.js';
-import { CertificationCancelNotAllowedError, NotFinalizedSessionError } from '../../../../shared/domain/errors.js';
+import { NotFinalizedSessionError } from '../../../../shared/domain/errors.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 
@@ -37,9 +37,6 @@ export const cancel = async function ({
   });
   if (!latestAssessmentResult) {
     throw new NotFoundError('No assessment result found');
-  }
-  if (latestAssessmentResult.status === 'rejected') {
-    throw new CertificationCancelNotAllowedError();
   }
 
   const event = new CertificationCancelled({

--- a/api/src/certification/session-management/domain/usecases/reject-certification-course.js
+++ b/api/src/certification/session-management/domain/usecases/reject-certification-course.js
@@ -1,4 +1,3 @@
-import { CertificationRejectNotAllowedError } from '../../../../shared/domain/errors.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationCourseRejected } from '../events/CertificationCourseRejected.js';
@@ -17,9 +16,6 @@ export const rejectCertificationCourse = async ({
   });
   if (!latestAssessmentResult) {
     throw new NotFoundError('No assessment result found');
-  }
-  if (latestAssessmentResult.status === 'cancelled') {
-    throw new CertificationRejectNotAllowedError();
   }
 
   certificationCourse.rejectForFraud();

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -1025,12 +1025,6 @@ class NotFinalizedSessionError extends DomainError {
   }
 }
 
-class CertificationCancelNotAllowedError extends DomainError {
-  constructor(message = 'A certification course cannot be cancelled while it is rejected.') {
-    super(message);
-  }
-}
-
 class CertificationRescoringNotAllowedError extends DomainError {
   constructor(message = 'A certification course cannot be rescored while it is cancelled or rejected.') {
     super(message);
@@ -1089,7 +1083,6 @@ export {
   CertificateVerificationCodeGenerationTooManyTrials,
   CertificationAlgorithmVersionError,
   CertificationBadgeForbiddenDeletionError,
-  CertificationCancelNotAllowedError,
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidateDeletionError,

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -1025,12 +1025,6 @@ class NotFinalizedSessionError extends DomainError {
   }
 }
 
-class CertificationRejectNotAllowedError extends DomainError {
-  constructor(message = 'A certification course cannot be rejected while it is cancelled.') {
-    super(message);
-  }
-}
-
 class CertificationCancelNotAllowedError extends DomainError {
   constructor(message = 'A certification course cannot be cancelled while it is rejected.') {
     super(message);
@@ -1107,7 +1101,6 @@ export {
   CertificationCenterMembershipDisableError,
   CertificationEndedByFinalizationError,
   CertificationEndedByInvigilatorError,
-  CertificationRejectNotAllowedError,
   CertificationRescoringNotAllowedError,
   ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,

--- a/api/tests/certification/session-management/unit/domain/usecases/cancel_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/cancel_test.js
@@ -1,15 +1,10 @@
+import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { cancel } from '../../../../../../src/certification/session-management/domain/usecases/cancel.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import {
-  CertificationCancelNotAllowedError,
-  NotFinalizedSessionError,
-  NotFoundError,
-} from '../../../../../../src/shared/domain/errors.js';
+import { NotFinalizedSessionError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import CertificationCancelled from '../../../../../../src/shared/domain/events/CertificationCancelled.js';
-import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
-import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
@@ -283,53 +278,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
       // then
       expect(error).to.be.instanceOf(NotFoundError);
       expect(certificationEvaluationRepository.rescoreV3Certification).to.not.have.been.called;
-    });
-  });
-
-  describe('when certification is rejected', function () {
-    it('should not cancel the certification and throw CertificationCancelNotAllowedError', async function () {
-      // given
-      const juryId = 123;
-      const session = domainBuilder.certification.sessionManagement.buildSessionManagement({
-        finalizedAt: new Date('2020-01-01'),
-        version: AlgorithmEngineVersion.V2,
-      });
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        id: 123,
-        sessionId: session.id,
-        version: AlgorithmEngineVersion.V2,
-      });
-      const certificationCourseRepository = {
-        get: sinon.stub(),
-      };
-      const sessionManagementRepository = {
-        isFinalized: sinon.stub(),
-      };
-      const certificationEvaluationRepository = {
-        rescoreV2Certification: sinon.stub(),
-      };
-      const courseAssessmentResultRepository = {
-        getLatestAssessmentResult: sinon.stub(),
-      };
-
-      certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-      sessionManagementRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(true);
-      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(
-        domainBuilder.buildAssessmentResult({ status: assessmentResultStatuses.REJECTED }),
-      );
-      // when
-      const error = await catchErr(cancel)({
-        certificationCourseId: 123,
-        juryId,
-        certificationCourseRepository,
-        sessionManagementRepository,
-        certificationEvaluationRepository,
-        courseAssessmentResultRepository,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(CertificationCancelNotAllowedError);
-      expect(certificationEvaluationRepository.rescoreV2Certification).to.not.have.been.called;
     });
   });
 });

--- a/api/tests/certification/session-management/unit/domain/usecases/reject-certification-course_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/reject-certification-course_test.js
@@ -1,12 +1,11 @@
+import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { CertificationCourseRejected } from '../../../../../../src/certification/session-management/domain/events/CertificationCourseRejected.js';
 import { rejectCertificationCourse } from '../../../../../../src/certification/session-management/domain/usecases/reject-certification-course.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
-import { CertificationRejectNotAllowedError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
-import { expect } from '../../../../../test-helper.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
@@ -172,41 +171,6 @@ describe('Unit | UseCase | reject-certification-course', function () {
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
-      expect(certificationCourseRepository.update).to.not.have.been.called;
-      expect(certificationEvaluationRepository.rescoreV3Certification).to.not.have.been.called;
-    });
-  });
-
-  describe('when certification is cancelled', function () {
-    it('should not reject the certification and throw CertificationRejectNotAllowedError', async function () {
-      // given
-      const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
-      const certificationEvaluationRepository = { rescoreV3Certification: sinon.stub() };
-      const courseAssessmentResultRepository = { getLatestAssessmentResult: sinon.stub() };
-      const juryId = 123;
-
-      const dependencies = {
-        certificationCourseRepository,
-        certificationEvaluationRepository,
-        courseAssessmentResultRepository,
-      };
-      const certificationCourse = domainBuilder.buildCertificationCourse({ version: AlgorithmEngineVersion.V3 });
-      const certificationCourseId = certificationCourse.getId();
-
-      certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
-      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(
-        domainBuilder.buildAssessmentResult({ status: assessmentResultStatuses.CANCELLED }),
-      );
-
-      // when
-      const error = await catchErr(rejectCertificationCourse)({
-        ...dependencies,
-        juryId,
-        certificationCourseId: certificationCourseId,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(CertificationRejectNotAllowedError);
       expect(certificationCourseRepository.update).to.not.have.been.called;
       expect(certificationEvaluationRepository.rescoreV3Certification).to.not.have.been.called;
     });


### PR DESCRIPTION
## 💥 Problème

Lorsque le pôle certif métier va sur la page de détail d’une certification passée dans une session finalisée non publiée, 3 boutons d’actions peuvent apparaître : 

- annuler la certification
- rejeter la certification
- re-scorer la certification

En cas d’erreur, les boutons d’annulation ou de rejet peuvent être inversés pour revenir en arrière à l’ancien statut de la certification avant le déclenchement de l’action.

Certaines règles en place bloquent l’affichage de ces boutons lorsque les circonstances métier ne semblent pas le nécessiter.

Dans certains cas particuliers, comme lorsqu’il y a eu des bugs qui font que la certification est considérée comme étant arrivée au bout alors que le candidat a répondu à moins de 20 questions sur 32, on peut se retrouver dans une situation de rejet sans affichage des boutons d’actions alors qu’on veut pouvoir annuler la certification.

## 👩‍🚀 Proposition

Afficher les boutons “annuler la certification” ou “rejeter la certification” pour toutes les certifications appartenant à des sessions finalisées mais non publiées, on compte sur le pôle certif métier et le caractère réversible de ces actions pour parer aux éventuelles erreurs.

## 👁️ Remarques

On en profite pour retirer deux blocages côté API.

## ♻️ Pour tester

- Ne pas pouvoir rejeter (via l'interface) une certification annulée
- Ne pas pouvoir annuler (via l'interface) une certification rejetée
- Pouvoir annuler (ou rejeter pour fraude) une certification rejetée pour manque de temps
