### PR TITLE
[TECH] Toujours utiliser les imports nommés pour le locale service

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -1,5 +1,5 @@
 import { BadRequestError, UnauthorizedError } from '../../../shared/application/errors/http-errors.js';
-import * as localeService from '../../../shared/domain/services/locale-service.js';
+import { getBaseLocale } from '../../../shared/domain/services/locale-service.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { getForwardedOrigin, RequestedApplication } from '../../../shared/infrastructure/utils/network.js';
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
@@ -60,7 +60,7 @@ async function createUser(request, h) {
   const { identityProvider, authenticationKey } = request.deserializedPayload;
 
   const locale = getUserLocale(request);
-  const language = localeService.getBaseLocale(locale);
+  const language = getBaseLocale(locale);
 
   const origin = getForwardedOrigin(request.headers);
   const requestedApplication = RequestedApplication.fromOrigin(origin);

--- a/api/src/identity-access-management/application/user/user.admin.route.js
+++ b/api/src/identity-access-management/application/user/user.admin.route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { BadRequestError, sendJsonApiError } from '../../../shared/application/errors/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
-import * as localeService from '../../../shared/domain/services/locale-service.js';
+import { getSupportedLanguages, getSupportedLocales } from '../../../shared/domain/services/locale-service.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { QUERY_TYPES } from '../../domain/constants/user-query.js';
 import { userAdminController } from './user.admin.controller.js';
@@ -106,9 +106,9 @@ export const userAdminRoutes = [
             attributes: Joi.object({
               'first-name': Joi.string().required(),
               'last-name': Joi.string().required(),
-              lang: Joi.string().valid(...localeService.getSupportedLanguages()),
+              lang: Joi.string().valid(...getSupportedLanguages()),
               locale: Joi.string()
-                .valid(...localeService.getSupportedLocales())
+                .valid(...getSupportedLocales())
                 .allow(null),
               email: Joi.string().allow(null),
               username: Joi.string().allow(null),

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -1,4 +1,3 @@
-import * as localeService from '../../../shared/domain/services/locale-service.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
@@ -119,11 +118,10 @@ const getUserAuthenticationMethods = async function (request, h, dependencies = 
  * @param request
  * @param h
  * @param {Object} dependencies
- * @param {LocaleService} dependencies.localeService
  * @param {UserSerializer} dependencies.userSerializer
  * @return {Promise<*>}
  */
-const createUser = async function (request, h, dependencies = { userSerializer, localeService }) {
+const createUser = async function (request, h, dependencies = { userSerializer }) {
   const locale = getUserLocale(request);
   const i18n = getI18nFromRequest(request);
 
@@ -254,11 +252,10 @@ const rememberUserHasSeenChallengeTooltip = async function (request, h, dependen
  * @param request
  * @param h
  * @param {Object} dependencies
- * @param {LocaleService} dependencies.localeService
  * @param {UserSerializer} dependencies.userSerializer
  * @return {Promise<*>}
  */
-const upgradeToRealUser = async function (request, h, dependencies = { userSerializer, localeService }) {
+const upgradeToRealUser = async function (request, h, dependencies = { userSerializer }) {
   const userId = request.auth.credentials.userId;
   const locale = getUserLocale(request);
 

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -4,7 +4,7 @@ import XRegExp from 'xregexp';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { config } from '../../../shared/config.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
-import * as localeService from '../../../shared/domain/services/locale-service.js';
+import { getSupportedLanguages, getSupportedLocales } from '../../../shared/domain/services/locale-service.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { userController } from './user.controller.js';
 import { userVerification } from './user-existence-verification-pre-handler.js';
@@ -58,9 +58,9 @@ export const userRoutes = [
             attributes: Joi.object({
               'first-name': Joi.string().required(),
               'last-name': Joi.string().required(),
-              lang: Joi.string().valid(...localeService.getSupportedLanguages()),
+              lang: Joi.string().valid(...getSupportedLanguages()),
               locale: Joi.string()
-                .valid(...localeService.getSupportedLocales())
+                .valid(...getSupportedLocales())
                 .allow(null),
               email: Joi.string().allow(null),
               username: Joi.string().allow(null),
@@ -176,9 +176,9 @@ export const userRoutes = [
               'anonymous-user-token': Joi.string().optional(), // TODO: Remove 2 weeks after the fronts have been updated in production
               // TODO: attributes bellow should not be sent, they are not used.
               username: Joi.string().allow(null),
-              lang: Joi.string().valid(...localeService.getSupportedLanguages()),
+              lang: Joi.string().valid(...getSupportedLanguages()),
               locale: Joi.string()
-                .valid(...localeService.getSupportedLocales())
+                .valid(...getSupportedLocales())
                 .allow(null),
               'is-anonymous': Joi.boolean().allow(null),
               'must-validate-terms-of-service': Joi.boolean().allow(null),
@@ -325,7 +325,7 @@ export const userRoutes = [
       validate: {
         params: Joi.object({
           id: identifiersType.userId,
-          lang: Joi.string().valid(...localeService.getSupportedLocales()),
+          lang: Joi.string().valid(...getSupportedLocales()),
         }),
       },
       pre: [

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -1,47 +1,48 @@
 import dayjs from 'dayjs';
 import lodash from 'lodash';
 
-import * as localeService from '../../../shared/domain/services/locale-service.js';
+import {
+  coerceLanguage,
+  getDefaultLocale,
+  getNearestSupportedLocale,
+} from '../../../shared/domain/services/locale-service.js';
 import { anonymizeGeneralizeDate } from '../../../shared/infrastructure/utils/date-utils.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
 const { toLower } = lodash;
 
 class User {
-  constructor(
-    {
-      id,
-      cgu,
-      createdAt,
-      pixCertifTermsOfServiceAccepted,
-      email,
-      emailConfirmedAt,
-      username,
-      firstName,
-      knowledgeElements,
-      lastName,
-      lastTermsOfServiceValidatedAt,
-      lastPixCertifTermsOfServiceValidatedAt,
-      lastDataProtectionPolicySeenAt,
-      hasSeenAssessmentInstructions,
-      hasSeenNewDashboardInfo,
-      hasSeenFocusedChallengeTooltip,
-      hasSeenOtherChallengesTooltip,
-      mustValidateTermsOfService,
-      lang,
-      locale,
-      isAnonymous,
-      memberships = [],
-      pixScore,
-      scorecards = [],
-      updatedAt,
-      campaignParticipations = [],
-      authenticationMethods = [],
-      hasBeenAnonymised,
-      hasBeenAnonymisedBy,
-    } = {},
-    dependencies = { localeService },
-  ) {
+  constructor({
+    id,
+    cgu,
+    createdAt,
+    pixCertifTermsOfServiceAccepted,
+    email,
+    emailConfirmedAt,
+    username,
+    firstName,
+    knowledgeElements,
+    lastName,
+    lastTermsOfServiceValidatedAt,
+    lastPixCertifTermsOfServiceValidatedAt,
+    lastDataProtectionPolicySeenAt,
+    hasSeenAssessmentInstructions,
+    hasSeenNewDashboardInfo,
+    hasSeenFocusedChallengeTooltip,
+    hasSeenOtherChallengesTooltip,
+    mustValidateTermsOfService,
+    lang,
+    locale,
+    isAnonymous,
+    memberships = [],
+    pixScore,
+    scorecards = [],
+    updatedAt,
+    campaignParticipations = [],
+    authenticationMethods = [],
+    hasBeenAnonymised,
+    hasBeenAnonymisedBy,
+  } = {}) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
@@ -61,8 +62,8 @@ class User {
     this.hasSeenNewDashboardInfo = hasSeenNewDashboardInfo;
     this.hasSeenFocusedChallengeTooltip = hasSeenFocusedChallengeTooltip;
     this.knowledgeElements = knowledgeElements;
-    this.lang = dependencies.localeService.coerceLanguage(lang);
-    this.locale = dependencies.localeService.getNearestSupportedLocale(locale);
+    this.lang = coerceLanguage(lang);
+    this.locale = getNearestSupportedLocale(locale);
     this.isAnonymous = isAnonymous;
     this.pixScore = pixScore;
     this.memberships = memberships;
@@ -94,13 +95,13 @@ class User {
     return pixAuthenticationMethod ? pixAuthenticationMethod.authenticationComplement?.password : null;
   }
 
-  changeLocale(newLocale, dependencies = { localeService }) {
+  changeLocale(newLocale) {
     if (!newLocale) {
-      this.locale = dependencies.localeService.getDefaultLocale();
+      this.locale = getDefaultLocale();
       return true;
     }
     if (!this.locale || this.locale !== newLocale) {
-      this.locale = dependencies.localeService.getNearestSupportedLocale(newLocale);
+      this.locale = getNearestSupportedLocale(newLocale);
       return true;
     }
 

--- a/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
+++ b/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
@@ -1,37 +1,34 @@
-import * as localeService from '../../../shared/domain/services/locale-service.js';
+import { getNearestSupportedLocale } from '../../../shared/domain/services/locale-service.js';
 
 class UserDetailsForAdmin {
-  constructor(
-    {
-      id,
-      cgu,
-      username,
-      firstName,
-      lastName,
-      email,
-      pixOrgaTermsOfServiceAccepted,
-      pixCertifTermsOfServiceAccepted,
-      organizationLearners,
-      authenticationMethods,
-      createdAt,
-      updatedAt,
-      lang,
-      locale,
-      lastTermsOfServiceValidatedAt,
-      lastPixOrgaTermsOfServiceValidatedAt,
-      lastPixCertifTermsOfServiceValidatedAt,
-      lastLoggedAt,
-      emailConfirmedAt,
-      userLogin,
-      hasBeenAnonymised,
-      hasBeenAnonymisedBy,
-      anonymisedByFirstName,
-      anonymisedByLastName,
-      isPixAgent,
-      lastApplicationConnections,
-    } = {},
-    dependencies = { localeService },
-  ) {
+  constructor({
+    id,
+    cgu,
+    username,
+    firstName,
+    lastName,
+    email,
+    pixOrgaTermsOfServiceAccepted,
+    pixCertifTermsOfServiceAccepted,
+    organizationLearners,
+    authenticationMethods,
+    createdAt,
+    updatedAt,
+    lang,
+    locale,
+    lastTermsOfServiceValidatedAt,
+    lastPixOrgaTermsOfServiceValidatedAt,
+    lastPixCertifTermsOfServiceValidatedAt,
+    lastLoggedAt,
+    emailConfirmedAt,
+    userLogin,
+    hasBeenAnonymised,
+    hasBeenAnonymisedBy,
+    anonymisedByFirstName,
+    anonymisedByLastName,
+    isPixAgent,
+    lastApplicationConnections,
+  } = {}) {
     this.id = id;
     this.cgu = cgu;
     this.firstName = firstName;
@@ -44,7 +41,7 @@ class UserDetailsForAdmin {
     this.authenticationMethods = authenticationMethods;
     this.createdAt = createdAt;
     this.lang = lang;
-    this.locale = dependencies.localeService.getNearestSupportedLocale(locale);
+    this.locale = getNearestSupportedLocale(locale);
     this.lastTermsOfServiceValidatedAt = lastTermsOfServiceValidatedAt;
     this.lastPixOrgaTermsOfServiceValidatedAt = lastPixOrgaTermsOfServiceValidatedAt;
     this.lastPixCertifTermsOfServiceValidatedAt = lastPixCertifTermsOfServiceValidatedAt;

--- a/api/src/identity-access-management/domain/models/UserToCreate.js
+++ b/api/src/identity-access-management/domain/models/UserToCreate.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import * as localeService from '../../../shared/domain/services/locale-service.js';
+import { getNearestSupportedLocale } from '../../../shared/domain/services/locale-service.js';
 
 class UserToCreate {
   constructor({
@@ -20,7 +20,6 @@ class UserToCreate {
     hasSeenOtherChallengesTooltip = false,
     createdAt,
     updatedAt,
-    dependencies = { localeService },
   } = {}) {
     this.firstName = firstName;
     this.lastName = lastName;
@@ -31,7 +30,7 @@ class UserToCreate {
     this.mustValidateTermsOfService = mustValidateTermsOfService;
     this.lastTermsOfServiceValidatedAt = lastTermsOfServiceValidatedAt;
     this.lang = lang;
-    this.locale = dependencies.localeService.getNearestSupportedLocale(locale);
+    this.locale = getNearestSupportedLocale(locale);
     this.hasSeenNewDashboardInfo = hasSeenNewDashboardInfo;
     this.isAnonymous = isAnonymous;
     this.hasSeenFocusedChallengeTooltip = hasSeenFocusedChallengeTooltip;

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { config } from '../../../../../src/shared/config.js';
-import * as localeService from '../../../../../src/shared/domain/services/locale-service.js';
+import { getDefaultLocale } from '../../../../../src/shared/domain/services/locale-service.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
@@ -112,10 +112,10 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
       const user = new User(undefined);
 
       // when
-      user.changeLocale(null, { localeService });
+      user.changeLocale(null);
 
       // then
-      expect(user.locale).to.equal(localeService.getDefaultLocale());
+      expect(user.locale).to.equal(getDefaultLocale());
     });
 
     context('when user has no locale', function () {
@@ -129,9 +129,9 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
         const locale3 = 'fr-BE';
 
         // when
-        user1.changeLocale(locale1, { localeService });
-        user2.changeLocale(locale2, { localeService });
-        user3.changeLocale(locale3, { localeService });
+        user1.changeLocale(locale1);
+        user2.changeLocale(locale2);
+        user3.changeLocale(locale3);
 
         // then
         expect(user1.locale).to.equal('fr');
@@ -159,7 +159,7 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
         const user = new User({ locale: 'nl-BE' });
 
         // when
-        user.changeLocale('fr-FR', { localeService });
+        user.changeLocale('fr-FR');
 
         // then
         expect(user.locale).to.equal('fr-FR');

--- a/api/tests/shared/unit/domain/services/locale-service.test.js
+++ b/api/tests/shared/unit/domain/services/locale-service.test.js
@@ -1,11 +1,20 @@
-import * as localeService from '../../../../../src/shared/domain/services/locale-service.js';
+import {
+  fallbackChallengeLocales,
+  getBaseLocale,
+  getDefaultChallengeLocale,
+  getDefaultLocale,
+  getNearestChallengeLocale,
+  getNearestSupportedLocale,
+  getSupportedLanguages,
+  isFranceLocale,
+} from '../../../../../src/shared/domain/services/locale-service.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Domain | Service | Locale', function () {
   describe('getSupportedLanguages', function () {
     it('returns languages computed from the supported locales', function () {
       // when
-      const result = localeService.getSupportedLanguages();
+      const result = getSupportedLanguages();
 
       // then
       expect(result).to.deep.equal(['de', 'en', 'es', 'fr', 'nl', 'it']);
@@ -19,7 +28,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
         const name = 'fr-FR';
 
         // when
-        const locale = localeService.getNearestSupportedLocale(name);
+        const locale = getNearestSupportedLocale(name);
 
         // then
         expect(locale).to.equal('fr-FR');
@@ -32,7 +41,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
         const name = 'fr-fr';
 
         // when
-        const locale = localeService.getNearestSupportedLocale(name);
+        const locale = getNearestSupportedLocale(name);
 
         // then
         expect(locale).to.equal('fr-FR');
@@ -45,7 +54,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
         const name = 'fr-CA';
 
         // when
-        const locale = localeService.getNearestSupportedLocale(name);
+        const locale = getNearestSupportedLocale(name);
 
         // then
         expect(locale).to.equal('fr');
@@ -58,7 +67,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
         const name = 'br_FR';
 
         // when
-        const locale = localeService.getNearestSupportedLocale(name);
+        const locale = getNearestSupportedLocale(name);
 
         // then
         expect(locale).to.equal('fr');
@@ -71,7 +80,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
         const name = 'anInvalidLocaleName';
 
         // when
-        const locale = localeService.getNearestSupportedLocale(name);
+        const locale = getNearestSupportedLocale(name);
 
         // then
         expect(locale).to.equal('fr');
@@ -89,7 +98,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       ].forEach(({ locale, expectedBaseLocale }) => {
         it(`returns the corresponding base locale ${expectedBaseLocale} for ${locale}`, function () {
           // given / when
-          const baseLocale = localeService.getBaseLocale(locale);
+          const baseLocale = getBaseLocale(locale);
 
           // then
           expect(baseLocale).to.equal(expectedBaseLocale);
@@ -101,10 +110,10 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       ['fr_FR', 'yo-yo-yo', null].forEach((invalidLocale) => {
         it(`returns the default base locale for ${invalidLocale}`, function () {
           // given / when
-          const baseLocale = localeService.getBaseLocale(invalidLocale);
+          const baseLocale = getBaseLocale(invalidLocale);
 
           // then
-          const defaultBaseLocale = new Intl.Locale(localeService.getDefaultLocale()).language;
+          const defaultBaseLocale = new Intl.Locale(getDefaultLocale()).language;
           expect(baseLocale).to.equal(defaultBaseLocale);
         });
       });
@@ -116,10 +125,10 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       ['fr-fr', 'fr-FR'].forEach((franceLocale) => {
         it(`returns true for ${franceLocale}`, function () {
           // given / when
-          const isFranceLocale = localeService.isFranceLocale(franceLocale);
+          const result = isFranceLocale(franceLocale);
 
           // then
-          expect(isFranceLocale).to.be.true;
+          expect(result).to.be.true;
         });
       });
     });
@@ -128,10 +137,10 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       ['fr', 'en', 'en-GB', null].forEach((franceLocale) => {
         it(`returns true for ${franceLocale}`, function () {
           // given / when
-          const isFranceLocale = localeService.isFranceLocale(franceLocale);
+          const result = isFranceLocale(franceLocale);
 
           // then
-          expect(isFranceLocale).to.be.false;
+          expect(result).to.be.false;
         });
       });
     });
@@ -144,10 +153,10 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
         const locale = null;
 
         // when
-        const challengeLocale = localeService.getNearestChallengeLocale(locale);
+        const challengeLocale = getNearestChallengeLocale(locale);
 
         // then
-        expect(challengeLocale).to.equal(localeService.getDefaultChallengeLocale());
+        expect(challengeLocale).to.equal(getDefaultChallengeLocale());
       });
     });
 
@@ -163,7 +172,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       ].forEach(({ locale, expectedChallengeLocale }) => {
         it(`returns the challenge locale: ${expectedChallengeLocale} for locale: ${locale}`, function () {
           // when
-          const challengeLocale = localeService.getNearestChallengeLocale(locale);
+          const challengeLocale = getNearestChallengeLocale(locale);
 
           // then
           expect(challengeLocale).to.equal(expectedChallengeLocale);
@@ -178,7 +187,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       const locale = 'fr';
 
       // when
-      const result = localeService.fallbackChallengeLocales(locale);
+      const result = fallbackChallengeLocales(locale);
 
       // then
       expect(result).to.deep.equal(['fr']);
@@ -189,7 +198,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       const locale = 'fr-FR';
 
       // when
-      const result = localeService.fallbackChallengeLocales(locale);
+      const result = fallbackChallengeLocales(locale);
 
       // then
       expect(result).to.deep.equal(['fr-FR', 'fr']);


### PR DESCRIPTION
## 🪧 Problème

Les fonctions utilitaire de `shared/domain/services/locale-service.js` sont parfois réalisé en import namespace (`import * as localeService from '...'`) et parfois en import nommé (`import { getBaseLocale } from '...'`)

## 🌈 Proposition

Préférer l'utilisation des imports nommés, car c'est l'utilisation par défaut des IDE et permet aux outils (ex: linter, knip...) de facilement parcourir les dépendances entre les modules.

## ✊ Remarques

N/A

## 🎉 Pour tester

La CI est verte.
