### PR TITLE
[FEATURE] Permettre la création et la mise à jour d'un contenu formatif pour le moteur de recommandations (PIX-23118)

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -117,7 +117,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
 
   @action
   toggleRegistrationRequired() {
-    set(this.form, 'registrationRequired', !this.form.registrationRequired);
+    this.form.registrationRequired = !this.form.registrationRequired;
   }
 
   @action

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -2,7 +2,9 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import PixTextArea from '@1024pix/pix-ui/components/pix-textarea';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -14,7 +16,7 @@ import { eq } from 'ember-truth-helpers';
 import set from 'lodash/set';
 import ENV from 'pix-admin/config/environment';
 
-import { optionsLocaleList, optionsTypeList } from '../../models/training';
+import { optionsLocaleList, optionsModeList, optionsTypeList } from '../../models/training';
 import Card from '../card';
 
 class Form {
@@ -31,8 +33,28 @@ class Form {
   @tracked editorLogoUrl;
   @tracked editorName;
   @tracked isDisabled;
+  @tracked deliveryMode;
+  @tracked registrationRequired;
+  @tracked description;
+  @tracked objectives;
+  @tracked program;
 
-  constructor({ title, internalTitle, link, type, duration, locales, editorLogoUrl, editorName, isDisabled } = {}) {
+  constructor({
+    title,
+    internalTitle,
+    link,
+    type,
+    duration,
+    locales,
+    editorLogoUrl,
+    editorName,
+    isDisabled,
+    deliveryMode,
+    registrationRequired,
+    description,
+    objectives,
+    program,
+  } = {}) {
     this.title = title || null;
     this.internalTitle = internalTitle || null;
     this.link = link || null;
@@ -42,6 +64,11 @@ class Form {
     this.editorLogoUrl = editorLogoUrl || null;
     this.editorName = editorName || null;
     this.isDisabled = isDisabled || false;
+    this.deliveryMode = deliveryMode || null;
+    this.registrationRequired = registrationRequired || false;
+    this.description = description || null;
+    this.objectives = objectives ? objectives.split(';').join(';\n') : null;
+    this.program = program || null;
   }
 }
 
@@ -59,6 +86,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
     super(...arguments);
     this.optionsTypeList = optionsTypeList;
     this.optionsLocaleList = optionsLocaleList;
+    this.optionsModeList = optionsModeList;
     this.form = new Form(this.args.model);
     this.loadModules();
   }
@@ -85,6 +113,11 @@ export default class CreateOrUpdateTrainingForm extends Component {
   @action
   toggleIsDisabled() {
     set(this.form, 'isDisabled', !this.form.isDisabled);
+  }
+
+  @action
+  toggleRegistrationRequired() {
+    set(this.form, 'registrationRequired', !this.form.registrationRequired);
   }
 
   @action
@@ -115,7 +148,6 @@ export default class CreateOrUpdateTrainingForm extends Component {
   @action
   async onSubmit(event) {
     event.preventDefault();
-
     const training = {
       title: this.form.title,
       internalTitle: this.form.internalTitle,
@@ -126,6 +158,11 @@ export default class CreateOrUpdateTrainingForm extends Component {
       editorName: this.form.editorName,
       isDisabled: this.form.isDisabled,
       editorLogoUrl: this.form.editorLogoUrl,
+      deliveryMode: this.form.deliveryMode,
+      registrationRequired: this.form.registrationRequired,
+      description: this.form.description,
+      objectives: this.form.objectives,
+      program: this.form.program,
     };
 
     try {
@@ -285,6 +322,49 @@ export default class CreateOrUpdateTrainingForm extends Component {
               <:label>Mettre en pause</:label>
             </PixCheckbox>
           {{/if}}
+        </Card>
+        <Card class="admin-form__card" @title={{t "pages.trainings.training.form.recommendation-engine.card-title"}}>
+          <PixSelect
+            @placeholder={{t "pages.trainings.training.form.recommendation-engine.delivery-mode.placeholder"}}
+            @value={{this.form.deliveryMode}}
+            @options={{this.optionsModeList}}
+            @onChange={{fn this.updateSelect "deliveryMode"}}
+          >
+            <:label>{{t "pages.trainings.training.form.recommendation-engine.delivery-mode.label"}}</:label>
+          </PixSelect>
+          <PixSegmentedControl
+            @toggled={{this.form.registrationRequired}}
+            @onChange={{this.toggleRegistrationRequired}}
+          >
+            <:label>{{t "pages.trainings.training.form.recommendation-engine.registration-required.label"}}</:label>
+            <:viewA>{{t "common.words.no"}}</:viewA>
+            <:viewB>{{t "common.words.yes"}}</:viewB>
+          </PixSegmentedControl>
+          <PixTextArea
+            @id="trainingDescription"
+            rows="4"
+            value={{this.form.description}}
+            {{on "change" (fn this.updateForm "description")}}
+          >
+            <:label>{{t "pages.trainings.training.form.recommendation-engine.description.label"}}</:label>
+          </PixTextArea>
+          <PixTextArea
+            @id="trainingObjectives"
+            @subLabel={{t "pages.trainings.training.form.recommendation-engine.objectives.sub-label"}}
+            rows="6"
+            value={{this.form.objectives}}
+            {{on "change" (fn this.updateForm "objectives")}}
+          >
+            <:label>{{t "pages.trainings.training.form.recommendation-engine.objectives.label"}}</:label>
+          </PixTextArea>
+          <PixTextArea
+            @id="trainingProgram"
+            rows="6"
+            value={{this.form.program}}
+            {{on "change" (fn this.updateForm "program")}}
+          >
+            <:label>{{t "pages.trainings.training.form.recommendation-engine.program.label"}}</:label>
+          </PixTextArea>
         </Card>
       </section>
       <section class="admin-form__actions">

--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -23,6 +23,14 @@ export const localeCategories = {
 
 export const optionsLocaleList = formatList(localeCategories);
 
+export const deliveryModeCategories = {
+  hybrid: 'Hybride',
+  remote: 'À distance',
+  onSite: 'En présentiel',
+};
+
+export const optionsModeList = formatList(deliveryModeCategories);
+
 export default class Training extends Model {
   @attr('string') title;
   @attr('string') internalTitle;
@@ -33,6 +41,11 @@ export default class Training extends Model {
   @attr('string') editorLogoUrl;
   @attr('boolean') isRecommendable;
   @attr('boolean') isDisabled;
+  @attr('string') deliveryMode;
+  @attr('boolean') registrationRequired;
+  @attr('string') description;
+  @attr('string') objectives;
+  @attr('string') program;
   @attr({
     defaultValue: () => ({
       days: 0,

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -2,7 +2,7 @@ import { clickByName, fillByLabel, render, within } from '@1024pix/ember-testing
 import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CreateOrUpdateTrainingForm from 'pix-admin/components/trainings/create-or-update-training-form';
-import { localeCategories, typeCategories } from 'pix-admin/models/training';
+import { deliveryModeCategories, localeCategories, typeCategories } from 'pix-admin/models/training';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -62,6 +62,35 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
     assert
       .dom(screen.getByRole('link', { name: 'Voir la liste des logos éditeur' }))
       .hasAttribute('href', 'https://example-assets.net/list/contenu-formatif/editeur');
+    assert
+      .dom(screen.getByLabelText(t('pages.trainings.training.form.recommendation-engine.delivery-mode.label')))
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('radiogroup', {
+          name: t('pages.trainings.training.form.recommendation-engine.registration-required.label'),
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('textbox', {
+          name: t('pages.trainings.training.form.recommendation-engine.description.label'),
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('textbox', {
+          name: new RegExp(t('pages.trainings.training.form.recommendation-engine.objectives.label')),
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('textbox', { name: t('pages.trainings.training.form.recommendation-engine.program.label') }),
+      )
+      .exists();
   });
 
   test('it should call onSubmit when form is valid', async function (assert) {
@@ -97,6 +126,11 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
         editorLogoUrl: `http://localhost:4202/logo-placeholder.png`,
         duration: { days: 0, hours: 0, minutes: 0 },
         isDisabled: false,
+        deliveryMode: 'hybrid',
+        registrationRequired: false,
+        description: 'Une description',
+        objectives: 'Objectif 1;Objectif 2',
+        program: 'Un programme détaillé',
       };
 
       // when
@@ -135,6 +169,29 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
         .exists();
       assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
       assert.dom(screen.getByRole('button', { name: 'Modifier le contenu formatif' })).exists();
+      assert.strictEqual(
+        screen.getByLabelText(t('pages.trainings.training.form.recommendation-engine.delivery-mode.label')).innerText,
+        deliveryModeCategories[model.deliveryMode],
+      );
+      assert
+        .dom(
+          screen.getByRole('textbox', {
+            name: t('pages.trainings.training.form.recommendation-engine.description.label'),
+          }),
+        )
+        .hasValue(model.description);
+      assert
+        .dom(
+          screen.getByRole('textbox', {
+            name: new RegExp(t('pages.trainings.training.form.recommendation-engine.objectives.label')),
+          }),
+        )
+        .hasValue('Objectif 1;\nObjectif 2');
+      assert
+        .dom(
+          screen.getByRole('textbox', { name: t('pages.trainings.training.form.recommendation-engine.program.label') }),
+        )
+        .hasValue(model.program);
     });
   });
 
@@ -176,6 +233,43 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       assert.ok(onSubmitStub.called);
       const submittedData = onSubmitStub.getCall(0).firstArg;
       assert.strictEqual(submittedData.editorLogoUrl, 'https://assets.pix.org/contenu-formatif/editeur/new-logo.svg');
+    });
+
+    test('should save description on form submission', async function (assert) {
+      // given
+      const onSubmitStub = sinon.stub();
+      const screen = await render(
+        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmitStub}} @onCancel={{onCancel}} /></template>,
+      );
+
+      // when
+      await fillIn(
+        screen.getByRole('textbox', {
+          name: t('pages.trainings.training.form.recommendation-engine.description.label'),
+        }),
+        'Ma description',
+      );
+      await triggerEvent('form', 'submit');
+
+      // then
+      sinon.assert.calledOnceWith(onSubmitStub, sinon.match({ description: 'Ma description' }));
+      assert.ok(true);
+    });
+
+    test('should toggle registrationRequired when segmented control is clicked', async function (assert) {
+      // given
+      const onSubmitStub = sinon.stub();
+      await render(
+        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmitStub}} @onCancel={{onCancel}} /></template>,
+      );
+
+      // when
+      await clickByName(t('common.words.yes'));
+      await triggerEvent('form', 'submit');
+
+      // then
+      sinon.assert.calledOnceWith(onSubmitStub, sinon.match({ registrationRequired: true }));
+      assert.ok(true);
     });
 
     test('should toggle isDisabled field when checkbox is clicked', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1915,6 +1915,28 @@
           "locales": {
             "label": "Locales",
             "placeholder": "-- Select one or more locales --"
+          },
+          "recommendation-engine": {
+            "card-title": "Recommendation engine specific data",
+            "delivery-mode": {
+              "label": "Delivery mode",
+              "placeholder": "-- Select a delivery mode --"
+            },
+            "description": {
+              "label": "Description"
+            },
+            "objectives": {
+              "label": "Objectives",
+              "sub-label": "Separate each objective with a semicolon (;)"
+            },
+            "program": {
+              "label": "Program"
+            },
+            "registration-required": {
+              "label": "Registration required",
+              "no": "No",
+              "yes": "Yes"
+            }
           }
         },
         "list": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1925,6 +1925,28 @@
           "locales": {
             "label": "Locales",
             "placeholder": "-- Sélectionnez une ou plusieurs locales --"
+          },
+          "recommendation-engine": {
+            "card-title": "Données spécifiques au moteur de recommandation",
+            "delivery-mode": {
+              "label": "Modalité",
+              "placeholder": "-- Sélectionnez une modalité --"
+            },
+            "description": {
+              "label": "Description"
+            },
+            "objectives": {
+              "label": "Objectifs",
+              "sub-label": "Séparer chaque objectif par un point virgule (;)"
+            },
+            "program": {
+              "label": "Programme"
+            },
+            "registration-required": {
+              "label": "Inscription requise",
+              "no": "Non",
+              "yes": "Oui"
+            }
           }
         },
         "list": {

--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -156,11 +156,12 @@ const register = async function (server) {
                 'editor-logo-url': Joi.string().regex(editorLogoUrlValidation).required(),
                 'delivery-mode': Joi.string()
                   .valid(...Object.values(Training.modes))
+                  .allow(null)
                   .optional(),
-                description: Joi.string().optional(),
-                program: Joi.string().optional(),
-                'registration-required': Joi.boolean().optional(),
-                objectives: Joi.string().optional(),
+                description: Joi.string().allow(null, '').optional(),
+                program: Joi.string().allow(null, '').optional(),
+                'registration-required': Joi.boolean().allow(null).optional(),
+                objectives: Joi.string().allow(null, '').optional(),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),
@@ -241,11 +242,12 @@ const register = async function (server) {
                 'editor-logo-url': Joi.string().regex(editorLogoUrlValidation).required(),
                 'delivery-mode': Joi.string()
                   .valid(...Object.values(Training.modes))
+                  .allow(null)
                   .optional(),
-                description: Joi.string().optional(),
-                program: Joi.string().optional(),
-                'registration-required': Joi.boolean().optional(),
-                objectives: Joi.string().optional(),
+                description: Joi.string().allow(null, '').optional(),
+                program: Joi.string().allow(null, '').optional(),
+                'registration-required': Joi.boolean().allow(null).optional(),
+                objectives: Joi.string().allow(null, '').optional(),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -134,7 +134,10 @@ const deserialize = function (payload) {
   return new Deserializer({
     keyForAttribute: 'camelCase',
     transform(deserializedTraining) {
-      const objectives = deserializedTraining.objectives?.split(';').map((objective) => objective.trim());
+      const objectives = deserializedTraining.objectives
+        ?.split(';')
+        .map((objective) => objective.trim())
+        .filter(Boolean);
       const duration = deserializedTraining.duration;
       if (!duration) return { ...deserializedTraining, objectives };
 

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -11,7 +11,7 @@ const serializeForAdmin = function (training = {}, meta) {
       duration.minutes = duration.minutes || 0;
       return structuredClone({
         ...record,
-        objectives: record.objectives.join(';'),
+        objectives: record.objectives?.join(';') ?? null,
         isRecommendable: record.isRecommendable,
       });
     },

--- a/api/tests/devcomp/integration/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/integration/application/trainings/training-route_test.js
@@ -1141,6 +1141,72 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
         });
       });
 
+      describe('when optional reco engine fields are null', function () {
+        it('should return 200 and accept null values', async function () {
+          // given
+          sinon.stub(trainingController, 'update').returns('ok');
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response(true));
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          const payload = {
+            data: {
+              attributes: {
+                'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
+                description: null,
+                objectives: null,
+                program: null,
+                'delivery-mode': null,
+                'registration-required': null,
+              },
+            },
+          };
+
+          // when
+          const result = await httpTestServer.request('PATCH', '/api/admin/trainings/12344', payload);
+
+          // then
+          expect(result.statusCode).to.equal(200);
+          sinon.assert.calledOnce(trainingController.update);
+        });
+      });
+
+      describe('when optional reco engine fields are empty strings', function () {
+        it('should return 200 and accept empty string values', async function () {
+          // given
+          sinon.stub(trainingController, 'update').returns('ok');
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response(true));
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          const payload = {
+            data: {
+              attributes: {
+                'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
+                description: '',
+                objectives: '',
+                program: '',
+              },
+            },
+          };
+
+          // when
+          const result = await httpTestServer.request('PATCH', '/api/admin/trainings/12344', payload);
+
+          // then
+          expect(result.statusCode).to.equal(200);
+          sinon.assert.calledOnce(trainingController.update);
+        });
+      });
+
       describe('when editorLogoUrl is not a valid url', function () {
         it('should return 400', async function () {
           // given

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -329,6 +329,17 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
       // then
       expect(json).to.deep.equal(expectedSerializedTraining);
     });
+
+    it('should serialize objectives as null when objectives is null', function () {
+      // given
+      const training = domainBuilder.buildTrainingForAdmin({ objectives: null });
+
+      // when
+      const json = serializer.serializeForAdmin(training);
+
+      // then
+      expect(json.data.attributes.objectives).to.be.null;
+    });
   });
 
   describe('#serialize', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -458,7 +458,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             'delivery-mode': Training.modes.REMOTE,
             program: 'Programme',
             'registration-required': false,
-            objectives: 'Objectif 1          ;  Objectif 2',
+            objectives: 'Objectif 1          ;\n;;;  Objectif 2 ; Objectif 3',
           },
         },
       };
@@ -479,8 +479,44 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
         deliveryMode: Training.modes.REMOTE,
         registrationRequired: false,
         program: 'Programme',
-        objectives: ['Objectif 1', 'Objectif 2'],
+        objectives: ['Objectif 1', 'Objectif 2', 'Objectif 3'],
       });
+    });
+
+    it('should filter empty objectives caused by trailing semicolon', async function () {
+      // given
+      const jsonTraining = {
+        data: {
+          type: 'training',
+          attributes: {
+            objectives: 'Objectif 1;Objectif 2;',
+          },
+        },
+      };
+
+      // when
+      const training = await serializer.deserialize(jsonTraining);
+
+      // then
+      expect(training.objectives).to.deep.equal(['Objectif 1', 'Objectif 2']);
+    });
+
+    it('should filter empty objectives caused by multiple consecutive semicolons', async function () {
+      // given
+      const jsonTraining = {
+        data: {
+          type: 'training',
+          attributes: {
+            objectives: 'Objectif 1;\n;\n;;;;Objectif 2;;;Objectif 3;\n;;',
+          },
+        },
+      };
+
+      // when
+      const training = await serializer.deserialize(jsonTraining);
+
+      // then
+      expect(training.objectives).to.deep.equal(['Objectif 1', 'Objectif 2', 'Objectif 3']);
     });
 
     [


### PR DESCRIPTION
## 🪧 Problème
Dans le cadre du moteur de recommandations, On souhaite pouvoir créer de nouveaux champs pour les contenus formatifs.

## 🌈 Proposition
Rendre cette administration possible dans pix admin. 

## ✊ Remarques
Il a fallu mettre à jour l'api pour gérer le cas des champs null ou vides.
La visualisation du détail sera faite dans un autre ticket
Dans le champs objectif, j'ai fait en sorte que chaque objectif apparaisse à la ligne pour le formatage. Je pense qu'on pourra reprendre ça aussi pour l'affichage du détail.

## 🎉 Pour tester

- Aller sur pix admin dans la rubrique [des contenus formatifs](https://admin-pr16556.review.pix.fr/trainings)
- Créer un nouveau contenu formatif avec les nouveaux champs
- Vérifier que c'est ok
- Le retrouver dans la liste
- Le mettre à jour
- Recliquer sur modifier
- Constater que les champs ont bien été mis à jour

On peut aussi d'amuser à parcourir les différents contenus formatif qu'on avait déjà créé, et constater le bon affichage des objectifs (par exemple [Apprendre à peindre comme Monet](https://admin-pr16556.review.pix.fr/trainings/8003/details))

- Ajouter un nouvel objectif pour le CF sur Apprendre à peindre comme Monet
- Aller sur [app](https://app-pr16556.review.pix.fr/campagnes/EDUMULTIP/evaluation/resultats) avec dave-comp@example.net
- Saisir le code EDUMULTIP
- Vérifier que le CF sur Monet a bien été mis à jour, et que le nouvel objectif est là.

Dans le cas de champs longs et bien remplis vérifier que l'affichage reste correct
Ne pas hésiter à bafouiller dans le champs Objectifs