### PR TITLE
[TECH] Préparer le GitHub Actions pour la merge queue

### DIFF
--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -1,7 +1,10 @@
 name: commits check
+
 on:
-  # eslint-disable-next-line yml/no-empty-mapping-value
   pull_request:
+  merge_group:
+    types: [checks_requested]
+
 jobs:
   block-autosquash-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-node-version-availability-on-scalingo.yml
+++ b/.github/workflows/check-node-version-availability-on-scalingo.yml
@@ -3,6 +3,8 @@ name: Check node version availability on Scalingo
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   check-node-compatibility:

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,7 +1,11 @@
 name: pr title check
+
 on:
   pull_request:
     types: [opened, edited, ready_for_review, reopened]
+  merge_group:
+    types: [checks_requested]
+
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-modulix-content.yaml
+++ b/.github/workflows/test-modulix-content.yaml
@@ -3,6 +3,8 @@ name: Test Modulix content
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+  merge_group:
+    types: [checks_requested]
 
 defaults:
   run:

--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -4,7 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, unlabeled]
   push:
-    branches: dev
+    branches:
+      - dev
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   trigger-ci:


### PR DESCRIPTION
## 🚙 Problème

Pour déclencher les GitHub Actions dans la merge queue GitHub, il est nécessaire d'ajouter le trigger `merge_group` avec le type `checks_requested`.

## 🍃 Proposition

Modifier les triggers des GitHub actions qui doivent se déclencher dans la merge queue.

## 🦵 Remarques

N/A

## 🔗 Pour tester

La CI doit passer sans souci. Ça n'a pas d'impact sur la CI actuelle.
