### PR TITLE
[TECH] Supprimer le FT addEmailConnectionMethodEnabled (PIX-22578)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -102,13 +102,6 @@ export default {
     devDefaultValues: { test: true, reviewApp: false },
     tags: ['team-acces', 'audit-logger'],
   },
-  addEmailConnectionMethodEnabled: {
-    type: 'boolean',
-    description: 'Enable adding email connection method',
-    defaultValue: false,
-    devDefaultValues: { test: false, reviewApp: false },
-    tags: ['team-acces', 'pix-api', 'mon-pix', 'frontend', 'backend'],
-  },
   restrictedOidcProvidersForEmailCreation: {
     type: 'array',
     description:

--- a/api/src/identity-access-management/domain/models/UserAccountInfo.js
+++ b/api/src/identity-access-management/domain/models/UserAccountInfo.js
@@ -1,5 +1,4 @@
 export class UserAccountInfo {
-  #addEmailConnectionMethodEnabled;
   #oidcAuthenticationMethods;
   #restrictedOidcProvidersForEmailCreation;
 
@@ -9,7 +8,6 @@ export class UserAccountInfo {
     username,
     canSelfDeleteAccount,
     restrictedOidcProvidersForEmailCreation = [],
-    addEmailConnectionMethodEnabled = false,
     oidcAuthenticationMethods = [],
   }) {
     this.id = id;
@@ -17,14 +15,10 @@ export class UserAccountInfo {
     this.username = username;
     this.canSelfDeleteAccount = canSelfDeleteAccount;
     this.#restrictedOidcProvidersForEmailCreation = restrictedOidcProvidersForEmailCreation;
-    this.#addEmailConnectionMethodEnabled = addEmailConnectionMethodEnabled;
     this.#oidcAuthenticationMethods = oidcAuthenticationMethods;
   }
 
   get canAddEmailConnectionMethod() {
-    if (!this.#addEmailConnectionMethodEnabled) {
-      return false;
-    }
     if (this.email) {
       return false;
     }

--- a/api/src/identity-access-management/domain/usecases/get-user-account-info.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-user-account-info.usecase.js
@@ -13,7 +13,6 @@ const getUserAccountInfo = async ({
   const oidcAuthenticationMethods = await authenticationMethodRepository.findAllOidcAuthenticationMethodsByUser({
     userId,
   });
-  const addEmailConnectionMethodEnabled = await featureToggles.get('addEmailConnectionMethodEnabled');
   const restrictedOidcProvidersForEmailCreation = await featureToggles.get('restrictedOidcProvidersForEmailCreation');
 
   return new UserAccountInfo({
@@ -22,7 +21,6 @@ const getUserAccountInfo = async ({
     username: user.username,
     canSelfDeleteAccount,
     oidcAuthenticationMethods,
-    addEmailConnectionMethodEnabled,
     restrictedOidcProvidersForEmailCreation,
   });
 };

--- a/api/tests/identity-access-management/integration/domain/usecases/get-user-account-info.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-user-account-info.usecase.test.js
@@ -8,77 +8,49 @@ describe('Integration | Identity Access Management  | Domain | Usecases | get-us
     await featureToggles.set('isSelfAccountDeletionEnabled', false);
   });
 
-  describe('when feature toggle addEmailConnectionMethodEnabled is not enabled', function () {
-    it('returns user account info with canAddEmailConnectionMethod set to false', async function () {
-      // given
-      await featureToggles.set('addEmailConnectionMethodEnabled', false);
+  describe('when user has no email', function () {
+    describe('when user has at least one authorized identity provider', function () {
+      it('returns user account info with canAddEmailConnectionMethod set to true', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser({ email: null });
+        databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+          userId: user.id,
+          identityProvider: 'AUTHORIZED_IDENTITY_PROVIDER',
+        });
+        await databaseBuilder.commit();
 
-      const user = databaseBuilder.factory.buildUser();
-      await databaseBuilder.commit();
+        // when
+        const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
 
-      // when
-      const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
-
-      // then
-      expect(userAccountInfo).to.deep.equal({
-        id: user.id,
-        email: user.email,
-        username: user.username,
-        canSelfDeleteAccount: false,
+        // then
+        expect(userAccountInfo).to.deep.equal({
+          id: user.id,
+          email: null,
+          username: user.username,
+          canSelfDeleteAccount: false,
+        });
+        expect(userAccountInfo.canAddEmailConnectionMethod).to.be.true;
       });
-      expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
-    });
-  });
-
-  describe('when feature toggle addEmailConnectionMethodEnabled is enabled', function () {
-    beforeEach(async function () {
-      await featureToggles.set('addEmailConnectionMethodEnabled', true);
     });
 
-    describe('when user has no email', function () {
-      describe('when user has at least one authorized identity provider', function () {
-        it('returns user account info with canAddEmailConnectionMethod set to true', async function () {
-          // given
-          const user = databaseBuilder.factory.buildUser({ email: null });
-          databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
-            userId: user.id,
-            identityProvider: 'AUTHORIZED_IDENTITY_PROVIDER',
-          });
-          await databaseBuilder.commit();
+    describe('when user has no authorized identity provider', function () {
+      it('returns user account info with canAddEmailConnectionMethod set to false', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser({ email: null });
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
+        await databaseBuilder.commit();
 
-          // when
-          const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
+        // when
+        const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
 
-          // then
-          expect(userAccountInfo).to.deep.equal({
-            id: user.id,
-            email: null,
-            username: user.username,
-            canSelfDeleteAccount: false,
-          });
-          expect(userAccountInfo.canAddEmailConnectionMethod).to.be.true;
+        // then
+        expect(userAccountInfo).to.deep.equal({
+          id: user.id,
+          email: null,
+          username: user.username,
+          canSelfDeleteAccount: false,
         });
-      });
-
-      describe('when user has no authorized identity provider', function () {
-        it('returns user account info with canAddEmailConnectionMethod set to false', async function () {
-          // given
-          const user = databaseBuilder.factory.buildUser({ email: null });
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
-          await databaseBuilder.commit();
-
-          // when
-          const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
-
-          // then
-          expect(userAccountInfo).to.deep.equal({
-            id: user.id,
-            email: null,
-            username: user.username,
-            canSelfDeleteAccount: false,
-          });
-          expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
-        });
+        expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
       });
     });
   });

--- a/api/tests/identity-access-management/unit/domain/models/UserAccountInfo.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserAccountInfo.test.js
@@ -28,17 +28,16 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
   });
 
   describe('#canAddEmailConnectionMethod', function () {
-    context('when addEmailConnectionMethodEnabled feature toggle is false', function () {
+    context('when user already has an email', function () {
       it('canAddEmailConnectionMethod returns false', function () {
         // given
         const userAccountInfo = new UserAccountInfo({
           id: 123,
-          email: null,
+          email: 'user@example.net',
           username: 'user123',
           canSelfDeleteAccount: true,
-          addEmailConnectionMethodEnabled: false,
           restrictedOidcProvidersForEmailCreation,
-          oidcAuthenticationMethods: [{ identityProvider: 'OIDC_PARTNER' }],
+          oidcAuthenticationMethods: [{ identityProvider: 'AUTHORIZED_OIDC_PARTNER' }],
         });
 
         // when / then
@@ -46,18 +45,17 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
       });
     });
 
-    context('when addEmailConnectionMethodEnabled is true', function () {
-      context('when user already has an email', function () {
+    context('when user has no email', function () {
+      context('when oidcAuthenticationMethods is empty', function () {
         it('canAddEmailConnectionMethod returns false', function () {
           // given
           const userAccountInfo = new UserAccountInfo({
             id: 123,
-            email: 'user@example.net',
+            email: null,
             username: 'user123',
             canSelfDeleteAccount: true,
-            addEmailConnectionMethodEnabled: true,
             restrictedOidcProvidersForEmailCreation,
-            oidcAuthenticationMethods: [{ identityProvider: 'AUTHORIZED_OIDC_PARTNER' }],
+            oidcAuthenticationMethods: [],
           });
 
           // when / then
@@ -65,62 +63,40 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
         });
       });
 
-      context('when user has no email', function () {
-        context('when oidcAuthenticationMethods is empty', function () {
-          it('canAddEmailConnectionMethod returns false', function () {
-            // given
-            const userAccountInfo = new UserAccountInfo({
-              id: 123,
-              email: null,
-              username: 'user123',
-              canSelfDeleteAccount: true,
-              addEmailConnectionMethodEnabled: true,
-              restrictedOidcProvidersForEmailCreation,
-              oidcAuthenticationMethods: [],
-            });
-
-            // when / then
-            expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+      context('when user has one oidcAuthenticationMethod from a restricted provider', function () {
+        it('canAddEmailConnectionMethod returns false', function () {
+          // given
+          const userAccountInfo = new UserAccountInfo({
+            id: 123,
+            email: null,
+            username: 'user123',
+            canSelfDeleteAccount: true,
+            restrictedOidcProvidersForEmailCreation,
+            oidcAuthenticationMethods: [{ identityProvider: 'RESTRICTED_OIDC_PROVIDER_1' }],
           });
+
+          // when / then
+          expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
         });
+      });
 
-        context('when user has one oidcAuthenticationMethod from a restricted provider', function () {
-          it('canAddEmailConnectionMethod returns false', function () {
-            // given
-            const userAccountInfo = new UserAccountInfo({
-              id: 123,
-              email: null,
-              username: 'user123',
-              canSelfDeleteAccount: true,
-              addEmailConnectionMethodEnabled: true,
-              restrictedOidcProvidersForEmailCreation,
-              oidcAuthenticationMethods: [{ identityProvider: 'RESTRICTED_OIDC_PROVIDER_1' }],
-            });
-
-            // when / then
-            expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+      context('when at least one oidcAuthenticationMethod is not a restricted SSO provider', function () {
+        it('canAddEmailConnectionMethod returns true', function () {
+          // given
+          const userAccountInfo = new UserAccountInfo({
+            id: 123,
+            email: null,
+            username: 'user123',
+            canSelfDeleteAccount: true,
+            restrictedOidcProvidersForEmailCreation,
+            oidcAuthenticationMethods: [
+              { identityProvider: 'OIDC_PARTNER' },
+              { identityProvider: 'RESTRICTED_OIDC_PARTNER_1' },
+            ],
           });
-        });
 
-        context('when at least one oidcAuthenticationMethod is not a restricted SSO provider', function () {
-          it('canAddEmailConnectionMethod returns true', function () {
-            // given
-            const userAccountInfo = new UserAccountInfo({
-              id: 123,
-              email: null,
-              username: 'user123',
-              canSelfDeleteAccount: true,
-              addEmailConnectionMethodEnabled: true,
-              restrictedOidcProvidersForEmailCreation,
-              oidcAuthenticationMethods: [
-                { identityProvider: 'OIDC_PARTNER' },
-                { identityProvider: 'RESTRICTED_OIDC_PARTNER_1' },
-              ],
-            });
-
-            // when / then
-            expect(userAccountInfo.canAddEmailConnectionMethod).to.be.true;
-          });
+          // when / then
+          expect(userAccountInfo.canAddEmailConnectionMethod).to.be.true;
         });
       });
     });

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -32,7 +32,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'use-pix-orga-new-auth-design': false,
             'is-pix-plus-candidate-a11y-enabled': false,
             'are-module-short-id-urls-enabled': false,
-            'add-email-connection-method-enabled': false,
             'are-combined-courses-enabled': true,
           },
         },

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -7,5 +7,4 @@ export default class FeatureToggle extends Model {
   @attr('boolean') areModuleShortIdUrlsEnabled;
   @attr('boolean') areCombinedCoursesEnabled;
   @attr('array') disabledLocalesInFrontend;
-  @attr('boolean') addEmailConnectionMethodEnabled;
 }

--- a/mon-pix/tests/acceptance/user-account/connection-methods-test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods-test.js
@@ -155,8 +155,6 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
     module('when canAddEmailConnectionMethod conditions are true', function () {
       test('displays empty email label and add email button', async function (assert) {
         // given
-        server.create('feature-toggle', { id: '0', addEmailConnectionMethodEnabled: true });
-
         const userDetails = {
           email: 'only.sso@example.net',
         };
@@ -243,7 +241,6 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
   module('email adding', function () {
     test('is able to add the mail, enter the code received, and be successfully redirected to account page', async function (assert) {
       // given
-      server.create('feature-toggle', { id: '0', addEmailConnectionMethodEnabled: true });
       const user = server.create('user', 'withCanAddEmailConnectionMethod');
       server.create('authentication-method', 'withGenericOidcIdentityProvider', { user });
       await authenticate(user);

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/connection-methods-test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/connection-methods-test.js
@@ -140,13 +140,9 @@ module('Unit | Controller | user-account | connection-methods', function (hooks)
   });
 
   module('#canAddEmailConnectionMethod', function () {
-    module('when feature toggle is enabled and canAddEmailConnectionMethod is true', function () {
+    module('when canAddEmailConnectionMethod is true', function () {
       test('returns true', function (assert) {
         // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { addEmailConnectionMethodEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
         const controller = this.owner.lookup('controller:authenticated/user-account/connection-methods');
         const model = {
           user: {},
@@ -162,13 +158,9 @@ module('Unit | Controller | user-account | connection-methods', function (hooks)
       });
     });
 
-    module('when feature toggle is enabled and canAddEmailConnectionMethod is false', function () {
+    module('when canAddEmailConnectionMethod is false', function () {
       test('returns false', function (assert) {
         // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { addEmailConnectionMethodEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
         const controller = this.owner.lookup('controller:authenticated/user-account/connection-methods');
         const model = {
           user: {},


### PR DESCRIPTION
## 💥 Problème

Supprimer le FT `addEmailConnectionMethodEnabled` (ajouté avec la PR #15529) 1 mois après l’activation de ce FT, qui a eu lieu le 29 avr. 2026.

## 👩‍🚀 Proposition

Supprimer le FT `addEmailConnectionMethodEnabled`.

## 👁️ Remarques

RAS

## ♻️ Pour tester

Vérifier qu’il n’y a pas de régression sur la fonctionnalité : 

1. Créer un compte en se connectant par SSO avec un fournisseur d'identité OIDC
2. Aller dans `Mon Compte`, puis dans l’onglet `Mes méthodes de connexion`
3. Cliquer sur le bouton `Ajouter une adresse e-mail`
4. Ajouter une adresse email déjà présente en base et vérifier l'affichage de l'erreur `Adresse e-mail invalide ou déjà utilisée`
5. Ajouter une adresse email disponible valide et vérifier l'affichage de la page de validation de code, avec la phrase `Saisissez le code de vérification reçu à l'adresse e-mail :` et l'adresse email qui a été spécifiée.
6. Vérifier la bonne réception du courriel
7. Entrer le code de vérification reçu
8. Constater le message de succès
9. Constater que l’utilisateur a une nouvelle méthode de connexion qui a été ajoutée