### PR TITLE
[FEATURE] Créer une route pour récupérer l'organisation liée à un centre de certification (PIX-22630)

### DIFF
--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
@@ -7,6 +7,7 @@ import {
 } from '../../infrastructure/serializers/csv/certification-center-archive-csv-serializer.js';
 import * as certificationCenterSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
 import * as certificationCenterForAdminSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js';
+import { attachedOrganizationSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.js';
 
 const archiveCertificationCenter = async function (request, h) {
   const certificationCenterId = request.params.certificationCenterId;
@@ -97,12 +98,21 @@ const update = async function (request) {
   return certificationCenterForAdminSerializer.serialize(updatedCertificationCenter);
 };
 
+const findAttachedOrganizationsForAdmin = async function (request) {
+  const certificationCenterId = request.params.certificationCenterId;
+
+  const organizations = await usecases.findAttachedOrganizationsForAdmin({ certificationCenterId });
+
+  return attachedOrganizationSerializer.serialize(organizations);
+};
+
 const certificationCenterAdminController = {
   archiveCertificationCenter,
   getTemplateForArchiveInBatch,
   archiveInBatch,
   create,
   findPaginatedFilteredCertificationCenters,
+  findAttachedOrganizationsForAdmin,
   getCertificationCenterDetails,
   update,
 };

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
@@ -209,6 +209,35 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/certification-centers/{certificationCenterId}/organizations',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+        },
+        handler: (request) => certificationCenterAdminController.findAttachedOrganizationsForAdmin(request),
+        tags: ['api', 'organizational-entities', 'certification-centers'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, CERTIF, SUPPORT ou METIER permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet la récuperation des informations de ou des organisations rattachées au centre de certification.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/organizational-entities/domain/models/AttachedOrganization.js
+++ b/api/src/organizational-entities/domain/models/AttachedOrganization.js
@@ -1,0 +1,15 @@
+class AttachedOrganization {
+  /**
+   * @param {Object} params
+   * @param {number} params.id
+   * @param {string} params.name
+   * @param {string} params.externalId
+   */
+  constructor({ id, name, externalId } = {}) {
+    this.id = id;
+    this.name = name;
+    this.externalId = externalId;
+  }
+}
+
+export { AttachedOrganization };

--- a/api/src/organizational-entities/domain/usecases/find-attached-organizations-for-admin.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/find-attached-organizations-for-admin.usecase.js
@@ -1,0 +1,15 @@
+/**
+ * @typedef {import('../../infrastructure/repositories/organization-for-admin.repository.js')} OrganizationForAdminRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {OrganizationForAdminRepository} params.organizationForAdminRepository
+ * @param {number} params.certificationCenterId
+ * @returns {Promise<AttachedOrganization[]>}
+ */
+const findAttachedOrganizationsForAdmin = async function ({ certificationCenterId, organizationForAdminRepository }) {
+  return organizationForAdminRepository.findAttachedByCertificationCenterId({ certificationCenterId });
+};
+
+export { findAttachedOrganizationsForAdmin };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -98,6 +98,7 @@ import { findAllAdministrationTeams } from './find-all-administration-teams.usec
 import { findAllOrganizationLearnerTypes } from './find-all-organization-learner-types.refactor.js';
 import { findAllTags } from './find-all-tags.usecase.js';
 import { findAttachedCertificationCenterForAdmin } from './find-attached-certification-center-for-admin.usecase.js';
+import { findAttachedOrganizationsForAdmin } from './find-attached-organizations-for-admin.usecase.js';
 import { findChildrenOrganizations } from './find-children-organizations.usecase.js';
 import { findOrganizationFeatures } from './find-organization-features.js';
 import { findPaginatedFilteredCertificationCenters } from './find-paginated-filtered-certification-centers.usecase.js';
@@ -133,6 +134,7 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedFilteredNetworks,
   findAllTags,
   findAttachedCertificationCenterForAdmin,
+  findAttachedOrganizationsForAdmin,
   findChildrenOrganizations,
   findOrganizationFeatures,
   findPaginatedFilteredCertificationCenters,
@@ -160,6 +162,8 @@ const usecasesWithoutInjectedDependencies = {
  * @property {createTag} createTag
  * @property {detachParentOrganizationFromOrganization} detachParentOrganizationFromOrganization
  * @property {findPaginatedFilteredCertificationCenters} findPaginatedFilteredCertificationCenters
+ * @property {findAttachedOrganizationsForAdmin} findAttachedOrganizationsForAdmin
+ * @property {findAttachedCertificationCenterForAdmin} findAttachedCertificationCenterForAdmin
  * @property {getOrganizationDetails} getOrganizationDetails
  * @property {getOrganizationStatistics} getOrganizationStatistics
  * @property {getNetworkDetails} getNetworkDetails

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -4,6 +4,7 @@ import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { MissingAttributesError, NotFoundError } from '../../../shared/domain/errors.js';
 import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
+import { AttachedOrganization } from '../../domain/models/AttachedOrganization.js';
 import { OrganizationForAdmin } from '../../domain/models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../../domain/models/OrganizationLearnerType.js';
 import { Tag } from '../../domain/models/Tag.js';
@@ -386,6 +387,32 @@ const getOrganizationParticipantsStatistics = async ({ campaignStatsApi, organiz
   return campaignStatsApi.getOrganizationParticipantsStatistics(organizationId);
 };
 
+/**
+ * @type {function}
+ * @param {number} certificationCenterId
+ * @returns {Promise<AttachedOrganization[]>}
+ */
+const findAttachedByCertificationCenterId = async ({ certificationCenterId }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const organizations = await knexConn('fct_structures')
+    .select({
+      id: 'organizations.id',
+      name: 'organizations.name',
+      externalId: 'organizations.externalId',
+    })
+    .rightJoin('organizations', 'organizations.id', 'fct_structures.organization_id')
+    .where({ certification_center_id: certificationCenterId });
+
+  return organizations.map(
+    (organization) =>
+      new AttachedOrganization({
+        id: organization.id,
+        name: organization.name,
+        externalId: organization.externalId,
+      }),
+  );
+};
+
 async function _addOrUpdateDataProtectionOfficer(knexConn, dataProtectionOfficer) {
   await knexConn(DATA_PROTECTION_OFFICERS_TABLE_NAME)
     .insert(dataProtectionOfficer)
@@ -565,6 +592,7 @@ export const organizationForAdminRepository = {
   archive,
   createProOrganizationInvitation,
   exist,
+  findAttachedByCertificationCenterId,
   findExistingIds,
   findPaginatedFiltered,
   findChildrenByParentOrganizationId,

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.js
@@ -3,7 +3,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Serializer } = jsonapiSerializer;
 
 const serialize = function (organizations) {
-  return new Serializer('organizations', {
+  return new Serializer('attached-organizations', {
     attributes: ['name', 'externalId'],
   }).serialize(organizations);
 };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (organizations) {
+  return new Serializer('organizations', {
+    attributes: ['name', 'externalId'],
+  }).serialize(organizations);
+};
+
+export const attachedOrganizationSerializer = { serialize };

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -540,4 +540,32 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
       });
     });
   });
+
+  describe('GET /api/admin/certification-centers/{certificationCenterId}/organizations', function () {
+    it('should return organization attached to a given certification center and http code 200', async function () {
+      // given
+      const server = await createServer();
+
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      databaseBuilder.factory.buildOrganizationWithStructure({
+        certificationCenterId: certificationCenter.id,
+      });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/certification-centers/${certificationCenter.id}/organizations`,
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].type).to.equal('organizations');
+    });
+  });
 });

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -541,8 +541,8 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
     });
   });
 
-  describe('GET /api/admin/certification-centers/{certificationCenterId}/organizations', function () {
-    it('should return organization attached to a given certification center and http code 200', async function () {
+  describe('GET /api/admin/certification-centers/{certificationCenterId}/attached-organizations', function () {
+    it('should return the organizations attached to a given certification center and http code 200', async function () {
       // given
       const server = await createServer();
 
@@ -565,7 +565,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data[0].type).to.equal('organizations');
+      expect(response.result.data[0].type).to.equal('attached-organizations');
     });
   });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import sinon from 'sinon';
 
+import { AttachedOrganization } from '../../../../../src/organizational-entities/domain/models/AttachedOrganization.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
 import { repositories } from '../../../../../src/organizational-entities/infrastructure/repositories/index.js';
@@ -1952,6 +1953,74 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
       // then
       expect(foundOrganizationIds).to.deep.equal([]);
+    });
+  });
+
+  describe('#findAttachedByCertificationCenterId', function () {
+    describe('when a certification center is linked to an organization', function () {
+      it('returns organization linked to a given certification center', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+        const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({
+          certificationCenterId: certificationCenterId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganization = await repositories.organizationForAdminRepository.findAttachedByCertificationCenterId(
+          { certificationCenterId },
+        );
+
+        // then
+        expect(foundOrganization).to.have.lengthOf(1);
+        expect(foundOrganization[0].id).to.equal(organization.id);
+        expect(foundOrganization[0]).to.be.instanceOf(AttachedOrganization);
+      });
+
+      it('does not return organization linked to another certification center', async function () {
+        // given
+        const firstCertificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        const { organization: firstOrganization } = databaseBuilder.factory.buildOrganizationWithStructure({
+          certificationCenterId: firstCertificationCenter.id,
+        });
+
+        const secondCertificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        databaseBuilder.factory.buildOrganizationWithStructure({
+          certificationCenterId: secondCertificationCenter.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganization = await repositories.organizationForAdminRepository.findAttachedByCertificationCenterId(
+          {
+            certificationCenterId: firstCertificationCenter.id,
+          },
+        );
+
+        // then
+        expect(foundOrganization[0].id).to.equal(firstOrganization.id);
+      });
+    });
+
+    describe('when a given certification center has no linked organization', function () {
+      it('returns an empty array', async function () {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganization = await repositories.organizationForAdminRepository.findAttachedByCertificationCenterId(
+          {
+            certificationCenterId: certificationCenter.id,
+          },
+        );
+
+        // then
+        expect(foundOrganization).to.be.an('array').that.is.empty;
+      });
     });
   });
 });

--- a/api/tests/organizational-entities/unit/application/certification-center/certification-center.admin.route_test.js
+++ b/api/tests/organizational-entities/unit/application/certification-center/certification-center.admin.route_test.js
@@ -7,48 +7,102 @@ import { securityPreHandlers } from '../../../../../src/shared/application/secur
 import { expect } from '../../../../test-helper.js';
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 
-describe('Unit | Certification Center | Application | Route | Admin', function () {
-  describe('when the authenticated user has one of the accepted roles', function () {
-    [
-      'checkAdminMemberHasRoleSuperAdmin',
-      'checkAdminMemberHasRoleCertif',
-      'checkAdminMemberHasRoleSupport',
-      'checkAdminMemberHasRoleMetier',
-    ].forEach((roleMethod) => {
-      it('should call archiveCertificationCenter controller method', async function () {
+describe('Unit | Organizational Entities | Application | Route | Admin | Certification Center', function () {
+  let httpTestServer;
+
+  beforeEach(async function () {
+    sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('POST /api/admin/certification-centers/{certificationCenterId}/archive', function () {
+    describe('when the authenticated user has one of the accepted roles', function () {
+      [
+        'checkAdminMemberHasRoleSuperAdmin',
+        'checkAdminMemberHasRoleCertif',
+        'checkAdminMemberHasRoleSupport',
+        'checkAdminMemberHasRoleMetier',
+      ].forEach((roleMethod) => {
+        it('should call archiveCertificationCenter controller method', async function () {
+          // given
+          sinon.stub(securityPreHandlers, roleMethod).returns(() => true);
+          securityPreHandlers.hasAtLeastOneAccessOf.callsFake((_handlers) => {
+            return () => true;
+          });
+          sinon.stub(usecases, 'archiveCertificationCenter').returns('ok');
+          sinon.stub(certificationCenterAdminController, 'archiveCertificationCenter').returns('ok');
+
+          // when
+          await httpTestServer.request('POST', '/api/admin/certification-centers/1/archive');
+
+          // then
+          sinon.assert.called(certificationCenterAdminController.archiveCertificationCenter);
+        });
+      });
+    });
+
+    describe('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
         // given
-        sinon.stub(securityPreHandlers, roleMethod).returns(() => true);
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
         sinon.stub(usecases, 'archiveCertificationCenter').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
         sinon.stub(certificationCenterAdminController, 'archiveCertificationCenter').returns('ok');
 
         // when
-        await httpTestServer.request('POST', '/api/admin/certification-centers/1/archive');
+        const response = await httpTestServer.request('POST', '/api/admin/certification-centers/1/archive');
 
         // then
-        sinon.assert.called(certificationCenterAdminController.archiveCertificationCenter);
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(certificationCenterAdminController.archiveCertificationCenter);
       });
     });
   });
 
-  describe('when the user authenticated has no role', function () {
-    it('should return 403 HTTP status code', async function () {
-      // given
-      sinon
-        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
-      sinon.stub(usecases, 'archiveCertificationCenter').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-      sinon.stub(certificationCenterAdminController, 'archiveCertificationCenter').returns('ok');
+  describe('GET /api/admin/certification-centers/{id}/certification-centers', function () {
+    describe('when the user authenticated has no role', function () {
+      it('returns a 403 HTTP status code', async function () {
+        // given
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/certification-centers/1/archive');
+        sinon.stub(certificationCenterAdminController, 'findAttachedOrganizationsForAdmin');
 
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(certificationCenterAdminController.archiveCertificationCenter);
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/certification-centers/1/organizations');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(certificationCenterAdminController.findAttachedOrganizationsForAdmin);
+      });
+    });
+
+    const authorizedRoles = [
+      { role: 'SuperAdmin', stub: 'checkAdminMemberHasRoleSuperAdmin' },
+      { role: 'Support', stub: 'checkAdminMemberHasRoleSupport' },
+      { role: 'Certif', stub: 'checkAdminMemberHasRoleCertif' },
+      { role: 'Metier', stub: 'checkAdminMemberHasRoleMetier' },
+    ];
+
+    authorizedRoles.forEach(({ role, stub }) => {
+      describe(`when the user has ${role} role`, function () {
+        it('returns a 200 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, stub).callsFake((request, h) => h.response(true));
+          securityPreHandlers.hasAtLeastOneAccessOf.callsFake((_handlers) => {
+            return () => true;
+          });
+          sinon.stub(certificationCenterAdminController, 'findAttachedOrganizationsForAdmin').returns('ok');
+
+          // when
+          const response = await httpTestServer.request('GET', '/api/admin/certification-centers/1/organizations');
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          sinon.assert.calledOnce(certificationCenterAdminController.findAttachedOrganizationsForAdmin);
+        });
+      });
     });
   });
 });

--- a/api/tests/organizational-entities/unit/application/certification-center/certification-center.admin.route_test.js
+++ b/api/tests/organizational-entities/unit/application/certification-center/certification-center.admin.route_test.js
@@ -61,7 +61,7 @@ describe('Unit | Organizational Entities | Application | Route | Admin | Certifi
     });
   });
 
-  describe('GET /api/admin/certification-centers/{id}/certification-centers', function () {
+  describe('GET /api/admin/certification-centers/{id}/organizations', function () {
     describe('when the user authenticated has no role', function () {
       it('returns a 403 HTTP status code', async function () {
         // given

--- a/api/tests/organizational-entities/unit/domain/usecases/find-attached-organizations-for-admin.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/find-attached-organizations-for-admin.usecase.test.js
@@ -1,0 +1,28 @@
+import sinon from 'sinon';
+
+import { findAttachedOrganizationsForAdmin } from '../../../../../src/organizational-entities/domain/usecases/find-attached-organizations-for-admin.usecase.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Domain | UseCase | find-attached-organization-for-admin', function () {
+  let organizationForAdminRepository;
+
+  beforeEach(function () {
+    organizationForAdminRepository = {
+      findAttachedByCertificationCenterId: sinon.stub(),
+    };
+  });
+
+  it('calls findAttachedByCertificationCenterId with the given certification center id', async function () {
+    // given
+    const certificationCenterId = 123;
+    organizationForAdminRepository.findAttachedByCertificationCenterId.resolves([]);
+
+    // when
+    await findAttachedOrganizationsForAdmin({ certificationCenterId, organizationForAdminRepository });
+
+    // then
+    expect(organizationForAdminRepository.findAttachedByCertificationCenterId).to.have.been.calledOnceWithExactly({
+      certificationCenterId,
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.test.js
@@ -1,0 +1,49 @@
+import { AttachedOrganization } from '../../../../../../../src/organizational-entities/domain/models/AttachedOrganization.js';
+import { attachedOrganizationSerializer } from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Infrastructure | Serializers | JSONAPI | Organizations-Administrations | attached-organization', function () {
+  describe('#serialize', function () {
+    it('should convert an array of AttachedOrganization models into JSON API data', function () {
+      // given
+      const firstOrganization = new AttachedOrganization({
+        id: 1,
+        name: 'My attached organization',
+        externalId: 'EXT123',
+      });
+      const secondOrganization = new AttachedOrganization({
+        id: 2,
+        name: 'My other organization',
+        externalId: 'EXT456',
+      });
+      const organizations = [firstOrganization, secondOrganization];
+
+      const expectedJSON = {
+        data: [
+          {
+            type: 'organizations',
+            id: '1',
+            attributes: {
+              name: 'My attached organization',
+              'external-id': 'EXT123',
+            },
+          },
+          {
+            type: 'organizations',
+            id: '2',
+            attributes: {
+              name: 'My other organization',
+              'external-id': 'EXT456',
+            },
+          },
+        ],
+      };
+
+      // when
+      const json = attachedOrganizationSerializer.serialize(organizations);
+
+      // then
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.test.js
@@ -21,7 +21,7 @@ describe('Unit | Infrastructure | Serializers | JSONAPI | Organizations-Administ
       const expectedJSON = {
         data: [
           {
-            type: 'organizations',
+            type: 'attached-organizations',
             id: '1',
             attributes: {
               name: 'My attached organization',
@@ -29,7 +29,7 @@ describe('Unit | Infrastructure | Serializers | JSONAPI | Organizations-Administ
             },
           },
           {
-            type: 'organizations',
+            type: 'attached-organizations',
             id: '2',
             attributes: {
               name: 'My other organization',


### PR DESCRIPTION
## 🪧 Problème

Maintenant qu'il est possible de récupérer le centre de certification lié à une organisation, nous avons besoin de faire l'inverse: récupérer une organisation liée à un centre de certif.

## 🌈 Proposition

Créer un nouveau endpoint sur la ressource certification-centers, afin de récupérer l'organisation rattachée.

## ✊ Remarques

Un dernier commit optionnel propose deux modifications à discuter avec l'équipe:
- utiliser le type de ressource "attached-organizations" dans le serializer afin de respecter le standard JSON API et  pouvoir ainsi utiliser le bon modèle côté front automatiquement avec Ember
- renommer le endpoint en `/api/admin/organizations/{organizationId}/attached-organizations` pour que le nom et le type de la ressource soient cohérents.

## 🎉 Pour tester
- récupérer un token valide sur Pix Admin
- récupérer l'ID du centre de certification: `Lycée 1 de l'Académie de Versailles`
- via un CURL ou un client HTTP, requêtez en GET le endpoint suivant: `/api/admin/certification-centers/{certificationCenterId}/organizations`

```
TOKEN=$(curl -s -X POST https://admin-pr16566.review.pix.fr/api/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=password&username=superadmin@example.net&password=pix123" \
  | jq -r '.access_token') && \
curl -s https://admin-pr16566.review.pix.fr/api/admin/certification-centers/<ID>/organizations \
  -H "Authorization: Bearer $TOKEN" | jq
```


- constater que l'API renvoie un tableau avec une organization
- tenter de requêter avec un id d'un autre centre pour constater un tableau vide
