### PR TITLE
[BUGFIX] problème de responsive sur l'icône des items des parcours combinés (PIX-22903)

### DIFF
--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -20,7 +20,7 @@ const Content = <template>
     <div class="combined-course-item__content">
       <div class="combined-course-item__icon">
         {{#if @iconUrl}}
-          <img role="presentation" src={{@iconUrl}} alt="" height="42" />
+          <img role="presentation" src={{@iconUrl}} alt="" />
         {{/if}}
       </div>
       <div class="combined-course-item__text">
@@ -34,8 +34,8 @@ const Content = <template>
           </div>
         {{/if}}
       </div>
-
     </div>
+
     {{#if @isLocked}}
       <div class="combined-course-item__indicator--locked">
         <PixIcon @name="lock" @plainIcon={{true}} @ariaHidden={{true}} />

--- a/mon-pix/app/styles/components/combined-courses/_combined-courses.scss
+++ b/mon-pix/app/styles/components/combined-courses/_combined-courses.scss
@@ -167,6 +167,12 @@
     align-items: center;
     justify-content: center;
 
+    img {
+      width: auto;
+      min-width: var(--pix-spacing-8x);
+      height: 42px;
+    }
+
     svg {
       width: 100%;
       height: 100%;


### PR DESCRIPTION
## 🚙 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Problème de responsive sur l'icône dans les items des parcours combinés

## 🍃 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Gestion de la taille dans le css, avec une min-width définie.

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Connection sur PixApp avec learneremail1000_1@example.net, code COMBINIX1.
Sur la page du parcours, passer en mode device mobile.
Le picto ne doit pas rétrécir.
