### PR TITLE
[FEATURE] Uniformiser le design de la sélection de sujets dans Pix Admin (PIX-22817)

### DIFF
--- a/admin/app/components/common/tubes-selection/tube.gjs
+++ b/admin/app/components/common/tubes-selection/tube.gjs
@@ -1,6 +1,7 @@
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
@@ -112,10 +113,32 @@ export default class Tube extends Component {
     {{#if @displayDeviceCompatibility}}
       <td class="table__column--center">
         <div class="icon-container" aria-label="{{if @tube.mobile 'compatible mobile' 'incompatible mobile'}}">
-          <PixIcon @name={{this.mobileIcon}} @plainIcon={{true}} class="{{if @tube.mobile 'is-responsive'}}" />
+          <PixTooltip @position="bottom" @isInline={{true}}>
+            <:triggerElement>
+              <PixIcon @name={{this.mobileIcon}} class="{{if @tube.mobile 'is-responsive' 'not-responsive'}}" />
+            </:triggerElement>
+            <:tooltip>
+              {{#if @tube.mobile}}
+                Compatible avec smartphone
+              {{else}}
+                Non compatible avec smartphone
+              {{/if}}
+            </:tooltip>
+          </PixTooltip>
         </div>
         <div class="icon-container" aria-label="{{if @tube.tablet 'compatible tablette' 'incompatible tablette'}}">
-          <PixIcon @name={{this.tabletIcon}} @plainIcon={{true}} class="{{if @tube.tablet 'is-responsive'}}" />
+          <PixTooltip @position="bottom" @isInline={{true}}>
+            <:triggerElement>
+              <PixIcon @name={{this.tabletIcon}} class="{{if @tube.tablet 'is-responsive' 'not-responsive'}}" />
+            </:triggerElement>
+            <:tooltip>
+              {{#if @tube.tablet}}
+                Compatible avec tablette
+              {{else}}
+                Non compatible avec tablette
+              {{/if}}
+            </:tooltip>
+          </PixTooltip>
         </div>
       </td>
     {{/if}}

--- a/admin/app/styles/components/common/tubes-selection.scss
+++ b/admin/app/styles/components/common/tubes-selection.scss
@@ -52,7 +52,11 @@
   }
 
   .is-responsive {
-    color: var(--pix-success-700);
+    fill: var(--pix-primary-500);
+  }
+
+  .not-responsive {
+    fill: var(--pix-neutral-100);
   }
 
   table {
@@ -182,15 +186,18 @@
 
   .skill-square {
     padding: 0 4px;
-    color: var(--pix-neutral-0);
     border-radius: 4px;
 
     &__active {
-      background-color: var(--pix-success-700);
+      color: var(--pix-neutral-0);
+      font-weight: bold;
+      background-color: var(--pix-primary-500);
     }
 
     &__missing {
-      background-color: var(--pix-error-700);
+      color: var(--pix-neutral-300);
+      font-weight: normal;
+      background-color: var(--pix-neutral-20);
     }
   }
 }


### PR DESCRIPTION
## 🚙 Problème
La page de sélection de sujets a été revue dans Pix Orga lords de l'ajout de la sélection de niveaux. A ce moment le design a été revue et des tooltips ont été rajoutées. Il faudrait reproduire ces modification dans Pix Admin également. 

## 🍃 Proposition
Uniformiser le design de la sélection de sujets dans Pix Admin

## 🔗 Pour tester
- Se connecter à Pix Admin
- Créer un nouveau profil cible
- Constater les évolutions du design et l'ajout des tooltips