### PR TITLE
[FEATURE] Cacher le bouton de création de version (PIX-22993)

### DIFF
--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -7,12 +7,15 @@ import { t } from 'ember-intl';
 export default class Header extends Component {
   @service intl;
   @service currentUser;
+  @service router;
 
   get frameworkLabel() {
     return this.intl.t(`components.certification-frameworks.labels.${this.args.certificationFramework.name}`);
   }
 
   get canCreateVersion() {
+    if (this.router.currentRouteName.startsWith('authenticated.certification-frameworks.item.framework.new-version'))
+      return false;
     return this.currentUser.adminMember.isSuperAdmin && this.args.certificationFramework?.name !== 'CLEA';
   }
 

--- a/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
@@ -1,4 +1,5 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import Header from 'pix-admin/components/certification-frameworks/item/header';
 import { module, test } from 'qunit';
 
@@ -11,6 +12,11 @@ module('Integration | Component | certification-frameworks/item/header', functio
 
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
+
+    class routerStub extends Service {
+      currentRouteName = 'super.route';
+    }
+    this.owner.register('service:router', routerStub);
   });
 
   test('it should display the framework label in breadcrumb and title', async function (assert) {
@@ -67,6 +73,25 @@ module('Integration | Component | certification-frameworks/item/header', functio
       // then
       assert
         .dom(screen.queryByText(t('components.certification-frameworks.item.framework.create-button')))
+        .doesNotExist();
+    });
+
+    test('it should not display the create button on new version page', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const serviceRouter = this.owner.lookup('service:router');
+      serviceRouter.currentRouteName = 'authenticated.certification-frameworks.item.framework.new-version';
+      const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
+
+      // when
+      const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
+
+      // then
+      assert
+        .dom(
+          screen.queryByRole('button', { name: t('components.certification-frameworks.item.framework.create-button') }),
+        )
         .doesNotExist();
     });
   });


### PR DESCRIPTION
## 🚙 Problème
Le boutton "créer une nouvelle version du référentiel" ne disparait pas lorsque que l'on arrive sur la page de création d'une nouvelle version.
<img width="410" height="96" alt="image" src="https://github.com/user-attachments/assets/8e8eb95c-5e10-4f7d-a838-8cfb23d9f6ab" />


## 🍃 Proposition

Vérifier la route front pour le cacher au besoin

## 🦵 Remarques
RAS
## 🔗 Pour tester

Essayer de créer une nouvelle version et ce boutton devrait disparaitre :) 
<img width="1267" height="709" alt="image" src="https://github.com/user-attachments/assets/d577c579-f595-4579-a89f-03e4ae046deb" />
