### PR TITLE
[BUGFIX] Ne pas renvoyer d'id de profil cible à la place d'id de blueprint quand on crée un parcours combiné sur PixOrga (PIX-22960)

### DIFF
--- a/api/src/quest/domain/usecases/create-combined-course.js
+++ b/api/src/quest/domain/usecases/create-combined-course.js
@@ -1,4 +1,4 @@
-import { ForbiddenAccess } from '../../../shared/domain/errors.js';
+import { ForbiddenAccess, NotFoundError } from '../../../shared/domain/errors.js';
 import { Campaign } from '../models/Campaign.js';
 
 export const createCombinedCourse = async ({
@@ -17,6 +17,9 @@ export const createCombinedCourse = async ({
   const combinedCourseBlueprint = await combinedCourseBlueprintRepository.findById({
     id: combinedCourseForCreation.blueprintId,
   });
+  if (!combinedCourseBlueprint) {
+    throw new NotFoundError();
+  }
   if (!combinedCourseBlueprint.organizationIds.includes(combinedCourseForCreation.organizationId)) {
     throw new ForbiddenAccess();
   }

--- a/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
@@ -2,7 +2,7 @@ import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourseForCreation } from '../../../../../src/quest/domain/models/combined-course/CombinedCourseForCreation.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
-import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
+import { ForbiddenAccess, NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
@@ -94,6 +94,31 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     expect(campaigns[1].customResultPageButtonText).to.equal('Continuer');
   });
 
+  it('should throw NotFoundError when blueprint is not found with the id in payload', async function () {
+    //given
+    const combinedCourseBlueprintId = databaseBuilder.factory.buildCombinedCourseBlueprint().id;
+    const { organizationId } = databaseBuilder.factory.buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId });
+    const userId = databaseBuilder.factory.buildUser().id;
+
+    await databaseBuilder.commit();
+
+    const nameInput = 'Un parcours combiné';
+
+    const combinedCourseForCreation = new CombinedCourseForCreation({
+      blueprintId: 999,
+      organizationId,
+      name: nameInput,
+    });
+
+    // when
+    const error = await catchErr(usecases.createCombinedCourse)({
+      combinedCourseForCreation,
+      creatorId: userId,
+    });
+
+    //then
+    expect(error).to.be.instanceOf(NotFoundError);
+  });
   it('should throw ForbiddenAccess error when blueprint is not linked to the organization', async function () {
     // given
     const moduleId1 = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';

--- a/orga/app/adapters/campaign.js
+++ b/orga/app/adapters/campaign.js
@@ -30,7 +30,9 @@ export default class CampaignAdapter extends ApplicationAdapter {
     const payload = this.serialize(snapshot);
 
     if (payload.data.attributes.type === 'COMBINED_COURSE') {
-      payload.data.relationships['combined-course-blueprint'] = { data: { id: snapshot.record.targetProfile.id } };
+      payload.data.relationships['combined-course-blueprint'] = {
+        data: { id: snapshot.record.combinedCourseBlueprint.id },
+      };
       const url = `${this.host}/${this.namespace}/combined-courses`;
 
       return this.ajax(url, 'POST', { data: payload });

--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -162,10 +162,8 @@ export default class CreateForm extends Component {
 
   @action
   selectCombinedCourseBlueprint(blueprintId) {
-    // We call blueprint target profiles temporarily as we plan to create a parent domain model for the two
-    // Same for the combined courses and campaigns
-    const record = this.store.createRecord('target-profile', { id: blueprintId });
-    this.args.campaign.targetProfile = record;
+    const record = this.store.peekRecord('combined-course-blueprint', blueprintId);
+    this.args.campaign.combinedCourseBlueprint = record;
   }
 
   @action
@@ -426,7 +424,7 @@ export default class CreateForm extends Component {
               @options={{this.blueprintOwnerOptions}}
               @hideDefaultOption={{true}}
               @onChange={{this.selectCombinedCourseBlueprint}}
-              @value={{@campaign.targetProfile.id}}
+              @value={{@campaign.combinedCourseBlueprint.id}}
               @requiredLabel={{t "common.form.mandatory-fields-title"}}
               @errorMessage={{if @errors.blueprint (t "api-error-messages.campaign-creation.target-profile-required")}}
               @locale={{this.locale.currentLocale}}

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -35,6 +35,7 @@ export default class Campaign extends Model {
 
   @belongsTo('organization', { async: true, inverse: 'campaigns' }) organization;
   @belongsTo('target-profile', { async: true, inverse: null }) targetProfile;
+  @belongsTo('combined-course-blueprint', { async: true, inverse: null }) combinedCourseBlueprint;
 
   @belongsTo('campaign-collective-result', { async: true, inverse: null }) campaignCollectiveResult;
   @belongsTo('campaign-result-levels-per-tubes-and-competence', { async: true, inverse: null })


### PR DESCRIPTION
## 💥 Problème
Quand un prescripteur clique sur "Créer une campagne" dans Orga, qu'il choisit comme objectif "Evaluer les compétences de mes participants", qu'il sélectionne un parcours, puis qu'il change d'objectif pour "Développer des compétences" en ne sélectionnant rien comme schéma de parcours avant de cliquer sur "Créer", on envoie un id de profil cible à la place d'envoyer un id de schéma de parcours combiné.

## 👩‍🚀 Proposition
On ajoute un attribut "combinedCourseBlueprint" au model campaign sur le front et on l'utilise pour envoyer la valeur.
On lève une erreur explicite côté back pour identifier le cas au moment de la création.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
Reproduire le cas de bug et vérifier qu'on n'a pas d'erreur + vérifier que le parcours est bien créé en base

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
