### PR TITLE
[FEATURE] Supprime la table organization_learner_passage_participations (PIX-22558)

### DIFF
--- a/api/db/migrations/20260612133800_delete-organization-learner-passage-participations.js
+++ b/api/db/migrations/20260612133800_delete-organization-learner-passage-participations.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'organization_learner_passage_participations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.delete().from(TABLE_NAME);
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment(
+      'this table contains specific data related to passages for organization_learner_participations table',
+    );
+    table.increments('id').primary().notNullable();
+    table.string('moduleId').notNullable();
+    table
+      .integer('organizationLearnerParticipationId')
+      .references('organization_learner_participations.id')
+      .index()
+      .notNullable();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🚙 Problème
On n'a plus besoin de la table organization_learner_passage_participations, puisque les données sont désormais stockées dans organization_learner_participations. 

## 🍃 Proposition
On supprime les données puis la table.

## 🔗 Pour tester
npm run db:rollback:latest
npm run db:migrate
