### PR TITLE
[TECH] Filtrer les knowledge elements sur les skills du profil cible lors de l'export CSV des résultats de campagne (PIX-XXXX)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -48,6 +48,7 @@ class CampaignAssessmentExport {
     },
   ) {
     this.stream.write(this.#buildHeader());
+    const targetedSkillIds = this.learningContent.skills.map((skill) => skill.id);
     const campaignParticipationInfoChunks = _.chunk(
       campaignParticipationInfos,
       constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING,
@@ -84,6 +85,7 @@ class CampaignAssessmentExport {
               return { userId, campaignParticipationId };
             }),
             fetchFromSnapshot: this.campaign.isExam,
+            skillIds: targetedSkillIds,
           });
 
         const csvLines = campaignParticipationInfoChunk.map((campaignParticipationInfo) =>

--- a/api/src/prescription/shared/domain/services/knowledge-element-for-participation-service.js
+++ b/api/src/prescription/shared/domain/services/knowledge-element-for-participation-service.js
@@ -76,11 +76,12 @@ class KnowledgeElementForParticipationService {
     throw new Error(`find knowledge-elements for campaign of type ${campaign.type} not implemented`);
   }
 
-  async findUniqByUsersOrCampaignParticipationIds({ participationInfos, fetchFromSnapshot }) {
+  async findUniqByUsersOrCampaignParticipationIds({ participationInfos, fetchFromSnapshot, skillIds }) {
     if (!fetchFromSnapshot) {
-      return await this.knowledgeElementRepository.findUniqByUserIds({
-        userIds: participationInfos.map(({ userId }) => userId),
-      });
+      const userIds = participationInfos.map(({ userId }) => userId);
+      return skillIds?.length
+        ? await this.knowledgeElementRepository.findUniqByUserIdsAndSkillIds({ userIds, skillIds })
+        : await this.knowledgeElementRepository.findUniqByUserIds({ userIds });
     }
 
     return await this.knowledgeElementSnapshotRepository.findCampaignParticipationKnowledgeElementSnapshots(

--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -26,12 +26,7 @@ async function findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, skillI
   return keCollection.latestUniqNonResetKnowledgeElements;
 }
 
-const findUniqByUserIds = async function ({ userIds }) {
-  if (userIds.length === 0) return [];
-
-  const knexConn = DomainTransaction.getConnection();
-  const knowledgeElementRows = await knexConn(tableName).whereIn('userId', userIds);
-
+const groupUniqKnowledgeElementsByUserId = ({ userIds, knowledgeElementRows }) => {
   const knowledgeElementsByUserId = new Map(userIds.map((userId) => [userId, []]));
   for (const row of knowledgeElementRows) {
     knowledgeElementsByUserId.get(row.userId)?.push(new KnowledgeElement(row));
@@ -44,6 +39,24 @@ const findUniqByUserIds = async function ({ userIds }) {
       knowledgeElements: keCollection.latestUniqNonResetKnowledgeElements,
     };
   });
+};
+
+const findUniqByUserIds = async function ({ userIds }) {
+  if (userIds.length === 0) return [];
+
+  const knexConn = DomainTransaction.getConnection();
+  const knowledgeElementRows = await knexConn(tableName).whereIn('userId', userIds);
+
+  return groupUniqKnowledgeElementsByUserId({ userIds, knowledgeElementRows });
+};
+
+const findUniqByUserIdsAndSkillIds = async function ({ userIds, skillIds }) {
+  if (userIds.length === 0) return [];
+
+  const knexConn = DomainTransaction.getConnection();
+  const knowledgeElementRows = await knexConn(tableName).whereIn('userId', userIds).whereIn('skillId', skillIds);
+
+  return groupUniqKnowledgeElementsByUserId({ userIds, knowledgeElementRows });
 };
 
 const batchSave = async function ({ knowledgeElements }) {
@@ -109,4 +122,5 @@ export {
   findUniqByUserIdAndCompetenceId,
   findUniqByUserIdGroupedByCompetenceId,
   findUniqByUserIds,
+  findUniqByUserIdsAndSkillIds,
 };

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
@@ -22,7 +22,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         badges: [],
       };
       stageCollection = {};
-      learningContent = { skillNames: [], competences: [], areas: [] };
+      learningContent = { skills: [], skillNames: [], competences: [], areas: [] };
       campaign = domainBuilder.prescription.campaign.buildCampaign.ofTypeAssessment({ externalIdLabel: null });
 
       const listSkills1 = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });

--- a/api/tests/prescription/shared/integration/domain/services/knowledge-element-for-participation-service_test.js
+++ b/api/tests/prescription/shared/integration/domain/services/knowledge-element-for-participation-service_test.js
@@ -1076,6 +1076,58 @@ describe('Integration | Prescription | Shared | Service | KnowledgeElementForPar
           },
         ]);
       });
+
+      it('should only return knowledge element matching the given skillIds', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+        }).id;
+        const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+        const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+        const otherAnswerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+        const domainKEOnTargetedSkill = domainBuilder.buildKnowledgeElement({
+          id: 1,
+          userId,
+          skillId: 'acquisABC123',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2021-01-01'),
+        });
+        const domainKEOnOtherSkill = domainBuilder.buildKnowledgeElement({
+          id: 2,
+          userId,
+          skillId: 'acquisDEF456',
+          answerId: otherAnswerId,
+          assessmentId,
+          createdAt: new Date('2022-01-01'),
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement(domainKEOnTargetedSkill);
+        databaseBuilder.factory.buildKnowledgeElement(domainKEOnOtherSkill);
+
+        await databaseBuilder.commit();
+
+        const res = await knowledgeElementForParticipationService.findUniqByUsersOrCampaignParticipationIds({
+          participationInfos: [
+            {
+              userId,
+              campaignParticipationId,
+            },
+          ],
+          fetchFromSnapshot: false,
+          skillIds: ['acquisABC123'],
+        });
+
+        // then
+        expect(res).to.deep.equal([
+          {
+            userId,
+            knowledgeElements: [domainKEOnTargetedSkill],
+          },
+        ]);
+      });
     });
   });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -422,4 +422,47 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       ]);
     });
   });
+
+  describe('#findUniqByUserIdsAndSkillIds', function () {
+    let userId1;
+    let userId2;
+
+    beforeEach(function () {
+      userId1 = databaseBuilder.factory.buildUser().id;
+      userId2 = databaseBuilder.factory.buildUser().id;
+      return databaseBuilder.commit();
+    });
+
+    it('should only return knowledge elements matching the given skillIds', async function () {
+      // given
+      const user1knowledgeElementOnTargetedSkill = databaseBuilder.factory.buildKnowledgeElement({
+        userId: userId1,
+        createdAt: new Date('2020-01-01'),
+        skillId: 'rec1',
+      });
+      databaseBuilder.factory.buildKnowledgeElement({
+        userId: userId1,
+        createdAt: new Date('2020-01-02'),
+        skillId: 'recOutOfScope',
+      });
+      databaseBuilder.factory.buildKnowledgeElement({
+        userId: userId2,
+        createdAt: new Date('2019-01-01'),
+        skillId: 'recOutOfScope',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const knowledgeElementsByUserId = await repositories.knowledgeElementRepository.findUniqByUserIdsAndSkillIds({
+        userIds: [userId1, userId2],
+        skillIds: ['rec1'],
+      });
+
+      // then
+      expect(knowledgeElementsByUserId[0].knowledgeElements).to.have.deep.members([
+        user1knowledgeElementOnTargetedSkill,
+      ]);
+      expect(knowledgeElementsByUserId[1].knowledgeElements).to.be.empty;
+    });
+  });
 });


### PR DESCRIPTION
## 🪧 Problème

Lors du téléchargement du CSV des résultats d'une campagne d'évaluation, la récupération des knowledge elements des participations en cours (non partagées, hors EXAM) chargeait tous les KE de chaque utilisateur.

Or seuls les KE rattachés aux skills du profil cible sont réellement exploités : les autres étaient systématiquement écartés plus loin (getKnowledgeElementsGroupedByCompetence). On rapatriait donc beaucoup de données pour rien, ce qui pèse sur la mémoire de l'API

## 🌈 Proposition

Ajout d'une fonction dédiée findUniqByUserIdsAndSkillIds qui restreint la requête aux skills du profil cible.

## ✊ Remarques

💓 prescription 💓

## 🎉 Pour tester
 
- [ ] Tester l'export de résultats 
