### PR TITLE
[BUGFIX] Corriger le compteur de candidats de l'espace surveillant (PIX-23040).

### DIFF
--- a/certif/app/components/session-supervising/candidate-list.gjs
+++ b/certif/app/components/session-supervising/candidate-list.gjs
@@ -11,11 +11,12 @@ import CandidateInList from 'pix-certif/components/session-supervising/candidate
 export default class CandidateList extends Component {
   @tracked filter = '';
 
-  get authorizedToStartCandidates() {
-    return this.args.candidates.reduce((authorizedToStartCandidates, candidate) => {
-      if (candidate.authorizedToStart) return authorizedToStartCandidates + 1;
-      return authorizedToStartCandidates;
-    }, 0);
+  get startedCandidatesCount() {
+    return this.args.candidates.filter((c) => c.hasStarted).length;
+  }
+
+  get activeCandidatesCount() {
+    return this.args.candidates.filter((c) => (c.authorizedToStart && !c.assessmentStatus) || c.hasStarted).length;
   }
 
   get filteredCandidates() {
@@ -90,11 +91,14 @@ export default class CandidateList extends Component {
               @size={{true}}
             />
           </div>
-          <p class='session-supervising-candidate-list__candidates-count'>{{t
-              'pages.session-supervising.candidate-list.authorized-to-start-candidates'
-              authorizedToStartCandidates=this.authorizedToStartCandidates
+          <p class='session-supervising-candidate-list__candidates-count'>
+            {{t
+              'pages.session-supervising.candidate-list.active-candidates'
+              activeCandidates=this.activeCandidatesCount
+              startedCandidates=this.startedCandidatesCount
               totalCandidates=@candidates.length
-            }}</p>
+            }}
+          </p>
           <ul class='session-supervising-candidate-list__candidates'>
             {{#each this.filteredCandidates as |candidate|}}
               <CandidateInList

--- a/certif/tests/integration/components/session-supervising/candidate-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list-test.js
@@ -92,8 +92,9 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
         assert
           .dom(
             screen.getByText(
-              t('pages.session-supervising.candidate-list.authorized-to-start-candidates', {
-                authorizedToStartCandidates: 0,
+              t('pages.session-supervising.candidate-list.active-candidates', {
+                activeCandidates: 0,
+                startedCandidates: 0,
                 totalCandidates: this.certificationCandidates.length,
               }),
             ),
@@ -159,8 +160,8 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
       });
     });
 
-    module('when some candidates are authorized to start', function () {
-      test('it renders the number of authorized to start candidates', async function (assert) {
+    module('when some candidates are active', function () {
+      test('it renders the number of active and started candidates', async function (assert) {
         // given
         this.certificationCandidates = [
           store.createRecord('certification-candidate-for-supervising', {
@@ -172,6 +173,25 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
             firstName: 'Star',
             lastName: 'Lord',
             authorizedToStart: true,
+            assessmentStatus: 'started',
+          }),
+          store.createRecord('certification-candidate-for-supervising', {
+            firstName: 'Completed',
+            lastName: 'Lord',
+            authorizedToStart: true,
+            assessmentStatus: 'completed',
+          }),
+          store.createRecord('certification-candidate-for-supervising', {
+            firstName: 'Ended',
+            lastName: 'Lord',
+            authorizedToStart: true,
+            assessmentStatus: 'endedByInvigilator',
+          }),
+          store.createRecord('certification-candidate-for-supervising', {
+            firstName: 'Aborted',
+            lastName: 'Lord',
+            authorizedToStart: true,
+            assessmentStatus: 'aborted',
           }),
           store.createRecord('certification-candidate-for-supervising', {
             firstName: 'Gammvert',
@@ -189,8 +209,9 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
         assert
           .dom(
             screen.getByText(
-              t('pages.session-supervising.candidate-list.authorized-to-start-candidates', {
-                authorizedToStartCandidates: 2,
+              t('pages.session-supervising.candidate-list.active-candidates', {
+                activeCandidates: 2,
+                startedCandidates: 1,
                 totalCandidates: this.certificationCandidates.length,
               }),
             ),

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -531,7 +531,7 @@
         }
       },
       "candidate-list": {
-        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} attending",
+        "active-candidates": "{activeCandidates}/{totalCandidates} {activeCandidates, plural,one {candidate} other {candidates}} attending{activeCandidates, plural,=0 {} other { ({startedCandidates} of whom are currently doing the test)}}",
         "clear-field": "Clear the field",
         "indicate-candidates-attendance": "Please confirm the attendance of each candidate to allow them to start their certification exam.",
         "no-candidate": "No candidate enrolled in this session",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -531,7 +531,7 @@
         }
       },
       "candidate-list": {
-        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat présent} other {candidats présents}}",
+        "active-candidates": "{activeCandidates}/{totalCandidates} {activeCandidates, plural,one {candidat présent} other {candidats présents}}{activeCandidates, plural,=0 {} other { (dont {startedCandidates} en cours de test)}}",
         "clear-field": "Vider le champ",
         "indicate-candidates-attendance": "Confirmez la présence de chaque candidat pour l'autoriser à commencer son test de certification.",
         "no-candidate": "Aucun candidat inscrit à cette session",


### PR DESCRIPTION
## 🚙 Problème

Le nombre de candidats apparaissant dans l'espace surveillant n'est pas correct.
Lorsque les candidats entrent en certification, ils sortent du nombre de candidats comptabilisés comme “présence confirmée”.

## 🍃 Proposition

Un candidat devrait apparaître parmi le nombre de “candidats présents” : 
- depuis le clic de confirmation du surveillant (bouton “confirmer la présence”)
- s'il est en train de passer sa certification

Pour mettre en évidence ce deuxième point, le nombre de candidat ayant commencé la certif a été explicité dans le texte affiché.

## 🔗 Pour tester

Entrer en certif avec un candidat en RA dans une session avec plusieurs candidats présents.
Le compteur devrait afficher les bons nombres !
