### PR TITLE
[FEATURE] Ajouter une API pour enregistrer l'avis d'un utilisateur sur une recommandation de CF (PIX-22946)(PIX-22933)

### DIFF
--- a/api/db/database-builder/factory/build-user-recommended-training.js
+++ b/api/db/database-builder/factory/build-user-recommended-training.js
@@ -7,6 +7,7 @@ const buildUserRecommendedTraining = function ({
   userId,
   trainingId,
   campaignParticipationId,
+  isRelevant,
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -15,7 +16,7 @@ const buildUserRecommendedTraining = function ({
   }
   return databaseBuffer.pushInsertable({
     tableName: USER_RECOMMENDED_TRAININGS_TABLE_NAME,
-    values: { id, userId, trainingId, campaignParticipationId, createdAt, updatedAt },
+    values: { id, userId, trainingId, campaignParticipationId, isRelevant, createdAt, updatedAt },
   });
 };
 

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
@@ -15,8 +15,24 @@ const findTrainings = async function (request, h, dependencies = { trainingSeria
   return dependencies.trainingSerializer.serialize(trainings);
 };
 
+const saveUserRelevanceFeedbackOnRecommendedTraining = async function (request, h) {
+  const { userId } = request.auth.credentials;
+  const { campaignParticipationId, trainingId } = request.params;
+  const isRelevant = request.payload.data.attributes['is-relevant'];
+
+  await devcompUsecases.saveUserRelevanceFeedbackOnRecommendedTraining({
+    userId,
+    trainingId,
+    campaignParticipationId,
+    isRelevant,
+  });
+
+  return h.response().code(204);
+};
+
 const campaignParticipationController = {
   findTrainings,
+  saveUserRelevanceFeedbackOnRecommendedTraining,
 };
 
 export { campaignParticipationController };

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-route.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-route.js
@@ -17,7 +17,35 @@ const register = async function (server) {
         handler: campaignParticipationController.findTrainings,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            '- Récupération des formations de la campagne d‘un utilisateur',
+            "- Récupération des formations de la campagne d'un utilisateur",
+        ],
+        tags: ['api', 'campaign-participations', 'trainings'],
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/campaign-participations/{campaignParticipationId}/trainings/{trainingId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            campaignParticipationId: identifiersType.campaignParticipationId,
+            trainingId: identifiersType.trainingId,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                'is-relevant': Joi.boolean().required(),
+              }).required(),
+            }).required(),
+          }).required(),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        handler: campaignParticipationController.saveUserRelevanceFeedbackOnRecommendedTraining,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Enregistrement de la pertinence d'un contenu formatif recommandé",
         ],
         tags: ['api', 'campaign-participations', 'trainings'],
       },

--- a/api/src/devcomp/domain/read-models/UserRecommendedTraining.js
+++ b/api/src/devcomp/domain/read-models/UserRecommendedTraining.js
@@ -13,6 +13,7 @@ class UserRecommendedTraining {
     program,
     objectives,
     description,
+    isRelevant,
   } = {}) {
     this.id = id;
     this.title = title;
@@ -23,6 +24,7 @@ class UserRecommendedTraining {
     this.editorName = editorName;
     this.editorLogoUrl = editorLogoUrl;
     this.deliveryMode = deliveryMode;
+    this.isRelevant = isRelevant;
     this.registrationRequired = registrationRequired;
     this.program = program;
     this.objectives = objectives;

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -61,6 +61,7 @@ import { getUserModuleStatuses } from './get-user-module-statuses.js';
 import { handleTrainingRecommendation } from './handle-training-recommendation.js';
 import { promptToLLMChat } from './prompt-to-llm-chat.js';
 import { recordPassageEvents } from './record-passage-events.js';
+import { saveUserRelevanceFeedbackOnRecommendedTraining } from './save-user-relevance-feedback-on-recommended-training.js';
 import { startEmbedLlmChat } from './start-embed-llm-chat.js';
 import { terminatePassage } from './terminate-passage.js';
 import { updateTraining } from './update-training.js';
@@ -97,6 +98,7 @@ const usecasesWithoutInjectedDependencies = {
   handleTrainingRecommendation,
   promptToLLMChat,
   recordPassageEvents,
+  saveUserRelevanceFeedbackOnRecommendedTraining,
   startEmbedLlmChat,
   terminatePassage,
   updateTraining,

--- a/api/src/devcomp/domain/usecases/save-user-relevance-feedback-on-recommended-training.js
+++ b/api/src/devcomp/domain/usecases/save-user-relevance-feedback-on-recommended-training.js
@@ -1,0 +1,27 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
+
+export const saveUserRelevanceFeedbackOnRecommendedTraining = async ({
+  userId,
+  trainingId,
+  campaignParticipationId,
+  isRelevant,
+  userRecommendedTrainingRepository,
+}) => {
+  const existingUserRecommendedTraining =
+    await userRecommendedTrainingRepository.findByCampaignParticipationIdAndTrainingIdAndUserId({
+      userId,
+      trainingId,
+      campaignParticipationId,
+    });
+
+  if (!existingUserRecommendedTraining) {
+    throw new NotFoundError('UserRecommendedTraining not Found for given parameters');
+  }
+
+  return userRecommendedTrainingRepository.save({
+    userId,
+    trainingId,
+    campaignParticipationId,
+    isRelevant,
+  });
+};

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -183,7 +183,7 @@ async function findPaginatedByUserId({ userId, locale, page }) {
   const knexConn = DomainTransaction.getConnection();
 
   const baseQuery = knexConn(TABLE_NAME)
-    .select('trainings.*')
+    .select('trainings.*', 'isRelevant')
     .distinct('trainings.id')
     .join(USER_RECOMMENDED_TRAININGS_TABLE_NAME, 'trainings.id', 'trainingId')
     .where({ userId, isDisabled: false })

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -21,6 +21,21 @@ const findByCampaignParticipationId = async function ({ campaignParticipationId,
   return trainings.map(_toDomain);
 };
 
+const findByCampaignParticipationIdAndTrainingIdAndUserId = async function ({
+  campaignParticipationId,
+  trainingId,
+  userId,
+}) {
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+    .select('trainings.*', 'isRelevant')
+    .innerJoin('trainings', 'trainings.id', `${USER_RECOMMENDED_TRAININGS_TABLE_NAME}.trainingId`)
+    .where({ campaignParticipationId, trainingId, userId, isDisabled: false })
+    .first();
+
+  return result ? _toDomain(result) : null;
+};
+
 const findModulesByCampaignParticipationIds = async function ({ campaignParticipationIds }) {
   const knexConn = DomainTransaction.getConnection();
   const moduleLinks = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
@@ -57,6 +72,7 @@ const deleteCampaignParticipationIds = async ({ campaignParticipationIds }) => {
 export {
   deleteCampaignParticipationIds,
   findByCampaignParticipationId,
+  findByCampaignParticipationIdAndTrainingIdAndUserId,
   findModulesByCampaignParticipationIds,
   hasRecommendedTrainings,
   save,

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -13,7 +13,7 @@ const save = function ({ userId, trainingId, campaignParticipationId, isRelevant
 const findByCampaignParticipationId = async function ({ campaignParticipationId, locale }) {
   const knexConn = DomainTransaction.getConnection();
   const trainings = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
-    .select('trainings.*')
+    .select('trainings.*', 'isRelevant')
     .innerJoin('trainings', 'trainings.id', `${USER_RECOMMENDED_TRAININGS_TABLE_NAME}.trainingId`)
     .where({ campaignParticipationId, isDisabled: false })
     .whereRaw('? = ANY(locales)', locale)

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -2,12 +2,12 @@ import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserRecommendedTraining } from '../../domain/read-models/UserRecommendedTraining.js';
 
-const save = function ({ userId, trainingId, campaignParticipationId }) {
+const save = function ({ userId, trainingId, campaignParticipationId, isRelevant }) {
   const knexConn = DomainTransaction.getConnection();
   return knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
-    .insert({ userId, trainingId, campaignParticipationId })
+    .insert({ userId, trainingId, campaignParticipationId, isRelevant, updatedAt: knexConn.fn.now() })
     .onConflict(['userId', 'trainingId', 'campaignParticipationId'])
-    .merge({ updatedAt: knexConn.fn.now() });
+    .merge(['isRelevant', 'updatedAt']);
 };
 
 const findByCampaignParticipationId = async function ({ campaignParticipationId, locale }) {

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -99,6 +99,7 @@ const serialize = function (training = {}, meta) {
       'program',
       'objectives',
       'description',
+      'isRelevant',
     ],
     targetProfileSummaries: {
       ref: 'id',

--- a/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -47,6 +47,7 @@ describe('Acceptance | API | Campaign Participations', function () {
         'editor-logo-url': training.editorLogoUrl,
         'delivery-mode': Training.modes.HYBRID,
         'registration-required': false,
+        'is-relevant': null,
         program: 'Programme du contenu formatif',
         objectives: [],
         description: "<p>Voici la description d'un contenu formatif</p>",

--- a/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -53,4 +53,86 @@ describe('Acceptance | API | Campaign Participations', function () {
       });
     });
   });
+
+  describe('PATCH /api/campaign-participations/{campaignParticipationId}/trainings/{trainingId}', function () {
+    it('should return 204 when the userRecommendedTraining exists', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ userId: user.id });
+      const training = databaseBuilder.factory.buildTraining();
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId: user.id,
+        trainingId: training.id,
+        campaignParticipationId: campaignParticipation.id,
+      });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/campaign-participations/${campaignParticipation.id}/trainings/${training.id}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        payload: {
+          data: {
+            attributes: {
+              'is-relevant': true,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should return 404 when the userRecommendedTraining does not exist', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ userId: user.id });
+      const training = databaseBuilder.factory.buildTraining();
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/campaign-participations/${campaignParticipation.id}/trainings/${training.id}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        payload: {
+          data: {
+            attributes: {
+              'is-relevant': false,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+
+    it('should return 401 when the user is not authenticated', async function () {
+      // given
+      const options = {
+        method: 'PATCH',
+        url: `/api/campaign-participations/1/trainings/1`,
+        payload: {
+          data: {
+            attributes: {
+              'is-relevant': true,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+  });
 });

--- a/api/tests/devcomp/acceptance/application/user-trainings/users-trainings-route_test.js
+++ b/api/tests/devcomp/acceptance/application/user-trainings/users-trainings-route_test.js
@@ -27,7 +27,12 @@ describe('Acceptance | Routes | UserTrainingsRoute', function () {
       //given
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({ userId });
       const { id: trainingId } = databaseBuilder.factory.buildTraining();
-      databaseBuilder.factory.buildUserRecommendedTraining({ userId, trainingId, campaignParticipationId });
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId,
+        trainingId,
+        campaignParticipationId,
+        isRelevant: false,
+      });
       await databaseBuilder.commit();
 
       // when
@@ -53,6 +58,7 @@ describe('Acceptance | Routes | UserTrainingsRoute', function () {
             'editor-logo-url':
               'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
             description: "<p>Voici la description d'un contenu formatif</p>",
+            'is-relevant': false,
           },
           relationships: {
             'target-profile-summaries': {

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -767,11 +767,13 @@ describe('Integration | Repository | training-repository', function () {
         userId,
         trainingId: training1.id,
         campaignParticipationId,
+        isRelevant: true,
       });
       databaseBuilder.factory.buildUserRecommendedTraining({
         userId,
         trainingId: training2.id,
         campaignParticipationId,
+        isRelevant: true,
       });
       databaseBuilder.factory.buildUserRecommendedTraining({
         userId,
@@ -793,8 +795,8 @@ describe('Integration | Repository | training-repository', function () {
       // then
       expect(userRecommendedTrainings).to.be.lengthOf(2);
       expect(userRecommendedTrainings).to.deep.equal([
-        new UserRecommendedTraining({ ...training1, duration: { hours: 6 } }),
-        new UserRecommendedTraining({ ...training2, duration: { hours: 6 } }),
+        new UserRecommendedTraining({ ...training1, duration: { hours: 6 }, isRelevant: true }),
+        new UserRecommendedTraining({ ...training2, duration: { hours: 6 }, isRelevant: true }),
       ]);
       expect(pagination).to.deep.equal({
         page: 1,

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -16,6 +16,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
         userId: databaseBuilder.factory.buildUser().id,
         trainingId: databaseBuilder.factory.buildTraining().id,
         campaignParticipationId: databaseBuilder.factory.buildCampaignParticipation().id,
+        isRelevant: true,
       };
       await databaseBuilder.commit();
 
@@ -30,7 +31,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
           campaignParticipationId: userRecommendedTraining.campaignParticipationId,
         })
         .first();
-      expect(_.omit(persistedUserRecommendedTraining, ['id', 'createdAt', 'updatedAt', 'isRelevant'])).to.deep.equal(
+      expect(_.omit(persistedUserRecommendedTraining, ['id', 'createdAt', 'updatedAt'])).to.deep.equal(
         userRecommendedTraining,
       );
     });

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -205,6 +205,32 @@ describe('Integration | Repository | user-recommended-training-repository', func
       );
     });
 
+    it('should not return recommended training for disabled training', async function () {
+      // given
+      const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+      const training = databaseBuilder.factory.buildTraining({ isDisabled: true });
+      const userRecommendedTraining1 = {
+        userId,
+        trainingId: training.id,
+        campaignParticipationId,
+        isRelevant: true,
+      };
+
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining1);
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRecommendedTrainingRepository.findByCampaignParticipationIdAndTrainingIdAndUserId({
+        campaignParticipationId,
+        trainingId: training.id,
+        userId,
+      });
+
+      // then
+      expect(result).to.be.null;
+    });
+
     describe('when recommended training does not exist for given campaignParticipationId, trainingId and userId', function () {
       it('should return null', async function () {
         // given

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -74,16 +74,19 @@ describe('Integration | Repository | user-recommended-training-repository', func
         userId,
         trainingId: training.id,
         campaignParticipationId,
+        isRelevant: true,
       };
       const userRecommendedTraining2 = {
         userId,
         trainingId: databaseBuilder.factory.buildTraining().id,
         campaignParticipationId,
+        isRelevant: false,
       };
       const userRecommendedTrainingWithAnotherLocale = {
         userId,
         trainingId: databaseBuilder.factory.buildTraining({ locales: ['en'] }).id,
         campaignParticipationId,
+        isRelevant: false,
       };
       const anotherCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
       const anotherUserRecommendedTraining = {
@@ -106,7 +109,9 @@ describe('Integration | Repository | user-recommended-training-repository', func
       // then
       expect(result).to.have.lengthOf(2);
       expect(result[0]).to.be.instanceOf(UserRecommendedTraining);
-      expect(result[0]).to.deep.equal(new UserRecommendedTraining({ ...training, duration: { hours: 6 } }));
+      expect(result[0]).to.deep.equal(
+        new UserRecommendedTraining({ ...training, duration: { hours: 6 }, isRelevant: true }),
+      );
     });
 
     it('should not return disabled recommended trainings for given campaignParticipationId and locale', async function () {
@@ -136,7 +141,9 @@ describe('Integration | Repository | user-recommended-training-repository', func
       // then
       expect(result).to.have.lengthOf(1);
       expect(result[0]).to.be.instanceOf(UserRecommendedTraining);
-      expect(result[0]).to.deep.equal(new UserRecommendedTraining({ ...training, duration: { hours: 6 } }));
+      expect(result[0]).to.deep.equal(
+        new UserRecommendedTraining({ ...training, duration: { hours: 6 }, isRelevant: null }),
+      );
     });
 
     it('should return an empty array when user has no recommended training for this campaignParticipation', async function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -160,6 +160,72 @@ describe('Integration | Repository | user-recommended-training-repository', func
       expect(result).to.have.lengthOf(0);
     });
   });
+  describe('#findByCampaignParticipationIdAndTrainingIdAndUserId', function () {
+    it('should return recommended training for given campaignParticipationId, trainingId and userId', async function () {
+      // given
+      const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+      const training = databaseBuilder.factory.buildTraining();
+      const userRecommendedTraining1 = {
+        userId,
+        trainingId: training.id,
+        campaignParticipationId,
+        isRelevant: true,
+      };
+      const userRecommendedTraining2 = {
+        userId,
+        trainingId: databaseBuilder.factory.buildTraining().id,
+        campaignParticipationId,
+        isRelevant: false,
+      };
+
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining1);
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining2);
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRecommendedTrainingRepository.findByCampaignParticipationIdAndTrainingIdAndUserId({
+        campaignParticipationId,
+        trainingId: training.id,
+        userId,
+      });
+
+      // then
+      expect(result).to.be.instanceOf(UserRecommendedTraining);
+      expect(result).to.deep.equal(
+        new UserRecommendedTraining({ ...training, duration: { hours: 6 }, isRelevant: true }),
+      );
+    });
+
+    describe('when recommended training does not exist for given campaignParticipationId, trainingId and userId', function () {
+      it('should return null', async function () {
+        // given
+        const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+        const training = databaseBuilder.factory.buildTraining();
+        const userRecommendedTraining1 = {
+          userId,
+          trainingId: training.id,
+          campaignParticipationId,
+          isRelevant: true,
+        };
+        databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining1);
+
+        const otherUserId = databaseBuilder.factory.buildUser().id;
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await userRecommendedTrainingRepository.findByCampaignParticipationIdAndTrainingIdAndUserId({
+          campaignParticipationId,
+          trainingId: training.id,
+          userId: otherUserId,
+        });
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+  });
 
   describe('#findModulesByCampaignParticipationIds', function () {
     it('should return saved recommended modules for given campaignParticipationId', async function () {

--- a/api/tests/devcomp/unit/domain/usecases/save-user-relevance-feedback-on-recommended-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/save-user-relevance-feedback-on-recommended-training_test.js
@@ -1,0 +1,71 @@
+import sinon from 'sinon';
+
+import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+describe('Integration | Devcomp | Domain | UseCases | saveUserRelevanceFeedbackOnRecommendedTraining', function () {
+  it('it returns NotFoundError when userRecommendedTraining does not exist', async function () {
+    // given
+    const params = {
+      userId: 'user123',
+      trainingId: 'training456',
+      campaignParticipationId: 'campaignParticipation789',
+    };
+
+    const dataToSave = {
+      ...params,
+      isRelevant: true,
+    };
+
+    const userRecommendedTrainingRepositoryStub = {
+      findByCampaignParticipationIdAndTrainingIdAndUserId: sinon.stub().resolves(null),
+    };
+
+    // when
+    const error = await catchErr(usecases.saveUserRelevanceFeedbackOnRecommendedTraining)({
+      ...dataToSave,
+      userRecommendedTrainingRepository: userRecommendedTrainingRepositoryStub,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(NotFoundError);
+  });
+
+  it('it returns userRecommendedTraing when it exists', async function () {
+    // given
+    const params = {
+      userId: 'user123',
+      trainingId: 'training456',
+      campaignParticipationId: 'campaignParticipation789',
+    };
+    const dataToSave = {
+      ...params,
+      isRelevant: true,
+    };
+
+    const userRecommendedTraining = Symbol('userRecommendedTraining');
+    const savedUserRecommendedTraining = Symbol('savedUserRecommendedTraining');
+
+    const userRecommendedTrainingRepositoryStub = {
+      findByCampaignParticipationIdAndTrainingIdAndUserId: sinon.stub().resolves(userRecommendedTraining),
+      save: sinon.stub().resolves(savedUserRecommendedTraining),
+    };
+
+    // when
+    const result = await usecases.saveUserRelevanceFeedbackOnRecommendedTraining({
+      ...dataToSave,
+      userRecommendedTrainingRepository: userRecommendedTrainingRepositoryStub,
+    });
+
+    // then
+    expect(result).to.deep.equal(savedUserRecommendedTraining);
+    expect(
+      userRecommendedTrainingRepositoryStub.findByCampaignParticipationIdAndTrainingIdAndUserId,
+    ).to.have.been.calledOnceWithExactly({ ...params });
+    expect(userRecommendedTrainingRepositoryStub.save).to.have.been.calledOnceWithExactly({
+      ...dataToSave,
+    });
+  });
+});

--- a/mon-pix/app/adapters/training.js
+++ b/mon-pix/app/adapters/training.js
@@ -9,4 +9,17 @@ export default class Training extends ApplicationAdapter {
     }
     return super.urlForQuery(query, ...args);
   }
+
+  updateRelevance({ campaignParticipationId, trainingId, isRelevant }) {
+    const url = `${this.host}/${this.namespace}/campaign-participations/${campaignParticipationId}/trainings/${trainingId}`;
+    return this.ajax(url, 'PATCH', {
+      data: {
+        data: {
+          attributes: {
+            'is-relevant': isRelevant,
+          },
+        },
+      },
+    });
+  }
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -19,6 +19,19 @@ export default class CardModal extends Component {
 
   @tracked isTrainingRecommendationRelevant = null;
 
+  constructor(...args) {
+    super(...args);
+    this.isTrainingRecommendationRelevant = this.args.training.isRelevant ?? null;
+  }
+
+  get isPositiveFeedback() {
+    return this.isTrainingRecommendationRelevant === true;
+  }
+
+  get isNegativeFeedback() {
+    return this.isTrainingRecommendationRelevant === false;
+  }
+
   @action
   async submitFeedback(feedbackResponse) {
     this.isTrainingRecommendationRelevant = feedbackResponse;
@@ -106,12 +119,14 @@ export default class CardModal extends Component {
                 @iconName="thumbUp"
                 @triggerAction={{fn this.submitFeedback true}}
                 @size="small"
+                class={{if this.isPositiveFeedback "selected"}}
               />
               <PixIconButton
                 @ariaLabel={{t "common.no"}}
                 @iconName="dislike"
                 @triggerAction={{fn this.submitFeedback false}}
                 @size="small"
+                class={{if this.isNegativeFeedback "selected"}}
               />
             </fieldset>
           </form>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -6,6 +6,7 @@ import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -14,12 +15,20 @@ import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 import RegistrationCardTag from './registration-card-tag';
 
 export default class CardModal extends Component {
+  @service store;
+
   @tracked isTrainingRecommendationRelevant = null;
 
   @action
-  submitFeedback(feedbackResponse) {
+  async submitFeedback(feedbackResponse) {
     this.isTrainingRecommendationRelevant = feedbackResponse;
-    //TODO call API to submit feedback
+    const campaignParticipationId = this.args.training.belongsTo('campaignParticipation').id();
+    const adapter = this.store.adapterFor('training');
+    await adapter.updateRelevance({
+      campaignParticipationId,
+      trainingId: this.args.training.id,
+      isRelevant: feedbackResponse,
+    });
   }
 
   <template>

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -18,6 +18,7 @@ export default class Training extends Model {
   @attr('string') program;
   @attr('boolean') registrationRequired;
   @attr('string') description;
+  @attr('boolean') isRelevant;
 
   @belongsTo('campaign-participation', { async: true, inverse: 'trainings' }) campaignParticipation;
 

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -18,7 +18,7 @@ export default class Training extends Model {
   @attr('string') program;
   @attr('boolean') registrationRequired;
   @attr('string') description;
-  @attr('boolean') isRelevant;
+  @attr('boolean', { allowNull: true }) isRelevant;
 
   @belongsTo('campaign-participation', { async: true, inverse: 'trainings' }) campaignParticipation;
 

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -20,7 +20,7 @@
     display: flex;
     gap: var(--pix-spacing-8x);
     margin-top: var(--pix-spacing-4x);
-    padding : 3px 5px 7px;
+    padding: 3px 5px 7px;
     overflow-y: auto;
     scrollbar-width: none;
     scroll-behavior: smooth;
@@ -28,28 +28,28 @@
 }
 
 .results-recommendation-engine-training-card {
-    @extend %pix-shadow-default;
+  @extend %pix-shadow-default;
 
-    display: flex;
-    flex-direction: column;
-    gap: var(--pix-spacing-4x);
-    justify-content: space-between;
-    width: 329px;
-    height: 315px;
-    padding: var(--pix-spacing-3x);
-    padding-bottom: var(--pix-spacing-6x);
-    background-color: var(--pix-neutral-0);
-    border-radius: 16px 0 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+  justify-content: space-between;
+  width: 329px;
+  height: 315px;
+  padding: var(--pix-spacing-3x);
+  padding-bottom: var(--pix-spacing-6x);
+  background-color: var(--pix-neutral-0);
+  border-radius: 16px 0 16px 16px;
 
   @include breakpoints.device-is('mobile') {
     min-width: 280px;
   }
 
-    &__tag {
-      @extend %pix-body-xs;
+  &__tag {
+    @extend %pix-body-xs;
 
-      width: fit-content;
-    }
+    width: fit-content;
+  }
 
   &__tag-icon {
     width: 1rem;
@@ -218,6 +218,13 @@
     gap: var(--pix-spacing-2x);
     align-items: center;
 
+    .selected {
+      color: var(--pix-neutral-0);
+      background-color: var(--pix-neutral-800);
+      outline: 1px solid var(--pix-neutral-0);
+      outline-offset: -3px;
+    }
+
     legend {
       @extend %pix-body-m;
 
@@ -228,6 +235,7 @@
   &__action-buttons {
     display: flex;
     gap: var(--pix-spacing-2x);
+    align-items: center;
     justify-content: flex-end;
 
     @include breakpoints.device-is('mobile') {

--- a/mon-pix/mirage/routes/campaign-participations/index.js
+++ b/mon-pix/mirage/routes/campaign-participations/index.js
@@ -1,5 +1,6 @@
 import getCampaignParticipationTrainings from './get-campaign-participation-trainings';
 import postCampaignParticipation from './post-campaign-participation';
+import saveTrainingRelevance from './save-training-relevance';
 import shareCampaignParticipation from './share-campaign-participation';
 
 export default function index(config) {
@@ -8,4 +9,6 @@ export default function index(config) {
   config.patch('/campaign-participations/:id', shareCampaignParticipation);
 
   config.get('/campaign-participations/:id/trainings', getCampaignParticipationTrainings);
+
+  config.patch('/campaign-participations/:id/trainings/:trainingId', saveTrainingRelevance);
 }

--- a/mon-pix/mirage/routes/campaign-participations/save-training-relevance.js
+++ b/mon-pix/mirage/routes/campaign-participations/save-training-relevance.js
@@ -1,0 +1,8 @@
+export default function (schema, request) {
+  const trainingId = request.params.trainingId;
+  const requestBody = JSON.parse(request.requestBody);
+  const isRelevant = requestBody.data.attributes['is-relevant'];
+  const training = schema.trainings.find(trainingId);
+  training.update({ isRelevant });
+  return training;
+}

--- a/mon-pix/mirage/serializers/campaign-participation.js
+++ b/mon-pix/mirage/serializers/campaign-participation.js
@@ -8,6 +8,9 @@ export default ApplicationSerializer.extend({
       assessment: {
         related: `/api/assessments/${campaignParticipation.assessmentId}`,
       },
+      trainings: {
+        related: `/api/campaign-participations/${campaignParticipation.id}/trainings`,
+      },
     };
   },
 });

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -95,6 +95,9 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         const modal = await screen.findByRole('dialog');
 
         // when
+        assert.dom(within(modal).getByRole('button', { name: t('common.no') })).doesNotHaveClass('selected');
+        assert.dom(within(modal).getByRole('button', { name: t('common.yes') })).doesNotHaveClass('selected');
+
         const thumbsUpButton = within(modal).getByRole('button', { name: t('common.yes') });
         const thumbsDownButton = within(modal).getByRole('button', { name: t('common.no') });
         assert.dom(thumbsUpButton).doesNotHaveClass('selected');

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -1,7 +1,8 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -63,6 +64,55 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
 
       // then
       assert.dom('.evaluation-results:not(.evaluation-results-recommendation-engine)').doesNotExist();
+    });
+
+    module('when campaign has trainings', function (hooks) {
+      hooks.beforeEach(function () {
+        server.create('training', {
+          campaignParticipation,
+          title: 'Formation test',
+          link: 'https://example.net/',
+          type: 'webinaire',
+          duration: { hours: 2, days: 1, minutes: 0 },
+          deliveryMode: 'remote',
+          editorName: 'Éditeur test',
+          editorLogoUrl: 'https://example.net/logo.svg',
+          objectives: ['Objectif 1'],
+          program: 'Programme test',
+          description: 'Description test',
+          registrationRequired: false,
+          isRelevant: null,
+        });
+      });
+
+      test('in the card modal, saves the user feedback when thumb is clicked', async function (assert) {
+        // given
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const trainingCardButton = screen.getByRole('button', {
+          name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
+        });
+        await click(trainingCardButton);
+        const modal = await screen.findByRole('dialog');
+
+        // when
+        const thumbsUpButton = within(modal).getByRole('button', { name: t('common.yes') });
+        const thumbsDownButton = within(modal).getByRole('button', { name: t('common.no') });
+        assert.dom(thumbsUpButton).doesNotHaveClass('selected');
+        assert.dom(thumbsDownButton).doesNotHaveClass('selected');
+
+        // then
+        await click(thumbsDownButton);
+        assert.dom(thumbsUpButton).doesNotHaveClass('selected');
+        assert.dom(thumbsDownButton).hasClass('selected');
+
+        const actionButtons = within(modal).getByRole('list');
+        await click(within(actionButtons).getByRole('button', { name: t('common.actions.close') }));
+        await click(trainingCardButton);
+
+        const reopenedModal = await screen.findByRole('dialog');
+        assert.dom(within(reopenedModal).getByRole('button', { name: t('common.yes') })).doesNotHaveClass('selected');
+        assert.dom(within(reopenedModal).getByRole('button', { name: t('common.no') })).hasClass('selected');
+      });
     });
 
     module('when device is mobile', function () {

--- a/mon-pix/tests/unit/adapters/training-test.js
+++ b/mon-pix/tests/unit/adapters/training-test.js
@@ -37,4 +37,33 @@ module('Unit | Adapters | Training', function (hooks) {
       assert.true(url.endsWith('/api/trainings'));
     });
   });
+
+  module('#updateRelevance', function (hooks) {
+    let adapter;
+
+    hooks.beforeEach(function () {
+      adapter = this.owner.lookup('adapter:training');
+      adapter.ajax = sinon.stub().resolves();
+    });
+
+    test('should call PATCH on the correct url with the right payload', async function (assert) {
+      // given
+      const campaignParticipationId = 1;
+      const trainingId = 2;
+
+      // when
+      await adapter.updateRelevance({
+        campaignParticipationId,
+        trainingId,
+        isRelevant: true,
+      });
+
+      // then
+      assert.ok(
+        adapter.ajax.calledWith(sinon.match('/api/campaign-participations/1/trainings/2'), 'PATCH', {
+          data: { data: { attributes: { 'is-relevant': true } } },
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## 💥 Problème
Actuellement, il n'est pas possible de donner un avis sur la pertinence de la recommandation d'un contenu formatif. 

## 👩‍🚀 Proposition
Créer une route api qui permette de récupérer la valeur `isRelevant` d'un `userRecommendedTraining`
Créer une route PATCH qui permette de créer / mettre à jour `isRelevant`
Faire le branchement côté front pour que les pouces permettent de mettre à jour la pertinence du contenu formatif

## 👁️ Remarques
Le style appliqué pour le pouce est temporaire en attendant d'avoir le bon côté pix ui.
J'ai fait un test seul test d'acceptance pour tester aussi le branchement avec un appel du store, mais cela aurait aussi pu être fait en intégration avec un stub

## ♻️ Pour tester
- Aller sur la page de fin de parcours [EVAL12345](https://app-pr16382.review.pix.fr/campagnes/EVAL12345/) avec dave-comp@example.net
- Ouvrir la modale
- Clicker sur un pouce "up"
- actualiser la page
- constater que le pouce a bien été enregistré et que c'est toujorus le bon qui est séléectionné
- Ferme la même chose avec un pouce "down"
