### PR TITLE
[FEATURE] Ne pas proposer de transcription pour les short vidéo qui n'en ont pas (PIX-23184)

### DIFF
--- a/mon-pix/app/components/module/element/short-video.gjs
+++ b/mon-pix/app/components/module/element/short-video.gjs
@@ -47,6 +47,10 @@ export default class ModulixShortVideoElement extends ModuleElement {
     this.modalIsOpen = false;
   }
 
+  get hasTranscriptionText() {
+    return Boolean(this.args.element.transcription);
+  }
+
   <template>
     <div class="element-short-video">
       {{#if this.shouldShowFallback}}
@@ -64,9 +68,11 @@ export default class ModulixShortVideoElement extends ModuleElement {
           {{on "error" this.onVideoError}}
         ></video>
       {{/if}}
-      <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>
-        {{t "pages.modulix.buttons.element.transcription"}}
-      </PixButton>
+      {{#if this.hasTranscriptionText}}
+        <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>
+          {{t "pages.modulix.buttons.element.transcription"}}
+        </PixButton>
+      {{/if}}
       <PixModal
         @title={{t "pages.modulix.modals.transcription.title"}}
         @showModal={{this.modalIsOpen}}

--- a/mon-pix/tests/integration/components/module/element/short-video_test.gjs
+++ b/mon-pix/tests/integration/components/module/element/short-video_test.gjs
@@ -108,4 +108,25 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
       elementId: shortVideoId,
     });
   });
+
+  module('when the component does not have a transcription text', function () {
+    test('it should hide the transcription button', async function (assert) {
+      // given
+      const url = 'https://assets.pix.org/modules/placeholder-video.mp4';
+
+      const shortVideoId = 'id';
+      const shortVideoElement = {
+        id: shortVideoId,
+        url,
+        title: 'title',
+        transcription: '',
+      };
+
+      //  when
+      const screen = await render(<template><ModulixShortVideo @element={{shortVideoElement}} /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Afficher la transcription' })).doesNotExist();
+    });
+  });
 });


### PR DESCRIPTION
## 🪧 Problème

Actuellement, on affiche le bouton de transcription pour les short vidéo, sans aucune condition.

## 🌈 Proposition

Quand il n’y a pas de transcription pour une short vidéo, cacher le bouton.

## ✊ Remarques

RAS

## 🎉 Pour tester

- Ouvrir le module [Anatomie d’un message d’arnaque](https://app-pr16596.review.pix.fr/modules/82920553/anatomie-message-arnaque/passage?grainIndex=6)
- Dans un stepper vertical, on trouve une short-video de souris qui survole un lien de Phishing
- Le bouton "afficher la transcription" ne doit pas apparaître sous cette short-video
