### PR TITLE
[TECH] Ajouter un index sur userId dans la table 'certification-center-memberships' (PIX-23044)

### DIFF
--- a/api/db/migrations/20260605135529_add-index-to-user-id-in-certification-center-memberships-table.js
+++ b/api/db/migrations/20260605135529_add-index-to-user-id-in-certification-center-memberships-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-center-memberships';
+const COLUMN_NAME = 'userId';
+
+const up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.index(COLUMN_NAME);
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🚙 Problème

On a beaucoup de scans sur la table `certifications-center-memberships`. Ce qui laisse penser qu'il manque un index sur cette table. On a actuellement 3 index:
- id
- certificationCenterId
- composite userId + certificationCenterId + WHERE disabledAt is null
 
2 index existaient avant sur userId et certificationCenterId. Ils ont été supprimés en 2020 (https://github.com/1024pix/pix/pull/1052/commits/f4630516d19ebe642b836b966f4925c265053564) puis celui sur certificationCenterId a été remis en 2025 (https://github.com/1024pix/pix/pull/12164/commits/7f494633262ec99aae729fb4e3565fadf88bc0f2).

À priori, à cause du where, l'index composite userId et certificationCenterId ne profiterait pas au userId.

## 🍃 Proposition

On ajoute un index sur userId.

## 🦵 Remarques

RAS

## 🔗 Pour tester
- vérifier que la migration s'exécute correctement et que la table `certification-center-memberships` possède maintenant les 4 index.
