### PR TITLE
[TECH] Enlever le trigger merge_group pour certaines actions CI

### DIFF
--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -2,8 +2,6 @@ name: commits check
 
 on:
   pull_request:
-  merge_group:
-    types: [checks_requested]
 
 jobs:
   block-autosquash-commits:

--- a/.github/workflows/check-node-version-availability-on-scalingo.yml
+++ b/.github/workflows/check-node-version-availability-on-scalingo.yml
@@ -3,8 +3,6 @@ name: Check node version availability on Scalingo
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  merge_group:
-    types: [checks_requested]
 
 jobs:
   check-node-compatibility:

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -3,8 +3,6 @@ name: pr title check
 on:
   pull_request:
     types: [opened, edited, ready_for_review, reopened]
-  merge_group:
-    types: [checks_requested]
 
 jobs:
   lint-pr-title:

--- a/.github/workflows/test-modulix-content.yaml
+++ b/.github/workflows/test-modulix-content.yaml
@@ -3,8 +3,6 @@ name: Test Modulix content
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-  merge_group:
-    types: [checks_requested]
 
 defaults:
   run:


### PR DESCRIPTION
## 🪧 Problème

On ne doit pas exécuter certaines actions dans la merge queue

## 🌈 Proposition

Enlever le trigger `merge_group` dans les actions qui ne doivent pas se déclencher dans la merge queue.

## ✊ Remarques

N/A

## 🎉 Pour tester

N/A