### PR TITLE
[TECH] Ajouter des seeds pour lier un centre de certification à une organisation (PIX-22627)

### DIFF
--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -77,12 +77,24 @@ const buildOrganization = function buildOrganization({
  * @param {number} options.networkId - Id of the network to attach the organization to
  * @param {number} [options.parentStructureId] - Id of the parent structure (null for a head organization)
  * @param {object} [options.organizationData] - Any parameter accepted by buildOrganization
+ * @param {number} [options.certificationCenterId] - optional certification center id to link to the organization
  * @returns {{ organization: object, structure: object }}
  */
-const buildOrganizationInNetwork = function ({ networkId, parentStructureId = null, organizationData = {} } = {}) {
+const buildOrganizationInNetwork = function ({
+  networkId,
+  parentStructureId = null,
+  organizationData = {},
+  certificationCenterId = null,
+} = {}) {
   const organization = buildOrganization(organizationData);
   const structure = buildStructure();
-  buildFactStructure({ structureId: structure.id, networkId, organizationId: organization.id, parentStructureId });
+  buildFactStructure({
+    structureId: structure.id,
+    networkId,
+    organizationId: organization.id,
+    parentStructureId,
+    certificationCenterId,
+  });
   return { organization, structure };
 };
 

--- a/api/db/seeds/data/team-acquisition/build-networks.js
+++ b/api/db/seeds/data/team-acquisition/build-networks.js
@@ -113,6 +113,12 @@ function _buildScoNetwork(databaseBuilder) {
       },
     });
 
+    const certificationCenterLyceeVersailles = databaseBuilder.factory.buildCertificationCenter({
+      name: "Lycée 1 de l'Académie de Versailles",
+      type: 'SCO',
+      createdAt: new Date('2026-09-03'),
+    });
+
     databaseBuilder.factory.buildOrganizationInNetwork({
       networkId: network.id,
       parentStructureId: academieVersaillesStructure.id,
@@ -124,10 +130,16 @@ function _buildScoNetwork(databaseBuilder) {
         isManagingStudents: true,
         createdAt: new Date('2026-09-03'),
         updatedAt: new Date('2026-09-03'),
-
         administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
         organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
       },
+      certificationCenterId: certificationCenterLyceeVersailles.id,
+    });
+
+    const certificationCenterCollegeVersailles = databaseBuilder.factory.buildCertificationCenter({
+      name: "Collège 1 de l'Académie de Versailles",
+      type: 'SCO',
+      createdAt: new Date('2026-09-03'),
     });
 
     databaseBuilder.factory.buildOrganizationInNetwork({
@@ -141,10 +153,10 @@ function _buildScoNetwork(databaseBuilder) {
         isManagingStudents: true,
         createdAt: new Date('2026-09-03'),
         updatedAt: new Date('2026-09-03'),
-
         administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
         organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
       },
+      certificationCenterId: certificationCenterCollegeVersailles.id,
     });
   }
 


### PR DESCRIPTION
## 🚙 Problème

On commence à développer la fonctionnalité de lien entre une organisation et un centre de certif. On a besoin de données représentatives.

## 🍃 Proposition

Modifier les seeds pour inclure deux organisations qui sont rattachées à un centre de certif chacune.

## 🦵 Remarques

RAS

## 🔗 Pour tester

- `db:reset` ne génère pas d'erreur
- test au vert
