### PR TITLE
[BUGFIX] Afficher l'image du niveau du candidat de certif uniquement lorsque la session est publiée (PIX-23199).

### DIFF
--- a/api/src/certification/results/domain/models/CertificateSummary.js
+++ b/api/src/certification/results/domain/models/CertificateSummary.js
@@ -73,8 +73,6 @@ export class CertificateSummary {
     reachedMeshIndex,
     eduV3ExternalJuryResult,
   }) {
-    let status, extraCertificationStatus;
-
     const mappingAssessmentResultStatuses = {
       [AssessmentResult.status.CANCELLED]: CERTIFICATE_STATUSES.CANCELLED,
       [AssessmentResult.status.VALIDATED]: CERTIFICATE_STATUSES.VALIDATED,
@@ -89,7 +87,10 @@ export class CertificateSummary {
 
     const isWaitingForResult = !isPublished;
     const isCancelled = assessmentResultStatus === AssessmentResult.status.CANCELLED;
+    const isRejectedV3 =
+      AlgorithmEngineVersion.isV3(algorithmVersion) && assessmentResultStatus === AssessmentResult.status.REJECTED;
 
+    let status, extraCertificationStatus;
     if (isWaitingForResult) {
       status = CERTIFICATE_STATUSES.WAITING_FOR_RESULTS;
       extraCertificationStatus = null;
@@ -108,12 +109,10 @@ export class CertificateSummary {
       ? CERTIFICATE_TYPES.CERTIFICATE
       : CERTIFICATE_TYPES.ATTESTATION;
 
-    const isRejectedV3 =
-      AlgorithmEngineVersion.isV3(algorithmVersion) && assessmentResultStatus === AssessmentResult.status.REJECTED;
-
-    const certificateMeshLevel = isRejectedV3
-      ? null
-      : new CertificateMeshLevel({ reachedMeshIndex, certificationFramework, eduV3ExternalJuryResult });
+    const certificateMeshLevel =
+      isRejectedV3 || isWaitingForResult
+        ? null
+        : new CertificateMeshLevel({ reachedMeshIndex, certificationFramework, eduV3ExternalJuryResult });
 
     return new CertificateSummary({
       id,

--- a/api/tests/certification/results/unit/domain/models/CertificateSummary_test.js
+++ b/api/tests/certification/results/unit/domain/models/CertificateSummary_test.js
@@ -32,20 +32,11 @@ describe('Unit | Domain | Models | CertificationSummary', function () {
     context('status computation', function () {
       context('when certification is not published', function () {
         [
-          {
-            assessmentResultStatus: AssessmentResult.status.REJECTED,
-            expectedReachedMeshLevel: null,
-          },
-          {
-            assessmentResultStatus: AssessmentResult.status.VALIDATED,
-            expectedReachedMeshLevel: 'LEVEL_BEGINNER_1',
-          },
-          {
-            assessmentResultStatus: AssessmentResult.status.CANCELLED,
-            expectedReachedMeshLevel: 'LEVEL_BEGINNER_1',
-          },
-        ].forEach(({ assessmentResultStatus, expectedReachedMeshLevel }) => {
-          it(`should set the status of the certificate as WAIT_FOR_RESULTS when assessment result status is ${assessmentResultStatus}`, function () {
+          AssessmentResult.status.REJECTED,
+          AssessmentResult.status.VALIDATED,
+          AssessmentResult.status.CANCELLED,
+        ].forEach((assessmentResultStatus) => {
+          it(`should set the status of the certificate as WAIT_FOR_RESULTS and reachedMeshLevel to null when assessment result status is ${assessmentResultStatus}`, function () {
             const actualCertificateSummary = CertificateSummary.buildFrom({
               ...baseData,
               assessmentResultStatus,
@@ -63,7 +54,7 @@ describe('Unit | Domain | Models | CertificationSummary', function () {
               status: CERTIFICATE_STATUSES.WAITING_FOR_RESULTS,
               extraCertificationStatus: null,
               certificateType: CERTIFICATE_TYPES.CERTIFICATE,
-              reachedMeshLevel: expectedReachedMeshLevel,
+              reachedMeshLevel: null,
             });
 
             expect(actualCertificateSummary).to.deepEqualInstance(expectedCertificateSummary);
@@ -140,7 +131,7 @@ describe('Unit | Domain | Models | CertificationSummary', function () {
               status: CERTIFICATE_STATUSES.WAITING_FOR_RESULTS,
               extraCertificationStatus: null,
               certificateType: CERTIFICATE_TYPES.CERTIFICATE,
-              reachedMeshLevel: 'LEVEL_BEGINNER_1',
+              reachedMeshLevel: null,
             });
 
             expect(actualCertificateSummary).to.deepEqualInstance(expectedCertificateSummary);
@@ -239,6 +230,26 @@ describe('Unit | Domain | Models | CertificationSummary', function () {
 
           // then
           expect(actualCertificateSummary.reachedMeshLevel).to.equal('LEVEL_INDEPENDENT_3');
+        });
+      });
+
+      context('when certification is Pix+ EDU and not published', function () {
+        it('should set reachedMeshLevel to null and status to WAITING_FOR_RESULTS regardless of the external jury result', function () {
+          // when
+          const actualCertificateSummary = CertificateSummary.buildFrom({
+            ...baseData,
+            certificationFramework: Frameworks.EDU_2ND_DEGRE,
+            algorithmVersion: AlgorithmEngineVersion.V3,
+            assessmentResultStatus: AssessmentResult.status.VALIDATED,
+            isPublished: false,
+            isExtraCertificationAcquired: true,
+            reachedMeshIndex: 0,
+            eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+          });
+
+          // then
+          expect(actualCertificateSummary.reachedMeshLevel).to.be.null;
+          expect(actualCertificateSummary.status).to.equal(CERTIFICATE_STATUSES.WAITING_FOR_RESULTS);
         });
       });
 


### PR DESCRIPTION
## 🪧 Problème

Lorsqu’un candidat a passé une certification Pix+ mais que les résultats n’ont pas encore été publiés par le pôle certif métier, il peut voir une card correspondant à sa certification Pix+ dans son onglet “Mes certifications” de Pix App.

Cette card mentionne le niveau scoré automatiquement alors que le jury Pix ne s’est pas encore prononcé.

## 🌈 Proposition

Tant que la session n'est pas publiée, alors le candidat continue de voir "en attente de résultat" et un hexagone grisé.

## 🎉 Pour tester

Tester les ≠ cas en RA.

Dont le cas : 
- Avoir une certif Pix+ Edu publiée avec son jury externe 
> <img width="576" height="172" alt="image" src="https://github.com/user-attachments/assets/3152f1e2-ba76-42c8-b342-f5b9f1b27a31" />

- La dépublier et voir cette même card en mode "en attente"
> <img width="581" height="169" alt="image" src="https://github.com/user-attachments/assets/edf39bdb-8e95-435e-9fbf-0fe7239c8c6f" />


