### PR TITLE
[BUGFIX] Ne pas détacher tous les blueprints d'une organisation quand on en détache une (PIX-23122)

### DIFF
--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -72,7 +72,10 @@ async function updateShares({ combinedCourseBlueprint, knexConn }) {
   );
 
   if (organizationIdsToRemove.length > 0) {
-    await knexConn('combined_course_blueprint_shares').delete().whereIn('organizationId', organizationIdsToRemove);
+    await knexConn('combined_course_blueprint_shares')
+      .delete()
+      .where('combinedCourseBlueprintId', currentCombinedCourseBlueprint.id)
+      .whereIn('organizationId', organizationIdsToRemove);
   }
 
   if (organizationIdsToAdd.length > 0) {

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -92,6 +92,37 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       expect(result.organizationIds).deep.equal([combinedCourseBlueprintShare2.organizationId]);
     });
 
+    it('should only delete the given blueprint shared with the organization, not other blueprints for the same organization', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const combinedCourseBlueprintShareToDetach = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId: organization.id,
+      });
+      const combinedCourseBlueprintShareToKeep = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId: organization.id,
+      });
+      await databaseBuilder.commit();
+
+      const combinedCourseBlueprintToDetach = await combinedCourseBluePrintRepository.findById({
+        id: combinedCourseBlueprintShareToDetach.combinedCourseBlueprintId,
+      });
+      combinedCourseBlueprintToDetach.detachOrganization({ organizationId: organization.id });
+
+      // when
+      await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint: combinedCourseBlueprintToDetach });
+
+      // then
+      const resultForKeptShare = await combinedCourseBluePrintRepository.findById({
+        id: combinedCourseBlueprintShareToKeep.combinedCourseBlueprintId,
+      });
+      expect(resultForKeptShare.organizationIds).to.deep.equal([organization.id]);
+
+      const resultForDetachedShare = await combinedCourseBluePrintRepository.findById({
+        id: combinedCourseBlueprintShareToDetach.combinedCourseBlueprintId,
+      });
+      expect(resultForDetachedShare.organizationIds).to.deep.equal([]);
+    });
+
     it('should add combined course blueprint share for a given organizationId', async function () {
       // given
       const organization1 = databaseBuilder.factory.buildOrganization();


### PR DESCRIPTION
## 🚙 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lorsque plusieurs blueprints sont rattachés à une organisation et que l’on clique sur “détacher” au niveau d’un blueprint dans PixAdmin, on détache tous les blueprints de l’organisation en question au lieu de ne supprimer que le blueprint sur lequel on a fait l’action. 

## 🍃 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Dans `updateShares` du combinedcourseBlueprintRepository, on ne spécifie pas le blueprint pour lequel on doit supprimer les Shares : ajout du where pour spécifier le blueprint, et ne pas supprimer tous les shares pour l'organization

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Se connecter sur PixAdmin.
Attacher la même organization à plusieurs blueprints.
Détacher l'une des organizations. Les autres doivent toujours être attachées.