### PR TITLE
[FEATURE] Utiliser le nouveau modèle des CGU quand un utilisateur récupère son compte (sortie du SCO) (PIX-23228)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
@@ -9,6 +9,7 @@ import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
  *   accountRecoveryDemandRepository: AccountRecoveryDemandRepository,
  *   cryptoService: CryptoService,
  *   authenticationMethodRepository: AuthenticationMethodRepository,
+ *   legalDocumentApiRepository, LegalDocumentApiRepository,
  *   userRepository: UserRepository,
  * }} params
  * @return {Promise<void>}
@@ -20,6 +21,7 @@ export const updateUserForAccountRecovery = async function ({
   accountRecoveryDemandRepository,
   cryptoService,
   authenticationMethodRepository,
+  legalDocumentApiRepository,
   userRepository,
 }) {
   const { userId, newEmail } = await scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand({
@@ -55,15 +57,14 @@ export const updateUserForAccountRecovery = async function ({
     identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
   });
 
-  const now = new Date();
+  await legalDocumentApiRepository.acceptPixAppTos({ userId });
+
   await userRepository.updateWithEmailConfirmed({
     id: userId,
     userAttributes: {
       username: null,
-      cgu: true,
       email: newEmail,
-      emailConfirmedAt: now,
-      lastTermsOfServiceValidatedAt: now,
+      emailConfirmedAt: new Date(),
     },
   });
 

--- a/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
@@ -5,32 +5,32 @@ import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
  * @param {{
  *   password: string,
  *   temporaryKey: string,
+ *   scoAccountRecoveryService: ScoAccountRecoveryService,
  *   accountRecoveryDemandRepository: AccountRecoveryDemandRepository,
+ *   cryptoService: CryptoService,
  *   authenticationMethodRepository: AuthenticationMethodRepository,
  *   userRepository: UserRepository,
- *   cryptoService: CryptoService,
- *   scoAccountRecoveryService: ScoAccountRecoveryService,
  * }} params
  * @return {Promise<void>}
  */
 export const updateUserForAccountRecovery = async function ({
   password,
   temporaryKey,
-  userRepository,
-  authenticationMethodRepository,
-  accountRecoveryDemandRepository,
   scoAccountRecoveryService,
+  accountRecoveryDemandRepository,
   cryptoService,
+  authenticationMethodRepository,
+  userRepository,
 }) {
   const { userId, newEmail } = await scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand({
     temporaryKey,
     accountRecoveryDemandRepository,
     userRepository,
   });
+
   const hashedPassword = await cryptoService.hashPassword(password);
 
   const hasAnAuthenticationMethodFromPix = await authenticationMethodRepository.hasIdentityProviderPIX({ userId });
-
   if (hasAnAuthenticationMethodFromPix) {
     await authenticationMethodRepository.updatePassword({
       userId,
@@ -50,22 +50,22 @@ export const updateUserForAccountRecovery = async function ({
     });
   }
 
-  const now = new Date();
-  const userValuesToUpdate = {
-    username: null,
-    cgu: true,
-    email: newEmail,
-    emailConfirmedAt: now,
-    lastTermsOfServiceValidatedAt: now,
-  };
   await authenticationMethodRepository.removeByUserIdAndIdentityProvider({
     userId,
     identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
   });
 
+  const now = new Date();
   await userRepository.updateWithEmailConfirmed({
     id: userId,
-    userAttributes: userValuesToUpdate,
+    userAttributes: {
+      username: null,
+      cgu: true,
+      email: newEmail,
+      emailConfirmedAt: now,
+      lastTermsOfServiceValidatedAt: now,
+    },
   });
+
   await accountRecoveryDemandRepository.markAsBeingUsed(temporaryKey);
 };

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-for-account-recovery.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-for-account-recovery.usecase.test.js
@@ -2,10 +2,15 @@ import sinon from 'sinon';
 
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+const { PIX_APP } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Identity Access Management | Domain | UseCase | update-user-for-account-recovery', function () {
   context('when domain transaction throw an error', function () {
@@ -151,12 +156,17 @@ describe('Integration | Identity Access Management | Domain | UseCase | update-u
       });
     });
 
-    it('updates user values', async function () {
+    it('updates Pix App terms of service', async function () {
       // given
+      const legalDocumentVersionId = databaseBuilder.factory.buildLegalDocumentVersion({
+        service: PIX_APP,
+        type: TOS,
+      }).id;
+
       const password = 'pix123';
-      const user = databaseBuilder.factory.buildUser({ email: 'oldEmail@example.net' });
+      const userId = databaseBuilder.factory.buildUser({ email: 'oldEmail@example.net' }).id;
       const accountRecoveryDemand = databaseBuilder.factory.buildAccountRecoveryDemand({
-        userId: user.id,
+        userId,
         oldEmail: 'oldEmail@example.net',
         newEmail: 'newEmail@example.net',
       });
@@ -169,7 +179,16 @@ describe('Integration | Identity Access Management | Domain | UseCase | update-u
       });
 
       // then
-      const foundUser = await knex('users').where({ id: user.id }).first();
+
+      // New document acceptance
+      const legalDocumentVersionUserAcceptance = await knex('legal-document-version-user-acceptances')
+        .select()
+        .where({ legalDocumentVersionId, userId })
+        .first();
+      expect(legalDocumentVersionUserAcceptance).to.exist;
+
+      // Legacy document acceptance
+      const foundUser = await knex('users').where({ id: userId }).first();
       expect(foundUser.cgu).to.be.true;
       expect(foundUser).to.include({ email: 'newemail@example.net' });
       expect(foundUser.emailConfirmedAt).to.deep.equal(now);


### PR DESCRIPTION
## 🪧 Problème

Quand un utilisateur récupère son compte (sortie du SCO), il n’y a pas de double écriture dans le nouveau système (la table `legal-document-version-user-acceptances`).

## 🌈 Proposition

Quand un utilisateur récupère son compte (sortie du SCO), écrire la validation des CGU par l’utilisateur dans le nouveau système (la table `legal-document-version-user-acceptances`).

## ✊ Remarques

RAS

## 🎉 Pour tester

<img width="1014" height="606" alt="Screenshot_2026-06-19_at_14-46-53_Récupérer_mon_compte_Pix" src="https://github.com/user-attachments/assets/f159113d-6970-43c5-a89d-7642e180ad10" />

1. Aller sur l’URL pour la récupération de compte (sortie du SCO)
2. Remplir la demande de récupération pour un utilisateur éligible,
   par exemple 
   * INE : `123456789MA`
   * Prénom : `Mikasa`
   * Nom :  `Ackerman`
   * Date de naissance :  `2014-04-04`
3. Aller au bout du processus de récupération (jusqu’à la validation du formulaire où il est demandé une adresse email, un mot de passe et l’acceptation des CGU)
4. Constater qu’il y un nouvel enregistrement correspondant dans la table `legal-document-version-user-acceptances`