### PR TITLE
[FEATURE] Ajouter la colonne isRelevant dans la table user-recommended-trainings (PIX-22944)

### DIFF
--- a/api/db/migrations/20260601083610_add-column-isrelevant-for-user-recommended-trainings.js
+++ b/api/db/migrations/20260601083610_add-column-isrelevant-for-user-recommended-trainings.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'user-recommended-trainings';
+const COLUMN_NAME = 'isRelevant';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .boolean(COLUMN_NAME)
+      .defaultTo(null)
+      .comment('To report if trainings recommendation is relevant according to the user');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -30,7 +30,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
           campaignParticipationId: userRecommendedTraining.campaignParticipationId,
         })
         .first();
-      expect(_.omit(persistedUserRecommendedTraining, ['id', 'createdAt', 'updatedAt'])).to.deep.equal(
+      expect(_.omit(persistedUserRecommendedTraining, ['id', 'createdAt', 'updatedAt', 'isRelevant'])).to.deep.equal(
         userRecommendedTraining,
       );
     });


### PR DESCRIPTION
## 🌍 Problème

Nous avons besoin de stocker l’information comme quoi l’utilisateur a trouvé pertinent ou non la recommandation d’un contenu formatif.

## 👩‍🚀 Proposition

Faire une migration pour ajouter la colonne isRelevant dans la table `user-recommended-trainings`. La colonne est de type boolean avec NULL comme valeur par défaut.

## 👁️ Remarques

RAS

## ♻️ Pour tester

- Se connecter à la DB
- Vérifier que dans `user-recommended-trainings` la colonne `isRelevant` existe, qu'elle est de type booléen et qu'elle peut être NULL