### PR TITLE
[BUGFIX] Corriger le crash de l'import SIECLE sur les gros fichiers

### DIFF
--- a/api/src/prescription/learner-management/domain/models/ScoOrganizationLearnerSet.js
+++ b/api/src/prescription/learner-management/domain/models/ScoOrganizationLearnerSet.js
@@ -35,6 +35,10 @@ class ScoOrganizationLearnerSet {
         ({ nationalStudentId }) => nationalStudentId === reconciledStudent.nationalStudentId,
       );
 
+      if (!studentToImport) {
+        return;
+      }
+
       if (this.#shouldBeReconciled(allOrganizationLearnersInSameOrganization, reconciledStudent, studentToImport)) {
         studentToImport.userId = reconciledStudent.account.userId;
       }

--- a/api/tests/prescription/learner-management/unit/domain/models/ScoOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/ScoOrganizationLearnerSet_test.js
@@ -76,6 +76,20 @@ describe('Unit | Models | ScoOrganizationLearnerSet', function () {
       expect(scoOrganizationLearnerSet.learners[0].userId).to.be.null;
     });
 
+    it('ignores reconciled students absent from the current chunk without throwing', function () {
+      // reconciledStudents is computed over the whole file while a set only holds one chunk,
+      // so a reconciled student may not have any matching learner in this chunk.
+      const learner = new OrganizationLearner({ nationalStudentId: 'INE1', organizationId: 1 });
+      const reconciledStudentInOtherChunk = new Student({
+        nationalStudentId: 'INE_FROM_OTHER_CHUNK',
+        account: { userId: 42, organizationId: 1, birthdate: '2000-01-01' },
+      });
+      const scoOrganizationLearnerSet = new ScoOrganizationLearnerSet([learner]);
+
+      expect(() => scoOrganizationLearnerSet.reconcile([reconciledStudentInOtherChunk], [])).to.not.throw();
+      expect(scoOrganizationLearnerSet.learners[0].userId).to.be.undefined;
+    });
+
     it('does not assign userId when the user has multiple national student IDs in reconciled students', function () {
       const learner1 = new OrganizationLearner({ nationalStudentId: 'INE1', organizationId: 1 });
       const learner2 = new OrganizationLearner({ nationalStudentId: 'INE2', organizationId: 1 });


### PR DESCRIPTION
## 🌱 Problème

Le job `ImportFromSiecleJob` échoue en production sur les **gros fichiers SIECLE**
```
TypeError: Cannot read properties of undefined (reading 'organizationId')
```
Depuis le refactor de la réconciliation, `reconciledStudents` est calculé **une fois sur tout le fichier**, alors que `ScoOrganizationLearnerSet.reconcile()` est appelé **par chunk** (1000 élèves). Pour un élève réconcilié appartenant à un autre chunk, `studentToImport = this.#learners.find(...)` renvoie `undefined`, et `#shouldBeReconciled` plante en lisant `studentToImport.organizationId`.

## 🐣 Proposition

🛡️ Ajout d'un garde-fou dans `reconcile()` : on **ignore les élèves réconciliés absents du chunk courant** (ils sont traités avec leur propre chunk).

On **conserve volontairement le calcul global** de `reconciledStudents` : il est nécessaire pour détecter, à l'échelle du fichier entier, les comptes utilisateurs rattachés à plusieurs INE (`userIdsWithMultipleNationalStudentIds`). Repasser à un calcul par chunk rouvrirait ce trou de correction sur les fichiers multi-chunks (et multiplierait les requêtes `findByOrganizationId`).

## 🐝 Pour tester

✅ 
Vous pouvez aussi faire un import avec des milliers de personnes...

voir aussi [PR#16229](https://github.com/1024pix/pix/pull/16229)
