### PR TITLE
[TECH] :broom: Suppression de la colonne `hasSeenEndTestScreen` devenue inutile dans la table `certification-courses` (PIX-21297)

### DIFF
--- a/api/db/migrations/20260616114157_remove-has-seen-end-test-screen-col.js
+++ b/api/db/migrations/20260616114157_remove-has-seen-end-test-screen-col.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'hasSeenEndTestScreen';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🪧 Problème

La colonne `hasSeenEndTestScreen` est devenue inutile

## 🌈 Proposition

Supprimer la colonne `hasSeenEndTestScreen` de la table  `certification-courses`

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

Déploiement API OK et tests vert