### PR TITLE
[FEATURE] Ajout d'une pré-sélection de sujets lorsque l'on créé une nouvelle version de certification (PIX-22874)

### DIFF
--- a/admin/app/adapters/certification-consolidated-framework.js
+++ b/admin/app/adapters/certification-consolidated-framework.js
@@ -1,5 +1,6 @@
 import ApplicationAdapter from './application';
 
+// TODO supprimer ce fichier + le modèle. On va faire du POST /api/admin/certification-versions
 export default class CertificationConsolidatedFrameworkAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 

--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -1,4 +1,3 @@
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -6,7 +6,6 @@ import FrameworkHistory from './framework/framework-history';
 import History from './target-profile/history';
 
 export default class CertificationFramework extends Component {
-  @service store;
   @tracked targetProfilesHistory;
   @tracked frameworkHistory;
 
@@ -26,7 +25,7 @@ export default class CertificationFramework extends Component {
   }
 
   <template>
-    <FrameworkHistory @frameworkKey={{@frameworkKey}} />
+    <FrameworkHistory @frameworkKey={{@frameworkKey}} @frameworkHistory={{@frameworkHistory}} />
 
     {{#if this.targetProfilesHistory}}
       <History @targetProfilesHistory={{this.targetProfilesHistory}} />

--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -32,13 +32,11 @@ export default class FrameworkHistory extends Component {
 
   constructor() {
     super(...arguments);
-
-    this.#onMount();
+    this.frameworkHistory = this.args.frameworkHistory?.history ?? [];
   }
 
-  async #onMount() {
-    const frameworkHistory = await this.store.queryRecord('framework-history', this.args.frameworkKey);
-    this.frameworkHistory = frameworkHistory?.history;
+  get hasHistory() {
+    return this.frameworkHistory.length > 0;
   }
 
   @action
@@ -85,97 +83,97 @@ export default class FrameworkHistory extends Component {
   }
 
   <template>
-    {{#if this.frameworkHistory}}
-      <section class="framework-versions">
-        <PixTable
-          @variant="admin"
-          @caption={{t "components.certification-frameworks.item.framework.history.table.caption"}}
-          @data={{this.frameworkHistory}}
-        >
-          <:columns as |version context|>
-            <PixTableColumn @context={{context}}>
-              <:header>
-                {{t "components.certification-frameworks.item.framework.history.table.columns.version-id"}}
-              </:header>
-              <:cell>
-                {{version.id}}
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{context}}>
-              <:header>
-                {{t
-                  "components.certification-frameworks.item.framework.history.table.columns.maximum-assessment-length"
-                }}
-              </:header>
-              <:cell>
-                {{version.maximumAssessmentLength}}
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{context}}>
-              <:header>
-                <PixIcon @name="time" @ariaHidden={{true}} />
-                {{t "components.certification-frameworks.item.framework.history.table.columns.assessment-duration"}}
-              </:header>
-              <:cell>
-                {{formatMinutes version.assessmentDuration}}
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{context}}>
-              <:header>
-                <PixIcon @name="calendar" @ariaHidden={{true}} />
-                {{t "components.certification-frameworks.item.framework.history.table.columns.start-date"}}
-              </:header>
-              <:cell>
-                <strong>{{if version.startDate (formatDate version.startDate) "-"}}</strong>
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{context}}>
-              <:header>
-                <PixIcon @name="calendar" @ariaHidden={{true}} />
-                {{t "components.certification-frameworks.item.framework.history.table.columns.expiration-date"}}
-              </:header>
-              <:cell>
-                <strong>{{if version.expirationDate (formatDate version.expirationDate) "-"}}</strong>
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{context}}>
-              <:header>
-                {{t "components.certification-frameworks.item.framework.history.table.columns.status"}}
-              </:header>
-              <:cell>
-                <PixTag @color={{get STATUS_COLORS version.status}}>
-                  {{t (concat "components.certification-frameworks.item.framework.history.statuses." version.status)}}
-                </PixTag>
-              </:cell>
-            </PixTableColumn>
-            <PixTableColumn @context={{context}}>
-              <:header>
-                {{t "components.certification-frameworks.item.framework.history.table.columns.actions"}}
-              </:header>
-              <:cell>
-                <PixIconButton
-                  @triggerAction={{fn this.viewVersion version.id version.status}}
-                  @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.view"}}
-                  @iconName="eye"
-                />
-                <PixIconButton
-                  @triggerAction={{this.editVersion}}
-                  @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.edit"}}
-                  @iconName="edit"
-                  @isDisabled={{not (eq version.status "DRAFT")}}
-                />
-                <PixIconButton
-                  @triggerAction={{fn this.showDeleteVersionModal version.id}}
-                  @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.delete"}}
-                  @iconName="delete"
-                  @isDisabled={{not (eq version.status "DRAFT")}}
-                />
-              </:cell>
-            </PixTableColumn>
-          </:columns>
-        </PixTable>
-      </section>
-    {{/if}}
+    <section class="framework-versions">
+      <PixTable
+        @variant="admin"
+        @caption={{t "components.certification-frameworks.item.framework.history.table.caption"}}
+        @data={{this.frameworkHistory}}
+      >
+        <:columns as |version context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.certification-frameworks.item.framework.history.table.columns.version-id"}}
+            </:header>
+            <:cell>
+              {{version.id}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.certification-frameworks.item.framework.history.table.columns.maximum-assessment-length"}}
+            </:header>
+            <:cell>
+              {{version.maximumAssessmentLength}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              <PixIcon @name="time" @ariaHidden={{true}} />
+              {{t "components.certification-frameworks.item.framework.history.table.columns.assessment-duration"}}
+            </:header>
+            <:cell>
+              {{formatMinutes version.assessmentDuration}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              <PixIcon @name="calendar" @ariaHidden={{true}} />
+              {{t "components.certification-frameworks.item.framework.history.table.columns.start-date"}}
+            </:header>
+            <:cell>
+              <strong>{{if version.startDate (formatDate version.startDate) "-"}}</strong>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              <PixIcon @name="calendar" @ariaHidden={{true}} />
+              {{t "components.certification-frameworks.item.framework.history.table.columns.expiration-date"}}
+            </:header>
+            <:cell>
+              <strong>{{if version.expirationDate (formatDate version.expirationDate) "-"}}</strong>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.certification-frameworks.item.framework.history.table.columns.status"}}
+            </:header>
+            <:cell>
+              <PixTag @color={{get STATUS_COLORS version.status}}>
+                {{t (concat "components.certification-frameworks.item.framework.history.statuses." version.status)}}
+              </PixTag>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.certification-frameworks.item.framework.history.table.columns.actions"}}
+            </:header>
+            <:cell>
+              <PixIconButton
+                @triggerAction={{fn this.viewVersion version.id version.status}}
+                @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.view"}}
+                @iconName="eye"
+              />
+              <PixIconButton
+                @triggerAction={{this.editVersion}}
+                @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.edit"}}
+                @iconName="edit"
+                @isDisabled={{not (eq version.status "DRAFT")}}
+              />
+              <PixIconButton
+                @triggerAction={{fn this.showDeleteVersionModal version.id}}
+                @ariaLabel={{t "components.certification-frameworks.item.framework.history.table.actions.delete"}}
+                @iconName="delete"
+                @isDisabled={{not (eq version.status "DRAFT")}}
+              />
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+
+      {{#unless this.hasHistory}}
+        <p>{{t "components.certification-frameworks.item.framework.history.table.empty"}}</p>
+      {{/unless}}
+    </section>
 
     {{#if this.selectedVersion}}
       <CertificationVersionDetailModal

--- a/admin/app/components/certification-frameworks/item/framework/new-version-form.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/new-version-form.gjs
@@ -42,6 +42,35 @@ export default class NewVersionForm extends Component {
     }
   }
 
+  get checkedTubes() {
+    if (!this.args.activeVersion) return [];
+
+    const competences = [];
+    const thematics = [];
+    const tubes = [];
+
+    const areas = this.args.activeVersion.hasMany('areas').value();
+
+    for (const area of areas) {
+      competences.push(...area.hasMany('competences').value());
+    }
+
+    for (const competence of competences) {
+      thematics.push(...competence.hasMany('thematics').value());
+    }
+
+    for (const thematic of thematics) {
+      tubes.push(...thematic.hasMany('tubes').value());
+    }
+
+    return tubes.flat();
+  }
+
+  get checkedAreas() {
+    if (!this.args.activeVersion) return [];
+    return this.args.activeVersion.hasMany('areas').value();
+  }
+
   <template>
     <h2 class="framework-creation-form__title">
       {{t "components.certification-frameworks.item.framework.new-version-form.title"}}
@@ -53,10 +82,12 @@ export default class NewVersionForm extends Component {
           <TubesSelection
             @frameworks={{@frameworks}}
             @onChange={{this.onTubesSelectionChange}}
+            @initialAreas={{this.checkedAreas}}
+            @initialCappedTubes={{this.checkedTubes}}
             @displaySkillDifficultyAvailability={{true}}
             @displaySkillDifficultySelection={{false}}
             @displayDeviceCompatibility={{true}}
-            @displayJsonImportButton={{true}}
+            @displayJsonImportButton={{false}}
           />
           <ul class="framework-creation-form__buttons">
             <li>

--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -16,6 +16,14 @@ export default class Header extends Component {
     return this.currentUser.adminMember.isSuperAdmin && this.args.certificationFramework?.name !== 'CLEA';
   }
 
+  get activeCertificationVersionId() {
+    return {
+      activeVersionId: this.args.frameworkHistory?.history.find(
+        (frameworkHistory) => frameworkHistory.status == 'ACTIVE',
+      )?.id,
+    };
+  }
+
   get links() {
     return [
       {
@@ -44,6 +52,7 @@ export default class Header extends Component {
         <PixButtonLink
           class="framework__creation-button"
           @route="authenticated.certification-frameworks.item.framework.new-version"
+          @query={{this.activeCertificationVersionId}}
           @iconBefore="add"
         >
           {{t "components.certification-frameworks.item.framework.create-button"}}

--- a/admin/app/routes/authenticated/certification-frameworks/item.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item.js
@@ -21,7 +21,10 @@ export default class ItemRoute extends Route {
       );
     }
 
+    const frameworkHistory = await this.store.queryRecord('framework-history', this.certificationFrameworkKey);
+
     return {
+      frameworkHistory,
       frameworkKey: this.certificationFrameworkKey,
       currentCertificationFramework,
       currentComplementaryCertification,

--- a/admin/app/routes/authenticated/certification-frameworks/item/framework/new-version.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/framework/new-version.js
@@ -3,14 +3,22 @@ import { service } from '@ember/service';
 import RSVP from 'rsvp';
 
 export default class FrameworkRoute extends Route {
+  queryParams = {
+    activeVersionId: { refreshModel: true },
+  };
   @service store;
 
-  async model() {
+  async model(params) {
+    let activeVersion;
     const frameworks = await this.store.findAll('framework');
     const item = await this.modelFor('authenticated.certification-frameworks.item');
+    if (params?.activeVersionId) {
+      activeVersion = await this.store.findRecord('certification-version', params.activeVersionId);
+    }
     return RSVP.hash({
       frameworks,
       scope: item.frameworkKey,
+      activeVersion,
     });
   }
 }

--- a/admin/app/templates/authenticated/certification-frameworks/item.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item.gjs
@@ -5,7 +5,10 @@ import Header from 'pix-admin/components/certification-frameworks/item/header';
   {{pageTitle "Référentiel " @model.frameworkKey " | Pix Admin" replace=true}}
 
   <div class="page">
-    <Header @certificationFramework={{@model.currentCertificationFramework}} />
+    <Header
+      @certificationFramework={{@model.currentCertificationFramework}}
+      @frameworkHistory={{@model.frameworkHistory}}
+    />
 
     <section class="page-body certification-framework">
       {{outlet}}

--- a/admin/app/templates/authenticated/certification-frameworks/item/framework/index.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item/framework/index.gjs
@@ -5,5 +5,6 @@ import Framework from 'pix-admin/components/certification-frameworks/item/framew
     @frameworkKey={{@model.frameworkKey}}
     @certificationFramework={{@model.currentCertificationFramework}}
     @hasTargetProfilesHistory={{@model.hasTargetProfilesHistory}}
+    @frameworkHistory={{@model.frameworkHistory}}
   />
 </template>

--- a/admin/app/templates/authenticated/certification-frameworks/item/framework/new-version.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item/framework/new-version.gjs
@@ -1,3 +1,5 @@
 import NewVersionForm from 'pix-admin/components/certification-frameworks/item/framework/new-version-form';
 
-<template><NewVersionForm @frameworks={{@model.frameworks}} @scope={{@model.scope}} /></template>
+<template>
+  <NewVersionForm @frameworks={{@model.frameworks}} @scope={{@model.scope}} @activeVersion={{@model.activeVersion}} />
+</template>

--- a/admin/tests/acceptance/authenticated/team/list-test.js
+++ b/admin/tests/acceptance/authenticated/team/list-test.js
@@ -101,7 +101,6 @@ module('Acceptance | Team | List', function (hooks) {
       await screen.findByRole('dialog');
 
       await clickByName('Confirmer');
-      // await this.pauseTest();
 
       // then
 

--- a/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
@@ -16,12 +16,16 @@ module('Integration | Component | certification-frameworks/item/framework', func
   });
 
   module('#frameworkHistory', function () {
-    test('it should display the framework history when there are existing framework versions', async function (assert) {
+    test('it should display the framework history', async function (assert) {
       // given
-      store.queryRecord = sinon.stub().resolves({ history: ['20250101080000', '20240101080000'] });
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [],
+      });
 
       // when
-      const screen = await render(<template><Framework @frameworkKey="DROIT" /></template>);
+      const screen = await render(
+        <template><Framework @frameworkKey="DROIT" @frameworkHistory={{frameworkHistory}} /></template>,
+      );
 
       // then
       assert
@@ -31,14 +35,24 @@ module('Integration | Component | certification-frameworks/item/framework', func
           }),
         )
         .exists();
+      assert
+        .dom(screen.getByText(t('components.certification-frameworks.item.framework.history.table.empty')))
+        .exists();
     });
   });
 
   module('when the framework is CORE', function () {
     test('it should not display target profiles history section', async function (assert) {
+      // given
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [],
+      });
+
       // when
       const screen = await render(
-        <template><Framework @frameworkKey="CORE" @hasTargetProfilesHistory={{false}} /></template>,
+        <template>
+          <Framework @frameworkKey="CORE" @hasTargetProfilesHistory={{false}} @frameworkHistory={{frameworkHistory}} />
+        </template>,
       );
 
       // then
@@ -60,6 +74,9 @@ module('Integration | Component | certification-frameworks/item/framework', func
         targetProfilesHistory: [{ id: 1, name: 'Profil A', attachedAt: new Date('2024-01-01'), detachedAt: null }],
         reload: sinon.stub().resolves(),
       };
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [],
+      });
 
       // when
       const screen = await render(
@@ -68,6 +85,7 @@ module('Integration | Component | certification-frameworks/item/framework', func
             @frameworkKey="DROIT"
             @certificationFramework={{certificationFramework}}
             @hasTargetProfilesHistory={{true}}
+            @frameworkHistory={{frameworkHistory}}
           />
         </template>,
       );
@@ -89,6 +107,9 @@ module('Integration | Component | certification-frameworks/item/framework', func
         targetProfilesHistory: [],
         reload: sinon.stub().resolves(),
       };
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [],
+      });
 
       // when
       await render(
@@ -97,6 +118,7 @@ module('Integration | Component | certification-frameworks/item/framework', func
             @frameworkKey="DROIT"
             @certificationFramework={{certificationFramework}}
             @hasTargetProfilesHistory={{true}}
+            @frameworkHistory={{frameworkHistory}}
           />
         </template>,
       );

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -9,7 +9,7 @@ import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-ren
 module('Integration | Component | Complementary certifications/Item/Framework | Framework history', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let intl, store, pixToast, frameworkItem1, frameworkItem2, frameworkItem3, frameworkHistory;
+  let intl, store, pixToast, frameworkItem1, frameworkItem2, frameworkItem3;
 
   hooks.beforeEach(function () {
     intl = this.owner.lookup('service:intl');
@@ -40,13 +40,13 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       maximumAssessmentLength: 32,
       status: 'DRAFT',
     };
-
-    frameworkHistory = store.createRecord('framework-history', {
-      history: [frameworkItem1, frameworkItem2, frameworkItem3],
-    });
   });
 
   test('it should display the framework history', async function (assert) {
+    const frameworkHistory = store.createRecord('framework-history', {
+      history: [frameworkItem1, frameworkItem2, frameworkItem3],
+    });
+
     // when
     const screen = await render(
       <template><FrameworkHistory @frameworkKey="DROIT" @frameworkHistory={{frameworkHistory}} /></template>,
@@ -79,6 +79,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
   test('it opens the detail modal when clicking the view button', async function (assert) {
     // given
     sinon.stub(store, 'findRecord').resolves(store.createRecord('certification-version'));
+    const frameworkHistory = store.createRecord('framework-history', {
+      history: [frameworkItem1, frameworkItem2, frameworkItem3],
+    });
 
     // when
     const screen = await render(
@@ -99,6 +102,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
   test('it displays the framework label as the modal title', async function (assert) {
     // given
     sinon.stub(store, 'findRecord').resolves(store.createRecord('certification-version'));
+    const frameworkHistory = store.createRecord('framework-history', {
+      history: [frameworkItem1, frameworkItem2, frameworkItem3],
+    });
 
     // when
     const screen = await render(
@@ -126,6 +132,10 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       comments: '',
       areas: [],
     });
+    const frameworkHistory = store.createRecord('framework-history', {
+      history: [frameworkItem1, frameworkItem2, frameworkItem3],
+    });
+
     sinon.stub(certificationVersion, 'save').resolves();
     sinon.stub(store, 'findRecord').resolves(certificationVersion);
     sinon.stub(pixToast, 'sendSuccessNotification');
@@ -155,6 +165,10 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     });
 
     test('it should not be possible to delete an ACTIVE or ARCHIVED version', async function (assert) {
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [frameworkItem1, frameworkItem2, frameworkItem3],
+      });
+
       // when
       const screen = await render(
         <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
@@ -173,6 +187,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       const certificationVersion = store.createRecord('certification-version', { id: frameworkItem3.id });
       sinon.stub(store, 'findRecord').resolves(certificationVersion);
       sinon.stub(certificationVersion, 'destroyRecord').resolves();
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [frameworkItem1, frameworkItem2, frameworkItem3],
+      });
 
       const screen = await render(
         <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
@@ -193,6 +210,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
         const certificationVersion = store.createRecord('certification-version', { id: frameworkItem3.id });
         sinon.stub(store, 'findRecord').resolves(certificationVersion);
         sinon.stub(certificationVersion, 'destroyRecord').resolves();
+        const frameworkHistory = store.createRecord('framework-history', {
+          history: [frameworkItem1, frameworkItem2, frameworkItem3],
+        });
 
         const screen = await render(
           <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
@@ -210,6 +230,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     module('when deletion is a error', function () {
       test('it should send a toast for feedback ', async function (assert) {
         sinon.stub(pixToast, 'sendErrorNotification');
+        const frameworkHistory = store.createRecord('framework-history', {
+          history: [frameworkItem1, frameworkItem2, frameworkItem3],
+        });
 
         const certificationVersion = store.createRecord('certification-version', { id: frameworkItem3.id });
         sinon.stub(store, 'findRecord').resolves(certificationVersion);

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -9,7 +9,7 @@ import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-ren
 module('Integration | Component | Complementary certifications/Item/Framework | Framework history', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let intl, store, pixToast, frameworkItem1, frameworkItem2, frameworkItem3;
+  let intl, store, pixToast, frameworkItem1, frameworkItem2, frameworkItem3, frameworkHistory;
 
   hooks.beforeEach(function () {
     intl = this.owner.lookup('service:intl');
@@ -41,16 +41,16 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       status: 'DRAFT',
     };
 
-    sinon.stub(store, 'queryRecord').resolves(
-      store.createRecord('framework-history', {
-        history: [frameworkItem1, frameworkItem2, frameworkItem3],
-      }),
-    );
+    frameworkHistory = store.createRecord('framework-history', {
+      history: [frameworkItem1, frameworkItem2, frameworkItem3],
+    });
   });
 
   test('it should display the framework history', async function (assert) {
     // when
-    const screen = await render(<template><FrameworkHistory @frameworkKey="DROIT" /></template>);
+    const screen = await render(
+      <template><FrameworkHistory @frameworkKey="DROIT" @frameworkHistory={{frameworkHistory}} /></template>,
+    );
 
     // then
     assert
@@ -81,7 +81,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     sinon.stub(store, 'findRecord').resolves(store.createRecord('certification-version'));
 
     // when
-    const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+    const screen = await render(
+      <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
+    );
 
     await click(
       screen.getAllByRole('button', {
@@ -99,7 +101,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     sinon.stub(store, 'findRecord').resolves(store.createRecord('certification-version'));
 
     // when
-    const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+    const screen = await render(
+      <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
+    );
 
     await click(
       screen.getAllByRole('button', {
@@ -126,7 +130,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
     sinon.stub(store, 'findRecord').resolves(certificationVersion);
     sinon.stub(pixToast, 'sendSuccessNotification');
 
-    const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+    const screen = await render(
+      <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
+    );
 
     await click(
       screen.getAllByRole('button', {
@@ -150,7 +156,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
     test('it should not be possible to delete an ACTIVE or ARCHIVED version', async function (assert) {
       // when
-      const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+      const screen = await render(
+        <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
+      );
 
       // then
       assert.strictEqual(screen.getAllByRole('button', { name: deleteButtonName }).length, 3);
@@ -166,7 +174,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       sinon.stub(store, 'findRecord').resolves(certificationVersion);
       sinon.stub(certificationVersion, 'destroyRecord').resolves();
 
-      const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+      const screen = await render(
+        <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
+      );
 
       // when
       await click(screen.getAllByRole('button', { name: deleteButtonName })[2]);
@@ -184,7 +194,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
         sinon.stub(store, 'findRecord').resolves(certificationVersion);
         sinon.stub(certificationVersion, 'destroyRecord').resolves();
 
-        const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+        const screen = await render(
+          <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
+        );
 
         // when
         await click(screen.getAllByRole('button', { name: deleteButtonName })[2]);
@@ -203,7 +215,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
         sinon.stub(store, 'findRecord').resolves(certificationVersion);
         sinon.stub(certificationVersion, 'destroyRecord').rejects();
 
-        const screen = await render(<template><FrameworkHistory @frameworkKey="CORE" /></template>);
+        const screen = await render(
+          <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
+        );
 
         // when
         await click(screen.getAllByRole('button', { name: deleteButtonName })[2]);

--- a/admin/tests/integration/components/certification-frameworks/item/framework/new-version-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/new-version-form-test.gjs
@@ -1,4 +1,4 @@
-import { render, within } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import NewVersionForm from 'pix-admin/components/certification-frameworks/item/framework/new-version-form';
 import { module, test } from 'qunit';
@@ -8,20 +8,17 @@ import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-ren
 module('Integration | Component | complementary-certifications/item/framework/new-version-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display framework creation form', async function (assert) {
+  test('it should display framework creation form when there is no active version', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
-
     const frameworks = _createFrameworks(store);
-
-    store.createRecord('certification-framework', {
-      id: 'DROIT',
-      name: 'Pix+Droit',
-    });
 
     // when
     const screen = await render(<template><NewVersionForm @frameworks={{frameworks}} @scope="DROIT" /></template>);
 
+    assert.dom(screen.getByRole('button', { name: 'Référentiels :' })).exists();
+    await click(screen.getByRole('button', { name: 'Référentiels :' }));
+    assert.dom(await screen.findByRole('checkbox', { name: 'Pix' })).isChecked();
     assert
       .dom(
         screen.getByRole('button', {
@@ -35,11 +32,6 @@ module('Integration | Component | complementary-certifications/item/framework/ne
     await click(screen.getByLabelText('@tubeName1 : Tube 1'));
 
     // then
-    assert.ok(screen.getByRole('button', { name: 'Importer un fichier JSON' }));
-
-    const table = screen.getByRole('table', { name: 'Sélection des sujets' });
-    assert.ok(within(table).getByRole('columnheader', { name: 'Niveau' }));
-    assert.ok(within(table).getByRole('columnheader', { name: 'Compatibilité' }));
     assert.ok(
       screen.getByRole('heading', {
         name: t('components.certification-frameworks.item.framework.new-version-form.title'),
@@ -54,6 +46,43 @@ module('Integration | Component | complementary-certifications/item/framework/ne
       )
       .doesNotHaveAttribute('aria-disabled');
     assert.ok(screen.getByText(t('common.actions.cancel')));
+  });
+
+  test('it should pre-select tubes if an active version is loaded along', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const frameworks = _createFrameworks(store);
+
+    const activeVersion = store.createRecord('certification-version', {
+      id: '456',
+      startDate: new Date('2023-10-10'),
+      assessmentDuration: 90,
+      minimumAnswersRequiredForValidation: 20,
+      maximumAssessmentLength: 32,
+      comments: '',
+      areas: [...frameworks[0].hasMany('areas').value(), ...frameworks[1].hasMany('areas').value()],
+    });
+
+    // when
+    const screen = await render(
+      <template><NewVersionForm @frameworks={{frameworks}} @scope="PIX" @activeVersion={{activeVersion}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('button', { name: 'Référentiels :' })).exists();
+    await click(screen.getByRole('button', { name: 'Référentiels :' }));
+    assert.dom(await screen.findByRole('checkbox', { name: 'Pix' })).isChecked();
+    assert.dom(await screen.findByRole('checkbox', { name: 'Pix plus' })).isChecked();
+
+    await clickByName('1 · Titre domaine');
+    await clickByName('1 Titre competence');
+    assert.dom(await screen.getByLabelText('@tubeName1 : Tube 1')).isChecked();
+    assert.dom(await screen.getByLabelText('@tubeName2 : Tube 2')).isChecked();
+    assert.dom(await screen.getByLabelText('@tubeName3 : Tube 3')).isChecked();
+
+    await clickByName('1 · Titre domaine 2');
+    await clickByName('1 Titre competence 2');
+    assert.dom(await screen.getByLabelText('@tubeName4 : Tube 4')).isChecked();
   });
 });
 
@@ -85,10 +114,22 @@ function _createFrameworks(store) {
     }),
   ];
 
+  const otherTubes = [
+    store.createRecord('tube', {
+      id: 'tubeId4',
+      name: '@tubeName4',
+      practicalTitle: 'Tube 4',
+      skills: [],
+      level: 8,
+    }),
+  ];
+
   const thematics = [
     store.createRecord('thematic', { id: 'thematicId1', name: 'Thématique 1', tubes: tubes1 }),
     store.createRecord('thematic', { id: 'thematicId2', name: 'Thématique 2', tubes: tubes2 }),
   ];
+
+  const thematics2 = [store.createRecord('thematic', { id: 'thematicId3', name: 'Thématique 3', tubes: otherTubes })];
 
   const competences = [
     store.createRecord('competence', {
@@ -99,12 +140,32 @@ function _createFrameworks(store) {
     }),
   ];
 
+  const competences2 = [
+    store.createRecord('competence', {
+      id: 'competenceId2',
+      index: '1',
+      name: 'Titre competence 2',
+      thematics: thematics2,
+    }),
+  ];
+
   const areas = [
     store.createRecord('area', {
       id: 'areaId',
       title: 'Titre domaine',
       code: 1,
       competences,
+      frameworkId: 'frameworkId',
+    }),
+  ];
+
+  const areas2 = [
+    store.createRecord('area', {
+      id: 'areaId2',
+      title: 'Titre domaine 2',
+      code: 1,
+      competences: competences2,
+      frameworkId: 'pixPlusFrameworkId',
     }),
   ];
 
@@ -112,15 +173,13 @@ function _createFrameworks(store) {
   const framework2 = store.createRecord('framework', {
     id: 'pixPlusFrameworkId',
     name: 'Pix plus',
-    areas: [
-      store.createRecord('area', {
-        id: 'pixPlusAreaId',
-        title: 'Area pix plus',
-        code: 2,
-        competences,
-      }),
-    ],
+    areas: areas2,
   });
 
-  return [framework, framework2];
+  const framework3 = store.createRecord('framework', {
+    id: 'pixPlusDroitId',
+    name: 'DROIT',
+  });
+
+  return [framework, framework2, framework3];
 }

--- a/admin/tests/unit/routes/authenticated/certification-frameworks/item-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-frameworks/item-test.js
@@ -13,6 +13,7 @@ module('Unit | Route | authenticated/certification-frameworks/item', function (h
     store = this.owner.lookup('service:store');
     store.peekAll = sinon.stub();
     store.findAll = sinon.stub();
+    store.queryRecord = sinon.stub();
   });
 
   module('model()', function () {
@@ -24,6 +25,7 @@ module('Unit | Route | authenticated/certification-frameworks/item', function (h
         store.peekAll.withArgs('certification-framework').returns([cleaFramework]);
         store.peekAll.withArgs('complementary-certification').returns([cleaComplementary]);
         store.findAll.withArgs('complementary-certification').resolves([cleaComplementary]);
+        store.queryRecord.withArgs('framework-history').resolves(null);
 
         // when
         const result = await route.model({ certification_framework_key: 'CLEA' });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -515,7 +515,8 @@
                 "start-date": "Start date",
                 "status": "Status",
                 "version-id": "Version ID"
-              }
+              },
+              "empty": "This certification has no history"
             },
             "title": "Framework versions history"
           },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -523,7 +523,8 @@
                 "start-date": "Date d'activation",
                 "status": "Statut",
                 "version-id": "ID de version"
-              }
+              },
+              "empty": "Cette certification n'a pas d'histoire"
             },
             "title": "Historique des versions du référentiel"
           },


### PR DESCRIPTION
## 💥 Problème

Lorsque l'on crée une nouvelle version de certification, même si les sujet sont les même ou presque les même que la dernière version, il faut tout re-selectionner.

## 👩‍🚀 Proposition

Ajouter une pre-selection basé sur la version précédente

## 👁️ Remarques

Si pas de version précédente Pix est choisit de base et aucuns sujet est selectionné.

## ♻️ Pour tester

Créer une nouvellet certification et il devrait normalement avoir des cases pré-coché en fonction de la dernière version de certification