### PR TITLE
[FEATURE] Afficher le feedback dans la modale d'un contenu formatif (PIX-22948).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -2,103 +2,138 @@ import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { fn } from '@ember/helper';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 import RegistrationCardTag from './registration-card-tag';
 
-<template>
-  <PixModal
-    @title={{@training.title}}
-    @showModal={{@isOpen}}
-    @onCloseButtonClick={{@onClose}}
-    class="results-recommendation-engine-training-card-modal"
-  >
-    <:content>
-      <div class="results-recommendation-engine-training-card-modal__section">
-        <dl class="results-recommendation-engine-training-card-modal-section__description">
-          <RegistrationCardTag @registrationRequired={{@training.registrationRequired}} />
-          <dt>{{t "pages.skill-review.recommended-engine.modal.editor-name"}}<span>{{@training.editorName}}</span></dt>
-          <dd>{{htmlUnsafe @training.description}}</dd>
-        </dl>
-        <div class="results-recommendation-engine-training-card-modal-section__information">
-          {{#if @training.hasDuration}}
-            <dl class="results-recommendation-engine-training-card-modal-section__time-information">
-              <PixIcon @name="time" @ariaHidden={{true}} />
-              <dt>{{t "pages.skill-review.recommended-engine.modal.duration"}}</dt>
-              <dd class="results-recommendation-engine-training-card-modal-section__time-information--bold">
-                <span>{{@training.formattedDays}}</span>
-                <span>{{@training.formattedTime}}</span>
-              </dd>
-            </dl>
-          {{/if}}
-          <dl class="results-recommendation-engine-training-card-modal-section__localisation-information">
-            <PixIcon @name="mapPin" @ariaHidden={{true}} />
-            <dt>{{t "pages.skill-review.recommended-engine.modal.localisation"}}</dt>
-            <dd
-              class="results-recommendation-engine-training-card-modal-section__time-information results-recommendation-engine-training-card-modal-section__localisation-information--bold"
-            >{{@deliveryMode}}</dd>
-          </dl>
-        </div>
-      </div>
+export default class CardModal extends Component {
+  @tracked isTrainingRecommendationRelevant = null;
 
-      <PixAccordions>
-        <:title>
-          <h2>{{t "pages.skill-review.recommended-engine.modal.objectives"}}</h2>
-        </:title>
-        <:content>
-          <ul class="results-recommendation-engine-training-card-modal__objectives">
-            {{#each @training.objectives as |objective|}}
-              <li>
-                <PixIcon
-                  @name="checkCircle"
-                  @plainIcon={{true}}
-                  class="results-recommendation-engine-training-card-modal-objectives__icon"
-                  @ariaHidden={{true}}
-                />
-                {{htmlUnsafe objective}}
-              </li>
-            {{/each}}
-          </ul>
-        </:content>
-      </PixAccordions>
-      <PixAccordions>
-        <:title>
-          <h2>{{t "pages.skill-review.recommended-engine.modal.program"}}</h2>
-        </:title>
-        <:content>
-          <p class="results-recommendation-engine-training-card-modal__program">{{@training.program}}</p>
-        </:content>
-      </PixAccordions>
-    </:content>
-    <:footer>
-      <ul class="results-recommendation-engine-training-card-modal-footer">
-        <li>
-          <PixButton
-            @triggerAction={{@onClose}}
-            @variant="secondary"
-            class="results-recommendation-engine-training-card-modal-footer__cancel-button"
-          >
-            {{t "common.actions.close"}}
-          </PixButton>
-        </li>
-        <li>
-          <PixButtonLink
-            @href={{@training.link}}
-            target="_blank"
-            rel="noreferrer"
-            class="results-recommendation-engine-training-card-modal-footer__link-button"
-          >
-            {{#if @training.isModulix}}
-              {{t "pages.skill-review.recommended-engine.modal.actions.discover-module"}}
-            {{else}}
-              {{t "pages.skill-review.recommended-engine.modal.actions.discover-program"}}
-              <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
+  @action
+  submitFeedback(feedbackResponse) {
+    this.isTrainingRecommendationRelevant = feedbackResponse;
+    //TODO call API to submit feedback
+  }
+
+  <template>
+    <PixModal
+      @title={{@training.title}}
+      @showModal={{@isOpen}}
+      @onCloseButtonClick={{@onClose}}
+      class="results-recommendation-engine-training-card-modal"
+    >
+      <:content>
+        <div class="results-recommendation-engine-training-card-modal__section">
+          <dl class="results-recommendation-engine-training-card-modal-section__description">
+            <RegistrationCardTag @registrationRequired={{@training.registrationRequired}} />
+            <dt>{{t "pages.skill-review.recommended-engine.modal.editor-name"}}<span>{{@training.editorName}}</span>
+            </dt>
+            <dd>{{htmlUnsafe @training.description}}</dd>
+          </dl>
+          <div class="results-recommendation-engine-training-card-modal-section__information">
+            {{#if @training.hasDuration}}
+              <dl class="results-recommendation-engine-training-card-modal-section__time-information">
+                <PixIcon @name="time" @ariaHidden={{true}} />
+                <dt>{{t "pages.skill-review.recommended-engine.modal.duration"}}</dt>
+                <dd class="results-recommendation-engine-training-card-modal-section__time-information--bold">
+                  <span>{{@training.formattedDays}}</span>
+                  <span>{{@training.formattedTime}}</span>
+                </dd>
+              </dl>
             {{/if}}
-          </PixButtonLink>
-        </li>
-      </ul>
-    </:footer>
-  </PixModal>
-</template>
+            <dl class="results-recommendation-engine-training-card-modal-section__localisation-information">
+              <PixIcon @name="mapPin" @ariaHidden={{true}} />
+              <dt>{{t "pages.skill-review.recommended-engine.modal.localisation"}}</dt>
+              <dd
+                class="results-recommendation-engine-training-card-modal-section__time-information results-recommendation-engine-training-card-modal-section__localisation-information--bold"
+              >{{@deliveryMode}}</dd>
+            </dl>
+          </div>
+        </div>
+
+        <PixAccordions>
+          <:title>
+            <h2>{{t "pages.skill-review.recommended-engine.modal.objectives"}}</h2>
+          </:title>
+          <:content>
+            <ul class="results-recommendation-engine-training-card-modal__objectives">
+              {{#each @training.objectives as |objective|}}
+                <li>
+                  <PixIcon
+                    @name="checkCircle"
+                    @plainIcon={{true}}
+                    class="results-recommendation-engine-training-card-modal-objectives__icon"
+                    @ariaHidden={{true}}
+                  />
+                  {{htmlUnsafe objective}}
+                </li>
+              {{/each}}
+            </ul>
+          </:content>
+        </PixAccordions>
+        <PixAccordions>
+          <:title>
+            <h2>{{t "pages.skill-review.recommended-engine.modal.program"}}</h2>
+          </:title>
+          <:content>
+            <p class="results-recommendation-engine-training-card-modal__program">{{@training.program}}</p>
+          </:content>
+        </PixAccordions>
+      </:content>
+      <:footer>
+        <div class="results-recommendation-engine-training-card-modal-footer">
+          <form>
+            <fieldset class="results-recommendation-engine-training-card-modal-footer__feedback">
+              <legend>{{t "pages.skill-review.recommended-engine.modal.feedback.question"}}</legend>
+              <PixIconButton
+                @ariaLabel={{t "common.yes"}}
+                @iconName="thumbUp"
+                @triggerAction={{fn this.submitFeedback true}}
+                @size="small"
+              />
+              <PixIconButton
+                @ariaLabel={{t "common.no"}}
+                @iconName="dislike"
+                @triggerAction={{fn this.submitFeedback false}}
+                @size="small"
+              />
+            </fieldset>
+          </form>
+          <ul class="results-recommendation-engine-training-card-modal-footer__action-buttons">
+            <li>
+              <PixButton
+                @triggerAction={{@onClose}}
+                @variant="secondary"
+                class="results-recommendation-engine-training-card-modal-footer-action-buttons__cancel"
+              >
+                {{t "common.actions.close"}}
+              </PixButton>
+            </li>
+            <li>
+              <PixButtonLink
+                @href={{@training.link}}
+                target="_blank"
+                rel="noreferrer"
+                class="results-recommendation-engine-training-card-modal-footer-action-buttons__link"
+              >
+                {{#if @training.isModulix}}
+                  {{t "pages.skill-review.recommended-engine.modal.actions.discover-module"}}
+                {{else}}
+                  {{t "pages.skill-review.recommended-engine.modal.actions.discover-program"}}
+                  <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
+                {{/if}}
+              </PixButtonLink>
+            </li>
+          </ul>
+        </div>
+      </:footer>
+    </PixModal>
+  </template>
+}

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -147,6 +147,10 @@
   &__program {
     color: var(--pix-neutral-800);
   }
+
+  .pix-modal__footer {
+    justify-content: space-between;
+  }
 }
 
 .results-recommendation-engine-training-card-modal-section {
@@ -201,7 +205,7 @@
 .results-recommendation-engine-training-card-modal-footer {
   display: flex;
   gap: var(--pix-spacing-2x);
-  justify-content: flex-end;
+  align-items: center;
 
   @include breakpoints.device-is('mobile') {
     flex-direction: column;
@@ -209,13 +213,40 @@
     width: 100%
   }
 
-  &__link-button {
+  &__feedback {
+    display: flex;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+
+    legend {
+      @extend %pix-body-m;
+
+      float: left;
+    }
+  }
+
+  &__action-buttons {
+    display: flex;
+    gap: var(--pix-spacing-2x);
+    justify-content: flex-end;
+
+    @include breakpoints.device-is('mobile') {
+      flex-direction: column;
+      justify-content: center;
+      width: 100%
+    }
+  }
+}
+
+.results-recommendation-engine-training-card-modal-footer-action-buttons {
+
+  &__link {
     display: flex;
     gap: var(--pix-spacing-1x);
     justify-content: center;
   }
 
-  &__cancel-button {
+  &__cancel {
     width: 100%;
   }
 }

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -274,6 +274,26 @@ module(
             .exists();
         });
       });
+
+      test('should display a feedback for the relevance of the training', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({}));
+
+        // when
+        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
+        );
+
+        // then
+        const modal = await screen.findByRole('dialog');
+        assert.dom(within(modal).getByRole('button', { name: t('common.yes') })).exists();
+        assert.dom(within(modal).getByRole('button', { name: t('common.no') })).exists();
+        assert
+          .dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.feedback.question')))
+          .exists();
+      });
     });
 
     function _buildTraining({

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2254,6 +2254,9 @@
           },
           "duration": "Dauer",
           "editor-name": "Vorgeschlagen von : ",
+          "feedback": {
+            "question": "Ist dieser Vorschlag relevant?"
+          },
           "localisation": "Standort",
           "objectives": "Ziele",
           "program": "Programm"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2254,6 +2254,9 @@
           },
           "duration": "Duration",
           "editor-name": "Proposed by: ",
+          "feedback": {
+            "question": "Is this proposal relevant?"
+          },
           "localisation": "Location",
           "objectives": "Objectives",
           "program": "Programme"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2254,6 +2254,9 @@
           },
           "duration": "Duración",
           "editor-name": "Propuesto por: ",
+          "feedback": {
+            "question": "¿Es relevante esta propuesta?"
+          },
           "localisation": "Localización",
           "objectives": "Objetivos",
           "program": "Programa"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2254,6 +2254,9 @@
           },
           "duration": "Durée",
           "editor-name": "Proposé par : ",
+          "feedback": {
+            "question": "Cette proposition est-elle pertinente ?"
+          },
           "localisation": "Localisation",
           "objectives": "Objectifs",
           "program": "Programme"

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2254,6 +2254,9 @@
           },
           "duration": "Durata",
           "editor-name": "Proposto da : ",
+          "feedback": {
+            "question": "Questa proposta è pertinente?"
+          },
           "localisation": "Localizzazione",
           "objectives": "Obiettivi",
           "program": "Programma"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2254,6 +2254,9 @@
           },
           "duration": "Duur",
           "editor-name": "Voorgesteld door : ",
+          "feedback": {
+            "question": "Is dit voorstel relevant?"
+          },
           "localisation": "Locatie",
           "objectives": "Doelstellingen",
           "program": "Programma"


### PR DESCRIPTION
## 🚙 Problème

Le chantier de fin de parcours avec contenu recommandé se poursuit.
Cette fois on affiche une question à l'utilisateur pour qu'il indique la pertinence du contenu sur lequel il a cliqué.

## 🍃 Proposition

Afficher la question sur la modale

## 🔗 Pour tester

- Se connecter avec dave-comp@example.net, aller dans les parcours, voir le détails pour accéder à la page de fin de parcours.
- Cliquer sur un contenu formatif, voir la modale avec la question
- Cliquer sur le bouton ne fait rien, l'API n'existe pas encore
