### PR TITLE
[FEATURE] Créer le composant modal du catalogue (panneau droit de détails d'un parcours) (PIX-22675)

### DIFF
--- a/orga/app/adapters/target-profile-overview.js
+++ b/orga/app/adapters/target-profile-overview.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class TargetProfileOverviewAdapter extends ApplicationAdapter {
+  urlForFindRecord(id, modelName, snapshot) {
+    const { organizationId } = snapshot.adapterOptions;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/target-profiles/${id}`;
+  }
+}

--- a/orga/app/components/campaign/badges.gjs
+++ b/orga/app/components/campaign/badges.gjs
@@ -2,6 +2,10 @@ import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { t } from 'ember-intl';
 
 const isAcquired = (badge, acquiredBadges = []) => {
+  // if (hideBadgesAcquisition) {
+  //   return true;
+  // }
+
   let acquired = false;
   acquiredBadges.forEach((acquiredBadge) => {
     if (acquiredBadge.id === badge.id) {
@@ -9,6 +13,11 @@ const isAcquired = (badge, acquiredBadges = []) => {
     }
   });
   return acquired;
+};
+
+const getBadgeImageClass = (badge, acquiredBadges = [], hideBadgesAcquisition = false) => {
+  if (hideBadgesAcquisition) return;
+  if (!isAcquired(badge, acquiredBadges)) return 'badge--unacquired';
 };
 
 <template>
@@ -19,18 +28,20 @@ const isAcquired = (badge, acquiredBadges = []) => {
           src={{badge.imageUrl}}
           alt={{badge.altMessage}}
           tabindex="0"
-          class={{unless (isAcquired badge @acquiredBadges) "badge--unacquired"}}
+          class={{getBadgeImageClass badge @acquiredBadges @hideBadgesAcquisition}}
           aria-describedby="badge-tooltip-{{badge.id}}"
         />
       </:triggerElement>
       <:tooltip>
         {{badge.title}}
-        -
-        {{if
-          (isAcquired badge @acquiredBadges)
-          (t "pages.campaign-results.table.badge-tooltip.acquired")
-          (t "pages.campaign-results.table.badge-tooltip.unacquired")
-        }}
+        {{#unless @hideBadgesAcquisition}}
+          -
+          {{if
+            (isAcquired badge @acquiredBadges)
+            (t "pages.campaign-results.table.badge-tooltip.acquired")
+            (t "pages.campaign-results.table.badge-tooltip.unacquired")
+          }}
+        {{/unless}}
       </:tooltip>
     </PixTooltip>
   {{/each}}

--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -1,49 +1,78 @@
 import PixCard from '@1024pix/pix-ui/components/pix-card';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import { concat } from '@ember/helper';
+import { concat, hash } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 
+export function getCourseInfo(courseType) {
+  switch (courseType) {
+    case 'targetProfile':
+    case 'target-profile-overview':
+      return {
+        color: 'blue',
+        label: 'pages.catalogue.card.tag.target-profile',
+        image: 'https://assets.pix.org/sites/orga/target-profile.png',
+      };
+    case 'blueprint':
+    case 'combined-course-blueprint':
+      return {
+        color: 'yellow',
+        label: 'pages.catalogue.card.tag.blueprint',
+        image: 'https://assets.pix.org/sites/orga/combined-course.png',
+      };
+    default:
+      return null;
+  }
+}
+
 export default class CourseCard extends Component {
   get courseInfo() {
-    switch (this.args.course.type) {
-      case 'blueprint': {
-        return {
-          color: 'yellow',
-          label: 'pages.catalogue.card.tag.blueprint',
-          image: 'https://assets.pix.org/sites/orga/combined-course.png',
-        };
-      }
-      default: {
-        return {
-          color: 'blue',
-          label: 'pages.catalogue.card.tag.target-profile',
-          image: 'https://assets.pix.org/sites/orga/target-profile.png',
-        };
-      }
-    }
+    return getCourseInfo(this.args.course.type);
   }
+
   <template>
-    <PixCard
-      variant="orga"
-      @title={{@course.name}}
-      @subtitle={{if @course.category (t (concat "pages.campaign-creation.tags." @course.category))}}
-      @image={{this.courseInfo.image}}
-    >
-      <:tag>
-        <PixTag @color={{this.courseInfo.color}} class="course-card__tag">{{t this.courseInfo.label}}</PixTag>
-      </:tag>
-      <:footer>
-        {{#if (eq @course.type "targetProfile")}}
-          {{t "pages.catalogue.card.tubes-count" count=@course.nbTubes}}
-        {{else}}
-          {{t "pages.catalogue.card.modules-count" count=@course.nbModules}}
-        {{/if}}
-        {{#if @course.isSimplifiedAccess}}
-          <p class="course-card__footer">{{t "pages.catalogue.card.simplified-access"}}</p>
-        {{/if}}
-      </:footer>
-    </PixCard>
+    <div class="course-card__wrapper">
+      <PixCard
+        @variant="orga"
+        @title={{@course.name}}
+        @subtitle={{if @course.category (t (concat "pages.campaign-creation.tags." @course.category))}}
+        @image={{this.courseInfo.image}}
+      >
+        <:tag>
+          <PixTag @color={{this.courseInfo.color}} class="course-card__tag">{{t this.courseInfo.label}}</PixTag>
+        </:tag>
+        <:footer>
+          {{#if (eq @course.type "targetProfile")}}
+            {{t "pages.catalogue.card.tubes-count" count=@course.nbTubes}}
+          {{else}}
+            {{t "pages.catalogue.card.modules-count" count=@course.nbModules}}
+          {{/if}}
+          {{#if @course.isSimplifiedAccess}}
+            <p class="course-card__footer">{{t "pages.catalogue.card.simplified-access"}}</p>
+          {{/if}}
+        </:footer>
+      </PixCard>
+
+      {{#if (eq @course.type "targetProfile")}}
+        <LinkTo
+          @route="authenticated.catalogue.list"
+          @model={{@type}}
+          @query={{hash targetProfileId=@course.id}}
+          {{on "click" @selectCourse}}
+          aria-label={{t "pages.catalogue.modal.open-modal"}}
+        />
+      {{else if (eq @course.type "blueprint")}}
+        <LinkTo
+          @route="authenticated.catalogue.list"
+          @model={{@type}}
+          @query={{hash blueprintId=@course.id}}
+          {{on "click" @selectCourse}}
+          aria-label={{t "pages.catalogue.modal.open-modal"}}
+        />
+      {{/if}}
+    </div>
   </template>
 }

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -1,0 +1,118 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixOverlay from '@1024pix/pix-ui/components/pix-overlay';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { service } from '@ember/service';
+import { recordIdentifierFor } from '@ember-data/store';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import { gt } from 'ember-truth-helpers';
+
+import Badges from '../campaign/badges';
+import { getCourseInfo } from './course-card.gjs';
+
+export default class CourseModal extends Component {
+  @service currentUser;
+
+  get courseTypeInfo() {
+    const type = recordIdentifierFor(this.args.currentCourse).type;
+    return getCourseInfo(type);
+  }
+
+  get hasReachedPlacesLimit() {
+    return this.currentUser.placeStatistics?.hasReachedMaximumPlacesLimit;
+  }
+
+  get campaignCreationRoute() {
+    if (this.hasReachedPlacesLimit) {
+      return null;
+    }
+    return 'authenticated.campaigns.new';
+  }
+
+  get courseLevelLabel() {
+    if (this.args.currentCourse.level < 3) {
+      return 'pages.statistics.level.novice';
+    } else if (this.args.currentCourse.level < 5) {
+      return 'pages.statistics.level.independent';
+    } else if (this.args.currentCourse.level < 7) {
+      return 'pages.statistics.level.advanced';
+    } else {
+      return 'pages.statistics.level.expert';
+    }
+  }
+
+  <template>
+    <PixOverlay
+      @isVisible={{@isModalOpen}}
+      @onClose={{@closeModal}}
+      @focusOnClose={{@focusOnClose}}
+      @hasCenteredContent={{true}}
+    >
+      <div
+        class="course-modal"
+        role="dialog"
+        aria-labelledby="modal-title--{{this.id}}"
+        aria-describedby="modal-content--{{this.id}}"
+        aria-modal="true"
+      >
+        <div class="course-modal__course-content"></div>
+        <div class="course-modal__course-details">
+          <div class="course-modal__header">
+            <PixButton
+              @variant="tertiary"
+              @triggerAction={{@closeModal}}
+              @size="small"
+              @iconAfter="close"
+              class="course-modal__exit"
+            >
+              {{t "common.actions.exit"}}
+            </PixButton>
+          </div>
+          <div class="course-modal__body">
+            <div class="pix-card__image pix-card__image--orga">
+              <img src={{this.courseTypeInfo.image}} aria-hidden="true" alt={{@currentCourse.type}} />
+            </div>
+            <PixTag @color={{this.courseTypeInfo.color}} class="course-card__tag">
+              {{t this.courseTypeInfo.label}}
+            </PixTag>
+            <h1 id="modal-title--{{this.id}}" class="course-modal__body__name">{{@currentCourse.name}}</h1>
+            <p
+              id="modal-content--{{this.id}}"
+              class="course-modal__body__description"
+            >{{@currentCourse.description}}</p>
+
+            {{#if (gt @currentCourse.badges.length 0)}}
+              <h2 class="course-modal__body__badges-title">
+                {{t "pages.catalogue.modal.associated-badges"}}
+              </h2>
+              <div class="course-modal__body__badges">
+                <Badges @badges={{@currentCourse.badges}} @hideBadgesAcquisition={{true}} />
+              </div>
+            {{/if}}
+
+            <PixButtonLink
+              @route={{this.campaignCreationRoute}}
+              @isDisabled={{this.hasReachedPlacesLimit}}
+              @size="small"
+              class="course-modal__body__form-link"
+            >
+              {{t "pages.campaign-creation.target-profiles-label"}}
+            </PixButtonLink>
+          </div>
+          <div class="course-modal__footer">
+            <p class="course-modal__footer__text">
+              {{t this.courseLevelLabel}}
+              &nbsp;•&nbsp;
+              {{#if @currentCourse.isSimplifiedAccess}}
+                {{t "common.target-profile-details.simplified-access.without-account"}}
+              {{else}}
+                {{t "common.target-profile-details.simplified-access.with-account"}}
+              {{/if}}
+            </p>
+          </div>
+        </div>
+      </div>
+    </PixOverlay>
+  </template>
+}

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -4,18 +4,46 @@ import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { fn } from '@ember/helper';
+import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import CourseCard from 'pix-orga/components/catalogue/course-card';
 import EmptyState from 'pix-orga/components/ui/empty-state';
 import ENV from 'pix-orga/config/environment';
 
+import CourseModal from './course-modal.gjs';
+
 export default class List extends Component {
   @service locale;
   @service intl;
+  @service router;
+
+  @tracked isModalOpen = false;
+
+  constructor() {
+    super(...arguments);
+
+    if (this.args.currentCourse) {
+      this.isModalOpen = true;
+    }
+  }
+
+  @action
+  selectCourse() {
+    this.isModalOpen = true;
+  }
+
+  @action
+  closeModal() {
+    this.router.transitionTo('authenticated.catalogue.list', this.args.type, {
+      queryParams: { targetProfileId: null, blueprintId: null },
+    });
+    this.isModalOpen = false;
+  }
 
   get isClearFiltersButtonDisabled() {
     const { search = '', category, areas, competences } = this.args;
@@ -163,11 +191,19 @@ export default class List extends Component {
       {{#if this.filteredItems}}
         <div class="catalogue__list">
           {{#each this.filteredItems as |course|}}
-            <CourseCard @course={{course}} />
+            <CourseCard @course={{course}} @type={{@type}} @selectCourse={{this.selectCourse}} />
           {{/each}}
         </div>
       {{else}}
         <EmptyState @infoText={{t "pages.catalogue.empty-state"}} />
+      {{/if}}
+
+      {{#if @currentCourse}}
+        <CourseModal
+          @currentCourse={{@currentCourse}}
+          @closeModal={{this.closeModal}}
+          @isModalOpen={{this.isModalOpen}}
+        />
       {{/if}}
     </div>
   </template>

--- a/orga/app/models/target-profile-overview.js
+++ b/orga/app/models/target-profile-overview.js
@@ -1,0 +1,15 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default class TargetProfileOverview extends Model {
+  @attr('string') name;
+  @attr('string') description;
+  @attr('number') tubeCount;
+  @attr('number') thematicResultCount;
+  @attr('boolean') hasStage;
+  @attr('string') category;
+  @attr('boolean') areKnowledgeElementsResettable;
+  @attr('boolean') isSimplifiedAccess;
+
+  @hasMany('framework', { async: false, inverse: null }) frameworks;
+  @hasMany('badge', { async: false, inverse: null }) badges;
+}

--- a/orga/app/routes/authenticated/catalogue/list.js
+++ b/orga/app/routes/authenticated/catalogue/list.js
@@ -8,15 +8,21 @@ export default class AuthenticatedCatalogueFilter extends Route {
 
   #currentOrgaId = null;
 
+  queryParams = {
+    targetProfileId: { refreshModel: true },
+    blueprintId: { refreshModel: true },
+  };
+
   beforeModel(transition) {
     if (!['all', 'blueprint', 'targetProfile'].includes(transition.to.params?.type)) {
       return this.router.replaceWith('authenticated.catalogue.list', 'all');
     }
   }
 
-  async model({ type }) {
+  async model({ type, targetProfileId, blueprintId }) {
     this.handleCache();
     let courses = this.store.peekAll('course');
+    let currentCourse;
 
     if (courses.length === 0) {
       courses = await this.store.findAll('course', {
@@ -25,7 +31,17 @@ export default class AuthenticatedCatalogueFilter extends Route {
       });
     }
 
-    return { courses, type };
+    if (targetProfileId) {
+      currentCourse = await this.store.findRecord('target-profile-overview', targetProfileId, {
+        adapterOptions: { organizationId: this.currentUser.organization.id },
+      });
+    }
+
+    if (blueprintId) {
+      // TODO use blueprint findRecord
+    }
+
+    return { courses, currentCourse, type };
   }
 
   handleCache() {

--- a/orga/app/styles/components/courses/course-card.scss
+++ b/orga/app/styles/components/courses/course-card.scss
@@ -1,4 +1,25 @@
 .course-card {
+  &__wrapper {
+    position: relative;
+    transition: 0.2s ease;
+
+    &:hover {
+      transform: translateY(-5px);
+    }
+
+    .pix-card-wrapper {
+      height: 100%;
+    }
+
+    > a {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
   &__tag {
     margin: var(--pix-spacing-3x) var(--pix-spacing-3x) var(--pix-spacing-3x) 0;
   }

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -1,0 +1,116 @@
+@use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/shadows';
+
+.course-modal {
+  position: relative;
+  display: flex;
+  width: 100%;
+  max-width: 62rem;
+  height: 100%;
+  min-height: auto;
+  max-height: 42.5rem;
+  margin: 0 auto;
+  background-color: var(--pix-orga-50);
+  border-radius: var(--pix-spacing-4x);
+  margin-block: auto;
+
+  &__course-content {
+    flex: 1;
+  }
+
+  &__course-details {
+    @extend %pix-shadow-orga;
+
+    position: relative;
+    display: flex;
+    flex-basis: 24rem;
+    flex-direction: column;
+    flex-grow: 0;
+    flex-shrink: 0;
+    justify-content: center;
+    padding-top: var(--pix-spacing-10x);
+    padding-right: var(--pix-spacing-8x);
+    padding-bottom: 4.5rem;
+    padding-left: var(--pix-spacing-8x);
+    background-color: var(--pix-neutral-0);
+    border-radius: var(--pix-spacing-4x);
+    border-top-left-radius: var(--pix-spacing-10x);
+    border-bottom-left-radius: var(--pix-spacing-10x);
+  }
+
+  &__header {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 10;
+    padding-top: var(--pix-spacing-6x);
+    padding-right: var(--pix-spacing-8x);
+
+    &__exit {
+      align-self: flex-end;
+      text-decoration: none;
+    }
+  }
+
+  &__body {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+    align-items: flex-start;
+
+    &__name {
+      @extend %pix-title-xs;
+    }
+
+    &__description {
+      @extend %pix-body-m;
+    }
+
+    &__badges-title {
+      @extend %pix-title-xxs;
+
+      margin-top: var(--pix-spacing-4x);
+    }
+
+    &__badges {
+      display: flex;
+      flex-wrap: wrap;
+      width: 100%;
+
+      .pix-tooltip {
+        flex: 0 0 2.25rem;
+
+        img {
+          width: calc(100% + 0.75rem);
+          height: auto;
+        }
+      }
+    }
+
+    &__form-link {
+      align-self: center;
+      margin-top: var(--pix-spacing-6x);
+
+      // margin-bottom: var(--pix-spacing-8x);
+    }
+  }
+
+  &__footer {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 10;
+    width: 100%;
+    padding-right: var(--pix-spacing-8x);
+    padding-bottom: var(--pix-spacing-8x);
+    padding-left: var(--pix-spacing-8x);
+
+    &__text {
+      @extend %pix-body-s;
+
+      text-align: center;
+    }
+  }
+}

--- a/orga/app/styles/components/courses/index.scss
+++ b/orga/app/styles/components/courses/index.scss
@@ -1,1 +1,2 @@
 @use 'course-card';
+@use 'course-modal';

--- a/orga/app/templates/authenticated/catalogue/list.gjs
+++ b/orga/app/templates/authenticated/catalogue/list.gjs
@@ -10,5 +10,6 @@ import List from 'pix-orga/components/catalogue/list';
     @category={{@controller.category}}
     @areas={{@controller.areas}}
     @competences={{@controller.competences}}
+    @currentCourse={{@model.currentCourse}}
   />
 </template>

--- a/orga/tests/integration/components/campaign/badges-test.gjs
+++ b/orga/tests/integration/components/campaign/badges-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import Badges from 'pix-orga/components/campaign/badges';
 import { module, test } from 'qunit';
 
@@ -35,8 +36,9 @@ module('Integration | Component | Campaign | Badges', function (hooks) {
     const screen = await render(<template><Badges @badges={{badges}} @acquiredBadges={{acquiredBadges}} /></template>);
 
     // then
-    assert.ok(screen.getByText(/badge1 - Non acquis/i));
+    assert.ok(screen.getByText(`badge1 - ${t('pages.campaign-results.table.badge-tooltip.unacquired')}`));
   });
+
   test('should render acquired in the title', async function (assert) {
     // given
     const badges = [{ title: 'badge1', imageUrl: 'img1', altMessage: 'alt-img1' }];
@@ -46,6 +48,42 @@ module('Integration | Component | Campaign | Badges', function (hooks) {
     const screen = await render(<template><Badges @badges={{badges}} @acquiredBadges={{acquiredBadges}} /></template>);
 
     // then
-    assert.ok(screen.getByText(/badge1 - Acquis/i));
+    assert.ok(screen.getByText(`badge1 - ${t('pages.campaign-results.table.badge-tooltip.acquired')}`));
+  });
+
+  module('if badge acquisition is hidden', function () {
+    test('should only render badge name without "unacquired"', async function (assert) {
+      // given
+      const badges = [{ title: 'badge1', imageUrl: 'img1', altMessage: 'alt-img1' }];
+      const acquiredBadges = [];
+
+      // when
+      const screen = await render(
+        <template>
+          <Badges @badges={{badges}} @acquiredBadges={{acquiredBadges}} @hideBadgesAcquisition={{true}} />
+        </template>,
+      );
+
+      // then
+      assert.ok(screen.getByText('badge1'));
+      assert.notOk(screen.queryByText(`badge1 - ${t('pages.campaign-results.table.badge-tooltip.unacquired')}`));
+    });
+
+    test('should only render badge name without "acquired"', async function (assert) {
+      // given
+      const badges = [{ title: 'badge1', imageUrl: 'img1', altMessage: 'alt-img1' }];
+      const acquiredBadges = [badges[0]];
+
+      // when
+      const screen = await render(
+        <template>
+          <Badges @badges={{badges}} @acquiredBadges={{acquiredBadges}} @hideBadgesAcquisition={{true}} />
+        </template>,
+      );
+
+      // then
+      assert.ok(screen.getByText('badge1'));
+      assert.notOk(screen.queryByText(`badge1 - ${t('pages.campaign-results.table.badge-tooltip.acquired')}`));
+    });
   });
 });

--- a/orga/tests/integration/components/catalogue/course-card-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-card-test.gjs
@@ -1,88 +1,187 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import CourseCard from 'pix-orga/components/catalogue/course-card';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Catalogue::CourseCard', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  const selectCourse = sinon.stub();
+
+  test('it shows the course name as a heading', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const course = store.createRecord('course', { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5 });
+
+    const screen = await render(
+      <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+    );
+    const card = await screen.getByRole('article');
+
+    assert.dom(within(card).getByRole('heading', { name: 'Ma super formation' })).exists();
+  });
+
   module('for a "targetProfile" type course', function () {
-    test('it shows the course name as a heading', async function (assert) {
-      const course = { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5 };
-
-      const screen = await render(<template><CourseCard @course={{course}} /></template>);
-
-      assert.dom(screen.getByRole('heading', { name: 'Ma super formation' })).exists();
-    });
-
     test('it shows the "Parcours" type tag', async function (assert) {
-      const course = { name: 'Ma formation', type: 'targetProfile', nbTubes: 3 };
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', { name: 'Ma formation', type: 'targetProfile', nbTubes: 3 });
 
-      const screen = await render(<template><CourseCard @course={{course}} /></template>);
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
+      const card = await screen.getByRole('article');
 
-      assert.dom(screen.getByText(t('pages.catalogue.card.tag.target-profile'))).exists();
+      assert.dom(await within(card).findByText(t('pages.catalogue.card.tag.target-profile'))).exists();
     });
 
     test('it shows the number of tubes', async function (assert) {
-      const course = { name: 'Ma formation', type: 'targetProfile', nbTubes: 3 };
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', { name: 'Ma formation', type: 'targetProfile', nbTubes: 3 });
 
-      const screen = await render(<template><CourseCard @course={{course}} /></template>);
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
 
       assert.dom(screen.getByText(t('pages.catalogue.card.tubes-count', { count: 3 }))).exists();
-    });
-
-    module('course category', function () {
-      test('it shows the category label when a category is set', async function (assert) {
-        const course = { name: 'Ma formation', type: 'targetProfile', nbTubes: 1, category: 'COMPETENCES' };
-
-        const screen = await render(<template><CourseCard @course={{course}} /></template>);
-
-        assert.dom(screen.getByText(t('pages.campaign-creation.tags.COMPETENCES'))).exists();
-      });
-
-      test('it shows no category label when the course has no category', async function (assert) {
-        const course = { name: 'Ma formation', type: 'targetProfile', nbTubes: 1, category: null };
-
-        const screen = await render(<template><CourseCard @course={{course}} /></template>);
-
-        assert.notOk(screen.queryByText(t('pages.campaign-creation.tags.COMPETENCES')));
-      });
     });
   });
 
   module('for a "blueprint" type course', function () {
     test('it shows the "Parcours apprenant" type tag', async function (assert) {
-      const course = { name: 'Mon parcours', type: 'blueprint', nbModules: 4 };
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', { name: 'Mon parcours', type: 'blueprint', nbModules: 4 });
 
-      const screen = await render(<template><CourseCard @course={{course}} /></template>);
-      assert.dom(screen.getByText(t('pages.catalogue.card.tag.blueprint'))).exists();
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
+      const card = await screen.getByRole('article');
+
+      assert.dom(within(card).getByText(t('pages.catalogue.card.tag.blueprint'))).exists();
     });
 
     test('it shows the number of modules', async function (assert) {
-      const course = { name: 'Mon parcours', type: 'blueprint', nbModules: 4 };
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', { name: 'Mon parcours', type: 'blueprint', nbModules: 4 });
 
-      const screen = await render(<template><CourseCard @course={{course}} /></template>);
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
 
       assert.dom(screen.getByText(t('pages.catalogue.card.modules-count', { count: 4 }))).exists();
     });
   });
 
+  module('course category', function () {
+    test('it shows the category label when a category is set', async function (assert) {
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', {
+        name: 'Ma formation',
+        type: 'blueprint',
+        nbModules: 1,
+        category: 'COMPETENCES',
+      });
+
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
+
+      assert.dom(screen.getByText(t('pages.campaign-creation.tags.COMPETENCES'))).exists();
+    });
+
+    test('it shows no category label when the course has no category', async function (assert) {
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', {
+        name: 'Ma formation',
+        type: 'targetProfile',
+        nbTubes: 1,
+        category: null,
+      });
+
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
+
+      assert.notOk(screen.queryByText(t('pages.campaign-creation.tags.COMPETENCES')));
+    });
+  });
+
   module('simplified access', function () {
     test('it shows the simplified access mention when enabled', async function (assert) {
-      const course = { name: 'Ma formation', type: 'targetProfile', nbTubes: 2, isSimplifiedAccess: true };
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', {
+        name: 'Ma formation',
+        type: 'targetProfile',
+        nbTubes: 2,
+        isSimplifiedAccess: true,
+      });
 
-      const screen = await render(<template><CourseCard @course={{course}} /></template>);
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
       assert.dom(screen.getByText(t('pages.catalogue.card.simplified-access'))).exists();
     });
 
     test('it does not show the simplified access mention when disabled', async function (assert) {
-      const course = { name: 'Ma formation', type: 'targetProfile', nbTubes: 2, isSimplifiedAccess: false };
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', {
+        name: 'Ma formation',
+        type: 'targetProfile',
+        nbTubes: 2,
+        isSimplifiedAccess: false,
+      });
 
-      const screen = await render(<template><CourseCard @course={{course}} /></template>);
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
 
       assert.notOk(screen.queryByText(t('pages.catalogue.card.simplified-access')));
+    });
+  });
+
+  module('modal', function () {
+    module('for a "targetProfile" type course', function () {
+      test('it should redirect with targetProfileId parameter to open the modal when the card is clicked', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const course = store.createRecord('course', {
+          id: '1',
+          name: 'Ma super formation',
+          type: 'targetProfile',
+          nbTubes: 5,
+        });
+
+        // when
+        const screen = await render(
+          <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+        );
+        const link = screen.getByRole('link', { name: t('pages.catalogue.modal.open-modal') });
+
+        // then
+        assert.strictEqual(link.getAttribute('href'), '/catalogue/all?targetProfileId=1');
+      });
+    });
+    module('for a "blueprint" type course', function () {
+      test('it should redirect with blueprintId parameter to open the modal when the card is clicked', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const course = store.createRecord('course', {
+          id: '2',
+          name: 'Ma super formation',
+          type: 'blueprint',
+          nbTubes: 5,
+        });
+
+        // when
+        const screen = await render(
+          <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+        );
+        const link = screen.getByRole('link', { name: t('pages.catalogue.modal.open-modal') });
+
+        // then
+        assert.strictEqual(link.getAttribute('href'), '/catalogue/all?blueprintId=2');
+      });
     });
   });
 });

--- a/orga/tests/integration/components/catalogue/course-modal-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-modal-test.gjs
@@ -1,0 +1,269 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import CourseModal from 'pix-orga/components/catalogue/course-modal';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Catalogue::CourseModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let currentUser, store;
+
+  const closeModal = sinon.stub();
+
+  hooks.beforeEach(function () {
+    currentUser = this.owner.lookup('service:current-user');
+    store = this.owner.lookup('service:store');
+  });
+
+  module('modal display', function () {
+    test('it should show the modal if isModalOpen', async function (assert) {
+      // given
+      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation' });
+
+      // when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(await screen.findByRole('dialog', { name: currentCourse.name })).exists();
+    });
+
+    test('it should not show the modal if not isModalOpen', async function (assert) {
+      // given
+      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation' });
+
+      // when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{false}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('dialog', { name: currentCourse.name })).doesNotExist();
+    });
+  });
+
+  module('for a "targetProfile" type course', function () {
+    test('it shows the course content', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', {
+        name: 'Ma super formation',
+        description: 'description',
+      });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(currentCourse.name)).exists();
+      assert.dom(screen.getByText(currentCourse.description)).exists();
+      assert.dom(screen.getByText(t('pages.catalogue.card.tag.target-profile'))).exists();
+    });
+  });
+
+  module('for a "blueprint" type course', function () {
+    test('it shows the course content', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('combined-course-blueprint', {
+        name: 'Ma super formation',
+        description: 'description',
+      });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(currentCourse.name)).exists();
+      assert.dom(screen.getByText(currentCourse.description)).exists();
+      assert.dom(screen.getByText(t('pages.catalogue.card.tag.blueprint'))).exists();
+    });
+  });
+
+  module('badges', function () {
+    test('it shows course available badges', async function (assert) {
+      //given
+      const badge1 = store.createRecord('badge', { altMessage: 'altBadge1' });
+      const badge2 = store.createRecord('badge', { altMessage: 'altBadge2' });
+      const currentCourse = store.createRecord('target-profile-overview', {
+        name: 'Ma super formation',
+        badges: [badge1, badge2],
+      });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: t('pages.catalogue.modal.associated-badges') })).exists();
+      assert.dom(screen.getByRole('img', { name: 'altBadge1' })).exists();
+      assert.dom(screen.getByRole('img', { name: 'altBadge2' })).exists();
+    });
+
+    test('it hides badges section if there are none', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', {
+        name: 'Ma super formation',
+        badges: [],
+      });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      // // then
+      assert.dom(screen.queryByRole('heading', { name: t('pages.catalogue.modal.associated-badges') })).doesNotExist();
+    });
+  });
+
+  module('campaign creation page link', function () {
+    test('it shows enabled campaign creation route button if enough "places"', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation' });
+      sinon.stub(currentUser, 'placeStatistics').value({ hasReachedMaximumPlacesLimit: false });
+
+      //when
+      const screen = await render(
+        <template><CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} /></template>,
+      );
+      const submitButton = await screen.getByText(t('pages.campaign-creation.target-profiles-label'));
+
+      // // then
+      assert.dom(submitButton).hasAttribute('aria-disabled', 'false');
+    });
+
+    test('it disables campaign creation route button if not enough "places"', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation' });
+      sinon.stub(currentUser, 'placeStatistics').value({ hasReachedMaximumPlacesLimit: true });
+
+      //when
+      const screen = await render(
+        <template><CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} /></template>,
+      );
+      const submitButton = await screen.getByText(t('pages.campaign-creation.target-profiles-label'));
+
+      // then
+      assert.dom(submitButton).hasAttribute('aria-disabled', 'true');
+    });
+  });
+
+  module('level', function () {
+    test('it shows novice level', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation', level: 2 });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      //then
+      assert.dom(screen.getByText(t('pages.statistics.level.novice'), { exact: false })).exists();
+    });
+    test('it shows independent level', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation', level: 4 });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      //then
+      assert.dom(screen.getByText(t('pages.statistics.level.independent'), { exact: false })).exists();
+    });
+    test('it shows advanced level', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation', level: 6 });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      //then
+      assert.dom(screen.getByText(t('pages.statistics.level.advanced'), { exact: false })).exists();
+    });
+    test('it shows expert level', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation', level: 8 });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      //then
+      assert.dom(screen.getByText(t('pages.statistics.level.expert'), { exact: false })).exists();
+    });
+  });
+
+  module('simplified access', function () {
+    test('it shows course with simplified access label', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', {
+        name: 'Ma super formation',
+        isSimplifiedAccess: true,
+      });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      //then
+      assert
+        .dom(screen.getByText(t('common.target-profile-details.simplified-access.without-account'), { exact: false }))
+        .exists();
+    });
+    test('it shows course without simplified access label', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', {
+        name: 'Ma super formation',
+        isSimplifiedAccess: false,
+      });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      //then
+      assert
+        .dom(screen.getByText(t('common.target-profile-details.simplified-access.with-account'), { exact: false }))
+        .exists();
+    });
+  });
+});

--- a/orga/tests/integration/components/catalogue/list-test.gjs
+++ b/orga/tests/integration/components/catalogue/list-test.gjs
@@ -11,43 +11,47 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Catalogue::List', function (hooks) {
   setupIntlRenderingTest(hooks);
   let store;
+
   hooks.beforeEach(function () {
-    const router = this.owner.lookup('service:router');
     store = this.owner.lookup('service:store');
-    router.transitionTo = () => {};
   });
 
-  module('when there are no items', function () {
-    test('it displays an empty state', async function (assert) {
-      // given
-      const courses = [];
-      const updateFilter = sinon.stub();
+  test('it displays an empty state when there are no items', async function (assert) {
+    // given
+    const courses = [];
+    const updateFilter = sinon.stub();
 
-      // when
-      const screen = await render(<template><List @courses={{courses}} @updateFilter={{updateFilter}} /></template>);
+    // when
+    const screen = await render(<template><List @courses={{courses}} @updateFilter={{updateFilter}} /></template>);
 
-      // then
-      assert.dom(screen.getByText(t('pages.catalogue.empty-state'))).exists();
-    });
+    // then
+    assert.dom(screen.getByText(t('pages.catalogue.empty-state'))).exists();
   });
 
-  module('when there are course items', function () {
-    test('it shows all items', async function (assert) {
-      // given
-      const courses = [
-        { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
-        { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
-      ];
-      const updateFilter = sinon.stub();
+  test('it shows all items', async function (assert) {
+    // given
+    const courses = [
+      { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+      { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+    ];
+    const updateFilter = sinon.stub();
 
-      // when
-      const screen = await render(
-        <template><List @updateFilter={{updateFilter}} @courses={{courses}} @type="all" /></template>,
-      );
+    // when
+    const screen = await render(
+      <template><List @updateFilter={{updateFilter}} @courses={{courses}} @type="all" /></template>,
+    );
 
-      // then
-      assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
-      assert.dom(screen.getByRole('heading', { level: 3, name: 'Mon parcours combiné' })).exists();
+    // then
+    assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
+    assert.dom(screen.getByRole('heading', { level: 3, name: 'Mon parcours combiné' })).exists();
+  });
+
+  module('filters', function (hooks) {
+    let router;
+
+    hooks.beforeEach(function () {
+      router = this.owner.lookup('service:router');
+      sinon.stub(router, 'transitionTo');
     });
 
     module('type filters', function () {
@@ -477,6 +481,72 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         // then
         assert.ok(resetFilters.calledOnce);
       });
+    });
+  });
+
+  module('modal', function () {
+    test('it shows the modal if a currentCourse has been fetched', async function (assert) {
+      // given
+      const updateFilter = sinon.stub();
+      const courses = [{ name: 'Ma super formation', type: 'targetProfile' }];
+      const currentCourse = store.createRecord('target-profile-overview', {
+        name: 'Ma super formation',
+        description: 'description',
+      });
+
+      // when
+      const screen = await render(
+        <template>
+          <List @courses={{courses}} @updateFilter={{updateFilter}} @type="all" @currentCourse={{currentCourse}} />
+        </template>,
+      );
+
+      assert.dom(await screen.findByRole('dialog', { name: currentCourse.name })).exists();
+    });
+
+    test('it does not show the modal if no currentCourse has been fetched', async function (assert) {
+      // given
+      const updateFilter = sinon.stub();
+      const courses = [{ name: 'Ma super formation', type: 'targetProfile' }];
+
+      // when
+      const screen = await render(
+        <template>
+          <List @courses={{courses}} @updateFilter={{updateFilter}} @type="all" @currentCourse={{null}} />
+        </template>,
+      );
+
+      assert.dom(screen.queryByRole('dialog')).doesNotExist();
+    });
+
+    test('it redirects to close the modal with empty query params on exit button click', async function (assert) {
+      // given
+      const router = this.owner.lookup('service:router');
+      const updateFilter = sinon.stub();
+
+      const type = 'all';
+      const transitionToStub = sinon.stub(router, 'transitionTo').withArgs('authenticated.catalogue.list', type, {
+        queryParams: { targetProfileId: null, blueprintId: null },
+      });
+
+      const courses = [{ name: 'Ma super formation', type: 'targetProfile' }];
+      const currentCourse = store.createRecord('target-profile-overview', {
+        name: 'Ma super formation',
+        description: 'description',
+      });
+
+      // when
+      const screen = await render(
+        <template>
+          <List @courses={{courses}} @updateFilter={{updateFilter}} @type={{type}} @currentCourse={{currentCourse}} />
+        </template>,
+      );
+
+      await click(screen.getByRole('button', { name: t('common.actions.exit') }));
+
+      // then
+      sinon.assert.calledOnce(transitionToStub);
+      assert.ok(true);
     });
   });
 });

--- a/orga/tests/unit/routes/authenticated/catalogue/list-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue/list-test.js
@@ -41,65 +41,95 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
   });
 
   module('model', function () {
-    test('it fetches courses from the API when none are present in the store', async function (assert) {
-      // given
-      const route = this.owner.lookup('route:authenticated/catalogue/list');
-      const store = this.owner.lookup('service:store');
-      const currentUser = this.owner.lookup('service:current-user');
-      const organizationId = Symbol('organizationId');
-      sinon.stub(currentUser, 'organization').value({ id: organizationId });
-      const courses = Symbol('Courses');
+    module('courses', function () {
+      test('it fetches courses from the API when none are present in the store', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/catalogue/list');
+        const store = this.owner.lookup('service:store');
+        const currentUser = this.owner.lookup('service:current-user');
+        const organizationId = Symbol('organizationId');
+        sinon.stub(currentUser, 'organization').value({ id: organizationId });
+        const courses = Symbol('Courses');
 
-      sinon.stub(store, 'peekAll').withArgs('course').returns([]);
-      sinon
-        .stub(store, 'findAll')
-        .withArgs('course', { backgroundReload: false, adapterOptions: { organizationId } })
-        .resolves(courses);
+        sinon.stub(store, 'peekAll').withArgs('course').returns([]);
+        sinon
+          .stub(store, 'findAll')
+          .withArgs('course', { backgroundReload: false, adapterOptions: { organizationId } })
+          .resolves(courses);
 
-      // when
-      const result = await route.model({ type: 'all' });
+        // when
+        const result = await route.model({ type: 'all' });
 
-      // then
-      assert.ok(store.findAll.calledOnce);
-      assert.deepEqual(result, { courses, type: 'all' });
+        // then
+        assert.ok(store.findAll.calledOnce);
+        assert.deepEqual(result, { courses, currentCourse: undefined, type: 'all' });
+      });
+      test('it returns cached courses without calling the API when the store is not empty', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:current-user');
+        const organizationId = Symbol('organizationId');
+        sinon.stub(currentUser, 'organization').value({ id: organizationId });
+        const route = this.owner.lookup('route:authenticated/catalogue/list');
+        const store = this.owner.lookup('service:store');
+        const courses = [Symbol('Course')];
+        sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
+        sinon.stub(store, 'findAll');
+        sinon.stub(store, 'unloadAll');
+
+        // when
+        const result = await route.model({ type: 'all' });
+        // then
+        assert.ok(store.findAll.notCalled);
+        assert.deepEqual(result, { courses, currentCourse: undefined, type: 'all' });
+      });
+      test('it unload cached courses when organization change', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:current-user');
+        const organizationId = Symbol('organizationId');
+        sinon.stub(currentUser, 'organization').value({ id: organizationId });
+        const route = this.owner.lookup('route:authenticated/catalogue/list');
+        const store = this.owner.lookup('service:store');
+        const courses = [Symbol('Course')];
+        sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
+        sinon.stub(store, 'findAll');
+        sinon.stub(store, 'unloadAll');
+
+        // when
+        const result = await route.model({ type: 'all' });
+        // then
+        assert.ok(store.findAll.notCalled);
+        assert.deepEqual(result, { courses, currentCourse: undefined, type: 'all' });
+      });
     });
-    test('it returns cached courses without calling the API when the store is not empty', async function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:current-user');
-      const organizationId = Symbol('organizationId');
-      sinon.stub(currentUser, 'organization').value({ id: organizationId });
-      const route = this.owner.lookup('route:authenticated/catalogue/list');
-      const store = this.owner.lookup('service:store');
-      const courses = [Symbol('Course')];
-      sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
-      sinon.stub(store, 'findAll');
-      sinon.stub(store, 'unloadAll');
 
-      // when
-      const result = await route.model({ type: 'all' });
-      // then
-      assert.ok(store.findAll.notCalled);
-      assert.deepEqual(result, { courses, type: 'all' });
-    });
-    test('it unload cached courses when organization change', async function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:current-user');
-      const organizationId = Symbol('organizationId');
-      sinon.stub(currentUser, 'organization').value({ id: organizationId });
-      const route = this.owner.lookup('route:authenticated/catalogue/list');
-      const store = this.owner.lookup('service:store');
-      const courses = [Symbol('Course')];
-      sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
-      sinon.stub(store, 'findAll');
-      sinon.stub(store, 'unloadAll');
+    module('currentCourse', function () {
+      test('it fetches target-profile-overview matching targetProfileId query param', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/catalogue/list');
+        const store = this.owner.lookup('service:store');
+        const currentUser = this.owner.lookup('service:current-user');
+        const organizationId = Symbol('organizationId');
+        sinon.stub(currentUser, 'organization').value({ id: organizationId });
+        const courses = [Symbol('Course')];
+        const currentCourse = Symbol('CurrentCourse');
 
-      // when
-      const result = await route.model({ type: 'all' });
-      // then
-      assert.ok(store.findAll.notCalled);
-      assert.deepEqual(result, { courses, type: 'all' });
+        sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
+        sinon.stub(store, 'findAll');
+        sinon
+          .stub(store, 'findRecord')
+          .withArgs('target-profile-overview', 1, { adapterOptions: { organizationId } })
+          .returns(currentCourse);
+
+        // when
+        const result = await route.model({ type: 'all', targetProfileId: 1 });
+
+        // then
+        assert.ok(store.findRecord.calledOnce);
+        assert.deepEqual(result, { courses, currentCourse, type: 'all' });
+      });
     });
   });
+
   module('handleCache', function () {
     test('it unloads course items from cache when organization change', function (assert) {
       // given
@@ -117,7 +147,7 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
       // then
       assert.ok(store.unloadAll.calledOnceWithExactly('course'));
     });
-    test('it do nothing when organizationhas not changed', function (assert) {
+    test('it does nothing when organization has not changed', function (assert) {
       // given
       const currentUser = this.owner.lookup('service:current-user');
       const organizationId = Symbol('organizationId');

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -196,6 +196,7 @@
       "cancel": "Abbrechen",
       "close": "Schließen",
       "confirm": "Bestätigen",
+      "exit": "Beenden",
       "global": "Aktionen",
       "link-to-participant": "Alle Aktivitäten des Teilnehmers anzeigen",
       "save": "Registrieren"
@@ -1051,6 +1052,10 @@
           "placeholder": "Nach Titel suchen"
         },
         "nb-result": "{count, plural, =0 {Kein Kurs} =1 {{count} Kurs} other {{count} Kurse}}"
+      },
+      "modal": {
+        "associated-badges": "Zugehörige Abzeichen",
+        "open-modal": "Details zum Kurs anzeigen"
       },
       "tab-filters": {
         "all": "Alle",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -191,6 +191,7 @@
       "cancel": "Cancel",
       "close": "Close",
       "confirm": "Confirm",
+      "exit": "Exit",
       "global": "Actions",
       "link-to-participant": "See whole participant's activity",
       "save": "Save"
@@ -1061,6 +1062,10 @@
           "placeholder": "Search by title"
         },
         "nb-result": "{count, plural, =0 {No course} =1 {{count} course} other {{count} courses}}"
+      },
+      "modal": {
+        "associated-badges": "Related badges",
+        "open-modal": "View course details"
       },
       "tab-filters": {
         "all": "All",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -197,6 +197,7 @@
       "cancel": "Cancelar",
       "close": "Cerrar",
       "confirm": "Confirme",
+      "exit": "Salir",
       "global": "Acciones",
       "link-to-participant": "Ver toda la actividad de los participantes",
       "save": "Regístrese en"
@@ -1055,6 +1056,10 @@
           "placeholder": "Buscar por título"
         },
         "nb-result": "{count, plural, =0 {Ningún curso} =1 {{count} curso} other {{count} cursos}}"
+      },
+      "modal": {
+        "associated-badges": "Insignias relacionadas",
+        "open-modal": "Ver detalles del cursos"
       },
       "tab-filters": {
         "all": "Todos",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -191,6 +191,7 @@
       "cancel": "Annuler",
       "close": "Fermer",
       "confirm": "Confirmer",
+      "exit": "Quitter",
       "global": "Actions",
       "link-to-participant": "Voir toute l'activité du participant",
       "save": "Enregistrer"
@@ -1049,6 +1050,10 @@
           "placeholder": "Rechercher par titre"
         },
         "nb-result": "{count, plural, =0 {Aucun parcours} =1 {{count} parcours} other {{count} parcours}}"
+      },
+      "modal": {
+        "associated-badges": "Badges associés",
+        "open-modal": "Voir le détail du parcours"
       },
       "tab-filters": {
         "all": "Tous",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -197,6 +197,7 @@
       "cancel": "Annullamento",
       "close": "Chiudere",
       "confirm": "Confermare",
+      "exit": "Esci",
       "global": "Azioni",
       "link-to-participant": "Visualizza tutte le attività dei partecipanti",
       "save": "Registro"
@@ -1052,6 +1053,10 @@
           "placeholder": "Cerca per titolo"
         },
         "nb-result": "{count, plural, =0 {Nessun percorso} =1 {{count} percorso} other {{count} percorsi}}"
+      },
+      "modal": {
+        "associated-badges": "Badge associati",
+        "open-modal": "Visualizza i dettagli del percorso"
       },
       "tab-filters": {
         "all": "Tutti",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -196,6 +196,7 @@
       "cancel": "Annuleren",
       "close": "Sluiten",
       "confirm": "Bevestigen",
+      "exit": "Afsluiten",
       "global": "Acties",
       "link-to-participant": "Alle activiteiten van de deelnemer bekijken",
       "save": "Opslaan"
@@ -1048,6 +1049,10 @@
           "placeholder": "Zoeken op titel"
         },
         "nb-result": "{count, plural, =0 {Geen traject} =1 {{count} traject} other {{count} trajecten}}"
+      },
+      "modal": {
+        "associated-badges": "Gerelateerde badges",
+        "open-modal": "Bekijk de details van het traject"
       },
       "tab-filters": {
         "all": "Alle",


### PR DESCRIPTION
## 🚙 Problème

Actuellement, il n'est pas possible d'avoir plus de détails sur un parcours dans le catalogue.

## 🍃 Proposition

Rendre le composant card cliquable.
Créer un composant modal affichant plus de détails sur le parcours sélectionné.
On ne créé pour l'instant que la partie de droite de la modal avec les détails basiques du parcours.
La modal ne sera également dynamique qu'avec des parcours de type Profil Cible.

## 🦵 Remarques

On modifie le composant Badges existant pour afficher une liste de badges sans la notion d'acquisition de chaque badge.

Il est peut-être nécessaire de modifier le composant PixCard de PixUI pour pouvoir le rendre cliquable directement si on y ajoute une propriété lien.

## 🔗 Pour tester

Se connecter à Pix Orga
Se mettre sur une orga ayant accès à un catalogue, avec au moins un profil cible et un blueprint dans son catalogue

Cliquer sur un parcours de type PC dans le catalogue
- Les détails du parcours s'affiche, avec la bonne illustration et le bon tag de type "parcours"
- Il est possible de sortir de la modal avec le bouton quitter ou annuler
- Le clic sur le bouton "sélectionner le parcours" emmène vers la page de création de campagne
- Les badges s'affichent avec un tooltip au hover
- Si aucun badge n'est présent sur ce parcours, la section badges ne s'affiche pas

(Le clic sur la card ne fonctionne pas dans le cas d'un parcours de type Blueprint)