### PR TITLE
[FEATURE] Ajouter un prehandler permettant de vérifiant l'appartenance d'un blueprint à une organisation (PIX-23017)

### DIFF
--- a/api/src/quest/application/security-pre-handlers.js
+++ b/api/src/quest/application/security-pre-handlers.js
@@ -54,6 +54,25 @@ export async function checkParticipationBelongsToCombinedCourse(request, h) {
   }
 }
 
+export async function checkCombinedCourseBlueprintBelongsToOrganization(request, h) {
+  const { organizationId, combinedCourseBlueprintId } = request.params;
+  try {
+    const isCombinedCourseBlueprintInOrganization = await usecases.isCombinedCourseBlueprintInOrganization({
+      combinedCourseBlueprintId,
+      organizationId,
+    });
+    if (isCombinedCourseBlueprintInOrganization) {
+      return h.response(true);
+    }
+    return _replyForbiddenError(h);
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return _replyForbiddenError(h);
+    }
+    throw error;
+  }
+}
+
 function _replyForbiddenError(h) {
   const errorHttpStatusCode = 403;
   const jsonApiError = new JSONApi.Error({

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -47,6 +47,7 @@ const dependencies = {
   courseRepository: repositories.courseRepository,
   campaignParticipationRepository: repositories.campaignParticipationRepository,
   profileRewardRepository: repositories.profileRewardRepository,
+  combinedCourseBlueprintShareRepository: repositories.combinedCourseBlueprintShareRepository,
   codeGenerator,
   logger,
 };
@@ -78,6 +79,7 @@ import { getOrganizationAttestations } from './get-organization-attestations.js'
 import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
 import { getVerifiedCode } from './get-verified-code.js';
 import { hasAccessToCombinedCourse } from './has-access-to-combined-course.js';
+import { isCombinedCourseBlueprintInOrganization } from './is-combined-course-blueprint-in-organization.js';
 import { isParticipationOnCombinedCourse } from './is-participation-on-combined-course.js';
 import { rewardUser } from './reward-user.js';
 import { startCombinedCourse } from './start-combined-course.js';
@@ -119,6 +121,7 @@ const usecasesWithoutInjectedDependencies = {
   getOrganizationAttestations,
   getCourseByOrganizationId,
   isParticipationOnCombinedCourse,
+  isCombinedCourseBlueprintInOrganization,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/domain/usecases/is-combined-course-blueprint-in-organization.js
+++ b/api/src/quest/domain/usecases/is-combined-course-blueprint-in-organization.js
@@ -1,0 +1,19 @@
+/**
+ *
+ * @param {Object} params
+ * @param {number} params.combinedCourseBlueprintId
+ * @param {number} params.organizationId
+ * @param {import ('../usecases/index.js').CombinedCourseBlueprintShareRepository} params.combinedCourseBlueprintShareRepository
+ * @returns {Promise<boolean>}
+ */
+export async function isCombinedCourseBlueprintInOrganization({
+  combinedCourseBlueprintId,
+  organizationId,
+  combinedCourseBlueprintShareRepository,
+}) {
+  const result = await combinedCourseBlueprintShareRepository.findByCombinedCourseBlueprintIdAndOrganizationId({
+    combinedCourseBlueprintId,
+    organizationId,
+  });
+  return Boolean(result);
+}

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-share-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-share-repository.js
@@ -1,0 +1,13 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+export async function findByCombinedCourseBlueprintIdAndOrganizationId({ combinedCourseBlueprintId, organizationId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn('combined_course_blueprint_shares')
+    .where({
+      combinedCourseBlueprintId,
+      organizationId,
+    })
+    .first();
+
+  return result ?? null;
+}

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -17,6 +17,7 @@ import { AttestationStorage } from '../storage/attestation-storage.js';
 import * as attestationRepository from './attestation-repository.js';
 import * as campaignParticipationRepository from './campaign-participation-repository.js';
 import * as campaignRepository from './campaign-repository.js';
+import * as combinedCourseBlueprintShareRepository from './combined-course-blueprint-share-repository.js';
 import * as combinedCourseDetailsRepository from './combined-course-details-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
 import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
@@ -46,6 +47,7 @@ const repositoriesWithoutInjectedDependencies = {
   campaignRepository,
   combinedCourseRepository,
   courseRepository,
+  combinedCourseBlueprintShareRepository,
   combinedCourseDetailsRepository,
   combinedCourseParticipantRepository,
   combinedCourseParticipationRepository,

--- a/api/tests/quest/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/quest/acceptance/application/security-pre-handlers_test.js
@@ -1,6 +1,7 @@
 import { createServer } from '../../../../server.js';
 import {
   checkAuthorizationToAccessCombinedCourse,
+  checkCombinedCourseBlueprintBelongsToOrganization,
   checkCombinedCoursesFeatureIsEnabled,
   checkParticipationBelongsToCombinedCourse,
 } from '../../../../src/quest/application/security-pre-handlers.js';
@@ -16,7 +17,13 @@ import { generateAuthenticatedUserRequestHeaders } from '../../../tooling/test-u
 
 describe('Quest | Acceptance | Application | SecurityPreHandlers', function () {
   const jsonApiError403 = {
-    errors: [{ code: 403, title: 'Forbidden access', detail: 'Missing or insufficient permissions.' }],
+    errors: [
+      {
+        code: 403,
+        title: 'Forbidden access',
+        detail: 'Missing or insufficient permissions.',
+      },
+    ],
   };
 
   let server;
@@ -56,7 +63,10 @@ describe('Quest | Acceptance | Application | SecurityPreHandlers', function () {
 
     it('returns true if connected user is allowed to access given combined course', async function () {
       // given
-      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        userId,
+      });
 
       await databaseBuilder.commit();
 
@@ -188,6 +198,67 @@ describe('Quest | Acceptance | Application | SecurityPreHandlers', function () {
 
       expect(response.statusCode).to.equal(422);
       expect(response.payload).to.equal('Combined courses feature is disabled');
+    });
+  });
+
+  describe('#checkCombinedCourseBlueprintBelongsToOrganization', function () {
+    let combinedCourseBlueprintId, organizationId;
+
+    beforeEach(async function () {
+      const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+
+      combinedCourseBlueprintId = combinedCourseBlueprintShare.combinedCourseBlueprintId;
+      organizationId = combinedCourseBlueprintShare.organizationId;
+
+      server.route({
+        method: 'GET',
+        path: '/api/organization/{organizationId}/combined-course-blueprint/{combinedCourseBlueprintId}',
+        handler: (r, h) => h.response({}).code(200),
+        config: {
+          auth: false,
+          pre: [{ method: checkCombinedCourseBlueprintBelongsToOrganization }],
+        },
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('returns 200 OK if combined course blueprint belongs to organization', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: `/api/organization/${organizationId}/combined-course-blueprint/${combinedCourseBlueprintId}`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('returns an error if combined course blueprint does not belong to organization', async function () {
+      // given
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const { combinedCourseBlueprintId: otherCombinedCourseBlueprintId } =
+        databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+          organizationId: otherOrganizationId,
+        });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/organization/${organizationId}/combined-course-blueprint/${otherCombinedCourseBlueprintId}`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
   });
 });

--- a/api/tests/quest/integration/domain/usecases/is-combined-course-blueprint-in-organization_test.js
+++ b/api/tests/quest/integration/domain/usecases/is-combined-course-blueprint-in-organization_test.js
@@ -1,0 +1,43 @@
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Integration | Quest | Domain | UseCases | is-combined-course-blueprint-in-organization', function () {
+  it('should return true if the combined course blueprint belongs to the organization', async function () {
+    // given
+    //given
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+    const { combinedCourseBlueprintId, organizationId } = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.isCombinedCourseBlueprintInOrganization({
+      combinedCourseBlueprintId,
+      organizationId,
+    });
+
+    //then
+    expect(result).to.be.true;
+  });
+
+  it('should return false otherwise', async function () {
+    // given
+    //given
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.isCombinedCourseBlueprintInOrganization({
+      combinedCourseBlueprintId: 999,
+      organizationId: 999,
+    });
+
+    //then
+    expect(result).to.be.false;
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-share-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-share-repository_test.js
@@ -1,0 +1,46 @@
+import * as combinedCourseBlueprintShareRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprint-share-repository.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Quest | Integration | Repository | combined-course-blueprint-share', function () {
+  describe('#findByCombinedCourseBlueprintIdAndOrganizationId', function () {
+    it('should return a combined course blueprint share', async function () {
+      //given
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+      const { combinedCourseBlueprintId, organizationId } = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseBlueprintShareRepository.findByCombinedCourseBlueprintIdAndOrganizationId({
+        combinedCourseBlueprintId,
+        organizationId,
+      });
+
+      //then
+      expect(result.combinedCourseBlueprintId).to.equal(combinedCourseBlueprintId);
+      expect(result.organizationId).to.equal(organizationId);
+    });
+
+    describe('when combined course blueprint share does not exist', function () {
+      it('should return null', async function () {
+        //given
+        databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+        databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+        databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await combinedCourseBlueprintShareRepository.findByCombinedCourseBlueprintIdAndOrganizationId({
+          combinedCourseBlueprintId: 999,
+          organizationId: 999,
+        });
+
+        //then
+        expect(result).to.be.null;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🚙 Problème
Nous allons avoir besoin de récupérer le détail blueprint associé à une organisation. Or, il n’existe pas encore de moyen de vérifier qu’un blueprint appartient bien à une organisation.

## 🍃 Proposition
Ajouter un prehandler permettant de vérifiant l'appartenance d'un blueprint à une organisation

## 🔗 Pour tester
Les tests passent  