### PR TITLE
[TECH] Optimiser les performances de la route des parcours autonomes (PIX-XXXX)

### DIFF
--- a/api/src/evaluation/infrastructure/repositories/autonomous-course-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/autonomous-course-repository.js
@@ -70,7 +70,7 @@ async function get({ autonomousCourseId, campaignApi }) {
  * @returns {Promise<{autonomousCourses: Array<CampaignListItem>, meta: { page: number, pageSize: number, rowCount: number, pageCount: number} }>} returns a paginated list of autonomous courses
  */
 const findAllPaginated = async function ({ page, campaignApi }) {
-  const { models: autonomousCourses, meta } = await campaignApi.findAllForOrganization({
+  const { models: autonomousCourses, meta } = await campaignApi.findAllSummariesForOrganization({
     organizationId: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
     page,
   });

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -180,6 +180,33 @@ export const findAllForOrganization = async (payload) => {
 };
 
 /**
+ * @typedef CampaignSummaryListPayload
+ * @type {object}
+ * @property {number} organizationId
+ * @property {PageDefinition} page
+ */
+
+/**
+ * @function
+ * @name findAllSummariesForOrganization
+ * @description Lists an organization's campaigns with only their core attributes (no participation
+ * counts, owner or target profile joins).
+ *
+ * @param {CampaignSummaryListPayload} payload
+ * @returns {Promise<CampaignListResponse>}
+ */
+export const findAllSummariesForOrganization = async (payload) => {
+  const { models: campaigns, meta } = await usecases.findPaginatedOrganizationCampaignSummaries({
+    organizationId: payload.organizationId,
+    page: payload.page,
+  });
+
+  const campaignsList = campaigns.map((campaign) => new CampaignListItem(campaign));
+
+  return { models: campaignsList, meta };
+};
+
+/**
  * @function
  * @name findCampaignSkillIdsForCampaignParticipations
  *

--- a/api/src/prescription/campaign/domain/usecases/find-paginated-organization-campaign-summaries.js
+++ b/api/src/prescription/campaign/domain/usecases/find-paginated-organization-campaign-summaries.js
@@ -1,0 +1,7 @@
+const findPaginatedOrganizationCampaignSummaries = async ({ organizationId, page, campaignReportRepository }) =>
+  await campaignReportRepository.findAllPaginatedSummariesByOrganizationId({
+    organizationId,
+    page,
+  });
+
+export { findPaginatedOrganizationCampaignSummaries };

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -101,6 +101,7 @@ import { findCampaignSkillIdsForCampaignParticipations } from './find-campaign-s
 import { findPaginatedCampaignManagements } from './find-paginated-campaign-managements.js';
 import { findPaginatedCampaignParticipantActivities } from './find-paginated-campaign-participant-activities.js';
 import { findPaginatedFilteredOrganizationCampaigns } from './find-paginated-filtered-organization-campaigns.js';
+import { findPaginatedOrganizationCampaignSummaries } from './find-paginated-organization-campaign-summaries.js';
 import { getCampaign } from './get-campaign.js';
 import { getCampaignByCode } from './get-campaign-by-code.js';
 import { getCampaignManagement } from './get-campaign-management.js';
@@ -139,6 +140,7 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedCampaignManagements,
   findPaginatedCampaignParticipantActivities,
   findPaginatedFilteredOrganizationCampaigns,
+  findPaginatedOrganizationCampaignSummaries,
   getCampaignByCode,
   getCampaignManagement,
   getCampaignOfCampaignParticipation,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -161,6 +161,20 @@ const findPaginatedFilteredByOrganizationId = async function ({
   return { models: campaignReports, meta: { ...pagination, hasCampaigns } };
 };
 
+const findAllPaginatedSummariesByOrganizationId = async function ({ organizationId, page }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const query = knexConn('campaigns')
+    .select('id', 'name', 'code', 'type', 'createdAt', 'archivedAt')
+    .where({ organizationId })
+    .whereNull('deletedAt')
+    .orderBy('createdAt', 'DESC');
+
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
+
+  return { models: results, meta: pagination };
+};
+
 function _setSearchFiltersForQueryBuilder(qb, { name, ongoing = true, ownerName, isOwnedByMe }, userId) {
   if (name) {
     qb.whereILike('campaigns.name', `%${name}%`);
@@ -178,4 +192,4 @@ function _setSearchFiltersForQueryBuilder(qb, { name, ongoing = true, ownerName,
   }
 }
 
-export { findMasteryRates, findPaginatedFilteredByOrganizationId, get };
+export { findAllPaginatedSummariesByOrganizationId, findMasteryRates, findPaginatedFilteredByOrganizationId, get };

--- a/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
@@ -183,7 +183,6 @@ describe('Integration | Repository | Autonomous Course', function () {
           pageCount: 0,
           pageSize: 2,
           rowCount: 0,
-          hasCampaigns: false,
         });
       });
     });
@@ -215,7 +214,6 @@ describe('Integration | Repository | Autonomous Course', function () {
           pageCount: 3,
           pageSize: 2,
           rowCount: 6,
-          hasCampaigns: true,
         });
       });
     });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1197,4 +1197,56 @@ describe('Integration | Repository | Campaign-Report', function () {
       });
     });
   });
+
+  describe('#findAllPaginatedSummariesByOrganizationId', function () {
+    let organizationId;
+
+    beforeEach(async function () {
+      organizationId = databaseBuilder.factory.buildOrganization({}).id;
+      await databaseBuilder.commit();
+    });
+
+    it('should return a lightweight paginated list ordered by createdAt DESC', async function () {
+      // given
+      const oldest = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        name: 'Oldest',
+        createdAt: new Date('2020-01-01'),
+      });
+      const newest = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        name: 'Newest',
+        createdAt: new Date('2023-01-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const { models, meta } = await campaignReportRepository.findAllPaginatedSummariesByOrganizationId({
+        organizationId,
+        page: { number: 1, size: 10 },
+      });
+
+      // then
+      expect(models.map(({ id }) => id)).to.deep.equal([newest.id, oldest.id]);
+      expect(models[0]).to.have.all.keys('id', 'name', 'code', 'type', 'createdAt', 'archivedAt');
+      expect(meta).to.deep.equal({ page: 1, pageCount: 1, pageSize: 10, rowCount: 2 });
+    });
+
+    it('should exclude deleted campaigns', async function () {
+      // given
+      databaseBuilder.factory.buildCampaign({ organizationId, deletedAt: new Date() });
+      const kept = databaseBuilder.factory.buildCampaign({ organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const { models, meta } = await campaignReportRepository.findAllPaginatedSummariesByOrganizationId({
+        organizationId,
+        page: { number: 1, size: 10 },
+      });
+
+      // then
+      expect(models.map(({ id }) => id)).to.deep.equal([kept.id]);
+      expect(meta.rowCount).to.equal(1);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -277,4 +277,40 @@ describe('Unit | API | Campaigns', function () {
       });
     });
   });
+
+  describe('#findAllSummariesForOrganization', function () {
+    it('should return a paginated campaign summary list from organizationId', async function () {
+      // given
+      const organizationId = Symbol('organizationId');
+      const page = Symbol('page');
+      const meta = Symbol('meta');
+
+      const campaignInformation1 = {
+        id: 777,
+        code: 'SOMETHING',
+        name: 'Godzilla',
+        type: 'ASSESSMENT',
+        createdAt: new Date('2020-01-01'),
+        archivedAt: new Date('2023-01-01'),
+      };
+
+      sinon
+        .stub(usecases, 'findPaginatedOrganizationCampaignSummaries')
+        .withArgs({ organizationId, page })
+        .resolves({ models: [campaignInformation1], meta });
+
+      // when
+      const result = await campaignApi.findAllSummariesForOrganization({ organizationId, page });
+
+      // then
+      const firstCampaignListItem = result.models[0];
+      expect(result.meta).to.be.equal(meta);
+      expect(firstCampaignListItem).not.to.be.instanceOf(CampaignReport);
+      expect(firstCampaignListItem.id).to.be.equal(campaignInformation1.id);
+      expect(firstCampaignListItem.name).to.be.equal(campaignInformation1.name);
+      expect(firstCampaignListItem.createdAt).to.be.equal(campaignInformation1.createdAt);
+      expect(firstCampaignListItem.archivedAt).to.be.equal(campaignInformation1.archivedAt);
+      expect(firstCampaignListItem.tubes).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION

## 🪧 Problème

La route qui liste les parcours autonomes s'appuyait sur `campaignApi.findAllForOrganization`,
qui charge les campagnes avec l'ensemble de leurs jointures coûteuses (comptage des
participations, owner, profil cible). Pour cette liste, ces données ne sont pas utilisées :
on paie donc des jointures et des agrégations inutiles à chaque appel, ce qui dégrade les
temps de réponse de la route.

## 🌈 Proposition

Ajout d'une variante allégée du listing des campagnes d'une organisation :

- `campaignReportRepository.findAllPaginatedSummariesByOrganizationId` ne sélectionne que les
  attributs essentiels (`id`, `name`, `code`, `type`, `createdAt`, `archivedAt`), exclut les
  campagnes supprimées (`deletedAt`) et trie par `createdAt DESC`, sans aucune jointure.
- Nouveau usecase `findPaginatedOrganizationCampaignSummaries` et nouvel export cross-context
  `campaignApi.findAllSummariesForOrganization`.
- `autonomousCourseRepository.findAllPaginated` consomme désormais cette API allégée à la place
  de `findAllForOrganization`.


## 🎉 Pour tester

- [x] Sur PixAdmin, tester la visualisation des parcours autonomes.
