### PR TITLE
[TECH] Enlève des variables d'environnement plus utiles de la config front de Pix App (PIX-22942)

### DIFF
--- a/mon-pix/app/components/routes/combined-courses/presentation.gjs
+++ b/mon-pix/app/components/routes/combined-courses/presentation.gjs
@@ -9,7 +9,6 @@ import { and, eq } from 'ember-truth-helpers';
 import Attestation from 'mon-pix/components/combined-course/attestation';
 import CombinedCourseItem from 'mon-pix/components/combined-course/combined-course-item';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
-import ENV from 'mon-pix/config/environment';
 import { CombinedCourseStatuses } from 'mon-pix/models/combined-course';
 
 const CompletedText = <template>
@@ -50,7 +49,7 @@ const Header = <template>
         <PixTooltip @id="tooltip-satisfaction-survey" @position="right" @isInline={{true}}>
           <:triggerElement>
             <PixButtonLink
-              @href={{@surveyLink}}
+              @href={{@combinedCourse.surveyUrl}}
               target="_blank"
               rel="noopener noreferrer"
               @size="large"
@@ -86,7 +85,6 @@ export default class CombinedCoursePresentation extends Component {
         @startQuestParticipation={{this.startQuestParticipation}}
         @goToNextItem={{this.goToNextItem}}
         @isSurveyEnabled={{this.isSurveyEnabled}}
-        @surveyLink={{this.surveyLink}}
       />
       {{#if (eq @combinedCourse.reward.type "attestations")}}
         <Attestation @attestation={{@combinedCourse.reward}} />
@@ -137,17 +135,7 @@ export default class CombinedCoursePresentation extends Component {
     });
   }
 
-  get surveyLink() {
-    return this.args.combinedCourse.organizationId === ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID
-      ? ENV.APP.COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK
-      : this.args.combinedCourse.surveyUrl;
-  }
-
   get isSurveyEnabled() {
-    if (this.args.combinedCourse.organizationId === ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID) {
-      return true;
-    }
-
     return this.featureToggles.featureToggles?.isSurveyEnabledForCombinedCourses && this.args.combinedCourse.surveyUrl;
   }
 

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -135,15 +135,8 @@ module.exports = function (environment) {
       AUTHENTICATED_SOURCE_FROM_GAR: 'external',
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
-      FRANCE_TRAVAIL_ORGANIZATION_ID: parseInt(process.env.FRANCE_TRAVAIL_ORGANIZATION_ID, 10) ?? 1006,
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       AUTO_SHARE_AFTER_DATE: process.env.AUTO_SHARE_AFTER_DATE || '2025-07-18',
-      COMBINIX_SURVEY_LINK:
-        process.env.COMBINIX_SURVEY_LINK ||
-        'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
-      COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK:
-        process.env.COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK || 'https://tally.so/r/rj27xp',
-      ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST: process.env.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST || '1005',
       MODULIX_VERIFICATION_RESPONSE_DELAY: 500,
     },
 
@@ -226,11 +219,7 @@ module.exports = function (environment) {
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
-    ENV.APP.FRANCE_TRAVAIL_ORGANIZATION_ID = 456;
     ENV.APP.AUTO_SHARE_AFTER_DATE = '2025-07-18';
-    ENV.APP.COMBINIX_SURVEY_LINK = 'combinix.survey.link';
-    ENV.APP.COMBINIX_FRANCE_TRAVAIL_SURVEY_LINK = 'combinix.france-travail.survey.link';
-    ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = '1005';
 
     ENV.companion.disabled = true;
 

--- a/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
@@ -489,32 +489,6 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
       assert.notOk(screen.queryByRole('link', { name: t('pages.combined-courses.completed.survey-button') }));
     });
 
-    test('should display France Travail survey cta in all cases', async function (assert) {
-      // given
-      const FRANCE_TRAVAIL_ORGANIZATION_ID = 456;
-      const store = this.owner.lookup('service:store');
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: false });
-      const combinedCourse = store.createRecord('combined-course', {
-        id: 1,
-        status: CombinedCourseStatuses.COMPLETED,
-        code: 'COMBINIX9',
-        organizationId: FRANCE_TRAVAIL_ORGANIZATION_ID,
-        surveyUrl: 'combinix.france-travail.survey.link',
-      });
-
-      // when
-      const screen = await render(
-        <template><CombinedCoursesPresentation @combinedCourse={{combinedCourse}} /></template>,
-      );
-
-      // then
-      const link = screen.getByRole('link', { name: t('pages.combined-courses.completed.survey-button') });
-      assert.dom(link).hasAttribute('href', 'combinix.france-travail.survey.link');
-      assert.dom(link).hasAttribute('target', '_blank');
-      assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
-    });
-
     test('should display retry text for modules if there are any in the course', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## 🚙 Problème
On a ajouté via des précédentes PR le lien vers le questionnaire de fin de parcours combiné en BDD, et on le fait remonter jusqu'au front. 
On avait jusqu'à présent stocké ces informations dans des variables d'environnement front, qui ne sont donc plus utiles.

## 🍃 Proposition
On retire les variables d'environnement qui étaient utilisées pour cette logique-là. On retire aussi la logique propre à France Travail.

## 🔗 Pour tester
Test de non-régression : aller sur COMBINIX1, vérifier que le lien de questionnaire est toujours là.