### PR TITLE
[FEATURE] Vérifier que les ids des organisations sont bien des nombres avant l'insertion en BDD (PIX-23023)

### DIFF
--- a/admin/app/components/organizations/network.gjs
+++ b/admin/app/components/organizations/network.gjs
@@ -49,6 +49,9 @@ export default class OrganizationNetworkComponent extends Component {
             { childOrganizationId },
           );
           break;
+        case 'INVALID_CHILD_ORGANIZATION_IDS':
+          message = this.intl.t('components.organizations.network.attach-child-form.invalid-ids-error');
+          break;
         default:
           message = this.intl.t('common.notifications.generic-error');
       }

--- a/admin/app/components/organizations/network/attach-child-form.gjs
+++ b/admin/app/components/organizations/network/attach-child-form.gjs
@@ -2,11 +2,15 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class OrganizationNetworkAttachChildFormComponent extends Component {
+  @service intl;
+  @service pixToast;
+
   @tracked childOrganizationIds = '';
 
   @action
@@ -17,6 +21,13 @@ export default class OrganizationNetworkAttachChildFormComponent extends Compone
   @action
   submitForm(event) {
     event.preventDefault();
+    const hasInvalidId = this.childOrganizationIds.split(',').some((id) => !/^\d+$/.test(id.trim()));
+    if (hasInvalidId) {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.organizations.network.attach-child-form.invalid-ids-error'),
+      });
+      return;
+    }
     this.args.onFormSubmitted(this.childOrganizationIds);
     this.childOrganizationIds = '';
   }

--- a/admin/tests/integration/components/organizations/network-test.gjs
+++ b/admin/tests/integration/components/organizations/network-test.gjs
@@ -1,6 +1,6 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import Network from 'pix-admin/components/organizations/network';
 import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
@@ -140,6 +140,12 @@ module('Integration | Component | organizations/network', function (hooks) {
 
           const screen = await render(<template><Network @organization={{parentOrganization}} /></template>);
 
+          const input = screen.getByLabelText(t('components.organizations.network.attach-child-form.input-label'), {
+            exact: false,
+          });
+
+          await fillIn(input, 1);
+
           // when
           await click(screen.getByRole('button', { name: t('common.actions.add') }));
 
@@ -178,6 +184,11 @@ module('Integration | Component | organizations/network', function (hooks) {
           });
 
           const screen = await render(<template><Network @organization={{parentOrganization}} /></template>);
+          const input = screen.getByLabelText(t('components.organizations.network.attach-child-form.input-label'), {
+            exact: false,
+          });
+
+          await fillIn(input, alreadyAttachedChildOrganizationId);
 
           // when
           await click(screen.getByRole('button', { name: t('common.actions.add') }));
@@ -189,6 +200,40 @@ module('Integration | Component | organizations/network', function (hooks) {
                 'pages.organization-network.notifications.error.unable-to-attach-already-attached-child-organization',
                 { childOrganizationId: `${alreadyAttachedChildOrganizationId}` },
               ),
+            }),
+          );
+        });
+
+        test('it should display correct error notification for INVALID_CHILD_ORGANIZATION_IDS error code', async function (assert) {
+          // given
+          const parentOrganization = store.createRecord('organization', {
+            id: 1,
+            name: 'Parent Organization Name',
+            features: { PLACES_MANAGEMENT: { active: true } },
+            network,
+            hasMany: sinon.stub(),
+          });
+
+          const adapter = store.adapterFor('organization');
+          const attachChildOrganizationStub = sinon.stub(adapter, 'attachChildOrganization');
+          attachChildOrganizationStub.rejects({
+            errors: [{ code: 'INVALID_CHILD_ORGANIZATION_IDS' }],
+          });
+
+          const screen = await render(<template><Network @organization={{parentOrganization}} /></template>);
+          const input = screen.getByLabelText(t('components.organizations.network.attach-child-form.input-label'), {
+            exact: false,
+          });
+
+          await fillIn(input, 1847474);
+
+          // when
+          await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
+          // then
+          assert.true(
+            notificationErrorStub.calledOnceWithExactly({
+              message: t('components.organizations.network.attach-child-form.invalid-ids-error'),
             }),
           );
         });
@@ -214,6 +259,11 @@ module('Integration | Component | organizations/network', function (hooks) {
           });
 
           const screen = await render(<template><Network @organization={{parentOrganization}} /></template>);
+          const input = screen.getByLabelText(t('components.organizations.network.attach-child-form.input-label'), {
+            exact: false,
+          });
+
+          await fillIn(input, 1);
 
           // when
           await click(screen.getByRole('button', { name: t('common.actions.add') }));

--- a/admin/tests/integration/components/organizations/network/attach-child-form-test.gjs
+++ b/admin/tests/integration/components/organizations/network/attach-child-form-test.gjs
@@ -1,5 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click, fillIn, triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import AttachChildForm from 'pix-admin/components/organizations/network/attach-child-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -54,5 +56,36 @@ module('Integration | Component | organizations/network/attach-child-form', func
 
     // then
     assert.ok(onFormSubmitted.called, 'Form submission callback was called');
+  });
+
+  module('when ids contain non-numeric values', function (hooks) {
+    let sendErrorNotificationStub;
+
+    hooks.beforeEach(function () {
+      sendErrorNotificationStub = sinon.stub();
+      class PixToastStub extends Service {
+        sendErrorNotification = sendErrorNotificationStub;
+      }
+      this.owner.register('service:pixToast', PixToastStub);
+    });
+
+    test('should display an error notification and not submit the form', async function (assert) {
+      // given
+      const onFormSubmitted = sinon.stub();
+      const screen = await render(<template><AttachChildForm @onFormSubmitted={{onFormSubmitted}} /></template>);
+      const input = screen.getByRole('textbox');
+      await fillIn(input, 'abc');
+
+      // when
+      await click(screen.getByRole('button', { name: 'Ajouter' }));
+
+      // then
+      assert.true(
+        sendErrorNotificationStub.calledOnceWithExactly({
+          message: t('components.organizations.network.attach-child-form.invalid-ids-error'),
+        }),
+      );
+      assert.ok(onFormSubmitted.notCalled);
+    });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1045,6 +1045,7 @@
         "attach-child-form": {
           "input-information": "ID of organisation(s) to add",
           "input-label": "Add one or more child organisations",
+          "invalid-ids-error": "Identifiers must be integers, separated by commas.",
           "name": "Add child organisation(s) form"
         },
         "children-list": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1053,6 +1053,7 @@
         "attach-child-form": {
           "input-information": "ID d'organisation(s) à ajouter",
           "input-label": "Ajouter une ou plusieurs organisations filles",
+          "invalid-ids-error": "Les identifiants doivent être des nombres entiers, séparés par des virgules.",
           "name": "Formulaire d'ajout d'organisation(s) fille(s)"
         },
         "children-list": {

--- a/api/src/organizational-entities/domain/usecases/attach-child-organization-to-organization.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/attach-child-organization-to-organization.usecase.js
@@ -11,6 +11,8 @@ const attachChildOrganizationToOrganizationUsecase = withTransaction(
 
     const childOrganizationIdsArray = childOrganizationIds.split(',').map(Number);
 
+    _assertChildOrganizationIdsAreNumbers(childOrganizationIdsArray);
+
     for (const childOrganizationId of childOrganizationIdsArray) {
       _assertChildAndParentOrganizationIdsAreDifferent({
         childOrganizationId,
@@ -32,6 +34,15 @@ const attachChildOrganizationToOrganizationUsecase = withTransaction(
 );
 
 export { attachChildOrganizationToOrganizationUsecase };
+
+function _assertChildOrganizationIdsAreNumbers(ids) {
+  if (ids.some(isNaN)) {
+    throw new UnableToAttachChildOrganizationToParentOrganizationError({
+      code: 'INVALID_CHILD_ORGANIZATION_IDS',
+      message: 'Child organization IDs must be numbers',
+    });
+  }
+}
 
 function _assertChildAndParentOrganizationIdsAreDifferent({ childOrganizationId, parentOrganizationId }) {
   if (childOrganizationId === parentOrganizationId) {

--- a/api/tests/organizational-entities/integration/domain/usecases/attach-child-organization-to-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/attach-child-organization-to-organization.usecase.test.js
@@ -146,6 +146,32 @@ describe('Integration | Organizational Entities | Domain | UseCase | attach-chil
       });
     });
 
+    context('when at least one of children organization ids is not a number', function () {
+      it('throws an UnableToAttachChildOrganizationToParentOrganizationError', async function () {
+        // given
+        const { organization: parentOrganization } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+          headOrganization: { id: 123 },
+        });
+        await databaseBuilder.commit();
+
+        const childOrganizationIds = 'abc,456';
+
+        // when
+        const error = await catchErr(usecases.attachChildOrganizationToOrganization)({
+          parentOrganizationId: parentOrganization.id,
+          childOrganizationIds,
+        });
+
+        // then
+        expect(error).to.deepEqualInstance(
+          new UnableToAttachChildOrganizationToParentOrganizationError({
+            code: 'INVALID_CHILD_ORGANIZATION_IDS',
+            message: 'Child organization IDs must be numbers',
+          }),
+        );
+      });
+    });
+
     context('when at least one of children organization ids is equal to parent organization id', function () {
       it('throws an error', async function () {
         // given


### PR DESCRIPTION
## 🚙 Problème
Lors du rattachement d'une organisation fille, si on mettait autre chose que des chiffres dans l'input, on laissait tout passer et du coup on se retrouvais avec des 500 lors de l'insertion en BDD.

## 🍃 Proposition
Vérifier côté front si tous les ids de l'input sont bien des nombres, sinon renvoyer une erreur. Et même chose côté API également.

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
Se connecter à PixAdmin
Aller sur une organisation
Essayer de rattacher une organisation fille en mettant des caractères autre que chiffre -> Constater l'erreur
Mettre cette fois des ids valide et constater la non régression
🐈‍⬛ 
