### PR TITLE
[FEATURE] Ajouter le tag du niveau dans la page de certificat Pix+  (PIX-23007).

### DIFF
--- a/mon-pix/app/components/certifications/shareable-certificate/v3-pix-plus-certificate.gjs
+++ b/mon-pix/app/components/certifications/shareable-certificate/v3-pix-plus-certificate.gjs
@@ -158,7 +158,10 @@ export default class PixPlusCertificate extends Component {
         <PixBlock class="v3-pix-plus-certificate__results-infos-block">
           <img src="/images/illustrations/user-certifications/certificate-magnifier.png" alt="" />
           <div class="v3-pix-plus-certificate__results-infos-details">
-            <h3 class="v3-pix-plus-certificate__title">{{t "pages.certificate.results.title"}}</h3>
+            <h3 class="v3-pix-plus-certificate__title">
+              <span>{{t "pages.certificate.results.title"}}</span>
+              <PixTag class="mesh-level-tag" @color="yellow">{{this.reachedMeshLabel}}</PixTag>
+            </h3>
             <p><strong>{{@certificate.globalSummaryLabel}}</strong></p>
             {{@certificate.globalDescriptionLabel}}
           </div>

--- a/mon-pix/app/styles/components/user-certifications/v3-pix-plus-certificate.scss
+++ b/mon-pix/app/styles/components/user-certifications/v3-pix-plus-certificate.scss
@@ -57,6 +57,10 @@
 
     display: block;
   }
+
+  .mesh-level-tag {
+    vertical-align: middle;
+  }
 }
 
 .v3-pix-plus-certificate__stepper {

--- a/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-pix-plus-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-pix-plus-certificate-test.gjs
@@ -164,7 +164,9 @@ module('Integration | Component | Certifications | Shareable certificate | v3-pi
           <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
 
         // then
-        assert.dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') })).exists();
+        assert
+          .dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') + ' Expert' }))
+          .exists();
         assert.dom(screen.getByText('Summary label')).exists();
         assert.dom(screen.getByText('Description label')).exists();
       });
@@ -469,7 +471,9 @@ module('Integration | Component | Certifications | Shareable certificate | v3-pi
           <Certifications::ShareableCertificate::V3PixPlusCertificate @certificate={{this.certification}} />`);
 
       // then
-      assert.dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') })).exists();
+      assert
+        .dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') + ' Expert' }))
+        .exists();
       assert.dom(screen.getByText('Summary label')).exists();
       assert.dom(screen.getByText('Description label')).exists();
     });


### PR DESCRIPTION
## 🚙 Problème

Pour les résultats Pix+, à côté de “Lecture du résultat”, il manque un PixTag coloré avec le niveau obtenu. 

## 🍃 Proposition

Ajouter le tag dans le bloc de détail du résultat.
⚠️ Ne pas le faire pour le cas Pix+ edu “Admissible”.

## 🔗 Pour tester

Visualiser en RA des pages de détail de certif.
