### PR TITLE
[FEATURE] Ajouter un endpoint permettant de récupérer le détail d'un blueprint appartenant à une organisation (PIX-23018)

### DIFF
--- a/api/src/prescription/target-profile/application/api/target-profile-api.js
+++ b/api/src/prescription/target-profile/application/api/target-profile-api.js
@@ -47,6 +47,21 @@ export const getById = async (id) => {
 
 /**
  * @function
+ * @name getByIds
+ *
+ * @param {Array<number>} targetProfileIds
+ * @returns {Promise<TargetProfile[]>}
+ */
+export const getByIds = async (targetProfileIds) => {
+  const targetProfiles = await usecases.getTargetProfiles({
+    targetProfileIds,
+  });
+
+  return targetProfiles.map((targetProfile) => new TargetProfile(targetProfile));
+};
+
+/**
+ * @function
  * @name findSkillByTargetProfileIds
  *
  * @param {Array<number>} targetProfilsIds

--- a/api/src/prescription/target-profile/domain/usecases/get-target-profiles.js
+++ b/api/src/prescription/target-profile/domain/usecases/get-target-profiles.js
@@ -1,0 +1,5 @@
+const getTargetProfiles = async function ({ targetProfileIds, targetProfileRepository }) {
+  return targetProfileRepository.findByIds(targetProfileIds);
+};
+
+export { getTargetProfiles };

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -42,6 +42,7 @@ import { getTargetProfile } from './get-target-profile.js';
 import { getTargetProfileContentAsJson } from './get-target-profile-content-as-json.js';
 import { getTargetProfileForAdmin } from './get-target-profile-for-admin.js';
 import { getTargetProfileOverview } from './get-target-profile-overview.js';
+import { getTargetProfiles } from './get-target-profiles.js';
 import { markTargetProfileAsSimplifiedAccess } from './mark-target-profile-as-simplified-access.js';
 import { outdateTargetProfile } from './outdate-target-profile.js';
 import { updateTargetProfile } from './update-target-profile.js';
@@ -63,6 +64,7 @@ const usecasesWithoutInjectedDependencies = {
   getTargetProfileContentAsJson,
   getTargetProfileForAdmin,
   getTargetProfile,
+  getTargetProfiles,
   getTargetProfileOverview,
   markTargetProfileAsSimplifiedAccess,
   outdateTargetProfile,

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -3,6 +3,7 @@ import * as adminCombinedCourseBlueprintDetailsSerializer from '../infrastructur
 import * as combinedCourseBlueprintForCreationSerializer from '../infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js';
 import * as combinedCourseBlueprintForUpdateSerializer from '../infrastructure/serializers/combined-course-blueprint-for-update-serializer.js';
 import * as combinedCourseBlueprintOrganizationSerializer from '../infrastructure/serializers/combined-course-blueprint-organization-serializer.js';
+import * as combinedCourseBlueprintOverviewSerializer from '../infrastructure/serializers/combined-course-blueprint-overview-serializer.js';
 import * as combinedCourseBlueprintSerializer from '../infrastructure/serializers/combined-course-blueprint-serializer.js';
 
 const findAll = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
@@ -65,6 +66,13 @@ const findByOrganizationId = async (request, _, dependencies = { combinedCourseB
   return dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
 };
 
+const findOverviewById = async (request, _, dependencies = { combinedCourseBlueprintOverviewSerializer }) => {
+  const combinedCourseBlueprint = await usecases.findCombinedCourseBlueprintById({
+    id: request.params.blueprintId,
+  });
+  return dependencies.combinedCourseBlueprintOverviewSerializer.serialize(combinedCourseBlueprint);
+};
+
 const combinedCourseBlueprintController = {
   findAll,
   save,
@@ -73,6 +81,7 @@ const combinedCourseBlueprintController = {
   detachOrganization,
   attachOrganizations,
   findByOrganizationId,
+  findOverviewById,
 };
 
 export { combinedCourseBlueprintController };

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { combinedCourseBlueprintController } from './combined-course-blueprint-controller.js';
+import questSecurityPreHandlers from './security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([
@@ -202,6 +203,31 @@ const register = async function (server) {
         },
         handler: combinedCourseBlueprintController.update,
         notes: ['- Met à jour le schéma de parcours combiné'],
+        tags: ['api', 'combined-course'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/combined-course-blueprints/{blueprintId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+            blueprintId: identifiersType.combinedCourseBlueprintId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkUserBelongsToOrganization,
+            assign: 'checkUserBelongsToOrganization',
+          },
+          {
+            method: questSecurityPreHandlers.checkCombinedCourseBlueprintBelongsToOrganization,
+            assign: 'checkCombinedCourseBlueprintBelongsToOrganization',
+          },
+        ],
+        handler: combinedCourseBlueprintController.findOverviewById,
+        notes: ["- Récupère un schéma de parcours combinés partagés avec l'organisation"],
         tags: ['api', 'combined-course'],
       },
     },

--- a/api/src/quest/application/security-pre-handlers.js
+++ b/api/src/quest/application/security-pre-handlers.js
@@ -55,10 +55,10 @@ export async function checkParticipationBelongsToCombinedCourse(request, h) {
 }
 
 export async function checkCombinedCourseBlueprintBelongsToOrganization(request, h) {
-  const { organizationId, combinedCourseBlueprintId } = request.params;
+  const { organizationId, blueprintId } = request.params;
   try {
     const isCombinedCourseBlueprintInOrganization = await usecases.isCombinedCourseBlueprintInOrganization({
-      combinedCourseBlueprintId,
+      combinedCourseBlueprintId: blueprintId,
       organizationId,
     });
     if (isCombinedCourseBlueprintInOrganization) {
@@ -96,4 +96,5 @@ export default {
   checkUserCanManageCombinedCourse,
   checkParticipationBelongsToCombinedCourse,
   checkCombinedCoursesFeatureIsEnabled,
+  checkCombinedCourseBlueprintBelongsToOrganization,
 };

--- a/api/src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js
@@ -7,7 +7,8 @@ import {
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../quests/entities/Quest.js';
-import { buildRequirement } from '../../quests/value-objects/Requirement.js';
+import { buildRequirement, TYPES } from '../../quests/value-objects/Requirement.js';
+import { CombinedCourseBlueprintItem } from './CombinedCourseBlueprintItem.js';
 
 export class CombinedCourseBlueprint {
   constructor({
@@ -159,5 +160,28 @@ export class CombinedCourseBlueprint {
     if (!this.name) throw new ObjectValidationError('Name is required');
     if (!this.internalName) throw new ObjectValidationError('InternalName is required');
     if (!this.quest) throw new ObjectValidationError('Quest is required');
+  }
+
+  generateItems({ targetProfiles, modules, recommendableModules }) {
+    this.items = this.quest.successRequirements.map((requirement) => {
+      if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
+        const targetProfile = targetProfiles.find(
+          (targetProfile) => targetProfile.id === parseInt(requirement.data.targetProfileId.data),
+        );
+        return new CombinedCourseBlueprintItem({ id: targetProfile.id, name: targetProfile.name });
+      }
+      if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
+        const module = modules.find((module) => module.id === requirement.data.moduleId.data);
+        const recommendableModule = recommendableModules.find(({ moduleId }) => moduleId === module.id);
+
+        return new CombinedCourseBlueprintItem({
+          id: module.id,
+          name: module.title,
+          duration: module.duration,
+          image: module.image,
+          isRecommendable: Boolean(recommendableModule),
+        });
+      }
+    });
   }
 }

--- a/api/src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprintItem.js
+++ b/api/src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprintItem.js
@@ -1,0 +1,9 @@
+export class CombinedCourseBlueprintItem {
+  constructor({ id, name, duration, image, isRecommendable }) {
+    this.id = id;
+    this.name = name;
+    this.duration = duration;
+    this.image = image;
+    this.isRecommendable = isRecommendable;
+  }
+}

--- a/api/src/quest/domain/usecases/create-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/create-combined-course-blueprint.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CombinedCourseBlueprint } from '../models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
 
 export const createCombinedCourseBlueprint = async ({
@@ -5,7 +6,20 @@ export const createCombinedCourseBlueprint = async ({
   combinedCourseBlueprintRepository,
   targetProfileRepository,
 }) => {
-  await targetProfileRepository.findByIds({ ids: combinedCourseBlueprintForCreation.targetProfileIds });
+  const existingTargetProfiles = await targetProfileRepository.findByIds({
+    ids: combinedCourseBlueprintForCreation.targetProfileIds,
+  });
+
+  if (existingTargetProfiles.length !== combinedCourseBlueprintForCreation.targetProfileIds.length) {
+    const existingTargetProfileIds = existingTargetProfiles.map(({ id }) => id);
+    const notFoundTargetProfileIds = combinedCourseBlueprintForCreation.targetProfileIds.filter(
+      (id) => !existingTargetProfileIds.includes(id),
+    );
+
+    throw new NotFoundError(
+      `Le(s) profil(s) cible(s) avec le(s) id(s) ${notFoundTargetProfileIds.join(', ')} n'existe(nt) pas`,
+    );
+  }
 
   return combinedCourseBlueprintRepository.save({
     combinedCourseBlueprint: new CombinedCourseBlueprint({ ...combinedCourseBlueprintForCreation }),

--- a/api/src/quest/domain/usecases/find-combined-course-blueprint-by-id.js
+++ b/api/src/quest/domain/usecases/find-combined-course-blueprint-by-id.js
@@ -1,0 +1,25 @@
+export const findCombinedCourseBlueprintById = async ({
+  id,
+  combinedCourseBlueprintRepository,
+  targetProfileRepository,
+  moduleRepository,
+  recommendedModuleRepository,
+}) => {
+  const combinedCourseBlueprint = await combinedCourseBlueprintRepository.findById({ id });
+  const targetProfiles = await targetProfileRepository.findByIds({
+    ids: combinedCourseBlueprint.targetProfileIds,
+  });
+  const recommendableModules = await recommendedModuleRepository.findIdsByTargetProfileIds({
+    targetProfileIds: combinedCourseBlueprint.targetProfileIds,
+  });
+  const modules = await moduleRepository.getByIds({
+    moduleIds: combinedCourseBlueprint.moduleIds,
+  });
+
+  combinedCourseBlueprint.generateItems({
+    targetProfiles,
+    modules,
+    recommendableModules,
+  });
+  return combinedCourseBlueprint;
+};

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -64,6 +64,7 @@ import { deleteAndAnonymizeParticipationsForALearnerId } from './delete-and-anon
 import { deleteAndAnonymizeCombinedCourses } from './delete-and-anonymize-combined-courses.js';
 import { detachOrganizationFromCombinedCourseBlueprint } from './detach-organization-from-combined-course-blueprint.js';
 import { findByOrganizationId } from './find-by-organization-id.js';
+import { findCombinedCourseBlueprintById } from './find-combined-course-blueprint-by-id.js';
 import { findCombinedCourseBlueprints } from './find-combined-course-blueprints.js';
 import { findCombinedCourseByCampaignId } from './find-combined-course-by-campaign-id.js';
 import { findCombinedCourseByModuleIdAndUserId } from './find-combined-course-by-moduleId-and-user-id.js';
@@ -100,6 +101,7 @@ const usecasesWithoutInjectedDependencies = {
   getCombinedCourseStatistics,
   getCombinedCourseById,
   getCombinedCourseParticipationById,
+  findCombinedCourseBlueprintById,
   findCombinedCourseParticipations,
   findCombinedCourseBlueprints,
   getCombinedCoursesByOrganizationId,

--- a/api/src/quest/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/quest/infrastructure/repositories/target-profile-repository.js
@@ -1,11 +1,7 @@
 import { TargetProfile } from '../../domain/models/TargetProfile.js';
 
 export const findByIds = async function ({ ids, targetProfilesApi }) {
-  const targetProfiles = [];
-  for (const targetProfileId of ids) {
-    const targetProfile = await targetProfilesApi.getById(targetProfileId);
-    targetProfiles.push(targetProfile);
-  }
+  const targetProfiles = await targetProfilesApi.getByIds(ids);
   return targetProfiles.map(toDomain);
 };
 

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js
@@ -1,0 +1,29 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (combinedCourseBlueprint) {
+  return new Serializer('combined-course-blueprint-overview', {
+    attributes: [
+      'name',
+      'internalName',
+      'description',
+      'illustration',
+      'surveyLink',
+      'createdAt',
+      'updatedAt',
+      'items',
+    ],
+    items: {
+      ref: 'id',
+      included: true,
+      attributes: ['name', 'duration', 'image', 'isRecommendable'],
+    },
+    typeForAttribute: (attribute) => {
+      if (attribute === 'items') return 'combined-course-blueprint-items';
+      else return attribute;
+    },
+  }).serialize(combinedCourseBlueprint);
+};
+
+export { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js
@@ -4,16 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourseBlueprint) {
   return new Serializer('combined-course-blueprint-overview', {
-    attributes: [
-      'name',
-      'internalName',
-      'description',
-      'illustration',
-      'surveyLink',
-      'createdAt',
-      'updatedAt',
-      'items',
-    ],
+    attributes: ['name', 'internalName', 'description', 'illustration', 'createdAt', 'updatedAt', 'items'],
     items: {
       ref: 'id',
       included: true,

--- a/api/tests/prescription/target-profile/integration/domain/usecases/get-target-profiles_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/get-target-profiles_test.js
@@ -1,0 +1,30 @@
+import _ from 'lodash';
+
+import { usecases } from '../../../../../../src/prescription/target-profile/domain/usecases/index.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | UseCase | get-target-profiles', function () {
+  it('should return a list of target profiles', async function () {
+    // given
+    const targetProfile1 = databaseBuilder.factory.buildTargetProfile({ name: 'first target profile' });
+    const targetProfile2 = databaseBuilder.factory.buildTargetProfile({ name: 'second target profile' });
+    const targetProfile3 = databaseBuilder.factory.buildTargetProfile({ name: 'third target profile' });
+    await databaseBuilder.commit();
+
+    const targetProfileIds = [targetProfile1.id, targetProfile2.id, targetProfile3.id];
+
+    const expectedTargetProfilesAttributes = _.map([targetProfile1, targetProfile3, targetProfile2], (item) =>
+      _.pick(item, ['id', 'name', 'organizationId', 'outdated']),
+    );
+
+    // when
+    const foundTargetProfiles = await usecases.getTargetProfiles({ targetProfileIds });
+
+    // then
+    const foundTargetProfilesAttributes = _.map(foundTargetProfiles, (item) =>
+      _.pick(item, ['id', 'name', 'organizationId', 'outdated']),
+    );
+    expect(foundTargetProfilesAttributes).to.deep.members(expectedTargetProfilesAttributes);
+  });
+});

--- a/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
+++ b/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
@@ -120,4 +120,49 @@ describe('Unit | API | TargetProfile', function () {
       expect(result[0].difficulty).equals(18);
     });
   });
+
+  describe('#getByIds', function () {
+    it('should return an array of TargetProfile', async function () {
+      // given
+      const expectedTargetProfiles = [
+        new TargetProfile({
+          id: 1,
+          name: 'TargetProfile1',
+          internalName: 'InternalName1',
+          category: 'OTHER',
+          isSimplifiedAccess: true,
+        }),
+        new TargetProfile({
+          id: 2,
+          name: 'TargetProfile2',
+          internalName: 'InternalName2',
+          category: 'OTHER',
+          isSimplifiedAccess: false,
+        }),
+        new TargetProfile({
+          id: 3,
+          name: 'TargetProfile3',
+          internalName: 'InternalName3',
+          category: 'OTHER',
+          isSimplifiedAccess: true,
+        }),
+      ];
+
+      const findSkillsByTargetProfileIdsStub = sinon.stub(usecases, 'getTargetProfiles');
+      findSkillsByTargetProfileIdsStub
+        .withArgs({ targetProfileIds: [1, 2, 3] })
+        .resolves(
+          expectedTargetProfiles.map((expectedTargetProfile) =>
+            domainBuilder.buildTargetProfile(expectedTargetProfile),
+          ),
+        );
+
+      // when
+      const result = await targetProfileApi.getByIds([1, 2, 3]);
+
+      // then
+      expect(result).to.have.lengthOf(3);
+      expect(result).to.deep.equal(expectedTargetProfiles);
+    });
+  });
 });

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -23,7 +23,9 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'GET',
           url: `/api/admin/combined-course-blueprints`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
         };
 
         // when
@@ -40,7 +42,9 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     context('when user is admin ', function () {
       it('should create a combined course blueprint', async function () {
         // given
-        const attestation = databaseBuilder.factory.buildAttestation({ key: ATTESTATIONS.SIXTH_GRADE });
+        const attestation = databaseBuilder.factory.buildAttestation({
+          key: ATTESTATIONS.SIXTH_GRADE,
+        });
         const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         await databaseBuilder.commit();
 
@@ -54,14 +58,22 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               illustration: 'illustration.svg',
               'reward-id': attestation.id,
               'reward-type': 'ATTESTATION',
-              content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
+              content: [
+                {
+                  type: 'module',
+                  value: 'e67ec5d0',
+                  shortId: 'short-e67ec5d0',
+                },
+              ],
             },
           },
         };
         const options = {
           method: 'POST',
           url: `/api/admin/combined-course-blueprints`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
           payload,
         };
 
@@ -86,7 +98,9 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'GET',
           url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprint.id}`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
         };
 
         // when
@@ -112,7 +126,9 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'DELETE',
           url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprintId}/organizations/${organizationId}`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
         };
 
         // when
@@ -153,7 +169,9 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'POST',
           url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprintId}/organizations`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
           payload,
         };
 
@@ -229,7 +247,9 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'PATCH',
           url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprintId}`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
           payload,
         };
 
@@ -239,6 +259,42 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         // then
         expect(response.statusCode).to.equal(204);
       });
+    });
+  });
+
+  describe('GET /api/organizations/{organizationId}/combined-course-blueprints/{blueprintId}', function () {
+    let user;
+    let organization;
+    let combinedCourseBlueprint;
+
+    beforeEach(async function () {
+      user = databaseBuilder.factory.buildUser({});
+      organization = databaseBuilder.factory.buildOrganization({});
+      databaseBuilder.factory.buildMembership({
+        userId: user.id,
+        organizationId: organization.id,
+      });
+      combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint();
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        combinedCourseBlueprintId: combinedCourseBlueprint.id,
+        organizationId: organization.id,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return 200', async function () {
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organization.id}/combined-course-blueprints/${combinedCourseBlueprint.id}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/quest/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/quest/acceptance/application/security-pre-handlers_test.js
@@ -212,7 +212,7 @@ describe('Quest | Acceptance | Application | SecurityPreHandlers', function () {
 
       server.route({
         method: 'GET',
-        path: '/api/organization/{organizationId}/combined-course-blueprint/{combinedCourseBlueprintId}',
+        path: '/api/organization/{organizationId}/combined-course-blueprint/{blueprintId}',
         handler: (r, h) => h.response({}).code(200),
         config: {
           auth: false,

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-blueprint-by-id_test.js
@@ -1,0 +1,82 @@
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
+import { CombinedCourseBlueprintItem } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprintItem.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Integration | Quest | Domain | UseCases | find-combined-course-blueprint-by-id', function () {
+  it('should return a combined course blueprint', async function () {
+    // given
+    const targetProfile = databaseBuilder.factory.buildTargetProfile({
+      name: 'Diagnostic',
+    });
+    const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+    const quest = databaseBuilder.factory.buildQuest({
+      rewardType: null,
+      rewardId: null,
+      successRequirements: [
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+          targetProfileId: targetProfile.id,
+        }).toDTO(),
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+          moduleId,
+        }).toDTO(),
+      ],
+    });
+
+    const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
+      name: 'Schéma de parcours combiné',
+      questId: quest.id,
+    });
+
+    const trainingId = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      link: '/modules/demo-combinix-1',
+    }).id;
+    databaseBuilder.factory.buildTargetProfileTraining({
+      trainingId,
+      targetProfileId: targetProfile.id,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.findCombinedCourseBlueprintById({
+      id: combinedCourseBlueprint.id,
+    });
+
+    // then
+    expect(result).instanceOf(CombinedCourseBlueprint);
+    expect(result).to.deep.equal({
+      createdAt: combinedCourseBlueprint.createdAt,
+      description: combinedCourseBlueprint.description,
+      id: combinedCourseBlueprint.id,
+      illustration: combinedCourseBlueprint.illustration,
+      internalName: combinedCourseBlueprint.internalName,
+      name: combinedCourseBlueprint.name,
+      updatedAt: combinedCourseBlueprint.updatedAt,
+      surveyLink: null,
+      organizationIds: [],
+      items: [
+        new CombinedCourseBlueprintItem({
+          id: targetProfile.id,
+          name: 'Diagnostic',
+        }),
+        new CombinedCourseBlueprintItem({
+          id: moduleId,
+          name: 'Demo combinix 1',
+          duration: 1,
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+          isRecommendable: true,
+        }),
+      ],
+      quest: {
+        createdAt: quest.createdAt,
+        id: quest.id,
+        rewardId: quest.rewardId,
+        rewardType: quest.rewardType,
+        updatedAt: quest.updatedAt,
+      },
+    });
+  });
+});

--- a/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
 import { combinedCourseBlueprintController } from '../../../../src/quest/application/combined-course-blueprint-controller.js';
 import * as combinedCourseBlueprintRoute from '../../../../src/quest/application/combined-course-blueprint-route.js';
+import questSecurityPreHandlers from '../../../../src/quest/application/security-pre-handlers.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect } from '../../../test-helper.js';
 import { HttpTestServer } from '../../../tooling/server/http-test-server.js';
@@ -189,6 +190,7 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
       expect(securityPreHandlers.checkOrganizationAccess).to.have.been.called;
     });
   });
+
   describe('PATCH /api/admin/combined-course-blueprints/{combinedCourseBlueprintId}', function () {
     it('should call prehandler', async function () {
       // given
@@ -229,6 +231,85 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
         securityPreHandlers.checkAdminMemberHasRoleSupport,
         securityPreHandlers.checkAdminMemberHasRoleCertif,
       ]);
+    });
+  });
+
+  describe('GET /api/organizations/{organizationId}/combined-course-blueprints/{blueprintId}', function () {
+    it('should call findOverviewById', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').resolves(() => true);
+      sinon.stub(questSecurityPreHandlers, 'checkCombinedCourseBlueprintBelongsToOrganization').resolves(() => true);
+      sinon.stub(combinedCourseBlueprintController, 'findOverviewById').callsFake((_, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(combinedCourseBlueprintRoute);
+
+      // when
+      await httpTestServer.request(
+        'GET',
+        '/api/organizations/456/combined-course-blueprints/789',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
+
+      // then
+      expect(combinedCourseBlueprintController.findOverviewById).to.have.been.called;
+    });
+
+    describe('when the user does not belong to the organization', function () {
+      it('should return 403', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'checkUserBelongsToOrganization')
+          .callsFake((request, h) => h.response().code(403).takeover());
+        sinon.stub(questSecurityPreHandlers, 'checkCombinedCourseBlueprintBelongsToOrganization').resolves(() => true);
+        sinon.stub(combinedCourseBlueprintController, 'findOverviewById').callsFake((_, h) => h.response());
+
+        const httpTestServer = new HttpTestServer();
+        httpTestServer.setupAuthentication();
+        await httpTestServer.register(combinedCourseBlueprintRoute);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/organizations/456/combined-course-blueprints/789',
+          null,
+          null,
+          generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+        );
+
+        // then
+        expect(response.statusCode).equal(403);
+      });
+    });
+
+    describe('when the combined course blueprint does not belong to the organization', function () {
+      it('should return 403', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').resolves(() => true);
+        sinon
+          .stub(questSecurityPreHandlers, 'checkCombinedCourseBlueprintBelongsToOrganization')
+          .callsFake((request, h) => h.response().code(403).takeover());
+        sinon.stub(combinedCourseBlueprintController, 'findOverviewById').callsFake((_, h) => h.response());
+
+        const httpTestServer = new HttpTestServer();
+        httpTestServer.setupAuthentication();
+        await httpTestServer.register(combinedCourseBlueprintRoute);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/organizations/456/combined-course-blueprints/789',
+          null,
+          null,
+          generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+        );
+
+        // then
+        expect(response.statusCode).equal(403);
+      });
     });
   });
 });

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -352,7 +352,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
   });
 
   describe('#generateItems', function () {
-    it('should generate a list of step containing blueprint detailed content', function () {
+    it('should generate a list of combined course blueprint item', function () {
       // given
       const firstTargetProfileId = 1;
       const secondTargetProfileId = 2;
@@ -430,7 +430,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
 
       // when
       const combinedCourseBlueprint = new CombinedCourseBlueprint(values);
-      combinedCourseBlueprint.generateItems({ targetProfiles, modules, recommendableModules });
+      combinedCourseBlueprint.generateItems({
+        targetProfiles,
+        modules,
+        recommendableModules,
+      });
 
       // then
       expect(combinedCourseBlueprint.items).deep.equal([

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -1,5 +1,6 @@
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
+import { CombinedCourseBlueprintItem } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprintItem.js';
 import { CombinedCourseBlueprintForUpdate } from '../../../../../src/quest/domain/models/combined-course-blueprints/value-objects/CombinedCourseBlueprintForUpdate.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/combined-courses/entities/CombinedCourse.js';
 import { Quest } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
@@ -83,9 +84,15 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       values.quest = new Quest({
         eligibilityRequirements: [],
         successRequirements: [
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: 'moduleId-555' }),
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: 'moduleId-777' }),
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: firstTargetProfileId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: 'moduleId-555',
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: 'moduleId-777',
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: firstTargetProfileId,
+          }),
         ],
       });
 
@@ -103,7 +110,9 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       values.quest = new Quest({
         eligibilityRequirements: [],
         successRequirements: [
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: firstTargetProfileId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: firstTargetProfileId,
+          }),
         ],
       });
 
@@ -121,8 +130,12 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       values.quest = new Quest({
         eligibilityRequirements: [],
         successRequirements: [
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: 1 }),
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: 8 }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: 1,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: 8,
+          }),
         ],
       });
 
@@ -184,9 +197,15 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         rewardType,
         eligibilityRequirements: [],
         successRequirements: [
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: firstTargetProfileId }),
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: secondTargetProfileId }),
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: firstTargetProfileId,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: secondTargetProfileId,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId,
+          }),
         ],
       });
 
@@ -204,9 +223,15 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         rewardType,
         eligibilityRequirements: [],
         successRequirements: [
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: firstTargetProfileId }),
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: secondTargetProfileId }),
-          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: firstTargetProfileId,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: secondTargetProfileId,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId,
+          }),
         ],
       });
 
@@ -323,6 +348,126 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
 
       //then
       expect(combinedCourseBlueprint).to.deep.equal(expectedUpdatedBlueprint);
+    });
+  });
+
+  describe('#generateItems', function () {
+    it('should generate a list of step containing blueprint detailed content', function () {
+      // given
+      const firstTargetProfileId = 1;
+      const secondTargetProfileId = 2;
+      const thirdTargetProfileId = 3;
+
+      const module1Id = 'step1-module1';
+      const module2Id = 'step1-module2';
+      const module3Id = 'step2-module1';
+
+      values.quest = new Quest({
+        rewardId: null,
+        rewardType: null,
+        eligibilityRequirements: [],
+        successRequirements: [
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: firstTargetProfileId,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: module1Id,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: module2Id,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: secondTargetProfileId,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: thirdTargetProfileId,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: module3Id,
+          }),
+        ],
+      });
+      const targetProfiles = [
+        {
+          id: firstTargetProfileId,
+          name: 'Step1 Diag1',
+        },
+        {
+          id: secondTargetProfileId,
+          name: 'Step2 Diag1',
+        },
+        {
+          id: thirdTargetProfileId,
+          name: 'Step2 Diag2',
+        },
+      ];
+      const modules = [
+        {
+          id: 'step1-module1',
+          title: 'Module 1',
+          image: 'illustration.svg',
+          duration: 5,
+        },
+        {
+          id: 'step1-module2',
+          title: 'Module 2',
+          image: 'illustration.svg',
+          duration: 4,
+        },
+        {
+          id: 'step2-module1',
+          title: 'Module 3',
+          image: 'illustration.svg',
+          duration: 3,
+        },
+      ];
+      const recommendableModules = [
+        {
+          moduleId: 'step1-module2',
+          targetProfileIds: [firstTargetProfileId],
+        },
+      ];
+
+      // when
+      const combinedCourseBlueprint = new CombinedCourseBlueprint(values);
+      combinedCourseBlueprint.generateItems({ targetProfiles, modules, recommendableModules });
+
+      // then
+      expect(combinedCourseBlueprint.items).deep.equal([
+        new CombinedCourseBlueprintItem({
+          id: firstTargetProfileId,
+          name: 'Step1 Diag1',
+        }),
+        new CombinedCourseBlueprintItem({
+          id: module1Id,
+          name: 'Module 1',
+          duration: 5,
+          image: 'illustration.svg',
+          isRecommendable: false,
+        }),
+        new CombinedCourseBlueprintItem({
+          id: module2Id,
+          name: 'Module 2',
+          duration: 4,
+          image: 'illustration.svg',
+          isRecommendable: true,
+        }),
+        new CombinedCourseBlueprintItem({
+          id: secondTargetProfileId,
+          name: 'Step2 Diag1',
+        }),
+        new CombinedCourseBlueprintItem({
+          id: thirdTargetProfileId,
+          name: 'Step2 Diag2',
+        }),
+        new CombinedCourseBlueprintItem({
+          id: module3Id,
+          name: 'Module 3',
+          duration: 3,
+          image: 'illustration.svg',
+          isRecommendable: false,
+        }),
+      ]);
     });
   });
 });

--- a/api/tests/quest/unit/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/target-profile-repository_test.js
@@ -6,7 +6,7 @@ import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Repositories | target-profile', function () {
   describe('#findByIds', function () {
-    it('should call getById method from targetProfileApi', async function () {
+    it('should call getByIds method from targetProfileApi', async function () {
       // given
       const firstTargetProfileId = 1;
       const secondTargetProfileId = 2;
@@ -21,10 +21,12 @@ describe('Quest | Unit | Infrastructure | Repositories | target-profile', functi
         internalName: 'targetProfileInternalName2',
       });
       const targetProfilesApiStub = {
-        getById: sinon.stub(),
+        getByIds: sinon.stub(),
       };
-      targetProfilesApiStub.getById.withArgs(firstTargetProfileId).resolves(expectedFirstTargetProfile);
-      targetProfilesApiStub.getById.withArgs(secondTargetProfileId).resolves(expectedSecondTargetProfile);
+      targetProfilesApiStub.getByIds
+        .withArgs([firstTargetProfileId, secondTargetProfileId])
+        .resolves([expectedFirstTargetProfile, expectedSecondTargetProfile]);
+
       // when
       const result = await targetProfileRepository.findByIds({
         ids: [firstTargetProfileId, secondTargetProfileId],

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-overview-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-overview-serializer_test.js
@@ -1,0 +1,108 @@
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
+import { Quest } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
+import * as combinedCourseBlueprintOverviewSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprint-overview', function () {
+  it('#serialize', function () {
+    // given
+    const quest = new Quest({
+      eligibilityRequirements: [],
+      successRequirements: [],
+    });
+    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+      id: 1,
+      name: 'Mon parcours',
+      internalName: 'Mon modèle de parcours',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      illustration: '/illustrations/image.svg',
+      surveyLink: 'survey-link-test',
+      quest,
+    });
+    combinedCourseBlueprint.items = [
+      { id: 1, name: 'Diagnostic' },
+      {
+        id: 2,
+        name: 'Module 1',
+        duration: 1,
+        image: '/image.png',
+        isRecommendable: true,
+      },
+      {
+        id: 3,
+        name: 'Module 2',
+        duration: 2,
+        image: '/image.png',
+        isRecommendable: false,
+      },
+    ];
+
+    // when
+    const serializedCombinedCourseBlueprintOverview =
+      combinedCourseBlueprintOverviewSerializer.serialize(combinedCourseBlueprint);
+
+    // then
+    expect(serializedCombinedCourseBlueprintOverview).to.deep.equal({
+      data: {
+        attributes: {
+          name: 'Mon parcours',
+          'internal-name': 'Mon modèle de parcours',
+          illustration: '/illustrations/image.svg',
+          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          'survey-link': 'survey-link-test',
+          'created-at': combinedCourseBlueprint.createdAt,
+          'updated-at': combinedCourseBlueprint.updatedAt,
+        },
+        type: 'combined-course-blueprint-overview',
+        id: '1',
+        relationships: {
+          items: {
+            data: [
+              {
+                id: '1',
+                type: 'combined-course-blueprint-items',
+              },
+              {
+                id: '2',
+                type: 'combined-course-blueprint-items',
+              },
+              {
+                id: '3',
+                type: 'combined-course-blueprint-items',
+              },
+            ],
+          },
+        },
+      },
+      included: [
+        {
+          id: '1',
+          type: 'combined-course-blueprint-items',
+          attributes: {
+            name: 'Diagnostic',
+          },
+        },
+        {
+          id: '2',
+          type: 'combined-course-blueprint-items',
+          attributes: {
+            duration: 1,
+            image: '/image.png',
+            name: 'Module 1',
+            'is-recommendable': true,
+          },
+        },
+        {
+          id: '3',
+          type: 'combined-course-blueprint-items',
+          attributes: {
+            duration: 2,
+            image: '/image.png',
+            name: 'Module 2',
+            'is-recommendable': false,
+          },
+        },
+      ],
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-overview-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-overview-serializer_test.js
@@ -16,7 +16,6 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
       internalName: 'Mon modèle de parcours',
       description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
       illustration: '/illustrations/image.svg',
-      surveyLink: 'survey-link-test',
       quest,
     });
     combinedCourseBlueprint.items = [
@@ -49,7 +48,6 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
           'internal-name': 'Mon modèle de parcours',
           illustration: '/illustrations/image.svg',
           description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-          'survey-link': 'survey-link-test',
           'created-at': combinedCourseBlueprint.createdAt,
           'updated-at': combinedCourseBlueprint.updatedAt,
         },


### PR DESCRIPTION
## 🪧 Problème
Nous avons besoin de récupérer le détail d’un blueprint afin de l’afficher dans une modale dans le catalogue sur Pix Orga. Or, il n’existe pas aujourd’hui d’enpoint répondant à notre besoin. 

## 🌈 Proposition
Ajouter un endpoint permettant de récupérer le détail d'un blueprint appartenant à une organisation

## 🎉 Pour tester
```
ACCESS_TOKEN=$(curl -X 'POST' -s  'https://orga-pr16534.review.pix.fr/api/token' -d 'grant_type=password&username=admin-orga@example.net&password=pix123' | jq -r ".access_token")

curl -H "Authorization: Bearer $ACCESS_TOKEN" "https://orga-pr16534.review.pix.fr/api/organizations/1000/combined-course-blueprints/108618" | jq
```