### PR TITLE
[FEATURE] Exclure les parcours combinés de la requête sur les quêtes dans le completeAssessment() (PIX-23095)

### DIFF
--- a/api/src/profile/scripts/share-attestations-to-eligible-organizations.js
+++ b/api/src/profile/scripts/share-attestations-to-eligible-organizations.js
@@ -51,7 +51,7 @@ export class ShareAttestationsToEligibleOrganizationsScript extends Script {
       logger.info(`BEGIN: ShareAttestationsToEligibleOrganizationsScript`);
       const profileRewards = await this.fetchProfileRewardNotShared(options.startDate, options.endDate);
 
-      const quests = await questRepository.findAllWithReward();
+      const quests = await questRepository.findAllWithReward({ includeCombinedCourses: true });
 
       if (quests.length === 0) {
         return;

--- a/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
+++ b/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
@@ -9,7 +9,7 @@ export const getQuestResultsForCampaignParticipation = async ({
   logger,
 }) => {
   try {
-    const quests = await questRepository.findAllWithReward();
+    const quests = await questRepository.findAllWithReward({ includeCombinedCourses: false });
 
     if (quests.length === 0) {
       return [];

--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -12,7 +12,7 @@ export const rewardUser = async ({
     if (!userId) {
       return;
     }
-    const quests = await questRepository.findAllWithReward();
+    const quests = await questRepository.findAllWithReward({ includeCombinedCourses: false });
 
     if (quests.length === 0) {
       return;

--- a/api/src/quest/infrastructure/repositories/quest-repository.js
+++ b/api/src/quest/infrastructure/repositories/quest-repository.js
@@ -5,11 +5,16 @@ import { Quest } from '../../domain/models/quests/entities/Quest.js';
 
 const toDomain = (quests) => quests.map((quest) => new Quest(quest));
 
-const findAllWithReward = async () => {
+const findAllWithReward = async ({ includeCombinedCourses }) => {
   const knexConn = DomainTransaction.getConnection();
+  let query = knexConn('quests').select('quests.*').whereNotNull('rewardId');
 
-  const quests = await knexConn('quests').whereNotNull('rewardId');
-
+  if (!includeCombinedCourses) {
+    query = query
+      .leftJoin('combined_course_blueprints', 'quests.id', 'combined_course_blueprints.questId')
+      .whereNull('combined_course_blueprints.id');
+  }
+  const quests = await query;
   return toDomain(quests);
 };
 

--- a/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
@@ -124,7 +124,7 @@ describe('Quest | Integration | Repository | quest', function () {
   });
 
   describe('#findAllWithReward', function () {
-    it('should return all quests with reward', async function () {
+    it('it should return all quests with reward including those linked to combined courses', async function () {
       // given
       databaseBuilder.factory.buildQuest({
         id: 1,
@@ -133,6 +133,45 @@ describe('Quest | Integration | Repository | quest', function () {
         eligibilityRequirements: [],
         successRequirements: [],
       });
+      databaseBuilder.factory.buildQuest({
+        id: 2,
+        rewardType: REWARD_TYPES.ATTESTATION,
+        rewardId: 2,
+        eligibilityRequirements: [],
+        successRequirements: [],
+      });
+      const questToExclude = databaseBuilder.factory.buildQuest({
+        id: 3,
+        rewardType: null,
+        rewardId: null,
+        eligibilityRequirements: [],
+        successRequirements: [],
+      });
+
+      databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: 1 });
+
+      await databaseBuilder.commit();
+
+      // when
+      const quests = await questRepository.findAllWithReward({ includeCombinedCourses: true });
+      const questIds = quests.map((quest) => quest.id);
+
+      // then
+      expect(quests[0]).to.be.an.instanceof(Quest);
+      expect(quests).to.have.lengthOf(2);
+      expect(questIds).to.not.include(questToExclude.id);
+    });
+    it('should return the quests with reward id, not linked to combined courses, when param includeCombinedCourses is false', async function () {
+      // given
+      databaseBuilder.factory.buildQuest({
+        id: 1,
+        rewardType: REWARD_TYPES.ATTESTATION,
+        rewardId: 2,
+        eligibilityRequirements: [],
+        successRequirements: [],
+      });
+      databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: 1 });
+
       databaseBuilder.factory.buildQuest({
         id: 2,
         rewardType: REWARD_TYPES.ATTESTATION,
@@ -150,11 +189,12 @@ describe('Quest | Integration | Repository | quest', function () {
       await databaseBuilder.commit();
 
       // when
-      const quests = await questRepository.findAllWithReward();
+      const quests = await questRepository.findAllWithReward({ includeCombinedCourses: false });
 
       // then
       expect(quests[0]).to.be.an.instanceof(Quest);
-      expect(quests).to.have.lengthOf(2);
+      expect(quests).to.have.lengthOf(1);
+      expect(quests[0].id).to.equal(2);
     });
   });
 
@@ -215,7 +255,7 @@ describe('Quest | Integration | Repository | quest', function () {
       // when
       await questRepository.deleteByIds({ questIds: ['1', 3] });
 
-      const quests = await questRepository.findAllWithReward();
+      const quests = await questRepository.findAllWithReward({ includeCombinedCourses: true });
 
       // then
       expect(quests).to.have.lengthOf(1);


### PR DESCRIPTION
## 🚙 Problème
Dans le usecase rewardUser qui est appelé par completeAssessment(), on va chercher toutes les quêtes qui ont une récompense pour vérifier son attribution à l'utilisateur. Cette exclusion était à l'origine une manière déguisée d'exclure les parcours combinés de la requête.
Or, on va attribuer des récompenses aux quêtes liées aux parcours combinés. Il faut donc une nouvelle jointure qui permet d'exclure ces quêtes-là.

## 🍃 Proposition
On ajoute un paramètre includeCombinedCourses, qui peut être désactivé en passant false en paramètres pour exclure les quêtes liées à des parcours combinés.

## 🔗 Pour tester
Test de non-régression sur l'attribution d'une attestation à la suite d'une campagne hors parcours combiné.
Se connecter avec attestation-success, taper le code ATTEST001. Vérifier que l'utilisateur a bien sa récompense.

Test de non-régression sur l'attribution d'une récompense à la suite d'un parcours combiné
-> learner1 / SCOMBINIX