### PR TITLE
[FEATURE] Afficher les informations du moteur de reco (PIX-23119).

### DIFF
--- a/admin/app/components/trainings/training-details-card.gjs
+++ b/admin/app/components/trainings/training-details-card.gjs
@@ -2,8 +2,9 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-import { localeCategories, typeCategories } from '../../models/training';
+import { deliveryModeCategories, localeCategories, typeCategories } from '../../models/training';
 import Card from '../card';
+import SafeMarkdownToHtml from '../safe-markdown-to-html';
 
 export default class TrainingDetailsCard extends Component {
   @service url;
@@ -27,6 +28,14 @@ export default class TrainingDetailsCard extends Component {
 
   get typeLabel() {
     return typeCategories[this.args.training.type];
+  }
+
+  get deliveryModeLabel() {
+    return deliveryModeCategories[this.args.training.deliveryMode];
+  }
+
+  get formattedObjectives() {
+    return this.args.training.objectives?.split(';').filter(Boolean) ?? [];
   }
 
   <template>
@@ -90,6 +99,59 @@ export default class TrainingDetailsCard extends Component {
                 (t "pages.trainings.training.details.status-label.enabled")
                 (t "pages.trainings.training.details.status-label.disabled")
               }}</span>
+          </div>
+        </div>
+      </Card>
+
+      <Card
+        class="admin-form__card training-details__card"
+        @title={{t "pages.trainings.training.details.recommendationEngine"}}
+      >
+        <div class="training-details__block">
+          <div class="training-details__field">
+            <span class="training-details__label">{{t
+                "pages.trainings.training.form.recommendation-engine.description.label"
+              }}</span>
+            <span class="training-details__value"><SafeMarkdownToHtml
+                class="target-profile-details__description"
+                @markdown={{@training.description}}
+              /></span>
+          </div>
+          <div class="training-details__field">
+            <span class="training-details__label">
+              {{t "pages.trainings.training.form.recommendation-engine.program.label"}}
+            </span>
+            <span class="training-details__value">{{@training.program}}</span>
+          </div>
+        </div>
+        <div class="training-details__block">
+          <div class="training-details__field">
+            <span class="training-details__label">{{t
+                "pages.trainings.training.form.recommendation-engine.delivery-mode.label"
+              }}</span>
+            <span class="training-details__value">
+              {{this.deliveryModeLabel}}
+            </span>
+          </div>
+          <div class="training-details__field">
+            <span class="training-details__label">{{t
+                "pages.trainings.training.form.recommendation-engine.registration-required.label"
+              }}</span>
+            <span class="training-details__value">{{if
+                @training.registrationRequired
+                (t "common.words.yes")
+                (t "common.words.no")
+              }}</span>
+          </div>
+          <div class="training-details__field">
+            <span class="training-details__label">
+              {{t "pages.trainings.training.form.recommendation-engine.objectives.label"}}
+            </span>
+            <ul class="training-details__value training-details__list">
+              {{#each this.formattedObjectives as |objective|}}
+                <li>{{objective}}</li>
+              {{/each}}
+            </ul>
           </div>
         </div>
       </Card>

--- a/admin/app/styles/components/trainings/training-details-card.scss
+++ b/admin/app/styles/components/trainings/training-details-card.scss
@@ -55,7 +55,8 @@
 
   &__field {
     display: flex;
-    align-items: center;
+    gap: var(--pix-spacing-9x);
+    align-items: start;
     justify-content: space-between;
 
     &:not(:last-child) {
@@ -77,5 +78,8 @@
       text-decoration: underline;
     }
   }
-}
 
+  &__list {
+    list-style-type: disc;
+  }
+}

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -21,6 +21,11 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
       days: 2,
     },
     isRecommendable: true,
+    description: 'Une description du contenu formatif',
+    deliveryMode: 'remote',
+    registrationRequired: true,
+    objectives: 'Objectif 1;Objectif 2',
+    program: 'Un programme détaillé',
   };
 
   test('it should display the details', async function (assert) {
@@ -145,6 +150,55 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
       assert
         .dom(screen.getByRole('link', { name: 'https://app.pix.fr/modules/123/soleil (nouvelle fenêtre)' }))
         .exists();
+    });
+  });
+
+  module('Recommendation engine card', function () {
+    test('it should display the details', async function (assert) {
+      // when
+      const screen = await render(<template><TrainingDetailsCard @training={{training}} /></template>);
+
+      // then
+      assert.dom(screen.getByText(t('pages.trainings.training.details.recommendationEngine'))).exists();
+      assert.dom(screen.getByText(training.description)).exists();
+      assert.dom(screen.getByText(training.program)).exists();
+      assert.dom(screen.getByText('À distance')).exists();
+
+      const objectives = screen.getAllByRole('listitem');
+      assert.strictEqual(objectives.length, 2);
+
+      assert.strictEqual(objectives[0].textContent.trim(), 'Objectif 1');
+      assert.strictEqual(objectives[1].textContent.trim(), 'Objectif 2');
+    });
+
+    module('when registrationRequired is false', function () {
+      test('it should display "Non"', async function (assert) {
+        // given
+        const trainingWithRegistration = { ...training, registrationRequired: false };
+
+        // when
+        const screen = await render(
+          <template><TrainingDetailsCard @training={{trainingWithRegistration}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(t('common.words.no'))).exists();
+      });
+    });
+
+    module('when registrationRequired is true', function () {
+      test('it should display "Oui"', async function (assert) {
+        // given
+        const trainingWithRegistration = { ...training, registrationRequired: true };
+
+        // when
+        const screen = await render(
+          <template><TrainingDetailsCard @training={{trainingWithRegistration}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(t('common.words.yes'))).exists();
+      });
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1888,6 +1888,7 @@
           "internalTitle": "Internal title",
           "locales": "{ count, plural, one {Locale} other {Locales}}",
           "publishedOn": "Published on",
+          "recommendationEngine": "Information used by the recommendation engine",
           "status": "Status",
           "status-label": {
             "disabled": "Non-triggerable",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1898,6 +1898,7 @@
           "internalTitle": "Titre interne",
           "locales": "{ count, plural, one {Locale} other {Locales}}",
           "publishedOn": "Publié sur",
+          "recommendationEngine": "Informations utilisées pour le moteur de recommandation",
           "status": "Statut",
           "status-label": {
             "disabled": "Non déclenchable",


### PR DESCRIPTION
## 🪧 Problème

Suite du chantier des contenu formatifs version moteur de recommandation. On peut désormais créer et modifier le contenu formatif avec les nouvelles infos. Mais on ne les voit pas encore dans la page de détails.


## 🌈 Proposition

Afficher les infos dans une card, sous les informations générales du contenu formatifs

## ✊ Remarques

Y'a eu du Claude pour gérer les traduction :)) 

## 🎉 Pour tester

Aller sur Admin => https://admin-pr16564.review.pix.fr/trainings/8003/details
Voir la nouvelle liste d'information

A voir avec Julie : Est-ce que je scinde en deux ou je les mets tous en ligne ?
Les mettre en ligne sera peut être plus pertinent puisque certaines infos (programme et description) peuvent être conséquent.