### PR TITLE
[TECH] :recycle: Utilise une déclaration de fonction plutôt qu'assigner une fonction a une constante

### DIFF
--- a/api/db/template.js
+++ b/api/db/template.js
@@ -19,7 +19,7 @@ const COLUMN_NAME = 'authorId';
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-const up = async function (knex) {
+export async function up(knex) {
   await knex.schema.table(TABLE_NAME, function (table) {
     table
       .integer(COLUMN_NAME)
@@ -27,16 +27,14 @@ const up = async function (knex) {
       .references('author.id')
       .comment("Book author identifier - see 'author' table");
   });
-};
+}
 
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-const down = async function (knex) {
+export async function down(knex) {
   await knex.schema.table(TABLE_NAME, function (table) {
     table.dropColumn(COLUMN_NAME);
   });
-};
-
-export { down, up };
+}


### PR DESCRIPTION
## 🪧 Problème

Je trouve nos usages d'écriture de fonction assez incohérents, disparate.

Parfois, nous utilisons la forme « déclaration de fonction » parfois les « fonction fléchée » et parfois l'affectation de déclaration de fonction dans une constante.

## 🌈 Proposition

Utiliser les déclarations de fonction, sauf dans le cas de fonction anonyme (définie directement dans les paramètres d'une autre fonction).

Modification du template de migration de base de donnée pour avancer dans ce sens

## ✊ Remarques

Cette orientation nécessiterait peut-être une discussion plus longue, et un ADR ? Voir une règle de linter (https://eslint.org/docs/latest/rules/func-style) 

J'aime assez la documentation de MDN sur le sujet https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions

> An arrow function expression is a compact alternative to a traditional [function expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function), with some semantic differences and deliberate limitations in usage:

Ce qui pour moi signifie qu'en dehors de l'aspect esthétique, les fonctions fléchées permettent moins de chose. 
Ceci étant, je pense qu'elles sont vraiment très efficaces dans le cadre d'un callback (ou fonction anonyme).

Voir d'ailleurs le dernier paragraphe de la doc de MDN

> Perhaps the greatest benefit of using arrow functions is with methods like [setTimeout()](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout) and [EventTarget.prototype.addEventListener()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) that usually require some kind of closure, call(), apply(), or bind() to ensure that the function is executed in the proper scope.

Je n'ai pas cherché l'historique, mais les fonctions fléchées n'existaient pas avant. Et c'est sans doute pour réduire la pénibilité de gestion du `this` dans les fonctions utilisé en callback que cette nouvelle façon de déclarer des fonctions a été créé.


## 🎉 Pour tester

Copie de la branche en local
execution de la commande `npm run db:new-migration bla`

La commande devrait avoir généré un fichier de la forme

```javascript
const TABLE_NAME = 'book';
const COLUMN_NAME = 'authorId';

/**
 * @param { import("knex").Knex } knex
 * @returns { Promise<void> }
 */
export async function up(knex) {
  await knex.schema.table(TABLE_NAME, function (table) {
    table
      .integer(COLUMN_NAME)
      .defaultTo(null)
      .references('author.id')
      .comment("Book author identifier - see 'author' table");
  });
};

/**
 * @param { import("knex").Knex } knex
 * @returns { Promise<void> }
 */
export async function down(knex) {
  await knex.schema.table(TABLE_NAME, function (table) {
    table.dropColumn(COLUMN_NAME);
  });
};
```