### PR TITLE
[TECH] Ne pas exécuter la CI à tous les changements de label

### DIFF
--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -21,8 +21,8 @@ jobs:
     if: >
       github.event_name == 'push' ||
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-      (github.event_name == 'pull_request' && github.event.action == 'labeled' && contains(github.event.label.name, 'Run CI'))
+      (github.event_name == 'pull_request' && github.event.action != 'labeled' && !github.event.pull_request.draft) ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'Run CI')
 
     steps:
       - name: Extract branch name
@@ -38,7 +38,7 @@ jobs:
           CCI_TOKEN: ${{ secrets.PIX_SERVICE_CIRCLE_CI_TOKEN }}
 
       - name: Remove "Run CI" label
-        if: github.event_name == 'pull_request' && github.event.action == 'labeled' && contains(github.event.label.name, 'Run CI')
+        if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'Run CI'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "${{ github.event.label.name }}" --repo ${{ github.repository }}


### PR DESCRIPTION
## 🪧 Problème

Une erreur dans les conditions d'exécution dans l'action `trigger-ci.yml` fait qu'on exécute la CI sur le PR non draft dès qu'on ajoute un label (peut importe le label).

## 🌈 Proposition

Corriger la condition d'exécution pour prendre en compte uniquement le label `Run CI`.

## ✊ Remarques

N/A

## 🎉 Pour tester

Seul le label `Run CI` peut maintenant lancer la CI quand un label est appliqué.
