### PR TITLE
[BUGFIX] Ne plus supprimer les fichiers d'import en cas d'échec pour permettre les retry

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-fregata-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-fregata-file.js
@@ -57,7 +57,9 @@ const importLearnersFromFregataFile = withTransaction(async function ({
   } finally {
     organizationImport.process({ errors });
     await organizationImportRepository.save(organizationImport);
-    await importStorage.deleteFile({ filename: organizationImport.filename });
+    if (errors.length === 0) {
+      await importStorage.deleteFile({ filename: organizationImport.filename });
+    }
   }
 });
 

--- a/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-generic-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-generic-file.js
@@ -66,7 +66,9 @@ const importLearnersFromGenericFile = async function ({
   } finally {
     organizationImport.process({ errors });
     await organizationImportRepository.save(organizationImport);
-    await importStorage.deleteFile({ filename: organizationImport.filename });
+    if (errors.length === 0) {
+      await importStorage.deleteFile({ filename: organizationImport.filename });
+    }
   }
 };
 

--- a/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-siecle-file.js
@@ -58,10 +58,12 @@ async function importLearnersFromSiecleFile({
     } finally {
       organizationImport.process({ errors });
       await organizationImportRepository.save(organizationImport);
-      try {
-        await importStorage.deleteFile({ filename: organizationImport.filename });
-      } catch (error) {
-        logger.error(error);
+      if (errors.length === 0) {
+        try {
+          await importStorage.deleteFile({ filename: organizationImport.filename });
+        } catch (error) {
+          logger.error(error);
+        }
       }
     }
   });

--- a/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-sup-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-learners/import-learners-from-sup-file.js
@@ -32,7 +32,9 @@ const importLearnersFromSupFile = async function ({
   } finally {
     organizationImport.process({ errors });
     await organizationImportRepository.save(organizationImport);
-    await importStorage.deleteFile({ filename: organizationImport.filename });
+    if (errors.length === 0) {
+      await importStorage.deleteFile({ filename: organizationImport.filename });
+    }
   }
 };
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-fregata-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-fregata-file_test.js
@@ -168,7 +168,7 @@ describe('Unit | UseCase | importLearnersFromFregataFile', function () {
       expect(firstCallFirstArg.status).to.equal('IMPORT_ERROR');
     });
 
-    it('should delete file on s3', async function () {
+    it('should not delete file on s3 so the import can be retried', async function () {
       await catchErr(importLearnersFromFregataFile)({
         organizationImportId,
         i18n,
@@ -178,7 +178,7 @@ describe('Unit | UseCase | importLearnersFromFregataFile', function () {
         importStorage: importStorageStub,
       });
 
-      expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({ filename: organizationImport.filename });
+      expect(importStorageStub.deleteFile).to.have.been.not.called;
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-generic-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-generic-file_test.js
@@ -144,8 +144,7 @@ describe('Unit | UseCase | importLearnersFromGenericFile', function () {
         organizationImportRepositoryStub.save.calledOnceWith(organizationImportStub),
         'orgnizationImportRepository.save',
       ).to.be.true;
-      expect(importStorageStub.deleteFile.calledOnceWithExactly({ filename: s3Filepath }), 'importStorage.deleteFile')
-        .to.be.true;
+      expect(importStorageStub.deleteFile.called, 'importStorage.deleteFile').to.be.false;
     });
 
     context('error list', function () {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-siecle-file_test.js
@@ -104,6 +104,7 @@ describe('Unit | UseCase | importLearnersFromSiecleFile', function () {
     expect(organizationLearnerRepositoryStub.disableAllOrganizationLearnersInOrganization).to.have.been.not.called;
     expect(organizationImportStub.process).to.have.been.called;
     expect(organizationImportRepositoryStub.save).to.have.been.called;
+    expect(importStorageStub.deleteFile).to.have.been.not.called;
   });
 
   it('should save import state even if deleteFile crash but log error for tracking', async function () {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-sup-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-learners/import-learners-from-sup-file_test.js
@@ -167,6 +167,24 @@ describe('Unit | UseCase | importLearnersFromSupFile', function () {
         expect(firstCallFirstArg.errors).to.deep.equals([error]);
         expect(firstCallFirstArg.status).to.equal('IMPORT_ERROR');
       });
+
+      it('should not delete file on s3 so the import can be retried', async function () {
+        // given
+        const insertError = new Error('insert fail');
+        supOrganizationLearnerRepositoryStub.addStudents.rejects(insertError);
+
+        // when
+        await catchErr(importLearnersFromSupFile)({
+          organizationImportId,
+          i18n,
+          supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+          organizationImportRepository: organizationImportRepositoryStub,
+          importStorage: importStorageStub,
+        });
+
+        // then
+        expect(importStorageStub.deleteFile).to.have.been.not.called;
+      });
     });
   });
 });


### PR DESCRIPTION
## 🚙 Problème

Dans les usecases d'import d'élèves, le bloc `finally` supprimait le fichier source (`importStorage.deleteFile`) **même lorsque l'import échouait**.

Conséquences :
- Les rejeux (`FEW_RETRY` de pg-boss) étaient structurellement condamnés : à la 1ʳᵉ tentative ratée le fichier disparaissait, donc chaque retry repartait sur un fichier absent et échouait en `S3FileDoesNotExistError`.
- La vraie erreur d'origine était masquée dans les logs derrière cette erreur S3 trompeuse.

## 🍃 Proposition

On ne supprime désormais le fichier que **si l'import a réussi** (`errors.length === 0`). En cas d'échec, le fichier est conservé pour que le retry puisse le relire.

Appliqué de façon identique sur les 4 usecases d'import :
- `import-learners-from-siecle-file.js`
- `import-learners-from-fregata-file.js`
- `import-learners-from-generic-file.js`
- `import-learners-from-sup-file.js`

Le statut de l'import (`IMPORTED` / `IMPORT_ERROR`) continue d'être sauvegardé dans tous les cas — seule la suppression du fichier devient conditionnelle.

## 🔗 Pour tester

🟢 
