### PR TITLE
[FEATURE] Ignore les doublons dans l'import générique (PIX-21914)

### DIFF
--- a/api/src/prescription/learner-management/domain/models/CommonOrganizationLearner.js
+++ b/api/src/prescription/learner-management/domain/models/CommonOrganizationLearner.js
@@ -31,5 +31,16 @@ class CommonOrganizationLearner {
     }
     this.userId = userId;
   }
+  isEqual(learner) {
+    const hasSameAttribute = Object.keys(learner.attributes).every(
+      (key) => learner.attributes[key] === this.attributes[key],
+    );
+    return (
+      this.lastName === learner.lastName &&
+      this.firstName === learner.firstName &&
+      this.organizationId === learner.organizationId &&
+      hasSameAttribute
+    );
+  }
 }
 export { CommonOrganizationLearner };

--- a/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
+++ b/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
@@ -39,7 +39,7 @@ class ImportOrganizationLearnerSet {
     this.#learners = [];
     this.#existingLearners = [];
 
-    this.#unicityKeys = [];
+    this.#unicityKeys = new Map();
     this.#errors = [];
     this.#constructorValidation();
 
@@ -210,16 +210,18 @@ class ImportOrganizationLearnerSet {
   }
 
   #checkUnicityRule(learner) {
-    const learnerUnicityObject = this.#getLearnerUnicityObject(learner);
-    const aggregateUnicityKeys = Object.values(learnerUnicityObject).join('-');
-
-    if (!this.#unicityKeys.includes(aggregateUnicityKeys)) {
-      this.#unicityKeys.push(aggregateUnicityKeys);
+    const unicityLearnerValue = this.#getUnicityValue(learner);
+    if (!this.#unicityKeys.has(unicityLearnerValue)) {
+      this.#unicityKeys.set(unicityLearnerValue, learner);
       return null;
     } else {
-      return ModelValidationError.unicityError({
-        key: this.#unicityColumns.join('-'),
-      });
+      const duplicateLearner = this.#unicityKeys.get(unicityLearnerValue);
+      if (!this.#areLearnersEqual(duplicateLearner, learner)) {
+        return ModelValidationError.unicityError({
+          key: this.#unicityColumns.join('-'),
+        });
+      }
+      return null;
     }
   }
 
@@ -253,6 +255,20 @@ class ImportOrganizationLearnerSet {
     }
   }
 
+  #getUnicityValue(learner) {
+    const learnerUnicityObject = this.#getLearnerUnicityObject(learner);
+    return Object.values(learnerUnicityObject).join('-');
+  }
+
+  #areLearnersEqual(learner1, learner2) {
+    for (const column of this.#columnMapping) {
+      if (learner1[column.name] !== learner2[column.name]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   get filtersAvailableValues() {
     return this.#columnMapping
       .filter((header) => header.config?.displayable?.filterable?.type === 'list')
@@ -281,6 +297,10 @@ class ImportOrganizationLearnerSet {
     };
 
     this.#learners.forEach((learner) => {
+      const learnerAlreadyExist = learners.list.find((existingLearner) => learner.isEqual(existingLearner));
+      if (learnerAlreadyExist) {
+        return;
+      }
       learner.updateLearner({
         learnerList: this.#existingLearners,
         unicityKey: Object.values(this.#unicityColumnMapping),

--- a/api/tests/prescription/learner-management/unit/domain/models/CommonOrganizationLearner_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/CommonOrganizationLearner_test.js
@@ -91,4 +91,42 @@ describe('Unit | Models | CommonOrganizationLearner', function () {
       expect(learner.userId).to.be.equal(userId);
     });
   });
+
+  describe('#isEqual', function () {
+    const learnerAttributes = {
+      firstName: 'Kimberley',
+      lastName: 'Tartine',
+      organizationId: 3,
+      email: 'test@example.net',
+    };
+    context('same learner', function () {
+      it('returns true if learners are equals', function () {
+        const learnerA = new CommonOrganizationLearner(learnerAttributes);
+        const learnerB = new CommonOrganizationLearner({ ...learnerAttributes });
+        expect(learnerA.isEqual(learnerB)).true;
+      });
+    });
+    context('different learners', function () {
+      it('returns false if firstName is different', function () {
+        const learnerA = new CommonOrganizationLearner(learnerAttributes);
+        const learnerB = new CommonOrganizationLearner({ ...learnerAttributes, firstName: 'firstName' });
+        expect(learnerA.isEqual(learnerB)).false;
+      });
+      it('returns false if lastName is different', function () {
+        const learnerA = new CommonOrganizationLearner(learnerAttributes);
+        const learnerB = new CommonOrganizationLearner({ ...learnerAttributes, lastName: 'lastName' });
+        expect(learnerA.isEqual(learnerB)).false;
+      });
+      it('returns false if organizationId is different', function () {
+        const learnerA = new CommonOrganizationLearner(learnerAttributes);
+        const learnerB = new CommonOrganizationLearner({ ...learnerAttributes, organizationId: 1 });
+        expect(learnerA.isEqual(learnerB)).false;
+      });
+      it('returns false if attributes are different', function () {
+        const learnerA = new CommonOrganizationLearner(learnerAttributes);
+        const learnerB = new CommonOrganizationLearner({ ...learnerAttributes, email: 'email@example.net' });
+        expect(learnerA.isEqual(learnerB)).false;
+      });
+    });
+  });
 });

--- a/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
@@ -69,6 +69,27 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
         ]);
       });
 
+      it('should add a learner once if there is duplicate lines', async function () {
+        // given
+        const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+
+        // when
+        learnerSet.addLearners([learnerAttributes, learnerAttributes]);
+
+        //then
+        expect(learnerSet.learners.list).lengthOf(1);
+        expect(learnerSet.learners.list[0]).to.be.an.instanceOf(CommonOrganizationLearner);
+        expect(learnerSet.learners.list).to.deep.equal([
+          new CommonOrganizationLearner({
+            firstName: 'Tomie',
+            lastName: 'Katana',
+            organizationId,
+            "nom d'usage": 'Yolo',
+            group: 'Solo',
+          }),
+        ]);
+      });
+
       it('should add a learner with previous configuration', function () {
         const importFormat = {
           config: {
@@ -406,28 +427,17 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
           expect(errors[0].code).equal(VALIDATION_ERRORS.UNICITY_COLUMNS_REQUIRED);
         });
 
-        it('should throw unicity errors on one attribute', async function () {
+        it('should throw unicity errors if learner has same unicity value but different attributes', async function () {
           const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
 
-          const errors = await catchErr(learnerSet.addLearners, learnerSet)([learnerAttributes, learnerAttributes]);
+          const errors = await catchErr(
+            learnerSet.addLearners,
+            learnerSet,
+          )([learnerAttributes, { ...learnerAttributes, nom: 'Katnis' }]);
 
           expect(errors).lengthOf(1);
           expect(errors[0]).instanceOf(CsvImportError);
           expect(errors[0].meta.field).to.equal('prénom');
-          expect(errors[0].meta.line).to.equal(3);
-          expect(errors[0].code).to.equal('PROPERTY_NOT_UNIQ');
-        });
-
-        it('should throw unicity errors on multiple attributes', async function () {
-          importFormat.config.unicityColumns = ['prénom', 'group'];
-
-          const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
-
-          const errors = await catchErr(learnerSet.addLearners, learnerSet)([learnerAttributes, learnerAttributes]);
-
-          expect(errors).lengthOf(1);
-          expect(errors[0]).instanceOf(CsvImportError);
-          expect(errors[0].meta.field).to.equal('prénom-group');
           expect(errors[0].meta.line).to.equal(3);
           expect(errors[0].code).to.equal('PROPERTY_NOT_UNIQ');
         });


### PR DESCRIPTION
## 🚙 Problème

Suite au format ONDE v2, certain prescrit apparaissent plusieurs fois dans le fichier à importer. 
Cela rend l'import impossible car la contrainte d'unicité empêche de créer des doublons.

## 🍃 Proposition

On ignore les doublons si ils partagent la même clé d'unicité et les mêmes propriétés.
Dans le cas où on trouverait des prescrits avec une clé d'unicité identique mais des propiétés différentes, alors on lève une erreur.

## 🦵 Remarques

On a choisi la solution d'ignorer les doublons car on ne souhaite pas créer plusieurs fois le même prescrit<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
- faire un import onde avec 2 ligne en doublon => OK
- faire un import onde avec 2 ligne différentes mais avec le même INE => KO

On peut faire le meme test avec l'orga pro (clé d'unité sur nom / prenom / date de naissance)
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
