### PR TITLE
[BUGFIX] Supporte les participations anonymisées (PIX-22905)

### DIFF
--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -32,7 +32,6 @@ class CampaignParticipation {
     this.sharedAt = sharedAt;
     this.campaignId = campaignId;
     assert.ok(clientId, 'Client ID should be defined');
-    assert.ok(userId, 'User ID should be defined');
     this.participantId = crypto.hash('sha1', `${userId}_${clientId}`);
     this.masteryRate = masteryRate;
     this.tubes = tubes;


### PR DESCRIPTION
## 🚙 Problème

L'api maddo renvoie les participations à une campagne. Dans le cas où une utilisatrice demande à être anonimisée, on supprime le lien entre sont userId et sa participations.
Or le userId est requis sur le modèle CampaignParticipation
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🍃 Proposition

Ne pas rentre le userId obligatoire

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
- créer une campagne
- Participer à la campagne
- Récupérer les participations à la campagne avec maddo 
```
curl -X 'POST' -s \
  'https://pix-api-maddo-review-pr16402.osc-fr1.scalingo.io/api/application/token' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=meta campaigns'
```

puis 
```
curl https://pix-api-maddo-review-pr16402.osc-fr1.scalingo.io/api/campaigns/1000001/participations -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-type: application/json" | jq
```
- Anonymiser l'utilisateur 
- Récupérer les participations
- ne pas avoir d'erreur 500
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
