### PR TITLE
[FEATURE] Récupérer la donnée du clic de l'utilisateur lors de son accès à un contenu formatif (PIX-23073).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -12,7 +12,6 @@ import AcquiredBadgesCompact from './acquired-badges-compact';
 
 export default class EvaluationResultsHeroRecommendationEngine extends Component {
   @service currentUser;
-  @service pixMetrics;
   @service media;
 
   @tracked stagedMessageContentShowMoreEnabled = false;
@@ -57,25 +56,6 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
 
   @action toggleStagedMessage() {
     this.stagedMessageContentShowMoreEnabled = !this.stagedMessageContentShowMoreEnabled;
-  }
-
-  @action handleBackToHomepageDisplay() {
-    this.pixMetrics.trackEvent(
-      "Affichage du bouton 'Revenir à la page d'accueil dans le cadre du moteur de recommandation'",
-      {
-        disabled: true,
-        category: 'Fin de parcours',
-        action: 'Sortie de parcours',
-      },
-    );
-  }
-
-  @action handleBackToHomepageClick() {
-    this.pixMetrics.trackEvent("Clic sur le bouton 'Revenir à la page d'accueil'", {
-      disabled: true,
-      category: 'Fin de parcours',
-      action: 'Sortie de parcours',
-    });
   }
 
   <template>
@@ -125,13 +105,7 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
         {{/if}}
 
         <div class="evaluation-results-hero-recommendation-engine__actions">
-          {{this.handleBackToHomepageDisplay}}
-          <PixButtonLink
-            @route="authentication.login"
-            @size="small"
-            @variant="secondary-white"
-            onclick={{this.handleBackToHomepageClick}}
-          >
+          <PixButtonLink @route="authentication.login" @size="small" @variant="secondary-white">
             {{t "pages.skill-review.actions.back-to-pix"}}
           </PixButtonLink>
         </div>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -5,6 +5,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -42,6 +43,11 @@ export default class CardModal extends Component {
       trainingId: this.args.training.id,
       isRelevant: feedbackResponse,
     });
+  }
+
+  @action
+  onModalButtonClick() {
+    this.args.onModalButtonClick({ trainingId: this.args.training.id });
   }
 
   <template>
@@ -142,6 +148,7 @@ export default class CardModal extends Component {
             </li>
             <li>
               <PixButtonLink
+                {{on "click" this.onModalButtonClick}}
                 @href={{@training.link}}
                 target="_blank"
                 rel="noreferrer"

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -69,6 +69,7 @@ export default class Card extends Component {
       @formattedTime={{@training.formattedTime}}
       @isOpen={{this.modalIsOpen}}
       @onClose={{this.closeModal}}
+      @onModalButtonClick={{@onModalButtonClick}}
     />
   </template>
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -12,7 +12,11 @@ import TrainingCard from './training/card';
 
   <ul class="results-recommendation-engine-training__list">
     {{#each @trainings as |training|}}
-      <li><TrainingCard @training={{training}} @onCardClick={{@onCardClick}} /></li>
+      <li><TrainingCard
+          @training={{training}}
+          @onCardClick={{@onCardClick}}
+          @onModalButtonClick={{@onModalButtonClick}}
+        /></li>
     {{/each}}
   </ul>
 </template>

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -19,6 +19,12 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     });
   }
 
+  @action onModalButtonClick({ trainingId }) {
+    this.pixMetrics.trackEvent('Moteur de reco - Clic sur le bouton "Découvrir le programme/module"', {
+      trainingId,
+    });
+  }
+
   get hasTrainings() {
     return Boolean(this.trainings.length);
   }
@@ -56,7 +62,11 @@ export default class EvaluationResultsRecommendationEngine extends Component {
       />
 
       {{#if this.hasTrainings}}
-        <Trainings @trainings={{this.trainings}} @onCardClick={{this.onCardClick}} />
+        <Trainings
+          @trainings={{this.trainings}}
+          @onCardClick={{this.onCardClick}}
+          @onModalButtonClick={{this.onModalButtonClick}}
+        />
       {{/if}}
 
       <ResultsDetails

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -206,11 +206,12 @@
   display: flex;
   gap: var(--pix-spacing-2x);
   align-items: center;
+  justify-content: space-between;
+  width: 100%;
 
   @include breakpoints.device-is('mobile') {
     flex-direction: column;
     justify-content: center;
-    width: 100%
   }
 
   &__feedback {
@@ -235,8 +236,6 @@
   &__action-buttons {
     display: flex;
     gap: var(--pix-spacing-2x);
-    align-items: center;
-    justify-content: flex-end;
 
     @include breakpoints.device-is('mobile') {
       flex-direction: column;

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -144,11 +144,28 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
             name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
           }),
         );
+        await screen.findByRole('dialog');
 
         // then
         sinon.assert.calledWithExactly(trackEventStub, 'Moteur de reco - Clic sur la carte du contenu formatif', {
           trainingId: training.id,
         });
+
+        // when
+        await click(
+          screen.getByRole('link', {
+            name: `${t('pages.skill-review.recommended-engine.modal.actions.discover-program')} ${t('navigation.external-link-title')}`,
+          }),
+        );
+
+        // then
+        sinon.assert.calledWithExactly(
+          trackEventStub,
+          'Moteur de reco - Clic sur le bouton "Découvrir le programme/module"',
+          {
+            trainingId: training.id,
+          },
+        );
       });
     });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -326,6 +326,40 @@ module(
         sinon.assert.calledOnceWithExactly(onCardClickStub, { trainingId: training.id });
         assert.ok(true);
       });
+
+      module('when user clicks on button to start the training', function () {
+        test('should call onModalButtonClick function', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord('training', _buildTraining({}));
+          const onModalButtonClickStub = sinon.stub();
+          const onCardClickStub = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template>
+              <TrainingCard
+                @training={{training}}
+                @onCardClick={{onCardClickStub}}
+                @onModalButtonClick={{onModalButtonClickStub}}
+              />
+            </template>,
+          );
+          await click(
+            screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.training-card.aria-label') }),
+          );
+          await screen.findByRole('dialog');
+          await click(
+            screen.getByRole('link', {
+              name: `${t('pages.skill-review.recommended-engine.modal.actions.discover-program')} ${t('navigation.external-link-title')}`,
+            }),
+          );
+
+          // then
+          sinon.assert.calledOnceWithExactly(onModalButtonClickStub, { trainingId: training.id });
+          assert.ok(true);
+        });
+      });
     });
 
     function _buildTraining({


### PR DESCRIPTION
## 🚙 Problème

On souhaite prendre connaissance du parcours utilisateur lors de son arrivée sur la page de détails de fin de parcours - version moteur de recommandation de contenu formatif.

## 🍃 Proposition

Traquer le clic sur une le bouton d'accès à un contenu formatif sur la modale via Plausible, avec le service PixMetrics.


## 🔗 Pour tester

- Se connecter avec dave-comp ou perfect profile
- Ouvrir sa console navigateur et lire **toutes les requêtes**
- Aller sur un parcours et aller aux résultats.
- Cliquer sur un contenu formatif
- Cliquer sur le bouton Découvrir le programme/Accéder à un module
- Constater l'appel Plausible comportant : 
  - le code (campagne)
  - le trainingId
---

**(Enlever Ublock si les appels Plausible passent pas)**

---

- Aller sur Plausible, appli review.pix.fr
- Aller au bout de la page et choisir Funnel
- Constater qu'il y a 3 steps: accès à la page, clic sur la carte et clic sur le bouton
- En haut à droite de votre écran, il y a Filtres
- Cliquer sur code / is / choisir le code campagne ou vous êtes

Jouer avec les appels Plausible pour changer les %
