### PR TITLE
[FEATURE] Récupérer les nouvelles infos des contenus formatifs (PIX-23020)

### DIFF
--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -26,6 +26,11 @@ const serializeForAdmin = function (training = {}, meta) {
       'targetProfileSummaries',
       'isRecommendable',
       'isDisabled',
+      'deliveryMode',
+      'registrationRequired',
+      'program',
+      'objectives',
+      'description',
     ],
     trainingTriggers: {
       ref: 'id',

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -71,7 +71,9 @@ describe('Acceptance | Controller | training-controller', function () {
       // given
       const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       databaseBuilder.factory.buildTraining();
-      const { id: trainingId, ...trainingAttributes } = databaseBuilder.factory.buildTraining();
+      const { id: trainingId, ...trainingAttributes } = databaseBuilder.factory.buildTraining({
+        objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3'],
+      });
       const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ trainingId });
       const trainingTriggerTube = databaseBuilder.factory.buildTrainingTriggerTube({
         trainingTriggerId: trainingTrigger.id,
@@ -98,6 +100,11 @@ describe('Acceptance | Controller | training-controller', function () {
           'editor-logo-url': trainingAttributes.editorLogoUrl,
           'editor-name': trainingAttributes.editorName,
           'is-disabled': false,
+          'delivery-mode': Training.modes.HYBRID,
+          'registration-required': false,
+          program: 'Programme du contenu formatif',
+          description: "<p>Voici la description d'un contenu formatif</p>",
+          objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3'],
         },
       };
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -83,6 +83,11 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             locales: ['fr-fr'],
             title: 'Training 1',
             type: 'webinar',
+            'delivery-mode': Training.modes.REMOTE,
+            'registration-required': false,
+            program: 'Program name',
+            objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3', 'Objectif 4'],
+            description: 'une jolie description',
           },
           id: `${trainingId}`,
           relationships: {


### PR DESCRIPTION
## 🚙 Problème
De nouveaux attributs existent pour les contenus formatifs, mais ils ne remontent pas dans pix admin.

## 🍃 Proposition
Les faire remonter dans la route `GET /api/admin/trainings/{trainingId}`

## 🦵 Remarques
Merger d'abord https://github.com/1024pix/pix/pull/16499 ✅ 

## 🔗 Pour tester
Tests verts