### PR TITLE
[TECH] Traduire le format des tutoriels (PIX-22431)

### DIFF
--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -1,12 +1,15 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjsDurationHumanize from 'ember-dayjs/helpers/dayjs-duration-humanize';
+import t from 'ember-intl/helpers/t';
 import ActionChip from 'mon-pix/components/action-chip';
 import buttonStatusTypes from 'mon-pix/utils/button-status-types';
+import { normalizeAndRemoveAccents } from 'mon-pix/utils/tolerances-validation';
 
 export default class Card extends Component {
   <template>
@@ -27,7 +30,7 @@ export default class Card extends Component {
           <p class="tutorial-card-content__details">
             {{@tutorial.source}}
             •
-            {{@tutorial.format}}
+            {{t (concat "pages.tutorial-panel.format." (normalizeAndRemoveAccents @tutorial.format))}}
             •
             {{dayjsDurationHumanize @tutorial.duration "seconds"}}
           </p>

--- a/mon-pix/mirage/handlers/find-paginated-and-filtered-tutorials.js
+++ b/mon-pix/mirage/handlers/find-paginated-and-filtered-tutorials.js
@@ -38,6 +38,7 @@ function _findPaginatedAndFilteredRecommendedTutorials(schema, request) {
       schema.tutorials.create({
         link: 'https://example.net/',
         name: `Le tuto de la compétence ${competenceFilters[0]}`,
+        format: 'page',
       }),
     ];
   } else {

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -88,7 +88,7 @@ module('Integration | Component | comparison-window', function (hooks) {
       // given
       correction.setProperties({
         learningMoreTutorials: [
-          { titre: 'Ceci est un tuto', link: 'https://example.net', duration: '20:00:00', type: 'video' },
+          { titre: 'Ceci est un tuto', link: 'https://example.net', duration: '20:00:00', format: 'video' },
         ],
       });
 
@@ -144,7 +144,7 @@ module('Integration | Component | comparison-window', function (hooks) {
         // given
         correction.setProperties({
           learningMoreTutorials: [
-            { titre: 'Ceci est un tuto', link: 'https://example.net', duration: '20:00:00', type: 'video' },
+            { titre: 'Ceci est un tuto', link: 'https://example.net', duration: '20:00:00', format: 'video' },
           ],
         });
 

--- a/mon-pix/tests/integration/components/learning-more-panel-test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | learning-more-panel', function (hooks) {
           link: 'https://example.net/1',
           titre: 'Ceci est un tuto',
           duration: '20:00:00',
-          type: 'video',
+          format: 'video',
         },
       ]);
 
@@ -42,6 +42,7 @@ module('Integration | Component | learning-more-panel', function (hooks) {
           tubeName: '@first_tube',
           tubePracticalTitle: 'Practical Title',
           duration: '00:15:10',
+          format: 'page',
         });
 
         const tutorials = A([tuto1]);

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -327,6 +327,7 @@ module('Integration | Component | scorecard-details', function (hooks) {
             tubeName: '@first_tube',
             tubePracticalTitle: 'Practical Title',
             duration: '00:15:10',
+            format: 'video',
           });
           const tuto2 = store.createRecord('tutorial', {
             title: 'Tuto 2.1',
@@ -334,6 +335,7 @@ module('Integration | Component | scorecard-details', function (hooks) {
             tubeName: '@second_tube',
             tubePracticalTitle: 'Practical Title 1',
             duration: '00:04:00',
+            format: 'page',
           });
           const tuto3 = store.createRecord('tutorial', {
             title: 'Tuto 2.2',
@@ -341,6 +343,7 @@ module('Integration | Component | scorecard-details', function (hooks) {
             tubeName: '@second_tube',
             tubePracticalTitle: 'Practical Title',
             duration: '00:04:00',
+            format: 'page',
           });
 
           const tutorials = A([tuto1, tuto2, tuto3]);

--- a/mon-pix/tests/integration/components/tutorial-panel-test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel-test.js
@@ -34,13 +34,16 @@ module('Integration | Component | Tutorial Panel', function (hooks) {
 
     module('and a tutorial is present', function (hooks) {
       hooks.beforeEach(function () {
+        const store = this.owner.lookup('service:store');
+
         this.set('hint', 'Ceci est un indice');
         this.set('tutorials', [
-          {
+          store.createRecord('tutorial', {
             title: 'Ceci est un tuto',
             duration: '20:00:00',
             link: 'https://example.com',
-          },
+            format: 'page',
+          }),
         ]);
       });
 

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2407,6 +2407,18 @@
       "title": "Tutorial zur Kampagne"
     },
     "tutorial-panel": {
+      "format": {
+        "audio": "Audio",
+        "frise": "Zeitstrahl",
+        "image": "Bild",
+        "jeu": "Spiel",
+        "outil": "Tool",
+        "page": "Seite",
+        "pdf": "PDF",
+        "site": "Website",
+        "slide": "Diashow",
+        "video": "Video"
+      },
       "info": "Diese Links zu den Tutorials wurden von Pix-Nutzern vorgeschlagen.",
       "title": "Damit es beim nächsten Mal klappt"
     },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2407,6 +2407,18 @@
       "title": "Campaign tutorial"
     },
     "tutorial-panel": {
+      "format": {
+        "audio": "audio",
+        "frise": "timeline",
+        "image": "image",
+        "jeu": "game",
+        "outil": "tool",
+        "page": "page",
+        "pdf": "pdf",
+        "site": "website",
+        "slide": "slideshow",
+        "video": "video"
+      },
       "info": "These tutorial links have been suggested by Pix users.",
       "title": "For better results next time"
     },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2407,6 +2407,18 @@
       "title": "Tutorial de la campaña"
     },
     "tutorial-panel": {
+      "format": {
+        "audio": "audio",
+        "frise": "línea de tiempo",
+        "image": "imagen",
+        "jeu": "juego",
+        "outil": "herramienta",
+        "page": "página",
+        "pdf": "pdf",
+        "site": "sitio web",
+        "slide": "presentación",
+        "video": "video"
+      },
       "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
       "title": "Para acertar la próxima vez"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2407,6 +2407,18 @@
       "title": "Didacticiel de la campagne"
     },
     "tutorial-panel": {
+      "format": {
+        "audio": "audio",
+        "frise": "frise",
+        "image": "image",
+        "jeu": "jeu",
+        "outil": "outil",
+        "page": "page",
+        "pdf": "pdf",
+        "site": "site",
+        "slide": "diaporama",
+        "video": "vidéo"
+      },
       "info": "Ces liens vers les tutos ont été proposés par des utilisateurs de Pix.",
       "title": "Pour réussir la prochaine fois"
     },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2407,6 +2407,18 @@
       "title": "Tutorial della campagna"
     },
     "tutorial-panel": {
+      "format": {
+        "audio": "audio",
+        "frise": "linea del tempo",
+        "image": "immagine",
+        "jeu": "gioco",
+        "outil": "strumento",
+        "page": "pagina",
+        "pdf": "pdf",
+        "site": "sito web",
+        "slide": "presentazione",
+        "video": "video"
+      },
       "info": "Questi link alle esercitazioni sono stati suggeriti dagli utenti di Pix.",
       "title": "Per avere successo la prossima volta"
     },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2407,6 +2407,18 @@
       "title": "Campagne handleiding"
     },
     "tutorial-panel": {
+      "format": {
+        "audio": "audio",
+        "frise": "tijdlijn",
+        "image": "afbeelding",
+        "jeu": "spel",
+        "outil": "tool",
+        "page": "pagina",
+        "pdf": "pdf",
+        "site": "website",
+        "slide": "diavoorstelling",
+        "video": "video"
+      },
       "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers.",
       "title": "Om de volgende keer te slagen"
     },


### PR DESCRIPTION
## 🪧 Problème

Sur l'écran d'affichage des tutoriels, leur format n'est pas traduit : 
<img width="640" height="276" alt="image" src="https://github.com/user-attachments/assets/15d288ea-fb6b-43d5-8c6e-474d53d48fb6" />


## 🌈 Proposition

Traduire le format des tutoriels.

## 🥐 Remarques

Un commentaire sera ajouté, côté Pix Editor, qui indiquera qu'il faut désormais mettre à jour les nouvelles traductions si la liste des formats est modifiée.

## 🎉 Pour tester
- Se connecter sur la review app
- Faire des épreuves jusqu'à arriver au checkpoint.
- Constater que, sur les détails des tutoriels, le format est bien affiché.
- Changer la langue de l'application.
- Constater que le format est bien traduit (si un tutoriel existe dans la langue sélectionnée).
