### PR TITLE
[FEATURE] Ajouter un fallback vers la langue quand le tuto dans la locale n'existe pas (PIX-23001).

### DIFF
--- a/api/src/devcomp/infrastructure/repositories/tutorial-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/tutorial-repository.js
@@ -16,9 +16,12 @@ const TABLE_NAME = 'learningcontent.tutorials';
 export async function findByRecordIdsForCurrentUser({ ids, userId, locale }) {
   let tutorialDtos = await getInstance().getMany(ids);
   tutorialDtos = tutorialDtos.filter((tutorialDto) => tutorialDto);
+
   if (locale) {
-    const lang = getBaseLocale(locale);
-    tutorialDtos = tutorialDtos.filter((tutorialDto) => getBaseLocale(tutorialDto.locale) === lang);
+    const hasUserLocale = tutorialDtos.some((tutorial) => tutorial.locale === locale);
+    const tutorialLocale = hasUserLocale ? locale : getBaseLocale(locale);
+
+    tutorialDtos = tutorialDtos.filter((tutorialDto) => tutorialDto.locale === tutorialLocale);
   }
   tutorialDtos.sort(byId);
   const tutorials = tutorialDtos.map(toDomain);

--- a/api/tests/devcomp/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -211,6 +211,97 @@ describe('Integration | Repository | tutorial-repository', function () {
       expect(tutorials2).to.deep.equal([]);
       expect(tutorials3).to.deep.equal([]);
     });
+
+    describe('locale', function () {
+      beforeEach(async function () {
+        const tutorialsList = [
+          {
+            duration: '00:00:54',
+            format: 'video',
+            link: 'https://tuto.fr',
+            source: 'tuto.fr',
+            title: 'tuto0',
+            id: 'recTutorial0',
+            skillId: undefined,
+            locale: 'fr-FR',
+          },
+          {
+            duration: '00:01:54',
+            format: 'page',
+            link: 'https://tuto.com',
+            source: 'tuto.com',
+            title: 'tuto1',
+            id: 'recTutorial1',
+            skillId: undefined,
+            locale: 'fr',
+          },
+          {
+            duration: '00:01:54',
+            format: 'page',
+            link: 'https://tuto.com',
+            source: 'tuto.com',
+            title: 'tuto2',
+            id: 'recTutorial2',
+            skillId: undefined,
+            locale: 'en',
+          },
+        ];
+
+        databaseBuilder.factory.learningContent.build({
+          tutorials: tutorialsList,
+        });
+        await databaseBuilder.commit();
+      });
+      describe('When tutorials matching user locale', function () {
+        it('returns tutorials matching user locale', async function () {
+          // when
+          const tutorials = await tutorialRepository.findByRecordIdsForCurrentUser({
+            ids: ['recTutorial0', 'recTutorial1', 'recTutorial2'],
+            userId: null,
+            locale: 'fr-FR',
+          });
+
+          // then
+          expect(tutorials).lengthOf(1);
+          expect(tutorials[0]).deep.equal({
+            duration: '00:00:54',
+            format: 'video',
+            link: 'https://tuto.fr',
+            source: 'tuto.fr',
+            title: 'tuto0',
+            id: 'recTutorial0',
+            skillId: undefined,
+            tutorialEvaluation: undefined,
+            userSavedTutorial: undefined,
+          });
+        });
+      });
+
+      describe('When tutorials not matching user locale', function () {
+        it('returns tutorials matching language', async function () {
+          // when
+          const tutorials = await tutorialRepository.findByRecordIdsForCurrentUser({
+            ids: ['recTutorial1', 'recTutorial2'],
+            userId: null,
+            locale: 'fr-FR',
+          });
+
+          // then
+          expect(tutorials).lengthOf(1);
+          expect(tutorials[0]).deep.equal({
+            duration: '00:01:54',
+            format: 'page',
+            link: 'https://tuto.com',
+            source: 'tuto.com',
+            title: 'tuto1',
+            id: 'recTutorial1',
+            skillId: undefined,
+            tutorialEvaluation: undefined,
+            userSavedTutorial: undefined,
+          });
+        });
+      });
+    });
   });
 
   describe('#findPaginatedFilteredForCurrentUser', function () {


### PR DESCRIPTION
## 🚙 Problème
Désormais nous pouvons avoir des tutoriels de langue `fr` ou `fr-FR`.
Quand la locale de l'utilisateur est `fr-FR`.
Lorsqu'un acquis ne possède que des tutoriels `fr` alors nous voulons proposer les tutoriels `fr`,
si l'acquis possède des tutoriels `fr-FR` alors nous voulons proposer les tutoriels `fr-FR`.

## 🍃 Proposition

Mettre en place un fallback sur la langue lors de la récupération des tutoriels.

## 🦵 Remarques

RAS
## 🔗 Pour tester

ci au vert
