### PR TITLE
[BUGFIX] Corriger le problème de certificats N&B sur Chrome (PIX-23205).

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -62,7 +62,7 @@
         "openid-client": "^6.3.3",
         "papaparse": "^5.3.2",
         "pdf-lib": "^1.17.1",
-        "pdfkit": "^0.19.0",
+        "pdfkit": "^0.17.2",
         "pg": "^8.16.3",
         "pg-boss": "^12.15.0",
         "pg-query-stream": "^4.7.3",
@@ -2818,30 +2818,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6041,6 +6017,12 @@
         "node": "*"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/current-module-paths": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.3.tgz",
@@ -8550,10 +8532,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/js-md5": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
-      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -10889,17 +10872,16 @@
       }
     },
     "node_modules/pdfkit": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.19.0.tgz",
-      "integrity": "sha512-fCffpuHBwbEUDVpBexE3tE6OwvqOXHbLeR2ONWZEw0pCGlbZSkWLuXUw2k1MIkHNpwAgQ300ETXy/owe+ZK2bQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.2.tgz",
+      "integrity": "sha512-UnwF5fXy08f0dnp4jchFYAROKMNTaPqb/xgR8GtCzIcqoTnbOqtp3bwKvO4688oHI6vzEEs8Q6vqqEnC5IUELw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/ciphers": "^1.0.0",
-        "@noble/hashes": "^1.6.0",
+        "crypto-js": "^4.2.0",
         "fontkit": "^2.0.4",
-        "js-md5": "^0.8.3",
+        "jpeg-exif": "^1.1.4",
         "linebreak": "^1.1.0",
-        "png-js": "^1.1.0"
+        "png-js": "^1.0.0"
       }
     },
     "node_modules/pg": {

--- a/api/package.json
+++ b/api/package.json
@@ -144,7 +144,7 @@
     "openid-client": "^6.3.3",
     "papaparse": "^5.3.2",
     "pdf-lib": "^1.17.1",
-    "pdfkit": "^0.19.0",
+    "pdfkit": "^0.17.2",
     "pg": "^8.16.3",
     "pg-boss": "^12.15.0",
     "pg-query-stream": "^4.7.3",


### PR DESCRIPTION
## 🪧 Problème

La mise à jour de pdfkit réalisée dans la PR #16515 a provoqué une régression. Les certificats téléchargés sur Chrome se retrouvaient avec un fond en noir et blanc, là où aucun problème n'était rencontré sous Firefox.

<img width="1196" height="811" alt="Capture d’écran 2026-06-17 à 11 14 28" src="https://github.com/user-attachments/assets/373e8a02-19d8-4375-86de-acc7fc96105a" />

---
**Explication technique (Claude) :**

Quand PDFKit génère un PDF contenant une image JPEG (comme le fond du certificat), il ne "dessine" pas l'image — il l'embarque telle quelle dans le fichier PDF, accompagnée d'une fiche descriptive. Cette fiche
  indique au lecteur PDF (Chrome, Firefox, Acrobat…) comment interpréter les données de l'image. L'une des informations clés de cette fiche est l'espace colorimétrique : est-ce une image en couleur (DeviceRGB) ou en
  niveaux de gris (DeviceGray) ?
  
  Pour remplir cette fiche, PDFKit doit lire l'en-tête du fichier JPEG. Un fichier JPEG contient un bloc de métadonnées (appelé segment SOF) qui décrit entre autres le nombre de canaux de couleur de l'image :
  - 1 canal → niveaux de gris
  - 3 canaux → couleur (rouge, vert, bleu)
  
  Ce segment SOF est structuré comme suit (simplifié) :

  [taille du bloc] [précision] [hauteur] [largeur] [nombre de canaux] [id canal 1] [id canal 2]…

  Dans la version 0.18.0, PDFKit a réécrit le code qui lit ce segment. Par erreur, le code lit une case trop loin : au lieu de lire "nombre de canaux" (= 3 pour une image RGB), il lit "id du premier canal" (= 1, identifiant de la luminance). La valeur 1 est alors interprétée comme "1 canal" → niveaux de gris.

  Résultat : PDFKit génère un PDF qui déclare que le fond du certificat est une image en niveaux de gris, alors que c'est en réalité une image couleur.

  **Pourquoi Chrome est affecté mais pas Firefox**
  
  Les lecteurs PDF ne se comportent pas tous de la même façon face à cette incohérence :

  - Chrome (PDFium) fait confiance à la déclaration dans le PDF et affiche l'image en niveaux de gris → le fond apparaît grisé.
  - Firefox (PDF.js) ignore la déclaration et décode directement les données JPEG, qui contiennent elles-mêmes l'information de couleur → le fond s'affiche correctement.

## 🌈 Proposition

Dans une premier temps, retour à une version 0.17.X de la librairie qui ne contenait pas cette régression (elle utilisait une bibliothèque externe jpeg-exif pour lire les métadonnées JPEG, remplacée par du code maison 0.18.0).

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

Télécharger des certificats de tests Coeur et Pix+ sur différents navigateurs et vérifier qu'il n'y ait plus de problème.
