### PR TITLE
[TECH] Rend silencieuses les dépréciations ember de Pix Orga.

### DIFF
--- a/orga/app/app.js
+++ b/orga/app/app.js
@@ -1,3 +1,5 @@
+import './deprecation-workflow.js';
+
 import Application from '@ember/application';
 import setupInspector from '@embroider/legacy-inspector-support/ember-source-4.12';
 import compatModules from '@embroider/virtual/compat-modules';

--- a/orga/app/deprecation-workflow.js
+++ b/orga/app/deprecation-workflow.js
@@ -1,0 +1,18 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  workflow: [
+    {
+      handler: 'silence',
+      matchId: 'warp-drive.deprecate-tracking-package',
+    },
+    {
+      handler: 'silence',
+      matchId: 'importing-inject-from-ember-service',
+    },
+    {
+      handler: 'silence',
+      matchId: 'warp-drive:deprecate-legacy-request-methods',
+    },
+  ],
+});

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -41,6 +41,7 @@
         "ember-auto-import": "^2.12.1",
         "ember-cli": "^7.0.0",
         "ember-cli-babel": "^8.3.1",
+        "ember-cli-deprecation-workflow": "^4.0.1",
         "ember-cli-htmlbars": "^7.0.0",
         "ember-click-outside": "^6.1.1",
         "ember-cookies": "^1.3.0",
@@ -13456,6 +13457,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-4.0.1.tgz",
+      "integrity": "sha512-XJzUZVXyb6/nFKU7GzGRlHlcAl4KtkioBTjfuIHp1aysbRZ6XxYLSPtP090EbOxQBtYwAPsH2kPAtPS86tL2RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.9",
+        "decorator-transforms": "^2.2.2"
       }
     },
     "node_modules/ember-cli-get-component-path-option": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -71,6 +71,7 @@
     "ember-auto-import": "^2.12.1",
     "ember-cli": "^7.0.0",
     "ember-cli-babel": "^8.3.1",
+    "ember-cli-deprecation-workflow": "^4.0.1",
     "ember-cli-htmlbars": "^7.0.0",
     "ember-click-outside": "^6.1.1",
     "ember-cookies": "^1.3.0",


### PR DESCRIPTION
## 🚙 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Quand on développe sur Pix Orga, la console est polluée par beaucoup de warnings liés aux dépreciations d'Ember.


## 🍃 Proposition

On ajoute `ember-cli-deprecation-worflow` (https://github.com/ember-cli/ember-cli-deprecation-workflow) pour rendre silencieuses les dépréciations.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🦵 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester

En local, lancer Pix Orga et constater qu'aucun message de dépréciations Ember n'est affiché.

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
