### PR TITLE
[FEATURE] Tracker le clic sur la card de CF sur la page de résultats (PIX-22947)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -28,6 +28,7 @@ export default class Card extends Component {
 
   @action
   showModal() {
+    this.args.onCardClick({ trainingId: this.args.training.id });
     this.modalIsOpen = true;
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -12,7 +12,7 @@ import TrainingCard from './training/card';
 
   <ul class="results-recommendation-engine-training__list">
     {{#each @trainings as |training|}}
-      <li><TrainingCard @training={{training}} /></li>
+      <li><TrainingCard @training={{training}} @onCardClick={{@onCardClick}} /></li>
     {{/each}}
   </ul>
 </template>

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -10,6 +11,13 @@ import Trainings from '../../../campaigns/assessment/results-recommendation-engi
 
 export default class EvaluationResultsRecommendationEngine extends Component {
   @service media;
+  @service pixMetrics;
+
+  @action onCardClick({ trainingId }) {
+    this.pixMetrics.trackEvent('Moteur de reco - Clic sur la carte du contenu formatif', {
+      trainingId,
+    });
+  }
 
   get hasTrainings() {
     return Boolean(this.trainings.length);
@@ -48,7 +56,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
       />
 
       {{#if this.hasTrainings}}
-        <Trainings @trainings={{this.trainings}} />
+        <Trainings @trainings={{this.trainings}} @onCardClick={{this.onCardClick}} />
       {{/if}}
 
       <ResultsDetails

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -5,6 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { authenticate } from '../../helpers/authentication';
 import setupIntl from '../../helpers/setup-intl';
@@ -67,8 +68,10 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
     });
 
     module('when campaign has trainings', function (hooks) {
+      let training;
+
       hooks.beforeEach(function () {
-        server.create('training', {
+        training = server.create('training', {
           campaignParticipation,
           title: 'Formation test',
           link: 'https://example.net/',
@@ -115,6 +118,37 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         const reopenedModal = await screen.findByRole('dialog');
         assert.dom(within(reopenedModal).getByRole('button', { name: t('common.yes') })).doesNotHaveClass('selected');
         assert.dom(within(reopenedModal).getByRole('button', { name: t('common.no') })).hasClass('selected');
+      });
+
+      test('should track page and card information', async function (assert) {
+        // given
+        const trackEventStub = sinon.stub();
+        const trackPageStub = sinon.stub();
+        class MetricsStubService extends Service {
+          trackPage = trackPageStub;
+          trackEvent = trackEventStub;
+        }
+        this.owner.register('service:pix-metrics', MetricsStubService);
+
+        // when
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const metricsService = this.owner.lookup('service:metrics');
+
+        // then
+        sinon.assert.calledOnceWith(trackPageStub);
+        assert.strictEqual(metricsService.context.code, campaign.code);
+
+        // when
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
+          }),
+        );
+
+        // then
+        sinon.assert.calledWithExactly(trackEventStub, 'Moteur de reco - Clic sur la carte du contenu formatif', {
+          trainingId: training.id,
+        });
       });
     });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -3,6 +3,7 @@ import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import TrainingCard from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/training/card';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 
@@ -196,9 +197,12 @@ module(
           'training',
           _buildTraining({ type: 'modulix', duration: { days: 1, hours: 2, minutes: 10 } }),
         );
+        const onCardClickStub = sinon.stub();
 
         // when
-        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+        const screen = await render(
+          <template><TrainingCard @training={{training}} @onCardClick={{onCardClickStub}} /></template>,
+        );
         await click(
           screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
         );
@@ -232,9 +236,12 @@ module(
           // given
           const store = this.owner.lookup('service:store');
           const training = store.createRecord('training', _buildTraining({ type: 'modulix' }));
+          const onCardClickStub = sinon.stub();
 
           // when
-          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+          const screen = await render(
+            <template><TrainingCard @training={{training}} @onCardClick={{onCardClickStub}} /></template>,
+          );
           await click(
             screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
           );
@@ -256,9 +263,12 @@ module(
           // given
           const store = this.owner.lookup('service:store');
           const training = store.createRecord('training', _buildTraining({ type: 'webinaire' }));
+          const onCardClickStub = sinon.stub();
 
           // when
-          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+          const screen = await render(
+            <template><TrainingCard @training={{training}} @onCardClick={{onCardClickStub}} /></template>,
+          );
           await click(
             screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
           );
@@ -279,9 +289,12 @@ module(
         // given
         const store = this.owner.lookup('service:store');
         const training = store.createRecord('training', _buildTraining({}));
+        const onCardClickStub = sinon.stub();
 
         // when
-        const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+        const screen = await render(
+          <template><TrainingCard @training={{training}} @onCardClick={{onCardClickStub}} /></template>,
+        );
         await click(
           screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
         );
@@ -293,6 +306,25 @@ module(
         assert
           .dom(within(modal).getByText(t('pages.skill-review.recommended-engine.modal.feedback.question')))
           .exists();
+      });
+
+      test('should call onCardClick function', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({}));
+        const onCardClickStub = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template><TrainingCard @training={{training}} @onCardClick={{onCardClickStub}} /></template>,
+        );
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
+        );
+
+        // then
+        sinon.assert.calledOnceWithExactly(onCardClickStub, { trainingId: training.id });
+        assert.ok(true);
       });
     });
 


### PR DESCRIPTION
## 🚙 Problème

On souhaite prendre connaissance du parcours utilisateur lors de son arrivée sur la page de détails de fin de parcours - version moteur de recommandation de contenu formatif.

## 🍃 Proposition

Traquer le clic sur une carte de contenu formatif via Plausible, avec le service PixMetrics.

## 🦵 Remarques
Pour comprendre le tracking de la page de fin de parcours : 

Toutes les pages de l'application sont trackés sur Plausible via la fonction trackPage appelé au plus au niveau de l'application https://github.com/1024pix/pix/blob/3e13bfbf91287381742d623ff0978aca7cabcd7e/mon-pix/app/routes/application.js#L27

On a constaté que dans https://github.com/1024pix/pix/blob/3e13bfbf91287381742d623ff0978aca7cabcd7e/mon-pix/app/routes/campaigns.js#L19 une méthode `activate` permet à ce que toutes les routes (  /campagnes/..., etc ) ajoute les infos (code / type) dans le context pour Plausible.

Du coup tous les events au sein de ces pages profiteront de ce context rempli. 

Pour le clic de la carte de contenu formatif, pas besoin d'appeler nous même le code campagne, c'est déjà fait ! 
On a plus qu'a appelé le `trainingId`

## 🔗 Pour tester

- Se connecter avec dave-comp ou perfect profile
- Ouvrir sa console navigateur et lire **toutes les requêtes**
- Aller sur un parcours et aller aux résultats.
- 1er appel Plausible => C'est le `trackPage` quand on accède à la page de résultat (on peut y voir le param `code`) (lui on l'a pas dev ici mais c'est pour aider à comprendre)
- Cliquer sur un contenu formatif
- 2nd appel Plausible => Lui on le dev ici, constater qu'il porte en param `code` aussi

---

**(Enlever Ublock si les appels Plausible passent pas)**

---

- Aller sur Plausible, appli review.pix.fr
- Aller au bout de la page et choisir Funnel
- Constater qu'il y a 2 steps, accès à la page et clic sur la carte
- En haut à droite de votre écran, il y a Filtres
- Cliquer sur code / is / choisir le code campagne ou vous êtes

Jouer avec les appels Plausible pour changer les %
