### PR TITLE
[TECH] Enlever l'injection des sérialisers dans les controlleurs (part.1)

### DIFF
--- a/api/src/announcements/application/announcement-controller.js
+++ b/api/src/announcements/application/announcement-controller.js
@@ -1,17 +1,17 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as announcementSerializer from '../infrastructure/serializers/jsonapi/announcement-serializer.js';
 
-const get = async (request, h, dependencies = { announcementSerializer }) => {
+const get = async (request) => {
   const { name } = request.params;
   const announcement = await usecases.getAnnouncement({ name });
-  return dependencies.announcementSerializer.serialize(announcement);
+  return announcementSerializer.serialize(announcement);
 };
 
-const update = async (request, h, dependencies = { announcementSerializer }) => {
+const update = async (request) => {
   const { name } = request.params;
   const content = request.payload?.data?.attributes?.content ?? null;
   const announcement = await usecases.updateAnnouncement({ name, content });
-  return dependencies.announcementSerializer.serialize(announcement);
+  return announcementSerializer.serialize(announcement);
 };
 
 export const announcementController = {

--- a/api/src/banner/application/banner-controller.js
+++ b/api/src/banner/application/banner-controller.js
@@ -9,8 +9,6 @@ const getInformationBanner = async function (request) {
   return informationBannerSerializer.serialize(informationBanner);
 };
 
-const bannerController = {
+export const bannerController = {
   getInformationBanner,
 };
-
-export { bannerController };

--- a/api/src/identity-access-management/application/account-recovery/account-recovery.controller.js
+++ b/api/src/identity-access-management/application/account-recovery/account-recovery.controller.js
@@ -2,27 +2,15 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as studentInformationForAccountRecoverySerializer from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
 
-const checkAccountRecoveryDemand = async function (
-  request,
-  h,
-  dependencies = { studentInformationForAccountRecoverySerializer },
-) {
+const checkAccountRecoveryDemand = async function (request) {
   const temporaryKey = request.params.temporaryKey;
   const studentInformation = await usecases.getAccountRecoveryDetails({ temporaryKey });
-  return dependencies.studentInformationForAccountRecoverySerializer.serializeAccountRecovery(studentInformation);
+  return studentInformationForAccountRecoverySerializer.serializeAccountRecovery(studentInformation);
 };
 
-const sendEmailForAccountRecovery = async function (
-  request,
-  h,
-  dependencies = { studentInformationForAccountRecoverySerializer },
-) {
-  const studentInformation = await dependencies.studentInformationForAccountRecoverySerializer.deserialize(
-    request.payload,
-  );
-
+const sendEmailForAccountRecovery = async function (request, h) {
+  const studentInformation = await studentInformationForAccountRecoverySerializer.deserialize(request.payload);
   await usecases.sendEmailForAccountRecovery({ studentInformation });
-
   return h.response().code(204);
 };
 

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -80,7 +80,6 @@ async function createUser(request, h) {
 /**
  * @param request
  * @param h
- * @param dependencies
  * @return {Promise<*>}
  */
 async function findUserForReconciliation(request, h) {

--- a/api/src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.controller.js
+++ b/api/src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.controller.js
@@ -1,22 +1,16 @@
 import { usecases } from '../../domain/usecases/index.js';
 import * as studentInformationForAccountRecoverySerializer from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
 
-async function checkScoAccountRecovery(request, h, dependencies = { studentInformationForAccountRecoverySerializer }) {
-  const studentInformation = await dependencies.studentInformationForAccountRecoverySerializer.deserialize(
-    request.payload,
-  );
+async function checkScoAccountRecovery(request, h) {
+  const studentInformation = await studentInformationForAccountRecoverySerializer.deserialize(request.payload);
 
   const studentInformationForAccountRecovery = await usecases.checkScoAccountRecovery({
     studentInformation,
   });
 
-  return h.response(
-    dependencies.studentInformationForAccountRecoverySerializer.serialize(studentInformationForAccountRecovery),
-  );
+  return h.response(studentInformationForAccountRecoverySerializer.serialize(studentInformationForAccountRecovery));
 }
 
-const scoOrganizationLearnerController = {
+export const scoOrganizationLearnerController = {
   checkScoAccountRecovery,
 };
-
-export { scoOrganizationLearnerController };

--- a/api/src/identity-access-management/application/password/password.controller.js
+++ b/api/src/identity-access-management/application/password/password.controller.js
@@ -2,10 +2,10 @@ import { getUserLocale } from '../../../shared/infrastructure/utils/request-resp
 import { usecases } from '../../domain/usecases/index.js';
 import * as userSerializer from '../../infrastructure/serializers/jsonapi/user-serializer.js';
 
-const checkResetDemand = async function (request, h, dependencies = { userSerializer }) {
+const checkResetDemand = async function (request) {
   const temporaryKey = request.params.temporaryKey;
   const user = await usecases.getUserByResetPasswordDemand({ temporaryKey });
-  return dependencies.userSerializer.serialize(user);
+  return userSerializer.serialize(user);
 };
 
 const createResetPasswordDemand = async function (request, h) {

--- a/api/src/identity-access-management/application/saml/saml.controller.js
+++ b/api/src/identity-access-management/application/saml/saml.controller.js
@@ -73,6 +73,4 @@ const authenticateForSaml = async function (request, h) {
     .code(200);
 };
 
-const samlController = { metadata, login, assert, authenticateForSaml };
-
-export { samlController };
+export const samlController = { metadata, login, assert, authenticateForSaml };

--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -17,14 +17,6 @@ const authenticateAnonymousUser = async function (request, h) {
   return h.response(response).code(200);
 };
 
-/**
- * @param request
- * @param h
- * @param {{
- *   tokenService: TokenService
- * }} dependencies
- * @return {Promise<*>}
- */
 const createToken = async function (request, h) {
   let accessToken, refreshToken;
   let expirationDelaySeconds;

--- a/api/src/identity-access-management/application/user/user-existence-verification-pre-handler.js
+++ b/api/src/identity-access-management/application/user/user-existence-verification-pre-handler.js
@@ -2,15 +2,13 @@ import { UserNotFoundError } from '../../../shared/domain/errors.js';
 import * as errorSerializer from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
 import * as userRepository from '../../infrastructure/repositories/user.repository.js';
 
-const verifyById = function (request, h, dependencies = { userRepository, errorSerializer }) {
+const verifyById = function (request, h, dependencies = { userRepository }) {
   return dependencies.userRepository.get(request.params.id).catch((err) => {
     if (err instanceof UserNotFoundError) {
-      const serializedError = dependencies.errorSerializer.serialize(new UserNotFoundError().getErrorMessage());
+      const serializedError = errorSerializer.serialize(new UserNotFoundError().getErrorMessage());
       return h.response(serializedError).code(404).takeover();
     }
   });
 };
 
-const userVerification = { verifyById };
-
-export { userVerification };
+export const userVerification = { verifyById };

--- a/api/src/identity-access-management/application/user/user.admin.controller.js
+++ b/api/src/identity-access-management/application/user/user.admin.controller.js
@@ -9,69 +9,60 @@ import * as userLoginSerializer from '../../infrastructure/serializers/jsonapi/u
  *
  * @param request
  * @param h
- * @param {object} dependencies
- * @param {UserForAdminSerializer} dependencies.userForAdminSerializer
  * @returns {Promise<*>}
  */
-const findPaginatedFilteredUsers = async function (request, h, dependencies = { userForAdminSerializer }) {
+const findPaginatedFilteredUsers = async function (request) {
   const { filter, page, queryType } = request.query;
 
   const { models: users, pagination } = await usecases.findPaginatedFilteredUsers({ filter, page, queryType });
-  return dependencies.userForAdminSerializer.serialize(users, pagination);
+  return userForAdminSerializer.serialize(users, pagination);
 };
 
 /**
  * @param request
  * @param h
- * @param {object} dependencies
- * @param {UserLoginSerializer} dependencies.userLoginSerializer
  * @return {Promise<*>}
  */
-const unblockUserAccount = async function (request, h, dependencies = { userLoginSerializer }) {
+const unblockUserAccount = async function (request, h) {
   const userId = request.params.id;
   const userLogin = await usecases.unblockUserAccount({ userId });
-  return h.response(dependencies.userLoginSerializer.serialize(userLogin)).code(200);
+  return h.response(userLoginSerializer.serialize(userLogin)).code(200);
 };
 
 /**
  * @param request
  * @param h
  * @param {object} dependencies
- * @param {UserDetailsForAdminSerializer} dependencies.userDetailsForAdminSerializer
  * @return {Promise<*>}
  */
-const updateUserDetailsByAdmin = async function (request, h, dependencies = { userDetailsForAdminSerializer }) {
+const updateUserDetailsByAdmin = async function (request) {
   const updatedByAdminId = request.auth.credentials.userId;
   const userId = request.params.id;
-  const userDetailsToUpdate = dependencies.userDetailsForAdminSerializer.deserialize(request.payload);
+  const userDetailsToUpdate = userDetailsForAdminSerializer.deserialize(request.payload);
 
   const updatedUser = await usecases.updateUserDetailsByAdmin({ userId, userDetailsToUpdate, updatedByAdminId });
 
-  return dependencies.userDetailsForAdminSerializer.serializeForUpdate(updatedUser);
+  return userDetailsForAdminSerializer.serializeForUpdate(updatedUser);
 };
 
 /**
  *
  * @param request
  * @param h
- * @param dependencies
- * @param {UserDetailsForAdminSerializer} dependencies.userDetailsForAdminSerializer
  * @returns {Promise<*>}
  */
-const getUserDetails = async function (request, h, dependencies = { userDetailsForAdminSerializer }) {
+const getUserDetails = async function (request) {
   const userId = request.params.id;
   const userDetailsForAdmin = await usecases.getUserDetailsForAdmin({ userId });
-  return dependencies.userDetailsForAdminSerializer.serialize(userDetailsForAdmin);
+  return userDetailsForAdminSerializer.serialize(userDetailsForAdmin);
 };
 
 /**
  * @param request
  * @param h
- * @param dependencies
- * @param {UserDetailsForAdminSerializer} dependencies.userDetailsForAdminSerializer
  * @returns {Promise<*>}
  */
-const anonymizeUser = async function (request, h, dependencies = { userAnonymizedDetailsForAdminSerializer }) {
+const anonymizeUser = async function (request, h) {
   const userToAnonymizeId = request.params.id;
   const adminMemberId = request.auth.credentials.userId;
 
@@ -85,27 +76,24 @@ const anonymizeUser = async function (request, h, dependencies = { userAnonymize
 
   const anonymizedUser = await usecases.getUserDetailsForAdmin({ userId: userToAnonymizeId });
 
-  return h.response(dependencies.userAnonymizedDetailsForAdminSerializer.serialize(anonymizedUser)).code(200);
+  return h.response(userAnonymizedDetailsForAdminSerializer.serialize(anonymizedUser)).code(200);
 };
 
 /**
  * @param request
  * @param h
- * @param dependencies
- * @param {UserDetailsForAdminSerializer} dependencies.userDetailsForAdminSerializer
  * @returns {Promise<*>}
  */
-const addPixAuthenticationMethod = async function (request, h, dependencies = { userDetailsForAdminSerializer }) {
+const addPixAuthenticationMethod = async function (request, h) {
   const userId = request.params.id;
   const email = request.payload.data.attributes.email.trim().toLowerCase();
   const userUpdated = await usecases.addPixAuthenticationMethod({ userId, email });
-  return h.response(dependencies.userDetailsForAdminSerializer.serialize(userUpdated)).created();
+  return h.response(userDetailsForAdminSerializer.serialize(userUpdated)).created();
 };
 
 /**
  * @param request
  * @param h
- * @param dependencies
  * @returns {Promise<*>}
  */
 const removeAuthenticationMethod = async function (request, h) {
@@ -118,7 +106,6 @@ const removeAuthenticationMethod = async function (request, h) {
 /**
  * @param request
  * @param h
- * @param dependencies
  * @returns {Promise<void>}
  */
 const reassignAuthenticationMethod = async function (request, h) {
@@ -144,7 +131,7 @@ const reassignAuthenticationMethod = async function (request, h) {
  * @property {function} unblockUserAccount
  * @property {function} updateUserDetailsByAdmin
  */
-const userAdminController = {
+export const userAdminController = {
   addPixAuthenticationMethod,
   anonymizeUser,
   findPaginatedFilteredUsers,
@@ -154,5 +141,3 @@ const userAdminController = {
   unblockUserAccount,
   updateUserDetailsByAdmin,
 };
-
-export { userAdminController };

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -1,4 +1,3 @@
-import * as localeService from '../../../shared/domain/services/locale-service.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
@@ -23,27 +22,21 @@ const acceptPixCertifTermsOfService = async function (request, h) {
 /**
  * @param request
  * @param h
- * @param {{
- *   userSerializer: UserSerializer
- * }} dependencies
  * @return {Promise<*>}
  */
-const acceptPixLastTermsOfService = async function (request, h, dependencies = { userSerializer }) {
+const acceptPixLastTermsOfService = async function (request) {
   const authenticatedUserId = request.auth.credentials.userId;
 
   const updatedUser = await usecases.acceptPixLastTermsOfService({
     userId: authenticatedUserId,
   });
 
-  return dependencies.userSerializer.serialize(updatedUser);
+  return userSerializer.serialize(updatedUser);
 };
 
 /**
  * @param request
  * @param h
- * @param {{
- *   userSerializer: UserSerializer
- * }} dependencies
  * @return {Promise<*>}
  */
 const acceptPixOrgaTermsOfService = async function (request, h) {
@@ -59,82 +52,67 @@ const acceptPixOrgaTermsOfService = async function (request, h) {
 /**
  * @param request
  * @param h
- * @param {{
- *   userSerializer: UserSerializer
- * }} dependencies
  * @return {Promise<*>}
  */
-const changeUserLocale = async function (request, h, dependencies = { userSerializer }) {
+const changeUserLocale = async function (request) {
   const authenticatedUserId = request.auth.credentials.userId;
   const locale = getUserLocale(request);
 
   const updatedUser = await usecases.changeUserLocale({ userId: authenticatedUserId, locale });
 
-  return dependencies.userSerializer.serialize(updatedUser);
+  return userSerializer.serialize(updatedUser);
 };
 
 /**
  * @param request
  * @param h
- * @param {{
- *   userWithActivitySerializer: UserWithActivitySerializer
- * }} dependencies
  * @return {Promise<*>}
  */
-const getCurrentUser = async function (request, h, dependencies = { userWithActivitySerializer }) {
+const getCurrentUser = async function (request) {
   const authenticatedUserId = request.auth.credentials.userId;
 
   const result = await usecases.getCurrentUser({ authenticatedUserId });
 
-  return dependencies.userWithActivitySerializer.serialize(result);
+  return userWithActivitySerializer.serialize(result);
 };
 
 /**
  * @param request
  * @param h
- * @param {{
- *   userAccountInfoSerializer: UserAccountInfoSerializer
- * }} dependencies
  * @return {Promise<*>}
  */
-const getCurrentUserAccountInfo = async function (request, h, dependencies = { userAccountInfoSerializer }) {
+const getCurrentUserAccountInfo = async function (request) {
   const authenticatedUserId = request.auth.credentials.userId;
 
   const userAccountInfo = await usecases.getUserAccountInfo({ userId: authenticatedUserId });
 
-  return dependencies.userAccountInfoSerializer.serialize(userAccountInfo);
+  return userAccountInfoSerializer.serialize(userAccountInfo);
 };
 
 /**
  * @param request
  * @param h
- * @param {{
- *   authenticationMethodsSerializer: AuthenticationMethodsSerializer
- * }} dependencies
  * @return {Promise<*>}
  */
-const getUserAuthenticationMethods = async function (request, h, dependencies = { authenticationMethodsSerializer }) {
+const getUserAuthenticationMethods = async function (request) {
   const userId = request.params.id;
 
   const authenticationMethods = await usecases.findUserAuthenticationMethods({ userId });
 
-  return dependencies.authenticationMethodsSerializer.serialize(authenticationMethods);
+  return authenticationMethodsSerializer.serialize(authenticationMethods);
 };
 
 /**
  * @param request
  * @param h
- * @param {Object} dependencies
- * @param {LocaleService} dependencies.localeService
- * @param {UserSerializer} dependencies.userSerializer
  * @return {Promise<*>}
  */
-const createUser = async function (request, h, dependencies = { userSerializer, localeService }) {
+const createUser = async function (request, h) {
   const locale = getUserLocale(request);
   const i18n = getI18nFromRequest(request);
 
   const redirectionUrl = request.payload.meta ? request.payload.meta['redirection-url'] : null;
-  const user = dependencies.userSerializer.deserialize(request.payload);
+  const user = userSerializer.deserialize(request.payload);
 
   const password = request.payload.data.attributes.password;
 
@@ -146,7 +124,7 @@ const createUser = async function (request, h, dependencies = { userSerializer, 
     i18n,
   });
 
-  return h.response(dependencies.userSerializer.serialize(savedUser)).created();
+  return h.response(userSerializer.serialize(savedUser)).created();
 };
 
 /**
@@ -167,7 +145,7 @@ const updatePassword = async function (request, h) {
   return h.response().code(204);
 };
 
-const updateUserEmailWithValidation = async function (request, h, dependencies = { updateEmailSerializer }) {
+const updateUserEmailWithValidation = async function (request) {
   const userId = request.params.id;
   const code = request.payload.data.attributes.code;
 
@@ -176,10 +154,10 @@ const updateUserEmailWithValidation = async function (request, h, dependencies =
     code,
   });
 
-  return dependencies.updateEmailSerializer.serialize(updatedUserAttributes);
+  return updateEmailSerializer.serialize(updatedUserAttributes);
 };
 
-const addUserEmailWithValidation = async function (request, h, dependencies = { updateEmailSerializer }) {
+const addUserEmailWithValidation = async function (request) {
   const userId = request.params.id;
   const code = request.payload.data.attributes.code;
 
@@ -188,28 +166,21 @@ const addUserEmailWithValidation = async function (request, h, dependencies = { 
     code,
   });
 
-  return dependencies.updateEmailSerializer.serialize(updatedUserAttributes);
+  return updateEmailSerializer.serialize(updatedUserAttributes);
 };
 
 /**
  * @param request
  * @param h
- * @param {{
- *   userSerializer: UserSerializer
- * }} dependencies
  * @return {Promise<*>}
  */
-const rememberUserHasSeenLastDataProtectionPolicyInformation = async function (
-  request,
-  h,
-  dependencies = { userSerializer },
-) {
+const rememberUserHasSeenLastDataProtectionPolicyInformation = async function (request) {
   const authenticatedUserId = request.auth.credentials.userId;
 
   const updatedUser = await usecases.rememberUserHasSeenLastDataProtectionPolicyInformation({
     userId: authenticatedUserId,
   });
-  return dependencies.userSerializer.serialize(updatedUser);
+  return userSerializer.serialize(updatedUser);
 };
 
 const selfDeleteUserAccount = async function (request, h) {
@@ -221,11 +192,11 @@ const selfDeleteUserAccount = async function (request, h) {
   return h.response().code(204);
 };
 
-const sendVerificationCode = async function (request, h, dependencies = { emailVerificationSerializer }) {
+const sendVerificationCode = async function (request, h) {
   const locale = getUserLocale(request);
 
   const userId = request.auth.credentials.userId;
-  const { action, newEmail, password } = await dependencies.emailVerificationSerializer.deserialize(request.payload);
+  const { action, newEmail, password } = await emailVerificationSerializer.deserialize(request.payload);
 
   await usecases.sendVerificationCode({ locale, action, newEmail, password, userId });
   return h.response().code(204);
@@ -245,7 +216,7 @@ const getCertificationPointOfContact = async function (request) {
   return certificationPointOfContactSerializer.serialize(certificationPointOfContact);
 };
 
-const rememberUserHasSeenChallengeTooltip = async function (request, h, dependencies = { userSerializer }) {
+const rememberUserHasSeenChallengeTooltip = async function (request) {
   const authenticatedUserId = request.auth.credentials.userId;
   const challengeType = request.params.challengeType;
 
@@ -253,18 +224,15 @@ const rememberUserHasSeenChallengeTooltip = async function (request, h, dependen
     userId: authenticatedUserId,
     challengeType,
   });
-  return dependencies.userSerializer.serialize(updatedUser);
+  return userSerializer.serialize(updatedUser);
 };
 
 /**
  * @param request
  * @param h
- * @param {Object} dependencies
- * @param {LocaleService} dependencies.localeService
- * @param {UserSerializer} dependencies.userSerializer
  * @return {Promise<*>}
  */
-const upgradeToRealUser = async function (request, h, dependencies = { userSerializer, localeService }) {
+const upgradeToRealUser = async function (request, h) {
   const userId = request.auth.credentials.userId;
   const locale = getUserLocale(request);
 
@@ -284,7 +252,7 @@ const upgradeToRealUser = async function (request, h, dependencies = { userSeria
     password,
     locale,
   });
-  return h.response(dependencies.userSerializer.serialize(realUser));
+  return h.response(userSerializer.serialize(realUser));
 };
 
 export const userController = {

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -3,14 +3,10 @@ import { sharedUsecases } from '../../domain/usecases/index.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
 import { extractUserIdFromRequest, getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
 
-const getAssessmentWithNextChallenge = async function (
-  request,
-  h,
-  dependencies = { assessmentSerializer, extractUserIdFromRequest },
-) {
+const getAssessmentWithNextChallenge = async function (request) {
   const assessmentId = request.params.id;
   const locale = getChallengeLocale(request);
-  const userId = dependencies.extractUserIdFromRequest(request);
+  const userId = extractUserIdFromRequest(request);
 
   const { assessment, globalProgression } = await sharedUsecases.updateAssessmentWithNextChallenge({
     assessmentId,
@@ -19,11 +15,9 @@ const getAssessmentWithNextChallenge = async function (
   });
 
   const assessmentDto = AssessmentDtoFactory.toDto(assessment, globalProgression);
-  return dependencies.assessmentSerializer.serialize(assessmentDto);
+  return assessmentSerializer.serialize(assessmentDto);
 };
 
-const assessmentController = {
+export const assessmentController = {
   getAssessmentWithNextChallenge,
 };
-
-export { assessmentController };

--- a/api/src/shared/application/country/country-controller.js
+++ b/api/src/shared/application/country/country-controller.js
@@ -1,10 +1,9 @@
 import { sharedUsecases } from '../../domain/usecases/index.js';
 import * as countrySerializer from '../../infrastructure/serializers/jsonapi/country-serializer.js';
 
-const findCountries = async function (_request, _h, dependencies = { countrySerializer }) {
+const findCountries = async function () {
   const countries = await sharedUsecases.findCountries();
-  return dependencies.countrySerializer.serialize(countries);
+  return countrySerializer.serialize(countries);
 };
 
-const countryController = { findCountries };
-export { countryController };
+export const countryController = { findCountries };

--- a/api/src/shared/application/feature-toggles/feature-toggle-controller.js
+++ b/api/src/shared/application/feature-toggles/feature-toggle-controller.js
@@ -7,6 +7,4 @@ const getActiveFeatures = async function () {
   return serializer.serialize(featureTogglesList);
 };
 
-const featureToggleController = { getActiveFeatures };
-
-export { featureToggleController };
+export const featureToggleController = { getActiveFeatures };

--- a/api/src/shared/application/healthcheck/healthcheck-controller.js
+++ b/api/src/shared/application/healthcheck/healthcheck-controller.js
@@ -55,6 +55,4 @@ const checkForwardedOriginStatus = async function (request, h) {
   return h.response(forwardedOrigin).code(200);
 };
 
-const healthcheckController = { get, checkDbStatus, checkRedisStatus, checkForwardedOriginStatus };
-
-export { healthcheckController };
+export const healthcheckController = { get, checkDbStatus, checkRedisStatus, checkForwardedOriginStatus };

--- a/api/tests/identity-access-management/unit/application/password/password.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/password/password.controller.test.js
@@ -17,22 +17,16 @@ describe('Unit | Identity Access Management | Application | Controller | passwor
 
     beforeEach(function () {
       sinon.stub(usecases, 'getUserByResetPasswordDemand');
-      const userSerializerStub = {
-        serialize: sinon.stub(),
-      };
-      dependencies = {
-        userSerializer: userSerializerStub,
-      };
       usecases.getUserByResetPasswordDemand.resolves({ email });
     });
 
     it('returns serialized user', async function () {
       // when
-      await passwordController.checkResetDemand(request, hFake, dependencies);
+      const result = await passwordController.checkResetDemand(request, hFake, dependencies);
 
       // then
       expect(usecases.getUserByResetPasswordDemand).to.have.been.calledWithExactly({ temporaryKey });
-      expect(dependencies.userSerializer.serialize).to.have.been.calledWithExactly({ email });
+      expect(result.data.attributes.email).to.equal(email);
     });
   });
 

--- a/api/tests/identity-access-management/unit/application/user-existence-verification_test.js
+++ b/api/tests/identity-access-management/unit/application/user-existence-verification_test.js
@@ -13,14 +13,10 @@ describe('Unit | Pre-handler | User Verification', function () {
       },
     };
     let userRepository;
-    let errorSerializer;
 
     beforeEach(function () {
       userRepository = {
         get: sinon.stub(),
-      };
-      errorSerializer = {
-        serialize: sinon.stub(),
       };
     });
 
@@ -31,7 +27,7 @@ describe('Unit | Pre-handler | User Verification', function () {
         userRepository.get.resolves(userCount);
 
         // when
-        const response = await userVerification.verifyById(request, hFake, { userRepository, errorSerializer });
+        const response = await userVerification.verifyById(request, hFake, { userRepository });
 
         // then
         sinon.assert.calledOnce(userRepository.get);
@@ -44,14 +40,12 @@ describe('Unit | Pre-handler | User Verification', function () {
       it('should reply 404 status with a serialized error and takeOver the request', async function () {
         // given
         userRepository.get.rejects(new UserNotFoundError());
-        const serializedError = { serialized: 'error' };
-        errorSerializer.serialize.returns(serializedError);
 
         // when
-        const response = await userVerification.verifyById(request, hFake, { userRepository, errorSerializer });
+        const response = await userVerification.verifyById(request, hFake, { userRepository });
 
         // then
-        expect(response.source).to.deep.equal(serializedError);
+        expect(response.source.errors.length).to.equal(1);
         expect(response.isTakeOver).to.be.true;
         expect(response.statusCode).to.equal(404);
       });

--- a/api/tests/identity-access-management/unit/application/user/user.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.admin.controller.test.js
@@ -9,45 +9,37 @@ import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
 
 describe('Unit | Identity Access Management | Application | Controller | Admin | User', function () {
   describe('#findPaginatedFilteredUsers', function () {
-    let dependencies;
-
     beforeEach(function () {
       sinon.stub(usecases, 'findPaginatedFilteredUsers');
-      const userForAdminSerializer = { serialize: sinon.stub() };
-      dependencies = {
-        userForAdminSerializer,
-      };
     });
 
     it('returns a list of JSON API users fetched from the data repository', async function () {
       // given
       const request = { query: {} };
-      usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
-      dependencies.userForAdminSerializer.serialize.returns({ data: {}, meta: {} });
+      usecases.findPaginatedFilteredUsers.resolves({ models: [], pagination: {} });
 
       // when
-      await userAdminController.findPaginatedFilteredUsers(request, hFake, dependencies);
+      const result = await userAdminController.findPaginatedFilteredUsers(request, hFake);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledOnce;
-      expect(dependencies.userForAdminSerializer.serialize).to.have.been.calledOnce;
+      expect(result.data.length).to.equal(0);
     });
 
     it('returns a JSON API response with pagination information', async function () {
       // given
       const request = { query: {} };
-      const expectedResults = [new User({ id: 1 }), new User({ id: 2 }), new User({ id: 3 })];
-      const expectedPagination = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4 };
-      usecases.findPaginatedFilteredUsers.resolves({ models: expectedResults, pagination: expectedPagination });
+      const models = [new User({ id: 1 }), new User({ id: 2 }), new User({ id: 3 })];
+      const pagination = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4 };
+      usecases.findPaginatedFilteredUsers.resolves({ models, pagination });
 
       // when
-      await userAdminController.findPaginatedFilteredUsers(request, hFake, dependencies);
+      const result = await userAdminController.findPaginatedFilteredUsers(request, hFake);
 
       // then
-      expect(dependencies.userForAdminSerializer.serialize).to.have.been.calledWithExactly(
-        expectedResults,
-        expectedPagination,
-      );
+      const userIds = result.data.map((data) => data.id);
+      expect(userIds).to.deep.equal(['1', '2', '3']);
+      expect(result.meta).to.deep.equal({ itemsCount: 100, page: 2, pageSize: 25, pagesCount: 4 });
     });
 
     it('allows to filter users by first name', async function () {
@@ -57,7 +49,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
       // when
-      await userAdminController.findPaginatedFilteredUsers(request, hFake, dependencies);
+      await userAdminController.findPaginatedFilteredUsers(request, hFake);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledWithMatch(query);
@@ -70,7 +62,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
       // when
-      await userAdminController.findPaginatedFilteredUsers(request, hFake, dependencies);
+      await userAdminController.findPaginatedFilteredUsers(request, hFake);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledWithMatch(query);
@@ -83,7 +75,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
       // when
-      await userAdminController.findPaginatedFilteredUsers(request, hFake, dependencies);
+      await userAdminController.findPaginatedFilteredUsers(request, hFake);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledWithMatch(query);
@@ -100,7 +92,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
       // when
-      await userAdminController.findPaginatedFilteredUsers(request, hFake, dependencies);
+      await userAdminController.findPaginatedFilteredUsers(request, hFake);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledWithMatch(query);

--- a/api/tests/shared/unit/application/country/country-controller_test.js
+++ b/api/tests/shared/unit/application/country/country-controller_test.js
@@ -16,31 +16,10 @@ describe('Unit | Shared | Application | Controller | country-controller', functi
         domainBuilder.buildCountry({ code: '99324', name: 'Espagne' }),
       ];
 
-      const serializedCountries = [
-        {
-          id: '99345',
-          type: 'countries',
-          attributes: {
-            code: '99345',
-            name: 'Pologne',
-          },
-        },
-        {
-          id: '99324',
-          type: 'countries',
-          attributes: {
-            code: '99324',
-            name: 'Espagne',
-          },
-        },
-      ];
-
       const userId = 42;
-      const countrySerializerStub = { serialize: sinon.stub() };
       sinon.stub(sharedUsecases, 'findCountries');
 
       sharedUsecases.findCountries.resolves(countries);
-      countrySerializerStub.serialize.withArgs(countries).resolves(serializedCountries);
 
       const request = {
         params: { id: 'course_id' },
@@ -49,14 +28,30 @@ describe('Unit | Shared | Application | Controller | country-controller', functi
       };
 
       // when
-      const response = await countryController.findCountries(request, hFake, {
-        countrySerializer: countrySerializerStub,
-      });
+      const response = await countryController.findCountries(request, hFake);
 
       // then
       expect(sharedUsecases.findCountries).to.have.been.called;
-      expect(countrySerializerStub.serialize).to.have.been.calledWithExactly(countries);
-      expect(response).to.deep.equal(serializedCountries);
+      expect(response).to.deep.equal({
+        data: [
+          {
+            id: '99345_EGLNOOP',
+            type: 'countries',
+            attributes: {
+              code: '99345',
+              name: 'Pologne',
+            },
+          },
+          {
+            id: '99324_AEEGNPS',
+            type: 'countries',
+            attributes: {
+              code: '99324',
+              name: 'Espagne',
+            },
+          },
+        ],
+      });
     });
   });
 });

--- a/api/tests/unit/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/unit/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -7,12 +7,6 @@ import { hFake } from '../../../tooling/mocks/hapi.mock.js';
 
 describe('Unit | Application | Controller | sco-organization-learner', function () {
   describe('#checkScoAccountRecovery', function () {
-    const userId = 2;
-    let request = {
-      auth: { credentials: { userId } },
-      payload: { data: { attributes: {} } },
-    };
-
     beforeEach(function () {
       sinon.stub(usecases, 'checkScoAccountRecovery');
       usecases.checkScoAccountRecovery.resolves();
@@ -20,46 +14,50 @@ describe('Unit | Application | Controller | sco-organization-learner', function 
 
     it('should return student account information serialized', async function () {
       // given
-      const studentInformationForAccountRecoverySerializer = {
-        serialize: sinon.stub(),
-        deserialize: sinon.stub(),
-      };
-      hFake.request = { path: {} };
       const studentInformation = {
         ineIna: '1234567890A',
         firstName: 'Bob',
         lastName: 'Camond',
         birthdate: '2001-12-08',
       };
-      request = {
-        payload: {
-          data: {
-            type: 'student-information',
-            attributes: {
-              'ine-ina': studentInformation.ineIna,
-              'first-name': studentInformation.firstName,
-              'last-name': studentInformation.lastName,
-              birthdate: studentInformation.birthdate,
+
+      usecases.checkScoAccountRecovery.withArgs({ studentInformation }).resolves({
+        firstName: studentInformation.firstName,
+        lastName: studentInformation.lastName,
+        username: 'bcamond',
+        latestOrganizationName: 'foo',
+      });
+
+      // when
+      const response = await scoOrganizationLearnerController.checkScoAccountRecovery(
+        {
+          payload: {
+            data: {
+              type: 'student-information',
+              attributes: {
+                'ine-ina': studentInformation.ineIna,
+                'first-name': studentInformation.firstName,
+                'last-name': studentInformation.lastName,
+                birthdate: studentInformation.birthdate,
+              },
             },
           },
         },
-      };
-      const studentInformationForAccountRecovery = Symbol();
-      const studentInformationForAccountRecoveryJSONAPI = Symbol();
-
-      studentInformationForAccountRecoverySerializer.deserialize.withArgs(request.payload).resolves(studentInformation);
-      usecases.checkScoAccountRecovery.withArgs({ studentInformation }).resolves(studentInformationForAccountRecovery);
-      studentInformationForAccountRecoverySerializer.serialize
-        .withArgs(studentInformationForAccountRecovery)
-        .returns(studentInformationForAccountRecoveryJSONAPI);
-
-      // when
-      const response = await scoOrganizationLearnerController.checkScoAccountRecovery(request, hFake, {
-        studentInformationForAccountRecoverySerializer,
-      });
+        hFake,
+      );
 
       // then
-      expect(response.source).to.deep.equal(studentInformationForAccountRecoveryJSONAPI);
+      expect(response.source).to.deep.equal({
+        data: {
+          type: 'student-information-for-account-recoveries',
+          attributes: {
+            'first-name': 'Bob',
+            'last-name': 'Camond',
+            'latest-organization-name': 'foo',
+            username: 'bcamond',
+          },
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
## 🚙 Problème

Parfois on utilise directement les serializers dans les controlleurs, parfois on les injecte dans un attribut `dependencies`. 

Mais les serialisers sont des fonctions pures (déterministes et sans effet de bord), il y a pas d'intérêt de les injecter et mocker dans les tests unitaires. 

De plus, on fait un injection de dépendance basique, le module est importé directement dans le fichier et mis en valeur par défaut dans `dependencies` donc on ne fait pas d'inversion de dépendance (DIP)

## 🍃 Proposition

Il y a peu d'utilité à cette injection, je propose de simplifier et **directement utiliser les serialisers dans les contrôleurs** (sans injection). 

Ça permettrait moins de boilerplate de code et ça simplifie les tests unitaires. On pourrait appliquer ce principe à toutes les fonctions pures injectées dans les controllers (utilitaires...)

**Bounded contexts dans cette PR dont on a modifié les controllers:**
- `identity-access-management`
- `announcements`
- `banners`
- `shared`

## 🦵 Remarques

**Scout:** on en profite pour simplifier l'export des controlleurs en exportant directement l'objet du controlleur.

## 🔗 Pour tester

CI Ok
