### PR TITLE
[FEATURE] Pouvoir sélectionner des critères de sujets cappés à la création d'un blueprint (PIX-21717)

### DIFF
--- a/admin/app/adapters/combined-course-blueprint.js
+++ b/admin/app/adapters/combined-course-blueprint.js
@@ -14,4 +14,19 @@ export default class CombinedCourseBlueprintAdapter extends ApplicationAdapter {
     });
     return result;
   }
+
+  createRecord(store, type, snapshot) {
+    const { adapterOptions } = snapshot;
+    if (adapterOptions && adapterOptions.cappedTubeRequirements) {
+      const { cappedTubeRequirements } = adapterOptions;
+      const payload = this.serialize(snapshot);
+      payload.data.attributes['capped-tube-requirements'] = cappedTubeRequirements;
+
+      const url = this.urlForCreateRecord(type.modelName, snapshot);
+
+      return this.ajax(url, 'POST', { data: payload });
+    }
+
+    return super.createRecord(...arguments);
+  }
 }

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -14,6 +14,7 @@ import { eq, gt } from 'ember-truth-helpers';
 import PixFieldset from 'pix-admin/components/ui/pix-fieldset';
 
 import RequirementTag from '../common/combined-courses/requirement-tag';
+import TubesSelection from '../common/tubes-selection';
 import SelectAttestation from './select-attestation';
 
 export default class CombinedCourseBlueprintForm extends Component {
@@ -27,7 +28,7 @@ export default class CombinedCourseBlueprintForm extends Component {
 
   constructor() {
     super(...arguments);
-    this.blueprint = this.args.model ?? this.store.createRecord('combined-course-blueprint');
+    this.blueprint = this.args.model.blueprint ?? this.store.createRecord('combined-course-blueprint');
     this.router.on('routeWillChange', () => {
       if (this.blueprint.hasDirtyAttributes && !this.blueprint.isSaving) {
         this.blueprint.unloadRecord();
@@ -93,7 +94,11 @@ export default class CombinedCourseBlueprintForm extends Component {
   @action
   async save() {
     try {
-      await this.blueprint.save();
+      await this.blueprint.save({
+        adapterOptions: this.selectedTubes
+          ? { cappedTubeRequirements: [{ tubes: this.selectedTubes, threshold: this.threshold }] }
+          : null,
+      });
       this.pixToast.sendSuccessNotification({
         message: this.args.updateMode
           ? this.intl.t('components.combined-course-blueprints.update.notifications.success')
@@ -146,6 +151,19 @@ export default class CombinedCourseBlueprintForm extends Component {
   @action
   removeRequirement({ type, value }) {
     this.blueprint.content = this.blueprint.content.filter((item) => item.value !== value || item.type !== type);
+  }
+
+  @action
+  updateTubes(tubes) {
+    this.selectedTubes = tubes.map(({ id, level }) => ({
+      tubeId: id,
+      level,
+    }));
+  }
+
+  @action
+  onThresholdChange(e) {
+    this.threshold = e.target.value;
   }
 
   <template>
@@ -258,10 +276,25 @@ export default class CombinedCourseBlueprintForm extends Component {
 
         {{#unless @updateMode}}
           <SelectAttestation
-            @attestations={{@attestations}}
+            @attestations={{@model.attestations}}
             @value={{this.blueprint.rewardId}}
             @onChange={{this.setAttestation}}
           />
+
+          {{#if this.blueprint.rewardId}}
+            <TubesSelection @frameworks={{@model.frameworks}} @onChange={{this.updateTubes}} />
+            <PixInput
+              @id="blueprintThreshold"
+              class="combined-course-page__threshold"
+              type="number"
+              min="0"
+              max="100"
+              @requiredLabel={{t "common.forms.mandatory"}}
+              {{on "change" this.onThresholdChange}}
+            >
+              <:label>Taux de réussite requis</:label>
+            </PixInput>
+          {{/if}}
         {{/unless}}
 
         <PixInput

--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -11,4 +11,5 @@ export default class CombinedCourseBlueprint extends Model {
   @attr('string') surveyLink;
   @attr({ type: 'date', defaultValue: () => undefined }) createdAt;
   @attr({ defaultValue: () => [] }) content;
+  @attr() cappedTubeRequirements;
 }

--- a/admin/app/routes/authenticated/combined-course-blueprints/edit.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/edit.js
@@ -10,6 +10,9 @@ export default class EditRoute extends Route {
   }
 
   async model(params) {
-    return this.store.findRecord('combinedCourseBlueprint', params.combined_course_blueprint_id, { reload: true });
+    const blueprint = await this.store.findRecord('combinedCourseBlueprint', params.combined_course_blueprint_id, {
+      reload: true,
+    });
+    return { blueprint };
   }
 }

--- a/admin/app/routes/authenticated/combined-course-blueprints/new.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/new.js
@@ -4,7 +4,10 @@ import { inject as service } from '@ember/service';
 export default class NewRoute extends Route {
   @service store;
 
-  model() {
-    return this.store.findAll('attestation');
+  async model() {
+    const attestations = await this.store.findAll('attestation');
+    const frameworks = await this.store.findAll('framework');
+
+    return { attestations, frameworks };
   }
 }

--- a/admin/app/serializers/combined-course-blueprint.js
+++ b/admin/app/serializers/combined-course-blueprint.js
@@ -4,18 +4,21 @@ export default class CombinedCourseBlueprintSerializer extends ApplicationSerial
     const json = super.serialize(...arguments);
     json.data.attributes.content = json.data.attributes.content.map(({ type, value }) => ({ type, value }));
 
+    delete json.data.attributes['attestation-label'];
+
     if (snapshot.id) {
       delete json.data.id;
       delete json.data.attributes['created-at'];
       delete json.data.attributes['content'];
-      delete json.data.attributes['attestation-label'];
       delete json.data.attributes['reward-id'];
       delete json.data.attributes['reward-type'];
+      delete json.data.attributes['capped-tube-requirements'];
 
       for (const attribute of ['illustration', 'description', 'survey-link']) {
         json.data.attributes[attribute] = json.data.attributes[attribute] || null;
       }
     }
+
     return json;
   }
 }

--- a/admin/app/styles/components/combined-course/form.scss
+++ b/admin/app/styles/components/combined-course/form.scss
@@ -61,6 +61,9 @@
     gap: var(--pix-spacing-4x);
   }
 
-
+  &__threshold {
+      width: 134px;
+      margin-bottom: 16px;
+  }
 
 }

--- a/admin/app/templates/authenticated/combined-course-blueprints/edit.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/edit.gjs
@@ -10,9 +10,9 @@ export default class EditCombinedCourseBlueprint extends Component {
   <template>
     <div>
       <PixBreadcrumb @links={{this.links}} class="combined-course-blueprint__breadcrumb" />
-      <h1>{{@model.internalName}}</h1>
+      <h1>{{@model.blueprint.internalName}}</h1>
     </div>
-    {{pageTitle "Modification du schéma de parcours combiné : " @model.internalName}}
+    {{pageTitle "Modification du schéma de parcours combiné : " @model.blueprint.internalName}}
 
     <main class="main-admin-form">
       <CombinedCourseBlueprintForm @model={{@model}} @updateMode={{true}} />
@@ -26,7 +26,7 @@ export default class EditCombinedCourseBlueprint extends Component {
         label: this.intl.t('components.combined-course-blueprints.list.title'),
       },
       {
-        label: this.args.model.internalName,
+        label: this.args.model.blueprint.internalName,
       },
     ];
   }

--- a/admin/app/templates/authenticated/combined-course-blueprints/new.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/new.gjs
@@ -1,3 +1,3 @@
 import CombinedCourseBlueprintForm from 'pix-admin/components/combined-course-blueprints/form';
 
-<template><CombinedCourseBlueprintForm @attestations={{@model}} /></template>
+<template><CombinedCourseBlueprintForm @model={{@model}} /></template>

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { clickByName, visit, within } from '@1024pix/ember-testing-library';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -14,6 +14,9 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
   setupIntl(hooks);
 
   hooks.beforeEach(async function () {
+    const store = this.owner.lookup('service:store');
+    _createFramework(store);
+
     server.create('country', { code: '99100', name: 'France' });
     server.create('attestation', {
       templateName: 'parentalite',
@@ -56,10 +59,17 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
     await click(
       screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
     );
-
     await screen.findByRole('listbox');
-
     await click(screen.getByRole('option', { name: 'Parentalite' }));
+
+    await clickByName('1 · Titre domaine');
+    await clickByName('1 Titre competence');
+    await clickByName(/Sélection du niveau du sujet suivant : Tube/);
+    const tubesListbox = await within(
+      screen.getByRole('cell', { name: /Sélection du niveau du sujet suivant : Tube/ }),
+    ).findByRole('listbox');
+    await click(within(tubesListbox).getByRole('option', { name: '4' }));
+    await fillIn(screen.getByLabelText('Taux de réussite requis', { exact: false }), '50');
 
     await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 
@@ -82,4 +92,38 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
     //then
     assert.ok(screen.getByText(t('common.tables.empty-result')));
   });
+
+  function _createFramework(store) {
+    const tubes = [
+      store.createRecord('tube', {
+        id: 'tubeId1',
+        name: '@tubeName1',
+        practicalTitle: 'Tube 1',
+        skills: [],
+        level: 8,
+      }),
+    ];
+
+    const thematics = [store.createRecord('thematic', { id: 'thematicId', name: 'Thématique', tubes: tubes })];
+
+    const competences = [
+      store.createRecord('competence', {
+        id: 'competenceId',
+        index: '1',
+        name: 'Titre competence',
+        thematics,
+      }),
+    ];
+
+    const areas = [
+      store.createRecord('area', {
+        id: 'areaId',
+        title: 'Titre domaine',
+        code: 1,
+        competences,
+      }),
+    ];
+
+    return store.createRecord('framework', { id: 'frameworkId', name: 'Pix', areas });
+  }
 });

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render, within } from '@1024pix/ember-testing-library';
 import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CombinedCourseBlueprintForm from 'pix-admin/components/combined-course-blueprints/form';
@@ -23,17 +23,26 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
       const findRecordStub = sinon.stub(store, 'findRecord');
-      const attestations = [
-        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
-        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
-      ];
       findRecordStub
         .withArgs('module', 'module-123')
         .resolves({ id: 'full-id-module-123', shortId: 'module-123', title: 'module 123' });
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
 
+      const attestations = [
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
+      ];
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { attestations, frameworks };
+
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm @attestations={{attestations}} /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
@@ -84,7 +93,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       //then
       assert.ok(screen.getByRole('heading', { name: t('components.combined-course-blueprints.create.title') }));
       assert.ok(findRecordStub.calledTwice);
-      assert.ok(blueprintStub.save.calledOnce);
+      sinon.assert.calledOnceWith(blueprintStub.save, { adapterOptions: null });
       assert.strictEqual(blueprintStub.name, 'name');
       assert.strictEqual(blueprintStub.internalName, 'internalName');
       assert.deepEqual(blueprintStub.content, [
@@ -102,6 +111,127 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         }),
       );
       sinon.assert.calledWithExactly(router.transitionTo, 'authenticated.combined-course-blueprints.list');
+    });
+
+    test('it should display tubes selection component only if the user selects an attestation', async function (assert) {
+      //given
+      const attestations = [
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
+      ];
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { attestations, frameworks };
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
+
+      //then
+      assert.notOk(await screen.queryByRole('heading', { name: 'Sélection des sujets' }));
+
+      //when
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+      );
+      await screen.findByRole('listbox');
+
+      await click(screen.getByRole('option', { name: 'Parentalite' }));
+
+      //then
+      assert.ok(screen.getByRole('heading', { name: 'Sélection des sujets' }));
+    });
+
+    test('it should save blueprint with selected tubes requirements when they are selected', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const blueprint = store.createRecord('combined-course-blueprint', {
+        id: 1,
+        name: 'name',
+      });
+      sinon.stub(blueprint, 'save');
+      blueprint.save.resolves();
+
+      const attestations = [
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
+      ];
+
+      const tube = store.createRecord('tube', {
+        id: 'tubeId1',
+        name: '@tubeName1',
+        practicalTitle: 'Tube 1',
+        skills: [],
+        level: 8,
+      });
+
+      const thematic = store.createRecord('thematic', {
+        id: 'thematicId',
+        name: 'Thématique',
+        tubes: [tube],
+      });
+
+      const competence = store.createRecord('competence', {
+        id: 'competenceId',
+        index: '1',
+        name: 'Titre competence',
+        thematics: [thematic],
+      });
+
+      const area = store.createRecord('area', {
+        id: 'areaId',
+        title: 'Titre domaine',
+        code: 1,
+        competences: [competence],
+      });
+
+      const framework = store.createRecord('framework', {
+        id: 'frameworkId',
+        name: 'Pix',
+        areas: [area],
+      });
+
+      const model = {
+        attestations,
+        frameworks: [framework],
+        blueprint,
+      };
+
+      //when
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
+
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+      );
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Parentalite' }));
+
+      assert.ok(screen.getByRole('heading', { name: 'Sélection des sujets' }));
+      await clickByName('1 · Titre domaine');
+      await clickByName('1 Titre competence');
+      await clickByName(/Sélection du niveau du sujet suivant : Tube/);
+      const tubesListbox = await within(
+        screen.getByRole('cell', { name: /Sélection du niveau du sujet suivant : Tube/ }),
+      ).findByRole('listbox');
+      await click(within(tubesListbox).getByRole('option', { name: '4' }));
+      await fillIn(screen.getByLabelText('Taux de réussite requis', { exact: false }), '75');
+
+      await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
+
+      //then
+      sinon.assert.calledOnceWith(blueprint.save, {
+        adapterOptions: {
+          cappedTubeRequirements: [
+            {
+              tubes: [{ tubeId: 'tubeId1', level: 4 }],
+              threshold: '75',
+            },
+          ],
+        },
+      });
     });
   });
 
@@ -127,6 +257,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         rewardId: 5,
         rewardType: 'ATTESTATION',
       });
+      const model = { blueprint };
 
       sinon.stub(blueprint, 'save');
       blueprint.save.resolves();
@@ -135,7 +266,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       //when
       const screen = await render(
-        <template><CombinedCourseBlueprintForm @updateMode={{true}} @model={{blueprint}} /></template>,
+        <template><CombinedCourseBlueprintForm @updateMode={{true}} @model={{model}} /></template>,
       );
 
       await fillIn(
@@ -188,6 +319,15 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
   });
 
   module('error cases', function () {
+    const frameworks = [
+      {
+        id: 123,
+        name: 'Pix',
+        areas: [],
+      },
+    ];
+    const model = { frameworks };
+
     test('it should display a generic error message', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -199,7 +339,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 
@@ -227,7 +367,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 
@@ -261,7 +401,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 
@@ -299,7 +439,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         .rejects({ errors: [{ status: '404', detail: 'Le profil cible est introuvable' }] });
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
@@ -329,7 +469,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       findRecordStub.withArgs('module').rejects({ errors: [{ status: '404', detail: 'Le module est introuvable' }] });
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await click(screen.getByLabelText(t('components.combined-course-blueprints.labels.module')));
       await fillIn(
@@ -360,7 +500,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       findRecordStub.withArgs('target-profile').rejects();
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
@@ -388,8 +528,18 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         .withArgs('module', 'module123')
         .resolves({ id: 'full-id-module123', shortId: 'module123', title: 'module 123' });
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
+
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { frameworks };
+
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
@@ -417,9 +567,19 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       const findRecordStub = sinon.stub(store, 'findRecord');
 
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
+
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { frameworks };
+
       //when
 
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),

--- a/admin/tests/integration/templates/authenticated/combined-course-blueprints/new-test.gjs
+++ b/admin/tests/integration/templates/authenticated/combined-course-blueprints/new-test.gjs
@@ -9,8 +9,9 @@ module('Integration | Template | combined-course-blueprints | New', function (ho
   setupIntlRenderingTest(hooks);
 
   test('it should render combined course form component', async function (assert) {
+    const model = { blueprint: {} };
     // when
-    const screen = await render(<template><CreateCombinedCourseBlueprint /></template>);
+    const screen = await render(<template><CreateCombinedCourseBlueprint @model={{model}} /></template>);
 
     // then
     assert.ok(screen.getByRole('heading', { level: 1, name: t('components.combined-course-blueprints.create.title') }));

--- a/admin/tests/unit/serializers/combined-course-blueprint-test.js
+++ b/admin/tests/unit/serializers/combined-course-blueprint-test.js
@@ -20,6 +20,17 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
       rewardId: 5,
       rewardType: 'ATTESTATION',
       surveyLink: 'http://survey-link-test.fr',
+      cappedTubeRequirements: [
+        {
+          threshold: 0.5,
+          tubes: [
+            {
+              tubeId: '123',
+              level: 1,
+            },
+          ],
+        },
+      ],
     });
 
     const serializedRecord = record.serialize();
@@ -40,7 +51,17 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
                 value: 1,
               },
             ],
-            'attestation-label': 'Label attestation',
+            'capped-tube-requirements': [
+              {
+                threshold: 0.5,
+                tubes: [
+                  {
+                    tubeId: '123',
+                    level: 1,
+                  },
+                ],
+              },
+            ],
             'reward-id': 5,
             'reward-type': 'ATTESTATION',
             'survey-link': 'http://survey-link-test.fr',
@@ -67,6 +88,17 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
       rewardId: 5,
       rewardType: 'ATTESTATION',
       surveyLink: 'http://survey-link-test.fr',
+      'capped-tube-requirements': [
+        {
+          threshold: 0.5,
+          tubes: [
+            {
+              tubeId: '123',
+              level: 1,
+            },
+          ],
+        },
+      ],
     });
 
     const serializedRecord = record.serialize();

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -58,12 +58,17 @@ const register = async function (server) {
                 content: Joi.array(),
                 createdAt: Joi.date(),
                 'survey-link': Joi.string().allow(null),
+                'capped-tube-requirements': Joi.array()
+                  .items(
+                    Joi.object({
+                      tubes: Joi.array().items(Joi.object({ tubeId: Joi.string(), level: Joi.number().integer() })),
+                      threshold: Joi.number(),
+                    }),
+                  )
+                  .allow(null),
               },
             },
           }),
-          options: {
-            allowUnknown: true,
-          },
         },
         handler: combinedCourseBlueprintController.save,
         notes: ["- Creation d'un schéma de parcours combiné"],

--- a/api/src/quest/domain/models/combined-course-blueprints/value-objects/QuestInput.js
+++ b/api/src/quest/domain/models/combined-course-blueprints/value-objects/QuestInput.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { EntityValidationError } from '../../../../../shared/domain/errors.js';
 import { COMBINED_COURSE_ITEM_TYPES } from '../../../constants.js';
 import { Quest, REQUIREMENT_TYPES } from '../../quests/entities/Quest.js';
+import { buildRequirement } from '../../quests/value-objects/Requirement.js';
 import { CombinedCourseBlueprint } from '../entities/CombinedCourseBlueprint.js';
 
 const itemsSchema = Joi.array()
@@ -29,16 +30,43 @@ const itemsSchema = Joi.array()
   .required()
   .strict();
 
+const cappedTubesSchema = Joi.array().items(
+  Joi.object({
+    tubes: Joi.array().items(Joi.object({ tubeId: Joi.string(), level: Joi.number().integer() })),
+    threshold: Joi.number().integer(),
+  }),
+);
+
+const schema = Joi.object({
+  items: itemsSchema,
+  cappedTubeRequirements: cappedTubesSchema,
+  rewardId: Joi.alternatives()
+    .conditional('rewardType', {
+      is: Joi.string(),
+      then: Joi.number().integer().required(),
+      otherwise: undefined,
+    })
+    .allow(null),
+  rewardType: Joi.alternatives()
+    .conditional('rewardId', {
+      is: Joi.number().integer(),
+      then: Joi.string().required(),
+      otherwise: undefined,
+    })
+    .allow(null),
+});
+
 export class QuestInput {
-  constructor({ items, rewardId, rewardType } = {}) {
+  constructor({ items, rewardId, rewardType, cappedTubeRequirements = [] } = {}) {
     this.items = items;
     this.rewardId = rewardId;
     this.rewardType = rewardType;
+    this.cappedTubeRequirements = cappedTubeRequirements;
     this.#validate();
   }
 
   #validate() {
-    const { error } = itemsSchema.validate(this.items);
+    const { error } = schema.validate(this);
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: this.items });
     }
@@ -52,6 +80,18 @@ export class QuestInput {
       return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: item.value });
     });
 
+    const cappedTubes = this.cappedTubeRequirements.map((requirement) => {
+      return buildRequirement({
+        requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+        data: {
+          threshold: requirement.threshold,
+          cappedTubes: requirement.tubes,
+        },
+      });
+    });
+
+    successRequirements.push(...cappedTubes);
+
     return new Quest({
       eligibilityRequirements: [],
       successRequirements,
@@ -61,7 +101,12 @@ export class QuestInput {
   }
 
   static itemsFromQuest({ quest, modulesById }) {
-    return quest.successRequirements.map((requirement) => {
+    const items = quest.successRequirements.filter(
+      (item) =>
+        item.requirement_type === REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS ||
+        item.requirement_type === REQUIREMENT_TYPES.OBJECT.PASSAGES,
+    );
+    return items.map((requirement) => {
       if (requirement.requirement_type === REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
         return { type: COMBINED_COURSE_ITEM_TYPES.EVALUATION, value: requirement.data.targetProfileId.data };
       }

--- a/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseDetails.js
+++ b/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseDetails.js
@@ -7,6 +7,7 @@ import { cryptoService as injectedCryptoService } from '../../../../../shared/do
 import { CombinedCourse } from '../../combined-courses/entities/CombinedCourse.js';
 import { DataForQuest } from '../../quests/aggregates/DataForQuest.js';
 import { Eligibility } from '../../quests/aggregates/Eligibility.js';
+import { Quest, REQUIREMENT_TYPES } from '../../quests/entities/Quest.js';
 import { TYPES } from '../../quests/value-objects/Requirement.js';
 import {
   CampaignCombinedCourseItem,
@@ -294,7 +295,25 @@ export class CombinedCourseDetails extends CombinedCourse {
   }
 
   isSuccessful() {
-    return this.quest.isSuccessful(this.dataForQuest);
+    const successRequirements = this.quest.successRequirements.filter((successRequirements) => {
+      return (
+        successRequirements.requirement_type === REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS ||
+        successRequirements.requirement_type === REQUIREMENT_TYPES.CAPPED_TUBES ||
+        (successRequirements.requirement_type === REQUIREMENT_TYPES.OBJECT.PASSAGES &&
+          this.items.find((item) => item.id === successRequirements.data.moduleId.data))
+      );
+    });
+    const quest = new Quest({
+      id: this.quest.id,
+      createdAt: this.quest.createdAt,
+      updatedAt: this.quest.updatedAt,
+      rewardId: this.quest.rewardId,
+      rewardType: this.quest.rewardType,
+      eligibilityRequirements: this.quest.eligibilityRequirements,
+      successRequirements,
+    });
+
+    return quest.isSuccessful(this.dataForQuest);
   }
 
   get surveyUrl() {

--- a/api/src/quest/domain/models/quests/value-objects/Requirement.js
+++ b/api/src/quest/domain/models/quests/value-objects/Requirement.js
@@ -224,6 +224,7 @@ export class CappedTubesRequirement extends BaseRequirement {
 
   #validate(args) {
     const { error } = cappedTubesRequirementSchema.validate(args);
+
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: this.toDTO() });
     }

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js
@@ -20,6 +20,7 @@ const deserialize = async function (payload) {
     items: deserializedData.content ?? [],
     rewardId: deserializedData.rewardId,
     rewardType: REWARD_TYPES[deserializedData.rewardType] ?? null,
+    cappedTubeRequirements: deserializedData.cappedTubeRequirements ?? [],
   });
   return new CombinedCourseBlueprintForCreation({
     ...deserializedData,

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -58,13 +58,8 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               illustration: 'illustration.svg',
               'reward-id': attestation.id,
               'reward-type': 'ATTESTATION',
-              content: [
-                {
-                  type: 'module',
-                  value: 'e67ec5d0',
-                  shortId: 'short-e67ec5d0',
-                },
-              ],
+              content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
+              'capped-tube-requirements': [{ threshold: 20, tubes: [{ tubeId: 'tube1', level: 5 }] }],
             },
           },
         };

--- a/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
@@ -1,9 +1,9 @@
 import sinon from 'sinon';
 
-import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
 import { combinedCourseBlueprintController } from '../../../../src/quest/application/combined-course-blueprint-controller.js';
 import { combinedCourseBlueprintRoute } from '../../../../src/quest/application/combined-course-blueprint-route.js';
 import questSecurityPreHandlers from '../../../../src/quest/application/security-pre-handlers.js';
+import { REWARD_TYPES } from '../../../../src/quest/domain/constants.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect } from '../../../test-helper.js';
 import { HttpTestServer } from '../../../tooling/server/http-test-server.js';
@@ -53,8 +53,10 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
             'internal-name': 'Mon schéma de parcours combiné',
             description: 'La description combinix',
             illustration: 'illustration.svg',
-            'attestation-key': ATTESTATIONS.SIXTH_GRADE,
+            'reward-id': 1,
+            'reward-type': REWARD_TYPES.ATTESTATION,
             content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
+            'capped-tube-requirements': [{ threshold: 20, tubes: [{ tubeId: 'tube1', level: 5 }] }],
           },
         },
       };

--- a/api/tests/quest/unit/domain/models/QuestInput_test.js
+++ b/api/tests/quest/unit/domain/models/QuestInput_test.js
@@ -64,13 +64,22 @@ describe('Quest | Unit | Domain | Models | QuestInput', function () {
       ]);
     });
 
-    it('should build a quest from mixed items', function () {
+    it('should build a quest from mixed items and capped tubes requirements', function () {
       const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
       const targetProfileId = 42;
       const questInput = new QuestInput({
         items: [
           { type: 'module', value: moduleId },
           { type: 'evaluation', value: targetProfileId },
+        ],
+        cappedTubeRequirements: [
+          {
+            threshold: 20,
+            tubes: [
+              { tubeId: 'tube1', level: 5 },
+              { tubeId: 'tube2', level: 3 },
+            ],
+          },
         ],
       });
 
@@ -91,6 +100,16 @@ describe('Quest | Unit | Domain | Models | QuestInput', function () {
           data: {
             targetProfileId: { data: targetProfileId, comparison: CRITERION_COMPARISONS.EQUAL },
             status: { data: CampaignParticipationStatuses.SHARED, comparison: CRITERION_COMPARISONS.EQUAL },
+          },
+        },
+        {
+          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+          data: {
+            threshold: 20,
+            cappedTubes: [
+              { tubeId: 'tube1', level: 5 },
+              { tubeId: 'tube2', level: 3 },
+            ],
           },
         },
       ]);
@@ -125,6 +144,7 @@ describe('Quest | Unit | Domain | Models | QuestInput', function () {
           { type: 'module', value: moduleId, shortId },
           { type: 'evaluation', value: targetProfileId },
         ],
+        cappedTubeRequirements: [{ tubes: [{ level: 1, tubeId: 'abc' }], threshold: 20 }],
       }).toQuest();
       const modulesById = { [moduleId]: [{ shortId }] };
 

--- a/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
@@ -1203,10 +1203,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourseDetails', function () {
         ],
       });
 
-      combinedCourseDetails.recommandableModuleIds = [
+      combinedCourseDetails.setRecommandableModuleIds([
         { moduleId: 'abcdef2', targetProfileIds: [888] },
         { moduleId: 'abcdef1', targetProfileIds: [888] },
-      ];
+      ]);
       await combinedCourseDetails.setEncryptedUrl();
       combinedCourseDetails.setDataAndGenerateItems({
         recommendedModuleIdsForUser: [{ moduleId: 'abcdef2' }],
@@ -1215,6 +1215,44 @@ describe('Quest | Unit | Domain | Models | CombinedCourseDetails', function () {
 
       // then
       expect(combinedCourseDetails.isSuccessful()).to.be.true;
+    });
+    it('should return false when recommended modules is not fulfilled', async function () {
+      // given && when
+      const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
+        name,
+        code,
+        organizationId,
+        questId,
+        combinedCourseItems: [
+          { campaignId: 777, targetProfileId: 888 },
+          { moduleId: 'abcdef1' },
+          { moduleId: 'abcdef2' },
+        ],
+        cryptoService,
+      });
+
+      const dataForQuest = domainBuilder.buildCombinedCourseDataForQuest({
+        campaignParticipations: [{ campaignId: 777, status: CampaignParticipationStatuses.SHARED }],
+        passages: [
+          {
+            referenceId: 'abcdef2',
+            isTerminated: true,
+          },
+        ],
+      });
+
+      combinedCourseDetails.setRecommandableModuleIds([
+        { moduleId: 'abcdef2', targetProfileIds: [888] },
+        { moduleId: 'abcdef1', targetProfileIds: [888] },
+      ]);
+      await combinedCourseDetails.setEncryptedUrl();
+      combinedCourseDetails.setDataAndGenerateItems({
+        recommendedModuleIdsForUser: [{ moduleId: 'abcdef1' }, { moduleId: 'abcdef2' }],
+        dataForQuest,
+      });
+
+      // then
+      expect(combinedCourseDetails.isSuccessful()).to.be.false;
     });
   });
 });

--- a/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
@@ -1176,4 +1176,45 @@ describe('Quest | Unit | Domain | Models | CombinedCourseDetails', function () {
       expect(result.items[2].isCompleted).to.be.false;
     });
   });
+
+  describe('#isSuccessful', function () {
+    it('should only evaluate the completion of recommended modules to user specifically', async function () {
+      // given && when
+      const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
+        name,
+        code,
+        organizationId,
+        questId,
+        combinedCourseItems: [
+          { campaignId: 777, targetProfileId: 888 },
+          { moduleId: 'abcdef1' },
+          { moduleId: 'abcdef2' },
+        ],
+        cryptoService,
+      });
+
+      const dataForQuest = domainBuilder.buildCombinedCourseDataForQuest({
+        campaignParticipations: [{ campaignId: 777, status: CampaignParticipationStatuses.SHARED }],
+        passages: [
+          {
+            referenceId: 'abcdef2',
+            isTerminated: true,
+          },
+        ],
+      });
+
+      combinedCourseDetails.recommandableModuleIds = [
+        { moduleId: 'abcdef2', targetProfileIds: [888] },
+        { moduleId: 'abcdef1', targetProfileIds: [888] },
+      ];
+      await combinedCourseDetails.setEncryptedUrl();
+      combinedCourseDetails.setDataAndGenerateItems({
+        recommendedModuleIdsForUser: [{ moduleId: 'abcdef2' }],
+        dataForQuest,
+      });
+
+      // then
+      expect(combinedCourseDetails.isSuccessful()).to.be.true;
+    });
+  });
 });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-for-creation-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-for-creation-serializer_test.js
@@ -1,7 +1,13 @@
+import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { COMBINED_COURSE_ITEM_TYPES, REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
 import { CombinedCourseBlueprintForCreation } from '../../../../../src/quest/domain/models/combined-course-blueprints/value-objects/CombinedCourseBlueprintForCreation.js';
-import { Quest } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
+import {
+  CRITERION_COMPARISONS,
+  Quest,
+  REQUIREMENT_COMPARISONS,
+  REQUIREMENT_TYPES,
+} from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
 import * as combinedCourseBlueprintForCreationSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
@@ -27,6 +33,15 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
           'created-at': date,
           'updated-at': date,
           'survey-link': 'http://survey',
+          'capped-tube-requirements': [
+            {
+              tubes: [
+                { level: 1, tubeId: '2ef' },
+                { level: 2, tubeId: '3ag' },
+              ],
+              threshold: 20,
+            },
+          ],
         },
         type: 'combined-course-blueprints',
         id: '1',
@@ -53,6 +68,32 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
           successRequirements: [
             CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }),
             CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: 123 }),
+            {
+              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              comparison: REQUIREMENT_COMPARISONS.ALL,
+              data: {
+                moduleId: { data: moduleId, comparison: CRITERION_COMPARISONS.EQUAL },
+                isTerminated: { data: true, comparison: CRITERION_COMPARISONS.EQUAL },
+              },
+            },
+            {
+              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+              comparison: REQUIREMENT_COMPARISONS.ALL,
+              data: {
+                targetProfileId: { data: 123, comparison: CRITERION_COMPARISONS.EQUAL },
+                status: { data: CampaignParticipationStatuses.SHARED, comparison: CRITERION_COMPARISONS.EQUAL },
+              },
+            },
+            {
+              requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+              data: {
+                cappedTubes: [
+                  { level: 1, tubeId: '2ef' },
+                  { level: 2, tubeId: '3ag' },
+                ],
+                threshold: 20,
+              },
+            },
           ],
           rewardId: 5,
           rewardType: REWARD_TYPES.ATTESTATION,


### PR DESCRIPTION
## 🪧 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On veut que les admins, à la création d'un blueprint, puissent renseigner des critères de type sujet cappé.

## 🌈 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Côté front, on réutilise le composant existant `TubesSelection`. On construit les capped tubes avec un threshold, qui sont ajoutés au payload de création de blueprint.
Côté back, on ajoute les capped tubes reçus aux Requirements de la quête créée en même temps que le schéma de parcours combiné.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
Se connecter sur PixAdmin.
Sur la page de création d'un parcours combiné :
- sélectionner une attestation -> la sélection des sujets cappés doit s'afficher
- sélectionner des sujets cappés, avec leur niveau, et renseigner un taux de réussite -> le blueprint doit être créé sans erreur, et la quête correspondante doit contenir les requirements liés aux capped tubes