### PR TITLE
[FEATURE] Ajouter le nombre de participants par année à l'api interne de stats d'une orga (PIX-22994)

### DIFF
--- a/api/src/organizational-entities/domain/usecases/get-organization-statistics.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/get-organization-statistics.usecase.js
@@ -18,5 +18,5 @@ export async function getOrganizationStatistics({ organizationId, organizationFo
   }
 
   const statistics = await organizationForAdminRepository.getOrganizationParticipantsStatistics({ organizationId });
-  return { ...statistics, id: `${organizationId}_organization_statistics` };
+  return { ...statistics, id: `${statistics.organizationId}_organization_statistics` };
 }

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (statistics) {
   return new Serializer('organization-statistics', {
-    attributes: ['totalParticipantsCount'],
+    attributes: ['organizationId', 'totalParticipantsCount', 'totalParticipantsCountByYear'],
   }).serialize(statistics);
 };
 

--- a/api/src/prescription/campaign/application/api/campaign-stats-api.js
+++ b/api/src/prescription/campaign/application/api/campaign-stats-api.js
@@ -14,5 +14,5 @@ import { OrganizationStatistics } from './models/OrganizationStatistics.js';
  */
 export const getOrganizationParticipantsStatistics = async (organizationId) => {
   const statistics = await usecases.getOrganizationParticipantsStatistics({ organizationId });
-  return new OrganizationStatistics(statistics);
+  return new OrganizationStatistics({ organizationId, ...statistics });
 };

--- a/api/src/prescription/campaign/application/api/models/OrganizationStatistics.js
+++ b/api/src/prescription/campaign/application/api/models/OrganizationStatistics.js
@@ -1,5 +1,7 @@
 export class OrganizationStatistics {
-  constructor({ totalParticipantsCount }) {
+  constructor({ organizationId, totalParticipantsCount, totalParticipantsCountByYear }) {
+    this.organizationId = organizationId;
     this.totalParticipantsCount = totalParticipantsCount;
+    this.totalParticipantsCountByYear = totalParticipantsCountByYear;
   }
 }

--- a/api/src/prescription/campaign/domain/usecases/statistics/get-organization-participants-statistics.js
+++ b/api/src/prescription/campaign/domain/usecases/statistics/get-organization-participants-statistics.js
@@ -3,7 +3,7 @@
  * @param {Object} params
  * @param {Number} params.organizationId
  * @param {CampaignParticipationsStatsRepository} params.campaignParticipationsStatsRepository
- * @returns {Promise<{totalParticipantsCount: Number}>}
+ * @returns {Promise<{totalParticipantsCount: Number, totalParticipantsCountByYear: Array<{year: Number, count: Number}> | []}>}
  */
 
 const getOrganizationParticipantsStatistics = async function ({
@@ -12,7 +12,11 @@ const getOrganizationParticipantsStatistics = async function ({
 }) {
   const totalParticipantsCount =
     await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(organizationId);
-  return { totalParticipantsCount };
+
+  const totalParticipantsCountByYear =
+    await campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear(organizationId);
+
+  return { totalParticipantsCount, totalParticipantsCountByYear };
 };
 
 export { getOrganizationParticipantsStatistics };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -96,8 +96,23 @@ const countParticipantsByOrganizationId = async (organizationId) => {
   return count;
 };
 
+const countParticipantsByOrganizationIdGroupedByYear = async (organizationId) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('campaign-participations')
+    .select(knexConn.raw('EXTRACT(YEAR FROM "campaign-participations"."createdAt")::int AS year'))
+    .countDistinct('campaign-participations.organizationLearnerId AS count')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .where('campaigns.organizationId', organizationId)
+    .groupBy('year')
+    .orderBy('year', 'asc');
+
+  return result;
+};
+
 export {
   countParticipantsByOrganizationId,
+  countParticipantsByOrganizationIdGroupedByYear,
   countParticipationsByMasteryRate,
   countParticipationsByStatus,
   getAllParticipationsByCampaignId,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -83,15 +83,10 @@ const countParticipationsByStatus = async (campaignId) => {
 const countParticipantsByOrganizationId = async (organizationId) => {
   const knexConn = DomainTransaction.getConnection();
 
-  const [{ count }] = await knexConn
-    .count('* as count')
-    .from(
-      knexConn('campaign-participations')
-        .select('campaign-participations.organizationLearnerId')
-        .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-        .where('campaigns.organizationId', organizationId)
-        .groupBy('campaign-participations.organizationLearnerId'),
-    );
+  const [{ count }] = await knexConn('campaign-participations')
+    .countDistinct('campaign-participations.organizationLearnerId as count')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .where('campaigns.organizationId', organizationId);
 
   return count;
 };

--- a/api/tests/organizational-entities/integration/domain/usecases/get-organization-statistics.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/get-organization-statistics.usecase.test.js
@@ -10,10 +10,15 @@ describe('Integration | UseCases | get-organization-statistics', function () {
     const { organizationId, id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();
     const { id: otherOrganizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
     const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-    databaseBuilder.factory.buildCampaignParticipation({ organizationLearnerId, campaignId });
+    databaseBuilder.factory.buildCampaignParticipation({
+      organizationLearnerId,
+      campaignId,
+      createdAt: new Date('2020-01-01'),
+    });
     databaseBuilder.factory.buildCampaignParticipation({
       organizationLearnerId: otherOrganizationLearnerId,
       campaignId,
+      createdAt: new Date('2020-01-02'),
     });
 
     await databaseBuilder.commit();
@@ -22,7 +27,12 @@ describe('Integration | UseCases | get-organization-statistics', function () {
     const result = await usecases.getOrganizationStatistics({ organizationId });
 
     // then
-    expect(result).to.deep.equal({ totalParticipantsCount: 2, id: `${organizationId}_organization_statistics` });
+    expect(result).to.deep.equal({
+      organizationId,
+      totalParticipantsCount: 2,
+      id: `${organizationId}_organization_statistics`,
+      totalParticipantsCountByYear: [{ year: 2020, count: 2 }],
+    });
   });
 
   it('should throw an OrganizationNotFoundError when organization does not exist', async function () {

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.test.js
@@ -5,14 +5,21 @@ describe('Unit | Infrastructure | Serializers | JSONAPI | Organizations-Administ
   describe('#serialize', function () {
     it('should convert a statistics object into JSON API data', function () {
       // given
-      const statistics = { totalParticipantsCount: 42, id: '1_organization_statistics' };
+      const statistics = {
+        organizationId: 1,
+        totalParticipantsCount: 42,
+        id: '1_organization_statistics',
+        totalParticipantsCountByYear: [],
+      };
 
       const expectedJSON = {
         data: {
           type: 'organization-statistics',
           id: '1_organization_statistics',
           attributes: {
+            'organization-id': 1,
             'total-participants-count': 42,
+            'total-participants-count-by-year': [],
           },
         },
       };

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -596,4 +596,142 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
       expect(result).to.equal(2);
     });
   });
+
+  describe('#countParticipantsByOrganizationIdGroupedByYear', function () {
+    it('returns an array with participants count grouped by year for a given organizationId', async function () {
+      // given
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ organizationId, multipleSendings: true });
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        organizationLearnerId,
+        createdAt: new Date('2021-05-29'),
+        isImproved: true,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        organizationLearnerId,
+        createdAt: new Date('2025-05-29'),
+      });
+      const { id: otherLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        organizationLearnerId: otherLearnerId,
+        createdAt: new Date('2021-05-29'),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result =
+        await campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear(organizationId);
+
+      // then
+      expect(result).to.deep.equal([
+        {
+          year: 2021,
+          count: 2,
+        },
+        {
+          year: 2025,
+          count: 1,
+        },
+      ]);
+    });
+
+    it('only counts one participant if participant has multiple participations in same year', async function () {
+      // given
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ organizationId, multipleSendings: true });
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        organizationLearnerId,
+        createdAt: new Date('2021-05-29'),
+        isImproved: true,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        organizationLearnerId,
+        createdAt: new Date('2021-05-29'),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result =
+        await campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear(organizationId);
+
+      // then
+      expect(result).to.deep.equal([
+        {
+          year: 2021,
+          count: 1,
+        },
+      ]);
+    });
+
+    it('orders counts by ascendant year (from oldest to latest)', async function () {
+      // given
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        createdAt: new Date('2021-01-01'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        organizationLearnerId,
+        createdAt: new Date('2024-05-29'),
+      });
+
+      const { id: otherCampaignId } = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        createdAt: new Date('2022-01-01'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: otherCampaignId,
+        organizationLearnerId,
+        createdAt: new Date('2022-01-02'),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result =
+        await campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear(organizationId);
+
+      // then
+      expect(result).to.deep.equal([
+        {
+          year: 2022,
+          count: 1,
+        },
+        {
+          year: 2024,
+          count: 1,
+        },
+      ]);
+    });
+
+    it('should return count only for given organizationId', async function () {
+      // given
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const organizationWithNoParticipants = databaseBuilder.factory.buildOrganization();
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear(
+        organizationWithNoParticipants.id,
+      );
+
+      // then
+      expect(result).to.be.empty;
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/application/api/campaign-stats-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaign-stats-api_test.js
@@ -10,7 +10,11 @@ describe('Unit | API | CampaignStats', function () {
     it('returns the statistics for the given organization', async function () {
       // given
       const organizationId = 1;
-      const expectedStats = { totalParticipantsCount: 42 };
+      const expectedStats = {
+        organizationId,
+        totalParticipantsCount: 42,
+        totalParticipantsCountByYear: [{ year: 2025, count: 42 }],
+      };
       sinon
         .stub(usecases, 'getOrganizationParticipantsStatistics')
         .withArgs({ organizationId })

--- a/api/tests/prescription/campaign/unit/domain/usecases/statistics/get-organization-participants-statistics_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/statistics/get-organization-participants-statistics_test.js
@@ -4,11 +4,23 @@ import { getOrganizationParticipantsStatistics } from '../../../../../../../src/
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | UseCase | getOrganizationParticipantsStatistics', function () {
-  it('returns the total participants count for the given organization', async function () {
+  it('returns an object with the total participants count and total participants count grouped by year, for the given organization', async function () {
     // given
     const organizationId = 1;
-    const campaignParticipationsStatsRepository = { countParticipantsByOrganizationId: sinon.stub() };
+    const campaignParticipationsStatsRepository = {
+      countParticipantsByOrganizationId: sinon.stub(),
+      countParticipantsByOrganizationIdGroupedByYear: sinon.stub(),
+    };
     campaignParticipationsStatsRepository.countParticipantsByOrganizationId.withArgs(organizationId).resolves(42);
+
+    const totalParticipantsCount = 42;
+    const totalParticipantsCountByYear = [
+      { year: 2024, count: 5 },
+      { year: 2025, count: 8 },
+    ];
+    campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear
+      .withArgs(organizationId)
+      .resolves(totalParticipantsCountByYear);
 
     // when
     const result = await getOrganizationParticipantsStatistics({
@@ -17,14 +29,23 @@ describe('Unit | UseCase | getOrganizationParticipantsStatistics', function () {
     });
 
     // then
-    expect(result).to.deep.equal({ totalParticipantsCount: 42 });
+    expect(result).to.deep.equal({
+      totalParticipantsCount,
+      totalParticipantsCountByYear,
+    });
   });
 
   it('returns 0 when the organization has no participants', async function () {
     // given
     const organizationId = 1;
-    const campaignParticipationsStatsRepository = { countParticipantsByOrganizationId: sinon.stub() };
+    const campaignParticipationsStatsRepository = {
+      countParticipantsByOrganizationId: sinon.stub(),
+      countParticipantsByOrganizationIdGroupedByYear: sinon.stub(),
+    };
     campaignParticipationsStatsRepository.countParticipantsByOrganizationId.withArgs(organizationId).resolves(0);
+    campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear
+      .withArgs(organizationId)
+      .resolves([]);
 
     // when
     const result = await getOrganizationParticipantsStatistics({
@@ -33,6 +54,6 @@ describe('Unit | UseCase | getOrganizationParticipantsStatistics', function () {
     });
 
     // then
-    expect(result).to.deep.equal({ totalParticipantsCount: 0 });
+    expect(result).to.deep.equal({ totalParticipantsCount: 0, totalParticipantsCountByYear: [] });
   });
 });


### PR DESCRIPTION
## 🚙 Problème
Nous avons crée dans cette PR #16320 une api interne pour remonter la stat du nombre de participant total pour une organisation donnée.
Nous avons maintenant besoin en plus de la stat mais par année

## 🍃 Proposition
Faire remonter dans cette API interne la stat du nombre de participant pour une organisation par année. On pourra utiliser celle ci pour l'afficher dans une prochaine PR sur PixAdmin

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
Regarder sur PixAdmin en allant sur l'onglet statistiques dans l'onglet network le retour de l'API que les stats par années apparaissent
