### PR TITLE
[FEATURE]: ajout d'un index sur updatedAt  sur la table assessments

### DIFF
--- a/api/db/migrations/20260618095907_add_index-to-updated-at-in-assessments-table.js
+++ b/api/db/migrations/20260618095907_add_index-to-updated-at-in-assessments-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'assessments';
+const COLUMN_NAME = 'updatedAt';
+
+const up = async function (knex) {
+  await knex.raw('CREATE INDEX IF NOT EXISTS assessments_updated_at_index ON assessments ("updatedAt")');
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🪧 Problème

Dans le cadre de l'historisation des answers on va requeter les assessemnts sur la date de mise à jour et c'est long

## 🌈 Proposition
ajout d'un index sur la table


## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
