### PR TITLE
[BUGFIX] Mettre en forme correctement les prénoms composés des users pour les PDF d'attestations (PIX-23070)

### DIFF
--- a/api/src/profile/domain/models/User.js
+++ b/api/src/profile/domain/models/User.js
@@ -1,5 +1,3 @@
-import capitalize from 'lodash/capitalize.js';
-
 export class User {
   id;
   #firstName;
@@ -12,11 +10,11 @@ export class User {
   }
 
   get firstName() {
-    return capitalize(this.#firstName.toLowerCase());
+    return this.#firstName.toUpperCase().trim();
   }
 
   get lastName() {
-    return this.#lastName.toUpperCase();
+    return this.#lastName.toUpperCase().trim();
   }
 
   toForm(createdAt, locale, transformStringForFileName) {

--- a/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
@@ -53,9 +53,9 @@ describe('Profile | Integration | Domain | get-attestation-data-for-users', func
         secondUser.toForm(secondCreatedAt, locale, normalizeAndRemoveAccents),
       ]);
       expect(results.template).to.be.not.null;
-      expect(results.data[0].get('firstName')).to.equal('Alex');
+      expect(results.data[0].get('firstName')).to.equal('ALEX');
       expect(results.data[0].get('lastName')).to.equal('TERIEUR');
-      expect(results.data[1].get('firstName')).to.equal('Theo');
+      expect(results.data[1].get('firstName')).to.equal('THEO');
       expect(results.data[1].get('lastName')).to.equal('COURANT');
     });
 

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
@@ -62,7 +62,7 @@ describe('Profile | Integration | Domain | get-shared-attestations-for-organizat
         firstUser.toForm(firstProfileReward.createdAt, locale, normalizeAndRemoveAccents),
       ]);
       expect(results.template).to.be.not.null;
-      expect(results.data[0].get('firstName')).to.equal('Alex');
+      expect(results.data[0].get('firstName')).to.equal('ALEX');
       expect(results.data[0].get('lastName')).to.equal('TERIEUR');
     });
 
@@ -112,9 +112,9 @@ describe('Profile | Integration | Domain | get-shared-attestations-for-organizat
         locale,
       });
 
-      expect(results.data[0].get('firstName')).to.equal('Bob');
-      expect(results.data[1].get('firstName')).to.equal('Zoe');
-      expect(results.data[2].get('firstName')).to.equal('Alice');
+      expect(results.data[0].get('firstName')).to.equal('BOB');
+      expect(results.data[1].get('firstName')).to.equal('ZOE');
+      expect(results.data[2].get('firstName')).to.equal('ALICE');
     });
 
     it('should not return profile rewards for anonymous userIds', async function () {

--- a/api/tests/profile/unit/domain/models/User_test.js
+++ b/api/tests/profile/unit/domain/models/User_test.js
@@ -19,20 +19,20 @@ describe('Unit | Profile | Domain | Models | User', function () {
     clock.restore();
   });
 
-  it('should return lastName', function () {
+  it('should return uppercased firstName', function () {
     // when
-    const user = new User({ firstName: 'Théo', lastName: 'Courant' });
+    const user = new User({ firstName: ' théo-miCHel de la villette-- ', lastName: 'Courant' });
 
     // then
-    expect(user.lastName).to.equal('COURANT');
+    expect(user.firstName).to.equal('THÉO-MICHEL DE LA VILLETTE--');
   });
 
-  it('should return firstName', function () {
+  it('should return uppercased lastName', function () {
     // when
-    const user = new User({ firstName: 'théo', lastName: 'Courant' });
+    const user = new User({ firstName: 'Théo', lastName: ' courant--mArchand ' });
 
     // then
-    expect(user.firstName).to.equal('Théo');
+    expect(user.lastName).to.equal('COURANT--MARCHAND');
   });
 
   it('should transform to form', function () {


### PR DESCRIPTION
## 🚙 Problème

Actuellement, le prénom des Users sur les attestations n'ont que la première lettre de leur prénom en majuscule. Cela pose problème pour les prénoms composés, en particulier avec un tiret ou un espace entre les prénoms.

## 🍃 Proposition

~~Transformer en majuscules la première et toutes les lettres après un tiret ou un espace des prénoms de chaque User pour le bon affichage de leur prénom sur le PDF d'attestation.~~

Transformer en majuscules toutes les lettres du prénom de chaque User au moment du téléchargement de leur PDF d'attestation.

## 🦵 Remarques

~~Cela ne fonctionne actuellement que pour les tirets ou les espaces. Si d'autres caractères spéciaux doivent être pris en compte, il faudra les rajouter.~~

## 🔗 Pour tester

~~La review fonctionnelle a déjà été faite pour l'affichage des prénoms correctement formatés sur le PDF d'attestation (voir commentaire).~~

Mais il serait intéressant de compléter par un petit tour sur les apps vu qu'on a modifié un modèle User, même s'il est principalement utilisé pour les attestations.
