### PR TITLE
[FEATURE] suppression de la contrainte de clé étrangère sur la table KE vers answers.id (PIX-23053)

### DIFF
--- a/api/db/migrations/20260609150710_drop_fk_constraint_answer_on_ke.js
+++ b/api/db/migrations/20260609150710_drop_fk_constraint_answer_on_ke.js
@@ -1,3 +1,5 @@
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
 const TABLE_NAME = 'knowledge-elements';
 
 const up = async function (knex) {
@@ -6,10 +8,12 @@ const up = async function (knex) {
   });
 };
 
-const down = async function (knex) {
-  await knex.schema.table(TABLE_NAME, function (table) {
-    table.foreign('answerId').references('answers.id');
-  });
+const down = function () {
+  logger.info(
+    'No down function => it will failed as we have to many ke and answers, and also missing answers.',
+    'In case of revert, we will use another process, or scripts dedicated to that only.',
+    'It will include the rollback of the answers then it will add the FK',
+  );
 };
 
 export { down, up };

--- a/api/db/migrations/20260609150710_drop_fk_constraint_answer_on_ke.js
+++ b/api/db/migrations/20260609150710_drop_fk_constraint_answer_on_ke.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'knowledge-elements';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropForeign('answerId');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.foreign('answerId').references('answers.id');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🚙 Problème

Dans le cadre de l'impact team, on va supprimer les answers pour les assessments de type DEMO, PREVIEW, CAMPAIGN, PLACEMENT, COMPETENCE_EVALUATION
dont le statut est completed et la date de mise à jour (updatedAt) est supérieure ou égale 1 an
Le problème est que KE référence ces answers.

## 🍃 Proposition

Supprimer la contrainte

## 🦵 Remarques
Cette migration n'a pas vocation à être jouée avant l'été 2026 - pendant le grand ménage des answers
On ne met pas la colonne à null au cas où on devrait retrouver ces answers
(elles seront stockées dans des parquets sur un bucket)

## 🔗 Pour tester
executer la migration : constater la disparition de la contrainte
executer le rollback : constater le retour de la contrainte