### PR TITLE
[FEATURE] Mettre à jour les nouveaux champs de contenus formatifs (PIX-23116)

### DIFF
--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -239,6 +239,13 @@ const register = async function (server) {
                 locales: Joi.array().items(Joi.string().valid(...lowerCaseSupportedLocales)),
                 'editor-name': Joi.string().allow(null),
                 'editor-logo-url': Joi.string().regex(editorLogoUrlValidation).required(),
+                'delivery-mode': Joi.string()
+                  .valid(...Object.values(Training.modes))
+                  .optional(),
+                description: Joi.string().optional(),
+                program: Joi.string().optional(),
+                'registration-required': Joi.boolean().optional(),
+                objectives: Joi.string().optional(),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -172,6 +172,11 @@ async function update({ id, attributesToUpdate }) {
     'editorName',
     'editorLogoUrl',
     'isDisabled',
+    'deliveryMode',
+    'registrationRequired',
+    'program',
+    'objectives',
+    'description',
   ]);
   const knexConn = DomainTransaction.getConnection();
   const [updatedTraining] = await knexConn(TABLE_NAME)

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -9,8 +9,11 @@ const serializeForAdmin = function (training = {}, meta) {
       duration.days = duration.days || 0;
       duration.hours = duration.hours || 0;
       duration.minutes = duration.minutes || 0;
-
-      return structuredClone({ ...record, isRecommendable: record.isRecommendable });
+      return structuredClone({
+        ...record,
+        objectives: record.objectives.join(';'),
+        isRecommendable: record.isRecommendable,
+      });
     },
     attributes: [
       'id',

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -104,7 +104,7 @@ describe('Acceptance | Controller | training-controller', function () {
           'registration-required': false,
           program: 'Programme du contenu formatif',
           description: "<p>Voici la description d'un contenu formatif</p>",
-          objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3'],
+          objectives: 'Objectif 1;Objectif 2;Objectif 3',
         },
       };
 
@@ -243,7 +243,13 @@ describe('Acceptance | Controller | training-controller', function () {
       it('should update training and response with a 200', async function () {
         // given
         const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
-        const training = databaseBuilder.factory.buildTraining();
+        const training = databaseBuilder.factory.buildTraining({
+          deliveryMode: Training.modes.HYBRID,
+          registrationRequired: false,
+          program: 'Programme du contenu formatif à mettre à jour',
+          objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3 à mettre à jour'],
+          description: 'Une description à mettre à jour',
+        });
         await databaseBuilder.commit();
         const locales = ['fr', 'fr-fr'];
         const updatedTraining = {
@@ -257,6 +263,11 @@ describe('Acceptance | Controller | training-controller', function () {
             minutes: 2,
           },
           locales,
+          deliveryMode: Training.modes.REMOTE,
+          registrationRequired: true,
+          program: 'Programme du contenu formatif mis à jour',
+          objectives: 'Objectif 1;Objectif 2;Objectif 3 mis à jour',
+          description: 'Une description mis à jour',
         };
 
         options = {
@@ -278,6 +289,11 @@ describe('Acceptance | Controller | training-controller', function () {
                 },
                 'is-disabled': true,
                 locales,
+                'delivery-mode': updatedTraining.deliveryMode,
+                'registration-required': updatedTraining.registrationRequired,
+                program: updatedTraining.program,
+                objectives: updatedTraining.objectives,
+                description: updatedTraining.description,
               },
             },
           },
@@ -296,6 +312,11 @@ describe('Acceptance | Controller | training-controller', function () {
               editorName: updatedTraining.editorName,
               editorLogoUrl: updatedTraining.editorLogoUrl,
               isDisabled: updatedTraining.isDisabled,
+              deliveryMode: updatedTraining.deliveryMode,
+              registrationRequired: updatedTraining.registrationRequired,
+              program: updatedTraining.program,
+              objectives: updatedTraining.objectives,
+              description: updatedTraining.description,
             },
           },
         };
@@ -320,6 +341,11 @@ describe('Acceptance | Controller | training-controller', function () {
         );
         expect(response.result.data.attributes['is-disabled']).to.be.true;
         expect(response.result.data.attributes['locales']).to.deep.equal(locales);
+        expect(response.result.data.attributes['delivery-mode']).to.equal(Training.modes.REMOTE);
+        expect(response.result.data.attributes['registration-required']).to.equal(true);
+        expect(response.result.data.attributes.program).to.deep.equal(expectedResponse.data.attributes.program);
+        expect(response.result.data.attributes.objectives).to.deep.equal(expectedResponse.data.attributes.objectives);
+        expect(response.result.data.attributes.description).to.deep.equal(expectedResponse.data.attributes.description);
       });
     });
   });

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -663,6 +663,11 @@ describe('Integration | Repository | training-repository', function () {
         editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/nouveau-logo.svg',
         isDisabled: true,
         locales: ['fr-fr', 'fr'],
+        deliveryMode: Training.modes.ONSITE,
+        registrationRequired: true,
+        program: 'Programme du contenu formatif mis à jour',
+        objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3 mis à jour'],
+        description: 'Une description mise à jour',
         notExistingAttribute: 'notExistingValue',
       };
 
@@ -680,6 +685,11 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
       expect(updatedTraining.updatedAt).to.be.above(currentTraining.updatedAt);
       expect(updatedTraining.isDisabled).to.be.true;
+      expect(updatedTraining.deliveryMode).to.equal(Training.modes.ONSITE);
+      expect(updatedTraining.registrationRequired).to.be.true;
+      expect(updatedTraining.program).to.equal('Programme du contenu formatif mis à jour');
+      expect(updatedTraining.objectives).to.deep.equal(['Objectif 1', 'Objectif 2', 'Objectif 3 mis à jour']);
+      expect(updatedTraining.description).to.equal(attributesToUpdate.description);
     });
 
     it('should return updated training', async function () {
@@ -699,6 +709,11 @@ describe('Integration | Repository | training-repository', function () {
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/nouveau-logo.svg',
         isDisabled: true,
+        deliveryMode: Training.modes.ONSITE,
+        registrationRequired: true,
+        program: 'Programme du contenu formatif mis à jour',
+        objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3 mis à jour'],
+        description: 'Une description mise à jour',
       };
 
       // when
@@ -706,15 +721,7 @@ describe('Integration | Repository | training-repository', function () {
 
       // then
       expect(updatedTraining).to.be.instanceOf(TrainingForAdmin);
-      expect(updatedTraining.title).to.equal(attributesToUpdate.title);
-      expect(updatedTraining.internalTitle).to.equal(attributesToUpdate.internalTitle);
-      expect(updatedTraining.link).to.equal(attributesToUpdate.link);
-      expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
-      expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
-      expect(updatedTraining.targetProfileIds).to.deep.equal([targetProfile.id]);
-      expect(updatedTraining.isDisabled).to.be.true;
     });
-
     it('should not update other raws', async function () {
       // given
       const training = databaseBuilder.factory.buildTraining();

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -86,7 +86,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             'delivery-mode': Training.modes.REMOTE,
             'registration-required': false,
             program: 'Program name',
-            objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3', 'Objectif 4'],
+            objectives: 'Objectif 1;Objectif 2;Objectif 3;Objectif 4',
             description: 'une jolie description',
           },
           id: `${trainingId}`,


### PR DESCRIPTION
## 🪧 Problème
Dans le cadre du moteur de recommandations, Il y a des nouveau champs à prendre en compte lors de l'update de contenus formatifs

## 🌈 Proposition
Ajouter ces novueaux champs sur le route PATCH api/admin/trainings/{trainingId}

## ✊ Remarques
Le serializer pour admin a également été mis à jour pour retourner les objectifs au sein d'une même string, joints par des `';'`. Cela est donc maintenant également le cas pour la route GET (qui avait été oubliée, on retournait jusqu'alors un tableau d'objectifs)

## 🎉 Pour tester
Tests verts
