### PR TITLE
[TECH] Ajouter le certificationCenterId dans fct_structures (PIX-22683)

### DIFF
--- a/api/db/database-builder/factory/build-fact-structure.js
+++ b/api/db/database-builder/factory/build-fact-structure.js
@@ -6,6 +6,7 @@ const buildFactStructure = function ({
   parentStructureId,
   childStructureId,
   organizationId,
+  certificationCenterId,
 } = {}) {
   const values = {
     structure_id: structureId,
@@ -13,6 +14,7 @@ const buildFactStructure = function ({
     parent_structure_id: parentStructureId,
     child_structure_id: childStructureId,
     organization_id: organizationId,
+    certification_center_id: certificationCenterId,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'fct_structures',

--- a/api/db/migrations/20260605135737_add-certification-center-id-to-fct-structures.js
+++ b/api/db/migrations/20260605135737_add-certification-center-id-to-fct-structures.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'fct_structures';
+const COLUMN_NAME = 'certification_center_id';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .defaultTo(null)
+      .references('certification-centers.id')
+      .comment('References the ID of the certification center linked to the organization if any.');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1269,6 +1269,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
           expect(childrenOrganizationFactStructures).to.have.deep.members([
             {
+              certification_center_id: null,
               organization_id: firstChildOrganization.id,
               structure_id: firstChildStructure.id,
               network_id: network.id,
@@ -1276,6 +1277,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               child_structure_id: null,
             },
             {
+              certification_center_id: null,
               organization_id: secondChildOrganization.id,
               structure_id: secondChildStructure.id,
               parent_structure_id: parentStructure.id,

--- a/api/tests/organizational-entities/integration/domain/usecases/attach-child-organization-to-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/attach-child-organization-to-organization.usecase.test.js
@@ -38,6 +38,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | attach-chil
       ]);
       expect(childrenOrganizationFactStructures).to.have.deep.members([
         {
+          certification_center_id: null,
           organization_id: firstChildOrganization.id,
           structure_id: firstChildStructure.id,
           network_id: network.id,
@@ -45,6 +46,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | attach-chil
           child_structure_id: null,
         },
         {
+          certification_center_id: null,
           organization_id: secondChildOrganization.id,
           structure_id: secondChildStructure.id,
           parent_structure_id: parentStructure.id,
@@ -89,6 +91,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | attach-chil
       ]);
       expect(childrenOrganizationFactStructures).to.have.deep.members([
         {
+          certification_center_id: null,
           organization_id: level1ChildOrganization.id,
           structure_id: level1ChildStructure.id,
           network_id: network.id,
@@ -96,6 +99,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | attach-chil
           child_structure_id: null,
         },
         {
+          certification_center_id: null,
           organization_id: level2ChildOrganization.id,
           structure_id: level2ChildStructure.id,
           parent_structure_id: level1ChildStructure.id,

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -336,6 +336,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
         .where({ organization_id: childOrganization.id })
         .first();
       expect(updatedFactStructure).to.deep.equal({
+        certification_center_id: null,
         organization_id: childOrganization.id,
         structure_id: childStructure.id,
         network_id: network.id,

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1319,6 +1319,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       const fct_structure = await knex('fct_structures').where({ organization_id: savedOrganization.id }).first();
       const structure = await knex('structures').where({ id: fct_structure.structure_id }).first();
       expect(fct_structure).to.deep.equal({
+        certification_center_id: null,
         child_structure_id: null,
         network_id: null,
         organization_id: savedOrganization.id,


### PR DESCRIPTION
## 🚙 Problème

La table de faits `fct_structures` ne contient pas de référence vers un centre de certification.
Cette colonne est nécessaire pour associer une structure à un centre de certification.

## 🍃 Proposition

- Ajout de la colonne `certification_center_id`  via migration Knex

## 🔗 Pour tester

RAS
