### PR TITLE
[FEATURE] migration pour rendre le combinedCourseBlueprintId non nullable in table combined_courses

### DIFF
--- a/api/db/migrations/20260615094251_make-blueprint-id-non-nullable-in-combined-course-blueprints.js
+++ b/api/db/migrations/20260615094251_make-blueprint-id-non-nullable-in-combined-course-blueprints.js
@@ -1,0 +1,36 @@
+const TABLE_NAME = 'combined_courses';
+const COLUMN_NAME = 'combinedCourseBlueprintId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .notNullable()
+      .comment(
+        "Combined course blueprint used to create this combined course) - see 'combined_course_blueprints' table",
+      )
+      .alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .nullable()
+      .comment(
+        "Combined course blueprint used to create this combined course) - see 'combined_course_blueprints' table",
+      )
+      .alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🪧 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Les combinedCourseBlueprintId sont aujourd'hui nullables dans combined_courses, et ne devraient pas l'être.

## 🌈 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Migration pour rendre cette colonne non nullable.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
On a fait le ménage en prod pour ne plus avoir de cas où les combinedCourseBlueprintId sont nullables.
On a également ajusté les tests qui auraient cassé une fois la colonne rendue non nullable (dans [cette PR](https://github.com/1024pix/pix/pull/16522))

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
CI au vert
