### PR TITLE
[BUGFIX] Partager les resultats de toutes les quêtes obtenues (PIX-23051)

### DIFF
--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -24,15 +24,14 @@ async function shareProfileRewardWithOrganization(campaignParticipationId, userI
     campaignParticipationId,
   });
 
-  const lastResult = questResults.at(-1);
-  const profileRewardId = lastResult?.profileRewardId;
-
-  if (profileRewardId) {
-    await profileUsecases.shareProfileReward({
-      userId,
-      profileRewardId,
-      campaignParticipationId,
-    });
+  for (const questResult of questResults) {
+    if (questResult.profileRewardId) {
+      await profileUsecases.shareProfileReward({
+        userId,
+        profileRewardId: questResult.profileRewardId,
+        campaignParticipationId,
+      });
+    }
   }
 }
 

--- a/api/tests/evaluation/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/unit/application/assessments/assessment-controller_test.js
@@ -238,6 +238,44 @@ describe('Evaluation | Unit | Application | assessment-controller', function () 
         expect(questUsecases.getQuestResultsForCampaignParticipation).to.have.been.called;
         expect(profileUsecases.shareProfileReward).to.not.have.been.called;
       });
+
+      it('should share a profile rewards for each quest results', async function () {
+        // given
+        const userId = 12;
+        const campaignParticipationId = 456;
+        const profileRewardId = 789;
+        const secondProfileRewardId = 987;
+        assessment.userId = userId;
+        assessment.campaignParticipationId = campaignParticipationId;
+        assessment.isCampaignParticipationAvailable.returns(true);
+        featureToggles.get.resolves(true);
+        questUsecases.getQuestResultsForCampaignParticipation.resolves([
+          { profileRewardId },
+          { profileRewardId: secondProfileRewardId },
+        ]);
+        evaluationUsecases.completeAssessment.resolves(assessment);
+
+        // when
+        await assessmentController.completeAssessment({ params: { id: assessmentId } });
+
+        // then
+        expect(questUsecases.getQuestResultsForCampaignParticipation).to.have.been.calledWithExactly({
+          userId,
+          campaignParticipationId,
+        });
+
+        expect(profileUsecases.shareProfileReward).calledTwice;
+        expect(profileUsecases.shareProfileReward.getCall(0)).to.have.been.calledWithExactly({
+          userId,
+          profileRewardId,
+          campaignParticipationId,
+        });
+        expect(profileUsecases.shareProfileReward.getCall(1)).to.have.been.calledWithExactly({
+          userId,
+          profileRewardId: secondProfileRewardId,
+          campaignParticipationId,
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## 🚙 Problème

Lorsqu'on termine une évaluation, on déclenche l'obtention de récompenses ainsi que leurs partage.
Or on ne partage avec l'organisation que la dernière de la liste, dans le cas ou y en aurait plusieurs.

## 🍃 Proposition

Partager tous les récompenses de quêtes

## 🦵 Remarques

Le reward repository ignore les enregistrements multiples d'une récompense avec une orga.

## 🔗 Pour tester

- Créer 2 quêtes avec 2 récompenses avec une eligibilité communes (ex un critère one-of avec 1 PC dont un en commun) 
```json
{
  "rewardId": 107539,
  "rewardType": "attestations",
  "eligibilityRequirements": [
    {
      "requirement_type": "campaignParticipations",
      "comparison": "all",
      "data": { "targetProfileId": { "comparison": "equal", "data": 6001 } }
    }
  ],
  "successRequirements": [
    {
      "requirement_type": "campaignParticipations",
      "comparison": "all",
      "data": { "status": { "comparison": "equal", "data": "SHARED" } }
    }
  ]
}

```

- Créer une campagne sur le PC des quetes
- [Passer la campagne](https://app-pr16467.review.pix.fr/campagnes/DMBLXU154) et valider la quête
- Valider que les récompenses sont [partagées avec l'orga ](https://orga-pr16467.review.pix.fr/attestations?attestationKey=MAIRIEBUREAU&statuses=%5B%22OBTAINED%22%5D)  


- Créer une deuxième Campagne sur le 2e PC
- Passer la campagne
- Valider que l'on a pas ré-obtenus la récompenses et qu'elle n'est pas repartagées.
