### PR TITLE
[TECH] Mise à jour de la liste des versions lors de l'ajout d'un draft (PIX-23256)

### DIFF
--- a/admin/app/components/certification-frameworks/item/framework/new-version-form.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/new-version-form.gjs
@@ -41,6 +41,7 @@ export default class NewVersionForm extends Component {
       return;
     }
 
+    await this.store.queryRecord('framework-history', this.args.scope);
     this.router.transitionTo('authenticated.certification-frameworks.item.frameworks');
   }
 

--- a/admin/app/controllers/authenticated/trainings/training/target-profiles.js
+++ b/admin/app/controllers/authenticated/trainings/training/target-profiles.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import uniq from 'lodash/uniq';
 
 export default class TrainingDetailsTargetProfilesController extends Controller {
-  @service('store') store;
+  @service store;
   @service router;
   @service featureToggles;
   @tracked targetProfilesToAttach = '';

--- a/admin/app/routes/authenticated/certification-frameworks/item.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item.js
@@ -25,7 +25,7 @@ export default class ItemRoute extends Route {
 
   redirect(model, transition) {
     if (transition.to.name === 'authenticated.certification-frameworks.item.index') {
-      if (this.certificationFrameworkKey === 'CLEA') {
+      if (model.frameworkKey === 'CLEA') {
         this.router.transitionTo('authenticated.certification-frameworks.item.target-profile');
       } else {
         this.router.transitionTo('authenticated.certification-frameworks.item.frameworks');

--- a/admin/app/routes/authenticated/certification-frameworks/item.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item.js
@@ -13,31 +13,22 @@ export default class ItemRoute extends Route {
       (cf) => cf.name === params.certification_framework_key,
     );
 
-    let currentComplementaryCertification;
-    if (params.certification_framework_key === 'CLEA') {
-      const complementaryCertifications = await this.store.findAll('complementary-certification');
-      currentComplementaryCertification = complementaryCertifications.find(
-        (cc) => cc.key === params.certification_framework_key,
-      );
-    }
-
     const frameworkHistory = await this.store.queryRecord('framework-history', this.certificationFrameworkKey);
 
     return {
       frameworkHistory,
       frameworkKey: this.certificationFrameworkKey,
       currentCertificationFramework,
-      currentComplementaryCertification,
       hasTargetProfilesHistory: params.certification_framework_key !== 'CORE',
     };
   }
 
   redirect(model, transition) {
     if (transition.to.name === 'authenticated.certification-frameworks.item.index') {
-      if (this.certificationFrameworkKey !== 'CLEA') {
-        this.router.transitionTo('authenticated.certification-frameworks.item.frameworks');
-      } else {
+      if (this.certificationFrameworkKey === 'CLEA') {
         this.router.transitionTo('authenticated.certification-frameworks.item.target-profile');
+      } else {
+        this.router.transitionTo('authenticated.certification-frameworks.item.frameworks');
       }
     }
   }

--- a/admin/app/routes/authenticated/certification-frameworks/item/frameworks.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/frameworks.js
@@ -1,7 +1,15 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class FrameworkRoute extends Route {
+  @service router;
   model() {
     return this.modelFor('authenticated.certification-frameworks.item');
+  }
+
+  redirect(model) {
+    if (model.frameworkKey === 'CLEA') {
+      this.router.transitionTo('authenticated.certification-frameworks.item.target-profile');
+    }
   }
 }

--- a/admin/app/routes/authenticated/certification-frameworks/item/target-profile.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/target-profile.js
@@ -1,7 +1,21 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class TargetProfileRoute extends Route {
-  model() {
-    return this.modelFor('authenticated.certification-frameworks.item');
+  @service('store') store;
+
+  async model() {
+    const { frameworkHistory, frameworkKey, currentCertificationFramework, hasTargetProfilesHistory } = this.modelFor(
+      'authenticated.certification-frameworks.item',
+    );
+    const complementaryCertifications = await this.store.findAll('complementary-certification');
+    const currentComplementaryCertification = complementaryCertifications.find((cc) => cc.key === frameworkKey);
+    return {
+      frameworkHistory,
+      frameworkKey,
+      currentCertificationFramework,
+      hasTargetProfilesHistory,
+      currentComplementaryCertification,
+    };
   }
 }

--- a/admin/app/routes/authenticated/certification-frameworks/item/target-profile.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/target-profile.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class TargetProfileRoute extends Route {
-  @service('store') store;
+  @service store;
 
   async model() {
     const { frameworkHistory, frameworkKey, currentCertificationFramework, hasTargetProfilesHistory } = this.modelFor(

--- a/admin/app/routes/authenticated/certification-frameworks/item/target-profile/index.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/target-profile/index.js
@@ -2,7 +2,9 @@ import Route from '@ember/routing/route';
 
 export default class TargetProfileIndexRoute extends Route {
   async model() {
-    const { currentComplementaryCertification } = await this.modelFor('authenticated.certification-frameworks.item');
+    const { currentComplementaryCertification } = await this.modelFor(
+      'authenticated.certification-frameworks.item.target-profile',
+    );
     await currentComplementaryCertification.reload();
     return currentComplementaryCertification;
   }

--- a/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class BlueprintRoute extends Route {
-  @service('store') store;
+  @service store;
 
   async model(params) {
     return this.store.findRecord('combined-course-blueprint', params.combined_course_blueprint_id);

--- a/admin/app/routes/authenticated/combined-course-blueprints/list.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/list.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ListRoute extends Route {
-  @service('store') store;
+  @service store;
 
   model() {
     return this.store.findAll('combined-course-blueprint');

--- a/admin/app/routes/authenticated/combined-course-blueprints/new.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/new.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class NewRoute extends Route {
-  @service('store') store;
+  @service store;
 
   model() {
     return this.store.findAll('attestation');

--- a/admin/app/routes/authenticated/smart-random-simulator/get-next-challenge.js
+++ b/admin/app/routes/authenticated/smart-random-simulator/get-next-challenge.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
-  @service('store') store;
+  @service store;
   @service router;
 }

--- a/admin/tests/acceptance/authenticated/certification-frameworks/item/framework/new-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/item/framework/new-test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, within } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { Response } from 'miragejs';
@@ -148,13 +148,32 @@ module('Acceptance | Certification Framework | item | Framework | new', function
     });
 
     module('when the is no draft version in scope', function () {
-      test('should redirect to the versions list (draft not visible, TODO fix later PR)', async function (assert) {
+      test('should redirect to the versions list and see draft in list', async function (assert) {
         // given
         server.get('admin/certification-frameworks/:scope/framework-history', () => {
           return droitFrameworkHistory;
         });
         server.post('/admin/certification-versions', function (schema) {
-          return schema.create('certification-version');
+          droitFrameworkHistory.update({
+            history: [
+              ...droitFrameworkHistory.history,
+              {
+                id: 77,
+                startDate: null,
+                expirationDate: null,
+                assessmentDuration: 10,
+                maximumAssessmentLength: 30,
+                status: 'DRAFT',
+              },
+            ],
+          });
+          return schema.create('certification-version', {
+            id: 77,
+            startDate: null,
+            expirationDate: null,
+            assessmentDuration: 10,
+            maximumAssessmentLength: 30,
+          });
         });
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
@@ -163,6 +182,12 @@ module('Acceptance | Certification Framework | item | Framework | new', function
 
         // then
         assert.strictEqual(currentURL(), '/certification-frameworks/DROIT/frameworks');
+        const [, row1, row2] = await screen.findAllByRole('row');
+        assert.strictEqual(currentURL(), '/certification-frameworks/DROIT/frameworks');
+        assert.dom(within(row1).getByRole('cell', { name: '77' })).exists();
+        assert.dom(within(row1).getByRole('cell', { name: "En cours d'édition" })).exists();
+        assert.dom(within(row2).getByRole('cell', { name: '12' })).exists();
+        assert.dom(within(row2).getByRole('cell', { name: 'Actif' })).exists();
       });
     });
   });

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published-test.js
@@ -218,6 +218,9 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
         });
 
         const screen = await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
+        const button = screen.getByRole('button', {
+          name: 'Publier toutes les sessions',
+        });
         await clickByName('Publier toutes les sessions');
 
         await screen.findByRole('dialog');
@@ -227,7 +230,7 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
 
         // then
 
-        await waitForElementToBeRemoved(() => screen.queryByRole('button', { name: 'Publier toutes les sessions' }));
+        await waitForElementToBeRemoved(button);
         assert.dom(await screen.findByText('Aucun résultat')).exists();
       });
     });

--- a/admin/tests/unit/routes/authenticated/certification-frameworks/item-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-frameworks/item-test.js
@@ -17,26 +17,6 @@ module('Unit | Route | authenticated/certification-frameworks/item', function (h
   });
 
   module('model()', function () {
-    module('when the framework is CLEA', function () {
-      test('it should load complementary-certification and set hasTargetProfilesHistory to true', async function (assert) {
-        // given
-        const cleaFramework = { name: 'CLEA' };
-        const cleaComplementary = { key: 'CLEA' };
-        store.peekAll.withArgs('certification-framework').returns([cleaFramework]);
-        store.peekAll.withArgs('complementary-certification').returns([cleaComplementary]);
-        store.findAll.withArgs('complementary-certification').resolves([cleaComplementary]);
-        store.queryRecord.withArgs('framework-history').resolves(null);
-
-        // when
-        const result = await route.model({ certification_framework_key: 'CLEA' });
-
-        // then
-        assert.ok(store.findAll.calledWith('complementary-certification'));
-        assert.strictEqual(result.currentComplementaryCertification, cleaComplementary);
-        assert.true(result.hasTargetProfilesHistory);
-      });
-    });
-
     module('when the framework is CORE', function () {
       test('it should not load complementary-certification and set hasTargetProfilesHistory to false', async function (assert) {
         // given
@@ -53,7 +33,7 @@ module('Unit | Route | authenticated/certification-frameworks/item', function (h
       });
     });
 
-    module('when the framework is neither CORE nor CLEA', function () {
+    module('when the framework is not CORE', function () {
       test('it should not load complementary-certification and set hasTargetProfilesHistory to true', async function (assert) {
         // given
         const droitFramework = { name: 'DROIT' };


### PR DESCRIPTION
## 🪧 Problème

Après la PR précédente pour créer une version draft, juste après la redirection vers la liste, la version draft n'apparaissait pas

## 🌈 Proposition

Faire en sorte qu'elle apparaisse en forçant le refresh du `framework-history`

## ✊ Remarques
déplacement de code spécifique à la route `item.target-profile` dans son hook `model()`

## 🎉 Pour tester
Créer une draft, constater son apparition après redirection
