### PR TITLE
[FEATURE] Utiliser la locale de l'utilisateur pour traduire le référentiel lors de la récupération d'un profil cible (PIX-23170)

### DIFF
--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -23,7 +23,8 @@ const findLearningContentsByOrganizationId = async function (
 
 const getTargetProfileOverview = async function (request, _, dependencies = { targetProfileOverviewSerializer }) {
   const targetProfileId = request.params.targetProfileId;
-  const targetProfile = await usecases.getTargetProfileOverview({ targetProfileId });
+  const locale = getChallengeLocale(request);
+  const targetProfile = await usecases.getTargetProfileOverview({ targetProfileId, locale });
   return dependencies.targetProfileOverviewSerializer.serialize(targetProfile);
 };
 

--- a/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
@@ -80,4 +80,37 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
       expect(result).to.equal(serializedFrameworks);
     });
   });
+
+  describe('#getTargetProfileOverview', function () {
+    it('should fetch and return a target profile, serialized as JSONAPI', async function () {
+      // given
+      const locale = 'en';
+      const targetProfileId = 123;
+      const targetProfileOverview = Symbol('targetProfileOverview');
+      const serializedTargetProfileOverview = Symbol('serializedTargetProfileOverview');
+      const targetProfileOverviewSerializer = {
+        serialize: sinon.stub(),
+      };
+      sinon.stub(usecases, 'getTargetProfileOverview');
+
+      const request = {
+        params: { targetProfileId },
+        state: { locale },
+      };
+
+      usecases.getTargetProfileOverview.withArgs({ targetProfileId, locale: 'en' }).resolves(targetProfileOverview);
+
+      targetProfileOverviewSerializer.serialize
+        .withArgs(targetProfileOverview)
+        .returns(serializedTargetProfileOverview);
+
+      // when
+      const result = await targetProfileController.getTargetProfileOverview(request, hFake, {
+        targetProfileOverviewSerializer,
+      });
+
+      // then
+      expect(result).to.equal(serializedTargetProfileOverview);
+    });
+  });
 });

--- a/orga/app/components/catalogue/course-modal/target-profile-content.gjs
+++ b/orga/app/components/catalogue/course-modal/target-profile-content.gjs
@@ -1,6 +1,7 @@
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 const getTableName = (index, name) => `${index} - ${name}`;
 
@@ -32,8 +33,7 @@ export default class TargetProfileContent extends Component {
           <:columns as |tube context|>
             <PixTableColumn @context={{context}} class="course-modal__competence__description__column">
               <:header>
-                {{! TODO Trad }}
-                Nom et descriptif du sujet
+                {{t "pages.catalogue.modal.tube-name-and-description"}}
               </:header>
               <:cell>
                 <span class="course-modal__competence__description__title">
@@ -46,16 +46,14 @@ export default class TargetProfileContent extends Component {
             </PixTableColumn>
             <PixTableColumn @context={{context}} class="course-modal__competence__level__column">
               <:header>
-                {{! TODO Trad }}
-                Niveau max.
+                {{t "pages.catalogue.modal.max-level"}}
               </:header>
               <:cell>
                 <span class="course-modal__competence__level__data">
                   {{#if tube.maxLevel}}
                     {{tube.maxLevel}}
                   {{else}}
-                    {{! TODO Trad }}
-                    Sujet indisponible
+                    {{t "pages.catalogue.modal.tube-unavailable"}}
                   {{/if}}
                 </span>
               </:cell>

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1055,8 +1055,11 @@
       },
       "modal": {
         "associated-badges": "Zugehörige Abzeichen",
+        "max-level": "Max. Stufe",
         "open-modal": "Details zum Kurs anzeigen",
-        "select-course": "Diesen Kurs auswählen"
+        "select-course": "Diesen Kurs auswählen",
+        "tube-name-and-description": "Name und Beschreibung des Themas",
+        "tube-unavailable": "Thema nicht verfügbar"
       },
       "tab-filters": {
         "all": "Alle",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1065,8 +1065,11 @@
       },
       "modal": {
         "associated-badges": "Related badges",
+        "max-level": "Max level.",
         "open-modal": "View course details",
-        "select-course": "Select course"
+        "select-course": "Select course",
+        "tube-name-and-description": "Topic name and description",
+        "tube-unavailable": "Unavailable topic"
       },
       "tab-filters": {
         "all": "All",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1059,8 +1059,11 @@
       },
       "modal": {
         "associated-badges": "Insignias relacionadas",
+        "max-level": "Nivel máx.",
         "open-modal": "Ver detalles del cursos",
-        "select-course": "Seleccionar este curso"
+        "select-course": "Seleccionar este curso",
+        "tube-name-and-description": "Nombre y descripción del tema",
+        "tube-unavailable": "Tema no disponible"
       },
       "tab-filters": {
         "all": "Todos",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1056,8 +1056,11 @@
       },
       "modal": {
         "associated-badges": "Badge associati",
-        "open-modal": "Visualizza i dettagli del corso",
-        "select-course": "Seleziona questo corso"
+        "max-level": "Livello max.",
+        "open-modal": "Visualizza i dettagli del percorso",
+        "select-course": "Seleziona questo corso",
+        "tube-name-and-description": "Nome e descrizione dell'argomento",
+        "tube-unavailable": "Argomento non disponibile"
       },
       "tab-filters": {
         "all": "Tutti",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1052,8 +1052,11 @@
       },
       "modal": {
         "associated-badges": "Gerelateerde badges",
-        "open-modal": "Bekijk de details van het cursus",
-        "select-course": "Deze cursus selecteren"
+        "max-level": "Max. niveau",
+        "open-modal": "Bekijk de details van het traject",
+        "select-course": "Deze cursus selecteren",
+        "tube-name-and-description": "Naam en beschrijving van het onderwerp",
+        "tube-unavailable": "Onderwerp niet beschikbaar"
       },
       "tab-filters": {
         "all": "Alle",


### PR DESCRIPTION
## 🪧 Problème
Dans le cadre de l'affichage du contenu d'un profil cible dans le catalogue depuis Pix Orga, nous affichons les compétences et sujets composants ce profil cible. Cependant, la langue de l'utilisateur n'est pas prise en compte et les compétences et sujets sont affichés en français. 

## 🌈 Proposition
Utiliser la locale de l'utilisateur pour traduire le référentiel

## 🎉 Pour tester
```
ACCESS_TOKEN=$(curl -X 'POST' -s  'https://orga-pr16512.review.pix.org/api/token' -d 'grant_type=password&username=admin-orga@example.net&password=pix123' | jq -r ".access_token")

curl -H "Authorization: Bearer $ACCESS_TOKEN" "https://orga-pr16512.review.pix.org/api/organizations/1000/target-profiles/6001?lang=en" | jq
```

Ou

- Se connecter à Pix Orga (.org) avec une langue autre que "fr".
- Aller dans le catalogue et ouvrir un profil cible.
- Constater que le référentiel est traduit.