### PR TITLE
[TECH] Supprimer la dépendance tracked-build-ins sur Pix App (PIX-23243)

### DIFF
--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -3,6 +3,7 @@ import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { concat } from '@ember/helper';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
+import { trackedSet } from '@ember/reactive/collections';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -12,7 +13,6 @@ import Step from 'mon-pix/components/module/component/step';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 import { inc } from 'mon-pix/helpers/inc';
-import { TrackedSet } from 'tracked-built-ins';
 import { localCopy } from 'tracked-toolbox';
 
 import didInsert from '../../../modifiers/modifier-did-insert';
@@ -21,7 +21,7 @@ import { VERIFY_RESPONSE_DELAY } from './element';
 export const NEXT_STEP_BUTTON_DELAY = VERIFY_RESPONSE_DELAY;
 
 export default class ModulixStepper extends Component {
-  @tracked locallyAnsweredElements = new TrackedSet();
+  @tracked locallyAnsweredElements = trackedSet();
 
   @service modulixAutoScroll;
   @service modulixPreviewMode;

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
+import { trackedArray, trackedMap } from '@ember/reactive/collections';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -7,7 +8,6 @@ import QabProposalButton from 'mon-pix/components/module/element/qab/proposal-bu
 import QabCard from 'mon-pix/components/module/element/qab/qab-card';
 import QabScoreCard from 'mon-pix/components/module/element/qab/qab-score-card';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
-import { TrackedArray, TrackedMap } from 'tracked-built-ins';
 
 import { htmlUnsafe } from '../../../../helpers/html-unsafe';
 import ModuleElement from '../module-element';
@@ -23,15 +23,15 @@ export default class ModuleQab extends ModuleElement {
   @tracked currentCardIndex = 0;
   @tracked score = 0;
   @tracked displayedCards;
-  @tracked cardStatuses = new TrackedMap();
-  @tracked removedCards = new TrackedMap();
+  @tracked cardStatuses = trackedMap();
+  @tracked removedCards = trackedMap();
   @tracked reportInfo = {};
 
   @service passageEvents;
 
   constructor() {
     super(...arguments);
-    this.displayedCards = new TrackedArray(this.element.cards);
+    this.displayedCards = trackedArray(this.element.cards);
   }
 
   get numberOfCards() {
@@ -118,7 +118,7 @@ export default class ModuleQab extends ModuleElement {
     this.currentStep = 'cards';
     this.removedCards.clear();
     this.cardStatuses.clear();
-    this.displayedCards = new TrackedArray(this.element.cards);
+    this.displayedCards = trackedArray(this.element.cards);
     this.score = 0;
 
     this.passageEvents.record({

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { action } from '@ember/object';
+import { trackedSet } from '@ember/reactive/collections';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -9,12 +10,11 @@ import { eq } from 'ember-truth-helpers';
 import Element from 'mon-pix/components/module/component/element';
 import Stepper from 'mon-pix/components/module/component/stepper';
 import didInsert from 'mon-pix/modifiers/modifier-did-insert';
-import { TrackedSet } from 'tracked-built-ins';
 
 export default class ModuleGrain extends Component {
   @service modulixAutoScroll;
   @service intl;
-  @tracked answeredElements = new TrackedSet();
+  @tracked answeredElements = trackedSet();
   @tracked isSkipButtonDisabled = false;
 
   grain = this.args.grain;

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -96,7 +96,6 @@
         "sinon": "^22.0.0",
         "stylelint": "^17.11.1",
         "stylelint-order": "^8.1.1",
-        "tracked-built-ins": "^4.1.2",
         "tracked-toolbox": "^3.0.0",
         "webpack": "^5.106.2",
         "xss": "^1.0.15"
@@ -35653,17 +35652,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tracked-built-ins": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-4.1.2.tgz",
-      "integrity": "sha512-KiiV/Pzi7VNKTn9Fip6Ic54AjKgFfqows1Jq3L0WLVqZcvfswdhVxQ9yqqhTXsmgLhVzIgtdzNBH4ExqWf34BQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.10.2",
-        "decorator-transforms": "^2.0.0"
       }
     },
     "node_modules/tracked-toolbox": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -127,7 +127,6 @@
     "sinon": "^22.0.0",
     "stylelint": "^17.11.1",
     "stylelint-order": "^8.1.1",
-    "tracked-built-ins": "^4.1.2",
     "tracked-toolbox": "^3.0.0",
     "webpack": "^5.106.2",
     "xss": "^1.0.15"


### PR DESCRIPTION
## 🪧 Problème

Avec la mise à jour 6.8 d'ember, il n'y a plus besoin de la librairie `tracked-built-ins` avec l'import `@ember/reactive/collections`

## 🌈 Proposition

Utiliser l'import et supprimer la librairie sur Pix App.

## ✊ Remarques

RAS

## 🎉 Pour tester
### Grain
- Aller sur le 1er grain du module [Bac à sable](https://app-pr16576.review.pix.fr/modules/6a68bf32/bac-a-sable/passage)
- Tester le QCM déclarative
- Constater qu'il n'y a pas de régressions

### Stepper
- Aller sur le grain stepper du module [Bac à sable](https://app-pr16576.review.pix.fr/modules/6a68bf32/bac-a-sable/passage?grainIndex=2)
- Tester le QCU découverte et déclarative
- Constater qu'il n'y a pas de régressions et que le bouton suivant s'affiche bien

### QAB
- Aller sur le grain QAB du module [Bac à sable](https://app-pr16576.review.pix.fr/modules/6a68bf32/bac-a-sable/passage?grainIndex=11)
- Tester le QAB
- Constater qu'il n'y a pas de régressions 🚀 


