### PR TITLE
[TECH] Changer les conditions de déclenchement de la CI

### DIFF
--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -1,23 +1,26 @@
 name: Trigger CircleCI
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, unlabeled]
   push:
     branches:
       - dev
   merge_group:
     types: [checks_requested]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
 
 jobs:
   trigger-ci:
     runs-on: ubuntu-latest
 
-    # Triggered when :
-    # A merge group OR
-    #  The opened PR is not draft or is on "dev" branch
-    #  And doesn't have the label 'Development in progress' or the label 'Development in progress' label is removed
-    if: github.event_name == 'merge_group' || (((!github.event.pull_request.draft && github.event.pull_request.state == 'open') || github.ref == 'refs/heads/dev') && ((github.event.action == 'unlabeled' && github.event.label.name == 'Development in progress') || (github.event.action != 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'Development in progress'))))
+    # Triggered when : on "dev" branch OR in the merge queue OR not a draft PR OR commented with '/run-ci'
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-ci'))
 
     steps:
       - name: Extract branch name


### PR DESCRIPTION
## 🪧 Problème

Changer les conditions de déclenchement de la CI.

## 🌈 Proposition

1. Enlever la condition basée sur le label "Development in progress"
2. Ajouter la commande `/run-ci` pour déclencher la CI sur une PR draft

Les règles de déclencherment de CI sont quand :
- on push sur la branche "dev"
- Ou PR envoyée dans la merge queue
- Ou push sur la PR (non draft)
- Ou PR commentée avec '/run-ci'

## ✊ Remarques

<img width="1099" height="837" alt="image" src="https://github.com/user-attachments/assets/bd57f923-89dc-4678-8cee-7a44866021cf" />


## 🎉 Pour tester

1. Draft PR => pas de CI
2. Ajouter le commentaire `/run-ci` => CI déclenchée
3. PR non draft => CI déclenchée
4. Au merge => CI déclenchée dans la merge queue et sur dev
