### PR TITLE
[FEATURE] Envoyer une propriété feature sur les campagnes de type moteur de reco (PIX-23083)

### DIFF
--- a/mon-pix/app/routes/campaigns.js
+++ b/mon-pix/app/routes/campaigns.js
@@ -15,13 +15,21 @@ export default class CampaignsRoute extends Route {
     }
   }
 
-  activate() {
-    this.metrics.context.code = this.paramsFor('campaigns').code;
+  async activate() {
+    const campaignCode = this.paramsFor('campaigns').code;
+    const campaign = await this.store.queryRecord('campaign', { filter: { code: campaignCode } });
+
+    this.metrics.context.code = campaignCode;
     this.metrics.context.type = 'campaigns';
+
+    if (campaign.recommendationEngine) {
+      this.metrics.context.feature = 'RECOMMENDATION_ENGINE';
+    }
   }
 
   deactivate() {
     delete this.metrics.context.code;
     delete this.metrics.context.type;
+    delete this.metrics.context.feature;
   }
 }

--- a/mon-pix/tests/unit/routes/campaigns-test.js
+++ b/mon-pix/tests/unit/routes/campaigns-test.js
@@ -5,19 +5,48 @@ import sinon from 'sinon';
 module('Unit | Route | campaigns', function (hooks) {
   setupTest(hooks);
 
-  test('activate should set metrics context', function (assert) {
-    // Given
-    const route = this.owner.lookup('route:campaigns');
-    route.metrics = { context: {} };
-    const paramsForStub = sinon.stub(route, 'paramsFor').returns({ code: 'CAMPAIGN_CODE' });
+  module('#activate', function () {
+    test('should set metrics context', async function (assert) {
+      // Given
+      const route = this.owner.lookup('route:campaigns');
+      const store = this.owner.lookup('service:store');
+      route.metrics = { context: {} };
+      const campaignCode = 'CAMPAIGN_CODE';
+      const paramsForStub = sinon.stub(route, 'paramsFor').returns({ code: campaignCode });
 
-    // When
-    route.activate();
+      const queryRecordStub = sinon.stub(store, 'queryRecord').resolves({ recommendationEngine: false });
 
-    // Then
-    assert.deepEqual(route.metrics.context.code, 'CAMPAIGN_CODE');
-    assert.strictEqual(route.metrics.context.type, 'campaigns');
-    assert.ok(paramsForStub.calledWith('campaigns'));
+      // When
+      await route.activate();
+
+      // Then
+      sinon.assert.calledOnceWithExactly(paramsForStub, 'campaigns');
+      sinon.assert.calledOnceWithExactly(queryRecordStub, 'campaign', { filter: { code: campaignCode } });
+
+      assert.deepEqual(route.metrics.context.code, campaignCode);
+      assert.strictEqual(route.metrics.context.type, 'campaigns');
+      assert.strictEqual(route.metrics.context.feature, undefined);
+    });
+
+    module('when campaign has recommendationEngine feature', function () {
+      test('should set "feature" attribute in metrics context', async function (assert) {
+        // Given
+        const route = this.owner.lookup('route:campaigns');
+        const store = this.owner.lookup('service:store');
+        route.metrics = { context: {} };
+        sinon.stub(route, 'paramsFor').returns({ code: 'CAMPAIGN_CODE', recommendationEngine: true });
+
+        sinon.stub(store, 'queryRecord').resolves({ recommendationEngine: true });
+
+        // When
+        await route.activate();
+
+        // Then
+        assert.deepEqual(route.metrics.context.code, 'CAMPAIGN_CODE');
+        assert.strictEqual(route.metrics.context.type, 'campaigns');
+        assert.strictEqual(route.metrics.context.feature, 'RECOMMENDATION_ENGINE');
+      });
+    });
   });
 
   test('deactivate should unset metrics context', function (assert) {
@@ -27,6 +56,7 @@ module('Unit | Route | campaigns', function (hooks) {
       context: {
         code: 'CAMPAIGN_CODE',
         type: 'campaigns',
+        feature: 'RECOMMENDATION_ENGINE',
       },
     };
 
@@ -36,5 +66,6 @@ module('Unit | Route | campaigns', function (hooks) {
     // Then
     assert.strictEqual(route.metrics.context.code, undefined);
     assert.strictEqual(route.metrics.context.type, undefined);
+    assert.strictEqual(route.metrics.context.feature, undefined);
   });
 });


### PR DESCRIPTION
## 🚙 Problème

On voudrait distinguer les campagnes de type moteur de recommandation dans Plausible.

## 🍃 Proposition

Le faire en envoyant une donnée pour ça.

## 🦵 Remarques

On utilise du SCREAMING_SNAKE_CASE pour la valeur de `feature` car cela semble être la même chose pour les autres valeurs envoyés en dur dans le projet. 

## 🔗 Pour tester
- Se connecter avec dave-comp ou perfect profile
- Ouvrir sa console navigateur et lire **toutes les requêtes**
- Aller sur un parcours et aller aux résultats.
- Cliquer sur un contenu formatif
- Cliquer sur le bouton Découvrir le programme/Accéder à un module
- Constater, pour chaque appel, l'appel Plausible comportant : 
  - feature : `RECOMMENDATION_ENGINE`
---

**(Enlever Ublock si les appels Plausible passent pas)**

---

- Aller sur Plausible, appli review.pix.fr
- Cliquer sur `Filter -> Properties`
- Saisir comme propriété `feature` et comme valeur `RECOMMENDATION_ENGINE`
- Constater que les events envoyés sont bien là 🎉 
