### PR TITLE
[TECH] Enlever l'injection des sérialisers dans les controlleurs (devcomp)

### DIFF
--- a/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
@@ -2,7 +2,7 @@ import { getChallengeLocale } from '../../../shared/infrastructure/utils/request
 import { usecases as devcompUsecases } from '../../domain/usecases/index.js';
 import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
 
-const findTrainings = async function (request, h, dependencies = { trainingSerializer }) {
+const findTrainings = async function (request) {
   const { userId } = request.auth.credentials;
   const { id: campaignParticipationId } = request.params;
   const locale = getChallengeLocale(request);
@@ -12,7 +12,7 @@ const findTrainings = async function (request, h, dependencies = { trainingSeria
     campaignParticipationId,
     locale,
   });
-  return dependencies.trainingSerializer.serialize(trainings);
+  return trainingSerializer.serialize(trainings);
 };
 
 const saveUserRelevanceFeedbackOnRecommendedTraining = async function (request, h) {
@@ -30,9 +30,7 @@ const saveUserRelevanceFeedbackOnRecommendedTraining = async function (request, 
   return h.response().code(204);
 };
 
-const campaignParticipationController = {
+export const campaignParticipationController = {
   findTrainings,
   saveUserRelevanceFeedbackOnRecommendedTraining,
 };
-
-export { campaignParticipationController };

--- a/api/src/devcomp/application/module-issue-report/module-issue-report-controller.js
+++ b/api/src/devcomp/application/module-issue-report/module-issue-report-controller.js
@@ -25,6 +25,4 @@ const createModuleIssueReport = async function (request, h) {
     .created();
 };
 
-const moduleIssueReportController = { createModuleIssueReport };
-
-export { moduleIssueReportController };
+export const moduleIssueReportController = { createModuleIssueReport };

--- a/api/src/devcomp/application/modules-metadata/module-metadata-controller.js
+++ b/api/src/devcomp/application/modules-metadata/module-metadata-controller.js
@@ -7,8 +7,6 @@ async function getAllModulesMetadata() {
   return moduleMetadataSerializer.serialize(modulesMetadata);
 }
 
-const moduleMetadataController = {
+export const moduleMetadataController = {
   getAllModulesMetadata,
 };
-
-export { moduleMetadataController };

--- a/api/src/devcomp/application/modules/module-controller.js
+++ b/api/src/devcomp/application/modules/module-controller.js
@@ -1,7 +1,8 @@
 import { config } from '../../../shared/config.js';
 import { usecases } from '../../domain/usecases/index.js';
+import * as moduleSerializer from '../../infrastructure/serializers/jsonapi/module-serializer.js';
 
-const getByShortId = async function (request, h, { moduleSerializer }) {
+const getByShortId = async function (request) {
   const { shortId } = request.params;
   const encryptedRedirectionUrl = request.query.encryptedRedirectionUrl;
   const module = await usecases.getModuleByShortId({ shortId, encryptedRedirectionUrl });
@@ -20,6 +21,4 @@ const getJsonSchema = async function (_request, h) {
     .etag(jsonSchemaChecksum);
 };
 
-const modulesController = { getByShortId, getJsonSchema };
-
-export { modulesController };
+export const modulesController = { getByShortId, getJsonSchema };

--- a/api/src/devcomp/application/passage-events/passage-event-controller.js
+++ b/api/src/devcomp/application/passage-events/passage-event-controller.js
@@ -1,8 +1,9 @@
 import { BadRequestError } from '../../../shared/application/errors/http-errors.js';
 import { DomainError } from '../../../shared/domain/errors.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import * as passageEventSerializer from '../../infrastructure/serializers/jsonapi/passage-event-serializer.js';
 
-const create = async function (request, h, { usecases, passageEventSerializer }) {
+const create = async function (request, h, { usecases }) {
   try {
     const passageEvents = await passageEventSerializer.deserialize(request.payload);
     await usecases.recordPassageEvents({
@@ -20,6 +21,4 @@ const create = async function (request, h, { usecases, passageEventSerializer })
   }
 };
 
-const passageEventsController = { create };
-
-export { passageEventsController };
+export const passageEventsController = { create };

--- a/api/src/devcomp/application/passages/passage-controller.js
+++ b/api/src/devcomp/application/passages/passage-controller.js
@@ -1,7 +1,9 @@
 import * as llmChatSerializer from '../../../shared/infrastructure/serializers/llm-chat-serializer.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import * as elementAnswerSerializer from '../../infrastructure/serializers/jsonapi/element-answer-serializer.js';
+import * as passageSerializer from '../../infrastructure/serializers/jsonapi/passage-serializer.js';
 
-const create = async function (request, h, { usecases, passageSerializer }) {
+const create = async function (request, h, { usecases }) {
   const {
     'module-id': moduleId,
     'module-version': moduleVersion,
@@ -28,7 +30,7 @@ const create = async function (request, h, { usecases, passageSerializer }) {
   return h.response(serializedPassage).created();
 };
 
-const verifyAndSaveAnswer = async function (request, h, { usecases, elementAnswerSerializer }) {
+const verifyAndSaveAnswer = async function (request, h, { usecases }) {
   const { passageId } = request.params;
   const { 'element-id': elementId, 'user-response': userResponse } = request.payload.data.attributes;
   const elementAnswer = await usecases.verifyAndSaveAnswer({ passageId, elementId, userResponse });
@@ -62,6 +64,4 @@ const promptToLLMChat = async function (request, h, { usecases }) {
   return h.response(llmResponse).type('text/event-stream').code(201);
 };
 
-const passageController = { create, verifyAndSaveAnswer, terminate, startEmbedLlmChat, promptToLLMChat };
-
-export { passageController };
+export const passageController = { create, verifyAndSaveAnswer, terminate, startEmbedLlmChat, promptToLLMChat };

--- a/api/src/devcomp/application/trainings/training-controller.js
+++ b/api/src/devcomp/application/trainings/training-controller.js
@@ -5,33 +5,29 @@ import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/tr
 import * as trainingSummarySerializer from '../../infrastructure/serializers/jsonapi/training-summary-serializer.js';
 import * as trainingTriggerSerializer from '../../infrastructure/serializers/jsonapi/training-trigger-serializer.js';
 
-const findPaginatedTrainingSummaries = async function (request, h, dependencies = { trainingSummarySerializer }) {
+const findPaginatedTrainingSummaries = async function (request) {
   const { filter, page } = request.query;
 
   const { trainings, meta } = await usecases.findPaginatedTrainingSummaries({ filter, page });
-  return dependencies.trainingSummarySerializer.serialize(trainings, meta);
+  return trainingSummarySerializer.serialize(trainings, meta);
 };
 
-const findTargetProfileSummaries = async function (
-  request,
-  h,
-  dependencies = { targetProfileSummaryForAdminSerializer },
-) {
+const findTargetProfileSummaries = async function (request) {
   const { trainingId } = request.params;
   const targetProfileSummaries = await usecases.findTargetProfileSummariesForTraining({ trainingId });
-  return dependencies.targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries);
+  return targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries);
 };
 
-const getById = async function (request, h, dependencies = { trainingSerializer }) {
+const getById = async function (request) {
   const { trainingId } = request.params;
   const training = await usecases.getTraining({ trainingId });
-  return dependencies.trainingSerializer.serializeForAdmin(training);
+  return trainingSerializer.serializeForAdmin(training);
 };
 
-const create = async function (request, h, dependencies = { trainingSerializer }) {
-  const deserializedTraining = await dependencies.trainingSerializer.deserialize(request.payload);
+const create = async function (request, h) {
+  const deserializedTraining = await trainingSerializer.deserialize(request.payload);
   const createdTraining = await usecases.createTraining({ training: deserializedTraining });
-  return h.response(dependencies.trainingSerializer.serialize(createdTraining)).created();
+  return h.response(trainingSerializer.serialize(createdTraining)).created();
 };
 
 const duplicate = async function (request, h) {
@@ -40,11 +36,11 @@ const duplicate = async function (request, h) {
   return h.response({ trainingId: createdTraining.id }).created();
 };
 
-const update = async function (request, h, dependencies = { trainingSerializer }) {
+const update = async function (request) {
   const { trainingId } = request.params;
-  const training = await dependencies.trainingSerializer.deserialize(request.payload);
+  const training = await trainingSerializer.deserialize(request.payload);
   const updatedTraining = await usecases.updateTraining({ training: { ...training, id: trainingId } });
-  return dependencies.trainingSerializer.serializeForAdmin(updatedTraining);
+  return trainingSerializer.serializeForAdmin(updatedTraining);
 };
 
 const deleteTrainingTrigger = async function (request, h) {
@@ -53,9 +49,9 @@ const deleteTrainingTrigger = async function (request, h) {
   return h.response({}).code(204);
 };
 
-const createOrUpdateTrigger = async function (request, h, dependencies = { trainingTriggerSerializer }) {
+const createOrUpdateTrigger = async function (request) {
   const { trainingId } = request.params;
-  const { threshold, tubes, type } = await dependencies.trainingTriggerSerializer.deserialize(request.payload);
+  const { threshold, tubes, type } = await trainingTriggerSerializer.deserialize(request.payload);
 
   const createdOrUpdatedTrainingTrigger = await DomainTransaction.execute(async () => {
     return usecases.createOrUpdateTrainingTrigger({
@@ -66,7 +62,7 @@ const createOrUpdateTrigger = async function (request, h, dependencies = { train
     });
   });
 
-  return dependencies.trainingTriggerSerializer.serialize(createdOrUpdatedTrainingTrigger);
+  return trainingTriggerSerializer.serialize(createdOrUpdatedTrainingTrigger);
 };
 
 const attachTargetProfiles = async function (request, h) {
@@ -103,7 +99,7 @@ const findPaginatedTrainingsSummariesByTargetProfileId = async function (
   return dependencies.trainingSummarySerializer.serialize(trainings, meta);
 };
 
-const trainingController = {
+export const trainingController = {
   findPaginatedTrainingSummaries,
   findPaginatedTrainingsSummariesByTargetProfileId,
   findTargetProfileSummaries,
@@ -116,5 +112,3 @@ const trainingController = {
   attachTargetProfiles,
   detachTargetProfile,
 };
-
-export { trainingController };

--- a/api/src/devcomp/application/tutorial-evaluations/tutorial-evaluations-controller.js
+++ b/api/src/devcomp/application/tutorial-evaluations/tutorial-evaluations-controller.js
@@ -2,17 +2,14 @@ import { TutorialEvaluation } from '../../domain/models/TutorialEvaluation.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as tutorialEvaluationSerializer from '../../infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js';
 
-const evaluate = async function (request, h, dependencies = { tutorialEvaluationSerializer }) {
+const evaluate = async function (request, h) {
   const { userId } = request.auth.credentials;
   const { tutorialId } = request.params;
-  const { status = TutorialEvaluation.statuses.LIKED } = dependencies.tutorialEvaluationSerializer.deserialize(
-    request.payload,
-  );
+  const { status = TutorialEvaluation.statuses.LIKED } = tutorialEvaluationSerializer.deserialize(request.payload);
 
   const tutorialEvaluation = await usecases.addTutorialEvaluation({ userId, tutorialId, status });
 
   return h.response(tutorialEvaluationSerializer.serialize(tutorialEvaluation)).created();
 };
 
-const tutorialEvaluationsController = { evaluate };
-export { tutorialEvaluationsController };
+export const tutorialEvaluationsController = { evaluate };

--- a/api/src/devcomp/application/user-trainings/user-trainings-controller.js
+++ b/api/src/devcomp/application/user-trainings/user-trainings-controller.js
@@ -2,14 +2,7 @@ import { getChallengeLocale } from '../../../shared/infrastructure/utils/request
 import { usecases as devcompUsecases } from '../../domain/usecases/index.js';
 import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
 
-const findPaginatedUserRecommendedTrainings = async function (
-  request,
-  h,
-  dependencies = {
-    trainingSerializer,
-    devcompUsecases,
-  },
-) {
+const findPaginatedUserRecommendedTrainings = async function (request, h, dependencies = { devcompUsecases }) {
   const locale = getChallengeLocale(request);
   const { page } = request.query;
   const { userRecommendedTrainings, meta } = await dependencies.devcompUsecases.findPaginatedUserRecommendedTrainings({
@@ -18,11 +11,9 @@ const findPaginatedUserRecommendedTrainings = async function (
     page,
   });
 
-  return dependencies.trainingSerializer.serialize(userRecommendedTrainings, meta);
+  return trainingSerializer.serialize(userRecommendedTrainings, meta);
 };
 
-const userTrainingsController = {
+export const userTrainingsController = {
   findPaginatedUserRecommendedTrainings,
 };
-
-export { userTrainingsController };

--- a/api/src/devcomp/application/user-tutorials/user-tutorials-controller.js
+++ b/api/src/devcomp/application/user-tutorials/user-tutorials-controller.js
@@ -5,17 +5,17 @@ import * as userSavedTutorialRepository from '../../infrastructure/repositories/
 import * as tutorialSerializer from '../../infrastructure/serializers/jsonapi/tutorial-serializer.js';
 import * as userSavedTutorialSerializer from '../../infrastructure/serializers/jsonapi/user-saved-tutorial-serializer.js';
 
-const add = async function (request, h, dependencies = { userSavedTutorialSerializer }) {
+const add = async function (request, h) {
   const { userId } = request.auth.credentials;
   const { tutorialId } = request.params;
-  const userSavedTutorial = dependencies.userSavedTutorialSerializer.deserialize(request.payload);
+  const userSavedTutorial = userSavedTutorialSerializer.deserialize(request.payload);
 
   const createdUserSavedTutorial = await usecases.addTutorialToUser({ ...userSavedTutorial, userId, tutorialId });
 
-  return h.response(dependencies.userSavedTutorialSerializer.serialize(createdUserSavedTutorial)).created();
+  return h.response(userSavedTutorialSerializer.serialize(createdUserSavedTutorial)).created();
 };
 
-const find = async function (request, h, dependencies = { tutorialSerializer }) {
+const find = async function (request) {
   const { userId } = request.auth.credentials;
   const { page, filter: filters } = request.query;
   const locale = getUserLocale(request);
@@ -26,7 +26,7 @@ const find = async function (request, h, dependencies = { tutorialSerializer }) 
     page,
     lang,
   });
-  return dependencies.tutorialSerializer.serialize(tutorials, meta);
+  return tutorialSerializer.serialize(tutorials, meta);
 };
 
 const removeFromUser = async function (request, h, dependencies = { userSavedTutorialRepository }) {
@@ -38,5 +38,4 @@ const removeFromUser = async function (request, h, dependencies = { userSavedTut
   return h.response().code(204);
 };
 
-const userTutorialsController = { add, find, removeFromUser };
-export { userTutorialsController };
+export const userTutorialsController = { add, find, removeFromUser };

--- a/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
+++ b/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
@@ -1,15 +1,7 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as elementAnswerSerializer from '../serializers/jsonapi/element-answer-serializer.js';
-import * as moduleSerializer from '../serializers/jsonapi/module-serializer.js';
-import * as passageEventSerializer from '../serializers/jsonapi/passage-event-serializer.js';
-import * as passageSerializer from '../serializers/jsonapi/passage-serializer.js';
 
 const dependencies = {
   usecases,
-  elementAnswerSerializer,
-  moduleSerializer,
-  passageEventSerializer,
-  passageSerializer,
 };
 
 const handlerWithDependencies = (handler) => {

--- a/api/tests/devcomp/unit/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/unit/application/campaign-participations/campaign-participation-controller_test.js
@@ -6,16 +6,8 @@ import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Application | Controller | Campaign-Participation', function () {
   describe('#findTrainings', function () {
-    let dependencies;
-
     beforeEach(function () {
       sinon.stub(devcompUsecases, 'findCampaignParticipationTrainings');
-      const trainingSerializer = {
-        serialize: sinon.stub(),
-      };
-      dependencies = {
-        trainingSerializer,
-      };
     });
 
     it('should call usecase and serializer with expected parameters', async function () {
@@ -23,24 +15,22 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const campaignParticipationId = 123;
       const userId = 456;
       const locale = 'fr-fr';
-      const trainings = Symbol('trainings');
-      const expectedResults = Symbol('results');
+      const trainings = { id: 1, duration: {} };
       devcompUsecases.findCampaignParticipationTrainings
         .withArgs({ userId, campaignParticipationId, locale })
         .resolves(trainings);
-      dependencies.trainingSerializer.serialize.withArgs(trainings).returns(expectedResults);
 
       const request = {
         auth: { credentials: { userId } },
         params: { id: campaignParticipationId },
       };
-      const h = Symbol('h');
 
       // when
-      const response = await campaignParticipationController.findTrainings(request, h, dependencies);
+      const response = await campaignParticipationController.findTrainings(request);
 
       // then
-      expect(response).to.equal(expectedResults);
+      expect(response.data.id).to.equal('1');
+      expect(response.data.type).to.equal('trainings');
     });
   });
 });

--- a/api/tests/devcomp/unit/application/modules/module-controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/module-controller_test.js
@@ -9,26 +9,19 @@ describe('Unit | Devcomp | Application | Modules | Module Controller', function 
     it('should call getModuleByShortId use-case and return serialized modules', async function () {
       const shortId = 's0l3il';
       const encryptedRedirectionUrl = 'encryptedRedirectionUrl';
-      const serializedModule = Symbol('serialized modules');
-      const module = Symbol('modules');
+      const module = { id: 1, glossary: [], sections: [] };
       const getModuleByShortIdStub = sinon.stub(usecases, 'getModuleByShortId');
       usecases.getModuleByShortId.withArgs({ shortId, encryptedRedirectionUrl }).returns(module);
-      const moduleSerializer = {
-        serialize: sinon.stub(),
-      };
-      moduleSerializer.serialize.withArgs(module).returns(serializedModule);
 
       const result = await modulesController.getByShortId(
         { params: { shortId }, query: { encryptedRedirectionUrl } },
         null,
-        {
-          moduleSerializer,
-          usecases,
-        },
+        { usecases },
       );
 
-      expect(result).to.equal(serializedModule);
       expect(getModuleByShortIdStub).to.have.been.calledOnceWithExactly({ shortId, encryptedRedirectionUrl });
+      expect(result.data.id).to.equal('1');
+      expect(result.data.type).to.equal('modules');
     });
   });
 });

--- a/api/tests/devcomp/unit/application/passage-events/passage-event-controller_test.js
+++ b/api/tests/devcomp/unit/application/passage-events/passage-event-controller_test.js
@@ -4,68 +4,41 @@ import { passageEventsController } from '../../../../../src/devcomp/application/
 import { BadRequestError } from '../../../../../src/shared/application/errors/http-errors.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
+import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Unit | Devcomp | Application | Passage-Events | Controller', function () {
+  const payload = { data: { attributes: { events: [] } } };
+
   describe('#create', function () {
     it('should call recordPassageEvents use-case', async function () {
       // given
-      const serializedPayload = Symbol();
-      const deserializedPayload = Symbol();
-      const passageEventSerializer = {
-        deserialize: sinon.stub().returns(deserializedPayload),
-      };
-      const usecases = {
-        recordPassageEvents: sinon.stub(),
-      };
+      const usecases = { recordPassageEvents: sinon.stub() };
       usecases.recordPassageEvents.resolves();
-      const code = sinon.stub();
       const userId = 123;
-      const hStub = {
-        response: () => ({ code }),
-      };
 
       const request = {
-        payload: serializedPayload,
+        payload,
         headers: generateAuthenticatedUserRequestHeaders({ userId }),
       };
 
       // when
-      await passageEventsController.create(request, hStub, {
-        usecases,
-        passageEventSerializer,
-      });
+      await passageEventsController.create(request, hFake, { usecases });
 
       // then
-      expect(passageEventSerializer.deserialize).to.have.been.calledOnceWithExactly(serializedPayload);
-      expect(usecases.recordPassageEvents).to.have.been.calledWithExactly({
-        events: deserializedPayload,
-        userId,
-      });
-      expect(code).to.have.been.calledOnce;
+      expect(usecases.recordPassageEvents).to.have.been.calledWithExactly({ events: [], userId });
     });
 
     context('when recordPassageEvents usecase throws domain error', function () {
       it('should throw a "BadRequestError"', async function () {
         // given
-        const serializedPayload = Symbol();
-        const deserializedPayload = Symbol();
-        const passageEventSerializer = {
-          deserialize: sinon.stub().returns(deserializedPayload),
-        };
-
-        const hStub = {};
-
         const usecases = {
           recordPassageEvents: sinon.stub(),
         };
         usecases.recordPassageEvents.rejects(new DomainError('domainError'));
 
         // when
-        const promise = passageEventsController.create({ payload: serializedPayload }, hStub, {
-          usecases,
-          passageEventSerializer,
-        });
+        const promise = passageEventsController.create({ payload }, hFake, { usecases });
 
         // then
         await expect(promise).to.be.rejectedWith(BadRequestError, 'domainError');

--- a/api/tests/devcomp/unit/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/passage-controller_test.js
@@ -2,31 +2,20 @@ import sinon from 'sinon';
 
 import { passageController } from '../../../../../src/devcomp/application/passages/passage-controller.js';
 import { expect } from '../../../../test-helper.js';
+import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Unit | Devcomp | Application | Passages | Controller', function () {
   describe('#create', function () {
     it('should call createPassage and recordPassageEvents use-cases and return serialized passage', async function () {
       // given
-      const serializedPassage = Symbol('serialized modules');
       const moduleId = Symbol('module-id');
       const moduleVersion = Symbol('module-version');
       const occurredAtDate = new Date('2025-04-29');
       const occurredAt = occurredAtDate.getTime();
       const sequenceNumber = Symbol('sequence-number');
-      const passage = {
-        id: Symbol('passageId'),
-      };
+      const passage = { id: 456 };
       const userId = 123;
-      const passageSerializer = {
-        serialize: sinon.stub(),
-      };
-      passageSerializer.serialize.withArgs(passage).returns(serializedPassage);
-      const hStub = {
-        response: sinon.stub(),
-      };
-      const created = sinon.stub();
-      hStub.response.withArgs(serializedPassage).returns({ created });
 
       const request = {
         headers: generateAuthenticatedUserRequestHeaders({ userId }),
@@ -57,14 +46,12 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       usecases.createPassage.withArgs({ moduleId, userId }).returns(passage);
 
       // when
-      await passageController.create(request, hStub, {
-        passageSerializer,
-        usecases,
-      });
+      const result = await passageController.create(request, hFake, { usecases });
 
       // then
-      expect(created).to.have.been.called;
       expect(usecases.recordPassageEvents).to.have.been.calledOnceWith({ events: [passageStartedEvent] });
+      expect(result.source.data.id).to.equal('456');
+      expect(result.source.data.type).to.equal('passages');
     });
   });
 
@@ -76,26 +63,11 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const userResponse = Symbol('user-response');
       const uselessField = Symbol('useless-field');
 
-      const createdElementAnswer = Symbol('created element-answer');
-      const usecases = {
-        verifyAndSaveAnswer: sinon.stub(),
-      };
-      usecases.verifyAndSaveAnswer.withArgs({ passageId, elementId, userResponse }).resolves(createdElementAnswer);
-
-      const hStub = {
-        response: sinon.stub(),
-      };
-
-      const serializedElementAnswer = Symbol('serialized element-answer');
-
-      const elementAnswerSerializer = {
-        serialize: sinon.stub(),
-      };
-      elementAnswerSerializer.serialize.withArgs(createdElementAnswer).returns(serializedElementAnswer);
-
-      const createdStub = sinon.stub();
-      hStub.response.withArgs(serializedElementAnswer).returns({ created: createdStub });
-      createdStub.returns(serializedElementAnswer);
+      const usecases = { verifyAndSaveAnswer: sinon.stub() };
+      usecases.verifyAndSaveAnswer.withArgs({ passageId, elementId, userResponse }).resolves({
+        id: 1,
+        correction: { status: {} },
+      });
 
       // when
       const result = await passageController.verifyAndSaveAnswer(
@@ -103,15 +75,13 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
           params: { passageId },
           payload: { data: { attributes: { 'element-id': elementId, 'user-response': userResponse, uselessField } } },
         },
-        hStub,
-        {
-          usecases,
-          elementAnswerSerializer,
-        },
+        hFake,
+        { usecases },
       );
 
       // then
-      expect(result).to.equal(serializedElementAnswer);
+      expect(result.source.data.id).to.equal('1');
+      expect(result.source.data.type).to.equal('element-answers');
     });
   });
 

--- a/api/tests/devcomp/unit/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/unit/application/trainings/training-controller_test.js
@@ -11,18 +11,14 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
   describe('#findPaginatedTrainingSummaries', function () {
     it('should call the training findPaginatedTrainingSummaries use-case', async function () {
       // given
-      const expectedResult = Symbol('serialized-training-summaries');
-      const trainingSummaries = Symbol('trainingSummary');
-      const meta = Symbol('meta');
+      const trainingSummaries = [{ id: 1 }];
+      const meta = { page: 1 };
       const useCaseParameters = {
         filter: { id: 1 },
         page: { size: 2, number: 1 },
       };
 
       sinon.stub(usecases, 'findPaginatedTrainingSummaries').resolves({ trainings: trainingSummaries, meta });
-
-      const trainingSummarySerializer = { serialize: sinon.stub() };
-      trainingSummarySerializer.serialize.returns(expectedResult);
 
       // when
       const response = await trainingController.findPaginatedTrainingSummaries(
@@ -33,234 +29,111 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
           },
         },
         hFake,
-        { trainingSummarySerializer },
       );
 
       // then
       expect(usecases.findPaginatedTrainingSummaries).to.have.been.calledWithExactly(useCaseParameters);
-      expect(trainingSummarySerializer.serialize).to.have.been.calledOnce;
-      expect(response).to.deep.equal(expectedResult);
+      expect(response).to.deep.equal({
+        data: [{ id: '1', type: 'training-summaries' }],
+        meta: { page: 1 },
+      });
     });
   });
 
   describe('#getById', function () {
     it('should get training by id', async function () {
       // given
-      const expectedResult = Symbol('serialized-trainings');
-      const training = Symbol('training');
       const trainingId = 1;
-
-      sinon.stub(usecases, 'getTraining').resolves(training);
-      const trainingSerializer = { serializeForAdmin: sinon.stub() };
-      trainingSerializer.serializeForAdmin.returns(expectedResult);
+      sinon.stub(usecases, 'getTraining').resolves({ id: trainingId, duration: {} });
 
       // when
-      const response = await trainingController.getById(
-        {
-          params: {
-            trainingId,
-          },
-        },
-        hFake,
-        { trainingSerializer },
-      );
+      const response = await trainingController.getById({ params: { trainingId } }, hFake);
 
       // then
       expect(usecases.getTraining).to.have.been.calledWithExactly({ trainingId });
-      expect(trainingSerializer.serializeForAdmin).to.have.been.calledOnce;
-      expect(response).to.deep.equal(expectedResult);
+      expect(response.data.id).to.equal('1');
+      expect(response.data.type).to.equal('trainings');
     });
   });
 
   describe('#create', function () {
-    const deserializedTraining = {
-      title: 'Training title',
-      internalTitle: 'Training internal title',
-      duration: '2d2h2m',
-    };
-    const createdTraining = {
-      title: 'Training title',
-      internalTitle: 'Training internal title',
-      duration: {
-        days: 2,
-        hours: 2,
-        minutes: 2,
-      },
-    };
-    let trainingSerializer;
-
-    beforeEach(function () {
-      trainingSerializer = {
-        deserialize: sinon.stub(),
-        serialize: sinon.stub(),
-      };
-      trainingSerializer.deserialize.returns(deserializedTraining);
-      sinon.stub(usecases, 'createTraining').resolves(createdTraining);
-    });
-
     it('should call the training create use-case', async function () {
       // given
-      const payload = {
-        data: {
-          attributes: {
-            title: 'A new training',
-            internalTitle: 'A new internal training title',
-            locales: ['fr'],
-            duration: {
-              days: 2,
-              hours: 2,
-              minutes: 2,
-            },
-          },
-        },
-      };
-
-      // when
-      await trainingController.create({ payload }, hFake, { trainingSerializer });
-
-      // then
-      expect(trainingSerializer.deserialize).to.have.been.calledWithExactly(payload);
-      expect(usecases.createTraining).to.have.been.calledOnceWithExactly({ training: deserializedTraining });
-    });
-
-    it('should return a serialized training', async function () {
-      // given
-      const expectedSerializedTraining = {
+      const createdTraining = {
         title: 'A new training',
         internalTitle: 'A new internal training title',
+        locales: ['fr'],
         duration: {
-          hours: 5,
+          days: 2,
+          hours: 2,
+          minutes: 2,
         },
       };
-
-      trainingSerializer.serialize.returns(expectedSerializedTraining);
+      sinon.stub(usecases, 'createTraining').resolves(createdTraining);
+      const payload = { data: { attributes: createdTraining } };
 
       // when
-      const response = await trainingController.create(
-        {
-          data: {
-            attributes: {
-              title: 'A new training',
-              internalTitle: 'A new internal training title',
-              duration: {
-                hours: 5,
-              },
-            },
-          },
-        },
-        hFake,
-        { trainingSerializer },
-      );
+      const result = await trainingController.create({ payload }, hFake);
 
       // then
-      expect(trainingSerializer.serialize).to.have.been.calledWithExactly(createdTraining);
-      expect(response.source).to.deep.equal(expectedSerializedTraining);
+      expect(usecases.createTraining).to.have.been.calledOnceWithExactly({
+        training: {
+          title: 'A new training',
+          internalTitle: 'A new internal training title',
+          locales: ['fr'],
+          duration: '2d2h2m',
+        },
+      });
+      expect(result.source.data.type).to.equal('trainings');
+      expect(result.source.data.attributes.title).to.equal(createdTraining.title);
     });
   });
 
   describe('#duplicate', function () {
-    const createdTraining = {
-      id: 124,
-      title: 'Training title',
-      internalTitle: '[Copie] Training internal title',
-      duration: {
-        days: 2,
-        hours: 2,
-        minutes: 2,
-      },
-    };
-
     it('should call the duplicateTraining use-case', async function () {
       // given
+      const createdTraining = {
+        id: 124,
+        title: 'Training title',
+        internalTitle: '[Copie] Training internal title',
+        duration: {
+          days: 2,
+          hours: 2,
+          minutes: 2,
+        },
+      };
       sinon.stub(usecases, 'duplicateTraining').resolves(createdTraining);
       const trainingId = 123;
       const request = { params: { trainingId } };
-      const expectedSerializedTraining = { trainingId: createdTraining.id };
 
       // when
       const response = await trainingController.duplicate(request, hFake);
 
       // then
       expect(usecases.duplicateTraining).to.have.been.calledOnceWithExactly({ trainingId });
-      expect(response.source).to.deep.equal(expectedSerializedTraining);
+      expect(response.source).to.deep.equal({ trainingId: createdTraining.id });
     });
   });
 
   describe('#update', function () {
-    const deserializedTraining = { title: 'new title' };
-    const updatedTraining = { title: 'new title' };
-
-    let trainingSerializer;
-
-    beforeEach(function () {
-      trainingSerializer = {
-        serializeForAdmin: sinon.stub(),
-        deserialize: sinon.stub(),
-      };
-      trainingSerializer.deserialize.returns(deserializedTraining);
-      sinon.stub(usecases, 'updateTraining').resolves(updatedTraining);
-    });
-
     describe('when request is valid', function () {
       it('should call the training update use-case', async function () {
         // given
-        const useCaseParameters = {
-          training: { ...deserializedTraining, id: 134 },
-        };
-        const payload = {
-          data: {
-            attributes: {
-              title: 'New title',
-              link: 'https://example.net/new-link',
-            },
-          },
-        };
+        const trainingId = 123;
+        const training = { title: 'new title', link: 'https://example.net/new-link' };
+        sinon.stub(usecases, 'updateTraining').resolves({ id: trainingId, ...training, duration: {} });
+        const payload = { data: { attributes: training } };
 
         // when
-        await trainingController.update(
-          {
-            params: {
-              trainingId: 134,
-            },
-            payload,
-          },
-          hFake,
-          { trainingSerializer },
-        );
+        const result = await trainingController.update({ params: { trainingId }, payload }, hFake);
 
         // then
-        expect(trainingSerializer.deserialize).to.have.been.calledWithExactly(payload);
-        expect(usecases.updateTraining).to.have.been.calledWithExactly(useCaseParameters);
-      });
-
-      it('should return a serialized training', async function () {
-        // given
-        const payload = {
-          data: {
-            attributes: {
-              title: 'New title',
-              link: 'https://example.net/new-link',
-            },
-          },
-        };
-        const expectedSerializedUser = { message: 'serialized user' };
-        trainingSerializer.serializeForAdmin.returns(expectedSerializedUser);
-
-        // when
-        const response = await trainingController.update(
-          {
-            params: {
-              trainingId: 134,
-            },
-            payload,
-          },
-          hFake,
-          { trainingSerializer },
-        );
-
-        // then
-        expect(trainingSerializer.serializeForAdmin).to.have.been.calledWithExactly(updatedTraining);
-        expect(response).to.deep.equal(expectedSerializedUser);
+        expect(usecases.updateTraining).to.have.been.calledWithExactly({
+          training: { id: trainingId, ...training },
+        });
+        expect(result.data.id).to.equal(String(trainingId));
+        expect(result.data.type).to.equal('trainings');
+        expect(result.data.attributes.title).to.equal(training.title);
       });
     });
   });
@@ -273,69 +146,34 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
           attributes: {
             type: TrainingTrigger.types.PREREQUISITE,
             threshold: 45,
-          },
-          relationships: {
-            tubes: {
-              data: [
-                {
-                  id: 'recTube123',
-                  type: 'tubes',
-                },
-              ],
-            },
+            tubes: [{ id: 'recTube123', level: 2 }],
           },
         },
-        included: [
-          {
-            attributes: {
-              id: 'recTube123',
-              level: 2,
-            },
-            id: 'recTube123',
-            type: 'tubes',
-          },
-        ],
-      };
-
-      const deserializedTrigger = {
-        trainingId: Symbol('trainingId'),
-        threshold: Symbol('threshold'),
-        type: Symbol('type'),
-        tubes: Symbol('tubes'),
       };
 
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
         return callback();
       });
 
-      const createdTrigger = Symbol('createdTrigger');
-      const serializedTrigger = Symbol('serializedTrigger');
-      sinon.stub(usecases, 'createOrUpdateTrainingTrigger').resolves(createdTrigger);
-      const trainingTriggerSerializer = {
-        deserialize: sinon.stub(),
-        serialize: sinon.stub(),
-      };
-      trainingTriggerSerializer.deserialize.withArgs(payload).returns(deserializedTrigger);
-      trainingTriggerSerializer.serialize.withArgs(createdTrigger).returns(serializedTrigger);
+      sinon.stub(usecases, 'createOrUpdateTrainingTrigger').resolves({
+        id: 145,
+        type: TrainingTrigger.types.PREREQUISITE,
+        threshold: 45,
+        tubes: [{ id: 'recTube123', level: 2 }],
+      });
 
       // when
-      const result = await trainingController.createOrUpdateTrigger(
-        {
-          params: { trainingId: 145 },
-          payload,
-        },
-        hFake,
-        { trainingTriggerSerializer: trainingTriggerSerializer },
-      );
+      const result = await trainingController.createOrUpdateTrigger({ params: { trainingId: 145 }, payload }, hFake);
 
       // then
       expect(usecases.createOrUpdateTrainingTrigger).to.have.been.calledWithExactly({
         trainingId: 145,
-        threshold: deserializedTrigger.threshold,
-        type: deserializedTrigger.type,
-        tubes: deserializedTrigger.tubes,
+        threshold: 45,
+        type: TrainingTrigger.types.PREREQUISITE,
+        tubes: [{ id: 'recTube123', level: 2 }],
       });
-      expect(result).to.be.equal(serializedTrigger);
+      expect(result.data.id).to.equal('145');
+      expect(result.data.type).to.equal('training-triggers');
     });
   });
 
@@ -343,25 +181,14 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
     it('should call the findTargetProfileSummaries use-case', async function () {
       // given
       const trainingId = 145;
-      const targetProfileSummaries = Symbol('targetProfileSummaries');
-      const serializedTargetProfileSummaries = Symbol('serializedTargetProfileSummaries');
-      sinon.stub(usecases, 'findTargetProfileSummariesForTraining').resolves(targetProfileSummaries);
-
-      const targetProfileSummaryForAdminSerializer = {
-        serialize: sinon.stub(),
-      };
-      targetProfileSummaryForAdminSerializer.serialize
-        .withArgs(targetProfileSummaries)
-        .returns(serializedTargetProfileSummaries);
+      sinon.stub(usecases, 'findTargetProfileSummariesForTraining').resolves([{ id: 1 }]);
 
       // when
-      const result = await trainingController.findTargetProfileSummaries({ params: { trainingId } }, hFake, {
-        targetProfileSummaryForAdminSerializer: targetProfileSummaryForAdminSerializer,
-      });
+      const result = await trainingController.findTargetProfileSummaries({ params: { trainingId } }, hFake);
 
       // then
       expect(usecases.findTargetProfileSummariesForTraining).to.have.been.calledWithExactly({ trainingId });
-      expect(result).to.be.equal(serializedTargetProfileSummaries);
+      expect(result.data).to.deep.equal([{ id: '1', type: 'target-profile-summaries' }]);
     });
   });
 
@@ -391,23 +218,15 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
     it('should return trainings summaries', async function () {
       // given
       const targetProfileId = 123;
-      const expectedResult = Symbol('serialized-training-summaries');
-      const trainingSummaries = Symbol('trainingSummaries');
-      const meta = Symbol('meta');
       const useCaseParameters = {
         targetProfileId,
         page: { size: 2, number: 1 },
       };
 
       sinon.stub(usecases, 'findPaginatedTargetProfileTrainingSummaries').resolves({
-        trainings: trainingSummaries,
-        meta,
+        trainings: [{ id: 1 }],
+        meta: { page: 1 },
       });
-
-      const trainingSummarySerializer = {
-        serialize: sinon.stub(),
-      };
-      trainingSummarySerializer.serialize.withArgs(trainingSummaries, meta).returns(expectedResult);
 
       // when
       const response = await trainingController.findPaginatedTrainingsSummariesByTargetProfileId(
@@ -420,12 +239,12 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
           },
         },
         hFake,
-        { trainingSummarySerializer },
       );
 
       // then
       expect(usecases.findPaginatedTargetProfileTrainingSummaries).to.have.been.calledWithExactly(useCaseParameters);
-      expect(response).to.deep.equal(expectedResult);
+      expect(response.data).to.deep.equal([{ id: '1', type: 'training-summaries' }]);
+      expect(response.meta).to.deep.equal({ page: 1 });
     });
   });
 

--- a/api/tests/devcomp/unit/application/user-trainings/user-trainings-controller_test.js
+++ b/api/tests/devcomp/unit/application/user-trainings/user-trainings-controller_test.js
@@ -16,17 +16,13 @@ describe('Unit | Controller | user-trainings-controller', function () {
         state: { locale },
         query: { page },
       };
-      const expectedResult = Symbol('serialized-trainings');
-      const userRecommendedTrainings = Symbol('userRecommendedTrainings');
-      const meta = Symbol('meta');
+      const userRecommendedTrainings = [{ id: 1, duration: {} }];
+      const meta = { page: 1 };
       sinon.stub(devcompUsecases, 'findPaginatedUserRecommendedTrainings').resolves({ userRecommendedTrainings, meta });
-      const trainingSerializer = { serialize: sinon.stub() };
-      trainingSerializer.serialize.returns(expectedResult);
 
       // when
       const response = await userTrainingsController.findPaginatedUserRecommendedTrainings(request, hFake, {
         devcompUsecases,
-        trainingSerializer,
       });
 
       // then
@@ -36,8 +32,8 @@ describe('Unit | Controller | user-trainings-controller', function () {
         locale,
         page,
       });
-      expect(trainingSerializer.serialize).to.have.been.calledWithExactly(userRecommendedTrainings, meta);
-      expect(response).to.equal(expectedResult);
+      expect(response.data[0]).to.includes({ id: '1', type: 'trainings' });
+      expect(response.meta).to.deep.equal({ page: 1 });
     });
   });
 });

--- a/api/tests/devcomp/unit/application/user-tutorials/user-tutorials-controller_test.js
+++ b/api/tests/devcomp/unit/application/user-tutorials/user-tutorials-controller_test.js
@@ -12,11 +12,6 @@ describe('Unit | Controller | User-tutorials', function () {
       const tutorialId = 'tutorialId';
       const userId = 'userId';
       sinon.stub(usecases, 'addTutorialToUser').returns({ id: 'userTutorialId' });
-      const userSavedTutorialSerializer = {
-        deserialize: sinon.stub(),
-        serialize: sinon.stub(),
-      };
-      userSavedTutorialSerializer.deserialize.returns({});
 
       const request = {
         auth: { credentials: { userId } },
@@ -24,9 +19,7 @@ describe('Unit | Controller | User-tutorials', function () {
       };
 
       // when
-      await userTutorialsController.add(request, hFake, {
-        userSavedTutorialSerializer,
-      });
+      await userTutorialsController.add(request, hFake);
 
       // then
       const addTutorialToUserArgs = usecases.addTutorialToUser.firstCall.args[0];
@@ -41,11 +34,6 @@ describe('Unit | Controller | User-tutorials', function () {
         const tutorialId = 'tutorialId';
         const userId = 'userId';
         sinon.stub(usecases, 'addTutorialToUser').returns({ id: 'userTutorialId' });
-        const userSavedTutorialSerializer = {
-          deserialize: sinon.stub(),
-          serialize: sinon.stub(),
-        };
-        userSavedTutorialSerializer.deserialize.returns({ skillId });
 
         const request = {
           auth: { credentials: { userId } },
@@ -54,16 +42,14 @@ describe('Unit | Controller | User-tutorials', function () {
         };
 
         // when
-        await userTutorialsController.add(request, hFake, {
-          userSavedTutorialSerializer,
-        });
+        const result = await userTutorialsController.add(request, hFake);
 
         // then
         const addTutorialToUserArgs = usecases.addTutorialToUser.firstCall.args[0];
         expect(addTutorialToUserArgs).to.have.property('userId', userId);
         expect(addTutorialToUserArgs).to.have.property('tutorialId', tutorialId);
         expect(addTutorialToUserArgs).to.have.property('skillId', skillId);
-        expect(userSavedTutorialSerializer.deserialize).to.have.been.calledWithExactly(request.payload);
+        expect(result.source.data).to.deep.equal({ id: 'userTutorialId', type: 'user-saved-tutorials' });
       });
     });
   });
@@ -90,32 +76,31 @@ describe('Unit | Controller | User-tutorials', function () {
 
       const expectedFilters = request.query.filter;
       const expectedPage = request.query.page;
-      const expectedTutorials = Symbol('tutorials');
 
-      const returnedTutorials = Symbol('returned-tutorials');
-      const returnedMeta = Symbol('returned-meta');
+      const returnedTutorials = [{ id: 'tuto 1' }, { id: 'tuto 2' }];
+      const returnedMeta = { page: 1 };
       sinon.stub(usecases, 'findPaginatedFilteredTutorials').resolves({
         tutorials: returnedTutorials,
         meta: returnedMeta,
       });
-      const tutorialSerializer = {
-        deserialize: sinon.stub(),
-        serialize: sinon.stub(),
-      };
-      tutorialSerializer.serialize.returns(expectedTutorials);
 
       // when
-      const result = await userTutorialsController.find(request, hFake, { tutorialSerializer });
+      const result = await userTutorialsController.find(request, hFake);
 
       // then
-      expect(tutorialSerializer.serialize).to.have.been.calledWithExactly(returnedTutorials, returnedMeta);
       expect(usecases.findPaginatedFilteredTutorials).to.have.been.calledWithExactly({
         userId,
         filters: expectedFilters,
         page: expectedPage,
         lang: 'fr',
       });
-      expect(result).to.equal(expectedTutorials);
+      expect(result).to.deep.equal({
+        data: [
+          { id: 'tuto 1', type: 'tutorials' },
+          { id: 'tuto 2', type: 'tutorials' },
+        ],
+        meta: { page: 1 },
+      });
     });
   });
 


### PR DESCRIPTION
## 🚙 Problème

Parfois on utilise directement les serializers dans les controlleurs, parfois on les injecte dans un attribut `dependencies`. 

Mais les serialisers sont des fonctions pures (déterministes et sans effet de bord), il y a peu d'intérêt de les injecter et mocker dans les tests unitaires. 

## 🍃 Proposition

Il y a peu d'utilité à cette injection, je propose de simplifier et **directement utiliser les serialisers dans les contrôleurs** (sans injection). 

**Bounded contexts dans cette PR dont on a modifié les controllers:**
- `devcomp`

> [!IMPORTANT]
> **Ça change la façon dont sont fait les tests unitaires des controlleurs. On ne peut plus mocker par des `Symbol` les entrée/sortie des sérialisers.** 
C'est compréhensible de souhaiter cette façon de faire, donc on peut ne pas merger cette PR si vous souhaitez conserver cette méthode de test. L'avantage est que le test n'est pas indépendant du modèle, mais l'inconvénient est qu'on test l'implémentation plutôt que le comportement. 
_Est-ce que les controlleurs devraient avoir des tests unitaires? Est-ce que ces tests ne sont pas déjà couvert pas les tests d'acceptance de la couche application ?_

## 🦵 Remarques

**Scout:** on en profite pour simplifier l'export des controlleurs en exportant directement l'objet du controlleur.

## 🔗 Pour tester

CI Ok
