### PR TITLE
[FEATURE] Créer une route qui remonte un centre de certif associé à une organisation (PIX-22628)

### DIFF
--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -103,12 +103,13 @@ const buildOrganizationInNetwork = function ({
  *
  * @param {object} options
  * @param {object} [options.organizationData] - Any parameter accepted by buildOrganization
+ * @param {number} [options.certificationCenterId] - optional certification center id to link to the organization
  * @returns {{ organization: object, structure: object }}
  */
-const buildOrganizationWithStructure = function ({ organizationData } = {}) {
+const buildOrganizationWithStructure = function ({ organizationData, certificationCenterId } = {}) {
   const organization = buildOrganization(organizationData);
   const structure = buildStructure();
-  buildFactStructure({ structureId: structure.id, organizationId: organization.id });
+  buildFactStructure({ structureId: structure.id, organizationId: organization.id, certificationCenterId });
   return { organization, structure };
 };
 

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -11,6 +11,7 @@ import {
   deserializeForOrganizationsImport,
   requiredFieldNamesForOrganizationsImport,
 } from '../../infrastructure/serializers/csv/organizations-csv-serializer.js';
+import * as certificationCenterSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
 import * as organizationSerializer from '../../infrastructure/serializers/jsonapi/organization-serializer.js';
 import { organizationForAdminSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js';
 import * as organizationPlacesStatisticsSerializer from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js';
@@ -196,6 +197,15 @@ const getOrganizationStatistics = async function (request, h, dependencies = { o
   const statistics = await usecases.getOrganizationStatistics({ organizationId });
   return dependencies.organizationStatisticsSerializer.serialize(statistics);
 };
+
+const findAttachedCertificationCenterForAdmin = async function (request) {
+  const organizationId = request.params.organizationId;
+
+  const certificationCenter = await usecases.findAttachedCertificationCenterForAdmin({ organizationId });
+
+  return certificationCenterSerializer.serialize(certificationCenter);
+};
+
 const organizationAdminController = {
   getTemplateForAddTagsToOrganizations,
   addTagsToOrganizations,
@@ -217,6 +227,7 @@ const organizationAdminController = {
   findPaginatedFilteredOrganizations,
   findChildrenOrganizations,
   getOrganizationStatistics,
+  findAttachedCertificationCenterForAdmin,
 };
 
 export { organizationAdminController };

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -556,6 +556,35 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/organizations/{organizationId}/certification-centers',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: (request) => organizationAdminController.findAttachedCertificationCenterForAdmin(request),
+        tags: ['api', 'organizations'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, CERTIF, SUPPORT ou METIER permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet la récuperation des informations du centre de certification rattachée à une organisation.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/organizational-entities/domain/models/AttachedCertificationCenter.js
+++ b/api/src/organizational-entities/domain/models/AttachedCertificationCenter.js
@@ -1,0 +1,15 @@
+class AttachedCertificationCenter {
+  /**
+   * @param {Object} params
+   * @param {number} params.id
+   * @param {string} params.name
+   * @param {string} params.externalId
+   */
+  constructor({ id, name, externalId } = {}) {
+    this.id = id;
+    this.name = name;
+    this.externalId = externalId;
+  }
+}
+
+export { AttachedCertificationCenter };

--- a/api/src/organizational-entities/domain/usecases/find-attached-certification-center-for-admin.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/find-attached-certification-center-for-admin.usecase.js
@@ -1,0 +1,18 @@
+/**
+ * @typedef {import('../../infrastructure/repositories/certification-center-for-admin.repository.js')} CertificationCenterRepositoryForAdmin
+ */
+
+/**
+ * @param {Object} params
+ * @param {CertificationCenterRepositoryForAdmin} params.certificationCenterForAdminRepository
+ * @param {number} params.organizationId
+ * @returns {Promise<AttachedCertificationCenter[]>}
+ */
+const findAttachedCertificationCenterForAdmin = async function ({
+  organizationId,
+  certificationCenterForAdminRepository,
+}) {
+  return certificationCenterForAdminRepository.findAttachedByOrganizationId(organizationId);
+};
+
+export { findAttachedCertificationCenterForAdmin };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -97,6 +97,7 @@ import { detachParentOrganizationFromOrganization } from './detach-parent-organi
 import { findAllAdministrationTeams } from './find-all-administration-teams.usecase.js';
 import { findAllOrganizationLearnerTypes } from './find-all-organization-learner-types.refactor.js';
 import { findAllTags } from './find-all-tags.usecase.js';
+import { findAttachedCertificationCenterForAdmin } from './find-attached-certification-center-for-admin.usecase.js';
 import { findChildrenOrganizations } from './find-children-organizations.usecase.js';
 import { findOrganizationFeatures } from './find-organization-features.js';
 import { findPaginatedFilteredCertificationCenters } from './find-paginated-filtered-certification-centers.usecase.js';
@@ -131,6 +132,7 @@ const usecasesWithoutInjectedDependencies = {
   detachParentOrganizationFromOrganization,
   findPaginatedFilteredNetworks,
   findAllTags,
+  findAttachedCertificationCenterForAdmin,
   findChildrenOrganizations,
   findOrganizationFeatures,
   findPaginatedFilteredCertificationCenters,

--- a/api/src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js
@@ -1,5 +1,6 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
+import { AttachedCertificationCenter } from '../../domain/models/AttachedCertificationCenter.js';
 import { CenterForAdmin } from '../../domain/models/CenterForAdmin.js';
 
 const save = async function (certificationCenter) {
@@ -10,7 +11,7 @@ const save = async function (certificationCenter) {
     externalId: certificationCenter.externalId,
     createdBy: certificationCenter.createdBy,
   });
-  return _toDomain(certificationCenterCreated);
+  return _toDomainCenterForAdmin(certificationCenterCreated);
 };
 
 const update = async function (certificationCenter) {
@@ -45,9 +46,35 @@ const archive = async function ({ certificationCenterId, archivedBy, archiveDate
     .update({ archivedBy, archivedAt: archiveDate });
 };
 
-export { archive, save, update };
+/**
+ * @type {function}
+ * @param {number} organizationId
+ * @returns {Promise<AttachedCertificationCenter[]>}
+ */
+const findAttachedByOrganizationId = async (organizationId) => {
+  const knexConn = DomainTransaction.getConnection();
+  const certificationCenters = await knexConn('fct_structures')
+    .select({
+      id: 'certification-centers.id',
+      name: 'certification-centers.name',
+      externalId: 'certification-centers.externalId',
+    })
+    .rightJoin('certification-centers', 'certification-centers.id', 'fct_structures.certification_center_id')
+    .where({ organization_id: organizationId });
 
-function _toDomain(certificationCenterDTO) {
+  return certificationCenters.map(
+    (certificationCenter) =>
+      new AttachedCertificationCenter({
+        id: certificationCenter.id,
+        name: certificationCenter.name,
+        externalId: certificationCenter.externalId,
+      }),
+  );
+};
+
+export { archive, findAttachedByOrganizationId, save, update };
+
+function _toDomainCenterForAdmin(certificationCenterDTO) {
   return new CenterForAdmin({
     center: {
       id: certificationCenterDTO.id,

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1643,6 +1643,34 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       expect(response.result.data.id).to.equal(`${organizationId}_organization_statistics`);
     });
   });
+
+  describe('GET /api/organizations/{id}/certification-centers', function () {
+    it('should return certification-center attached to a given organization and http code 200', async function () {
+      // given
+      const server = await createServer();
+
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({
+        certificationCenterId: certificationCenter.id,
+      });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/organizations/${organization.id}/certification-centers`,
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].type).to.equal('certification-centers');
+    });
+  });
 });
 
 function _createMultipartPayload({ boundary, filename, fieldName, contentType, content }) {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin.repository.test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import { AttachedCertificationCenter } from '../../../../../src/organizational-entities/domain/models/AttachedCertificationCenter.js';
 import { CenterForAdmin } from '../../../../../src/organizational-entities/domain/models/CenterForAdmin.js';
 import * as certificationCenterForAdminRepository from '../../../../../src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -122,6 +123,68 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
             archiveDate,
           }),
         ).to.be.rejectedWith(NotFoundError);
+      });
+    });
+  });
+
+  describe('#findAttachedByOrganizationId', function () {
+    describe('when a given organization is linked to a certification center', function () {
+      it('returns certification center linked to a given organization', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+        const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({ certificationCenterId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundCertificationCenter = await certificationCenterForAdminRepository.findAttachedByOrganizationId(
+          organization.id,
+        );
+
+        // then
+        expect(foundCertificationCenter).to.have.lengthOf(1);
+        expect(foundCertificationCenter[0].id).to.equal(certificationCenterId);
+        expect(foundCertificationCenter[0]).to.be.instanceOf(AttachedCertificationCenter);
+      });
+
+      it('does not return certification center linked to another organization', async function () {
+        // given
+        const firstCertificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        const { organization: firstOrganization } = databaseBuilder.factory.buildOrganizationWithStructure({
+          certificationCenterId: firstCertificationCenter.id,
+        });
+
+        const secondCertificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        databaseBuilder.factory.buildOrganizationWithStructure({
+          certificationCenterId: secondCertificationCenter.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundCertificationCenter = await certificationCenterForAdminRepository.findAttachedByOrganizationId(
+          firstOrganization.id,
+        );
+
+        // then
+        expect(foundCertificationCenter[0].id).to.equal(firstCertificationCenter.id);
+      });
+    });
+
+    describe('when a given organization has no linked certification center', function () {
+      it('returns an empty array', async function () {
+        // given
+        const { organization } = databaseBuilder.factory.buildOrganizationWithStructure();
+        await databaseBuilder.commit();
+
+        // when
+        const foundCertificationCenter = await certificationCenterForAdminRepository.findAttachedByOrganizationId(
+          organization.id,
+        );
+
+        // then
+        expect(foundCertificationCenter).to.be.an('array').that.is.empty;
       });
     });
   });

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
@@ -10,6 +10,7 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
   let httpTestServer;
 
   beforeEach(async function () {
+    sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
   });
@@ -63,12 +64,7 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
     describe('when the user authenticated has no role', function () {
       it('returns a 403 HTTP status code', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) =>
-          h
-            .response({ errors: new Error('forbidden') })
-            .code(403)
-            .takeover(),
-        );
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
         sinon.stub(organizationAdminController, 'getOrganizationPlacesStatistics');
 
         // when
@@ -92,7 +88,7 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
         it('returns a 200 HTTP status code', async function () {
           // given
           sinon.stub(securityPreHandlers, stub).callsFake((request, h) => h.response(true));
-          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').callsFake((_handlers) => {
+          securityPreHandlers.hasAtLeastOneAccessOf.callsFake((_handlers) => {
             return () => true;
           });
           sinon.stub(organizationAdminController, 'getOrganizationPlacesStatistics').returns('ok');
@@ -112,12 +108,7 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
     describe('when the user authenticated has no role', function () {
       it('returns a 403 HTTP status code', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) =>
-          h
-            .response({ errors: new Error('forbidden') })
-            .code(403)
-            .takeover(),
-        );
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
         sinon.stub(organizationAdminController, 'getOrganizationStatistics');
 
         // when
@@ -141,7 +132,7 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
         it('returns a 200 HTTP status code', async function () {
           // given
           sinon.stub(securityPreHandlers, stub).callsFake((request, h) => h.response(true));
-          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').callsFake((_handlers) => {
+          securityPreHandlers.hasAtLeastOneAccessOf.callsFake((_handlers) => {
             return () => true;
           });
           sinon.stub(organizationAdminController, 'getOrganizationStatistics').returns('ok');
@@ -152,6 +143,51 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
           // then
           expect(response.statusCode).to.equal(200);
           sinon.assert.calledOnce(organizationAdminController.getOrganizationStatistics);
+        });
+      });
+    });
+  });
+
+  describe('GET /api/admin/organizations/{id}/certification-centers', function () {
+    describe('when the user authenticated has no role', function () {
+      it('returns a 403 HTTP status code', async function () {
+        // given
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
+
+        sinon.stub(organizationAdminController, 'findAttachedCertificationCenterForAdmin');
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/organizations/1/certification-centers');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(organizationAdminController.findAttachedCertificationCenterForAdmin);
+      });
+    });
+
+    const authorizedRoles = [
+      { role: 'SuperAdmin', stub: 'checkAdminMemberHasRoleSuperAdmin' },
+      { role: 'Support', stub: 'checkAdminMemberHasRoleSupport' },
+      { role: 'Certif', stub: 'checkAdminMemberHasRoleCertif' },
+      { role: 'Metier', stub: 'checkAdminMemberHasRoleMetier' },
+    ];
+
+    authorizedRoles.forEach(({ role, stub }) => {
+      describe(`when the user has ${role} role`, function () {
+        it('returns a 200 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, stub).callsFake((request, h) => h.response(true));
+          securityPreHandlers.hasAtLeastOneAccessOf.callsFake((_handlers) => {
+            return () => true;
+          });
+          sinon.stub(organizationAdminController, 'findAttachedCertificationCenterForAdmin').returns('ok');
+
+          // when
+          const response = await httpTestServer.request('GET', '/api/admin/organizations/1/certification-centers');
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          sinon.assert.calledOnce(organizationAdminController.findAttachedCertificationCenterForAdmin);
         });
       });
     });

--- a/api/tests/organizational-entities/unit/domain/usecases/find-attached-certification-center-for-admin.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/find-attached-certification-center-for-admin.usecase.test.js
@@ -1,0 +1,28 @@
+import sinon from 'sinon';
+
+import { findAttachedCertificationCenterForAdmin } from '../../../../../src/organizational-entities/domain/usecases/find-attached-certification-center-for-admin.usecase.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Domain | UseCase | find-attached-center-for-admin', function () {
+  let certificationCenterForAdminRepository;
+
+  beforeEach(function () {
+    certificationCenterForAdminRepository = {
+      findAttachedByOrganizationId: sinon.stub(),
+    };
+  });
+
+  it('calls findAttachedByOrganizationId with the given organizationId', async function () {
+    // given
+    const organizationId = 123;
+    certificationCenterForAdminRepository.findAttachedByOrganizationId.resolves([]);
+
+    // when
+    await findAttachedCertificationCenterForAdmin({ organizationId, certificationCenterForAdminRepository });
+
+    // then
+    expect(certificationCenterForAdminRepository.findAttachedByOrganizationId).to.have.been.calledOnceWithExactly(
+      organizationId,
+    );
+  });
+});


### PR DESCRIPTION
## 🚙 Problème

Afin d'afficher les détails d'un centre de certification associé à une organisation au sein d'un réseau, nous avons besoin d'exposer une route.

## 🍃 Proposition

Créer la route

## 🔗 Pour tester

Lancer ce curl et constater que la route renvoie les infos du centre de certification associé à l'organisation

```
TOKEN=$(curl -s -X POST https://admin-pr16479.review.pix.fr/api/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=password&username=superadmin@example.net&password=pix123" \
  | jq -r '.access_token') && \
curl -s https://admin-pr16479.review.pix.fr/api/admin/organizations/156363/certification-centers \
  -H "Authorization: Bearer $TOKEN" | jq
```

<img width="572" height="287" alt="image" src="https://github.com/user-attachments/assets/bed21906-1dbe-4a7e-916a-bab229f7033c" />
