### PR TITLE
[FEATURE] Éviter le rescoring lors du dérejet et désannulation (PIX-21378).

### DIFF
--- a/api/src/certification/session-management/domain/usecases/uncancel.js
+++ b/api/src/certification/session-management/domain/usecases/uncancel.js
@@ -1,44 +1,22 @@
 /**
- * @typedef {import('./index.js').CertificationCourseRepository} CertificationCourseRepository
- * @typedef {import('./index.js').CertificationEvaluationRepository} CertificationEvaluationRepository
- * @typedef {import('./index.js').SessionRepository} SessionRepository
+ * @typedef {import('./index.js').AssessmentResultRepository} AssessmentResultRepository
  */
-
-import { NotFinalizedSessionError } from '../../../../shared/domain/errors.js';
-import CertificationUncancelled from '../../../../shared/domain/events/CertificationUncancelled.js';
-import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 
 /**
  * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {number} params.juryId
- * @param {CertificationCourseRepository} params.certificationCourseRepository
- * @param {CertificationEvaluationRepository} params.certificationEvaluationRepository
- * @param {SessionManagementRepository} params.sessionManagementRepository
+ * @param {AssessmentResultRepository} params.assessmentResultRepository
  */
-export const uncancel = async function ({
-  certificationCourseId,
-  juryId,
-  certificationCourseRepository,
-  certificationEvaluationRepository,
-  sessionManagementRepository,
-}) {
-  const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
-  const isSessionFinalized = await sessionManagementRepository.isFinalized({ id: certificationCourse.getSessionId() });
-  if (!isSessionFinalized) {
-    throw new NotFinalizedSessionError();
-  }
-
-  const event = new CertificationUncancelled({
-    certificationCourseId: certificationCourse.getId(),
-    juryId,
+export const uncancel = async function ({ certificationCourseId, juryId, assessmentResultRepository }) {
+  const assessmentResult = await assessmentResultRepository.getByCertificationCourseId({
+    certificationCourseId,
   });
+  const newAssessmentResult = assessmentResult.clone();
+  newAssessmentResult.uncancel({ juryId });
 
-  if (AlgorithmEngineVersion.isV3(certificationCourse.getVersion())) {
-    return certificationEvaluationRepository.rescoreV3Certification({ event });
-  }
-
-  if (AlgorithmEngineVersion.isV2(certificationCourse.getVersion())) {
-    return certificationEvaluationRepository.rescoreV2Certification({ event });
-  }
+  await assessmentResultRepository.save({
+    certificationCourseId,
+    assessmentResult: newAssessmentResult,
+  });
 };

--- a/api/src/certification/session-management/domain/usecases/unreject-certification-course.js
+++ b/api/src/certification/session-management/domain/usecases/unreject-certification-course.js
@@ -1,23 +1,19 @@
-import { CertificationCourseUnrejected } from '../../../../shared/domain/events/CertificationCourseUnrejected.js';
-import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
-
 export const unrejectCertificationCourse = async ({
   certificationCourseId,
   juryId,
   certificationCourseRepository,
-  certificationEvaluationRepository,
+  assessmentResultRepository,
 }) => {
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
   certificationCourse.unrejectForFraud();
   await certificationCourseRepository.update({ certificationCourse });
 
-  const event = new CertificationCourseUnrejected({ certificationCourseId, juryId });
+  const assessmentResult = await assessmentResultRepository.getByCertificationCourseId({ certificationCourseId });
+  const newAssessmentResult = assessmentResult.clone();
+  newAssessmentResult.unreject({ juryId });
 
-  if (AlgorithmEngineVersion.isV3(certificationCourse.getVersion())) {
-    return certificationEvaluationRepository.rescoreV3Certification({ event });
-  }
-
-  if (AlgorithmEngineVersion.isV2(certificationCourse.getVersion())) {
-    return certificationEvaluationRepository.rescoreV2Certification({ event });
-  }
+  await assessmentResultRepository.save({
+    certificationCourseId,
+    assessmentResult: newAssessmentResult,
+  });
 };

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -56,6 +56,12 @@ class AssessmentResultNotRejectedError extends DomainError {
   }
 }
 
+class AssessmentResultIsNotCancelledError extends DomainError {
+  constructor(message = "La certification ne peut être désannulée car son statut n'est pas annulé.") {
+    super(message);
+  }
+}
+
 class AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError extends DomainError {
   constructor() {
     super('Autonomous course requires a target profile with simplified access.');
@@ -1074,6 +1080,7 @@ export {
   AssessmentEndedError,
   AssessmentLackOfChallengesError,
   AssessmentNotCompletedError,
+  AssessmentResultIsNotCancelledError,
   AssessmentResultNotCreatedError,
   AssessmentResultNotRejectedError,
   AuditLoggerApiError,

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -50,6 +50,12 @@ class AssessmentResultNotCreatedError extends DomainError {
   }
 }
 
+class AssessmentResultNotRejectedError extends DomainError {
+  constructor(message = "L'assessment result ne peut être unrejected car son statut n'est pas rejected.") {
+    super(message);
+  }
+}
+
 class AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError extends DomainError {
   constructor() {
     super('Autonomous course requires a target profile with simplified access.');
@@ -1069,6 +1075,7 @@ export {
   AssessmentLackOfChallengesError,
   AssessmentNotCompletedError,
   AssessmentResultNotCreatedError,
+  AssessmentResultNotRejectedError,
   AuditLoggerApiError,
   AuthenticationMethodAlreadyExistsError,
   AuthenticationMethodNotFoundError,

--- a/api/src/shared/domain/models/AssessmentResult.js
+++ b/api/src/shared/domain/models/AssessmentResult.js
@@ -2,7 +2,11 @@
  * @typedef {import('../../../certification/shared/domain/models/CompetenceMark.js').CompetenceMark} CompetenceMark
  * @typedef {import('../../../certification/shared/domain/models/JuryComment.js').JuryComment} JuryComment
  */
-import { AssessmentResultNotRejectedError, NotFinalizedSessionError } from '../errors.js';
+import {
+  AssessmentResultIsNotCancelledError,
+  AssessmentResultNotRejectedError,
+  NotFinalizedSessionError,
+} from '../errors.js';
 import { Assessment } from './Assessment.js';
 
 /**
@@ -114,6 +118,14 @@ class AssessmentResult {
       throw new NotFinalizedSessionError();
     }
     this.status = AssessmentResult.status.CANCELLED;
+  }
+
+  uncancel({ juryId }) {
+    if (this.status !== AssessmentResult.status.CANCELLED) {
+      throw new AssessmentResultIsNotCancelledError();
+    }
+    this.status = AssessmentResult.status.VALIDATED;
+    this.juryId = juryId;
   }
 }
 

--- a/api/src/shared/domain/models/AssessmentResult.js
+++ b/api/src/shared/domain/models/AssessmentResult.js
@@ -2,7 +2,7 @@
  * @typedef {import('../../../certification/shared/domain/models/CompetenceMark.js').CompetenceMark} CompetenceMark
  * @typedef {import('../../../certification/shared/domain/models/JuryComment.js').JuryComment} JuryComment
  */
-import { NotFinalizedSessionError } from '../errors.js';
+import { AssessmentResultNotRejectedError, NotFinalizedSessionError } from '../errors.js';
 import { Assessment } from './Assessment.js';
 
 /**
@@ -99,6 +99,14 @@ class AssessmentResult {
 
   reject() {
     this.status = AssessmentResult.status.REJECTED;
+  }
+
+  unreject({ juryId }) {
+    if (this.status !== AssessmentResult.status.REJECTED) {
+      throw new AssessmentResultNotRejectedError();
+    }
+    this.status = AssessmentResult.status.VALIDATED;
+    this.juryId = juryId;
   }
 
   cancel() {

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -1,399 +1,141 @@
 import { createServer } from '../../../../../server.js';
-import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { PIX_ADMIN } from '../../../../../src/shared/domain/constants.js';
-import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
-import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
-import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
-describe('Certification | Session-management | Acceptance | Application | Routes | cancellation', function () {
-  let server;
-  const challengeId = 'k_challenge_id';
-
-  beforeEach(async function () {
-    server = await createServer();
-
-    const learningContent = [
-      {
-        id: '1. Information et données',
-        competences: [
-          {
-            id: 'index Compétence A',
-            tubes: [
-              {
-                id: 'recTube1',
-                skills: [
-                  {
-                    id: 'recSkill0_0',
-                    nom: '@recSkill0_0',
-                    challenges: [{ id: challengeId }],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-        courses: [
-          {
-            id: 'rec_active_course_id',
-            name: "A la recherche de l'information #01",
-            description: "Mener une recherche et une veille d'information",
-            isActive: true,
-            competenceId: 'index Compétence A',
-            challengeIds: [challengeId],
-          },
-        ],
-      },
-    ];
-
-    const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    databaseBuilder.factory.learningContent.build(learningContentObjects);
-    await databaseBuilder.commit();
-  });
-
+describe('Certification | Session Management | Acceptance | Application | Routes | Cancellation', function () {
   describe('PATCH /api/admin/certification-courses/{certificationCourseId}/cancel', function () {
-    context('when certification is v2', function () {
-      it('should create a new cancelled assessment-result', async function () {
-        // given
-        const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
-        const session = databaseBuilder.factory.buildSession({
-          version: AlgorithmEngineVersion.V2,
-          finalizedAt: new Date('2024-01-15'),
-        });
-        const userId = databaseBuilder.factory.buildUser().id;
-        const candidate = databaseBuilder.factory.buildCertificationCandidate({
-          userId,
-          reconciledAt: new Date('2024-01-15'),
-          sessionId: session.id,
-        });
-        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
-          id: 123,
-          userId,
-          version: AlgorithmEngineVersion.V2,
-          sessionId: session.id,
-          candidateId: candidate.id,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
-        const assessment = databaseBuilder.factory.buildAssessment({
-          id: 456,
-          type: Assessment.types.CERTIFICATION,
-          userId: certificationCourse.userId,
-          certificationCourseId: certificationCourse.id,
-        });
-        databaseBuilder.factory.buildCertificationChallenge({
-          courseId: certificationCourse.id,
-          challengeId,
-        });
-        const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
-          assessmentId: assessment.id,
-        });
-        databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-          certificationCourseId: certificationCourse.id,
-          lastAssessmentResultId: assessmentResult.id,
-        });
-        databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResult.id });
-        const certificationChallengeOk = databaseBuilder.factory.buildCertificationChallenge({
-          courseId: certificationCourse.id,
-          isNeutralized: false,
-          challengeId,
-          competenceId: 'index Compétence A',
-          associatedSkillName: '@recSkill0_0',
-          associatedSkillId: 'recSkill0_0',
-        });
-        const answerId = databaseBuilder.factory.buildAnswer({
-          assessmentId: assessment.id,
-          challengeId: certificationChallengeOk.challengeId,
-          result: AnswerStatus.OK.status,
-        }).id;
-
-        databaseBuilder.factory.buildKnowledgeElement({
-          assessmentId: assessment.id,
-          answerId,
-          skillId: 'recSkill0_0',
-          competenceId: 'index Compétence A',
-          userId: certificationCourse.userId,
-          earnedPix: 16,
-        });
-
-        const options = {
-          method: 'PATCH',
-          url: '/api/admin/certification-courses/123/cancel',
-          headers: generateAuthenticatedUserRequestHeaders({ userId: juryMember.id }),
-        };
-        await databaseBuilder.commit();
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(204);
-        const cancelledAssessmentResult = await knex('assessment-results')
-          .where({
-            assessmentId: assessment.id,
-            status: AssessmentResult.status.CANCELLED,
-            juryId: juryMember.id,
-          })
-          .first();
-        expect(cancelledAssessmentResult).not.to.be.undefined;
-        expect(
-          await knex('certification-courses-last-assessment-results').where({
-            lastAssessmentResultId: cancelledAssessmentResult.id,
-            certificationCourseId: certificationCourse.id,
-          }),
-        ).not.to.be.null;
-        const competenceMarks = await knex('competence-marks').where({
-          assessmentResultId: cancelledAssessmentResult.id,
-        });
-        expect(competenceMarks).to.have.lengthOf(1);
-        expect(response.statusCode).to.equal(204);
-      });
-    });
-
-    context('when certification is v3', function () {
-      it('should create a new cancelled assessment-result', async function () {
-        // given
-        const versionId = databaseBuilder.factory.buildCertificationVersion({
-          startDate: new Date('2024-01-14'),
-          competencesScoringConfiguration: [
-            {
-              competence: 'index Compétence A',
-              values: [
-                {
-                  bounds: {
-                    max: 0,
-                    min: -5,
-                  },
-                  competenceLevel: 0,
-                },
-                {
-                  bounds: {
-                    max: 5,
-                    min: 0,
-                  },
-                  competenceLevel: 1,
-                },
-              ],
-            },
-          ],
-        }).id;
-        const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
-        const session = databaseBuilder.factory.buildSession({
-          version: AlgorithmEngineVersion.V3,
-          finalizedAt: new Date('2024-01-15'),
-        });
-        const userId = databaseBuilder.factory.buildUser().id;
-        const candidateId = databaseBuilder.factory.buildCertificationCandidate({
-          userId,
-          reconciledAt: new Date('2024-01-15'),
-          sessionId: session.id,
-          finalizedAt: new Date('2024-01-15'),
-        }).id;
-        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
-          id: 123,
-          userId,
-          version: AlgorithmEngineVersion.V3,
-          sessionId: session.id,
-          createdAt: new Date('2024-01-15'),
-          abortReason: 'technical',
-          candidateId,
-          versionId,
-        });
-        const assessment = databaseBuilder.factory.buildAssessment({
-          id: 456,
-          type: Assessment.types.CERTIFICATION,
-          userId: certificationCourse.userId,
-          certificationCourseId: certificationCourse.id,
-        });
-        databaseBuilder.factory.buildCertificationChallenge({
-          courseId: certificationCourse.id,
-          challengeId,
-        });
-        const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
-          assessmentId: assessment.id,
-        });
-        databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-          certificationCourseId: certificationCourse.id,
-          lastAssessmentResultId: assessmentResult.id,
-        });
-        databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResult.id });
-        const certificationChallengeOk = databaseBuilder.factory.buildCertificationChallenge({
-          courseId: certificationCourse.id,
-          isNeutralized: false,
-          challengeId,
-          competenceId: 'index Compétence A',
-          associatedSkillName: '@recSkill0_0',
-          associatedSkillId: 'recSkill0_0',
-        });
-        const answerId = databaseBuilder.factory.buildAnswer({
-          assessmentId: assessment.id,
-          challengeId: certificationChallengeOk.challengeId,
-          result: AnswerStatus.OK.status,
-        }).id;
-
-        databaseBuilder.factory.buildKnowledgeElement({
-          assessmentId: assessment.id,
-          answerId,
-          skillId: 'recSkill0_0',
-          competenceId: 'index Compétence A',
-          userId: certificationCourse.userId,
-          earnedPix: 16,
-        });
-
-        const options = {
-          method: 'PATCH',
-          url: '/api/admin/certification-courses/123/cancel',
-          headers: generateAuthenticatedUserRequestHeaders({ userId: juryMember.id }),
-        };
-        await databaseBuilder.commit();
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        const cancelledAssessmentResult = await knex('assessment-results')
-          .where({
-            assessmentId: assessment.id,
-            status: AssessmentResult.status.CANCELLED,
-            juryId: juryMember.id,
-          })
-          .first();
-
-        expect(response.statusCode).to.equal(204);
-        expect(cancelledAssessmentResult).not.to.be.undefined;
-        expect(
-          await knex('certification-courses-last-assessment-results').where({
-            lastAssessmentResultId: cancelledAssessmentResult.id,
-            certificationCourseId: certificationCourse.id,
-          }),
-        ).not.to.be.null;
-        const competenceMarks = await knex('competence-marks').where({
-          assessmentResultId: cancelledAssessmentResult.id,
-        });
-        expect(competenceMarks).to.have.lengthOf(0);
-      });
-    });
-  });
-
-  describe('PATCH /api/admin/certification-courses/{certificationCourseId}/uncancel', function () {
-    it('should uncancel the certification with a new assessment-result', async function () {
+    it('should create a new cancelled AssessmentResult', async function () {
       // given
+      const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
       const versionId = databaseBuilder.factory.buildCertificationVersion({
-        startDate: new Date('2024-01-14'),
-        challengesConfiguration: {
-          maximumAssessmentLength: 1,
-        },
-        competencesScoringConfiguration: [
-          {
-            competence: 'index Compétence A',
-            values: [
-              {
-                bounds: {
-                  max: 0,
-                  min: -5,
-                },
-                competenceLevel: 0,
-              },
-              {
-                bounds: {
-                  max: 5,
-                  min: 0,
-                },
-                competenceLevel: 1,
-              },
-            ],
-          },
-        ],
         minimumAnswersRequiredToValidateACertification: 1,
       }).id;
-      const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
       const session = databaseBuilder.factory.buildSession({
-        version: AlgorithmEngineVersion.V3,
-        finalizedAt: new Date('2024-01-15'),
+        finalizedAt: new Date(),
       });
-      const userId = databaseBuilder.factory.buildUser().id;
+
       const candidateId = databaseBuilder.factory.buildCertificationCandidate({
-        userId,
-        reconciledAt: new Date('2024-01-15'),
         sessionId: session.id,
-        finalizedAt: new Date('2024-01-15'),
+        userId,
+        reconciledAt: new Date('2020-01-01'),
       }).id;
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
-        id: 123,
-        userId,
-        version: AlgorithmEngineVersion.V3,
         sessionId: session.id,
-        createdAt: new Date('2024-01-15'),
-        abortReason: 'candidate',
+        userId,
         candidateId,
         versionId,
       });
+
       const assessment = databaseBuilder.factory.buildAssessment({
-        id: 456,
-        type: Assessment.types.CERTIFICATION,
-        userId: certificationCourse.userId,
+        type: 'CERTIFICATION',
+        userId,
         certificationCourseId: certificationCourse.id,
       });
-      databaseBuilder.factory.buildCertificationChallenge({
-        courseId: certificationCourse.id,
-        challengeId,
-      });
       const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+        status: AssessmentResult.status.VALIDATED,
         assessmentId: assessment.id,
-        status: AssessmentResult.status.CANCELLED,
+        certificationCourseId: certificationCourse.id,
       });
       databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
         certificationCourseId: certificationCourse.id,
         lastAssessmentResultId: assessmentResult.id,
       });
-      databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResult.id });
-      const certificationChallengeOk = databaseBuilder.factory.buildCertificationChallenge({
-        courseId: certificationCourse.id,
-        isNeutralized: false,
-        challengeId,
-        competenceId: 'index Compétence A',
-        associatedSkillName: '@recSkill0_0',
-        associatedSkillId: 'recSkill0_0',
-      });
-      databaseBuilder.factory.buildAnswer({
-        assessmentId: assessment.id,
-        challengeId: certificationChallengeOk.challengeId,
-        result: AnswerStatus.OK.status,
-      });
 
-      const options = {
-        method: 'PATCH',
-        url: '/api/admin/certification-courses/123/uncancel',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: juryMember.id }),
-      };
       await databaseBuilder.commit();
 
+      const server = await createServer();
+
       // when
-      const response = await server.inject(options);
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/admin/certification-courses/${certificationCourse.id}/cancel`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      });
 
       // then
-      const rejectedAssessmentResult = await knex('assessment-results')
-        .where({
-          assessmentId: assessment.id,
-          status: AssessmentResult.status.VALIDATED,
-          juryId: juryMember.id,
-        })
-        .first();
-
       expect(response.statusCode).to.equal(204);
-      expect(rejectedAssessmentResult).not.to.be.undefined;
-      expect(
-        await knex('certification-courses-last-assessment-results').where({
-          lastAssessmentResultId: rejectedAssessmentResult.id,
-          certificationCourseId: certificationCourse.id,
-        }),
-      ).not.to.be.null;
-      const competenceMarks = await knex('competence-marks').where({
-        assessmentResultId: rejectedAssessmentResult.id,
+      const assessmentResults = await knex('assessment-results')
+        .where({ assessmentId: assessment.id })
+        .orderBy('createdAt');
+
+      expect(assessmentResults).to.have.lengthOf(2);
+      expect(assessmentResults[0].id).to.equal(assessmentResult.id);
+      expect(assessmentResults[1].status).to.equal(AssessmentResult.status.CANCELLED);
+
+      const lastAssessmentResult = await knex('certification-courses-last-assessment-results').first();
+
+      expect(lastAssessmentResult).to.deep.equal({
+        certificationCourseId: certificationCourse.id,
+        lastAssessmentResultId: assessmentResults[1].id,
       });
-      expect(competenceMarks).to.have.lengthOf(1);
+    });
+  });
+
+  describe('PATCH /api/admin/certification-courses/{certificationCourseId}/uncancel', function () {
+    it('should create a new uncancelled AssessmentResult', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
+      const versionId = databaseBuilder.factory.buildCertificationVersion({
+        minimumAnswersRequiredToValidateACertification: 1,
+      }).id;
+      const session = databaseBuilder.factory.buildSession();
+
+      const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+        sessionId: session.id,
+        userId,
+        reconciledAt: new Date('2020-01-01'),
+      }).id;
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        sessionId: session.id,
+        userId,
+        candidateId,
+        versionId,
+      });
+
+      const assessment = databaseBuilder.factory.buildAssessment({
+        type: 'CERTIFICATION',
+        userId,
+        certificationCourseId: certificationCourse.id,
+      });
+      const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+        status: AssessmentResult.status.CANCELLED,
+        assessmentId: assessment.id,
+        certificationCourseId: certificationCourse.id,
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourse.id,
+        lastAssessmentResultId: assessmentResult.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/admin/certification-courses/${certificationCourse.id}/uncancel`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      });
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      const assessmentResults = await knex('assessment-results')
+        .where({ assessmentId: assessment.id })
+        .orderBy('createdAt');
+
+      expect(assessmentResults).to.have.lengthOf(2);
+      expect(assessmentResults[0].id).to.equal(assessmentResult.id);
+      expect(assessmentResults[1].status).to.equal(AssessmentResult.status.VALIDATED);
+
+      const lastAssessmentResult = await knex('certification-courses-last-assessment-results').first();
+
+      expect(lastAssessmentResult).to.deep.equal({
+        certificationCourseId: certificationCourse.id,
+        lastAssessmentResultId: assessmentResults[1].id,
+      });
     });
   });
 });

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -3,6 +3,7 @@ import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../src/certification/s
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
@@ -292,11 +293,18 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         versionId,
       });
 
-      const { assessment, assessmentResult } = await createSuccessfulCertificationCourse({
-        candidateId,
+      const assessment = databaseBuilder.factory.buildAssessment({
+        type: 'CERTIFICATION',
         userId,
-        certificationCourse,
+        certificationCourseId: certificationCourse.id,
       });
+      const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+        status: AssessmentResult.status.REJECTED,
+        assessmentId: assessment.id,
+        certificationCourseId: certificationCourse.id,
+      });
+
+      await databaseBuilder.commit();
 
       const server = await createServer();
 
@@ -426,6 +434,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         candidateId,
         versionId,
       });
+
       ({ certificationChallenges, assessmentResult } = await createSuccessfulCertificationCourse({
         candidateId,
         userId: superAdmin.id,

--- a/api/tests/certification/session-management/unit/domain/usecases/uncancel_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/uncancel_test.js
@@ -1,170 +1,45 @@
 import sinon from 'sinon';
 
 import { uncancel } from '../../../../../../src/certification/session-management/domain/usecases/uncancel.js';
-import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { NotFinalizedSessionError } from '../../../../../../src/shared/domain/errors.js';
-import CertificationUncancelled from '../../../../../../src/shared/domain/events/CertificationUncancelled.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Session-management | Unit | Domain | UseCases | uncancel', function () {
-  describe('when certification is a V2', function () {
-    it('should uncancel the certification', async function () {
+  describe('when certification is cancelled', function () {
+    it('should uncancel the certification without re-scoring', async function () {
       // given
+      const assessmentResultRepository = {
+        getByCertificationCourseId: sinon.stub(),
+        save: sinon.stub(),
+      };
       const juryId = 123;
-      const session = domainBuilder.certification.sessionManagement.buildSessionManagement({
-        finalizedAt: new Date('2020-01-01'),
-        version: AlgorithmEngineVersion.V2,
+
+      const dependencies = { assessmentResultRepository };
+
+      const canceledAssessmentResult = domainBuilder.buildAssessmentResult({
+        status: AssessmentResult.status.CANCELLED,
+        juryId: 456,
       });
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        id: 123,
-        sessionId: session.id,
-        version: AlgorithmEngineVersion.V2,
-      });
-      const certificationCourseRepository = {
-        get: sinon.stub(),
-      };
-      const certificationEvaluationRepository = {
-        rescoreV2Certification: sinon.stub(),
-      };
-      const sessionManagementRepository = {
-        isFinalized: sinon.stub(),
-      };
-      certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-      certificationEvaluationRepository.rescoreV2Certification.resolves();
-      sessionManagementRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(true);
+      assessmentResultRepository.getByCertificationCourseId.resolves(canceledAssessmentResult);
 
       // when
       await uncancel({
+        ...dependencies,
         certificationCourseId: 123,
         juryId,
-        certificationCourseRepository,
-        certificationEvaluationRepository,
-        sessionManagementRepository,
       });
 
       // then
-      expect(certificationEvaluationRepository.rescoreV2Certification).to.have.been.calledWithExactly({
-        event: new CertificationUncancelled({
-          certificationCourseId: certificationCourse.getId(),
-          juryId,
-        }),
-      });
-    });
-
-    describe('when session is not finalized', function () {
-      it('should not uncancel the certification', async function () {
-        // given
-        const juryId = 123;
-        const session = domainBuilder.certification.sessionManagement.buildSessionManagement({
-          finalizedAt: null,
-          version: AlgorithmEngineVersion.V2,
-        });
-        const certificationCourse = domainBuilder.buildCertificationCourse({
-          id: 123,
-          sessionId: session.id,
-          version: AlgorithmEngineVersion.V2,
-        });
-        const certificationCourseRepository = {
-          get: sinon.stub(),
-        };
-        const sessionManagementRepository = {
-          isFinalized: sinon.stub(),
-        };
-        certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-        sessionManagementRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(false);
-
-        // when
-        const error = await catchErr(uncancel)({
-          juryId,
-          certificationCourseId: 123,
-          certificationCourseRepository,
-          sessionManagementRepository,
-        });
-
-        // then
-        expect(error).to.be.instanceOf(NotFinalizedSessionError);
-      });
-    });
-  });
-
-  describe('when certification is a V3', function () {
-    it('should uncancel the certification', async function () {
-      // given
-      const juryId = 123;
-      const session = domainBuilder.certification.sessionManagement.buildSessionManagement({
-        finalizedAt: new Date('2020-01-01'),
-        version: AlgorithmEngineVersion.V3,
-      });
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        id: 123,
-        sessionId: session.id,
-        version: AlgorithmEngineVersion.V3,
-      });
-      const certificationCourseRepository = {
-        get: sinon.stub(),
-      };
-      const certificationEvaluationRepository = {
-        rescoreV3Certification: sinon.stub(),
-      };
-      const sessionManagementRepository = {
-        isFinalized: sinon.stub(),
-      };
-      certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-      certificationEvaluationRepository.rescoreV3Certification.resolves();
-      sessionManagementRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(true);
-
-      // when
-      await uncancel({
+      expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
         certificationCourseId: 123,
-        juryId,
-        certificationCourseRepository,
-        certificationEvaluationRepository,
-        sessionManagementRepository,
-      });
-
-      // then
-      expect(certificationEvaluationRepository.rescoreV3Certification).to.have.been.calledWithExactly({
-        event: new CertificationUncancelled({
-          certificationCourseId: certificationCourse.getId(),
+        assessmentResult: new AssessmentResult({
+          ...canceledAssessmentResult,
+          status: AssessmentResult.status.VALIDATED,
           juryId,
+          id: undefined,
+          createdAt: undefined,
         }),
-      });
-    });
-
-    describe('when session is not finalized', function () {
-      it('should not uncancel the certification', async function () {
-        // given
-        const juryId = 123;
-        const session = domainBuilder.certification.sessionManagement.buildSessionManagement({
-          finalizedAt: null,
-          version: AlgorithmEngineVersion.V3,
-        });
-        const certificationCourse = domainBuilder.buildCertificationCourse({
-          id: 123,
-          sessionId: session.id,
-          version: AlgorithmEngineVersion.V3,
-        });
-        const certificationCourseRepository = {
-          get: sinon.stub(),
-        };
-        const sessionManagementRepository = {
-          isFinalized: sinon.stub(),
-        };
-        certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-        sessionManagementRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(false);
-
-        // when
-        const error = await catchErr(uncancel)({
-          juryId,
-          certificationCourseId: 123,
-          certificationCourseRepository,
-          sessionManagementRepository,
-        });
-
-        // then
-        expect(error).to.be.instanceOf(NotFinalizedSessionError);
       });
     });
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/unreject-certification-course_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/unreject-certification-course_test.js
@@ -1,102 +1,64 @@
 import sinon from 'sinon';
 
 import { unrejectCertificationCourse } from '../../../../../../src/certification/session-management/domain/usecases/unreject-certification-course.js';
-import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
-import { CertificationCourseUnrejected } from '../../../../../../src/shared/domain/events/CertificationCourseUnrejected.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | UseCase | unreject-certification-course', function () {
-  describe('when certification is a V2', function () {
-    it('should unreject a rejected certification course', async function () {
-      // given
-      const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
-      const certificationEvaluationRepository = { rescoreV2Certification: sinon.stub() };
-      const juryId = 123;
+  it('should unreject a rejected certification course without re-scoring', async function () {
+    // given
+    const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
+    const assessmentResultRepository = {
+      getByCertificationCourseId: sinon.stub(),
+      save: sinon.stub(),
+    };
+    const juryId = 123;
 
-      const dependencies = {
-        certificationCourseRepository,
-        certificationEvaluationRepository,
-      };
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        isRejectedForFraud: true,
-        version: AlgorithmEngineVersion.V2,
-      });
-      const certificationCourseId = certificationCourse.getId();
-
-      certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
-      certificationCourseRepository.update.resolves();
-      certificationEvaluationRepository.rescoreV2Certification.resolves();
-
-      // when
-      await unrejectCertificationCourse({
-        ...dependencies,
-        juryId,
-        certificationCourseId: certificationCourseId,
-      });
-
-      // then
-      const expectedCertificationCourse = new CertificationCourse({
-        ...certificationCourse.toDTO(),
-        isRejectedForFraud: false,
-      });
-
-      expect(certificationCourseRepository.update).to.have.been.calledWithExactly({
-        certificationCourse: expectedCertificationCourse,
-      });
-      expect(certificationEvaluationRepository.rescoreV2Certification).to.have.been.calledOnceWithExactly({
-        event: new CertificationCourseUnrejected({
-          certificationCourseId,
-          juryId,
-        }),
-      });
+    const dependencies = {
+      certificationCourseRepository,
+      assessmentResultRepository,
+    };
+    const certificationCourse = domainBuilder.buildCertificationCourse({
+      isRejectedForFraud: true,
     });
-  });
+    const certificationCourseId = certificationCourse.getId();
 
-  describe('when certification is a V3', function () {
-    it('should unreject a rejected certification course', async function () {
-      // given
-      const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
-      const certificationEvaluationRepository = { rescoreV3Certification: sinon.stub() };
-      const juryId = 123;
+    certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
+    certificationCourseRepository.update.resolves();
 
-      const dependencies = {
-        certificationCourseRepository,
-        certificationEvaluationRepository,
-      };
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        isRejectedForFraud: true,
-        version: AlgorithmEngineVersion.V3,
-      });
-      const certificationCourseId = certificationCourse.getId();
+    const rejectedAssessmentResult = domainBuilder.buildAssessmentResult({
+      status: AssessmentResult.status.REJECTED,
+      juryId: 456,
+    });
+    assessmentResultRepository.getByCertificationCourseId.resolves(rejectedAssessmentResult);
 
-      certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
-      certificationCourseRepository.update.resolves();
-      certificationEvaluationRepository.rescoreV3Certification.resolves();
+    // when
+    await unrejectCertificationCourse({
+      ...dependencies,
+      juryId,
+      certificationCourseId: certificationCourseId,
+    });
 
-      // when
-      await unrejectCertificationCourse({
-        ...dependencies,
+    // then
+    const expectedCertificationCourse = new CertificationCourse({
+      ...certificationCourse.toDTO(),
+      isRejectedForFraud: false,
+    });
+
+    expect(certificationCourseRepository.update).to.have.been.calledWithExactly({
+      certificationCourse: expectedCertificationCourse,
+    });
+    expect(assessmentResultRepository.save).to.have.been.calledOnceWithExactly({
+      certificationCourseId,
+      assessmentResult: new AssessmentResult({
+        ...rejectedAssessmentResult,
+        status: AssessmentResult.status.VALIDATED,
         juryId,
-        certificationCourseId: certificationCourseId,
-      });
-
-      // then
-      const expectedCertificationCourse = new CertificationCourse({
-        ...certificationCourse.toDTO(),
-        isRejectedForFraud: false,
-      });
-
-      expect(certificationCourseRepository.update).to.have.been.calledWithExactly({
-        certificationCourse: expectedCertificationCourse,
-      });
-      expect(certificationEvaluationRepository.rescoreV3Certification).to.have.been.calledOnceWithExactly({
-        event: new CertificationCourseUnrejected({
-          certificationCourseId,
-          juryId,
-        }),
-      });
+        id: undefined,
+        createdAt: undefined,
+      }),
     });
   });
 });

--- a/api/tests/shared/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/shared/unit/domain/models/AssessmentResult_test.js
@@ -1,7 +1,9 @@
+import { AssessmentResultNotRejectedError } from '../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Domain | Models | AssessmentResult', function () {
   describe('#buildStartedAssessmentResult', function () {
@@ -54,6 +56,43 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
 
           // then
           expect(isValidated).to.be.false;
+        });
+      },
+    );
+  });
+
+  describe('#unreject', function () {
+    it('should set status to validated and assign the jury id when status is rejected', function () {
+      // given
+      const assessmentResult = domainBuilder.buildAssessmentResult({
+        status: AssessmentResult.status.REJECTED,
+        juryId: 456,
+      });
+
+      // when
+      assessmentResult.unreject({ juryId: 123 });
+
+      // then
+      expect(assessmentResult.status).to.equal(AssessmentResult.status.VALIDATED);
+      expect(assessmentResult.juryId).to.equal(123);
+    });
+
+    [AssessmentResult.status.VALIDATED, AssessmentResult.status.CANCELLED, AssessmentResult.status.ERROR].forEach(
+      (assessmentResultStatus) => {
+        it(`should throw AssessmentResultNotRejectedError when status is ${assessmentResultStatus}`, function () {
+          // given
+          const assessmentResult = domainBuilder.buildAssessmentResult({
+            status: assessmentResultStatus,
+            juryId: 456,
+          });
+
+          // when
+          const error = catchErrSync(() => assessmentResult.unreject({ juryId: 123 }))();
+
+          // then
+          expect(error).to.be.instanceOf(AssessmentResultNotRejectedError);
+          expect(assessmentResult.status).to.equal(assessmentResultStatus);
+          expect(assessmentResult.juryId).to.equal(456);
         });
       },
     );

--- a/api/tests/shared/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/shared/unit/domain/models/AssessmentResult_test.js
@@ -1,4 +1,7 @@
-import { AssessmentResultNotRejectedError } from '../../../../../src/shared/domain/errors.js';
+import {
+  AssessmentResultIsNotCancelledError,
+  AssessmentResultNotRejectedError,
+} from '../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../test-helper.js';
@@ -91,6 +94,43 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
 
           // then
           expect(error).to.be.instanceOf(AssessmentResultNotRejectedError);
+          expect(assessmentResult.status).to.equal(assessmentResultStatus);
+          expect(assessmentResult.juryId).to.equal(456);
+        });
+      },
+    );
+  });
+
+  describe('#uncancel', function () {
+    it('should set status to validated and assign the jury id when status is cancelled', function () {
+      // given
+      const assessmentResult = domainBuilder.buildAssessmentResult({
+        status: AssessmentResult.status.CANCELLED,
+        juryId: 456,
+      });
+
+      // when
+      assessmentResult.uncancel({ juryId: 123 });
+
+      // then
+      expect(assessmentResult.status).to.equal(AssessmentResult.status.VALIDATED);
+      expect(assessmentResult.juryId).to.equal(123);
+    });
+
+    [AssessmentResult.status.VALIDATED, AssessmentResult.status.REJECTED, AssessmentResult.status.ERROR].forEach(
+      (assessmentResultStatus) => {
+        it(`should throw AssessmentResultNotRejectedError when status is ${assessmentResultStatus}`, function () {
+          // given
+          const assessmentResult = domainBuilder.buildAssessmentResult({
+            status: assessmentResultStatus,
+            juryId: 456,
+          });
+
+          // when
+          const error = catchErrSync(() => assessmentResult.uncancel({ juryId: 123 }))();
+
+          // then
+          expect(error).to.be.instanceOf(AssessmentResultIsNotCancelledError);
           expect(assessmentResult.status).to.equal(assessmentResultStatus);
           expect(assessmentResult.juryId).to.equal(456);
         });


### PR DESCRIPTION
## 💥 Problème

Aujourd’hui, [plusieurs événements](https://miro.com/app/board/uXjVIctvH1k=/) viennent déclencher un rescoring d’une certification.

Parmi ceux-ci, la désannulation et la dérejet d’une certification.

Or, il n’est pas utile de venir rescorer une certification dans ces cas-là.

Les cas de fin de parcours, de finalisation de session et l’action au bouton dédié “rescorer” suffisent.

## 👩‍🚀 Proposition

Garder l’action de scorer uniquement pour les 3 cas nécessaires.

## ♻️ Pour tester

- Tester la désannulation et le dérejet sur PixAdmin en RA
