### PR TITLE
[FEATURE] Permet aux admins d'ajouter un lien de questionnaire à la création d'un blueprint (PIX-22939)

### DIFF
--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import formatDate from 'ember-intl/helpers/format-date';
 import { pageTitle } from 'ember-page-title';
+import { or } from 'ember-truth-helpers';
 import DownloadCombinedCourseBlueprint from 'pix-admin/components/combined-course-blueprints/download-combined-course-blueprint';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 
@@ -58,11 +59,14 @@ export default class Details extends Component {
               </DescriptionList.Item>
 
               {{#if @model.description}}
-
                 <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.description"}}>
                   <SafeMarkdownToHtml @markdown={{@model.description}} />
                 </DescriptionList.Item>
               {{/if}}
+
+              <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.survey-link"}}>
+                {{or @model.surveyLink (t "components.combined-course-blueprints.survey-link.not-provided")}}
+              </DescriptionList.Item>
 
               {{#if @model.illustration}}
                 <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.illustration"}}>

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -251,6 +251,17 @@ export default class CombineCourseBluePrintForm extends Component {
           @onChange={{this.setAttestation}}
         />
 
+        <PixInput
+          @id="surveyLink"
+          @value={{this.surveyLink}}
+          {{on "change" (fn this.setData "surveyLink")}}
+          class="combined-course-page__input"
+          rows="10"
+        >
+          <:label>
+            {{t "components.combined-course-blueprints.labels.survey-link"}}
+          </:label>
+        </PixInput>
       </form>
 
       <div class="combined-course-page__items">

--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -8,6 +8,7 @@ export default class CombinedCourseBlueprint extends Model {
   @attr('string') attestationLabel;
   @attr() rewardId;
   @attr('string') rewardType;
+  @attr('string') surveyLink;
   @attr({ type: 'date', defaultValue: () => undefined }) createdAt;
   @attr({ defaultValue: () => [] }) content;
 }

--- a/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
@@ -22,6 +22,7 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
       description: 'Mon super parcours apprenant',
       illustration: 'http://pix.fr/mon-illu.png',
       attestationLabel: '6ème',
+      surveyLink: 'http://pix-survey-test.fr',
       content: [
         { type: 'module', value: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a', shortId: 'abc-123' },
         { type: 'evaluation', value: 123 },
@@ -37,10 +38,25 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
     assert.ok(screen.getByText('Parcours apprenant'));
     assert.ok(screen.getByText('25/12/2025'));
     assert.ok(screen.getByText('6ème'));
+    assert.ok(screen.getByText('http://pix-survey-test.fr'));
     assert.ok(screen.getByText('Mon super parcours apprenant'));
     assert.ok(screen.getByText('Module - abc-123', { exact: false }));
     assert.ok(screen.getByText('Profil cible - 123', { exact: false }));
     assert.ok(screen.getByRole('link', { name: t('components.combined-course-blueprints.list.downloadButton') }));
+  });
+
+  test('it should not display survey link if not available', async function (assert) {
+    // given
+    const combinedCourseBlueprint = {
+      id: 123,
+      internalName: 'Modèle de parcours apprenant',
+    };
+
+    // when
+    const screen = await render(<template><Details @model={{combinedCourseBlueprint}} /></template>);
+
+    // then
+    assert.ok(screen.getByText(t('components.combined-course-blueprints.survey-link.not-provided')));
   });
 
   test('should hide description and illustration if not provided', async function (assert) {

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -63,6 +63,11 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
     await fillIn(screen.getByLabelText(t('components.combined-course-blueprints.labels.description')), 'description');
 
+    await fillIn(
+      screen.getByLabelText(t('components.combined-course-blueprints.labels.survey-link')),
+      'http://survey-link.fr',
+    );
+
     await click(
       screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
     );
@@ -84,6 +89,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
     ]);
     assert.strictEqual(blueprintStub.illustration, 'illustrations/hello.svg');
     assert.strictEqual(blueprintStub.description, 'description');
+    assert.strictEqual(blueprintStub.surveyLink, 'http://survey-link.fr');
     assert.strictEqual(blueprintStub.rewardId, 5);
     assert.strictEqual(blueprintStub.rewardType, 'ATTESTATION');
     assert.ok(

--- a/admin/tests/unit/serializers/combined-course-blueprint-test.js
+++ b/admin/tests/unit/serializers/combined-course-blueprint-test.js
@@ -19,6 +19,7 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
       attestationLabel: 'Label attestation',
       rewardId: 5,
       rewardType: 'ATTESTATION',
+      surveyLink: 'http://survey-link-test.fr',
     });
 
     const serializedRecord = record.serialize();
@@ -42,6 +43,7 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
             'attestation-label': 'Label attestation',
             'reward-id': 5,
             'reward-type': 'ATTESTATION',
+            'survey-link': 'http://survey-link-test.fr',
           },
         },
       },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -688,6 +688,7 @@
         "itemId": "Id",
         "module": "Module",
         "name": "External name",
+        "survey-link": "Survey link url",
         "target-profile": "Target profile"
       },
       "list": {
@@ -705,6 +706,9 @@
       "organizations": {
         "detach-organization": "Are you sure you want to detach <strong>{organizationName}</strong> from combined course blueprint <strong>{name}</strong>",
         "detach-organization-success": "Blueprint is not shared with organization {name} anymore."
+      },
+      "survey-link": {
+        "not-provided": "No survey link has been defined"
       }
     },
     "layout": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -696,6 +696,7 @@
         "itemId": "Identifiant",
         "module": "Module",
         "name": "Nom externe",
+        "survey-link": "Url du questionnaire de fin de parcours",
         "target-profile": "Profil cible"
       },
       "list": {
@@ -713,6 +714,9 @@
       "organizations": {
         "detach-organization": "Etes-vous sûr de vouloir détacher l'organisation <strong>{organizationName}</strong> du schéma de parcours <strong>{name}</strong>",
         "detach-organization-success": "Le schéma de parcours n'est plus partagé avec l'organisation {name}."
+      },
+      "survey-link": {
+        "not-provided": "Aucun questionnaire paramétré"
       }
     },
     "layout": {

--- a/api/src/quest/domain/models/AdminCombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/AdminCombinedCourseBlueprint.js
@@ -12,6 +12,7 @@ export class AdminCombinedCourseBlueprint {
     rewardId = null,
     rewardType = null,
     quest,
+    surveyLink = null,
     createdAt,
     updatedAt,
     organizationIds = [],
@@ -26,6 +27,7 @@ export class AdminCombinedCourseBlueprint {
     this.rewardId = rewardId;
     this.rewardType = rewardType;
     this.quest = quest;
+    this.surveyLink = surveyLink;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
 

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -10,6 +10,7 @@ export class CombinedCourseBlueprint {
     internalName,
     description,
     illustration,
+    surveyLink = null,
     createdAt,
     updatedAt,
     organizationIds = [],
@@ -20,6 +21,7 @@ export class CombinedCourseBlueprint {
     this.internalName = internalName;
     this.description = description;
     this.illustration = illustration;
+    this.surveyLink = surveyLink;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.organizationIds = organizationIds;

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -34,6 +34,7 @@ export async function save({ combinedCourseBlueprint }) {
     internalName: combinedCourseBlueprint.internalName,
     description: combinedCourseBlueprint.description,
     illustration: combinedCourseBlueprint.illustration,
+    surveyUrl: combinedCourseBlueprint.surveyLink,
     updatedAt: knexConn.fn.now(),
     questId,
   };
@@ -41,7 +42,7 @@ export async function save({ combinedCourseBlueprint }) {
   const createdBlueprint = await knexConn('combined_course_blueprints')
     .insert(blueprintToSave)
     .onConflict('id')
-    .merge(['updatedAt', 'name', 'internalName', 'description', 'illustration', 'questId'])
+    .merge(['updatedAt', 'name', 'internalName', 'description', 'illustration', 'surveyUrl', 'questId'])
     .returning('*');
 
   const doesCombinedCourseBlueprintExists = !!combinedCourseBlueprint.id;
@@ -148,6 +149,7 @@ function _toDomain(rawData, quest) {
     description: rawData.description,
     illustration: rawData.illustration,
     content: rawData.content,
+    surveyLink: rawData.surveyLink,
     createdAt: rawData.createdAt,
     updatedAt: rawData.updatedAt,
     organizationIds: rawData.organizationIds,
@@ -162,6 +164,7 @@ function _buildSelectFields(knexConn) {
     internalName: 'combined_course_blueprints.internalName',
     description: 'combined_course_blueprints.description',
     illustration: 'combined_course_blueprints.illustration',
+    surveyLink: 'combined_course_blueprints.surveyUrl',
     createdAt: 'combined_course_blueprints.createdAt',
     updatedAt: 'combined_course_blueprints.updatedAt',
     organizationIds: knexConn.raw(`array_remove(array_agg("combined_course_blueprint_shares"."organizationId"), NULL)`),

--- a/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js
@@ -10,6 +10,7 @@ const serialize = function (adminCombinedCourseBlueprintDetails) {
       'description',
       'illustration',
       'content',
+      'surveyLink',
       'createdAt',
       'updatedAt',
       'attestationLabel',

--- a/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js
@@ -8,7 +8,7 @@ const { Deserializer, Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourseBlueprint) {
   return new Serializer('combined-course-blueprints', {
-    attributes: ['name', 'internalName', 'description', 'illustration', 'createdAt', 'updatedAt'],
+    attributes: ['name', 'internalName', 'description', 'illustration', 'surveyLink', 'createdAt', 'updatedAt'],
   }).serialize(combinedCourseBlueprint);
 };
 

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourseBlueprint) {
   return new Serializer('combined-course-blueprints', {
-    attributes: ['name', 'internalName', 'description', 'illustration', 'createdAt', 'updatedAt'],
+    attributes: ['name', 'internalName', 'description', 'illustration', 'surveyLink', 'createdAt', 'updatedAt'],
   }).serialize(combinedCourseBlueprint);
 };
 

--- a/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprint_test.js
@@ -20,6 +20,7 @@ describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprint ', funct
         attestationLabel: 'Parentalité',
         rewardId: 1,
         rewardType: 'attestations',
+        surveyLink: 'survey-link-test',
         quest,
         createdAt: new Date(),
         updatedAt: new Date(),

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -14,6 +14,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         internalName: 'internalName',
         description: 'description',
         illustration: 'illustration',
+        surveyLink: 'survey-link-test',
         createdAt: new Date('2024-01-25'),
         updatedAt: new Date('2024-01-26'),
         organizationIds: [],

--- a/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-details-serializer_test.js
@@ -18,6 +18,7 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
         { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: 123 },
       ],
       attestationLabel: '6ème',
+      surveyLink: 'survey-link-test',
       organizationIds: [],
       quest: new Quest({ eligibilityRequirements: [], successRequirements: [], rewardId: null, rewardType: null }),
     });
@@ -40,6 +41,7 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
           'created-at': adminCombinedCourseBlueprintDetails.createdAt,
           'updated-at': adminCombinedCourseBlueprintDetails.updatedAt,
           'attestation-label': '6ème',
+          'survey-link': 'survey-link-test',
         },
         type: 'combined-course-blueprints',
         id: '1',

--- a/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-serializer_test.js
@@ -26,6 +26,7 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
           content: items,
           'created-at': date,
           'updated-at': date,
+          'survey-link': 'http://survey',
         },
         type: 'combined-course-blueprints',
         id: '1',
@@ -56,6 +57,7 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
           rewardId: 5,
           rewardType: REWARD_TYPES.ATTESTATION,
         }),
+        surveyLink: 'http://survey',
       }),
     );
   });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
@@ -11,6 +11,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
       internalName: 'Mon modèle de parcours',
       description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
       illustration: '/illustrations/image.svg',
+      surveyLink: 'survey-link-test',
       organizationIds: [],
     });
 
@@ -25,6 +26,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
           'internal-name': 'Mon modèle de parcours',
           illustration: '/illustrations/image.svg',
           description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          'survey-link': 'survey-link-test',
           'created-at': combinedCourseBlueprint.createdAt,
           'updated-at': combinedCourseBlueprint.updatedAt,
         },


### PR DESCRIPTION
## 💥 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On veut que les admins puissent définir un lien de questionnaire de fin de parcours, ajouté au niveau du blueprint.

## 👩‍🚀 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Ajout du lien du questionnaire dans l'api de création d'un blueprint, et affichage du lien paramétré dans les détails côté admin.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
On traitera dans un second temps la possibilité de modifier ce champs une fois créé : on va en profiter pour rendre plusieurs champs éditables dans les détails d'un blueprint.

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Se connecter sur Pix Admin.
Aller dans "schémas de parcours" et créer un nouveau schéma en renseignant une url de questionnaire.
Aller sur les détails du parcours créé : l'url du questionnaire doit s'afficher.
Actualiser la page : l'url est toujours là.

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
