### PR TITLE
[BUGFIX] Corriger les accents mal encodés dans les prénoms des tables certification-courses/candidates (PIX-23223).

### DIFF
--- a/api/scripts/certification/correct-certification-courses-firstnames-bad-encoding.js
+++ b/api/scripts/certification/correct-certification-courses-firstnames-bad-encoding.js
@@ -1,0 +1,250 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class CorrectCertificationCoursesFirstnamesBadEncoding extends Script {
+  constructor() {
+    super({
+      description:
+        'Some candidates firstnames in certification-courses and certification-candidates tables have some badly ' +
+        'encoded accents. The goal here is to replace those weirdly encoded characters (UTF-8 ↔ ISO-8859-1)',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info(`Script execution started with options ${JSON.stringify(options)}`);
+
+    const trx = await knex.transaction();
+
+    try {
+      const correctedCertificationCourseIds = await correctFirstNames(trx, 'certification-courses');
+      const correctedCertificationCandidateIds = await correctFirstNames(trx, 'certification-candidates');
+
+      const certificationCoursesTotal = correctedCertificationCourseIds.size;
+      const certificationCandidatesTotal = correctedCertificationCandidateIds.size;
+
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(
+          `${certificationCoursesTotal} certification-courses rows and ` +
+            `${certificationCandidatesTotal} certification-candidates rows would have been updated`,
+        );
+        return;
+      } else {
+        await trx.commit();
+        logger.info(
+          `Script finished. Number of rows with weirdly encoded firstnames corrected : ` +
+            `${certificationCoursesTotal} certification-courses, ` +
+            `${certificationCandidatesTotal} certification-candidates, youpi`,
+        );
+      }
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+async function correctFirstNames(trx, tableName) {
+  const correctedIds = new Set();
+
+  for (const { badAccent, goodAccent } of badlyEncodedAccents) {
+    const updatedRows = await trx(tableName)
+      .where('firstName', 'like', `%${badAccent}%`)
+      .update({ firstName: knex.raw('REPLACE(??, ?, ?)', ['firstName', badAccent, goodAccent]) })
+      .returning('id');
+
+    updatedRows.forEach(({ id }) => correctedIds.add(id));
+  }
+
+  const corrections = { ...firstNamesDictionary1, ...firstNamesDictionary2 };
+  for (const [badFirstName, goodFirstName] of Object.entries(corrections)) {
+    const updatedRows = await trx(tableName)
+      .where('firstName', badFirstName)
+      .update({ firstName: goodFirstName })
+      .returning('id');
+
+    updatedRows.forEach(({ id }) => correctedIds.add(id));
+  }
+
+  return correctedIds;
+}
+
+const badlyEncodedAccents = [
+  { badAccent: 'Ã©', goodAccent: 'é' },
+  { badAccent: 'Ã¨', goodAccent: 'è' },
+  { badAccent: 'Ã«', goodAccent: 'ë' },
+  { badAccent: 'Ã¯', goodAccent: 'ï' },
+  { badAccent: 'Ã§', goodAccent: 'ç' },
+];
+
+const firstNamesDictionary1 = {
+  'Amï¿œlia': 'Amélia',
+  'Amï¿œlie': 'Amélie',
+  'Anaï¿œlle': 'Anaëlle',
+  'Anaï¿œs': 'Anaïs',
+  'Andrï¿œa': 'Andréa',
+  'Angï¿œle': 'Angèle',
+  'Angï¿œlo': 'Angélo',
+  'Anne-Amï¿œlie': 'Anne-Amélie',
+  'Aurï¿œlia': 'Aurélia',
+  'Aurï¿œlien': 'Aurélien',
+  'Azalï¿œe': 'Azalée',
+  'Azï¿œlie': 'Azélie',
+  'Bï¿œatrice': 'Béatrice',
+  'Bï¿œrangï¿œre': 'Bérangère',
+  'Bï¿œrenger': 'Bérenger',
+  'Bï¿œrï¿œnice': 'Bérénice',
+  'Cï¿œcile': 'Cécile',
+  'Cï¿œcilia': 'Cécilia',
+  'Cï¿œdric': 'Cédric',
+  'Cï¿œlia': 'Célia',
+  'Cï¿œlian': 'Célian',
+  'Charlï¿œne': 'Charlène',
+  'Chloï¿œ': 'Chloé',
+  'Clï¿œmence': 'Clémence',
+  'Clï¿œment': 'Clément',
+  'Danaï¿œ': 'Danaé',
+  'Dorothï¿œe': 'Dorothée',
+  'Elï¿œonore': 'Eléonore',
+  'Fï¿œlicie': 'Félicie',
+  'Fï¿œlix': 'Félix',
+  'Franï¿œois': 'François',
+  'Gaï¿œtane': 'Gaëtane',
+  'Galatï¿œe': 'Galatée',
+  'Grï¿œgoire': 'Grégoire',
+  'Hï¿œloï¿œse': 'Héloïse',
+  'Inï¿œs': 'Inès',
+  'Ismaï¿œl': 'Ismaël',
+  'Jï¿œrï¿œme': 'Jérôme',
+  'Joï¿œl': 'Joël',
+  'Kouamï¿œ': 'Kouamé',
+  'Laurï¿œne': 'Laurène',
+  'Lï¿œa': 'Léa',
+  'Lï¿œna': 'Léna',
+  'Lï¿œo': 'Léo',
+  'Lï¿œon': 'Léon',
+  'Lï¿œonard': 'Léonard',
+  'Lï¿œopold': 'Léopold',
+  'Loï¿œc': 'Loïc',
+  'Loï¿œse': 'Loïse',
+  'Macï¿œo': 'Macéo',
+  'Maï¿œline': 'Maëline',
+  'Maï¿œlys': 'Maëlys',
+  'Marie-Grï¿œce': 'Marie-Grâce',
+  'Mathï¿œo': 'Mathéo',
+  'Mattï¿œo': 'Mattéo',
+  'Matthï¿œo': 'Matthéo',
+  'Mï¿œlina': 'Mélina',
+  'Mï¿œline': 'Méline',
+  'Mï¿œlissa': 'Mélissa',
+  'Mï¿œlodie': 'Mélodie',
+  'Michaï¿œl': 'Michaël',
+  'Mickaï¿œl': 'Mickaël',
+  'Naï¿œl': 'Naël',
+  'Naï¿œma': 'Naïma',
+  'Nï¿œo': 'Néo',
+  'Noï¿œ': 'Noé',
+  'Ocï¿œane': 'Océane',
+  'Raphaï¿œl': 'Raphaël',
+  'Rï¿œmi': 'Rémi',
+  'Salomï¿œ': 'Salomé',
+  'Sï¿œlï¿œne': 'Sélène',
+  'Solï¿œne': 'Solène',
+  'Thaï¿œs': 'Thaïs',
+  'Thï¿œa': 'Théa',
+  'Thï¿œo': 'Théo',
+  'Timï¿œo': 'Timéo',
+  'Timothï¿œ': 'Timothé',
+  'Timothï¿œe': 'Timothée',
+  'Waï¿œl': 'Waël',
+  'Wenaï¿œl': 'Wenaël',
+  'Zï¿œlie': 'Zélie',
+  'Zï¿œphire': 'Zéphire',
+  'Zoï¿œ': 'Zoé',
+};
+
+const firstNamesDictionary2 = {
+  'Aim�': 'Aimé',
+  'Aliz�a': 'Alizéa',
+  'Am�lie': 'Amélie',
+  'Ana�lle': 'Anaëlle',
+  'Ana�s': 'Anaïs',
+  'Ang�lique': 'Angélique',
+  'Aur�lie Jos�phine Marina': 'Aurélie Joséphine Marina',
+  'Aur�lien': 'Aurélien',
+  'Beno�t': 'Benoît',
+  'Bethsa�da': 'Bethsaïda',
+  'C�lia': 'Célia',
+  'C�sar': 'César',
+  'Charl�ne': 'Charlène',
+  'Chlo�': 'Chloé',
+  'Cl�mence': 'Clémence',
+  'Cl�mentine': 'Clémentine',
+  'Elo�se': 'Eloïse',
+  'Eryne-Zo�': 'Eryne-Zoé',
+  'Eug�ne': 'Eugène',
+  'F�lice': 'Félice',
+  'Fran�ois': 'François',
+  'Ga�l': 'Gaël',
+  'G�raldine': 'Géraldine',
+  'Gr�gory': 'Grégory',
+  'Gwena�lle': 'Gwenaëlle',
+  'Gwenna�s': 'Gwennaïs',
+  'H�l�na': 'Héléna',
+  'H�l�ne': 'Hélène',
+  'H�lo�se': 'Héloïse',
+  'In�s': 'Inès',
+  'Jean-Fran�ois': 'Jean-François',
+  'K�vin': 'Kévin',
+  'L�a': 'Léa',
+  'L�ana': 'Léana',
+  'L�ane': 'Léane',
+  'L�anne': 'Léanne',
+  'L�ia': 'Léia',
+  'Lena�g': 'Lenaïg',
+  'L�o': 'Léo',
+  'L�onie': 'Léonie',
+  'Ma�li': 'Maëli',
+  'Ma�lie': 'Maëlie',
+  'Ma�lyne': 'Maëlyne',
+  'Ma�va': 'Maëva',
+  'Mah�': 'Mahé',
+  'Ma�ana': 'Maïana',
+  'Mano�lle': 'Manoëlle',
+  'Mat�o': 'Matéo',
+  'Math�o': 'Mathéo',
+  'Matt�o': 'Mattéo',
+  'Matth�o': 'Matthéo',
+  'M�lanie': 'Mélanie',
+  'M�lina': 'Mélina',
+  'M�linda': 'Mélinda',
+  'M�lodie': 'Mélodie',
+  'Na�ma': 'Naïma',
+  'Natha�l': 'Nathaël',
+  'No�': 'Noé',
+  'No�mie': 'Noémie',
+  'No�my': 'Noëmy',
+  'Oc�ane': 'Océane',
+  'Oph�lie': 'Ophélie',
+  'P�n�lope': 'Pénélope',
+  'Rapha�l': 'Raphaël',
+  'R�mi': 'Rémi',
+  'Salom�': 'Salomé',
+  'S�bastien': 'Sébastien',
+  'S�verin': 'Séverin',
+  'Th�o': 'Théo',
+  'Th�odore': 'Théodore',
+  'Zo�': 'Zoé',
+};
+
+await ScriptRunner.execute(import.meta.url, CorrectCertificationCoursesFirstnamesBadEncoding);

--- a/api/tests/certification/scripts/correct-certification-courses-firstnames-bad-encoding_test.js
+++ b/api/tests/certification/scripts/correct-certification-courses-firstnames-bad-encoding_test.js
@@ -1,0 +1,252 @@
+import sinon from 'sinon';
+
+import { CorrectCertificationCoursesFirstnamesBadEncoding } from '../../../scripts/certification/correct-certification-courses-firstnames-bad-encoding.js';
+import { expect } from '../../test-helper.js';
+import { databaseBuilder, knex } from '../../tooling/databases.js';
+import { catchErr } from '../../tooling/test-utils/error.js';
+
+describe('Certification | Scripts | CorrectCertificationCandidatesAccentsBadEncoding', function () {
+  let courseGoodFirstName,
+    courseCase1,
+    courseCase2,
+    courseCase3,
+    courseCase4,
+    courseCase5,
+    courseMultipleAccentsCase,
+    courseDictonary1,
+    courseDictonary2,
+    courseDictonary3,
+    courseDictonary4,
+    candidateGoodFirstName,
+    candidateCase1,
+    candidateCase2,
+    candidateCase3,
+    candidateCase4,
+    candidateCase5,
+    candidateMultipleAccentsCase,
+    candidateDictonary1,
+    candidateDictonary2,
+    candidateDictonary3,
+    candidateDictonary4,
+    script,
+    logger;
+
+  beforeEach(function () {
+    script = new CorrectCertificationCoursesFirstnamesBadEncoding();
+    logger = {
+      info: sinon.stub(),
+      error: sinon.stub(),
+    };
+
+    courseGoodFirstName = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'Héloïse-Françoise',
+    });
+    courseCase1 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'CÃ©dric',
+    });
+    courseCase2 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'HelÃ¨ne',
+    });
+    courseCase3 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'IsmaÃ«l',
+    });
+    courseCase4 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'MatheÃ¯s',
+    });
+    courseCase5 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'FranÃ§oise',
+    });
+    courseDictonary1 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'Mickaï¿œl',
+    });
+    courseDictonary2 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'Hï¿œloï¿œse',
+    });
+    courseDictonary3 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'Cl�mentine',
+    });
+    courseDictonary4 = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'Jean-Fran�ois',
+    });
+    courseMultipleAccentsCase = databaseBuilder.factory.buildCertificationCourse({
+      firstName: 'AndrÃ©-MichÃ¨le',
+    });
+
+    candidateGoodFirstName = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'Héloïse-Françoise',
+    });
+    candidateCase1 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'CÃ©dric',
+    });
+    candidateCase2 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'HelÃ¨ne',
+    });
+    candidateCase3 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'IsmaÃ«l',
+    });
+    candidateCase4 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'MatheÃ¯s',
+    });
+    candidateCase5 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'FranÃ§oise',
+    });
+    candidateDictonary1 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'Mickaï¿œl',
+    });
+    candidateDictonary2 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'Hï¿œloï¿œse',
+    });
+    candidateDictonary3 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'Cl�mentine',
+    });
+    candidateDictonary4 = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'Jean-Fran�ois',
+    });
+    candidateMultipleAccentsCase = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'AndrÃ©-MichÃ¨le',
+    });
+
+    return databaseBuilder.commit();
+  });
+
+  context('dryRun ON', function () {
+    it('does not persist the changes', async function () {
+      await script.handle({
+        logger,
+        options: { dryRun: true },
+      });
+
+      const courseFirstNames = await knex.select('firstName').from('certification-courses').orderBy('id');
+      const candidateFirstNames = await knex.select('firstName').from('certification-candidates').orderBy('id');
+
+      expect(logger.info).to.have.been.calledWith(`Script execution started with options {"dryRun":true}`);
+      expect(logger.info).to.have.been.calledWith(
+        '10 certification-courses rows and 10 certification-candidates rows would have been updated',
+      );
+      expect(logger.error).to.not.have.been.called;
+
+      expect(courseFirstNames[0].firstName).to.equal(courseGoodFirstName.firstName);
+      expect(courseFirstNames[1].firstName).to.equal(courseCase1.firstName);
+      expect(courseFirstNames[2].firstName).to.equal(courseCase2.firstName);
+      expect(courseFirstNames[3].firstName).to.equal(courseCase3.firstName);
+      expect(courseFirstNames[4].firstName).to.equal(courseCase4.firstName);
+      expect(courseFirstNames[5].firstName).to.equal(courseCase5.firstName);
+      expect(courseFirstNames[6].firstName).to.equal(courseDictonary1.firstName);
+      expect(courseFirstNames[7].firstName).to.equal(courseDictonary2.firstName);
+      expect(courseFirstNames[8].firstName).to.equal(courseDictonary3.firstName);
+      expect(courseFirstNames[9].firstName).to.equal(courseDictonary4.firstName);
+      expect(courseFirstNames[10].firstName).to.equal(courseMultipleAccentsCase.firstName);
+
+      expect(candidateFirstNames[0].firstName).to.equal(candidateGoodFirstName.firstName);
+      expect(candidateFirstNames[1].firstName).to.equal(candidateCase1.firstName);
+      expect(candidateFirstNames[2].firstName).to.equal(candidateCase2.firstName);
+      expect(candidateFirstNames[3].firstName).to.equal(candidateCase3.firstName);
+      expect(candidateFirstNames[4].firstName).to.equal(candidateCase4.firstName);
+      expect(candidateFirstNames[5].firstName).to.equal(candidateCase5.firstName);
+      expect(candidateFirstNames[6].firstName).to.equal(candidateDictonary1.firstName);
+      expect(candidateFirstNames[7].firstName).to.equal(candidateDictonary2.firstName);
+      expect(candidateFirstNames[8].firstName).to.equal(candidateDictonary3.firstName);
+      expect(candidateFirstNames[9].firstName).to.equal(candidateDictonary4.firstName);
+      expect(candidateFirstNames[10].firstName).to.equal(candidateMultipleAccentsCase.firstName);
+    });
+  });
+
+  context('dryRun OFF', function () {
+    context('when there are no errors', function () {
+      it('persists all the changes', async function () {
+        await script.handle({
+          logger,
+          options: {
+            dryRun: false,
+          },
+        });
+
+        const courseFirstNames = await knex.select('firstName').from('certification-courses').orderBy('id');
+        const candidateFirstNames = await knex.select('firstName').from('certification-candidates').orderBy('id');
+
+        expect(logger.info).to.have.been.calledWith(`Script execution started with options {"dryRun":false}`);
+        expect(logger.info).to.have.been.calledWith(
+          'Script finished. Number of rows with weirdly encoded firstnames corrected : ' +
+            '10 certification-courses, 10 certification-candidates, youpi',
+        );
+        expect(logger.error).to.not.have.been.called;
+
+        expect(courseFirstNames).to.have.lengthOf(11);
+        expect(courseFirstNames[0].firstName).to.equal(courseGoodFirstName.firstName);
+        expect(courseFirstNames[1].firstName).to.equal('Cédric');
+        expect(courseFirstNames[2].firstName).to.equal('Helène');
+        expect(courseFirstNames[3].firstName).to.equal('Ismaël');
+        expect(courseFirstNames[4].firstName).to.equal('Matheïs');
+        expect(courseFirstNames[5].firstName).to.equal('Françoise');
+        expect(courseFirstNames[6].firstName).to.equal('Mickaël');
+        expect(courseFirstNames[7].firstName).to.equal('Héloïse');
+        expect(courseFirstNames[8].firstName).to.equal('Clémentine');
+        expect(courseFirstNames[9].firstName).to.equal('Jean-François');
+        expect(courseFirstNames[10].firstName).to.equal('André-Michèle');
+
+        expect(candidateFirstNames).to.have.lengthOf(11);
+        expect(candidateFirstNames[0].firstName).to.equal(candidateGoodFirstName.firstName);
+        expect(candidateFirstNames[1].firstName).to.equal('Cédric');
+        expect(candidateFirstNames[2].firstName).to.equal('Helène');
+        expect(candidateFirstNames[3].firstName).to.equal('Ismaël');
+        expect(candidateFirstNames[4].firstName).to.equal('Matheïs');
+        expect(candidateFirstNames[5].firstName).to.equal('Françoise');
+        expect(candidateFirstNames[6].firstName).to.equal('Mickaël');
+        expect(candidateFirstNames[7].firstName).to.equal('Héloïse');
+        expect(candidateFirstNames[8].firstName).to.equal('Clémentine');
+        expect(candidateFirstNames[9].firstName).to.equal('Jean-François');
+        expect(candidateFirstNames[10].firstName).to.equal('André-Michèle');
+      });
+    });
+
+    context('when an error occurs during the process', function () {
+      it('rolls back every change and rethrows the error', async function () {
+        const rawStub = sinon.stub(knex, 'raw');
+        rawStub.callThrough();
+        rawStub
+          .withArgs('REPLACE(??, ?, ?)', ['firstName', 'Ã§', 'ç'])
+          .throws(new Error('SABOTAGING_TO_TRIGGER_ROLLBACK'));
+
+        const err = await catchErr(script.handle)({
+          logger,
+          options: { dryRun: false },
+        });
+
+        expect(err.message).to.equal('SABOTAGING_TO_TRIGGER_ROLLBACK');
+
+        const courseFirstNames = await knex.select('firstName').from('certification-courses').orderBy('id');
+        const candidateFirstNames = await knex.select('firstName').from('certification-candidates').orderBy('id');
+
+        expect(courseFirstNames).to.have.lengthOf(11);
+        expect(courseFirstNames[0].firstName).to.equal(courseGoodFirstName.firstName);
+        expect(courseFirstNames[1].firstName).to.equal(courseCase1.firstName);
+        expect(courseFirstNames[2].firstName).to.equal(courseCase2.firstName);
+        expect(courseFirstNames[3].firstName).to.equal(courseCase3.firstName);
+        expect(courseFirstNames[4].firstName).to.equal(courseCase4.firstName);
+        expect(courseFirstNames[5].firstName).to.equal(courseCase5.firstName);
+        expect(courseFirstNames[6].firstName).to.equal(courseDictonary1.firstName);
+        expect(courseFirstNames[7].firstName).to.equal(courseDictonary2.firstName);
+        expect(courseFirstNames[8].firstName).to.equal(courseDictonary3.firstName);
+        expect(courseFirstNames[9].firstName).to.equal(courseDictonary4.firstName);
+        expect(courseFirstNames[10].firstName).to.equal(courseMultipleAccentsCase.firstName);
+
+        expect(candidateFirstNames).to.have.lengthOf(11);
+        expect(candidateFirstNames[0].firstName).to.equal(candidateGoodFirstName.firstName);
+        expect(candidateFirstNames[1].firstName).to.equal(candidateCase1.firstName);
+        expect(candidateFirstNames[2].firstName).to.equal(candidateCase2.firstName);
+        expect(candidateFirstNames[3].firstName).to.equal(candidateCase3.firstName);
+        expect(candidateFirstNames[4].firstName).to.equal(candidateCase4.firstName);
+        expect(candidateFirstNames[5].firstName).to.equal(candidateCase5.firstName);
+        expect(candidateFirstNames[6].firstName).to.equal(candidateDictonary1.firstName);
+        expect(candidateFirstNames[7].firstName).to.equal(candidateDictonary2.firstName);
+        expect(candidateFirstNames[8].firstName).to.equal(candidateDictonary3.firstName);
+        expect(candidateFirstNames[9].firstName).to.equal(candidateDictonary4.firstName);
+        expect(candidateFirstNames[10].firstName).to.equal(candidateMultipleAccentsCase.firstName);
+
+        expect(logger.info).to.have.been.calledWith(`Script execution started with options {"dryRun":false}`);
+        expect(logger.info).to.not.have.been.calledWithMatch('Script finished');
+        expect(logger.error).to.not.have.been.called;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

Suite à un import SIECLE qui venait encoder plusieurs fois les prénoms, certains caractères accentués se retrouvaient mal encodés dans la table.

## 🌈 Proposition

Mettre à jour les prénoms pour qu'ils retrouvent leur accent bien formaté.

## ✊ Remarques

Seuls les cas vraiment sûrs ont été traités.
Pour certains prénoms, n'étant pas sûr de l'accent caché derrière, j'ai préféré laissé tel quel.
Ces prénoms pourront être traités manuellement plus tard.

## 🎉 Pour tester

- En local
- Ajouter des lignes dans `certification-courses` et `certification-candidates` avec des prénoms ayant des accents mal encodés (voir ticket pour trouver des exemples)
- Lancer le script en dryRun puis sans
- Vérifier que les accents sont bien modifiés
