### PR TITLE
[TECH] Mettre en place le FT isSessionLogoutEnabled (PIX-23084)

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('array') disabledLocalesInFrontend;
+  @attr('boolean') isSessionLogoutEnabled;
 }

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -130,4 +130,11 @@ export default {
     devDefaultValues: { test: true, reviewApp: true },
     tags: ['team-combinix', 'pix-api', 'frontend'],
   },
+  isSessionLogoutEnabled: {
+    type: 'boolean',
+    description: 'Enable session logout',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: false },
+    tags: ['team-acces', 'frontend', 'backend', 'pix-api', 'mon-pix', 'pix-orga', 'pix-certif', 'pix-admin'],
+  },
 };

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -62,13 +62,6 @@ export default {
     devDefaultValues: { test: true, reviewApp: true },
     tags: ['frontend', 'team-prescription'],
   },
-  usePixOrgaNewAuthDesign: {
-    type: 'boolean',
-    description: 'Displays the new design of authentication pages',
-    defaultValue: false,
-    devDefaultValues: { test: false, reviewApp: true },
-    tags: ['frontend', 'team-acces', 'pix-orga'],
-  },
   isPixPlusCandidateA11yEnabled: {
     type: 'boolean',
     description: 'Enable candidate accessibility adjustment for Pix+ certifications',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,7 +29,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,
-            'use-pix-orga-new-auth-design': false,
             'is-pix-plus-candidate-a11y-enabled': false,
             'are-module-short-id-urls-enabled': false,
             'are-combined-courses-enabled': true,

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -33,6 +33,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-pix-plus-candidate-a11y-enabled': false,
             'are-module-short-id-urls-enabled': false,
             'are-combined-courses-enabled': true,
+            'is-session-logout-enabled': false,
           },
         },
       };

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('boolean') isPixPlusCandidateA11yEnabled;
   @attr('array') disabledLocalesInFrontend;
+  @attr('boolean') isSessionLogoutEnabled;
 }

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -7,4 +7,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') areModuleShortIdUrlsEnabled;
   @attr('boolean') areCombinedCoursesEnabled;
   @attr('array') disabledLocalesInFrontend;
+  @attr('boolean') isSessionLogoutEnabled;
 }

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('array') disabledLocalesInFrontend;
   @attr('boolean') displayCatalogue;
+  @attr('boolean') isSessionLogoutEnabled;
 }


### PR DESCRIPTION
## 🚙 Problème

La déconnexion de session avec révocation de tous les tokens dans tous les cas de connexion est sensible car il y a un risque d’empêcher des utilisateurs de se déconnecter (accessoirement pour changer de compte).

## 🍃 Proposition

Mise en place du FT `isSessionLogoutEnabled` pour le back et le front (tags `frontend`, `backend`). Ce FT va permettre d’activer sereinement la fonctionnalité en recette, pour nous assurer que tout fonctionne bien, aussi au niveau du back qu’au niveau du front, sur tous les navigateurs, avant de l’activer en production.

## 🦵 Remarques

On profite de cette PR pour supprimer le FT `usePixOrgaNewAuthDesign` Accès qui n’est plus utilisé depuis longtemps.

## 🔗 Pour tester

1. Aller sur les frontaux Pix App, Pix Orga, Pix Certif et Pix Admin
2. Constater que dans chacun de ces frontaux, au chargement, l’appel `/api/feature-toggles?id=0` renvoie le FT `is-session-logout-enabled: false`
3. Activer le FT : 
   ```shell
   npm run toggles -- --key=isSessionLogoutEnabled --value=true
   ```
4. Aller sur les frontaux Pix App, Pix Orga, Pix Certif et Pix Admin et les recharger
5. Constater que dans chacun de ces frontaux, au chargement, l’appel `/api/feature-toggles?id=0` renvoie le FT `is-session-logout-enabled: true`