### PR TITLE
[BUGFIX] Message d'erreur erroné lors d'une tentative d'accès à une session déjà finalisée (PIX-23027)

### DIFF
--- a/api/src/certification/session-management/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session-management/application/http-error-mapper-configuration.js
@@ -8,6 +8,7 @@ import {
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
+  SessionFinalized,
   SessionNotAccessible,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,
@@ -41,6 +42,10 @@ const sessionDomainErrorMappingConfiguration = [
   {
     name: SessionNotAccessible.name,
     httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
+  },
+  {
+    name: SessionFinalized.name,
+    httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code),
   },
   {
     name: InvalidSessionSupervisingLoginError.name,

--- a/api/src/certification/session-management/domain/errors.js
+++ b/api/src/certification/session-management/domain/errors.js
@@ -75,6 +75,12 @@ class SessionNotAccessible extends DomainError {
   }
 }
 
+class SessionFinalized extends DomainError {
+  constructor() {
+    super('Certification session is finalized', 'SESSION_FINALIZED');
+  }
+}
+
 class CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually extends DomainError {
   constructor(message = 'Le signalement ne peut pas être modifié manuellement') {
     super(message);
@@ -105,6 +111,7 @@ export {
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
+  SessionFinalized,
   SessionNotAccessible,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,

--- a/api/src/certification/session-management/domain/usecases/supervise-session.js
+++ b/api/src/certification/session-management/domain/usecases/supervise-session.js
@@ -10,6 +10,7 @@ import { withTransaction } from '../../../../shared/domain/DomainTransaction.js'
 import {
   CertificationCenterIsArchivedError,
   InvalidSessionSupervisingLoginError,
+  SessionFinalized,
   SessionNotAccessible,
 } from '../errors.js';
 
@@ -38,7 +39,7 @@ export const superviseSession = withTransaction(
     const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
 
     if (session.isNotAccessible) {
-      throw new SessionNotAccessible();
+      throw new SessionFinalized();
     }
 
     const certificationCenterAccess = await certificationCenterAccessRepository.getCertificationCenterAccess({

--- a/api/tests/certification/session-management/unit/domain/errors_test.js
+++ b/api/tests/certification/session-management/unit/domain/errors_test.js
@@ -26,6 +26,10 @@ describe('Certification | session-management | Unit | Domain | Errors', function
     expect(errors.SessionNotAccessible).to.exist;
   });
 
+  it('should export a SessionFinalized error', function () {
+    expect(errors.SessionFinalized).to.exist;
+  });
+
   it('should export a certificationCenterIsArchived error', function () {
     expect(errors.CertificationCenterIsArchivedError).to.exist;
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/supervise-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/supervise-session_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import {
   CertificationCenterIsArchivedError,
   InvalidSessionSupervisingLoginError,
+  SessionFinalized,
   SessionNotAccessible,
 } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { InvigilatorSession } from '../../../../../../src/certification/session-management/domain/read-models/InvigilatorSession.js';
@@ -69,7 +70,7 @@ describe('Unit | UseCase | supervise-session', function () {
     expect(error.message).to.equal('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
   });
 
-  it('should throw a SessionNotAccessible when the session is not accessible', async function () {
+  it('should throw a SessionFinalized when the session is finalized', async function () {
     // given
     const sessionId = 123;
     const certificationCenter = domainBuilder.buildCertificationCenter();
@@ -97,7 +98,7 @@ describe('Unit | UseCase | supervise-session', function () {
     });
 
     // then
-    expect(error).to.be.an.instanceOf(SessionNotAccessible);
+    expect(error).to.be.an.instanceOf(SessionFinalized);
   });
 
   it('should a Certification center is archived error when certification center is archived', async function () {

--- a/certif/app/components/login-session-invigilator/form.gjs
+++ b/certif/app/components/login-session-invigilator/form.gjs
@@ -48,6 +48,9 @@ export default class LoginSessionInvigilator extends Component {
         case 'CERTIFICATION_CENTER_IS_ARCHIVED':
           this.formError = this.intl.t('pages.session-supervising.login.form.errors.certification-center-archived');
           break;
+        case 'SESSION_FINALIZED':
+          this.formError = this.intl.t('pages.session-supervising.login.form.errors.session-finalized');
+          break;
         case 'SESSION_NOT_ACCESSIBLE':
           this.formError = this.intl.t('pages.session-supervising.login.form.errors.session-not-accessible', {
             date: dayjsUtcFormat([error.meta?.blockedAccessDate, 'DD/MM/YYYY'], {}),

--- a/certif/tests/integration/components/login-session-invigilator/form-test.gjs
+++ b/certif/tests/integration/components/login-session-invigilator/form-test.gjs
@@ -93,6 +93,38 @@ module('Integration | Component | Login session invigilator | Form', function (h
       });
     });
 
+    module('when the session is finalized', function () {
+      test('it should display a session finalized error', async function (assert) {
+        // given
+        const authenticateInvigilator = sinon.stub().rejects({ errors: [{ code: 'SESSION_FINALIZED' }] });
+
+        // when
+        const screen = await render(
+          <template><LoginSessionInvigilatorForm @authenticateInvigilator={{authenticateInvigilator}} /></template>,
+        );
+
+        await fillIn(
+          screen.getByLabelText(t('pages.session-supervising.login.form.session-number'), { exact: false }),
+          222,
+        );
+        await fillIn(
+          screen.getByLabelText(t('pages.session-supervising.login.form.session-password.label'), { exact: false }),
+          222,
+        );
+        await click(screen.getByRole('button', { name: t('pages.session-supervising.login.form.actions.invigilate') }));
+
+        // then
+        assert.ok(authenticateInvigilator.called);
+        assert
+          .dom(
+            within(screen.getByRole('alert')).getByText(
+              t('pages.session-supervising.login.form.errors.session-finalized'),
+            ),
+          )
+          .exists();
+      });
+    });
+
     module('when the session is not accessible', function () {
       test('it should display an error with the blocked access date', async function (assert) {
         // given

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -569,6 +569,7 @@
             "certification-center-archived": "“You cannot access the certification centre because it is disabled.”",
             "incorrect-data": "The session number and/or the session password entered are incorrect.",
             "mandatory-fields": "The fields “Session number” and “Session password” are required.",
+            "session-finalized": "The session has been finalized. Access to its invigilator space is no longer possible.",
             "session-not-accessible": "Opening of your PixCertif space on {date} (00:00, Metropolitan France time)."
           },
           "session-number": "Session number",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -569,6 +569,7 @@
             "certification-center-archived": "“Vous ne pouvez pas accéder au centre de certification car ce dernier est désactivé.”",
             "incorrect-data": "Le numéro de session et/ou le mot de passe saisis sont incorrects.",
             "mandatory-fields": "Les champs \"Numéro de la session\" et \"Mot de passe de session\" sont obligatoires.",
+            "session-finalized": "La session a été finalisée. L'accès à son espace surveillant n'est plus possible.",
             "session-not-accessible": "Ouverture de votre espace PixCertif le {date} (00h00, heure France métropolitaine)."
           },
           "session-number": "Numéro de la session",


### PR DESCRIPTION
## 🚙 Problème

Un surveillant tente d’accéder à l’espace surveillant d’une session qui a déjà été finalisée, il visualise le message d'erreur correspondant au blocage des espace sco. 

## 🍃 Proposition

La même erreur SESSION_NOT_ACCESSIBLE était remontée pour les espaces bloqués par le calendrier sco que pour une session finalisée. Ajout d'une nouvelle erreur SESSION_FINALIZED et de son wording associé
  
<img width="40%" alt="Capture d’écran du 2026-06-11 12-14-50" src="https://github.com/user-attachments/assets/a7133b4d-6191-40b3-9d8d-076894a5934e" />


## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
Essayer d'accéder à l'espace survellant d'une session finalisée (exemple : 7403)
