### PR TITLE
[FEATURE] Afficher un QCM déclaratif dans un Module (PIX-22844)

### DIFF
--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -13,6 +13,7 @@ import FlashcardsElement from 'mon-pix/components/module/element/flashcards/flas
 import ImageElement from 'mon-pix/components/module/element/image';
 import QabElement from 'mon-pix/components/module/element/qab/qab';
 import QcmElement from 'mon-pix/components/module/element/qcm';
+import QcmDeclarativeElement from 'mon-pix/components/module/element/qcm-declarative';
 import QcuElement from 'mon-pix/components/module/element/qcu';
 import QcuDeclarativeElement from 'mon-pix/components/module/element/qcu-declarative';
 import QcuDiscoveryElement from 'mon-pix/components/module/element/qcu-discovery';
@@ -84,6 +85,8 @@ export default class ModulixElement extends Component {
         @correction={{this.getLastCorrectionForElement @element}}
         @updateSkipButton={{@updateSkipButton}}
       />
+    {{else if (eq @element.type "qcm-declarative")}}
+      <QcmDeclarativeElement @element={{@element}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "qrocm")}}
       <QrocmElement
         @element={{@element}}

--- a/mon-pix/app/components/module/element/_qcm-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcm-declarative.scss
@@ -1,0 +1,93 @@
+@use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
+
+.element-qcm-declarative {
+  width: 100%;
+  padding: var(--pix-spacing-6x);
+  padding-bottom: var(--pix-spacing-10x);
+  background-color: rgb(var(--pix-primary-100-inline), 0.6);
+  border-radius: var(--pix-spacing-4x) var(--pix-spacing-4x) 0 0;
+
+  &__instruction {
+    @extend %pix-body-m;
+
+    padding-bottom: var(--pix-spacing-3x);
+    font-weight: var(--pix-font-bold);
+  }
+
+  &__complementary-instruction {
+    @extend %pix-body-s;
+
+    margin: var(--pix-spacing-3x) 0;
+    color: var(--pix-neutral-500);
+  }
+
+  &__short-proposals,
+  &__proposals,
+  &__3-short-proposals {
+    margin-top: var(--pix-spacing-4x);
+  }
+
+  &__proposals {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__short-proposals {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &__3-short-proposals {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  &--submit {
+    margin-top: var(--pix-spacing-6x);
+  }
+
+  @include breakpoints.device-is('mobile') {
+    &__short-proposals,
+    &__3-short-proposals {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__feedback {
+    @media (not (prefers-reduced-motion: reduce)) {
+      animation: 0.75s zoom-in-zoom-out ease;
+
+      @keyframes zoom-in-zoom-out {
+        0% {
+          scale: 100%;
+          overflow: hidden;
+        }
+
+        50% {
+          scale: 110%;
+        }
+
+        100% {
+          scale: 100%;
+        }
+      }
+    }
+  }
+}
+
+.element-qcm-declarative-feedback {
+  &__content {
+    @extend %pix-body-l;
+
+    padding: var(--pix-spacing-6x);
+    color: var(--pix-neutral-0);
+    background: var(--pix-neutral-800);
+    border-radius: 0 0 var(--pix-spacing-4x) var(--pix-spacing-4x);
+  }
+
+  &__report-button {
+    display: flex;
+    justify-content: flex-end;
+  }
+}

--- a/mon-pix/app/components/module/element/_qcm-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcm-declarative.scss
@@ -19,7 +19,7 @@
     @extend %pix-body-s;
 
     margin: var(--pix-spacing-3x) 0;
-    color: var(--pix-neutral-500);
+    color: var(--pix-neutral-800);
   }
 
   &__short-proposals,

--- a/mon-pix/app/components/module/element/qcm-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcm-declarative.gjs
@@ -1,0 +1,124 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import { VERIFY_RESPONSE_DELAY } from '../component/element';
+import ModulixIssueReportBlock from '../issue-report/issue-report-block';
+import ModuleElement from './module-element';
+
+export default class ModuleQcmDeclarative extends ModuleElement {
+  @service modulixPreviewMode;
+  @service passageEvents;
+
+  @tracked selectedProposalIds = new Set();
+  @tracked shouldDisplayFeedback = false;
+  @tracked reportInfo = {};
+  @tracked isAnswering = false;
+  @tracked isSubmitted = false;
+
+  get feedback() {
+    return this.element.feedback.diagnosis;
+  }
+
+  get disableInput() {
+    return this.isSubmitted || this.isAnswering;
+  }
+
+  get canValidateElement() {
+    return false;
+  }
+
+  @action
+  checkboxSelected(proposalId) {
+    if (this.selectedProposalIds.has(proposalId)) {
+      this.selectedProposalIds.delete(proposalId);
+    } else {
+      this.selectedProposalIds.add(proposalId);
+    }
+  }
+
+  @action
+  async onAnswer(event) {
+    event.preventDefault();
+    this.isAnswering = true;
+    const answer = [...this.selectedProposalIds];
+    super.onAnswer(event);
+
+    await this.waitFor(VERIFY_RESPONSE_DELAY);
+    await this.args.onAnswer({ element: this.element });
+    this.reportInfo = {
+      answer: answer.join(', '),
+      elementId: this.element.id,
+    };
+
+    this.isSubmitted = true;
+    this.shouldDisplayFeedback = true;
+    this.passageEvents.record({
+      type: 'QCM_DECLARATIVE_ANSWERED',
+      data: {
+        elementId: this.element.id,
+        answer,
+      },
+    });
+  }
+
+  waitFor(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
+  }
+
+  <template>
+    <form class="element-qcm-declarative" onSubmit={{this.onAnswer}} aria-describedby="instruction-{{this.element.id}}">
+      <fieldset>
+        <legend class="screen-reader-only">
+          {{t "pages.modulix.qcmDeclarative.direction"}}
+        </legend>
+        <p class="element-qcm-declarative__instruction" id="instruction-{{this.element.id}}">
+          {{htmlUnsafe this.element.instruction}}
+        </p>
+        <p class="element-qcm-declarative__complementary-instruction">
+          {{t "pages.modulix.qcmDeclarative.complementaryInstruction"}}
+        </p>
+        <div role="region" class="element-qcm-declarative__{{this.proposalsStyle}}">
+          {{#each this.element.proposals as |proposal|}}
+            <PixCheckbox
+              name={{this.proposal.id}}
+              @isDisabled={{this.disableInput}}
+              @variant="modulix"
+              {{on "click" (fn this.checkboxSelected proposal.id)}}
+            >
+              <:label>{{htmlUnsafe proposal.content}}</:label>
+            </PixCheckbox>
+          {{/each}}
+          {{#if this.modulixPreviewMode.isEnabled}}
+            <div class="element-qcm-declarative__feedback" role="status" tabindex="-1">
+              <div class="element-qcm-declarative-feedback__content">
+                {{htmlUnsafe this.element.feedback.diagnosis}}
+              </div>
+            </div>
+          {{/if}}
+        </div>
+        {{#unless this.isSubmitted}}
+          <PixButton class="element-qcm-declarative--submit" @triggerAction={{this.onAnswer}}>{{t
+              "pages.modulix.buttons.activity.submit"
+            }}</PixButton>
+        {{/unless}}
+      </fieldset>
+    </form>
+    {{#if this.shouldDisplayFeedback}}
+      <div class="element-qcm-declarative__feedback" role="status" tabindex="-1">
+        <div class="element-qcm-declarative-feedback__content">
+          {{htmlUnsafe this.feedback}}
+        </div>
+        <div class="element-qcm-declarative-feedback__report-button">
+          <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
+        </div>
+      </div>
+    {{/if}}
+  </template>
+}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -38,6 +38,7 @@ export default class ModuleGrain extends Component {
     'qcu-declarative',
     'qcu-discovery',
     'qcm',
+    'qcm-declarative',
     'qrocm',
     'separator',
     'text',
@@ -54,7 +55,7 @@ export default class ModuleGrain extends Component {
     'transition',
   ];
 
-  static LOCALLY_ANSWERABLE_ELEMENTS = ['qab', 'qcu-declarative', 'qcu-discovery', 'flashcards'];
+  static LOCALLY_ANSWERABLE_ELEMENTS = ['qab', 'qcm-declarative', 'qcu-declarative', 'qcu-discovery', 'flashcards'];
 
   @tracked isStepperFinished = this.hasStepper === false;
 

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -110,6 +110,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use '../components/module/element/qcu-declarative' as *;
 @use '../components/module/element/qcu-discovery' as *;
 @use '../components/module/element/qcm' as *;
+@use '../components/module/element/qcm-declarative' as *;
 @use '../components/module/element/qrocm' as *;
 @use '../components/module/element/separator' as *;
 @use '../components/module/element/text' as *;

--- a/mon-pix/tests/integration/components/module/qcm-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm-declarative_test.gjs
@@ -1,0 +1,180 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+// eslint-disable-next-line no-restricted-imports
+import { click, find } from '@ember/test-helpers';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
+import ModuleQcmDeclarative from 'mon-pix/components/module/element/qcm-declarative';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | QcmDeclarative', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let clock;
+
+  hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers();
+  });
+
+  hooks.afterEach(function () {
+    clock.restore();
+  });
+
+  test('it should display an instruction, a complementary instruction and a list of proposals', async function (assert) {
+    // given
+    const qcmDeclarativeElement = _getQcmDeclarativeElement();
+    const { complementaryInstruction, proposals } = qcmDeclarativeElement;
+
+    // when
+    const screen = await render(<template><ModuleQcmDeclarative @element={{qcmDeclarativeElement}} /></template>);
+    const form = find('form');
+    const submitButton = screen.getByRole('button', { name: 'Soumettre ma sélection' });
+
+    // then
+    assert.dom(form).exists();
+    assert.ok(screen.getByText('Lesquels de ces oiseaux croisez-vous près de chez vous ?'));
+    assert.ok(screen.getByText(complementaryInstruction));
+    assert.strictEqual(screen.getAllByRole('checkbox').length, qcmDeclarativeElement.proposals.length);
+    assert.ok(screen.getByLabelText(proposals[0].content));
+    assert.ok(screen.getByLabelText(proposals[1].content));
+    assert.ok(screen.getByLabelText(proposals[2].content));
+    assert.ok(screen.getByLabelText(proposals[3].content));
+    assert.dom(submitButton).exists();
+  });
+
+  module('when user clicks on several propositions', function () {
+    test('should disable interaction, call action, send an event when submit button is clicked, then display feedback and hide submit button', async function (assert) {
+      // given
+      const onAnswerStub = sinon.stub();
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const qcmDeclarativeElement = _getQcmDeclarativeElement();
+      const { proposals, feedback } = qcmDeclarativeElement;
+
+      // when
+      const screen = await render(
+        <template><ModuleQcmDeclarative @element={{qcmDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+
+      const proposal1Element = screen.getByLabelText(proposals[0].content);
+      const proposal2Element = screen.getByLabelText(proposals[1].content);
+      const proposal3Element = screen.getByLabelText(proposals[2].content);
+      const proposal4Element = screen.getByLabelText(proposals[3].content);
+      await click(proposal1Element);
+      await click(proposal3Element);
+
+      const submitButton = screen.getByRole('button', { name: 'Soumettre ma sélection' });
+      await click(submitButton);
+
+      // then
+      assert.dom(proposal1Element).hasAria('disabled', 'true');
+      assert.dom(proposal2Element).hasAria('disabled', 'true');
+      assert.dom(proposal3Element).hasAria('disabled', 'true');
+      assert.dom(proposal4Element).hasAria('disabled', 'true');
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+      sinon.assert.calledWith(onAnswerStub, { element: qcmDeclarativeElement });
+
+      assert.dom(screen.getByText(feedback.diagnosis)).exists();
+
+      assert.dom(screen.queryByRole('button', { name: 'Soumettre ma sélection' })).doesNotExist();
+      assert.dom(screen.getByText('Signaler')).exists();
+    });
+
+    test('it should record a passage-event', async function (assert) {
+      // given
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      const passageEventRecordStub = sinon.stub(passageEventService, 'record');
+      const onAnswerStub = sinon.stub();
+
+      const qcmDeclarativeElement = _getQcmDeclarativeElement();
+
+      // when
+      const screen = await render(
+        <template><ModuleQcmDeclarative @element={{qcmDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+      const submitButton = screen.getByRole('button', { name: 'Soumettre ma sélection' });
+      await submitButton.click();
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
+
+      // then
+      sinon.assert.calledWithExactly(onAnswerStub, {
+        element: qcmDeclarativeElement,
+      });
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'QCM_DECLARATIVE_ANSWERED',
+        data: {
+          elementId: qcmDeclarativeElement.id,
+          answer: [],
+        },
+      });
+      assert.ok(true);
+    });
+  });
+
+  module('when preview mode is enable', function () {
+    test('should display the feedback, without clicking any checkboxes nor submitting', async function (assert) {
+      // given
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+      const qcmDeclarativeElement = _getQcmDeclarativeElement();
+
+      const { feedback } = qcmDeclarativeElement;
+
+      // when
+      const screen = await render(<template><ModuleQcmDeclarative @element={{qcmDeclarativeElement}} /></template>);
+
+      // then
+      assert.dom(screen.getByText(feedback.diagnosis)).exists();
+    });
+  });
+
+  module('when qcm declarative has short proposals', function () {
+    test('should display proposals in a grid', async function (assert) {
+      // given
+      const hasShortProposals = true;
+      const qcmDeclarativeElementWithShortProposals = _getQcmDeclarativeElement(hasShortProposals);
+
+      // when
+      const screen = await render(
+        <template><ModuleQcmDeclarative @element={{qcmDeclarativeElementWithShortProposals}} /></template>,
+      );
+
+      // then
+      const proposalsGroup = screen.getByRole('region');
+      assert.dom(proposalsGroup).hasClass('element-qcm-declarative__short-proposals');
+    });
+  });
+});
+
+function _getQcmDeclarativeElement(hasShortProposals = false) {
+  const instruction = '<p>Lesquels de ces oiseaux croisez-vous près de chez vous ?</p>';
+  const complementaryInstruction = 'Sélectionnez la ou les réponses de votre choix.';
+
+  const proposals = [
+    {
+      id: '1',
+      content: 'Le moineau',
+    },
+    {
+      id: '2',
+      content: 'Le pigeon',
+    },
+    {
+      id: '3',
+      content: 'La mésange charbonière',
+    },
+    {
+      id: '3',
+      content: 'La huppe fasciée',
+    },
+  ];
+  const feedback = {
+    diagnosis: 'Vous en avez de la chance !',
+  };
+
+  return { instruction, hasShortProposals, complementaryInstruction, proposals, feedback };
+}

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1649,6 +1649,7 @@
       "buttons": {
         "activity": {
           "retry": "Erneut versuchen",
+          "submit": "Meine Auswahl absenden",
           "verify": "Meine Antwort überprüfen"
         },
         "element": {
@@ -1868,6 +1869,10 @@
       },
       "qcm": {
         "direction": "Wähle mehrere Antworten aus."
+      },
+      "qcmDeclarative": {
+        "complementaryInstruction": "Wählen Sie den oder die gewünschten Vorschläge aus.",
+        "direction": "Wählen Sie den oder die gewünschten Vorschläge aus."
       },
       "qcu": {
         "direction": "Wähle nur eine Antwort aus."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1649,6 +1649,7 @@
       "buttons": {
         "activity": {
           "retry": "Retry",
+          "submit": "Submit my selection",
           "verify": "Verify my answer"
         },
         "element": {
@@ -1868,6 +1869,10 @@
       },
       "qcm": {
         "direction": "Select several answers."
+      },
+      "qcmDeclarative": {
+        "complementaryInstruction": "Select one or more proposals.",
+        "direction": "Select one or many proposals."
       },
       "qcu": {
         "direction": "Select a single answer."

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1649,6 +1649,7 @@
       "buttons": {
         "activity": {
           "retry": "Volver a intentarlo",
+          "submit": "Enviar mi selección",
           "verify": "Comprobar mi respuesta"
         },
         "element": {
@@ -1868,6 +1869,10 @@
       },
       "qcm": {
         "direction": "Selecciona varias respuestas."
+      },
+      "qcmDeclarative": {
+        "complementaryInstruction": "Seleccione la propuesta o propuestas que desee.",
+        "direction": "Seleccione la propuesta o propuestas que desee."
       },
       "qcu": {
         "direction": "Selecciona una sola respuesta."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1649,6 +1649,7 @@
       "buttons": {
         "activity": {
           "retry": "Réessayer",
+          "submit": "Soumettre ma sélection",
           "verify": "Vérifier ma réponse"
         },
         "element": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1869,6 +1869,10 @@
       "qcm": {
         "direction": "Sélectionnez plusieurs réponses."
       },
+      "qcmDeclarative": {
+        "complementaryInstruction": "Sélectionnez la ou les réponses de votre choix.",
+        "direction": "Sélectionnez la ou les propositions de votre choix."
+      },
       "qcu": {
         "direction": "Sélectionnez une seule réponse."
       },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1649,6 +1649,7 @@
       "buttons": {
         "activity": {
           "retry": "Riprova",
+          "submit": "Invia la mia selezione",
           "verify": "Controlla la mia risposta"
         },
         "element": {
@@ -1868,6 +1869,10 @@
       },
       "qcm": {
         "direction": "Seleziona diverse risposte."
+      },
+      "qcmDeclarative": {
+        "complementaryInstruction": "Seleziona la o le proposte che preferisci.",
+        "direction": "Seleziona la o le proposte che preferisci."
       },
       "qcu": {
         "direction": "Seleziona una sola risposta."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1649,6 +1649,7 @@
       "buttons": {
         "activity": {
           "retry": "Probeer het opnieuw",
+          "submit": "Mijn selectie indienen",
           "verify": "Controleer mijn antwoord"
         },
         "element": {
@@ -1868,6 +1869,10 @@
       },
       "qcm": {
         "direction": "Kies meerdere antwoorden."
+      },
+      "qcmDeclarative": {
+        "complementaryInstruction": "Selecteer het voorstel of de voorstellen van uw keuze.",
+        "direction": "Selecteer het voorstel of de voorstellen van uw keuze."
       },
       "qcu": {
         "direction": "Kies één antwoord"


### PR DESCRIPTION
## 🚙 Problème

L'API est capable de retourner un qcm-declarative, mais PixApp ne sait pas l'afficher.

## 🍃 Proposition

Afficher un QCM-declarative dans un module.
Maquette Figma : https://www.figma.com/design/eO4BQwUjOjesNFBZONwvCP/-MAIN--Modulix?node-id=2107-442&p=f&m=dev

## 🦵 Remarques

- ~~On a modifié `canValidateElement` de `module-element` pour ne pas avoir à l'écrire dans le nouvel elemen (aucune contrainte à cliquer sur le bouton de soumission puisque il est autorisé de ne sélectionner aucune proposition)~~ => UPDATE: on oblige à cocher au moins 1 proposition
- On a dû changer la couleur de l'instruction complémentaire pour être conforme aux exigences d'a11y
- On a ajouté une trace d'apprentissage dans le cas où l'utilisateur répond

## 🔗 Pour tester

- Ouvrir le [bac-a-sable](https://app-pr16483.review.pix.fr/modules/6a68bf32/bac-a-sable)
- Ouvrir la console Développeur
- Trouver le qcm déclaratif et cocher toutes les propositions, puis soumettre
- Vérifier qu'un appel pour enregistrer un passage-event a été fait (`/passage-events`)
- Le feedback s'affiche, le bouton "Soumettre sa sélection" disparaît
- Le bouton "Signaler" devient visible