### PR TITLE
[FEATURE] Ajouter les nouvelles données dans la création d'un contenu formatif (PIX-23020)

### DIFF
--- a/api/db/seeds/data/common/tooling/training-tooling.js
+++ b/api/db/seeds/data/common/tooling/training-tooling.js
@@ -49,6 +49,11 @@ async function createTraining({
   locales,
   editorName,
   editorLogoUrl,
+  deliveryMode,
+  registrationRequired,
+  program,
+  objectives,
+  description,
   attachedTargetProfileIds = [],
   configTriggers,
 }) {
@@ -78,6 +83,11 @@ async function createTraining({
     locales,
     editorName,
     editorLogoUrl,
+    deliveryMode,
+    registrationRequired,
+    program,
+    objectives,
+    description,
   });
   attachedTargetProfileIds.map((targetProfileId) =>
     databaseBuilder.factory.buildTargetProfileTraining({

--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -4,6 +4,7 @@ import { BadRequestError, NotFoundError, sendJsonApiError } from '../../../share
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { getSupportedLocales } from '../../../shared/domain/services/locale-service.js';
 import { editorLogoUrlValidation, identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { Training } from '../../domain/models/Training.js';
 import { trainingController as trainingsController } from './training-controller.js';
 
 const lowerCaseSupportedLocales = getSupportedLocales().map((supportedLocale) => supportedLocale.toLowerCase());
@@ -153,6 +154,13 @@ const register = async function (server) {
                   .default([]),
                 'editor-name': Joi.string().required(),
                 'editor-logo-url': Joi.string().regex(editorLogoUrlValidation).required(),
+                'delivery-mode': Joi.string()
+                  .valid(...Object.values(Training.modes))
+                  .optional(),
+                description: Joi.string().optional(),
+                program: Joi.string().optional(),
+                'registration-required': Joi.boolean().optional(),
+                objectives: Joi.string().optional(),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),

--- a/api/src/devcomp/domain/read-models/TrainingForAdmin.js
+++ b/api/src/devcomp/domain/read-models/TrainingForAdmin.js
@@ -12,6 +12,11 @@ class TrainingForAdmin {
     editorLogoUrl,
     trainingTriggers,
     isDisabled,
+    deliveryMode,
+    registrationRequired,
+    program,
+    objectives,
+    description,
   } = {}) {
     this.id = id;
     this.title = title;
@@ -25,6 +30,11 @@ class TrainingForAdmin {
     this.editorLogoUrl = editorLogoUrl;
     this.trainingTriggers = trainingTriggers;
     this.isDisabled = isDisabled;
+    this.deliveryMode = deliveryMode;
+    this.registrationRequired = registrationRequired;
+    this.program = program;
+    this.objectives = objectives;
+    this.description = description;
   }
 
   get isRecommendable() {

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -151,6 +151,11 @@ async function create({ training }) {
     'locales',
     'editorName',
     'editorLogoUrl',
+    'deliveryMode',
+    'registrationRequired',
+    'program',
+    'objectives',
+    'description',
   ]);
   const [createdTraining] = await knexConn(TABLE_NAME).insert(pickedAttributes).returning('*');
   return new TrainingForAdmin(createdTraining);

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -126,15 +126,15 @@ const deserialize = function (payload) {
   return new Deserializer({
     keyForAttribute: 'camelCase',
     transform(deserializedTraining) {
+      const objectives = deserializedTraining.objectives?.split(';').map((objective) => objective.trim());
       const duration = deserializedTraining.duration;
-      if (!duration) return deserializedTraining;
+      if (!duration) return { ...deserializedTraining, objectives };
 
       const { days, hours, minutes } = duration;
-      const formattedDuration = `${days}d${hours}h${minutes}m`;
-
       return {
         ...deserializedTraining,
-        duration: formattedDuration,
+        objectives,
+        duration: `${days}d${hours}h${minutes}m`,
       };
     },
   }).deserialize(payload);

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -1,4 +1,5 @@
 import { createServer } from '../../../../../server.js';
+import { Training } from '../../../../../src/devcomp/domain/models/Training.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
@@ -163,6 +164,11 @@ describe('Acceptance | Controller | training-controller', function () {
           locales: ['fr', 'fr-fr'],
           'editor-name': 'Un ministère',
           'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/mon-logo.svg',
+          'delivery-mode': 'remote',
+          description: 'Une sommaire description',
+          program: 'un programme bien détaillé',
+          'registration-required': true,
+          objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3', 'Objectif 4'],
         },
       };
 
@@ -184,6 +190,11 @@ describe('Acceptance | Controller | training-controller', function () {
               locales: ['fr', 'fr-fr'],
               'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/mon-logo.svg',
               'editor-name': 'Un ministère',
+              'delivery-mode': Training.modes.REMOTE,
+              description: 'Une sommaire description',
+              program: 'un programme bien détaillé',
+              'registration-required': true,
+              objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3', 'Objectif 4'],
             },
           },
         },

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -194,7 +194,7 @@ describe('Acceptance | Controller | training-controller', function () {
               description: 'Une sommaire description',
               program: 'un programme bien détaillé',
               'registration-required': true,
-              objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3', 'Objectif 4'],
+              objectives: 'Objectif 1;Objectif 2;Objectif 3;Objectif 4',
             },
           },
         },

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -599,6 +599,11 @@ describe('Integration | Repository | training-repository', function () {
         locales: ['fr'],
         editorName: 'Un ministère',
         editorLogoUrl: 'https://mon-logo.svg',
+        deliveryMode: Training.modes.REMOTE,
+        registrationRequired: true,
+        program: 'Le programme',
+        objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3'],
+        description: 'La plus belle des descriptions',
       };
 
       // when

--- a/api/tests/devcomp/unit/domain/read-models/TrainingForAdmin_test.js
+++ b/api/tests/devcomp/unit/domain/read-models/TrainingForAdmin_test.js
@@ -1,3 +1,4 @@
+import { Training } from '../../../../../src/devcomp/domain/models/Training.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
@@ -17,6 +18,11 @@ describe('Unit | Domain | Read-Models | TrainingForAdmin', function () {
         targetProfileIds: [1, 2, 3],
         editorName: 'Editor name',
         editorLogoUrl: 'https://editor.logo.url',
+        deliveryMode: Training.modes.REMOTE,
+        registrationRequired: false,
+        program: 'Nom du programme',
+        objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3', 'Objectif 4'],
+        description: 'Une jolie description',
         trainingTriggers: [trainingTrigger],
       });
 
@@ -31,6 +37,11 @@ describe('Unit | Domain | Read-Models | TrainingForAdmin', function () {
       expect(training.targetProfileIds).to.deep.equal([1, 2, 3]);
       expect(training.editorName).to.equal('Editor name');
       expect(training.editorLogoUrl).to.equal('https://editor.logo.url');
+      expect(training.deliveryMode).to.equal('remote');
+      expect(training.registrationRequired).to.equal(false);
+      expect(training.program).to.equal('Nom du programme');
+      expect(training.objectives).to.deep.equal(['Objectif 1', 'Objectif 2', 'Objectif 3', 'Objectif 4']);
+      expect(training.description).to.equal('Une jolie description');
       expect(training.trainingTriggers).to.deep.equal([trainingTrigger]);
     });
   });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -439,6 +439,10 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/editor_logo_url.svg',
             'is-disabled': true,
             description: "<p>Voici la description d'un contenu formatif pour le ministère</p>",
+            'delivery-mode': Training.modes.REMOTE,
+            program: 'Programme',
+            'registration-required': false,
+            objectives: 'Objectif 1          ;  Objectif 2',
           },
         },
       };
@@ -456,6 +460,10 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
         editorName: 'Ministère education nationale',
         isDisabled: true,
         description: "<p>Voici la description d'un contenu formatif pour le ministère</p>",
+        deliveryMode: Training.modes.REMOTE,
+        registrationRequired: false,
+        program: 'Programme',
+        objectives: ['Objectif 1', 'Objectif 2'],
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-training-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-for-admin.js
@@ -1,3 +1,4 @@
+import { Training } from '../../../../src/devcomp/domain/models/Training.js';
 import { TrainingForAdmin } from '../../../../src/devcomp/domain/read-models/TrainingForAdmin.js';
 
 const buildTrainingForAdmin = function ({
@@ -13,6 +14,11 @@ const buildTrainingForAdmin = function ({
   targetProfileIds = [1],
   editorName = 'Ministère education nationale',
   editorLogoUrl = 'https://assets.pix.org/contenu-formatif/editeur/editor_logo_url.svg',
+  deliveryMode = Training.modes.REMOTE,
+  registrationRequired = false,
+  program = 'Program name',
+  objectives = ['Objectif 1', 'Objectif 2', 'Objectif 3', 'Objectif 4'],
+  description = 'une jolie description',
   trainingTriggers,
   isDisabled = false,
 } = {}) {
@@ -28,6 +34,11 @@ const buildTrainingForAdmin = function ({
     editorName,
     editorLogoUrl,
     trainingTriggers,
+    deliveryMode,
+    registrationRequired,
+    program,
+    objectives,
+    description,
     isDisabled,
   });
 };


### PR DESCRIPTION
## 🚙 Problème
On souhaite pouvoir créer les contenus formatif pour le moateur de reco avec des nouvelles propriétés.

## 🍃 Proposition
Les prendre en compte sur la route API `POST api/admin/trainings`

## 🦵 Remarques
N/A

## 🔗 Pour tester
- Aller sur [pix admin](https://admin-pr16499.review.pix.fr/)
- Vérifier que la création d'un cf se déroule toujours sans accros