### PR TITLE
[TECH] Vérifie les labels bloquants sur la merge queue.

### DIFF
--- a/.github/workflows/check-blocking-labels.yaml
+++ b/.github/workflows/check-blocking-labels.yaml
@@ -7,6 +7,8 @@ on:
       - labeled
       - unlabeled
       - synchronize
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   check-blocking-labels:


### PR DESCRIPTION
## 🪧 Problème

La vérification des labels bloquants n'est pas faite pour la merge queue, ce qui empêche de rendre obligatoire cette vérification.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌈 Proposition

On ajoute le trigger "on: merge-group" pour faire la vérification sur la merge queue
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
