### PR TITLE
[TECH] Supprimer le taux de couverture de organizations/{id}/campaigns (PIX-23241)

### DIFF
--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -83,21 +83,6 @@ const register = async function (server) {
                     code: Joi.string().description('Code campagne'),
                     createdAt: Joi.date().description('Date de création de la campagne'),
                     archivedAt: Joi.date().description("Date d'archivage de la campagne"),
-                    tubes: Joi.array()
-                      .items(
-                        Joi.object({
-                          competenceId: Joi.string().description('ID de la compétence auquel appartient le sujet'),
-                          id: Joi.string().description('ID du sujet'),
-                          maxLevel: Joi.number().description('Niveau maximum atteignable dans cette campagne'),
-                          meanLevel: Joi.number().description('Niveau moyen obtenu dans cette campagne'),
-                          practicalDescription: Joi.string().description('Description du sujet'),
-                          practicalTitle: Joi.string().description('Titre du sujet'),
-                        }).label('CampaignTube'),
-                      )
-                      .label('CampaignTubes')
-                      .description(
-                        'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
-                      ),
                   }).label('Campaign'),
                 )
                 .label('Campaigns'),

--- a/api/src/maddo/domain/models/Campaign.js
+++ b/api/src/maddo/domain/models/Campaign.js
@@ -1,5 +1,5 @@
 export class Campaign {
-  constructor({ id, name, type, targetProfileName, code, archivedAt, createdAt, tubes }) {
+  constructor({ id, name, type, targetProfileName, code, archivedAt, createdAt }) {
     this.id = id;
     this.name = name;
     this.type = type;
@@ -7,6 +7,5 @@ export class Campaign {
     this.code = code;
     this.createdAt = createdAt;
     this.archivedAt = archivedAt;
-    this.tubes = tubes;
   }
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -5,7 +5,7 @@ import { Campaign } from '../../domain/models/Campaign.js';
 export async function findByOrganizationId(organizationId, page, locale) {
   const campaigns = await campaignAPI.findAllForOrganization({
     organizationId,
-    withCoverRate: true,
+    withCoverRate: false,
     page,
     locale,
   });

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -2,8 +2,6 @@ import { createMaddoServer } from '../../../../server.maddo.js';
 import { Campaign } from '../../../../src/maddo/domain/models/Campaign.js';
 import { Organization } from '../../../../src/maddo/domain/models/Organization.js';
 import { CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import { KnowledgeElementCollection } from '../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
-import { KnowledgeElement } from '../../../../src/shared/domain/models/KnowledgeElement.js';
 import { expect } from '../../../test-helper.js';
 import { databaseBuilder } from '../../../tooling/databases.js';
 import { generateValidRequestAuthorizationHeaderForApplication } from '../../../tooling/test-utils/http-server.js';
@@ -97,32 +95,6 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
       });
       databaseBuilder.factory.buildCampaign({ organizationId: orgaNotInJurisdiction.id });
 
-      const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
-      const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
-      const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
-      const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
-      const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
-
-      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign1InJurisdiction.id, skillId });
-      const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildMembership({ organizationId: orgaNotInJurisdiction.id, userId });
-
-      const participationUser = databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign1InJurisdiction.id,
-        userId,
-      });
-
-      const ke = databaseBuilder.factory.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.VALIDATED,
-        skillId,
-        userId: participationUser.userId,
-      });
-
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({
-        campaignParticipationId: participationUser.id,
-        snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
-      });
-
       await databaseBuilder.commit();
 
       const options = {
@@ -152,16 +124,6 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
           code: campaign1InJurisdiction.code,
           createdAt: campaign1InJurisdiction.createdAt,
           archivedAt: campaign1InJurisdiction.archivedAt,
-          tubes: [
-            {
-              id: tube.id,
-              competenceId,
-              maxLevel: 2,
-              meanLevel: 2,
-              practicalDescription: tube.practicalDescription_i18n['fr'],
-              practicalTitle: tube.practicalTitle_i18n['fr'],
-            },
-          ],
         }),
       ]);
     });
@@ -211,34 +173,9 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
           organizationId: orgaInJurisdiction.id,
           targetProfileId: targetProfile.id,
         });
-        const campaign2InJurisdiction = databaseBuilder.factory.buildCampaign({
+
+        databaseBuilder.factory.buildCampaign({
           organizationId: orgaInJurisdiction.id,
-        });
-
-        const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
-        const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
-        const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
-        const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
-        const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
-
-        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign1InJurisdiction.id, skillId });
-        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign2InJurisdiction.id, skillId });
-        const userId = databaseBuilder.factory.buildUser().id;
-
-        const participationUser = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign1InJurisdiction.id,
-          userId,
-        });
-
-        const ke = databaseBuilder.factory.buildKnowledgeElement({
-          status: KnowledgeElement.StatusType.VALIDATED,
-          skillId,
-          userId: participationUser.userId,
-        });
-
-        databaseBuilder.factory.buildKnowledgeElementSnapshot({
-          campaignParticipationId: participationUser.id,
-          snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
         });
 
         await databaseBuilder.commit();
@@ -265,91 +202,6 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
             code: campaign1InJurisdiction.code,
             createdAt: campaign1InJurisdiction.createdAt,
             archivedAt: campaign1InJurisdiction.archivedAt,
-            tubes: [
-              {
-                id: tube.id,
-                competenceId,
-                maxLevel: 2,
-                meanLevel: 2,
-                practicalDescription: tube.practicalDescription_i18n['fr'],
-                practicalTitle: tube.practicalTitle_i18n['fr'],
-              },
-            ],
-          }),
-        ]);
-      });
-    });
-
-    context('language negociation', function () {
-      it('should return translated tube title and description', async function () {
-        // given
-        const locale = 'en';
-        const targetProfile = databaseBuilder.factory.buildTargetProfile();
-        const campaignInJurisdiction = databaseBuilder.factory.buildCampaign({
-          organizationId: orgaInJurisdiction.id,
-          targetProfileId: targetProfile.id,
-        });
-
-        const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
-        const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
-        const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
-        const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
-        const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
-
-        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaignInJurisdiction.id, skillId });
-        const userId = databaseBuilder.factory.buildUser().id;
-
-        const participationUser = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignInJurisdiction.id,
-          userId,
-        });
-
-        const ke = databaseBuilder.factory.buildKnowledgeElement({
-          status: KnowledgeElement.StatusType.VALIDATED,
-          skillId,
-          userId: participationUser.userId,
-        });
-
-        databaseBuilder.factory.buildKnowledgeElementSnapshot({
-          campaignParticipationId: participationUser.id,
-          snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
-        });
-
-        await databaseBuilder.commit();
-
-        const options = {
-          method: 'GET',
-          url: `/api/organizations/${orgaInJurisdiction.id}/campaigns?page[number]=1&page[size]=1`,
-          headers: {
-            authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'campaigns'),
-            cookie: `locale=${locale}`,
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.campaigns).to.deep.equal([
-          new Campaign({
-            id: campaignInJurisdiction.id,
-            name: campaignInJurisdiction.name,
-            type: campaignInJurisdiction.type,
-            targetProfileName: targetProfile.name,
-            code: campaignInJurisdiction.code,
-            createdAt: campaignInJurisdiction.createdAt,
-            archivedAt: campaignInJurisdiction.archivedAt,
-            tubes: [
-              {
-                id: tube.id,
-                competenceId,
-                maxLevel: 2,
-                meanLevel: 2,
-                practicalDescription: tube.practicalDescription_i18n.en,
-                practicalTitle: tube.practicalTitle_i18n.en,
-              },
-            ],
           }),
         ]);
       });

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
@@ -1,7 +1,5 @@
 import { Campaign } from '../../../../../src/maddo/domain/models/Campaign.js';
 import { findByOrganizationId } from '../../../../../src/maddo/infrastructure/repositories/campaign-repository.js';
-import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
-import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 
@@ -21,49 +19,6 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
         targetProfileId: targetProfile.id,
       });
       databaseBuilder.factory.buildCampaign({ organizationId: otherOrganizationId });
-
-      const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
-      const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
-      const competence = databaseBuilder.factory.learningContent.buildCompetence({ areaId });
-      const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId: competence.id });
-      const skill = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' });
-
-      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign1.id, skillId: skill.id });
-      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign2.id, skillId: skill.id });
-      const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId });
-
-      const participationUser = databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign1.id,
-        userId,
-      });
-
-      const ke = databaseBuilder.factory.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.VALIDATED,
-        skillId: skill.id,
-        userId: participationUser.userId,
-      });
-
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({
-        campaignParticipationId: participationUser.id,
-        snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
-      });
-
-      const participationUser2 = databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign2.id,
-        userId,
-      });
-
-      const ke2 = databaseBuilder.factory.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.INVALIDATED,
-        skillId: skill.id,
-        userId: participationUser.userId,
-      });
-
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({
-        campaignParticipationId: participationUser2.id,
-        snapshot: new KnowledgeElementCollection([ke2]).toSnapshot(),
-      });
 
       await databaseBuilder.commit();
 
@@ -85,16 +40,6 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
           code: campaign1.code,
           createdAt: campaign1.createdAt,
           archivedAt: campaign1.archivedAt,
-          tubes: [
-            {
-              competenceId: competence.id,
-              id: tube.id,
-              maxLevel: skill.level,
-              meanLevel: 2,
-              practicalDescription: tube.practicalDescription_i18n.en,
-              practicalTitle: tube.practicalTitle_i18n.en,
-            },
-          ],
         }),
         new Campaign({
           id: campaign2.id,
@@ -104,16 +49,6 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
           code: campaign2.code,
           archivedAt: campaign2.archivedAt,
           createdAt: campaign2.createdAt,
-          tubes: [
-            {
-              competenceId: competence.id,
-              id: tube.id,
-              maxLevel: skill.level,
-              meanLevel: 0,
-              practicalDescription: tube.practicalDescription_i18n.en,
-              practicalTitle: tube.practicalTitle_i18n.en,
-            },
-          ],
         }),
       ]);
     });


### PR DESCRIPTION
## 🪧 Problème

Le taux de couverture à l'échelle de la campagne brasse beaucoup trop de données
Il est déjà dispo à l'échelle des participations

## 🌈 Proposition

Ne plus le mettre à dispo au niveau des campagnes

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
- faire un curl, voir que ça marche
- tests verts ✅ 
