### PR TITLE
[TECH] Deplacer les scripts de banner dans leur contexte

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "clean": "rm -rf node_modules",
     "cache:refresh": "node --env-file-if-exists=.env scripts/refresh-cache.js",
-    "banner:add": "node --env-file-if-exists=.env banner/scripts/add.js",
-    "banner:remove": "node --env-file-if-exists=.env banner/scripts/remove.js",
+    "banner:add": "node --env-file-if-exists=.env src/banner/application/scripts/add.js",
+    "banner:remove": "node --env-file-if-exists=.env src/banner/application/scripts/remove.js",
     "datamart:create": "node --env-file-if-exists=.env scripts/database/create-database --name datamart",
     "datamart:delete": "node --env-file-if-exists=.env scripts/database/drop-database --name datamart",
     "datamart:new-migration": "npx knex --knexfile datamart/knexfile.js migrate:make --stub $PWD/db/template.js $migrationname",

--- a/api/src/banner/application/scripts/add.js
+++ b/api/src/banner/application/scripts/add.js
@@ -1,6 +1,6 @@
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { informationBannersStorage } from '../../src/shared/infrastructure/key-value-storages/index.js';
+import { Script } from '../../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../../shared/application/scripts/script-runner.js';
+import { informationBannersStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 
 export class AddInformationBanners extends Script {
   constructor() {

--- a/api/src/banner/application/scripts/remove.js
+++ b/api/src/banner/application/scripts/remove.js
@@ -1,6 +1,6 @@
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { informationBannersStorage } from '../../src/shared/infrastructure/key-value-storages/index.js';
+import { Script } from '../../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../../shared/application/scripts/script-runner.js';
+import { informationBannersStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 
 export class RemoveInformationBanners extends Script {
   constructor() {


### PR DESCRIPTION
## 🪧 Problème

Les scripts `api/banner/scripts/add.js` et `api/banner/scripts/remove.js` doivent être dans le contexte `banner`

## 🌈 Proposition

Déplacer ces scripts dans `api/banner/application/scripts`

## ✊ Remarques

N/A

## 🎉 Pour tester

Exécuter depuis `api`:
- `npm run banner:add -- --help`
- `npm run banner:remove -- --help`
