### PR TITLE
[FEATURE] Affiche le lien de questionnaire en fin de parcours selon l'url défini pour le schéma de parcours (PIX-22937)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -86,6 +86,7 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
     description: combinedCourseData.blueprint.description,
     illustration: combinedCourseData.blueprint.illustration,
     questId: blueprintQuestId,
+    surveyUrl: combinedCourseData.blueprint.surveyUrl,
   });
 
   let campaignId;

--- a/api/db/seeds/data/team-prescription/fixtures/pro-combined-course.js
+++ b/api/db/seeds/data/team-prescription/fixtures/pro-combined-course.js
@@ -17,6 +17,7 @@ export const PRO_COMBINED_COURSE = {
     ],
     description:
       "#Un parcours\n pour découvrir l'essentiel sur l'intelligence artificielle : [comprendre sa définition](http://pix.fr), ses domaines d'application, comment elle fonctionne, ainsi que ses enjeux, notamment en matière d'impact environnemental.",
+    surveyUrl: 'http://pix.fr',
   },
   combinedCourse: {
     code: 'COMBINIX1',

--- a/api/src/quest/domain/models/combined-course-participation/CombinedCourseDetails.js
+++ b/api/src/quest/domain/models/combined-course-participation/CombinedCourseDetails.js
@@ -25,11 +25,11 @@ export class CombinedCourseDetails extends CombinedCourse {
   reward = null;
 
   constructor(
-    { id, code, organizationId, name, description, illustration, questId },
+    { id, code, organizationId, name, description, illustration, questId, surveyUrl },
     quest,
     cryptoService = injectedCryptoService,
   ) {
-    super({ id, code, organizationId, name, description, illustration, questId }, quest);
+    super({ id, code, organizationId, name, description, illustration, questId, surveyUrl }, quest);
     this.cryptoService = cryptoService;
   }
 

--- a/api/src/quest/domain/models/combined-course/CombinedCourse.js
+++ b/api/src/quest/domain/models/combined-course/CombinedCourse.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import { CombinedCourseParticipation } from '../combined-course-participation/CombinedCourseParticipation.js';
 
 const schema = Joi.object({
   id: Joi.number().allow(null),
@@ -9,6 +10,12 @@ const schema = Joi.object({
   name: Joi.string().required(),
   description: Joi.string().allow(null),
   illustration: Joi.string().allow(null),
+  participations: Joi.array().items(Joi.object().instance(CombinedCourseParticipation)),
+  questId: Joi.number(),
+  surveyUrl: Joi.string().uri().allow(null),
+  blueprintId: Joi.number().allow(null),
+  deletedAt: Joi.date().allow(null),
+  deletedBy: Joi.number().allow(null),
 });
 export class CombinedCourse {
   #quest;
@@ -23,6 +30,7 @@ export class CombinedCourse {
       illustration,
       participations = [],
       questId,
+      surveyUrl = null,
       blueprintId = null,
       deletedAt = null,
       deletedBy = null,
@@ -37,11 +45,12 @@ export class CombinedCourse {
     this.illustration = illustration;
     this.participations = participations;
     this.questId = questId;
+    this.surveyUrl = surveyUrl;
     this.blueprintId = blueprintId;
     this.deletedAt = deletedAt;
     this.deletedBy = deletedBy;
 
-    this.#validate({ id, code, organizationId, name, description, illustration });
+    this.#validate();
 
     this.#quest = quest;
   }
@@ -58,10 +67,10 @@ export class CombinedCourse {
     return this.participations.filter((participation) => participation.isCompleted()).length;
   }
 
-  #validate(combinedCourse) {
-    const { error } = schema.validate(combinedCourse);
+  #validate() {
+    const { error } = schema.validate(this);
     if (error) {
-      throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: combinedCourse });
+      throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: this });
     }
   }
 }

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -71,15 +71,21 @@ const _baseQuery = (knexConn) => {
       'combined_courses.updatedAt',
       'combined_courses.deletedAt',
       'combined_courses.deletedBy',
-      'questId',
+      'combined_courses.questId',
       'quests.createdAt as questCreatedAt',
       'quests.updatedAt as questUpdatedAt',
       'quests.rewardType as questRewardType',
       'quests.eligibilityRequirements as questEligibilityRequirements',
       'quests.successRequirements as questSuccessRequirements',
       'quests.rewardId as questRewardId',
+      'combined_course_blueprints.surveyUrl as surveyUrl',
     )
     .join('quests', 'quests.id', 'combined_courses.questId')
+    .leftJoin(
+      'combined_course_blueprints',
+      'combined_course_blueprints.id',
+      'combined_courses.combinedCourseBlueprintId',
+    )
     .whereNull('combined_courses.deletedAt');
 };
 
@@ -168,6 +174,7 @@ const _toDomain = ({
   questEligibilityRequirements,
   questSuccessRequirements,
   questRewardId,
+  surveyUrl,
 }) => {
   return new CombinedCourse(
     {
@@ -179,6 +186,7 @@ const _toDomain = ({
       illustration,
       questId,
       blueprintId: combinedCourseBlueprintId,
+      surveyUrl,
       deletedAt,
       deletedBy,
     },

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -14,6 +14,7 @@ const serialize = function (combinedCourse) {
       'items',
       'reward',
       'shortId',
+      'surveyUrl',
     ],
     items: {
       ref: 'id',

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-by-module-id-and-user-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-by-module-id-and-user-id_test.js
@@ -85,6 +85,7 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
         blueprintId: null,
         deletedAt: null,
         deletedBy: null,
+        surveyUrl: null,
       },
       {
         id: combinedCourse2.id,
@@ -98,6 +99,7 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
         blueprintId: null,
         deletedAt: null,
         deletedBy: null,
+        surveyUrl: null,
       },
     ]);
   });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -20,7 +20,14 @@ describe('Quest | Integration | Repository | combined-course', function () {
       // given
       const code = 'SOMETHING';
       const { id: organizationId } = databaseBuilder.factory.buildOrganization();
-      const combinedCourse = databaseBuilder.factory.buildCombinedCourse({ code, organizationId });
+      const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
+        surveyUrl: 'http://link.to/survey',
+      });
+      const combinedCourse = databaseBuilder.factory.buildCombinedCourse({
+        code,
+        organizationId,
+        combinedCourseBlueprintId: combinedCourseBlueprint.id,
+      });
       await databaseBuilder.commit();
 
       // when
@@ -28,7 +35,13 @@ describe('Quest | Integration | Repository | combined-course', function () {
 
       // then
       expect(combinedCourseResult).to.be.an.instanceof(CombinedCourse);
-      expect(combinedCourseResult).to.deep.equal(new CombinedCourse(combinedCourse));
+      expect(combinedCourseResult).to.deep.equal(
+        new CombinedCourse({
+          ...combinedCourse,
+          blueprintId: combinedCourseBlueprint.id,
+          surveyUrl: combinedCourseBlueprint.surveyUrl,
+        }),
+      );
     });
 
     it('should throw NotFoundError if combined course does not exist', async function () {
@@ -627,6 +640,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           illustration: combinedCourseWithModule.illustration,
           participations: [],
           questId: combinedCourseWithModule.questId,
+          surveyUrl: null,
           blueprintId: null,
           deletedAt: null,
           deletedBy: null,
@@ -640,6 +654,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           illustration: otherCombinedCourseWithModule.illustration,
           participations: [],
           questId: otherCombinedCourseWithModule.questId,
+          surveyUrl: null,
           blueprintId: null,
           deletedAt: null,
           deletedBy: null,
@@ -668,6 +683,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           illustration: combinedCourseWithModule.illustration,
           participations: [],
           questId: combinedCourseWithModule.questId,
+          surveyUrl: null,
           blueprintId: null,
           deletedAt: null,
           deletedBy: null,
@@ -681,6 +697,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           illustration: combinedCourseWithModuleAndOtherOrga.illustration,
           participations: [],
           questId: combinedCourseWithModuleAndOtherOrga.questId,
+          surveyUrl: null,
           blueprintId: null,
           deletedAt: null,
           deletedBy: null,

--- a/api/tests/quest/unit/domain/models/combined-course/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course/CombinedCourse_test.js
@@ -10,16 +10,18 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
     const organizationId = 1;
     const name = 'name';
     const code = 'code';
+    const surveyUrl = 'http://survey-link.com';
 
     // when
-    const combinedCourseDetails = new CombinedCourse({ id, organizationId, name, code, questId: 2 });
+    const combinedCourse = new CombinedCourse({ id, organizationId, name, code, questId: 2, surveyUrl });
 
     // then
-    expect(combinedCourseDetails.code).to.deep.equal(code);
-    expect(combinedCourseDetails.name).to.deep.equal(name);
-    expect(combinedCourseDetails.organizationId).to.deep.equal(organizationId);
-    expect(combinedCourseDetails.id).to.deep.equal(id);
-    expect(combinedCourseDetails.questId).to.deep.equal(2);
+    expect(combinedCourse.code).to.deep.equal(code);
+    expect(combinedCourse.name).to.deep.equal(name);
+    expect(combinedCourse.organizationId).to.deep.equal(organizationId);
+    expect(combinedCourse.id).to.deep.equal(id);
+    expect(combinedCourse.questId).to.deep.equal(2);
+    expect(combinedCourse.surveyUrl).to.deep.equal(surveyUrl);
   });
 
   it('should throw when combined course model does not pass validation', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -18,6 +18,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
       combinedCourseItems: [{ campaignId: 1 }, { moduleId: 7 }],
       rewardId: 456,
       rewardType: REWARD_TYPES.ATTESTATION,
+      surveyUrl: 'http://link.to/survey',
     });
     await combinedCourseDetails.setEncryptedUrl();
     const obtainedAt = new Date();
@@ -93,6 +94,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
           status: CombinedCourseStatuses.NOT_STARTED,
           description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
           illustration: '/illustrations/image.svg',
+          'survey-url': 'http://link.to/survey',
         },
         relationships: {
           items: {

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -7,7 +7,7 @@ import { Eligibility } from '../../../../src/quest/domain/models/Eligibility.js'
 import { Module } from '../../../../src/quest/domain/models/Module.js';
 import { Quest } from '../../../../src/quest/domain/models/Quest.js';
 
-function buildCombinedCourse({ name, code, organizationId, questId } = {}) {
+function buildCombinedCourse({ name, code, organizationId, questId, surveyUrl } = {}) {
   return new CombinedCourse({
     id: 1,
     code: code ?? 'COMBINIX1',
@@ -16,6 +16,7 @@ function buildCombinedCourse({ name, code, organizationId, questId } = {}) {
     description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
     illustration: '/illustrations/image.svg',
     questId: questId ?? 777,
+    surveyUrl,
   });
 }
 
@@ -28,8 +29,9 @@ function buildCombinedCourseDetails({
   cryptoService,
   rewardId = null,
   rewardType = null,
+  surveyUrl,
 } = {}) {
-  const combinedCourse = buildCombinedCourse({ name, code, organizationId, questId });
+  const combinedCourse = buildCombinedCourse({ name, code, organizationId, questId, surveyUrl });
 
   const campaigns = [];
   const modules = [];

--- a/mon-pix/app/components/routes/combined-courses/presentation.gjs
+++ b/mon-pix/app/components/routes/combined-courses/presentation.gjs
@@ -137,27 +137,18 @@ export default class CombinedCoursePresentation extends Component {
     });
   }
 
-  get isSurveyEnabled() {
-    const surveyEnabledForCombinedCourses = this.featureToggles.featureToggles?.isSurveyEnabledForCombinedCourses;
+  get surveyLink() {
+    return this.args.combinedCourse.organizationId === ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID
+      ? ENV.APP.COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK
+      : this.args.combinedCourse.surveyUrl;
+  }
 
+  get isSurveyEnabled() {
     if (this.args.combinedCourse.organizationId === ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID) {
       return true;
     }
 
-    if (!ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST) return surveyEnabledForCombinedCourses;
-
-    const organizationsToExclude = ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST.split(',');
-
-    return (
-      surveyEnabledForCombinedCourses &&
-      !organizationsToExclude.includes(this.args.combinedCourse.organizationId.toString())
-    );
-  }
-
-  get surveyLink() {
-    return this.args.combinedCourse.organizationId === ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID
-      ? ENV.APP.COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK
-      : ENV.APP.COMBINIX_SURVEY_LINK;
+    return this.featureToggles.featureToggles?.isSurveyEnabledForCombinedCourses && this.args.combinedCourse.surveyUrl;
   }
 
   get shouldDisplayRetryModulesText() {

--- a/mon-pix/app/models/combined-course.js
+++ b/mon-pix/app/models/combined-course.js
@@ -16,6 +16,7 @@ export default class CombinedCourse extends Model {
   @attr('string') status;
   @attr('string') description;
   @attr('string') illustration;
+  @attr('string') surveyUrl;
 
   @hasMany('combined-course-item', { async: false, inverse: 'combinedCourse' }) items;
   @belongsTo('combined-course-reward', { async: false, inverse: null }) reward;

--- a/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
@@ -2,7 +2,6 @@ import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CombinedCoursesPresentation from 'mon-pix/components/routes/combined-courses/presentation';
-import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -422,7 +421,7 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
       assert.ok(screen.getByRole('heading', { name: t('pages.combined-courses.completed.title') }));
       assert.notOk(screen.queryByText(t('pages.combined-courses.items.tagText')));
     });
-    test('should display survey cta', async function (assert) {
+    test('should display survey cta if available', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const featureToggles = this.owner.lookup('service:featureToggles');
@@ -432,6 +431,7 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
         status: CombinedCourseStatuses.COMPLETED,
         code: 'COMBINIX9',
         organizationId: 123,
+        surveyUrl: 'combinix.survey.link',
       });
 
       // when
@@ -446,40 +446,11 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
       assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
     });
 
-    test('should display France Travail survey cta in all cases', async function (assert) {
-      // given
-      const FRANCE_TRAVAIL_ORGANIZATION_ID = 456;
-      const store = this.owner.lookup('service:store');
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: false });
-      const combinedCourse = store.createRecord('combined-course', {
-        id: 1,
-        status: CombinedCourseStatuses.COMPLETED,
-        code: 'COMBINIX9',
-        organizationId: FRANCE_TRAVAIL_ORGANIZATION_ID,
-      });
-
-      // when
-      const screen = await render(
-        <template><CombinedCoursesPresentation @combinedCourse={{combinedCourse}} /></template>,
-      );
-
-      // then
-      const link = screen.getByRole('link', { name: t('pages.combined-courses.completed.survey-button') });
-      assert.dom(link).hasAttribute('href', 'combinix.france-travail.survey.link');
-      assert.dom(link).hasAttribute('target', '_blank');
-      assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
-    });
-
-    test('should not display survey cta when organization is in the exclusion list', async function (assert) {
+    test('should not display survey cta if no link for combined course', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const featureToggles = this.owner.lookup('service:featureToggles');
       sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: true });
-
-      const originalExcluded = ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST;
-      ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = '123,456';
-
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
         status: CombinedCourseStatuses.COMPLETED,
@@ -494,24 +465,19 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
 
       // then
       assert.notOk(screen.queryByRole('link', { name: t('pages.combined-courses.completed.survey-button') }));
-
-      ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = originalExcluded;
     });
 
-    test('should display survey cta when organization is not in the exclusion list', async function (assert) {
+    test('should not display survey cta if feature toggle is disabled', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: true });
-
-      const originalExcluded = ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST;
-      ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = '456,789';
-
+      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: false });
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
         status: CombinedCourseStatuses.COMPLETED,
         code: 'COMBINIX9',
         organizationId: 123,
+        surveyUrl: 'combinix.survey.link',
       });
 
       // when
@@ -520,10 +486,35 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
       );
 
       // then
-      assert.ok(screen.queryByRole('link', { name: t('pages.combined-courses.completed.survey-button') }));
-
-      ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = originalExcluded;
+      assert.notOk(screen.queryByRole('link', { name: t('pages.combined-courses.completed.survey-button') }));
     });
+
+    test('should display France Travail survey cta in all cases', async function (assert) {
+      // given
+      const FRANCE_TRAVAIL_ORGANIZATION_ID = 456;
+      const store = this.owner.lookup('service:store');
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: false });
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.COMPLETED,
+        code: 'COMBINIX9',
+        organizationId: FRANCE_TRAVAIL_ORGANIZATION_ID,
+        surveyUrl: 'combinix.france-travail.survey.link',
+      });
+
+      // when
+      const screen = await render(
+        <template><CombinedCoursesPresentation @combinedCourse={{combinedCourse}} /></template>,
+      );
+
+      // then
+      const link = screen.getByRole('link', { name: t('pages.combined-courses.completed.survey-button') });
+      assert.dom(link).hasAttribute('href', 'combinix.france-travail.survey.link');
+      assert.dom(link).hasAttribute('target', '_blank');
+      assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
+    });
+
     test('should display retry text for modules if there are any in the course', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## 🚙 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On veut afficher aux utilisateurs, en fin de parcours, le lien du questionnaire paramétré au niveau du blueprint.

## 🍃 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Récupération du surveyUrl dans le modèle de CombinedCourse, et affichage du lien si l'url est dispo.

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
On laisse pour l'instant la logique propre au questionnaire France Travail. On pourra la retirer une fois qu'on aura ajouté l'id de participation à l'envoi du formulaire (PIX-22941), quand on fera le clean dans les variables d'environnement (PIX-22942)

## 🔗 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Passer la feature toggle à true dans la RA.
Exemple `scalingo -a pix-api-review-pr16465 run "npm run toggles -- --key=isSurveyEnabledForCombinedCourses --value=true" `

Sur PixApp se connecter avec attestation-blank@example.net. Faire le parcours COMBINIX1.
Aller au bout du parcours.
Le lien du questionnaire doit s'afficher.