### PR TITLE
[FEATURE] Rendre l'externalId optionnel lors de la création d'organisations en masse (PIX-22931)

### DIFF
--- a/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
+++ b/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
@@ -15,9 +15,7 @@ const schema = Joi.object({
       'string.empty': 'Le type n’est pas renseigné.',
       'any.only': `Le type fourni doit avoir l'une des valeurs suivantes : ${Object.values(Organization.types)}`,
     }),
-  externalId: Joi.string().required().messages({
-    'string.empty': "L'externalId n’est pas renseigné.",
-  }),
+  externalId: Joi.string().allow(null),
   name: Joi.string().required().messages({
     'string.empty': 'Le nom n’est pas renseigné.',
   }),

--- a/api/src/organizational-entities/infrastructure/serializers/csv/organizations-csv-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/csv/organizations-csv-serializer.js
@@ -62,6 +62,7 @@ export async function deserializeForOrganizationsImport(file) {
         }
       } else {
         if (
+          columnName === 'externalId' ||
           columnName === 'identityProviderForCampaigns' ||
           columnName === 'DPOFirstName' ||
           columnName === 'DPOLastName' ||

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -77,7 +77,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         const organizationsWithEmptyValues = [
           {
             type: '',
-            externalId: '',
+            externalId: null,
             name: '',
             provinceCode: '',
             credit: '',
@@ -108,10 +108,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           {
             attribute: 'type',
             message: 'Le type n’est pas renseigné.',
-          },
-          {
-            attribute: 'externalId',
-            message: "L'externalId n’est pas renseigné.",
           },
           {
             attribute: 'name',

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
@@ -49,7 +49,6 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
             // given
             const organization = {
               type: organizationType,
-              externalId: 'EXTERNAL_ID',
               name: 'Organization Name',
               createdBy: 0,
               administrationTeamId: 1,
@@ -96,7 +95,6 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.message).to.equal(`Échec de validation de l'entité.`);
         expect(error.invalidAttributes).to.have.deep.members([
           { attribute: 'type', message: '"type" is required' },
-          { attribute: 'externalId', message: '"externalId" is required' },
           { attribute: 'name', message: '"name" is required' },
           { attribute: 'createdBy', message: "L'id du créateur est manquant" },
           { attribute: 'administrationTeamId', message: "L'id de l'équipe en charge est manquant" },


### PR DESCRIPTION
## 💥 Problème

Actuellement, l'externalId est une donnée obligatoire pour la création en masse, mais cette règle n'a plus lieu d'être. Ce champs est d'ailleurs non obligatoire pour la création unitaire.

## 👩‍🚀 Proposition

Rendre l'externalId optionnel.

## 👁️ Remarques

RAS

## ♻️ Pour tester
Dans Pix Admin, se connecter en tant que super admin
- aller dans Administration -> Déploiement
- télécharger le template de création d'organisations en masse
- le remplir sans renseigner d'externalId
- constater que l;organisation est bien créée
- créer une orga avec externalId pour vérifier la non-régression

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
