### PR TITLE
[FEATURE] Maddo - Permettre d'ordonner les participations d'une autre manière (PIX-22906)

### DIFF
--- a/api/src/maddo/application/campaigns-controller.js
+++ b/api/src/maddo/application/campaigns-controller.js
@@ -5,7 +5,7 @@ export async function getCampaignParticipations(
   h,
   dependencies = { getCampaignParticipations: usecases.getCampaignParticipations },
 ) {
-  const { page, since, authenticationRequestedData = [] } = request.query;
+  const { page, since, sort, authenticationRequestedData = [] } = request.query;
   const { models: campaignParticipations, meta } = await dependencies.getCampaignParticipations({
     campaignId: request.params.campaignId,
     clientId: request.auth.credentials.client_id,
@@ -14,6 +14,7 @@ export async function getCampaignParticipations(
       : [authenticationRequestedData],
     page,
     since,
+    sort,
   });
   return h
     .response({ campaignParticipations, page: { number: meta.page, size: meta.pageSize, count: meta.pageCount } })

--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -22,6 +22,12 @@ const register = async function (server) {
               number: Joi.number().integer().empty('').allow(null).optional(),
               size: Joi.number().integer().max(200).empty('').allow(null).optional(),
             }).default({}),
+            sort: Joi.array().items(
+              Joi.object({
+                value: Joi.string().empty('').allow(null).optional(),
+                type: Joi.string().valid('asc', 'desc').empty(['', null]).allow(null).optional(),
+              }),
+            ),
             authenticationRequestedData: Joi.alternatives(Joi.array().items(Joi.string()), Joi.string()).optional(),
           }),
         },

--- a/api/src/maddo/domain/usecases/get-campaign-participations.js
+++ b/api/src/maddo/domain/usecases/get-campaign-participations.js
@@ -7,6 +7,7 @@ export const getCampaignParticipations = async ({
   clientId,
   page,
   since,
+  sort,
   authenticationRequestedData,
   campaignsAPI,
   organizationRepository,
@@ -17,6 +18,7 @@ export const getCampaignParticipations = async ({
     campaignId,
     page,
     since,
+    sort,
   });
   const identityProviderForCampaigns =
     await organizationRepository.findIdentityProviderForCampaignsByCampaignId(campaignId);

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -147,7 +147,16 @@ const updateInBatchByIds = async function (campaignParticipations) {
   });
 };
 
-const findInfoByCampaignId = async function ({ campaignId, page, since }) {
+const findInfoByCampaignId = async function ({
+  campaignId,
+  page,
+  since,
+  sort = [
+    { value: 'lastName', type: 'ASC' },
+    { value: 'firstName', type: 'ASC' },
+    { value: 'createdAt', type: 'DESC' },
+  ],
+}) {
   const knexConn = DomainTransaction.getConnection();
   const query = knexConn('campaign-participations')
     .select([
@@ -164,10 +173,9 @@ const findInfoByCampaignId = async function ({ campaignId, page, since }) {
       'view-active-organization-learners.id',
       'campaign-participations.organizationLearnerId',
     )
-    .where({ campaignId, 'campaign-participations.deletedAt': null })
-    .orderBy('lastName', 'ASC')
-    .orderBy('firstName', 'ASC')
-    .orderBy('createdAt', 'DESC');
+    .where({ campaignId, 'campaign-participations.deletedAt': null });
+
+  sort.forEach((order) => query.orderBy(order.value, order.type));
 
   if (since !== undefined) {
     const sinceDate = new Date(since);

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -197,6 +197,7 @@ export const findCampaignSkillIdsForCampaignParticipations = async (campaignPart
  * @type {object}
  * @property {number} campaignId
  * @property {string} since
+ * @property {Array<object>} sort
  * @property {PageDefinition} page
  */
 
@@ -207,11 +208,12 @@ export const findCampaignSkillIdsForCampaignParticipations = async (campaignPart
  * @param {CampaignParticipationsPayload} payload
  * @returns {Promise<{models: Array<AssessmentCampaignParticipationAPI>|Array<ProfilesCollectionCampaignParticipationAPI>, meta: Pagination}>}
  */
-export const getCampaignParticipations = async function ({ campaignId, page, since }) {
+export const getCampaignParticipations = async function ({ campaignId, page, since, sort }) {
   const { models: campaignParticipations, meta } = await usecases.getCampaignParticipations({
     campaignId,
     page,
     since,
+    sort,
   });
   return {
     models: campaignParticipations.map((campaignParticipation) =>

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -88,6 +88,7 @@ export const getCampaignParticipations = async function ({
   locale,
   page,
   since,
+  sort,
   campaignRepository,
   badgeRepository,
   badgeForCalculationRepository,
@@ -103,6 +104,7 @@ export const getCampaignParticipations = async function ({
     campaignId,
     page,
     since,
+    sort,
   });
   const participationIds = participations.map(({ id }) => id);
 

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -579,6 +579,99 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
       });
     });
 
+    context('should handle sort', function () {
+      let campaign, clientId, tube, competenceId, skillId;
+
+      beforeEach(async function () {
+        const orgaInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
+        databaseBuilder.factory.buildOrganization({ name: 'orga-not-in-jurisdiction' });
+
+        const tag = databaseBuilder.factory.buildTag();
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: orgaInJurisdiction.id, tagId: tag.id });
+
+        clientId = 'client';
+        databaseBuilder.factory.buildClientApplication({
+          clientId: 'client',
+          jurisdiction: { rules: [{ name: 'tags', value: [tag.name] }] },
+        });
+
+        const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+        const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+        competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+        tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+        skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+
+        campaign = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.ASSESSMENT,
+          organizationId: orgaInJurisdiction.id,
+        });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should returns participations sorted by given sort param', async function () {
+        // given
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner();
+        const participationCreatedLast = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.STARTED,
+          participantExternalId: 'started last',
+          createdAt: new Date('2026-01-01'),
+        });
+        const participationCreatedFirst = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.STARTED,
+          participantExternalId: 'started first',
+          masteryRate: null,
+          createdAt: new Date('2024-01-03'),
+          organizationLearnerId: organizationLearner.id,
+        });
+
+        const participationCreatedSecond = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.SHARED,
+          masteryRate: 0.1,
+          validatedSkillsCount: 10,
+          participantExternalId: 'started 2nd',
+          createdAt: new Date('2025-01-01'),
+          sharedAt: new Date('2025-01-01'),
+        });
+        const ke = databaseBuilder.factory.buildKnowledgeElement({
+          status: KnowledgeElement.StatusType.VALIDATED,
+          skillId,
+          userId: participationCreatedFirst.userId,
+        });
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          campaignParticipationId: participationCreatedSecond.id,
+          snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
+        });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/participations?sort[0][value]=createdAt&sort[0][type]=asc`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(
+              clientId,
+              'pix-client',
+              'campaigns meta',
+            ),
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.campaignParticipations[0].createdAt).to.deep.equal(participationCreatedFirst.createdAt);
+        expect(response.result.campaignParticipations[1].createdAt).to.deep.equal(participationCreatedSecond.createdAt);
+        expect(response.result.campaignParticipations[2].createdAt).to.deep.equal(participationCreatedLast.createdAt);
+      });
+    });
+
     context('when authentication data are requested', function () {
       let campaign;
       let authorization;

--- a/api/tests/maddo/domain/integration/usecases/get-campaign-participations_test.js
+++ b/api/tests/maddo/domain/integration/usecases/get-campaign-participations_test.js
@@ -11,31 +11,88 @@ import { databaseBuilder } from '../../../../tooling/databases.js';
 
 describe('Integration | Maddo | UseCase | get-campaign-participations', function () {
   describe('#getCampaignParticipations', function () {
+    let organization, clientId, campaign, user1, user2;
+
+    beforeEach(async function () {
+      // given
+      organization = databaseBuilder.factory.buildOrganization({
+        identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+      });
+
+      clientId = 'test-client';
+
+      const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+      const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+      const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+      const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+      const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+
+      user1 = databaseBuilder.factory.buildUser({ firstName: 'John', lastName: 'Doe' });
+      user2 = databaseBuilder.factory.buildUser({ firstName: 'Jane', lastName: 'Smith' });
+
+      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        userId: user1.id,
+        firstName: 'Jane',
+        lastName: 'Smith',
+      });
+
+      const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        userId: user2.id,
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+
+      campaign = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.ASSESSMENT,
+        organizationId: organization.id,
+      });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+
+      const participation1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.SHARED,
+        organizationLearnerId: organizationLearner1.id,
+        userId: user1.id,
+        masteryRate: 0.8,
+        validatedSkillsCount: 10,
+        createdAt: new Date('2025-01-01'),
+      });
+
+      const ke = databaseBuilder.factory.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId,
+        userId: user1.id,
+      });
+
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        campaignParticipationId: participation1.id,
+        snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
+      });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.STARTED,
+        organizationLearnerId: organizationLearner2.id,
+        userId: user2.id,
+        masteryRate: null,
+        createdAt: new Date('2026-01-01'),
+      });
+
+      await databaseBuilder.commit();
+    });
+
     context('when organization has an identity provider', function () {
       it('should add authenticationId to participations when users have matching authentication methods', async function () {
         // given
-        const organization = databaseBuilder.factory.buildOrganization({
-          identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
-        });
-
         const tag = databaseBuilder.factory.buildTag();
         databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag.id });
 
-        const clientId = 'test-client';
         databaseBuilder.factory.buildClientApplication({
           clientId,
           jurisdiction: { rules: [{ name: 'tags', value: [tag.name] }] },
         });
-
-        const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
-        const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
-        const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
-        const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
-        const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
-
-        const user1 = databaseBuilder.factory.buildUser({ firstName: 'John', lastName: 'Doe' });
-        const user2 = databaseBuilder.factory.buildUser({ firstName: 'Jane', lastName: 'Smith' });
-
         // Create authentication methods with external identifiers
         databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
           userId: user1.id,
@@ -44,54 +101,6 @@ describe('Integration | Maddo | UseCase | get-campaign-participations', function
         databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
           userId: user2.id,
           externalIdentifier: 'external-id-user2',
-        });
-
-        const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          userId: user1.id,
-          firstName: 'John',
-          lastName: 'Doe',
-        });
-
-        const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          userId: user2.id,
-          firstName: 'Jane',
-          lastName: 'Smith',
-        });
-
-        const campaign = databaseBuilder.factory.buildCampaign({
-          type: CampaignTypes.ASSESSMENT,
-          organizationId: organization.id,
-        });
-        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
-
-        const participation1 = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-          status: CampaignParticipationStatuses.SHARED,
-          organizationLearnerId: organizationLearner1.id,
-          userId: user1.id,
-          masteryRate: 0.8,
-          validatedSkillsCount: 10,
-        });
-
-        const ke = databaseBuilder.factory.buildKnowledgeElement({
-          status: KnowledgeElement.StatusType.VALIDATED,
-          skillId,
-          userId: user1.id,
-        });
-
-        databaseBuilder.factory.buildKnowledgeElementSnapshot({
-          campaignParticipationId: participation1.id,
-          snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
-        });
-
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-          status: CampaignParticipationStatuses.STARTED,
-          organizationLearnerId: organizationLearner2.id,
-          userId: user2.id,
-          masteryRate: null,
         });
 
         await databaseBuilder.commit();
@@ -105,11 +114,29 @@ describe('Integration | Maddo | UseCase | get-campaign-participations', function
         // then
         expect(models).to.have.lengthOf(2);
 
-        const participationWithUser1 = models.find((p) => p.participantFirstName === 'John');
-        const participationWithUser2 = models.find((p) => p.participantFirstName === 'Jane');
+        const participationWithUser1 = models.find((p) => p.participantFirstName === 'Jane');
+        const participationWithUser2 = models.find((p) => p.participantFirstName === 'John');
 
         expect(participationWithUser1.authenticationId).to.equal('external-id-user1');
         expect(participationWithUser2.authenticationId).to.equal('external-id-user2');
+      });
+    });
+    context('when a sort param is added', function () {
+      it('should sort by the given param', async function () {
+        //given
+        const sort = [{ value: 'createdAt', type: 'asc' }];
+
+        // when
+        const { models } = await usecases.getCampaignParticipations({
+          campaignId: campaign.id,
+          clientId,
+          sort,
+        });
+
+        // then
+        expect(models).to.have.lengthOf(2);
+        expect(models[0].createdAt).to.deep.equal(new Date('2025-01-01'));
+        expect(models[1].createdAt).to.deep.equal(new Date('2026-01-01'));
       });
     });
   });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1406,6 +1406,116 @@ describe('Integration | Repository | Campaign Participation', function () {
         });
       });
     });
+
+    context('sort', function () {
+      let campaignId;
+
+      beforeEach(async function () {
+        // given
+        campaignId = campaign1.id;
+
+        const organizationLearner2 = {
+          organizationId,
+          firstName: 'Jean',
+          lastName: 'Bart',
+          division: '6emeA',
+          group: null,
+          attributes: { hobby: 'Genky' },
+          studentNumber: '1003',
+        };
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(organizationLearner2, {
+          campaignId,
+          createdAt: new Date('2018-03-15T14:59:35Z'),
+          sharedAt: new Date('2018-03-16T14:59:35Z'),
+          validatedSkillsCount: 10,
+          pixScore: 10,
+          masteryRate: null,
+        });
+
+        const organizationLearner1Namesake = {
+          organizationId,
+          firstName: 'Hubert',
+          lastName: 'Parterre',
+          division: '6emeB',
+          group: null,
+          attributes: { hobby: 'Genky' },
+          studentNumber: '1004',
+        };
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(organizationLearner1Namesake, {
+          campaignId,
+          createdAt: new Date('2021-03-15T14:59:35Z'),
+          sharedAt: new Date('2021-03-16T14:59:35Z'),
+          validatedSkillsCount: 10,
+          pixScore: 10,
+          masteryRate: null,
+        });
+
+        await databaseBuilder.commit();
+      });
+      it('should order by lastName, firstName and createdAt by default', async function () {
+        // when
+        const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId({
+          campaignId,
+        });
+
+        // then
+        const attributes = participationResultDatas.map((participationResultData) =>
+          _.pick(participationResultData, ['participantFirstName', 'participantLastName', 'createdAt']),
+        );
+
+        expect(attributes).to.deep.equal([
+          {
+            createdAt: new Date('2018-03-15T14:59:35Z'),
+            participantFirstName: 'Jean',
+            participantLastName: 'Bart',
+          },
+          {
+            createdAt: new Date('2021-03-15T14:59:35Z'),
+            participantFirstName: 'Hubert',
+            participantLastName: 'Parterre',
+          },
+          {
+            createdAt: campaignParticipation1.createdAt,
+            participantFirstName: 'Hubert',
+            participantLastName: 'Parterre',
+          },
+        ]);
+      });
+
+      it('should order by given sort', async function () {
+        // when
+        const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId({
+          campaignId,
+          sort: [
+            { value: 'createdAt', type: 'asc' },
+            { value: 'lastName', type: 'asc' },
+            { value: 'firstName', type: 'asc' },
+          ],
+        });
+
+        // then
+        const attributes = participationResultDatas.map((participationResultData) =>
+          _.pick(participationResultData, ['participantFirstName', 'participantLastName', 'createdAt']),
+        );
+        expect(attributes).to.deep.equal([
+          {
+            createdAt: campaignParticipation1.createdAt,
+            participantFirstName: 'Hubert',
+            participantLastName: 'Parterre',
+          },
+          {
+            createdAt: new Date('2018-03-15T14:59:35Z'),
+            participantFirstName: 'Jean',
+            participantLastName: 'Bart',
+          },
+          {
+            createdAt: new Date('2021-03-15T14:59:35Z'),
+            participantFirstName: 'Hubert',
+            participantLastName: 'Parterre',
+          },
+        ]);
+      });
+    });
   });
 
   describe('#findOneByCampaignIdAndUserId', function () {

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
@@ -48,7 +48,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         level: 2,
         competenceId: competence.id,
       }).id;
-      const organizationLearner1 = buildOrganizationLearner({ lastName: 'Albert' });
+      const organizationLearner1 = buildOrganizationLearner({ lastName: 'Michel' });
 
       const targetProfile = buildTargetProfile();
 
@@ -110,7 +110,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       });
 
       const organizationLearner2 = buildOrganizationLearner({
-        lastName: 'Michele',
+        lastName: 'Albert',
         organizationId: organizationLearner1.organizationId,
       });
       buildCampaignParticipation({
@@ -138,20 +138,23 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       await databaseBuilder.commit();
 
       const page = {
-        size: 1,
+        size: 2,
         number: 1,
       };
       const since = new Date('2020-01-02').getTime();
+
+      const sort = [{ value: 'createdAt', type: 'asc' }];
       // when
       const { models, meta } = await usecases.getCampaignParticipations({
         campaignId: campaign.id,
         locale: FRENCH_SPOKEN,
         page,
         since,
+        sort,
       });
 
       // then
-      expect(models).to.have.lengthOf(1);
+      expect(models).to.have.lengthOf(2);
       expect(models[0]).to.deep.equal(
         new AssessmentCampaignParticipation({
           campaignParticipationId: participation1.id,
@@ -202,8 +205,8 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       );
       expect(meta).to.deep.equal({
         page: 1,
-        pageCount: 2,
-        pageSize: 1,
+        pageCount: 1,
+        pageSize: 2,
         rowCount: 2,
       });
     });


### PR DESCRIPTION
## 💥 Problème

Le repo ne propose qu'une seule manière de filtrer les participations alors que via Maddo on aimerait traiter l'ordre différemment

## 👩‍🚀 Proposition

Ajouter un param "orders" au repo afin de pouvoir ordonner selon le besoin

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
- CI au vert
- pouvoir faire un appel Maddo avec un param `orders` 
1. Récupérer un token d'acces
```bash
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr16371.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=campaigns' | jq -r .access_token)
```
2. Récupérer les participations
```bash
 curl  'https://pix-api-maddo-review-pr16371.osc-fr1.scalingo.io/api/campaigns/6000/participations?sort\[0\]\[value\]=createdAt&sort\[0\]\[type\]=desc' -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-type: application/json" | jq
```
   
    - essayer avec plusieurs paramètres
- vérifier que cela n'impacte pas pas liste de participations dans la page pixOrga résultats d'une campagne de collecte de profil
 
