### PR TITLE
[FEATURE] Accepter les CGU Pix App avec le nouveau modèle (PIX-21743) 

### DIFF
--- a/api/db/database-builder/factory/build-legal-document-version.js
+++ b/api/db/database-builder/factory/build-legal-document-version.js
@@ -1,3 +1,5 @@
+import { LegalDocumentService } from '../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import { databaseBuffer } from '../database-buffer.js';
 
 const buildLegalDocumentVersion = function ({
@@ -12,4 +14,11 @@ const buildLegalDocumentVersion = function ({
   });
 };
 
-export { buildLegalDocumentVersion };
+const buildPixAppTos = function () {
+  return buildLegalDocumentVersion({
+    service: LegalDocumentService.VALUES.PIX_APP,
+    type: LegalDocumentType.VALUES.TOS,
+  });
+};
+
+export { buildLegalDocumentVersion, buildPixAppTos };

--- a/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
@@ -26,6 +26,7 @@ async function createOidcUser({
   audience,
   authenticationSessionService,
   oidcAuthenticationServiceRegistry,
+  legalDocumentApiRepository,
   authenticationMethodRepository,
   userToCreateRepository,
   userLoginRepository,
@@ -73,6 +74,8 @@ async function createOidcUser({
     userToCreateRepository,
     authenticationMethodRepository,
   });
+
+  await legalDocumentApiRepository.acceptPixAppTos({ userId });
 
   await _updateUserLastConnection({
     userId,

--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -30,6 +30,7 @@ const createUser = async function ({
   emailValidationDemandRepository,
   userRepository,
   userToCreateRepository,
+  legalDocumentApiRepository,
   cryptoService,
   userService,
   userValidator,
@@ -42,6 +43,7 @@ const createUser = async function ({
     userValidator,
     passwordValidator,
   });
+
   const userHasValidatedPixTermsOfService = user.cgu === true;
   if (userHasValidatedPixTermsOfService) {
     user.lastTermsOfServiceValidatedAt = new Date();
@@ -57,6 +59,8 @@ const createUser = async function ({
       userToCreateRepository,
       authenticationMethodRepository,
     });
+
+    await legalDocumentApiRepository.acceptPixAppTos({ userId: savedUser.id });
 
     const token = await emailValidationDemandRepository.save(savedUser.id);
 

--- a/api/src/identity-access-management/domain/usecases/upgrade-to-real-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/upgrade-to-real-user.usecase.js
@@ -14,6 +14,7 @@ const upgradeToRealUser = async function ({
   authenticationMethodRepository,
   emailValidationDemandRepository,
   emailRepository,
+  legalDocumentApiRepository,
   cryptoService,
 }) {
   const user = await userRepository.getFullById(userId);
@@ -40,6 +41,8 @@ const upgradeToRealUser = async function ({
       }),
     });
     await authenticationMethodRepository.create({ authenticationMethod });
+
+    await legalDocumentApiRepository.acceptPixAppTos({ userId });
 
     const token = await emailValidationDemandRepository.save(realUser.id);
 

--- a/api/src/identity-access-management/scripts/mass-create-user-accounts.js
+++ b/api/src/identity-access-management/scripts/mass-create-user-accounts.js
@@ -7,6 +7,7 @@ import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
 import { cryptoService } from '../../shared/domain/services/crypto-service.js';
 import * as userService from '../domain/services/user-service.js';
 import * as authenticationMethodRepository from '../infrastructure/repositories/authentication-method.repository.js';
+import { legalDocumentApiRepository } from '../infrastructure/repositories/legal-document-api.repository.js';
 import { userToCreateRepository } from '../infrastructure/repositories/user-to-create.repository.js';
 
 export const csvSchemas = [
@@ -50,12 +51,14 @@ export class MassCreateUserAccountsScript extends Script {
         };
         const hashedPassword = await cryptoService.hashPassword(userDTO.password);
 
-        await userService.createUserWithPassword({
+        const savedUser = await userService.createUserWithPassword({
           user: userToCreate,
           hashedPassword,
           userToCreateRepository,
           authenticationMethodRepository,
         });
+
+        await legalDocumentApiRepository.acceptPixAppTos({ userId: savedUser.id });
       }
     });
   }

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -382,6 +382,9 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
 
     it('returns an accessToken with a 200 HTTP status code', async function () {
       // given
+      const pixAppTos = databaseBuilder.factory.buildPixAppTos();
+      await databaseBuilder.commit();
+
       const start = new Date();
       const firstName = 'Brice';
       const lastName = 'Glace';
@@ -448,6 +451,9 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
       const lastUserApplicationConnection = await knex('last-user-application-connections').first();
       expect(lastUserApplicationConnection.application).to.equal('app');
       expect(lastUserApplicationConnection.lastLoggedAt).to.be.greaterThanOrEqual(start);
+
+      const legalDocumentAcceptation = await knex('legal-document-version-user-acceptances').first();
+      expect(legalDocumentAcceptation.legalDocumentVersionId).to.equal(pixAppTos.id);
     });
 
     context('when authentication key has expired', function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-user.usecase.test.js
@@ -2,10 +2,14 @@ import { User } from '../../../../../src/identity-access-management/domain/model
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { expect } from '../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | create-user', function () {
   it('returns the saved user', async function () {
     // given
+    const pixAppTos = databaseBuilder.factory.buildPixAppTos();
+    await databaseBuilder.commit();
+
     const userData = { firstName: 'First', lastName: 'Last', email: 'first.last@example.net', cgu: true };
     const user = new User(userData);
     const password = 'P@ssW0rd';
@@ -16,5 +20,12 @@ describe('Integration | Identity Access Management | Domain | UseCase | create-u
     // then
     expect(savedUser).to.be.instanceOf(User);
     expect(savedUser).to.include(userData);
+    expect(savedUser.cgu).to.be.true;
+    expect(savedUser.lastTermsOfServiceValidatedAt).to.be.instanceOf(Date);
+
+    const legalDocumentAcceptation = await knex('legal-document-version-user-acceptances')
+      .where({ userId: savedUser.id })
+      .first();
+    expect(legalDocumentAcceptation.legalDocumentVersionId).to.equal(pixAppTos.id);
   });
 });

--- a/api/tests/identity-access-management/integration/domain/usecases/upgrade-to-real-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/upgrade-to-real-user.usecase.test.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
@@ -9,19 +7,9 @@ import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | upgradeToRealUser', function () {
-  let clock;
-
-  beforeEach(function () {
-    const now = new Date('2024-12-25');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
-  });
-
   it('upgrades an anonymous user to a real user', async function () {
     // given
+    const pixAppTos = databaseBuilder.factory.buildPixAppTos();
     const anonymousUser = databaseBuilder.factory.buildUser.anonymous();
     await databaseBuilder.commit();
 
@@ -52,6 +40,11 @@ describe('Integration | Identity Access Management | Domain | UseCase | upgradeT
 
     const authenticationMethod = await knex('authentication-methods').where({ userId: realUser.id }).first();
     expect(authenticationMethod.identityProvider).to.equal(NON_OIDC_IDENTITY_PROVIDERS.PIX.code);
+
+    const legalDocumentAcceptation = await knex('legal-document-version-user-acceptances')
+      .where({ userId: realUser.id })
+      .first();
+    expect(legalDocumentAcceptation.legalDocumentVersionId).to.equal(pixAppTos.id);
 
     await expect('SendEmailJob').to.have.been.performed.withJobsCount(1);
   });

--- a/api/tests/identity-access-management/integration/scripts/mass-create-user-accounts.script.test.js
+++ b/api/tests/identity-access-management/integration/scripts/mass-create-user-accounts.script.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import { MassCreateUserAccountsScript } from '../../../../src/identity-access-management/scripts/mass-create-user-accounts.js';
 import { expect } from '../../../test-helper.js';
-import { knex } from '../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../tooling/databases.js';
 
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -44,19 +44,17 @@ describe('Integration | Identity Access Management | Scripts | mass-create-user-
   });
 
   describe('#handle', function () {
-    const now = new Date();
-    let clock;
+    const now = new Date('2026-06-01');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should insert users', async function () {
       // given
+      const pixAppTos = databaseBuilder.factory.buildPixAppTos();
+      await databaseBuilder.commit();
+
       const usersInRaw = [
         {
           firstName: 'Sandy',
@@ -78,16 +76,16 @@ describe('Integration | Identity Access Management | Scripts | mass-create-user-
 
       // then
       const firstUserFound = await knex('users').where({ lastName: 'Kilo' }).first();
-      expect(firstUserFound).to.contains({
+      expect(firstUserFound).to.deep.contains({
         firstName: 'Sandy',
         lastName: 'Kilo',
         email: 'sandy-kilo@example.net',
         cgu: true,
+        lastTermsOfServiceValidatedAt: now,
+        mustValidateTermsOfService: false,
         pixCertifTermsOfServiceAccepted: false,
         hasSeenAssessmentInstructions: false,
         username: null,
-        mustValidateTermsOfService: false,
-        lastTermsOfServiceValidatedAt: null,
         lang: 'fr',
         hasSeenNewDashboardInfo: false,
         isAnonymous: false,
@@ -95,9 +93,14 @@ describe('Integration | Identity Access Management | Scripts | mass-create-user-
         hasSeenFocusedChallengeTooltip: false,
         hasSeenOtherChallengesTooltip: false,
         lastPixCertifTermsOfServiceValidatedAt: null,
+        createdAt: now,
+        updatedAt: now,
       });
-      expect(firstUserFound.createdAt).to.deep.equal(now);
-      expect(firstUserFound.updatedAt).to.deep.equal(now);
+
+      const legalDocumentAcceptation = await knex('legal-document-version-user-acceptances')
+        .where({ userId: firstUserFound.id })
+        .first();
+      expect(legalDocumentAcceptation.legalDocumentVersionId).to.equal(pixAppTos.id);
 
       const secondUserFound = await knex('users').where({ lastName: 'Desavoie' }).first();
       expect(secondUserFound).to.contains({

--- a/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
@@ -9,6 +9,7 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-user', function () {
   let authenticationMethodRepository;
   let userToCreateRepository;
+  let legalDocumentApiRepository;
   let authenticationSessionService;
   let oidcAuthenticationService;
   let oidcAuthenticationServiceRegistry;
@@ -17,6 +18,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
     authenticationMethodRepository = {
       findOneByExternalIdentifierAndIdentityProvider: sinon.stub(),
       updateLastLoggedAtByIdentityProvider: sinon.stub(),
+    };
+
+    legalDocumentApiRepository = {
+      acceptPixAppTos: sinon.stub(),
     };
 
     authenticationSessionService = {
@@ -30,6 +35,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
       createAccessToken: sinon.stub(),
       saveIdToken: sinon.stub(),
     };
+
     oidcAuthenticationServiceRegistry = {
       getOidcProviderServiceByCode: sinon.stub().returns(oidcAuthenticationService),
     };
@@ -46,6 +52,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
         authenticationKey,
         authenticationMethodRepository,
         userToCreateRepository,
+        legalDocumentApiRepository,
         authenticationSessionService,
       });
 
@@ -74,6 +81,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
         oidcAuthenticationServiceRegistry,
         authenticationMethodRepository,
         userToCreateRepository,
+        legalDocumentApiRepository,
       });
 
       // then

--- a/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
@@ -29,6 +29,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
   let passwordValidator;
   let userValidator;
   let emailValidationDemandRepository;
+  let legalDocumentApiRepository;
   let token;
 
   beforeEach(function () {
@@ -42,6 +43,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
     userToCreateRepository = { create: sinon.stub() };
     emailRepository = { sendEmailAsync: sinon.stub() };
     campaignRepository = { getByCode: sinon.stub() };
+    legalDocumentApiRepository = { acceptPixAppTos: sinon.stub() };
 
     cryptoService = { hashPassword: sinon.stub() };
     userService = { createUserWithPassword: sinon.stub() };
@@ -83,6 +85,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         emailValidationDemandRepository,
         userRepository,
         userToCreateRepository,
+        legalDocumentApiRepository,
         cryptoService,
         userService,
         userValidator,
@@ -106,6 +109,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         emailValidationDemandRepository,
         userRepository,
         userToCreateRepository,
+        legalDocumentApiRepository,
         cryptoService,
         userService,
         userValidator,
@@ -129,6 +133,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         emailValidationDemandRepository,
         userRepository,
         userToCreateRepository,
+        legalDocumentApiRepository,
         cryptoService,
         userService,
         userValidator,
@@ -166,6 +171,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
+          legalDocumentApiRepository,
           cryptoService,
           userService,
           userValidator,
@@ -208,6 +214,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
+          legalDocumentApiRepository,
           cryptoService,
           userService,
           userValidator,
@@ -252,6 +259,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
+          legalDocumentApiRepository,
           cryptoService,
           userService,
           userValidator,
@@ -261,68 +269,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // then
         expect(error).to.be.instanceOf(EntityValidationError);
         expect(error.invalidAttributes).to.have.lengthOf(3);
-      });
-    });
-
-    context('when user has accepted terms of service', function () {
-      it('should update the validation date', async function () {
-        // given
-        const user = new User({
-          email: userEmail,
-          cgu: true,
-        });
-
-        // when
-        await createUser({
-          user,
-          locale,
-          password,
-          campaignCode,
-          authenticationMethodRepository,
-          campaignRepository,
-          emailRepository,
-          emailValidationDemandRepository,
-          userRepository,
-          userToCreateRepository,
-          cryptoService,
-          userService,
-          userValidator,
-          passwordValidator,
-        });
-
-        // then
-        expect(user.lastTermsOfServiceValidatedAt).to.be.an.instanceOf(Date);
-      });
-    });
-
-    context('when user has not accepted terms of service', function () {
-      it('should not update the validation date', async function () {
-        // given
-        const user = new User({
-          email: userEmail,
-          cgu: false,
-        });
-
-        // when
-        await createUser({
-          user,
-          locale,
-          password,
-          campaignCode,
-          authenticationMethodRepository,
-          campaignRepository,
-          emailRepository,
-          emailValidationDemandRepository,
-          userRepository,
-          userToCreateRepository,
-          cryptoService,
-          userService,
-          userValidator,
-          passwordValidator,
-        });
-
-        // then
-        expect(user.lastTermsOfServiceValidatedAt).not.to.be.an.instanceOf(Date);
       });
     });
   });
@@ -342,6 +288,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         campaignRepository,
         emailRepository,
         emailValidationDemandRepository,
+        legalDocumentApiRepository,
         userRepository,
         cryptoService,
         userService,
@@ -369,6 +316,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
+          legalDocumentApiRepository,
           cryptoService,
           userService,
           userValidator,
@@ -395,6 +343,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
+          legalDocumentApiRepository,
           cryptoService,
           userService,
         });
@@ -416,6 +365,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
+          legalDocumentApiRepository,
           cryptoService,
           userService,
           userValidator,
@@ -463,6 +413,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
+          legalDocumentApiRepository,
           cryptoService,
           userService,
           userValidator,
@@ -498,6 +449,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
             emailValidationDemandRepository,
             userRepository,
             userToCreateRepository,
+            legalDocumentApiRepository,
             cryptoService,
             userService,
             userValidator,
@@ -535,6 +487,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
             emailValidationDemandRepository,
             userRepository,
             userToCreateRepository,
+            legalDocumentApiRepository,
             cryptoService,
             userService,
             userValidator,
@@ -572,6 +525,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         emailValidationDemandRepository,
         userRepository,
         userToCreateRepository,
+        legalDocumentApiRepository,
         cryptoService,
         userService,
         userValidator,


### PR DESCRIPTION
## 🚙 Problème

Avec le nouveau système des documents légaux, on souhaite l'utiliser pour accepter les CGU Pix App quand l'utilisateur créé son compte.

## 🍃 Proposition

Appeler l'API d'acceptation des CGU Pix App pour les cas d'utilisation suivants : 
1. Création de compte via email et mot de passe 
2. Création de compte via OIDC
3. Conversion d'un compte anonyme en compte réel
4. Script de création de comptes en masse

## 🦵 Remarques

Pour les cas d'utilisation suivants, on ne doit pas accepter les CGU : 
1. Création de compte d'élève via email/username et mot de passe
2. Création de compte d'élève via le GAR

## 🔗 Pour tester

**Pré-requis:** Créer un document des CGU Pix App
```shell
node src/legal-documents/scripts/add-new-legal-document-version.js --type=TOS --service=pix-app --versionAt=2026-05-05
```

**Scénario 1:** Création de compte via email et mot de passe 

**Scénario 2:** Création de compte via OIDC

**Scénario 3:** Conversion d'un compte anonyme en compte réel
1. Parcours utilisateur anonyme: `https://app.dev.pix.fr/campagnes/AUTOCOUR1`
2. Créer le compte en fin de parcours

**Scénario 4:** Script de création de comptes en masse
```bash
node src/identity-access-management/scripts/mass-create-user-accounts.js --env-file=.env --file /tmp/uploads/file.csv
```

Avec un fichier CSV du type:
```csv
firstName,lastName,email,password
Dik,Tektive,dik.tektive@example.net,P@ssW0rd
Dik2,Tektive2,dik2.tektive2@example.net,P@ssW0rd
```

**Pour chaque scénario vérifier que :**
- table `users` avec `cgu=true` et `mustValidateTermsOfService=false`
- table `legal-document-version-user-acceptances` vérifier l'utilisateur apparaît pour les CGU de Pix App