### PR TITLE
[FEATURE] Afficher le nombre de participants par année dans l'onglet statistiques d'une orga (PIX-22756)

### DIFF
--- a/admin/app/components/organizations/statistics.gjs
+++ b/admin/app/components/organizations/statistics.gjs
@@ -1,8 +1,12 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { t } from 'ember-intl';
 
 <template>
-  <section>
+  <section class="organization-statistics-page-section">
     <PixIndicatorCard
       class="organization-statistics__card"
       @title={{t "components.organizations.statistics.total-participants-count.title"}}
@@ -13,6 +17,37 @@ import { t } from 'ember-intl';
       {{@statistics.totalParticipantsCount}}
 
     </PixIndicatorCard>
+    <PixTable
+      @variant="admin"
+      @data={{@statistics.totalParticipantsCountByYear}}
+      @caption={{t "components.organizations.statistics.total-participants-count-by-year.caption"}}
+      @displayCaption={{true}}
+    >
+      <:columns as |row context|>
+        <PixTableColumn @context={{context}}>
+          <:header>{{t "components.organizations.statistics.total-participants-count-by-year.headers.year"}}</:header>
+          <:cell>{{row.year}}</:cell>
+        </PixTableColumn>
 
+        <PixTableColumn @context={{context}}>
+          <:header>{{t "components.organizations.statistics.total-participants-count-by-year.headers.count"}}
+            <PixTooltip @isWide={{true}} @id="participants-count-by-year-tooltip" @position="top">
+              <:triggerElement>
+                <PixIcon
+                  @name="help"
+                  @plainIcon={{true}}
+                  @ariaHidden={{true}}
+                  aria-describedby="participants-count-by-year-tooltip"
+                />
+              </:triggerElement>
+              <:tooltip>
+                {{t "components.organizations.statistics.total-participants-count-by-year.headers.count-tooltip"}}
+              </:tooltip>
+            </PixTooltip>
+          </:header>
+          <:cell>{{row.count}}</:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
   </section>
 </template>

--- a/admin/app/components/organizations/statistics.scss
+++ b/admin/app/components/organizations/statistics.scss
@@ -1,3 +1,9 @@
 .organization-statistics__card {
   width: 500px;
 }
+
+.organization-statistics-page-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+}

--- a/admin/app/models/organization-statistic.js
+++ b/admin/app/models/organization-statistic.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class OrganizationStatistic extends Model {
   @attr('number') totalParticipantsCount;
+  @attr('array') totalParticipantsCountByYear;
 }

--- a/admin/tests/integration/components/organizations/statistics-test.gjs
+++ b/admin/tests/integration/components/organizations/statistics-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import Statistics from 'pix-admin/components/organizations/statistics';
 import { module, test } from 'qunit';
@@ -32,5 +32,36 @@ module('Integration | Component | Organizations | Statistics', function (hooks) 
     assert.ok(
       screen.getByText(t('components.organizations.statistics.total-participants-count.info'), { hidden: true }),
     );
+  });
+
+  test('displays total participants count by year in table', async function (assert) {
+    // given
+    const statistics = store.createRecord('organization-statistic', {
+      totalParticipantsCountByYear: [{ year: 2023, count: 1234 }],
+    });
+
+    // when
+    const screen = await render(<template><Statistics @statistics={{statistics}} /></template>);
+
+    // then
+    const table = screen.getByRole('table', {
+      name: t('components.organizations.statistics.total-participants-count-by-year.caption'),
+    });
+
+    assert.ok(
+      within(table).getByRole('columnheader', {
+        name: t('components.organizations.statistics.total-participants-count-by-year.headers.count'),
+      }),
+    );
+    assert.ok(
+      within(table).getByRole('columnheader', {
+        name: t('components.organizations.statistics.total-participants-count-by-year.headers.year'),
+      }),
+    );
+    assert
+      .dom(within(table).getByRole('tooltip', { hidden: true }))
+      .hasText(t('components.organizations.statistics.total-participants-count-by-year.headers.count-tooltip'));
+    assert.ok(within(table).getByRole('cell', { name: '2023' }));
+    assert.ok(within(table).getByRole('cell', { name: '1234' }));
   });
 });

--- a/admin/tests/integration/components/organizations/statistics-test.gjs
+++ b/admin/tests/integration/components/organizations/statistics-test.gjs
@@ -1,0 +1,36 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import Statistics from 'pix-admin/components/organizations/statistics';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Organizations | Statistics', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(async function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  test('displays total participants count', async function (assert) {
+    // given
+    const statistics = store.createRecord('organization-statistic', {
+      totalParticipantsCount: 1234,
+    });
+
+    // when
+    const screen = await render(<template><Statistics @statistics={{statistics}} /></template>);
+
+    // then
+    assert.strictEqual(
+      screen.getByRole('term').textContent.trim(),
+      t('components.organizations.statistics.total-participants-count.title'),
+    );
+    assert.strictEqual(screen.getByRole('definition').textContent.trim(), '1234');
+    assert.ok(
+      screen.getByText(t('components.organizations.statistics.total-participants-count.info'), { hidden: true }),
+    );
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1094,6 +1094,14 @@
         "total-participants-count": {
           "info": "The total number of unique participants from the organisation who have started at least one campaign participation since the organisation was created (regardless of the status of the campaigns, participations or participants, whether deleted or not)",
           "title": "Total number of participants"
+        },
+        "total-participants-count-by-year": {
+          "caption": "Number of unique participants per year",
+          "headers": {
+            "count": "Participants count",
+            "count-tooltip": "Number of participants from the organisation who have started at least one campaign participation, per year (regardless of the status of the campaigns, participations or participants, whether deleted or not).",
+            "year": "Year"
+          }
         }
       },
       "target-profiles-section": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1102,6 +1102,14 @@
         "total-participants-count": {
           "info": "Nombre total de participants uniques de l'organisation ayant débuté au moins une participation à une campagne depuis la création de l'organisation (peu importe le statut des campagnes, des participations, ou des participants, supprimé ou non)",
           "title": "Nombre total de participants"
+        },
+        "total-participants-count-by-year": {
+          "caption": "Nombre de participants uniques par année",
+          "headers": {
+            "count": "Nombre de participants",
+            "count-tooltip": "Nombre de participants de l'organisation ayant débuté au moins une participation à une campagne, par année (peu importe le statut des campagnes, des participations, ou des participants, supprimé ou non).",
+            "year": "Année"
+          }
         }
       },
       "target-profiles-section": {


### PR DESCRIPTION
## 🚙 Problème
Maintenant que nous avons commencé à afficher des stats concernant les participants d'une orga dans PixAdmin, nous voudrions afficher également ces stats par année

## 🍃 Proposition
Faire remonter depuis l'api interne les stats des participants par année pour une organisation donnée, puis afficher celle ci dans un tableau dans l'onglet statistiques d'une organisation sur PixAdmin

## 🦵 Remarques
On a déjà constaté des soucis de perf pour la requête faisant le count total notamment pour une de nos plus grosse organisation. On va devoir se pencher sur la question prochainement. 

## 🔗 Pour tester
Se connecter sur PixAdmin
Aller sur une organisation (ex: id 1005)
Aller sur l'onglet statistiques
Voir la présence du tableau avec les stats par année
