### PR TITLE
[FEATURE] Ajouter le tracking sur les accordéons de la modale (PIX-23074)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -20,6 +20,8 @@ export default class CardModal extends Component {
 
   @tracked isTrainingRecommendationRelevant = null;
 
+  firedAccordions = new Set();
+
   constructor(...args) {
     super(...args);
     this.isTrainingRecommendationRelevant = this.args.training.isRelevant ?? null;
@@ -33,8 +35,7 @@ export default class CardModal extends Component {
     return this.isTrainingRecommendationRelevant === false;
   }
 
-  @action
-  async submitFeedback(feedbackResponse) {
+  @action async submitFeedback(feedbackResponse) {
     this.isTrainingRecommendationRelevant = feedbackResponse;
     const campaignParticipationId = this.args.training.belongsTo('campaignParticipation').id();
     const adapter = this.store.adapterFor('training');
@@ -45,9 +46,14 @@ export default class CardModal extends Component {
     });
   }
 
-  @action
-  onModalButtonClick() {
+  @action onModalButtonClick() {
     this.args.onModalButtonClick({ trainingId: this.args.training.id });
+  }
+
+  @action onModalAccordionClick(accordionName) {
+    if (this.firedAccordions.has(accordionName)) return;
+    this.firedAccordions.add(accordionName);
+    this.args.onModalAccordionClick({ trainingId: this.args.training.id, accordionName });
   }
 
   <template>
@@ -86,7 +92,7 @@ export default class CardModal extends Component {
           </div>
         </div>
 
-        <PixAccordions>
+        <PixAccordions {{on "click" (fn this.onModalAccordionClick "OBJECTIVES")}}>
           <:title>
             <h2>{{t "pages.skill-review.recommended-engine.modal.objectives"}}</h2>
           </:title>
@@ -106,7 +112,7 @@ export default class CardModal extends Component {
             </ul>
           </:content>
         </PixAccordions>
-        <PixAccordions>
+        <PixAccordions {{on "click" (fn this.onModalAccordionClick "PROGRAM")}}>
           <:title>
             <h2>{{t "pages.skill-review.recommended-engine.modal.program"}}</h2>
           </:title>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -70,6 +70,7 @@ export default class Card extends Component {
       @isOpen={{this.modalIsOpen}}
       @onClose={{this.closeModal}}
       @onModalButtonClick={{@onModalButtonClick}}
+      @onModalAccordionClick={{@onModalAccordionClick}}
     />
   </template>
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -16,6 +16,7 @@ import TrainingCard from './training/card';
           @training={{training}}
           @onCardClick={{@onCardClick}}
           @onModalButtonClick={{@onModalButtonClick}}
+          @onModalAccordionClick={{@onModalAccordionClick}}
         /></li>
     {{/each}}
   </ul>

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -25,6 +25,13 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     });
   }
 
+  @action onModalAccordionClick({ trainingId, accordionName }) {
+    this.pixMetrics.trackEvent("Moteur de reco - Clic sur l'accordéon de la modale du contenu formatif", {
+      trainingId,
+      accordionName,
+    });
+  }
+
   get hasTrainings() {
     return Boolean(this.trainings.length);
   }
@@ -66,6 +73,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
           @trainings={{this.trainings}}
           @onCardClick={{this.onCardClick}}
           @onModalButtonClick={{this.onModalButtonClick}}
+          @onModalAccordionClick={{this.onModalAccordionClick}}
         />
       {{/if}}
 

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -124,10 +124,12 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         // given
         const trackEventStub = sinon.stub();
         const trackPageStub = sinon.stub();
+
         class MetricsStubService extends Service {
           trackPage = trackPageStub;
           trackEvent = trackEventStub;
         }
+
         this.owner.register('service:pix-metrics', MetricsStubService);
 
         // when
@@ -150,6 +152,46 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         sinon.assert.calledWithExactly(trackEventStub, 'Moteur de reco - Clic sur la carte du contenu formatif', {
           trainingId: training.id,
         });
+
+        // when
+        await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.objectives') }));
+
+        // then
+        sinon.assert.calledWithExactly(
+          trackEventStub,
+          "Moteur de reco - Clic sur l'accordéon de la modale du contenu formatif",
+          {
+            trainingId: training.id,
+            accordionName: 'OBJECTIVES',
+          },
+        );
+
+        // when
+        await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.objectives') }));
+        await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.objectives') }));
+
+        // then
+        sinon.assert.callCount(trackEventStub, 3);
+
+        // when
+        await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.program') }));
+
+        // then
+        sinon.assert.calledWithExactly(
+          trackEventStub,
+          "Moteur de reco - Clic sur l'accordéon de la modale du contenu formatif",
+          {
+            trainingId: training.id,
+            accordionName: 'PROGRAM',
+          },
+        );
+
+        // when
+        await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.program') }));
+        await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.program') }));
+
+        // then
+        sinon.assert.callCount(trackEventStub, 4);
 
         // when
         await click(


### PR DESCRIPTION
## 🚙 Problème
On souhaite tracker les click sur les accordéons de la modale afin de voir s'il sont utilisés.

## 🍃 Proposition
Ajouter le tracking

## 🦵 Remarques
Le tracking est remonté une seule fois. Si on clique plusieurs fois, on ne réenvoit pas l'event afin de limiter le volume d'informations.

Se rebase sur la [PR](https://github.com/1024pix/pix/pull/16468) une fois mergée 

## 🔗 Pour tester

- Se connecter avec dave-comp@example.net sur [la page de résultats](https://app-pr16475.review.pix.fr/campagnes/EDUMULTIP) 
- Clicker sur une carte de contenus formatifs
- Désactiver tous les bloqueurs de pubs et de tracker 
- Ouvrir la console développeur
- clicker sur un accordéon
- constater que l'évènement est déclenché et envoyé à plausible
- reclicker sur le même accordéon
- constater qu'aucun évènement n'est envoyé pour l'accordéon
- clicker sur un autre accordéon
- constater que l'évènement est bien envoyé
- reclicker sur le même accordéon
- constater que l'évènement n'est pas réenvoyé
- respirer un coup
- Aller sur plausible
- constater que les évènements d'accordéons sont bien remontés
