### PR TITLE
[FEATURE] Rendre l’expiration des tokens obligatoire et améliorer les méthodes restore des authenticators des applications Front (PIX-22655)

### DIFF
--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -53,6 +53,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
     return {
       access_token: data.access_token,
       user_id: decodedAccessToken.user_id,
+      expiresAt: decodedAccessToken.exp * 1000,
       source: identityProvider.source,
       identityProviderCode: identityProvider.code,
     };

--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -61,10 +61,14 @@ export default class OidcAuthenticator extends BaseAuthenticator {
 
   restore(data) {
     return new Promise((resolve, reject) => {
-      if (!isEmpty(data['access_token'])) {
-        resolve(data);
+      if (isEmpty(data['access_token'])) {
+        reject();
       }
-      reject();
+      if (data.expiresAt <= new Date().getTime()) {
+        reject();
+      }
+
+      resolve(data);
     });
   }
 }

--- a/admin/tests/unit/authenticators/oidc-test.js
+++ b/admin/tests/unit/authenticators/oidc-test.js
@@ -88,8 +88,9 @@ module('Unit | Authenticator | oidc', function (hooks) {
       sinon.assert.calledWith(window.fetch, `http://localhost:3000/api/admin/oidc/user/reconcile`, request);
       assert.deepEqual(token, {
         access_token: accessToken,
-        source,
         user_id: userId,
+        expiresAt: 4702193958000,
+        source,
         identityProviderCode,
       });
       assert.ok(true);
@@ -111,8 +112,9 @@ module('Unit | Authenticator | oidc', function (hooks) {
       sinon.assert.calledWith(window.fetch, 'http://localhost:3000/api/oidc/token', request);
       assert.deepEqual(token, {
         access_token: accessToken,
-        source,
         user_id: userId,
+        expiresAt: 4702193958000,
+        source,
         identityProviderCode,
       });
       assert.ok(true);

--- a/admin/tests/unit/authenticators/oidc-test.js
+++ b/admin/tests/unit/authenticators/oidc-test.js
@@ -147,4 +147,44 @@ module('Unit | Authenticator | oidc', function (hooks) {
       });
     });
   });
+
+  module('restore', function () {
+    module('when there is no access_token', function () {
+      test('it rejects', async function (assert) {
+        // given
+        const authenticator = this.owner.lookup('authenticator:oidc');
+        const data = {};
+
+        // when & then
+        await assert.rejects(authenticator.restore(data));
+      });
+    });
+
+    module('when there is an access_token', function () {
+      module('when the access_token is expired', function () {
+        test('it rejects', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:oidc');
+          const data = { expiresAt: new Date().getTime(), access_token: 'accessTokenData' };
+
+          // when & then
+          await assert.rejects(authenticator.restore(data));
+        });
+      });
+
+      module('when the access_token is not expired', function () {
+        test('it returns the still valid data', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:oidc');
+          const data = { expiresAt: new Date().getTime() + 60000, access_token: 'accessTokenData' };
+
+          // when
+          const result = await authenticator.restore(data);
+
+          // then
+          assert.strictEqual(result, data);
+        });
+      });
+    });
+  });
 });

--- a/api/src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js
+++ b/api/src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js
@@ -41,7 +41,7 @@ export class CertificationResultsLinkByEmailToken {
         scope: CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE,
       },
       config.authentication.secret,
-      { expiresIn: `${daysBeforeExpiration}d` },
+      `${daysBeforeExpiration}d`,
     );
   }
 }

--- a/api/src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js
+++ b/api/src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js
@@ -33,7 +33,7 @@ export class CertificationResultsLinkToken {
         scope: config.jwtConfig.certificationResults.scope,
       },
       config.authentication.secret,
-      { expiresIn: `${config.jwtConfig.certificationResults.tokenLifespan}` },
+      config.jwtConfig.certificationResults.tokenLifespan,
     );
   }
 }

--- a/api/src/identity-access-management/domain/models/ApplicationAccessToken.js
+++ b/api/src/identity-access-management/domain/models/ApplicationAccessToken.js
@@ -23,7 +23,7 @@ export class ApplicationAccessToken {
         scope: Array.isArray(scope) ? scope.join(' ') : scope,
       },
       config.authentication.secret,
-      { expiresIn: config.authentication.accessTokenLifespanMs },
+      config.authentication.accessTokenLifespanMs,
     );
   }
 }

--- a/api/src/identity-access-management/domain/models/PasswordExpirationToken.js
+++ b/api/src/identity-access-management/domain/models/PasswordExpirationToken.js
@@ -14,8 +14,10 @@ export class PasswordExpirationToken {
   }
 
   static generate({ userId }) {
-    return tokenService.encodeToken({ user_id: userId }, config.authentication.secret, {
-      expiresIn: config.authentication.passwordResetTokenLifespan,
-    });
+    return tokenService.encodeToken(
+      { user_id: userId },
+      config.authentication.secret,
+      config.authentication.passwordResetTokenLifespan,
+    );
   }
 }

--- a/api/src/identity-access-management/domain/models/UserAccessToken.js
+++ b/api/src/identity-access-management/domain/models/UserAccessToken.js
@@ -34,8 +34,10 @@ export class UserAccessToken {
   }
 
   static generate({ userId, source, audience, expirationDelaySeconds }) {
-    return tokenService.encodeToken({ user_id: userId, source, aud: audience }, config.authentication.secret, {
-      expiresIn: expirationDelaySeconds,
-    });
+    return tokenService.encodeToken(
+      { user_id: userId, source, aud: audience },
+      config.authentication.secret,
+      expirationDelaySeconds,
+    );
   }
 }

--- a/api/src/identity-access-management/domain/models/UserReconciliationSamlIdToken.js
+++ b/api/src/identity-access-management/domain/models/UserReconciliationSamlIdToken.js
@@ -33,7 +33,7 @@ export class UserReconciliationSamlIdToken {
         saml_id: samlId,
       },
       config.authentication.secret,
-      { expiresIn: config.authentication.tokenForStudentReconciliationLifespan },
+      config.authentication.tokenForStudentReconciliationLifespan,
     );
   }
 }

--- a/api/src/identity-access-management/domain/services/reset-password.service.js
+++ b/api/src/identity-access-management/domain/services/reset-password.service.js
@@ -6,9 +6,11 @@ import { tokenService } from '../../../shared/domain/services/token-service.js';
 const generateTemporaryKey = async function () {
   const randomBytesBuffer = await cryptoService.randomBytes(16);
   const base64RandomBytes = randomBytesBuffer.toString('base64');
-  return tokenService.encodeToken({ data: base64RandomBytes }, config.temporaryKey.secret, {
-    expiresIn: config.temporaryKey.tokenLifespan,
-  });
+  return tokenService.encodeToken(
+    { data: base64RandomBytes },
+    config.temporaryKey.secret,
+    config.temporaryKey.tokenLifespan,
+  );
 };
 
 const assertTemporaryKey = function (token) {

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -1,17 +1,21 @@
+import Joi from 'joi';
 import jsonwebtoken from 'jsonwebtoken';
 
 import { config } from '../../../../src/shared/config.js';
 import { InvalidTemporaryKeyError } from '../errors.js';
 
 /**
- * Encode and sign a payload into a JWT token (using jsonwebtoken library)
+ * Encodes and signs a payload into a JWT token with a time-limited validity
+ *
  * @param {Record<string, any>} payload Token payload
  * @param {string} secret Secret for the signature
- * @param {Record<string, any>} options Sign options (ex: { expiresIn })
+ * @param {number} expiresIn expressed in seconds or a string describing a time span, 60, ex. "2 days", "10h", "7d"
  * @returns The encoded and signed token
  */
-function encodeToken(payload, secret, options) {
-  return jsonwebtoken.sign(payload, secret, options);
+function encodeToken(payload, secret, expiresIn) {
+  Joi.assert(expiresIn, Joi.required());
+
+  return jsonwebtoken.sign(payload, secret, { expiresIn });
 }
 
 /**

--- a/api/tests/certification/results/unit/domain/models/tokens/CertificationResultsLinkByEmailToken.test.js
+++ b/api/tests/certification/results/unit/domain/models/tokens/CertificationResultsLinkByEmailToken.test.js
@@ -42,7 +42,7 @@ describe('Unit | Certification | Results | Domain | Model | CertificationResults
       const token = tokenService.encodeToken(
         { result_recipient_email: 'recipient@example.com', scope: 'certificationResultsByRecipientEmailLink' },
         config.authentication.secret,
-        { expiresIn: '1d' },
+        '1d',
       );
       expect(() => CertificationResultsLinkByEmailToken.decode(token)).to.throw(InvalidResultRecipientTokenError);
     });
@@ -51,7 +51,7 @@ describe('Unit | Certification | Results | Domain | Model | CertificationResults
       const token = tokenService.encodeToken(
         { session_id: 'sessionId!', scope: 'certificationResultsByRecipientEmailLink' },
         config.authentication.secret,
-        { expiresIn: '1d' },
+        '1d',
       );
       expect(() => CertificationResultsLinkByEmailToken.decode(token)).to.throw(InvalidResultRecipientTokenError);
     });
@@ -60,7 +60,7 @@ describe('Unit | Certification | Results | Domain | Model | CertificationResults
       const token = tokenService.encodeToken(
         { session_id: 'sessionId!', result_recipient_email: 'recipient@example.com', scope: 'wrong-scope' },
         config.authentication.secret,
-        { expiresIn: '1d' },
+        '1d',
       );
       expect(() => CertificationResultsLinkByEmailToken.decode(token)).to.throw(InvalidResultRecipientTokenError);
     });

--- a/api/tests/certification/results/unit/domain/models/tokens/CertificationResultsLinkToken.test.js
+++ b/api/tests/certification/results/unit/domain/models/tokens/CertificationResultsLinkToken.test.js
@@ -33,9 +33,11 @@ describe('Unit | Certification | Results | Domain | Model | CertificationResults
 
     it('throws error if session_id is missing', function () {
       // given
-      const token = tokenService.encodeToken({ scope: 'certification-scope' }, config.authentication.secret, {
-        expiresIn: `${config.jwtConfig.certificationResults.tokenLifespan}`,
-      });
+      const token = tokenService.encodeToken(
+        { scope: 'certification-scope' },
+        config.authentication.secret,
+        config.jwtConfig.certificationResults.tokenLifespan,
+      );
 
       // when / then
       expect(() => CertificationResultsLinkToken.decode(token)).to.throw(InvalidSessionResultTokenError);
@@ -46,9 +48,7 @@ describe('Unit | Certification | Results | Domain | Model | CertificationResults
       const token = tokenService.encodeToken(
         { session_id: 'sessionId!', scope: 'wrong-scope' },
         config.authentication.secret,
-        {
-          expiresIn: `${config.jwtConfig.certificationResults.tokenLifespan}`,
-        },
+        config.jwtConfig.certificationResults.tokenLifespan,
       );
 
       // when / then

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -1,8 +1,36 @@
+import Joi from 'joi';
+
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { tokenService } from '../../../../../src/shared/domain/services/token-service.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Domain | Services | Token Service', function () {
+  describe('encodeToken', function () {
+    it('generates a JWT', function () {
+      // given
+      const payload = { amstram: 'gram' };
+      const secret = 'someSecret';
+      const expiresIn = '3d';
+
+      // when
+      const result = tokenService.encodeToken(payload, secret, expiresIn);
+
+      // then
+      expect(result).to.be.a.string;
+    });
+
+    context('when expiresIn is not given', function () {
+      it('throws a ValidationError', function () {
+        // given
+        const payload = { amstram: 'gram' };
+        const secret = 'someSecret';
+
+        // when & then
+        expect(() => tokenService.encodeToken(payload, secret)).to.throw(Joi.ValidationError);
+      });
+    });
+  });
+
   describe('#extractUserId', function () {
     it('should return userId if the accessToken is valid', function () {
       // given

--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -4,10 +4,8 @@ import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 import ENV from 'mon-pix/config/environment';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 
-export default BaseAuthenticator.extend({
-  locale: service(),
-
-  serverTokenEndpoint: `${ENV.APP.API_HOST}/api/token/anonymous`,
+export default class AnonymousAuthenticator extends BaseAuthenticator {
+  @service locale;
 
   async authenticate({ campaignCode }) {
     const bodyObject = { campaign_code: campaignCode, lang: this.locale.currentLanguage };
@@ -25,7 +23,8 @@ export default BaseAuthenticator.extend({
       body,
     };
 
-    const response = await fetch(this.serverTokenEndpoint, options);
+    const url = `${ENV.APP.API_HOST}/api/token/anonymous`;
+    const response = await fetch(url, options);
 
     const data = await response.json();
     if (!response.ok) {
@@ -38,7 +37,7 @@ export default BaseAuthenticator.extend({
       access_token: data.access_token,
       user_id: decodedAccessToken.user_id,
     };
-  },
+  }
 
   restore(data) {
     return new Promise((resolve, reject) => {
@@ -47,5 +46,5 @@ export default BaseAuthenticator.extend({
       }
       reject();
     });
-  },
-});
+  }
+}

--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -42,10 +42,14 @@ export default class AnonymousAuthenticator extends BaseAuthenticator {
 
   restore(data) {
     return new Promise((resolve, reject) => {
-      if (!isEmpty(data['access_token'])) {
-        resolve(data);
+      if (isEmpty(data['access_token'])) {
+        reject();
       }
-      reject();
+      if (data.expiresAt <= new Date().getTime()) {
+        reject();
+      }
+
+      resolve(data);
     });
   }
 }

--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -36,6 +36,7 @@ export default class AnonymousAuthenticator extends BaseAuthenticator {
     return {
       access_token: data.access_token,
       user_id: decodedAccessToken.user_id,
+      expiresAt: decodedAccessToken.exp * 1000,
     };
   }
 

--- a/mon-pix/app/authenticators/gar.js
+++ b/mon-pix/app/authenticators/gar.js
@@ -3,14 +3,16 @@ import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 
 export default class GarAuthenticator extends BaseAuthenticator {
-  authenticate(token, tokenDecoder = decodeToken) {
+  authenticate(token) {
     const token_type = 'bearer';
-    const { user_id, source } = tokenDecoder(token);
+    const decodedAccessToken = decodeToken(token);
+
     return Promise.resolve({
       token_type,
       access_token: token,
-      user_id,
-      source,
+      user_id: decodedAccessToken.user_id,
+      expiresAt: decodedAccessToken.exp * 1000,
+      source: decodedAccessToken.source,
     });
   }
 

--- a/mon-pix/app/authenticators/gar.js
+++ b/mon-pix/app/authenticators/gar.js
@@ -18,10 +18,14 @@ export default class GarAuthenticator extends BaseAuthenticator {
 
   restore(data) {
     return new Promise((resolve, reject) => {
-      if (!isEmpty(data['access_token'])) {
-        resolve(data);
+      if (isEmpty(data['access_token'])) {
+        reject();
       }
-      reject();
+      if (data.expiresAt <= new Date().getTime()) {
+        reject();
+      }
+
+      resolve(data);
     });
   }
 }

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -52,8 +52,9 @@ export default class OidcAuthenticator extends BaseAuthenticator {
 
     return {
       access_token: data.access_token,
-      logoutUrlUuid: data.logout_url_uuid,
       user_id: decodedAccessToken.user_id,
+      expiresAt: decodedAccessToken.exp * 1000,
+      logoutUrlUuid: data.logout_url_uuid,
       source: identityProvider.source,
       shouldCloseSession: identityProvider.shouldCloseSession,
       identityProviderCode: identityProvider.code,

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -63,10 +63,14 @@ export default class OidcAuthenticator extends BaseAuthenticator {
 
   restore(data) {
     return new Promise((resolve, reject) => {
-      if (!isEmpty(data['access_token'])) {
-        resolve(data);
+      if (isEmpty(data['access_token'])) {
+        reject();
       }
-      reject();
+      if (data.expiresAt <= new Date().getTime()) {
+        reject();
+      }
+
+      resolve(data);
     });
   }
 

--- a/mon-pix/tests/unit/authenticators/anonymous-test.js
+++ b/mon-pix/tests/unit/authenticators/anonymous-test.js
@@ -1,0 +1,49 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../helpers/setup-intl';
+
+module('Unit | Authenticator | anonymous', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('restore', function () {
+    module('when there is no access_token', function () {
+      test('it rejects', async function (assert) {
+        // given
+        const authenticator = this.owner.lookup('authenticator:anonymous');
+        const data = {};
+
+        // when & then
+        await assert.rejects(authenticator.restore(data));
+      });
+    });
+
+    module('when there is an access_token', function () {
+      module('when the access_token is expired', function () {
+        test('it rejects', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:anonymous');
+          const data = { expiresAt: new Date().getTime(), access_token: 'accessTokenData' };
+
+          // when & then
+          await assert.rejects(authenticator.restore(data));
+        });
+      });
+
+      module('when the access_token is not expired', function () {
+        test('it returns the still valid data', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:anonymous');
+          const data = { expiresAt: new Date().getTime() + 60000, access_token: 'accessTokenData' };
+
+          // when
+          const result = await authenticator.restore(data);
+
+          // then
+          assert.strictEqual(result, data);
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/authenticators/gar-test.js
+++ b/mon-pix/tests/unit/authenticators/gar-test.js
@@ -13,22 +13,27 @@ module('Unit | Authenticator | gar', function (hooks) {
     test('should authenticate the user', async function (assert) {
       // given
       const authenticator = this.owner.lookup('authenticator:gar');
-      const token = Symbol('mon super token');
-
-      const decodeToken = sinon.stub().returns({ user_id: 1, source: 'gar' });
+      const token =
+        'aaa.' +
+        btoa(`{
+        "user_id": 1,
+        "source": "gar",
+        "iat": 1545321469,
+        "exp": 4702193958
+      }`) +
+        '.bbb';
 
       // when
-      const expectedResult = await authenticator.authenticate(token, decodeToken);
+      const result = await authenticator.authenticate(token);
 
       // then
-      sinon.assert.calledWith(decodeToken, token);
-      assert.deepEqual(expectedResult, {
+      assert.deepEqual(result, {
         token_type: 'bearer',
         access_token: token,
         user_id: 1,
+        expiresAt: 4702193958000,
         source: 'gar',
       });
-      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/unit/authenticators/gar-test.js
+++ b/mon-pix/tests/unit/authenticators/gar-test.js
@@ -36,4 +36,44 @@ module('Unit | Authenticator | gar', function (hooks) {
       });
     });
   });
+
+  module('restore', function () {
+    module('when there is no access_token', function () {
+      test('it rejects', async function (assert) {
+        // given
+        const authenticator = this.owner.lookup('authenticator:gar');
+        const data = {};
+
+        // when & then
+        await assert.rejects(authenticator.restore(data));
+      });
+    });
+
+    module('when there is an access_token', function () {
+      module('when the access_token is expired', function () {
+        test('it rejects', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:gar');
+          const data = { expiresAt: new Date().getTime(), access_token: 'accessTokenData' };
+
+          // when & then
+          await assert.rejects(authenticator.restore(data));
+        });
+      });
+
+      module('when the access_token is not expired', function () {
+        test('it returns the still valid data', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:gar');
+          const data = { expiresAt: new Date().getTime() + 60000, access_token: 'accessTokenData' };
+
+          // when
+          const result = await authenticator.restore(data);
+
+          // then
+          assert.strictEqual(result, data);
+        });
+      });
+    });
+  });
 });

--- a/mon-pix/tests/unit/authenticators/oidc-test.js
+++ b/mon-pix/tests/unit/authenticators/oidc-test.js
@@ -84,10 +84,11 @@ module('Unit | Authenticator | oidc', function (hooks) {
       sinon.assert.calledWith(window.fetch, 'http://localhost:3000/api/oidc/users', { ...request, body });
       assert.deepEqual(token, {
         access_token: accessToken,
+        user_id: userId,
+        expiresAt: 4702193958000,
         logoutUrlUuid,
         source,
         shouldCloseSession,
-        user_id: userId,
         identityProviderCode,
       });
     });
@@ -117,10 +118,11 @@ module('Unit | Authenticator | oidc', function (hooks) {
       sinon.assert.calledWith(window.fetch, 'http://localhost:3000/api/oidc/token', { ...request, body });
       assert.deepEqual(token, {
         access_token: accessToken,
+        user_id: userId,
+        expiresAt: 4702193958000,
         logoutUrlUuid,
         source,
         shouldCloseSession,
-        user_id: userId,
         identityProviderCode,
       });
     });

--- a/mon-pix/tests/unit/authenticators/oidc-test.js
+++ b/mon-pix/tests/unit/authenticators/oidc-test.js
@@ -197,4 +197,44 @@ module('Unit | Authenticator | oidc', function (hooks) {
       });
     });
   });
+
+  module('restore', function () {
+    module('when there is no access_token', function () {
+      test('it rejects', async function (assert) {
+        // given
+        const authenticator = this.owner.lookup('authenticator:oidc');
+        const data = {};
+
+        // when & then
+        await assert.rejects(authenticator.restore(data));
+      });
+    });
+
+    module('when there is an access_token', function () {
+      module('when the access_token is expired', function () {
+        test('it rejects', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:oidc');
+          const data = { expiresAt: new Date().getTime(), access_token: 'accessTokenData' };
+
+          // when & then
+          await assert.rejects(authenticator.restore(data));
+        });
+      });
+
+      module('when the access_token is not expired', function () {
+        test('it returns the still valid data', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:oidc');
+          const data = { expiresAt: new Date().getTime() + 60000, access_token: 'accessTokenData' };
+
+          // when
+          const result = await authenticator.restore(data);
+
+          // then
+          assert.strictEqual(result, data);
+        });
+      });
+    });
+  });
 });

--- a/orga/app/authenticators/oidc.js
+++ b/orga/app/authenticators/oidc.js
@@ -52,8 +52,9 @@ export default class OidcAuthenticator extends BaseAuthenticator {
 
     return {
       access_token: data.access_token,
-      logoutUrlUuid: data.logout_url_uuid,
       user_id: decodedAccessToken.user_id,
+      expiresAt: decodedAccessToken.exp * 1000,
+      logoutUrlUuid: data.logout_url_uuid,
       source: identityProvider.source,
       shouldCloseSession: identityProvider.shouldCloseSession,
       identityProviderCode: identityProvider.code,

--- a/orga/app/authenticators/oidc.js
+++ b/orga/app/authenticators/oidc.js
@@ -63,10 +63,14 @@ export default class OidcAuthenticator extends BaseAuthenticator {
 
   restore(data) {
     return new Promise((resolve, reject) => {
-      if (!isEmpty(data['access_token'])) {
-        resolve(data);
+      if (isEmpty(data['access_token'])) {
+        reject();
       }
-      reject();
+      if (data.expiresAt <= new Date().getTime()) {
+        reject();
+      }
+
+      resolve(data);
     });
   }
 

--- a/orga/tests/unit/authenticators/oidc-test.js
+++ b/orga/tests/unit/authenticators/oidc-test.js
@@ -232,4 +232,44 @@ module('Unit | Authenticator | oidc', function (hooks) {
       });
     });
   });
+
+  module('restore', function () {
+    module('when there is no access_token', function () {
+      test('it rejects', async function (assert) {
+        // given
+        const authenticator = this.owner.lookup('authenticator:oidc');
+        const data = {};
+
+        // when & then
+        await assert.rejects(authenticator.restore(data));
+      });
+    });
+
+    module('when there is an access_token', function () {
+      module('when the access_token is expired', function () {
+        test('it rejects', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:oidc');
+          const data = { expiresAt: new Date().getTime(), access_token: 'accessTokenData' };
+
+          // when & then
+          await assert.rejects(authenticator.restore(data));
+        });
+      });
+
+      module('when the access_token is not expired', function () {
+        test('it returns the still valid data', async function (assert) {
+          // given
+          const authenticator = this.owner.lookup('authenticator:oidc');
+          const data = { expiresAt: new Date().getTime() + 60000, access_token: 'accessTokenData' };
+
+          // when
+          const result = await authenticator.restore(data);
+
+          // then
+          assert.strictEqual(result, data);
+        });
+      });
+    });
+  });
 });

--- a/orga/tests/unit/authenticators/oidc-test.js
+++ b/orga/tests/unit/authenticators/oidc-test.js
@@ -84,10 +84,11 @@ module('Unit | Authenticator | oidc', function (hooks) {
       sinon.assert.calledWith(window.fetch, 'http://localhost:3000/api/oidc/users', { ...request, body });
       assert.deepEqual(token, {
         access_token: accessToken,
+        user_id: userId,
+        expiresAt: 4702193958000,
         logoutUrlUuid,
         source,
         shouldCloseSession,
-        user_id: userId,
         identityProviderCode,
       });
     });
@@ -117,10 +118,11 @@ module('Unit | Authenticator | oidc', function (hooks) {
       sinon.assert.calledWith(window.fetch, 'http://localhost:3000/api/oidc/token', { ...request, body });
       assert.deepEqual(token, {
         access_token: accessToken,
+        user_id: userId,
+        expiresAt: 4702193958000,
         logoutUrlUuid,
         source,
         shouldCloseSession,
-        user_id: userId,
         identityProviderCode,
       });
     });


### PR DESCRIPTION
## 🚙 Problème

Avec l’_authenticator_ `oidc` et l’_authenticator_ `gar` des applications Front (Pix App, Pix Orga, Pix Admin), les applications font des requêtes même lorsque l’AccessToken de l’utilisateur est expiré.

### 3 appels inutiles à Pix API pour l’_authenticator_ `oidc` 

<img width="1550" height="169" alt="authenticator-oidc" src="https://github.com/user-attachments/assets/35e45144-34d1-4b00-98ae-53ac1f22699a" />

### 1 appel inutile à Pix API pour l’_authenticator_ `gar`

<img width="1606" height="127" alt="authenticator-gar" src="https://github.com/user-attachments/assets/67b100e0-8b3d-472d-981f-24382445691a" />

## 🍃 Proposition

Faire évoluer la méthode restore des authenticators, suivant ce qui est fait dans l’OAuth2PasswordGrant de ember-simple-auth, pour prendre en compte l’expiration des AccessTokens. En cas d’expiration cela évite 3 appels à Pix API pour l’_authenticator_ `oidc` et 1 appel à Pix API pour l’_authenticator_ `gar`.

On met en place la même logique de code dans l’_authenticator_ `anonymous` pour avoir des codes uniformes, mais cela ne produit pas de changement de comportement par rapport à l’existant.

On profite de ce ticket pour rendre obligatoire l’expiration de tous les tokens JWT générés par Pix API en modifiant la fonction `tokenService.encodeToken`. Tous les tokens JWT ont bien actuellement tous une durée limitée de validation de par leur expiration, mais rien dans le code ne le force.

Le champ `exp` de la spec JWT cf. https://www.rfc-editor.org/info/rfc7519/#section-4.1.4 est : 
* optionnel
* est un nombre de secondes

C’est pourquoi, respectivement : 
* on se base sur le fait que l’expiration dans `tokenService.encodeToken` devient obligatoire
* on a choisit de stocker, dans le session store Ember, une propriété `expiresAt` en millisecondes de manière à pouvoir l’utiliser facilement avec l’objet `Date` de JavaScript.

## 🦵 Remarques

RAS

## 🔗 Pour tester

### Pour tester avec une authentification OIDC

1. Changer la configuration de Pix API pour avoir une courte durée de validité des Access Tokens générés pour les authentifications réalisées par SSO OIDC : 
```sql
update "oidc-providers" set "accessTokenLifespan"='30s';
```
2. Redémarrer Pix API
3. Dans une fenêtre de navigation privée, s’authentifier par SSO OIDC
4. Dans cette fenêtre de navigation privée, fermer l’onglet dans lequel le frontal Pix était ouvert
5. Attendre que les 30s de validité du token soit expirée
6. Rouvrir l’onglet précédent
7. Constater qu’aucun appel réseau avec une réponse `401` n’a été fait à Pix API

### Pour tester avec une authentification GAR

1. Changer la configuration de Pix API pour avoir une courte durée de validité des Access Tokens générés pour les authentifications GAR : 
```shell
SAML_ACCESS_TOKEN_LIFESPAN=30s
```
2. Redémarrer Pix API
3. Dans une fenêtre de navigation privée, s’authentifier par le SSO GAR (ou avec un faux-GAR)
4. Dans cette fenêtre de navigation privée, fermer l’onglet dans lequel le frontal Pix était ouvert
5. Attendre que les 30s de validité du token soit expirée
6. Rouvrir l’onglet précédent
7. Constater qu’aucun appel réseau avec une réponse `401` n’a été fait à Pix API

### Pour tester avec une authentification anonyme (parcours simplifié)

1. Changer la configuration de Pix API pour avoir une courte durée de validité des Access Tokens générés pour les parcours simplifiés : 
```shell
ANONYMOUS_ACCESS_TOKEN_LIFESPAN=30s
```
2. Constater qu’il n’y a pas de régression.