### PR TITLE
[FEATURE] QCM-declaratif - Pour répondre, il doit y avoir au moins une réponse (PIX-23187)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -5,6 +5,7 @@ import {
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
   QCMAnsweredEvent,
+  QCMDeclarativeAnsweredEvent,
   QCMRetriedEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
@@ -87,6 +88,8 @@ class PassageEventFactory {
         return new QROCMAnsweredEvent(eventData);
       case 'QCM_ANSWERED':
         return new QCMAnsweredEvent(eventData);
+      case 'QCM_DECLARATIVE_ANSWERED':
+        return new QCMDeclarativeAnsweredEvent(eventData);
       case 'QCM_RETRIED':
         return new QCMRetriedEvent(eventData);
       case 'QCU_ANSWERED':

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -183,12 +183,30 @@ class QROCMRetriedEvent extends PassageEventWithElement {
   }
 }
 
+class QCMDeclarativeAnsweredEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer }) {
+    super({
+      type: 'QCM_DECLARATIVE_ANSWERED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      data: { answer },
+    });
+
+    assertNotNullOrUndefined(answer, 'The answer is required for a QCMDeclarativeAnsweredEvent');
+  }
+}
+
 export {
   CustomDraftRetriedEvent,
   CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
   QCMAnsweredEvent,
+  QCMDeclarativeAnsweredEvent,
   QCMRetriedEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -4,6 +4,7 @@ import {
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
   QCMAnsweredEvent,
+  QCMDeclarativeAnsweredEvent,
   QCMRetriedEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
@@ -354,7 +355,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
         // when
         const error = catchErrSync(
           () =>
-            new QCUDeclarativeAnsweredEvent({
+            new QCMDeclarativeAnsweredEvent({
               id,
               occurredAt,
               createdAt,
@@ -367,7 +368,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
 
         // then
         expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The answer is required for a QCUDeclarativeAnsweredEvent');
+        expect(error.message).to.equal('The answer is required for a QCMDeclarativeAnsweredEvent');
       });
     });
   });
@@ -439,6 +440,70 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
       expect(qrocmAnsweredEvent.passageId).to.equal(passageId);
       expect(qrocmAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(qrocmAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
+    });
+  });
+
+  describe('#QCMDeclarativeAnsweredEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = '1,2';
+
+      // when
+      const qcmDeclarativeAnsweredEvent = new QCMDeclarativeAnsweredEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        answer,
+      });
+
+      // then
+      expect(qcmDeclarativeAnsweredEvent.id).to.equal(id);
+      expect(qcmDeclarativeAnsweredEvent.type).to.equal('QCM_DECLARATIVE_ANSWERED');
+      expect(qcmDeclarativeAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(qcmDeclarativeAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(qcmDeclarativeAnsweredEvent.passageId).to.equal(passageId);
+      expect(qcmDeclarativeAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qcmDeclarativeAnsweredEvent.data).to.deep.equal({ elementId, answer });
+    });
+
+    describe('when answer is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+        const answer = undefined;
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new QCUDeclarativeAnsweredEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              elementId,
+              answer,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The answer is required for a QCUDeclarativeAnsweredEvent');
+      });
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -7,6 +7,7 @@ import {
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
   QCMAnsweredEvent,
+  QCMDeclarativeAnsweredEvent,
   QCMRetriedEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
@@ -450,6 +451,25 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QCMAnsweredEvent);
+      });
+    });
+
+    describe('when given a QCM_DECLARATIVE_ANSWERED event', function () {
+      it('should return a QCMDeclarativeAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QCM_DECLARATIVE_ANSWERED',
+          answer: '1,3',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QCMDeclarativeAnsweredEvent);
       });
     });
 

--- a/mon-pix/app/components/module/element/_qcm-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcm-declarative.scss
@@ -74,6 +74,10 @@
       }
     }
   }
+
+  &__required-field-missing {
+    margin-top: var(--pix-spacing-4x);
+  }
 }
 
 .element-qcm-declarative-feedback {

--- a/mon-pix/app/components/module/element/qcm-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcm-declarative.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -30,8 +31,12 @@ export default class ModuleQcmDeclarative extends ModuleElement {
     return this.isSubmitted || this.isAnswering;
   }
 
+  get userResponse() {
+    return [...this.selectedProposalIds];
+  }
+
   get canValidateElement() {
-    return false;
+    return this.selectedProposalIds.size > 0;
   }
 
   @action
@@ -46,11 +51,17 @@ export default class ModuleQcmDeclarative extends ModuleElement {
   @action
   async onAnswer(event) {
     event.preventDefault();
-    this.isAnswering = true;
-    const answer = [...this.selectedProposalIds];
     super.onAnswer(event);
 
+    if (this.shouldDisplayRequiredMessage === true) {
+      return;
+    }
+
+    this.isAnswering = true;
+    const answer = [...this.selectedProposalIds];
+
     await this.waitFor(VERIFY_RESPONSE_DELAY);
+
     await this.args.onAnswer({ element: this.element });
     this.reportInfo = {
       answer: answer.join(', '),
@@ -63,7 +74,7 @@ export default class ModuleQcmDeclarative extends ModuleElement {
       type: 'QCM_DECLARATIVE_ANSWERED',
       data: {
         elementId: this.element.id,
-        answer,
+        answer: answer.join(', '),
       },
     });
   }
@@ -103,6 +114,13 @@ export default class ModuleQcmDeclarative extends ModuleElement {
             </div>
           {{/if}}
         </div>
+        {{#if this.shouldDisplayRequiredMessage}}
+          <div class="element-qcm-declarative__required-field-missing">
+            <PixNotificationAlert role="alert" @type="error" @withIcon={{true}}>
+              {{t "pages.modulix.verification-precondition-failed-alert.qcm-declarative"}}
+            </PixNotificationAlert>
+          </div>
+        {{/if}}
         {{#unless this.isSubmitted}}
           <PixButton class="element-qcm-declarative--submit" @triggerAction={{this.onAnswer}}>{{t
               "pages.modulix.buttons.activity.submit"

--- a/mon-pix/tests/integration/components/module/qcm-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm-declarative_test.gjs
@@ -44,7 +44,7 @@ module('Integration | Component | Module | QcmDeclarative', function (hooks) {
     assert.dom(submitButton).exists();
   });
 
-  module('when user clicks on several propositions', function () {
+  module('when user clicks on several propositions and submit', function () {
     test('should disable interaction, call action, send an event when submit button is clicked, then display feedback and hide submit button', async function (assert) {
       // given
       const onAnswerStub = sinon.stub();
@@ -89,12 +89,15 @@ module('Integration | Component | Module | QcmDeclarative', function (hooks) {
       const onAnswerStub = sinon.stub();
 
       const qcmDeclarativeElement = _getQcmDeclarativeElement();
+      const { proposals } = qcmDeclarativeElement;
 
       // when
       const screen = await render(
         <template><ModuleQcmDeclarative @element={{qcmDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
       );
       const submitButton = screen.getByRole('button', { name: 'Soumettre ma sélection' });
+      const proposal1Element = screen.getByLabelText(proposals[0].content);
+      await click(proposal1Element);
       await submitButton.click();
       await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
 
@@ -106,10 +109,31 @@ module('Integration | Component | Module | QcmDeclarative', function (hooks) {
         type: 'QCM_DECLARATIVE_ANSWERED',
         data: {
           elementId: qcmDeclarativeElement.id,
-          answer: [],
+          answer: '1',
         },
       });
       assert.ok(true);
+    });
+  });
+
+  module('when no proposal is selected', function () {
+    test('should display an error message when submit button is clicked', async function (assert) {
+      // given
+      const onAnswerStub = sinon.stub();
+      const qcmDeclarativeElement = _getQcmDeclarativeElement();
+
+      const screen = await render(
+        <template><ModuleQcmDeclarative @element={{qcmDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+
+      // when
+      const submitButton = screen.getByRole('button', { name: 'Soumettre ma sélection' });
+      await click(submitButton);
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+
+      // then
+      assert.dom(screen.getByRole('alert')).exists();
+      sinon.assert.notCalled(onAnswerStub);
     });
   });
 
@@ -151,6 +175,7 @@ module('Integration | Component | Module | QcmDeclarative', function (hooks) {
 });
 
 function _getQcmDeclarativeElement(hasShortProposals = false) {
+  const id = '0db62236-a758-4fbb-bbca-16d63d92ad6e';
   const instruction = '<p>Lesquels de ces oiseaux croisez-vous près de chez vous ?</p>';
   const complementaryInstruction = 'Sélectionnez la ou les réponses de votre choix.';
 
@@ -176,5 +201,5 @@ function _getQcmDeclarativeElement(hasShortProposals = false) {
     diagnosis: 'Vous en avez de la chance !',
   };
 
-  return { instruction, hasShortProposals, complementaryInstruction, proposals, feedback };
+  return { id, instruction, hasShortProposals, complementaryInstruction, proposals, feedback };
 }

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1912,6 +1912,7 @@
       },
       "verification-precondition-failed-alert": {
         "qcm": "Wähle zum Bestätigen mindestens zwei Antworten aus.",
+        "qcm-declarative": "Wähle zum Absenden mindestens eine Antwort aus.",
         "qcu": "Zum Bestätigen wähle eine Antwort aus.",
         "qrocm": "Fülle zum Bestätigen bitte alle Antwortfelder aus."
       }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1912,6 +1912,7 @@
       },
       "verification-precondition-failed-alert": {
         "qcm": "To validate, select at least two answers.",
+        "qcm-declarative": "To submit, select at least one answer.",
         "qcu": "To validate, select an answer.",
         "qrocm": "To validate, please complete all response fields."
       }

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1912,6 +1912,7 @@
       },
       "verification-precondition-failed-alert": {
         "qcm": "Para validar, selecciona al menos dos respuestas.",
+        "qcm-declarative": "Para enviar, selecciona al menos una respuesta.",
         "qcu": "Para validar, selecciona una respuesta.",
         "qrocm": "Para validar, rellena todos los campos de respuesta."
       }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1912,6 +1912,7 @@
       },
       "verification-precondition-failed-alert": {
         "qcm": "Pour valider, sélectionnez au moins deux réponses.",
+        "qcm-declarative": "Pour soumettre, sélectionnez au moins une réponse.",
         "qcu": "Pour valider, sélectionnez une réponse.",
         "qrocm": "Pour valider, veuillez remplir tous les champs réponse."
       }

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1912,6 +1912,7 @@
       },
       "verification-precondition-failed-alert": {
         "qcm": "Per confermare, seleziona almeno due risposte.",
+        "qcm-declarative": "Per inviare, seleziona almeno una risposta.",
         "qcu": "Per confermare, seleziona una risposta.",
         "qrocm": "Per convalidare, compila tutti i campi di risposta."
       }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1912,6 +1912,7 @@
       },
       "verification-precondition-failed-alert": {
         "qcm": "Selecteer ten minste twee antwoorden om te bevestigen.",
+        "qcm-declarative": "Selecteer ten minste één antwoord om te verzenden.",
         "qcu": "Selecteer een antwoord om te bevestigen.",
         "qrocm": "Vul alle antwoordvelden in om te bevestigen."
       }


### PR DESCRIPTION
## 🪧 Problème

Lors de la relecture de la PR précédente de qcm-declarative, il a été finalement demandé de ne pas autoriser de pouvoir répondre sans choisir au moins une proposition.

## 🌈 Proposition

- Ajouter un contrôle sur le nombre de réponse sélectionnées avant envoi de la réponse.
- Afficher un message d'alerte si aucune proposition n'est sélectionnée

## ✊ Remarques

- J'ai fait les ajouts côté API pour gérer un `passage-event` de type `QCM_DECLARATIVE_ANSWERED`
- Je n'avais pas de maquette pour l'affichage du `qcm-delcarativ`e avec le message d'alerte, donc j'ai fait à ma sauce en me basant sur le `qcm`

## 🎉 Pour tester

- Ouvrir le module [bac-a-sable](https://app-pr16550.review.pix.fr/modules/6a68bf32/bac-a-sable/details)
- Appuyer sur "soumettre" au qcm-declarative, sans sélectionner de proposition
- Un message d'erreur doit apparaître
- Sélectionner une option, cliquer sur soumettre. Le feedback s'affiche
- Un appel pour enregistrer le passage-event "qcm_declarative_answered" a été envoyé avec un retour 204