### PR TITLE
[FEATURE] Afficher les statistiques d'une orga sur Pix Admin (PIX-22896)

### DIFF
--- a/admin/app/adapters/organization-statistic.js
+++ b/admin/app/adapters/organization-statistic.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class OrganizationStatisticsAdapter extends ApplicationAdapter {
+  urlForQueryRecord(query) {
+    const { organizationId } = query;
+    delete query.organizationId;
+
+    return `${this.host}/${this.namespace}/admin/organizations/${organizationId}/statistics`;
+  }
+}

--- a/admin/app/components/organizations/statistics.gjs
+++ b/admin/app/components/organizations/statistics.gjs
@@ -1,0 +1,18 @@
+import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { t } from 'ember-intl';
+
+<template>
+  <section>
+    <PixIndicatorCard
+      class="organization-statistics__card"
+      @title={{t "components.organizations.statistics.total-participants-count.title"}}
+      @color="tertiary"
+      @iconName="users"
+      @info={{t "components.organizations.statistics.total-participants-count.info"}}
+    >
+      {{@statistics.totalParticipantsCount}}
+
+    </PixIndicatorCard>
+
+  </section>
+</template>

--- a/admin/app/components/organizations/statistics.scss
+++ b/admin/app/components/organizations/statistics.scss
@@ -1,0 +1,3 @@
+.organization-statistics__card {
+  width: 500px;
+}

--- a/admin/app/models/organization-statistic.js
+++ b/admin/app/models/organization-statistic.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class OrganizationStatistic extends Model {
+  @attr('number') totalParticipantsCount;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -52,6 +52,7 @@ Router.map(function () {
         });
         this.route('invitations');
         this.route('network');
+        this.route('statistics');
       });
     });
 

--- a/admin/app/routes/authenticated/organizations/get/statistics.js
+++ b/admin/app/routes/authenticated/organizations/get/statistics.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class Statistics extends Route {
+  @service store;
+
+  async model() {
+    const organization = await this.modelFor('authenticated.organizations.get');
+
+    return this.store.queryRecord('organization-statistic', { organizationId: organization.id });
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -120,3 +120,4 @@
 @use 'organizations/features-section' as *;
 @use 'organizations/head-information' as *;
 @use 'organizations/network/actions-section' as *;
+@use 'organizations/statistics' as *

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -76,6 +76,10 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
           {{t "pages.organization.navbar.network" nbrOfChildren=@model.children.length}}
         </LinkTo>
       {{/if}}
+
+      <LinkTo @route="authenticated.organizations.get.statistics" @model={{@model}}>
+        {{t "pages.organization.navbar.statistics"}}
+      </LinkTo>
     </PixTabs>
 
     {{outlet}}

--- a/admin/app/templates/authenticated/organizations/get/statistics.gjs
+++ b/admin/app/templates/authenticated/organizations/get/statistics.gjs
@@ -1,0 +1,7 @@
+import pageTitle from 'ember-page-title/helpers/page-title';
+import Statistics from 'pix-admin/components/organizations/statistics';
+
+<template>
+  {{pageTitle "Orga " @model.organization.id " | Statistiques"}}
+  <Statistics @statistics={{@model}} />
+</template>

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -415,6 +415,37 @@ module('Acceptance | Organizations | Get', function (hooks) {
           });
         });
       });
+
+      module('Statistics tab', function () {
+        test('it should display Statistics tab', async function (assert) {
+          // when
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // then
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+          assert.ok(
+            within(navigationTabs).getByRole('link', {
+              name: t('pages.organization.navbar.statistics'),
+            }),
+          );
+        });
+
+        test('it should navigate to organization statistics page when clicking tab', async function (assert) {
+          // given
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // when
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+          const statisticsTab = within(navigationTabs).getByRole('link', {
+            name: t('pages.organization.navbar.statistics'),
+          });
+          await click(statisticsTab);
+
+          // then
+          assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/statistics`);
+        });
+      });
     });
   });
 

--- a/admin/tests/mirage/handlers/organizations.js
+++ b/admin/tests/mirage/handlers/organizations.js
@@ -20,6 +20,18 @@ function getOrganizationPlacesStatistics() {
   };
 }
 
+function getOrganizationStatistics() {
+  return {
+    data: {
+      id: '123_organization_statistics',
+      type: 'organization-statistics',
+      attributes: {
+        'total-participants-count': 44,
+      },
+    },
+  };
+}
+
 function getOrganizationInvitations(schema, request) {
   const organizationId = request.params.id;
   return schema.organizationInvitations.where({ organizationId });
@@ -100,4 +112,5 @@ export {
   getOrganizationInvitations,
   getOrganizationPlaces,
   getOrganizationPlacesStatistics,
+  getOrganizationStatistics,
 };

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -28,6 +28,7 @@ import {
   getOrganizationInvitations,
   getOrganizationPlaces,
   getOrganizationPlacesStatistics,
+  getOrganizationStatistics,
 } from './handlers/organizations';
 import { createStage } from './handlers/stages';
 import {
@@ -389,6 +390,7 @@ export default function routes() {
   this.get('/admin/organizations/:id/invitations', getOrganizationInvitations);
   this.get('/admin/organizations/:id/places', getOrganizationPlaces);
   this.get('/admin/organizations/:id/places-statistics', getOrganizationPlacesStatistics);
+  this.get('/admin/organizations/:id/statistics', getOrganizationStatistics);
   this.post('/admin/organizations/:id/archive', archiveOrganization);
 
   this.get('/admin/frameworks');

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1089,6 +1089,12 @@
           }
         }
       },
+      "statistics": {
+        "total-participants-count": {
+          "info": "The total number of unique participants from the organisation who have started at least one campaign participation since the organisation was created (regardless of the status of the campaigns, participations or participants, whether deleted or not)",
+          "title": "Total number of participants"
+        }
+      },
       "target-profiles-section": {
         "table": {
           "caption": "Liste des profils cibles rattachés à l'organisation. Contient son identifiant et son nom interne. Une action permet de détacher le profil cible quand cela est possible."
@@ -1583,6 +1589,7 @@
         "invitations": "Invitations",
         "network": "Network {nbrOfChildren, plural, =0 {({nbrOfChildren} child)} =1 {({nbrOfChildren} child)} other {({nbrOfChildren} children)}}",
         "places": "Places",
+        "statistics": "Statistics",
         "tags": "Tags",
         "target-profiles": "Target profiles",
         "team": "Team"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1097,6 +1097,12 @@
           }
         }
       },
+      "statistics": {
+        "total-participants-count": {
+          "info": "Nombre total de participants uniques de l'organisation ayant débuté au moins une participation à une campagne depuis la création de l'organisation (peu importe le statut des campagnes, des participations, ou des participants, supprimé ou non)",
+          "title": "Nombre total de participants"
+        }
+      },
       "target-profiles-section": {
         "table": {
           "caption": "Liste des profils cibles rattachés à l'organisation. Contient son identifiant et son nom interne. Une action permet de détacher le profil cible quand cela est possible."
@@ -1593,6 +1599,7 @@
         "invitations": "Invitations",
         "network": "Réseau {nbrOfChildren, plural, =0 {({nbrOfChildren} fille)} =1 {({nbrOfChildren} fille)} other {({nbrOfChildren} filles)}}",
         "places": "Places",
+        "statistics": "Statistiques",
         "tags": "Tags",
         "target-profiles": "Profils cibles",
         "team": "Équipe"


### PR DESCRIPTION
## 🚙 Problème

Suite à la PR https://github.com/1024pix/pix/pull/16350, on veut maintenant pouvoir visualiser les statistiques d'une organisation sur sa page dans Pix Admin.

## 🍃 Proposition

Afficher un nouvel onglet statistiques sur la page de détail d'une organisation.

## 🦵 Remarques
RAS

## 🔗 Pour tester

Sur Pix Admin, connecté avec n'importe quel rôle:
- naviguer vers la page de détail d'une organisation
- constater la présence du nouvel onglet Statistiques
- naviguer dessus
- constater les statistiques (l'orga ID 1000 possède des participants à des campagnes)
