### PR TITLE
[BUGFIX] Ne pas construire une url de questionnaire de fin de parcours si on n'a pas d'url de base pour le blueprint (PIX-23233)

### DIFF
--- a/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseDetails.js
+++ b/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseDetails.js
@@ -298,6 +298,14 @@ export class CombinedCourseDetails extends CombinedCourse {
   }
 
   get surveyUrl() {
-    return this.#participation ? `${this.baseSurveyUrl}?participationId=${this.#participation.id}` : this.baseSurveyUrl;
+    if (!this.baseSurveyUrl) {
+      return null;
+    }
+
+    if (this.#participation) {
+      return `${this.baseSurveyUrl}?participationId=${this.#participation.id}`;
+    }
+
+    return this.baseSurveyUrl;
   }
 }

--- a/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
@@ -1090,6 +1090,30 @@ describe('Quest | Unit | Domain | Models | CombinedCourseDetails', function () {
         // then
         expect(combinedCourseDetails.surveyUrl).to.deep.equal('https://link.to/survey?participationId=1');
       });
+
+      it('should return surveyUrl only if baseSurveyUrl is defined', async function () {
+        // given & when
+        const combinedCourseParticipation = {
+          status: CombinedCourseParticipationStatuses.COMPLETED,
+          id: 1,
+        };
+        const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
+          name,
+          code,
+          organizationId,
+          questId,
+          combinedCourseItems: [{ campaignId: 3, targetProfileId: 999 }, { moduleId: 'abcde1' }],
+          cryptoService,
+          baseSurveyUrl: null,
+        });
+
+        await combinedCourseDetails.setEncryptedUrl();
+
+        combinedCourseDetails.setDataAndGenerateItems({ participation: combinedCourseParticipation });
+
+        // then
+        expect(combinedCourseDetails.surveyUrl).to.be.null;
+      });
     });
   });
 


### PR DESCRIPTION
## 🪧 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Le bouton avec le lien du questionnaire de fin de parcours ne devrait s’afficher que pour les parcours dont le blueprint a un surveyUrl. Or il s’affiche dans tous les cas, avec un lien invalide si on n’a pas de lien configuré.

Dans le getter de surveyUrl dans CombinedCourseDetails, on ajoute l'id de participation en query param. Dans le cas ou l'url de base est null, on lui ajoute quand meme les params, générant un lien invalide.

## 🌈 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Ajout d'un guard dans la méthode de construction du surveyUrl pour renvoyer null si le baseSurvey url n'est pas défini.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
Passer la feature toggle à true dans la RA.
Exemple scalingo -a pix-api-review-pr16573 run "npm run toggles -- --key=isSurveyEnabledForCombinedCourses --value=true" 

Sur PixApp se connecter avec learneremail1000_1@example.net. Faire le parcours COMBINIX1.
Aller au bout du parcours.
Le lien du questionnaire doit s'afficher.

Faire le parcours CBNOMOD.
Aller au bout du parcours.
Le lien du questionnaire ne doit pas s'afficher.
--> Alternativement, se connecter côté Admin, modifier le schéma de parcours qui contient le lien pour COMBINIX1 (l'un des "Parcours apprenant complet"), et supprimer l'url. Revenir sur PixApp, on ne doit plus avoir le bouton.
