### PR TITLE
[BUGFIX] Ne pas créer de récompense pour le passage d'un parcours combiné dont la quest n'a pas de récompense (PIX-23038)

### DIFF
--- a/api/src/quest/domain/usecases/update-combined-course-progress.js
+++ b/api/src/quest/domain/usecases/update-combined-course-progress.js
@@ -49,11 +49,11 @@ export async function updateCombinedCourseProgress({
       updatedCombinedCourseDetails.participation,
     );
     await combinedCourseParticipationRepository.update(organizationLearnerParticipation.fieldsForUpdate);
-    if (updatedCombinedCourseDetails.isSuccessful()) {
+
+    if (updatedCombinedCourseDetails.isSuccessful() && combinedCourse.quest.rewardId) {
       await rewardRepository.reward({
         userId,
         rewardId: combinedCourse.quest.rewardId,
-        rewardType: combinedCourse.quest.rewardType,
       });
     }
   }

--- a/api/tests/quest/integration/domain/usecases/update-combined-course-progress_test.js
+++ b/api/tests/quest/integration/domain/usecases/update-combined-course-progress_test.js
@@ -134,6 +134,49 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course-progr
         expect(profileRewards[0].rewardId).to.equal(reward.id);
       });
     });
+
+    context('when combined course contains no reward', function () {
+      it('should not reward the user', async function () {
+        /// given
+        const code = 'SOMETHING';
+        const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
+        const {
+          id: organizationLearnerId,
+          userId,
+          organizationId,
+        } = databaseBuilder.factory.buildOrganizationLearner();
+        const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({});
+        const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+          code,
+          organizationId,
+          questId,
+        });
+
+        // build terminated passages and started OrganizationLearnerParticipation Passages to validate right synchronization
+        databaseBuilder.factory.buildPassage({ userId, moduleId, terminatedAt: new Date() });
+        databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypePassage({
+          organizationLearnerId,
+          moduleId,
+          status: OrganizationLearnerParticipationStatuses.STARTED,
+        });
+
+        databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypeCombinedCourse({
+          organizationLearnerId,
+          combinedCourseId,
+          createdAt: new Date('2022-01-01'),
+          updatedAt: new Date('2022-01-01'),
+          status: OrganizationLearnerParticipationStatuses.STARTED,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await usecases.updateCombinedCourseProgress({ userId, code });
+
+        // then
+        const profileRewards = await repositories.rewardRepository.getByUserId({ userId });
+        expect(profileRewards).to.be.empty;
+      });
+    });
   });
 
   it('should update organization learner participations when passage is on a recommended module', async function () {


### PR DESCRIPTION
## 🚙 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

On a identifié pas mal de profile-reward en DB dont le rewardId était null.
Après investigation, les cas relevés correspondent à des complétion de parcours combinés pour lesquels aucune reward n’est configurée dans la quest. On n’aurait donc pas dû enregistrer de profile-reward pour eux.

2 soucis qui causent cette situation : 
- suite à la migration 20241227103334, les contraintes non-nullables sur les colonnes des profile-rewards ont sauté
- dans updateCombinedCourseProgress, on crée une reward à chaque fois qu’un parcours est succeeded, sans vérifier qu’on a bien un rewardId dans la quête. 

## 🍃 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Pour résoudre :
- on ajoute un guard dans updateCombinedCourseProgress pour ne créer la reward que si la quête permet d’en obtenir


## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

A faire pour le clean :
- on supprime les profile-reward sans rewardId
- on fait une migration pour repasser les colonnes de profile-rewards en non nullable

## 🔗 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Passer un parcours combiné dont la quête associée n'a pas de rewardId.
On ne doit pas avoir de création de profile-reward