### PR TITLE
[TECH] Migrer la vue Preview vers la nouvelle route API (PIX-22401)

### DIFF
--- a/mon-pix/app/adapters/module.js
+++ b/mon-pix/app/adapters/module.js
@@ -2,13 +2,8 @@ import ApplicationAdapter from './application';
 
 export default class Module extends ApplicationAdapter {
   queryRecord(store, type, query) {
-    if (query.shortId || query.slug) {
-      let url = '';
-      if (query.shortId) {
-        url = `${this.host}/${this.namespace}/modules/v2/${query.shortId}`;
-      } else if (query.slug) {
-        url = `${this.host}/${this.namespace}/modules/${query.slug}`;
-      }
+    if (query.shortId) {
+      let url = `${this.host}/${this.namespace}/modules/v2/${query.shortId}`;
 
       if (query.encryptedRedirectionUrl) {
         const encryptedRedirectionUrl = encodeURIComponent(query.encryptedRedirectionUrl);

--- a/mon-pix/app/controllers/old-module.js
+++ b/mon-pix/app/controllers/old-module.js
@@ -1,5 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class OldModule extends Controller {
-  queryParams = ['redirection'];
-}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -112,7 +112,8 @@ Router.map(function () {
     this.route('process-custom-passages', { path: '/:code/chargement' });
   });
 
-  this.route('module-preview-existing', { path: '/modules/preview/:slug' });
+  // eslint-disable-next-line ember/routes-segments-snake-case
+  this.route('module-preview-existing', { path: '/modules/preview/:shortId/:slug' });
   this.route('module-preview', { path: '/modules/preview' });
 
   // eslint-disable-next-line ember/routes-segments-snake-case

--- a/mon-pix/app/routes/module-preview-existing.js
+++ b/mon-pix/app/routes/module-preview-existing.js
@@ -5,7 +5,7 @@ export default class ModulePreviewExistingRoute extends Route {
   @service store;
 
   async model(params) {
-    const queryRecord = await this.store.queryRecord('module', { slug: params.slug });
+    const queryRecord = await this.store.queryRecord('module', { slug: params.slug, shortId: params.shortId });
     return queryRecord;
   }
 }

--- a/mon-pix/app/routes/module-preview-existing.js
+++ b/mon-pix/app/routes/module-preview-existing.js
@@ -3,9 +3,14 @@ import { service } from '@ember/service';
 
 export default class ModulePreviewExistingRoute extends Route {
   @service store;
+  @service router;
 
   async model(params) {
     const queryRecord = await this.store.queryRecord('module', { slug: params.slug, shortId: params.shortId });
     return queryRecord;
+  }
+
+  redirect(model) {
+    this.router.transitionTo('module-preview-existing', model.shortId, model.slug);
   }
 }

--- a/mon-pix/app/routes/module/details.js
+++ b/mon-pix/app/routes/module/details.js
@@ -9,6 +9,6 @@ export default class ModuleDetailsRoute extends Route {
   }
 
   redirect(model) {
-    this.router.replaceWith('module.details', model.shortId, model.slug);
+    this.router.transitionTo('module.details', model.shortId, model.slug);
   }
 }

--- a/mon-pix/mirage/routes/modules/get-old-module.js
+++ b/mon-pix/mirage/routes/modules/get-old-module.js
@@ -1,4 +1,0 @@
-export default function (schema, request) {
-  const slug = request.params.slug;
-  return schema.modules.findBy({ slug });
-}

--- a/mon-pix/mirage/routes/modules/index.js
+++ b/mon-pix/mirage/routes/modules/index.js
@@ -1,7 +1,5 @@
 import getModule from './get-module';
-import getOldModule from './get-old-module';
 
 export default function index(config) {
   config.get('/modules/v2/:shortId', getModule);
-  config.get('/modules/:slug', getOldModule);
 }

--- a/mon-pix/tests/acceptance/module/preview-existing-module_test.js
+++ b/mon-pix/tests/acceptance/module/preview-existing-module_test.js
@@ -30,4 +30,25 @@ module('Acceptance | Module | Routes | Preview Existing Module', function (hooks
     assert.strictEqual(currentURL(), '/modules/preview/s0l31l/existing-module');
     assert.dom(screen.getByRole('heading', { name: 'Existing Module' })).exists();
   });
+
+  test('should redirect to correct url when slug is not correct', async function (assert) {
+    // given
+    server.create('module', {
+      id: 'existing-module',
+      shortId: 's0l31l',
+      slug: 'existing-module',
+      title: 'Existing Module',
+      isBeta: true,
+      grains: [],
+      details: {},
+    });
+    const wrongSlug = 'blabla-module';
+
+    // when
+    const screen = await visit(`/modules/preview/s0l31l/${wrongSlug}`);
+
+    // then
+    assert.strictEqual(currentURL(), '/modules/preview/s0l31l/existing-module');
+    assert.dom(screen.getByRole('heading', { name: 'Existing Module' })).exists();
+  });
 });

--- a/mon-pix/tests/acceptance/module/preview-existing-module_test.js
+++ b/mon-pix/tests/acceptance/module/preview-existing-module_test.js
@@ -15,6 +15,7 @@ module('Acceptance | Module | Routes | Preview Existing Module', function (hooks
     // given
     server.create('module', {
       id: 'existing-module',
+      shortId: 's0l31l',
       slug: 'existing-module',
       title: 'Existing Module',
       isBeta: true,
@@ -23,10 +24,10 @@ module('Acceptance | Module | Routes | Preview Existing Module', function (hooks
     });
 
     // when
-    const screen = await visit('/modules/preview/existing-module');
+    const screen = await visit('/modules/preview/s0l31l/existing-module');
 
     // then
-    assert.strictEqual(currentURL(), '/modules/preview/existing-module');
+    assert.strictEqual(currentURL(), '/modules/preview/s0l31l/existing-module');
     assert.dom(screen.getByRole('heading', { name: 'Existing Module' })).exists();
   });
 });

--- a/mon-pix/tests/unit/adapters/module-test.js
+++ b/mon-pix/tests/unit/adapters/module-test.js
@@ -6,50 +6,6 @@ module('Unit | Adapter | Module | Module', function (hooks) {
   setupTest(hooks);
 
   module('#queryRecord', function () {
-    module('when query.slug is not defined', function () {
-      test('should trigger an ajax call with the default url and method', async function (assert) {
-        // given
-        const query = {
-          'other-prop': 'bac-a-sable',
-        };
-
-        const store = this.owner.lookup('service:store');
-        const adapter = this.owner.lookup('adapter:module');
-        const type = { modelName: 'module' };
-        sinon.stub(adapter, 'ajax').resolves();
-        const expectedUrl = `http://localhost:3000/api/modules`;
-
-        // when
-        await adapter.queryRecord(store, type, query);
-
-        // then
-        sinon.assert.calledWithExactly(adapter.ajax, expectedUrl, 'GET', { data: { 'other-prop': 'bac-a-sable' } });
-        assert.ok(true);
-      });
-    });
-
-    module('when query.slug is defined', function () {
-      test('should trigger an ajax call with the right url and method', async function (assert) {
-        // given
-        const query = {
-          slug: 'bac-a-sable',
-        };
-
-        const store = this.owner.lookup('service:store');
-        const adapter = this.owner.lookup('adapter:module');
-        const type = { modelName: 'module' };
-        sinon.stub(adapter, 'ajax').resolves();
-        const expectedUrl = `http://localhost:3000/api/modules/${query.slug}`;
-
-        // when
-        await adapter.queryRecord(store, type, query);
-
-        // then
-        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'GET');
-        assert.ok(true);
-      });
-    });
-
     module('when query.shortId is not defined', function () {
       test('should trigger an ajax call with the default url and method', async function (assert) {
         // given

--- a/mon-pix/tests/unit/routes/module/details-test.js
+++ b/mon-pix/tests/unit/routes/module/details-test.js
@@ -28,14 +28,14 @@ module('Unit | Route | modules | details', function (hooks) {
   });
 
   module('#redirect', function () {
-    test('should call replaceWith function with the right arguments', async function (assert) {
+    test('should call transitionTo function with the right arguments', async function (assert) {
       // given
       const model = {
         shortId: 'shortId',
         slug: 'slug',
       };
       const router = this.owner.lookup('service:router');
-      const replaceWithStub = sinon.stub(router, 'replaceWith');
+      const transitionToStub = sinon.stub(router, 'transitionTo');
 
       const route = this.owner.lookup('route:module.details');
 
@@ -43,7 +43,7 @@ module('Unit | Route | modules | details', function (hooks) {
       route.redirect(model);
 
       // then
-      sinon.assert.calledOnceWithExactly(replaceWithStub, 'module.details', model.shortId, model.slug);
+      sinon.assert.calledOnceWithExactly(transitionToStub, 'module.details', model.shortId, model.slug);
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/unit/routes/module/module-preview-existing-test.js
+++ b/mon-pix/tests/unit/routes/module/module-preview-existing-test.js
@@ -1,0 +1,36 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | module | module preview existing', function (hooks) {
+  setupTest(hooks);
+
+  test('should exist', function (assert) {
+    // when
+    const route = this.owner.lookup('route:module-preview-existing');
+
+    // then
+    assert.ok(route);
+  });
+
+  module('#redirect', function () {
+    test('should call transitionTo function with the right arguments', async function (assert) {
+      // given
+      const model = {
+        shortId: 'shortId',
+        slug: 'slug',
+      };
+      const router = this.owner.lookup('service:router');
+      const transitionToStub = sinon.stub(router, 'transitionTo');
+
+      const route = this.owner.lookup('route:module-preview-existing');
+
+      // when
+      route.redirect(model);
+
+      // then
+      sinon.assert.calledOnceWithExactly(transitionToStub, 'module-preview-existing', model.shortId, model.slug);
+      assert.ok(true);
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/module/passage-test.js
+++ b/mon-pix/tests/unit/routes/module/passage-test.js
@@ -116,7 +116,7 @@ module('Unit | Route | modules | passage', function (hooks) {
   });
 
   module('#redirect', function () {
-    test('should call replaceWith function with the right arguments', async function (assert) {
+    test('should call transitionTo function with the right arguments', async function (assert) {
       // given
       const module = {
         shortId: 'shortId',


### PR DESCRIPTION
> [!NOTE]  
> Le métier a reçu la communication le 03/06

## 🚙 Problème

Nous avons migré le routing d'affichage des modules vers la nouvelle route API, mais pas le routing pour la Preview des modules existants.

## 🍃 Proposition

Modifier pix-app afin d'utiliser le endpoint `api/modules/v2/:shortId` pour afficher une preview d'un module existant.

## 🦵 Remarques

- Il faudra supprimer l'ancien endpoint côté API
- Une fois mergé, faire la com' auprès du métier
- Gérer le fait qu'on peut mettre uniquement le shortId et arriver quand même sur le module. L'url changerait pour contenir `/modules/:shortId/:slug`

## 🔗 Pour tester
_PixApp: affichage d'un module existant_
- [Accéder au module bac-a-sable](https://app-pr16388.review.pix.fr/modules/preview/6a68bf32/bac-a-sable) en preview, avec le shortId
- Vérifier qu'on a bien le module qui s'affiche en mode Preview
- Essayer [cette url](https://app-pr16388.review.pix.fr/modules/preview/bac-a-sable) (sans shortId), et constater que la preview ne fonctionne pas

_PixApp: redirection URL d'un preview_
- [Accéder au module bac-a-sable](https://app-pr16388.review.pix.fr/modules/preview/6a68bf32/bac-a-sable) en preview, avec le shortId
- Dans l'url, modifier le slug avec n'importe quoi et taper sur Entrer
- L'url doit être remplacée par la bonne url

_Modulix Editor: prévisualisation d'un module_
- Ouvrir modulix-editor en local
- Remplacer, dans `index.js` l'url pour preview : 
```js
previewWindow = window.open(
      'https://app-pr16388.review.pix.fr/modules/preview',
      windowName,
    );
```
- Lancer localement modulix-editor
- Cliquer sur "Prévisualiser", et constater que l'on peut voir, déplié, un module en cours d'édition