### PR TITLE
[TECH] :broom: Réduction de l'utilisation de la librairie Lodash

### DIFF
--- a/api/src/certification/enrolment/domain/models/ComplementaryCertificationCourseWithResults.js
+++ b/api/src/certification/enrolment/domain/models/ComplementaryCertificationCourseWithResults.js
@@ -8,7 +8,6 @@
  * @property {Source} source
  */
 
-import { _ } from '../../../../shared/infrastructure/utils/lodash-utils.js';
 import { ChallengesReferential } from '../../../shared/domain/models/ChallengesReferential.js';
 
 class ComplementaryCertificationCourseWithResults {
@@ -27,10 +26,12 @@ class ComplementaryCertificationCourseWithResults {
   }
 
   isAcquiredExpectedLevelByPixSource() {
-    return _.some(this.results, {
-      source: ChallengesReferential.PIX,
-      acquired: true,
-      complementaryCertificationBadgeId: this.complementaryCertificationBadgeId,
+    return this.results?.some((r) => {
+      return (
+        r.source === ChallengesReferential.PIX &&
+        r.acquired === true &&
+        r.complementaryCertificationBadgeId === this.complementaryCertificationBadgeId
+      );
     });
   }
 

--- a/api/src/certification/session-management/domain/read-models/EuropeanNumericLevelFactory.js
+++ b/api/src/certification/session-management/domain/read-models/EuropeanNumericLevelFactory.js
@@ -1,10 +1,6 @@
-import lodash from 'lodash';
-
-const { remove, uniqBy } = lodash;
-
 import { EuropeanNumericLevel } from './EuropeanNumericLevel.js';
 
-class EuropeanNumericLevelFactory {
+export class EuropeanNumericLevelFactory {
   static buildFromCompetenceMarks(competenceMarks) {
     const europeanNumericLevels = [];
     competenceMarks.forEach(({ competenceCode, level }) => {
@@ -65,10 +61,7 @@ class EuropeanNumericLevelFactory {
         new EuropeanNumericLevel({ domainCompetenceId: '5', competenceId: '3', level: averageGlobalScore }),
       );
     }
-
-    remove(europeanNumericLevels, ({ level }) => level < 1);
-
-    return europeanNumericLevels;
+    return europeanNumericLevels.filter(({ level }) => level >= 1);
   }
 }
 
@@ -93,7 +86,5 @@ function _buildEuropeanNumericLevelFromMergedCompetenceMarks({
 }
 
 function _areAtLeastOneCompetenceByDomain(competenceMarks) {
-  return uniqBy(competenceMarks, 'areaCode').length === 5;
+  return new Set(competenceMarks.map(({ areaCode }) => areaCode)).size === 5;
 }
-
-export { EuropeanNumericLevelFactory };

--- a/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FinalizedSession } from '../../domain/models/FinalizedSession.js';
@@ -70,12 +68,7 @@ function _toDomainObject({ date, time, ...finalizedSession }) {
 }
 
 function _toDTO(finalizedSession) {
-  return _.omit(
-    {
-      ...finalizedSession,
-      date: finalizedSession.sessionDate,
-      time: finalizedSession.sessionTime,
-    },
-    ['sessionDate', 'sessionTime'],
-  );
+  // eslint-disable-next-line no-unused-vars
+  const { sessionDate, sessionTime, ...filteredFinalizedSession } = finalizedSession;
+  return { ...filteredFinalizedSession, date: finalizedSession.sessionDate, time: finalizedSession.sessionTime };
 }

--- a/api/src/certification/session-management/infrastructure/serializers/session-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-serializer.js
@@ -1,5 +1,4 @@
 import jsonapiSerializer from 'jsonapi-serializer';
-import _ from 'lodash';
 
 import isEmpty from '../../../../shared/infrastructure/utils/is-empty.js';
 import { SessionManagement } from '../../domain/models/SessionManagement.js';
@@ -53,7 +52,7 @@ export function deserialize(json) {
     version: attributes['version'],
   });
 
-  if (isEmpty(_.trim(result.examinerGlobalComment))) {
+  if (isEmpty(result.examinerGlobalComment?.trim())) {
     result.examinerGlobalComment = SessionManagement.NO_EXAMINER_GLOBAL_COMMENT;
   }
 


### PR DESCRIPTION
## 🚙 Problème

Nous utilisons une librairie externe (vecteur de risque sécu) alors que nous pourrions utiliser des fonctions JavaScript natives.

## 🍃 Proposition

Remplacement des fonctions Lodash par des équivalents en JavaScript Natif.

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
