### PR TITLE
[FEATURE] Rend certaines colonnes de la table profile-rewards non nullable

### DIFF
--- a/api/db/migrations/20260605070510_make-profile-rewards-reward-id-not-nullable.js
+++ b/api/db/migrations/20260605070510_make-profile-rewards-reward-id-not-nullable.js
@@ -1,0 +1,47 @@
+const TABLE_NAME = 'profile-rewards';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.bigInteger('userId').comment('The id of the user.').notNullable().alter();
+    table
+      .string('rewardType')
+      .comment('The table linked to the reward. The attestation table is one of the possible values.')
+      .notNullable()
+      .alter();
+    table
+      .bigInteger('rewardId')
+      .comment(
+        'The id of the reward linked to the user. For example, if the rewardType is “attestation”, the rewardId will be the id column of the attestation table.',
+      )
+      .notNullable()
+      .alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.bigInteger('userId').comment('The id of the user.').nullable().alter();
+    table
+      .string('rewardType')
+      .comment('The table linked to the reward. The attestation table is one of the possible values.')
+      .nullable()
+      .alter();
+    table
+      .bigInteger('rewardId')
+      .comment(
+        'The id of the reward linked to the user. For example, if the rewardType is “attestation”, the rewardId will be the id column of the attestation table.',
+      )
+      .nullable()
+      .alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🚙 Problème
On a constaté de nombreux enregistrements dans la table profile-rewards avec un rewardId à null.
Comme ce n'est pas cohérent par rapport au métier, on s'est dits que c'était une erreur (et en effet une migration est venue écraser la contrainte isNotNullable).

## 🍃 Proposition
On rend certaines colonnes non nullables : rewardId, rewardType, userId.

## 🔗 Pour tester
npm run db:migrate
npm run db:rollback:latest
