### PR TITLE
[FEATURE] Afficher le centre de certification rattaché à une organisation (PIX-22629)

### DIFF
--- a/admin/app/adapters/attached-certification-center.js
+++ b/admin/app/adapters/attached-certification-center.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class AttachedCertificationCenterAdapter extends ApplicationAdapter {
+  urlForQuery(query) {
+    const { organizationId } = query;
+    delete query.organizationId;
+    return `${this.host}/${this.namespace}/admin/organizations/${organizationId}/certification-centers`;
+  }
+}

--- a/admin/app/components/organizations/attached-certification-center.gjs
+++ b/admin/app/components/organizations/attached-certification-center.gjs
@@ -1,0 +1,35 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
+
+<template>
+  {{#if @attachedCertificationCenters.length}}
+    <PixTable
+      @variant="admin"
+      @caption={{t "components.organizations.attached-certification-center.table.caption"}}
+      @data={{@attachedCertificationCenters}}
+    >
+      <:columns as |certificationCenter context|>
+        <PixTableColumn @context={{context}}>
+          <:header>{{t "components.organizations.attached-certification-center.table.headers.id"}}</:header>
+          <:cell>
+            <LinkTo @route="authenticated.certification-centers.get" @model={{certificationCenter.id}}>
+              {{certificationCenter.id}}
+            </LinkTo>
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>{{t "components.organizations.attached-certification-center.table.headers.name"}}</:header>
+          <:cell>{{certificationCenter.name}}</:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>{{t "components.organizations.attached-certification-center.table.headers.external-id"}}</:header>
+          <:cell>{{certificationCenter.externalId}}</:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  {{else}}
+    <p>{{t "components.organizations.attached-certification-center.empty"}}</p>
+  {{/if}}
+</template>

--- a/admin/app/models/attached-certification-center.js
+++ b/admin/app/models/attached-certification-center.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AttachedCertificationCenter extends Model {
+  @attr('string') name;
+  @attr('string') externalId;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -53,6 +53,7 @@ Router.map(function () {
         this.route('invitations');
         this.route('network');
         this.route('statistics');
+        this.route('attached-certification-centers');
       });
     });
 

--- a/admin/app/routes/authenticated/organizations/get/attached-certification-centers.js
+++ b/admin/app/routes/authenticated/organizations/get/attached-certification-centers.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AttachedCertificationCenter extends Route {
+  @service store;
+
+  async model() {
+    const organization = this.modelFor('authenticated.organizations.get');
+    return this.store.query('attached-certification-center', { organizationId: organization.id });
+  }
+}

--- a/admin/app/serializers/attached-certification-center.js
+++ b/admin/app/serializers/attached-certification-center.js
@@ -1,0 +1,10 @@
+import ApplicationSerializer from './application';
+
+export default class AttachedCertificationCenterSerializer extends ApplicationSerializer {
+  modelNameFromPayloadKey(key) {
+    if (key === 'certification-centers') {
+      return 'attached-certification-center';
+    }
+    return super.modelNameFromPayloadKey(key);
+  }
+}

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -80,6 +80,10 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
       <LinkTo @route="authenticated.organizations.get.statistics" @model={{@model}}>
         {{t "pages.organization.navbar.statistics"}}
       </LinkTo>
+
+      <LinkTo @route="authenticated.organizations.get.attached-certification-centers" @model={{@model}}>
+        {{t "pages.organization.navbar.attached-certification-center"}}
+      </LinkTo>
     </PixTabs>
 
     {{outlet}}

--- a/admin/app/templates/authenticated/organizations/get/attached-certification-centers.gjs
+++ b/admin/app/templates/authenticated/organizations/get/attached-certification-centers.gjs
@@ -1,0 +1,3 @@
+import AttachedCertificationCenter from 'pix-admin/components/organizations/attached-certification-center';
+
+<template><AttachedCertificationCenter @attachedCertificationCenters={{@model}} /></template>

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -446,6 +446,37 @@ module('Acceptance | Organizations | Get', function (hooks) {
           assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/statistics`);
         });
       });
+
+      module('Attached certification center tab', function () {
+        test('it should display the attached certification center tab', async function (assert) {
+          // when
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // then
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+          assert.ok(
+            within(navigationTabs).getByRole('link', {
+              name: t('pages.organization.navbar.attached-certification-center'),
+            }),
+          );
+        });
+
+        test('it should navigate to attached certification center page when clicking tab', async function (assert) {
+          // given
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // when
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+          const tab = within(navigationTabs).getByRole('link', {
+            name: t('pages.organization.navbar.attached-certification-center'),
+          });
+          await click(tab);
+
+          // then
+          assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/attached-certification-centers`);
+        });
+      });
     });
   });
 

--- a/admin/tests/acceptance/authenticated/organizations/get/attached-certification-center-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/attached-certification-center-test.js
@@ -1,0 +1,42 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupIntl from 'pix-admin/tests/helpers/setup-intl';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+module('Acceptance | Organizations | Attached Certification Center', function (hooks) {
+  setupApplicationTest(hooks);
+  setupIntl(hooks);
+  setupMirage(hooks);
+
+  module('when user has role "SUPER_ADMIN"', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    });
+
+    test('clicking the ID cell redirects to the certification center page', async function (assert) {
+      // given
+      const certificationCenter = this.server.create('certification-center', { id: '100', name: 'Centre Pix Paris' });
+      const organizationId = this.server.create('organization', {
+        name: 'Orga avec CDC',
+        features: { PLACES_MANAGEMENT: { active: false } },
+      }).id;
+      this.server.create('attached-certification-center', {
+        id: certificationCenter.id,
+        organizationId,
+        name: certificationCenter.name,
+        externalId: 'EXT-001',
+      });
+
+      const screen = await visit(`/organizations/${organizationId}/attached-certification-centers`);
+
+      // when
+      await click(screen.getByRole('link', { name: certificationCenter.id }));
+
+      // then
+      assert.strictEqual(currentURL(), `/certification-centers/${certificationCenter.id}`);
+    });
+  });
+});

--- a/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
+++ b/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
@@ -1,0 +1,120 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import AttachedCertificationCenter from 'pix-admin/components/organizations/attached-certification-center';
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+
+module('Integration | Component | organizations/attached-certification-center', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when there is no attached certification center', function () {
+    test('it displays an empty message', async function (assert) {
+      // given
+      const attachedCertificationCenter = [];
+
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('components.organizations.attached-certification-center.empty'))).exists();
+    });
+  });
+
+  module('when there are attached certification centers', function () {
+    test('it displays the table with caption and column headers', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationCenter = store.createRecord('attached-certification-center', {
+        id: '123',
+        name: 'Centre Pix',
+        externalId: 'EXT-456',
+      });
+      const attachedCertificationCenters = [certificationCenter];
+
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenters}} />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('table', {
+            name: t('components.organizations.attached-certification-center.table.caption'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('columnheader', {
+            name: t('components.organizations.attached-certification-center.table.headers.id'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('columnheader', {
+            name: t('components.organizations.attached-certification-center.table.headers.name'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('columnheader', {
+            name: t('components.organizations.attached-certification-center.table.headers.external-id'),
+          }),
+        )
+        .exists();
+    });
+
+    test('it displays the certification centers in a table', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationCenter = store.createRecord('attached-certification-center', {
+        id: '123',
+        name: 'Centre Pix',
+        externalId: 'EXT-456',
+      });
+      const attachedCertificationCenter = [certificationCenter];
+
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('cell', { name: '123' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Centre Pix' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'EXT-456' })).exists();
+    });
+
+    test('it displays a link to the certification center page', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationCenter = store.createRecord('attached-certification-center', {
+        id: '123',
+        name: 'Centre Pix',
+        externalId: 'EXT-456',
+      });
+      const attachedCertificationCenter = [certificationCenter];
+
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('link', { name: '123' })).hasAttribute('href', '/certification-centers/123');
+    });
+  });
+});

--- a/admin/tests/mirage/factories.js
+++ b/admin/tests/mirage/factories.js
@@ -1,5 +1,6 @@
 // This file imports and exports all factories for explicit registration in config.js
 
+import attachedCertificationCenter from './factories/attached-certification-center';
 import badge from './factories/badge';
 import certificationCandidate from './factories/certification-candidate';
 import certificationCenter from './factories/certification-center';
@@ -15,6 +16,7 @@ import training from './factories/training';
 import user from './factories/user';
 
 export default {
+  attachedCertificationCenter,
   badge,
   certificationCandidate,
   certificationCenter,

--- a/admin/tests/mirage/factories/attached-certification-center.js
+++ b/admin/tests/mirage/factories/attached-certification-center.js
@@ -1,0 +1,11 @@
+import { Factory } from 'miragejs';
+
+export default Factory.extend({
+  name(index) {
+    return `Centre de certification ${index}`;
+  },
+
+  externalId(index) {
+    return `EXT-${index}`;
+  },
+});

--- a/admin/tests/mirage/handlers/organizations.js
+++ b/admin/tests/mirage/handlers/organizations.js
@@ -104,11 +104,17 @@ function findPaginatedFilteredOrganizations(schema) {
   return json;
 }
 
+function getOrganizationAttachedCertificationCenters(schema, request) {
+  const organizationId = request.params.id;
+  return schema.attachedCertificationCenters.where({ organizationId });
+}
+
 export {
   archiveOrganization,
   findOrganizationCampaigns,
   findPaginatedFilteredOrganizations,
   findPaginatedOrganizationMemberships,
+  getOrganizationAttachedCertificationCenters,
   getOrganizationInvitations,
   getOrganizationPlaces,
   getOrganizationPlacesStatistics,

--- a/admin/tests/mirage/models.js
+++ b/admin/tests/mirage/models.js
@@ -4,6 +4,7 @@ import adminMember from './models/admin-member';
 import administrationTeam from './models/administration-team';
 import area from './models/area';
 import attachableTargetProfile from './models/attachable-target-profile';
+import attachedCertificationCenter from './models/attached-certification-center';
 import attestation from './models/attestation.js';
 import authenticationMethod from './models/authentication-method';
 import autonomousCourse from './models/autonomous-course';
@@ -79,6 +80,7 @@ export default {
   administrationTeam,
   area,
   attachableTargetProfile,
+  attachedCertificationCenter,
   attestation,
   authenticationMethod,
   autonomousCourse,

--- a/admin/tests/mirage/models/attached-certification-center.js
+++ b/admin/tests/mirage/models/attached-certification-center.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -25,6 +25,7 @@ import {
   findOrganizationCampaigns,
   findPaginatedFilteredOrganizations,
   findPaginatedOrganizationMemberships,
+  getOrganizationAttachedCertificationCenters,
   getOrganizationInvitations,
   getOrganizationPlaces,
   getOrganizationPlacesStatistics,
@@ -402,6 +403,7 @@ export default function routes() {
   this.get('/admin/organizations/:id/invitations', getOrganizationInvitations);
   this.get('/admin/organizations/:id/places', getOrganizationPlaces);
   this.get('/admin/organizations/:id/places-statistics', getOrganizationPlacesStatistics);
+  this.get('/admin/organizations/:id/certification-centers', getOrganizationAttachedCertificationCenters);
   this.get('/admin/organizations/:id/statistics', getOrganizationStatistics);
   this.post('/admin/organizations/:id/archive', archiveOrganization);
 

--- a/admin/tests/mirage/serializers.js
+++ b/admin/tests/mirage/serializers.js
@@ -1,5 +1,6 @@
 import application from './serializers/application';
 import area from './serializers/area';
+import attachedCertificationCenter from './serializers/attached-certification-center';
 import autonomousCourseListItem from './serializers/autonomous-course-list-item';
 import badge from './serializers/badge';
 import campaign from './serializers/campaign';
@@ -29,6 +30,7 @@ import user from './serializers/user';
 
 export default {
   application,
+  attachedCertificationCenter,
   area,
   autonomousCourseListItem,
   badge,

--- a/admin/tests/mirage/serializers/attached-certification-center.js
+++ b/admin/tests/mirage/serializers/attached-certification-center.js
@@ -1,0 +1,7 @@
+import { JSONAPISerializer } from 'miragejs';
+
+export default JSONAPISerializer.extend({
+  typeKeyForModel() {
+    return 'certification-centers';
+  },
+});

--- a/admin/tests/unit/adapters/attached-certification-center-test.js
+++ b/admin/tests/unit/adapters/attached-certification-center-test.js
@@ -1,0 +1,32 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Adapter | AttachedCertificationCenter', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:attached-certification-center');
+  });
+
+  module('#urlForQuery', function () {
+    test('it builds the correct URL from organizationId', function (assert) {
+      // when
+      const query = { organizationId: 10 };
+      const url = adapter.urlForQuery(query);
+
+      // then
+      assert.ok(url.endsWith('/admin/organizations/10/certification-centers'));
+    });
+
+    test('it removes organizationId from the query object', function (assert) {
+      // when
+      const query = { organizationId: 10 };
+      adapter.urlForQuery(query);
+
+      // then
+      assert.strictEqual(query.organizationId, undefined);
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/organizations/get/attached-certification-center-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/attached-certification-center-test.js
@@ -1,0 +1,33 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/organizations/get/attached-certification-centers', function (hooks) {
+  setupTest(hooks);
+
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/organizations/get/attached-certification-centers');
+  });
+
+  test('it exists', function (assert) {
+    assert.ok(route);
+  });
+
+  module('#model', function () {
+    test('it calls store.query with the organizationId and returns the result', async function (assert) {
+      // given
+      const certificationCenters = [{ id: '1', name: 'Centre Pix' }];
+      route.modelFor = sinon.stub().returns({ id: '42' });
+      route.store = { query: sinon.stub().resolves(certificationCenters) };
+
+      // when
+      const result = await route.model();
+
+      // then
+      sinon.assert.calledWith(route.store.query, 'attached-certification-center', { organizationId: '42' });
+      assert.strictEqual(result, certificationCenters);
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -863,6 +863,17 @@
       "all-tags": {
         "recently-used-tags": "List of tags recently used with {tagName}"
       },
+      "attached-certification-center": {
+        "empty": "No certification center attached.",
+        "table": {
+          "caption": "Certification center attached to the organisation.",
+          "headers": {
+            "external-id": "External ID",
+            "id": "ID",
+            "name": "Name"
+          }
+        }
+      },
       "creation": {
         "actions": {
           "add-child-organization": "Add child organization"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -871,6 +871,17 @@
       "all-tags": {
         "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"
       },
+      "attached-certification-center": {
+        "empty": "Aucun centre de certification rattaché.",
+        "table": {
+          "caption": "Centre de certification rattaché à l'organisation.",
+          "headers": {
+            "external-id": "Identifiant externe",
+            "id": "ID du centre",
+            "name": "Nom du centre de certification rattaché"
+          }
+        }
+      },
       "creation": {
         "actions": {
           "add-child-organization": "Ajouter une organisation fille"
@@ -1622,6 +1633,7 @@
       },
       "navbar": {
         "aria-label": "Navigation de la section organisation",
+        "attached-certification-center": "Lien certif",
         "campaigns": "Campagnes",
         "details": "Détails",
         "features": "Fonctionnalités",


### PR DESCRIPTION
## 🪧 Problème

Dans pix admin, la page d'une organisation ne permettait pas de visualiser le centre de certification qui lui est rattaché. L'information existait côté API mais n'était pas exposée dans Pix Admin.

## 🌈 Proposition

Ajout d'un nouvel onglet "Liens certif" sur la page d'une organisation, accessible à `GET /organizations/:id/attached-certification-center`.

Le tableau affiche l'ID (cliquable vers la page du CDC), le nom et l'identifiant externe du centre.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
- Se connecter sur Pix Admin
- Naviguer vers une organisation ayant un centre de certification rattaché (https://admin-pr16581.review.pix.fr/organizations/156435/details)
- Cliquer sur l'onglet **"Liens certif"**
- Vérifier que le tableau affiche le CDC avec son ID, son nom et son identifiant externe
- Cliquer sur l'ID dans le tableau → vérifier la redirection vers la page du centre de certification
- Naviguer vers une organisation sans CDC rattaché → vérifier que le message vide s'affiche
