### PR TITLE
[FEATURE] Gérer les requêtes trop longue pour les statistiques des organisations (PIX-23160)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -1,8 +1,11 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 import { getLatestParticipationSharedForOneLearner } from './helpers/get-latest-participation-shared-for-one-learner.js';
 
 const { SHARED, STARTED } = CampaignParticipationStatuses;
+
+const TIMEOUT = 3000;
 
 const getParticipationsActivityByDate = async function (campaignId) {
   const knexConn = DomainTransaction.getConnection();
@@ -83,10 +86,23 @@ const countParticipationsByStatus = async (campaignId) => {
 const countParticipantsByOrganizationId = async (organizationId) => {
   const knexConn = DomainTransaction.getConnection();
 
-  const [{ count }] = await knexConn('campaign-participations')
-    .countDistinct('campaign-participations.organizationLearnerId as count')
-    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .where('campaigns.organizationId', organizationId);
+  let count = null;
+
+  try {
+    const result = await knexConn('campaign-participations')
+      .countDistinct('campaign-participations.organizationLearnerId as count')
+      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+      .where('campaigns.organizationId', organizationId)
+      .first()
+      .timeout(TIMEOUT, { cancel: true });
+
+    count = result?.count;
+  } catch {
+    logger.error({
+      event: 'organization_participants_count_timeout',
+      message: `Request regarding organization ${organizationId} participants count has timed out. Exceeded ${TIMEOUT / 1000}s response time.`,
+    });
+  }
 
   return count;
 };
@@ -94,13 +110,23 @@ const countParticipantsByOrganizationId = async (organizationId) => {
 const countParticipantsByOrganizationIdGroupedByYear = async (organizationId) => {
   const knexConn = DomainTransaction.getConnection();
 
-  const result = await knexConn('campaign-participations')
-    .select(knexConn.raw('EXTRACT(YEAR FROM "campaign-participations"."createdAt")::int AS year'))
-    .countDistinct('campaign-participations.organizationLearnerId AS count')
-    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .where('campaigns.organizationId', organizationId)
-    .groupBy('year')
-    .orderBy('year', 'asc');
+  let result = null;
+
+  try {
+    result = await knexConn('campaign-participations')
+      .select(knexConn.raw('EXTRACT(YEAR FROM "campaign-participations"."createdAt")::int AS year'))
+      .countDistinct('campaign-participations.organizationLearnerId AS count')
+      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+      .where('campaigns.organizationId', organizationId)
+      .groupBy('year')
+      .orderBy('year', 'asc')
+      .timeout(TIMEOUT, { cancel: true });
+  } catch {
+    logger.error({
+      event: 'organization_participants_count_timeout',
+      message: `Request regarding organization ${organizationId} participants count grouped by year has timed out. Exceeded ${TIMEOUT / 1000}s response time.`,
+    });
+  }
 
   return result;
 };

--- a/api/tests/prescription/campaign/unit/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -1,0 +1,80 @@
+import sinon from 'sinon';
+
+import * as campaignParticipationsStatsRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { logger } from '../../../../../../src/shared/infrastructure/utils/logger.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Repository | Campaign Participations Stats', function () {
+  let queryBuilder;
+  let knexConnStub;
+
+  beforeEach(function () {
+    queryBuilder = {
+      select: sinon.stub().returnsThis(),
+      countDistinct: sinon.stub().returnsThis(),
+      join: sinon.stub().returnsThis(),
+      where: sinon.stub().returnsThis(),
+      first: sinon.stub().returnsThis(),
+      groupBy: sinon.stub().returnsThis(),
+      orderBy: sinon.stub().returnsThis(),
+    };
+    knexConnStub = sinon.stub().returns(queryBuilder);
+    knexConnStub.raw = sinon.stub();
+    sinon.stub(DomainTransaction, 'getConnection').returns(knexConnStub);
+  });
+  describe('#countParticipantsByOrganizationId', function () {
+    it('returns null and logs when the query is in error', async function () {
+      // given
+      queryBuilder.timeout = sinon.stub().rejects(new Error('timeout'));
+      sinon.stub(logger, 'error');
+
+      // when
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(1);
+
+      // then
+      expect(result).to.be.null;
+      expect(logger.error.calledOnce).to.be.true;
+      expect(logger.error.firstCall.args[0]).to.include({ event: 'organization_participants_count_timeout' });
+    });
+
+    it('returns result when query does not timeout', async function () {
+      // given
+      queryBuilder.timeout = sinon.stub().resolves({ count: 42 });
+
+      // when
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationId(1);
+
+      // then
+      expect(result).to.equal(42);
+    });
+  });
+
+  describe('#countParticipantsByOrganizationIdGroupedByYear', function () {
+    it('returns null and logs when the query is in error', async function () {
+      // given
+      queryBuilder.timeout = sinon.stub().rejects(new Error('timeout'));
+      sinon.stub(logger, 'error');
+
+      // when
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear(1);
+
+      // then
+      expect(result).to.be.null;
+      expect(logger.error.calledOnce).to.be.true;
+      expect(logger.error.firstCall.args[0]).to.include({ event: 'organization_participants_count_timeout' });
+    });
+
+    it('returns result when query does not timeout', async function () {
+      // given
+      const expectedResult = [{ year: 2025, count: 42 }];
+      queryBuilder.timeout = sinon.stub().resolves(expectedResult);
+
+      // when
+      const result = await campaignParticipationsStatsRepository.countParticipantsByOrganizationIdGroupedByYear(1);
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème
Sur certaines organisations, le temps de calcul des statistiques est beaucoup trop long, et retourne une 500 côté API car la BDD mets trop de temps à répondre.

## 🌈 Proposition
Limiter le temps d'attente pour les requêtes sur les statistiques à 3secondes. Si elles dépassent, on coupe, on retourne des valeurs null et on envoie des logs sur datadog pour le suivi dans l'équipe.

## ✊ Remarques
On a choisi ce temps arbitraire de 3s, en se disant que c'était déjà bien assez long et pour éviter de ralentir toute l'api. En // de ça nos travaux avec l'équipe Data vont débuter afin d'avoir ces stats pré-calculés et donc ces temps devraient retomber a quelques ms. 
Pour l'instant si la requête remonte null, côté front aucune erreur, juste pas d'affichage des stats. On gère le loader + message dans le prochain ticket

## 🎉 Pour tester
Compliqué à faire en RA
- Cloner la branche
- Dans les deux méthodes, on peut ajouter un `select(knex.raw(pg_sleep(x)))` x étant le nombre en seconde ( donc 5 par exemple pour dépasser le timeout défini )
- Aller sur PixAdmin, cliquer sur une orga puis l'onglet statistiques
- Constater dans la console de l'API les logs avec l'event + message
- 🐈‍⬛ 
