### PR TITLE
[FEATURE] QCM déclaratif : Mettre à jour Pix-Checkbox (PIX-23189)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -123,6 +123,44 @@
                 {
                   "elements": [
                     {
+                    "id": "0401cef4-871e-40a3-876b-5d7571f8b556",
+                    "type": "qcm-declarative",
+                    "instruction": "<p>Quels sont tes petits plaisirs de la vie ?</p>",
+                    "hasShortProposals": false,
+                    "proposals": [
+                      {
+                        "id": "1",
+                        "content": "Manger les cookies glacés de Clément"
+                      },
+                      {
+                        "id": "2",
+                        "content": "Regarder un match de foot avec Eric"
+                      },
+                      {
+                        "id": "3",
+                        "content": "Se faire coacher au marathon par Matthias"
+                      },
+                      {
+                        "id": "4",
+                        "content": "Observer Andreia dessiner dans Slack"
+                      },
+                      {
+                        "id": "5",
+                        "content": "Ecouter du reggae avec Nico"
+                      },
+                      {
+                        "id": "6",
+                        "content": "Descendre une pente en ski de fond avec Julie"
+                      }
+                    ],
+                    "feedback": {
+                      "diagnosis": "<p>C'est sûr, c'est un vrai kiff !</p>"
+                    }
+                  }]
+                },
+                {
+                  "elements": [
+                    {
                       "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
                       "type": "qcu",
                       "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",

--- a/mon-pix/app/components/module/element/qcm-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcm-declarative.gjs
@@ -4,6 +4,7 @@ import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-al
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { trackedSet } from '@ember/reactive/collections';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -17,7 +18,7 @@ export default class ModuleQcmDeclarative extends ModuleElement {
   @service modulixPreviewMode;
   @service passageEvents;
 
-  @tracked selectedProposalIds = new Set();
+  selectedProposalIds = trackedSet();
   @tracked shouldDisplayFeedback = false;
   @tracked reportInfo = {};
   @tracked isAnswering = false;
@@ -79,6 +80,14 @@ export default class ModuleQcmDeclarative extends ModuleElement {
     });
   }
 
+  @action
+  getProposalState(proposalId) {
+    if (this.selectedProposalIds.has(proposalId)) {
+      return 'declarative-selected';
+    }
+    return 'declarative';
+  }
+
   waitFor(duration) {
     return new Promise((resolve) => setTimeout(resolve, duration));
   }
@@ -98,9 +107,10 @@ export default class ModuleQcmDeclarative extends ModuleElement {
         <div role="region" class="element-qcm-declarative__{{this.proposalsStyle}}">
           {{#each this.element.proposals as |proposal|}}
             <PixCheckbox
-              name={{this.proposal.id}}
+              name={{proposal.id}}
               @isDisabled={{this.disableInput}}
               @variant="modulix"
+              @state={{this.getProposalState proposal.id}}
               {{on "click" (fn this.checkboxSelected proposal.id)}}
             >
               <:label>{{htmlUnsafe proposal.content}}</:label>

--- a/mon-pix/app/components/module/element/qcm-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcm-declarative.gjs
@@ -42,6 +42,7 @@ export default class ModuleQcmDeclarative extends ModuleElement {
 
   @action
   checkboxSelected(proposalId) {
+    if (this.disableInput) return;
     if (this.selectedProposalIds.has(proposalId)) {
       this.selectedProposalIds.delete(proposalId);
     } else {

--- a/mon-pix/tests/integration/components/module/qcm-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm-declarative_test.gjs
@@ -109,6 +109,34 @@ module('Integration | Component | Module | QcmDeclarative', function (hooks) {
       await clock.tickAsync(VERIFY_RESPONSE_DELAY);
     });
 
+    test('should not change proposal state when clicking a checkbox after submission', async function (assert) {
+      // given
+      const onAnswerStub = sinon.stub();
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const qcmDeclarativeElement = _getQcmDeclarativeElement();
+      const { proposals } = qcmDeclarativeElement;
+
+      const screen = await render(
+        <template><ModuleQcmDeclarative @element={{qcmDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+
+      const proposal1Element = screen.getByLabelText(proposals[0].content);
+      const proposal2Element = screen.getByLabelText(proposals[1].content);
+      await click(proposal1Element);
+      const submitButton = screen.getByRole('button', { name: 'Soumettre ma sélection' });
+      await click(submitButton);
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+
+      // when - clicking after submission
+      await click(proposal1Element);
+      await click(proposal2Element);
+
+      // then - states must not have changed
+      assert.dom(proposal1Element.closest('label')).hasClass('pix-label-wrapped--state-modulix-declarative-selected');
+      assert.dom(proposal2Element.closest('label')).hasClass('pix-label-wrapped--state-modulix-declarative');
+    });
+
     test('it should record a passage-event', async function (assert) {
       // given
       const passageEventService = this.owner.lookup('service:passageEvents');

--- a/mon-pix/tests/integration/components/module/qcm-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm-declarative_test.gjs
@@ -82,6 +82,33 @@ module('Integration | Component | Module | QcmDeclarative', function (hooks) {
       assert.dom(screen.getByText('Signaler')).exists();
     });
 
+    test('should display selected proposals with declarative-selected state and unselected proposals with declarative state', async function (assert) {
+      // given
+      const onAnswerStub = sinon.stub();
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const qcmDeclarativeElement = _getQcmDeclarativeElement();
+      const { proposals } = qcmDeclarativeElement;
+
+      const screen = await render(
+        <template><ModuleQcmDeclarative @element={{qcmDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+
+      const proposal1Element = screen.getByLabelText(proposals[0].content);
+      const proposal2Element = screen.getByLabelText(proposals[1].content);
+      await click(proposal1Element);
+
+      // when
+      const submitButton = screen.getByRole('button', { name: 'Soumettre ma sélection' });
+      await click(submitButton);
+
+      // then - state is determined by selectedProposalIds, correct before timer resolves
+      assert.dom(proposal1Element.closest('label')).hasClass('pix-label-wrapped--state-modulix-declarative-selected');
+      assert.dom(proposal2Element.closest('label')).hasClass('pix-label-wrapped--state-modulix-declarative');
+
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+    });
+
     test('it should record a passage-event', async function (assert) {
       // given
       const passageEventService = this.owner.lookup('service:passageEvents');


### PR DESCRIPTION
## 🪧 Problème

Actuellement la checkbox du QCM déclaratif n’a pas le bon design.

## 🌈 Proposition

- Mettre à jour la dépendance pix-ui pour avoir les [nouveaux états de pixCheckbox](https://ui.pix.fr/?path=/docs/forms-checkbox-variant-modulix--docs)
- Modifier le qcm-declarative pour utiliser les états `declarative` et `declarative-selected` de PixCheckbox.

## ✊ Remarques

- J'ai utilisé `trackedset` pour permettre que l'ajout et la suppression d'éléments dans le `Set()` déclenche un changement d'état de la checkbox
- J'ai ajouté un qcm-declarative dans le premier stepper horizontal du bac-à-sable

## 🎉 Pour tester

- Ouvrir le [bac-a-sable](https://app-pr16571.review.pix.fr/modules/6a68bf32/bac-a-sable/passage)
- Afficher le qcm-declaratif
- Soumettre sans sélection : les checkbox ne changent pas d'état
- Sélectionner une ou plusieurs propositions. Soumettre
- Les checkbox changent d'état et sont disabled
- Afficher le 1er stepper horizontal, et faire de même dans le qcm-declarative qu'il contient
