### PR TITLE
[FEAT] Ajoute la possibilité de lier des critères de maîtrise de lots de sujets à un schéma de parcours combiné  (PIX-21717)

### DIFF
--- a/admin/app/adapters/combined-course-blueprint.js
+++ b/admin/app/adapters/combined-course-blueprint.js
@@ -16,7 +16,6 @@ export default class CombinedCourseBlueprintAdapter extends ApplicationAdapter {
   }
 
   createRecord(store, type, snapshot) {
-    console.log(type);
     const { adapterOptions } = snapshot;
 
     if (adapterOptions && adapterOptions.tubes) {

--- a/admin/app/adapters/combined-course-blueprint.js
+++ b/admin/app/adapters/combined-course-blueprint.js
@@ -17,11 +17,10 @@ export default class CombinedCourseBlueprintAdapter extends ApplicationAdapter {
 
   createRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
-
-    if (adapterOptions && adapterOptions.tubes) {
-      const { tubes } = adapterOptions;
+    if (adapterOptions && adapterOptions.cappedTubeRequirements) {
+      const { cappedTubeRequirements } = adapterOptions;
       const payload = this.serialize(snapshot);
-      payload.data.attributes.tubes = tubes;
+      payload.data.attributes.cappedTubeRequirements = cappedTubeRequirements;
 
       const url = this.urlForCreateRecord(type.modelName, snapshot);
 

--- a/admin/app/adapters/combined-course-blueprint.js
+++ b/admin/app/adapters/combined-course-blueprint.js
@@ -14,4 +14,21 @@ export default class CombinedCourseBlueprintAdapter extends ApplicationAdapter {
     });
     return result;
   }
+
+  createRecord(store, type, snapshot) {
+    console.log(type);
+    const { adapterOptions } = snapshot;
+
+    if (adapterOptions && adapterOptions.tubes) {
+      const { tubes } = adapterOptions;
+      const payload = this.serialize(snapshot);
+      payload.data.attributes.tubes = tubes;
+
+      const url = this.urlForCreateRecord(type.modelName, snapshot);
+
+      return this.ajax(url, 'POST', { data: payload });
+    }
+
+    return super.createRecord(...arguments);
+  }
 }

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -94,7 +94,7 @@ export default class CombinedCourseBlueprintForm extends Component {
   @action
   async save() {
     try {
-      await this.blueprint.save();
+      await this.blueprint.save({ adapterOptions: { tubes: this.selectedTubes } });
       this.pixToast.sendSuccessNotification({
         message: this.args.updateMode
           ? this.intl.t('components.combined-course-blueprints.update.notifications.success')

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -272,7 +272,9 @@ export default class CombinedCourseBlueprintForm extends Component {
             @onChange={{this.setAttestation}}
           />
 
-          <TubesSelection @frameworks={{@model.frameworks}} @onChange={{this.updateTubes}} />
+          {{#if this.blueprint.rewardId}}
+            <TubesSelection @frameworks={{@model.frameworks}} @onChange={{this.updateTubes}} />
+          {{/if}}
         {{/unless}}
 
         <PixInput

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -288,7 +288,7 @@ export default class CombinedCourseBlueprintForm extends Component {
               min="0"
               max="100"
               @requiredLabel={{t "common.forms.mandatory"}}
-              {{on "change" @onThresholdChange}}
+              {{on "change" this.onThresholdChange}}
             >
               <:label>Taux de réussite requis</:label>
             </PixInput>

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -154,7 +154,7 @@ export default class CombinedCourseBlueprintForm extends Component {
   @action
   updateTubes(tubes) {
     this.selectedTubes = tubes.map(({ id, level }) => ({
-      id,
+      tubeId: id,
       level,
     }));
   }

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -94,7 +94,9 @@ export default class CombinedCourseBlueprintForm extends Component {
   @action
   async save() {
     try {
-      await this.blueprint.save({ adapterOptions: { tubes: this.selectedTubes } });
+      await this.blueprint.save({
+        adapterOptions: { cappedTubeRequirements: [{ tubes: this.selectedTubes, threshold: this.threshold }] },
+      });
       this.pixToast.sendSuccessNotification({
         message: this.args.updateMode
           ? this.intl.t('components.combined-course-blueprints.update.notifications.success')
@@ -155,6 +157,11 @@ export default class CombinedCourseBlueprintForm extends Component {
       id,
       level,
     }));
+  }
+
+  @action
+  onThresholdChange(e) {
+    this.threshold = e.target.value;
   }
 
   <template>
@@ -274,6 +281,17 @@ export default class CombinedCourseBlueprintForm extends Component {
 
           {{#if this.blueprint.rewardId}}
             <TubesSelection @frameworks={{@model.frameworks}} @onChange={{this.updateTubes}} />
+            <PixInput
+              @id="blueprintThreshold"
+              class="combined-course-page__threshold"
+              type="number"
+              min="0"
+              max="100"
+              @requiredLabel={{t "common.forms.mandatory"}}
+              {{on "change" @onThresholdChange}}
+            >
+              <:label>Taux de réussite requis</:label>
+            </PixInput>
           {{/if}}
         {{/unless}}
 

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -149,6 +149,14 @@ export default class CombinedCourseBlueprintForm extends Component {
     this.blueprint.content = this.blueprint.content.filter((item) => item.value !== value || item.type !== type);
   }
 
+  @action
+  updateTubes(tubes) {
+    this.selectedTubes = tubes.map(({ id, level }) => ({
+      id,
+      level,
+    }));
+  }
+
   <template>
     <PixBlock @variant="admin" class="combined-course-page">
 
@@ -263,9 +271,9 @@ export default class CombinedCourseBlueprintForm extends Component {
             @value={{this.blueprint.rewardId}}
             @onChange={{this.setAttestation}}
           />
-        {{/unless}}
 
-        <TubesSelection @frameworks={{@model.frameworks}} />
+          <TubesSelection @frameworks={{@model.frameworks}} @onChange={{this.updateTubes}} />
+        {{/unless}}
 
         <PixInput
           @id="surveyLink"

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -28,7 +28,7 @@ export default class CombinedCourseBlueprintForm extends Component {
 
   constructor() {
     super(...arguments);
-    this.blueprint = this.args.model ?? this.store.createRecord('combined-course-blueprint');
+    this.blueprint = this.args.model.blueprint ?? this.store.createRecord('combined-course-blueprint');
     this.router.on('routeWillChange', () => {
       if (this.blueprint.hasDirtyAttributes && !this.blueprint.isSaving) {
         this.blueprint.unloadRecord();
@@ -102,6 +102,7 @@ export default class CombinedCourseBlueprintForm extends Component {
       });
       this.router.transitionTo('authenticated.combined-course-blueprints.list');
     } catch (responseError) {
+      console.log(responseError);
       if (!responseError.errors) {
         return this.pixToast.sendErrorNotification({
           message: this.args.updateMode

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -102,7 +102,6 @@ export default class CombinedCourseBlueprintForm extends Component {
       });
       this.router.transitionTo('authenticated.combined-course-blueprints.list');
     } catch (responseError) {
-      console.log(responseError);
       if (!responseError.errors) {
         return this.pixToast.sendErrorNotification({
           message: this.args.updateMode

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -14,6 +14,7 @@ import { eq, gt } from 'ember-truth-helpers';
 import PixFieldset from 'pix-admin/components/ui/pix-fieldset';
 
 import RequirementTag from '../common/combined-courses/requirement-tag';
+import TubesSelection from '../common/tubes-selection';
 import SelectAttestation from './select-attestation';
 
 export default class CombinedCourseBlueprintForm extends Component {
@@ -258,11 +259,13 @@ export default class CombinedCourseBlueprintForm extends Component {
 
         {{#unless @updateMode}}
           <SelectAttestation
-            @attestations={{@attestations}}
+            @attestations={{@model.attestations}}
             @value={{this.blueprint.rewardId}}
             @onChange={{this.setAttestation}}
           />
         {{/unless}}
+
+        <TubesSelection @frameworks={{@model.frameworks}} />
 
         <PixInput
           @id="surveyLink"

--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -11,4 +11,6 @@ export default class CombinedCourseBlueprint extends Model {
   @attr('string') surveyLink;
   @attr({ type: 'date', defaultValue: () => undefined }) createdAt;
   @attr({ defaultValue: () => [] }) content;
+  @attr() cappedTubesThreshold;
+  @attr() cappedTubes;
 }

--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -11,6 +11,5 @@ export default class CombinedCourseBlueprint extends Model {
   @attr('string') surveyLink;
   @attr({ type: 'date', defaultValue: () => undefined }) createdAt;
   @attr({ defaultValue: () => [] }) content;
-  @attr() cappedTubesThreshold;
   @attr() cappedTubes;
 }

--- a/admin/app/routes/authenticated/combined-course-blueprints/new.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/new.js
@@ -4,7 +4,10 @@ import { inject as service } from '@ember/service';
 export default class NewRoute extends Route {
   @service('store') store;
 
-  model() {
-    return this.store.findAll('attestation');
+  async model() {
+    const attestations = await this.store.findAll('attestation');
+    const frameworks = await this.store.findAll('framework');
+
+    return { attestations, frameworks };
   }
 }

--- a/admin/app/serializers/combined-course-blueprint.js
+++ b/admin/app/serializers/combined-course-blueprint.js
@@ -11,6 +11,7 @@ export default class CombinedCourseBlueprintSerializer extends ApplicationSerial
       delete json.data.attributes['attestation-label'];
       delete json.data.attributes['reward-id'];
       delete json.data.attributes['reward-type'];
+      delete json.data.attributes['capped-tubes'];
 
       for (const attribute of ['illustration', 'description', 'survey-link']) {
         json.data.attributes[attribute] = json.data.attributes[attribute] || null;

--- a/admin/app/styles/components/combined-course/form.scss
+++ b/admin/app/styles/components/combined-course/form.scss
@@ -61,6 +61,9 @@
     gap: var(--pix-spacing-4x);
   }
 
-
+  &__threshold {
+      width: 134px;
+      margin-bottom: 16px;
+  }
 
 }

--- a/admin/app/templates/authenticated/combined-course-blueprints/new.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/new.gjs
@@ -1,3 +1,3 @@
 import CombinedCourseBlueprintForm from 'pix-admin/components/combined-course-blueprints/form';
 
-<template><CombinedCourseBlueprintForm @attestations={{@model}} /></template>
+<template><CombinedCourseBlueprintForm @model={{@model}} /></template>

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { clickByName, visit, within } from "@1024pix/ember-testing-library";
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -14,6 +14,9 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
   setupIntl(hooks);
 
   hooks.beforeEach(async function () {
+    const store = this.owner.lookup('service:store');
+    _createFramework(store);
+
     server.create('country', { code: '99100', name: 'France' });
     server.create('attestation', {
       templateName: 'parentalite',
@@ -56,10 +59,13 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
     await click(
       screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
     );
-
     await screen.findByRole('listbox');
-
     await click(screen.getByRole('option', { name: 'Parentalite' }));
+
+    await clickByName('1 · Titre domaine');
+    await clickByName('1 Titre competence');
+    await clickByName(/Sélection du niveau du sujet suivant : Tube/);
+    await click(within(await screen.findByRole('listbox')).getByRole('option', { name: '4' }));
 
     await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 
@@ -82,4 +88,38 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
     //then
     assert.ok(screen.getByText(t('common.tables.empty-result')));
   });
+
+  function _createFramework(store) {
+    const tubes = [
+      store.createRecord('tube', {
+        id: 'tubeId1',
+        name: '@tubeName1',
+        practicalTitle: 'Tube 1',
+        skills: [],
+        level: 8,
+      }),
+    ];
+
+    const thematic = [store.createRecord('thematic', { id: 'thematicId', name: 'Thématique', tubes: tubes })];
+
+    const competence = [
+      store.createRecord('competence', {
+        id: 'competenceId',
+        index: '1',
+        name: 'Titre competence',
+        thematic,
+      }),
+    ];
+
+    const areas = [
+      store.createRecord('area', {
+        id: 'areaId',
+        title: 'Titre domaine',
+        code: 1,
+        competence,
+      }),
+    ];
+
+    return store.createRecord('framework', { id: 'frameworkId', name: 'Pix', areas });
+  }
 });

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
@@ -65,7 +65,11 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
     await clickByName('1 · Titre domaine');
     await clickByName('1 Titre competence');
     await clickByName(/Sélection du niveau du sujet suivant : Tube/);
-    await click(within(await screen.findByRole('listbox')).getByRole('option', { name: '4' }));
+    const tubesListbox = await within(
+      screen.getByRole('cell', { name: /Sélection du niveau du sujet suivant : Tube/ }),
+    ).findByRole('listbox');
+
+    await click(within(tubesListbox).getByRole('option', { name: '4' }));
 
     await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
@@ -1,4 +1,4 @@
-import { clickByName, visit, within } from "@1024pix/ember-testing-library";
+import { clickByName, visit, within } from '@1024pix/ember-testing-library';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -100,14 +100,14 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
       }),
     ];
 
-    const thematic = [store.createRecord('thematic', { id: 'thematicId', name: 'Thématique', tubes: tubes })];
+    const thematics = [store.createRecord('thematic', { id: 'thematicId', name: 'Thématique', tubes: tubes })];
 
-    const competence = [
+    const competences = [
       store.createRecord('competence', {
         id: 'competenceId',
         index: '1',
         name: 'Titre competence',
-        thematic,
+        thematics,
       }),
     ];
 
@@ -116,7 +116,7 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
         id: 'areaId',
         title: 'Titre domaine',
         code: 1,
-        competence,
+        competences,
       }),
     ];
 

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -166,6 +166,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         rewardId: 5,
         rewardType: 'ATTESTATION',
       });
+      const model = { blueprint };
 
       sinon.stub(blueprint, 'save');
       blueprint.save.resolves();
@@ -174,7 +175,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       //when
       const screen = await render(
-        <template><CombinedCourseBlueprintForm @updateMode={{true}} @model={{blueprint}} /></template>,
+        <template><CombinedCourseBlueprintForm @updateMode={{true}} @model={{ model }} /></template>,
       );
 
       await fillIn(

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -197,6 +197,15 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
   });
 
   module('error cases', function () {
+    const frameworks = [
+      {
+        id: 123,
+        name: 'Pix',
+        areas: [],
+      },
+    ];
+    const model = { frameworks };
+
     test('it should display a generic error message', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -206,15 +215,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       const pixToastErrorStub = sinon.stub(pixToast, 'sendErrorNotification');
 
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
-
-      const frameworks = [
-        {
-          id: 123,
-          name: 'Pix',
-          areas: [],
-        },
-      ];
-      const model = { frameworks };
 
       //when
       const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
@@ -243,15 +243,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       const pixToastErrorStub = sinon.stub(pixToast, 'sendErrorNotification');
 
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
-
-      const frameworks = [
-        {
-          id: 123,
-          name: 'Pix',
-          areas: [],
-        },
-      ];
-      const model = { frameworks };
 
       //when
       const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
@@ -288,7 +279,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 
@@ -326,7 +317,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         .rejects({ errors: [{ status: '404', detail: 'Le profil cible est introuvable' }] });
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
@@ -356,7 +347,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       findRecordStub.withArgs('module').rejects({ errors: [{ status: '404', detail: 'Le module est introuvable' }] });
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await click(screen.getByLabelText(t('components.combined-course-blueprints.labels.module')));
       await fillIn(
@@ -387,7 +378,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       findRecordStub.withArgs('target-profile').rejects();
 
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
@@ -415,8 +406,18 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         .withArgs('module', 'module123')
         .resolves({ id: 'full-id-module123', shortId: 'module123', title: 'module 123' });
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
+
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { frameworks };
+
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
@@ -444,9 +445,19 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       const findRecordStub = sinon.stub(store, 'findRecord');
 
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
+
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { frameworks };
+
       //when
 
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -32,11 +32,13 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
         { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
       ];
-      const frameworks = [{
-        id: 123,
-        name: 'Pix',
-        areas: [],
-      }];
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
       const model = { attestations, frameworks };
 
       //when
@@ -210,8 +212,8 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
           id: 123,
           name: 'Pix',
           areas: [],
-        }
-      ]
+        },
+      ];
       const model = { frameworks };
 
       //when
@@ -247,8 +249,8 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
           id: 123,
           name: 'Pix',
           areas: [],
-        }
-      ]
+        },
+      ];
       const model = { frameworks };
 
       //when

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -23,17 +23,24 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
       const findRecordStub = sinon.stub(store, 'findRecord');
-      const attestations = [
-        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
-        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
-      ];
       findRecordStub
         .withArgs('module', 'module-123')
         .resolves({ id: 'full-id-module-123', shortId: 'module-123', title: 'module 123' });
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
 
+      const attestations = [
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
+      ];
+      const frameworks = [{
+        id: 123,
+        name: 'Pix',
+        areas: [],
+      }];
+      const model = { attestations, frameworks };
+
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm @attestations={{attestations}} /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
@@ -198,8 +205,17 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
 
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        }
+      ]
+      const model = { frameworks };
+
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 
@@ -226,8 +242,17 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
 
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        }
+      ]
+      const model = { frameworks };
+
       //when
-      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
       await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -175,7 +175,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       //when
       const screen = await render(
-        <template><CombinedCourseBlueprintForm @updateMode={{true}} @model={{ model }} /></template>,
+        <template><CombinedCourseBlueprintForm @updateMode={{true}} @model={{model}} /></template>,
       );
 
       await fillIn(

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -112,6 +112,36 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       );
       sinon.assert.calledWithExactly(router.transitionTo, 'authenticated.combined-course-blueprints.list');
     });
+    test('it should display tubes selection component only if the user selects an attestation', async function (assert) {
+      //given
+      const attestations = [
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
+      ];
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { attestations, frameworks };
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
+
+      //then
+      assert.notOk(await screen.queryByRole('heading', { name: 'Sélection des sujets' }));
+
+      //when
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+      );
+      await screen.findByRole('listbox');
+
+      await click(screen.getByRole('option', { name: 'Parentalite' }));
+
+      //then
+      assert.ok(screen.getByRole('heading', { name: 'Sélection des sujets' }));
+    });
   });
 
   module('edition mode', function () {

--- a/admin/tests/integration/templates/authenticated/combined-course-blueprints/new-test.gjs
+++ b/admin/tests/integration/templates/authenticated/combined-course-blueprints/new-test.gjs
@@ -9,8 +9,9 @@ module('Integration | Template | combined-course-blueprints | New', function (ho
   setupIntlRenderingTest(hooks);
 
   test('it should render combined course form component', async function (assert) {
+    const model = { blueprint: {} };
     // when
-    const screen = await render(<template><CreateCombinedCourseBlueprint /></template>);
+    const screen = await render(<template><CreateCombinedCourseBlueprint @model={{model}} /></template>);
 
     // then
     assert.ok(screen.getByRole('heading', { level: 1, name: t('components.combined-course-blueprints.create.title') }));

--- a/admin/tests/unit/serializers/combined-course-blueprint-test.js
+++ b/admin/tests/unit/serializers/combined-course-blueprint-test.js
@@ -20,6 +20,17 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
       rewardId: 5,
       rewardType: 'ATTESTATION',
       surveyLink: 'http://survey-link-test.fr',
+      cappedTubes: [
+        {
+          threshold: 0.5,
+          tubes: [
+            {
+              tubeId: '123',
+              level: 1,
+            },
+          ],
+        },
+      ],
     });
 
     const serializedRecord = record.serialize();
@@ -41,6 +52,17 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
               },
             ],
             'attestation-label': 'Label attestation',
+            'capped-tubes': [
+              {
+                threshold: 0.5,
+                tubes: [
+                  {
+                    tubeId: '123',
+                    level: 1,
+                  },
+                ],
+              },
+            ],
             'reward-id': 5,
             'reward-type': 'ATTESTATION',
             'survey-link': 'http://survey-link-test.fr',
@@ -67,6 +89,17 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
       rewardId: 5,
       rewardType: 'ATTESTATION',
       surveyLink: 'http://survey-link-test.fr',
+      'capped-tubes': [
+        {
+          threshold: 0.5,
+          tubes: [
+            {
+              tubeId: '123',
+              level: 1,
+            },
+          ],
+        },
+      ],
     });
 
     const serializedRecord = record.serialize();

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -54,10 +54,11 @@ const register = async function (server) {
                 description: Joi.string().allow(null),
                 'reward-id': Joi.number().integer().allow(null),
                 'reward-type': Joi.string().allow(null),
+                'attestation-label': Joi.string().allow(null),
                 content: Joi.array(),
                 createdAt: Joi.date(),
                 'survey-link': Joi.string().allow(null),
-                'capped-tubes-requirements': Joi.array()
+                'capped-tube-requirements': Joi.array()
                   .items(
                     Joi.object({
                       tubes: Joi.array().items(Joi.object({ id: Joi.string(), level: Joi.number().integer() })),
@@ -68,9 +69,6 @@ const register = async function (server) {
               },
             },
           }),
-          options: {
-            allowUnknown: true,
-          },
         },
         handler: combinedCourseBlueprintController.save,
         notes: ["- Creation d'un schéma de parcours combiné"],

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -57,6 +57,14 @@ const register = async function (server) {
                 content: Joi.array(),
                 createdAt: Joi.date(),
                 'survey-link': Joi.string().allow(null),
+                'capped-tubes-requirements': Joi.array()
+                  .items(
+                    Joi.object({
+                      tubes: Joi.array().items(Joi.object({ id: Joi.string(), level: Joi.number().integer() })),
+                      threshold: Joi.string(),
+                    }),
+                  )
+                  .allow(null),
               },
             },
           }),

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -61,7 +61,7 @@ const register = async function (server) {
                 'capped-tube-requirements': Joi.array()
                   .items(
                     Joi.object({
-                      tubes: Joi.array().items(Joi.object({ id: Joi.string(), level: Joi.number().integer() })),
+                      tubes: Joi.array().items(Joi.object({ tubeId: Joi.string(), level: Joi.number().integer() })),
                       threshold: Joi.string(),
                     }),
                   )

--- a/api/src/quest/domain/models/QuestInput.js
+++ b/api/src/quest/domain/models/QuestInput.js
@@ -4,7 +4,7 @@ import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { COMBINED_COURSE_ITEM_TYPES } from '../constants.js';
 import { CombinedCourseBlueprint } from './CombinedCourseBlueprint.js';
 import { Quest, REQUIREMENT_TYPES } from './quests/entities/Quest.js';
-import cappedTubeRequirements from 'lodash';
+import { buildRequirement } from './quests/value-objects/Requirement.js';
 
 const itemsSchema = Joi.array()
   .items(
@@ -31,7 +31,7 @@ const itemsSchema = Joi.array()
   .strict();
 
 export class QuestInput {
-  constructor({ items, rewardId, rewardType, cappedTubeRequirements } = {}) {
+  constructor({ items, rewardId, rewardType, cappedTubeRequirements = [] } = {}) {
     this.items = items;
     this.rewardId = rewardId;
     this.rewardType = rewardType;
@@ -55,15 +55,16 @@ export class QuestInput {
     });
 
     const cappedTubes = this.cappedTubeRequirements.map((requirement) => {
-      return {
+      return buildRequirement({
         requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
         data: {
           threshold: requirement.threshold,
           cappedTubes: requirement.tubes,
         },
-      };
+      });
     });
-    successRequirements.push(cappedTubes);
+
+    successRequirements.push(...cappedTubes);
 
     return new Quest({
       eligibilityRequirements: [],

--- a/api/src/quest/domain/models/QuestInput.js
+++ b/api/src/quest/domain/models/QuestInput.js
@@ -4,6 +4,7 @@ import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { COMBINED_COURSE_ITEM_TYPES } from '../constants.js';
 import { CombinedCourseBlueprint } from './CombinedCourseBlueprint.js';
 import { Quest, REQUIREMENT_TYPES } from './quests/entities/Quest.js';
+import cappedTubeRequirements from 'lodash';
 
 const itemsSchema = Joi.array()
   .items(
@@ -30,10 +31,11 @@ const itemsSchema = Joi.array()
   .strict();
 
 export class QuestInput {
-  constructor({ items, rewardId, rewardType } = {}) {
+  constructor({ items, rewardId, rewardType, cappedTubeRequirements } = {}) {
     this.items = items;
     this.rewardId = rewardId;
     this.rewardType = rewardType;
+    this.cappedTubeRequirements = cappedTubeRequirements;
     this.#validate();
   }
 
@@ -51,6 +53,17 @@ export class QuestInput {
       }
       return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: item.value });
     });
+
+    const cappedTubes = this.cappedTubeRequirements.map((requirement) => {
+      return {
+        requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+        data: {
+          threshold: requirement.threshold,
+          cappedTubes: requirement.tubes,
+        },
+      };
+    });
+    successRequirements.push(cappedTubes);
 
     return new Quest({
       eligibilityRequirements: [],

--- a/api/src/quest/domain/models/QuestInput.js
+++ b/api/src/quest/domain/models/QuestInput.js
@@ -37,6 +37,25 @@ const cappedTubesSchema = Joi.array().items(
   }),
 );
 
+const schema = Joi.object({
+  items: itemsSchema,
+  cappedTubeRequirements: cappedTubesSchema,
+  rewardId: Joi.alternatives()
+    .conditional('rewardType', {
+      is: Joi.string(),
+      then: Joi.number().integer().required(),
+      otherwise: undefined,
+    })
+    .allow(null),
+  rewardType: Joi.alternatives()
+    .conditional('rewardId', {
+      is: Joi.number().integer(),
+      then: Joi.string().required(),
+      otherwise: undefined,
+    })
+    .allow(null),
+});
+
 export class QuestInput {
   constructor({ items, rewardId, rewardType, cappedTubeRequirements = [] } = {}) {
     this.items = items;
@@ -47,7 +66,7 @@ export class QuestInput {
   }
 
   #validate() {
-    const { error } = itemsSchema.validate(this.items);
+    const { error } = schema.validate(this);
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: this.items });
     }

--- a/api/src/quest/domain/models/QuestInput.js
+++ b/api/src/quest/domain/models/QuestInput.js
@@ -30,6 +30,13 @@ const itemsSchema = Joi.array()
   .required()
   .strict();
 
+const cappedTubesSchema = Joi.array().items(
+  Joi.object({
+    tubes: Joi.array().items(Joi.object({ tubeId: Joi.string(), level: Joi.number().integer() })),
+    threshold: Joi.string(),
+  }),
+);
+
 export class QuestInput {
   constructor({ items, rewardId, rewardType, cappedTubeRequirements = [] } = {}) {
     this.items = items;

--- a/api/src/quest/domain/models/quests/value-objects/Requirement.js
+++ b/api/src/quest/domain/models/quests/value-objects/Requirement.js
@@ -224,6 +224,7 @@ export class CappedTubesRequirement extends BaseRequirement {
 
   #validate(args) {
     const { error } = cappedTubesRequirementSchema.validate(args);
+
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: this.toDTO() });
     }

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js
@@ -20,6 +20,7 @@ const deserialize = async function (payload) {
     items: deserializedData.content ?? [],
     rewardId: deserializedData.rewardId,
     rewardType: REWARD_TYPES[deserializedData.rewardType] ?? null,
+    cappedTubeRequirements: deserializedData.cappedTubeRequirements ?? [],
   });
   return new CombinedCourseBlueprintForCreation({
     ...deserializedData,

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -55,7 +55,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               'reward-id': attestation.id,
               'reward-type': 'ATTESTATION',
               content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
-              'capped-tube-requirements': [{ threshold: '20', tubes: [{ id: 'tube1', level: 5 }] }],
+              'capped-tube-requirements': [{ threshold: '20', tubes: [{ tubeId: 'tube1', level: 5 }] }],
             },
           },
         };

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -55,7 +55,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               'reward-id': attestation.id,
               'reward-type': 'ATTESTATION',
               content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
-              cappedTubesRequirements: [{ threshold: '20', tubes: [{ id: 'tube1', level: 5 }] }],
+              'capped-tube-requirements': [{ threshold: '20', tubes: [{ id: 'tube1', level: 5 }] }],
             },
           },
         };

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -55,6 +55,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               'reward-id': attestation.id,
               'reward-type': 'ATTESTATION',
               content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
+              cappedTubesRequirements: [{ threshold: '20', tubes: [{ id: 'tube1', level: 5 }] }],
             },
           },
         };

--- a/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
 import { combinedCourseBlueprintController } from '../../../../src/quest/application/combined-course-blueprint-controller.js';
 import * as combinedCourseBlueprintRoute from '../../../../src/quest/application/combined-course-blueprint-route.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
@@ -54,7 +53,7 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
             illustration: 'illustration.svg',
             'attestation-label': '6ème',
             content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
-            'capped-tube-requirements': [{ threshold: '20', tubes: [{ id: 'tube1', level: 5 }] }],
+            'capped-tube-requirements': [{ threshold: '20', tubes: [{ tubeId: 'tube1', level: 5 }] }],
           },
         },
       };

--- a/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
@@ -52,8 +52,9 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
             'internal-name': 'Mon schéma de parcours combiné',
             description: 'La description combinix',
             illustration: 'illustration.svg',
-            'attestation-key': ATTESTATIONS.SIXTH_GRADE,
+            'attestation-label': '6ème',
             content: [{ type: 'module', value: 'e67ec5d0', shortId: 'short-e67ec5d0' }],
+            'capped-tube-requirements': [{ threshold: '20', tubes: [{ id: 'tube1', level: 5 }] }],
           },
         },
       };

--- a/api/tests/quest/unit/domain/models/QuestInput_test.js
+++ b/api/tests/quest/unit/domain/models/QuestInput_test.js
@@ -64,13 +64,22 @@ describe('Quest | Unit | Domain | Models | QuestInput', function () {
       ]);
     });
 
-    it('should build a quest from mixed items', function () {
+    it('should build a quest from mixed items and capped tubes requirements', function () {
       const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
       const targetProfileId = 42;
       const questInput = new QuestInput({
         items: [
           { type: 'module', value: moduleId },
           { type: 'evaluation', value: targetProfileId },
+        ],
+        cappedTubeRequirements: [
+          {
+            threshold: '20',
+            tubes: [
+              { tubeId: 'tube1', level: 5 },
+              { tubeId: 'tube2', level: 3 },
+            ],
+          },
         ],
       });
 
@@ -91,6 +100,16 @@ describe('Quest | Unit | Domain | Models | QuestInput', function () {
           data: {
             targetProfileId: { data: targetProfileId, comparison: CRITERION_COMPARISONS.EQUAL },
             status: { data: CampaignParticipationStatuses.SHARED, comparison: CRITERION_COMPARISONS.EQUAL },
+          },
+        },
+        {
+          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+          data: {
+            threshold: '20',
+            cappedTubes: [
+              { tubeId: 'tube1', level: 5 },
+              { tubeId: 'tube2', level: 3 },
+            ],
           },
         },
       ]);


### PR DESCRIPTION
## 🪧 Problème
On veut pouvoir conditionner l'obtention d'une récompense à la fin d'un parcours combiné à une maîtrise de lots de sujets à un niveau donné.

## 🌈 Proposition
On ajoute le composant de sélection de sujets cappés au formulaire de création du combined course blueprint.

## ✊ Remarques
L'update de ce critère n'est pas géré pour l'instant par le formulaire.

## 🎉 Pour tester
PixAdmin
-> Schémas de parcours -> Créer un nouveau schéma de parcours
-> Sélectionner une attestation
-> Sélectionner un ensemble de sujets
-> Définir un taux de maîtrise
-> Vérifier que la requête est bien partie sur /api/admin/combined-course-blueprints avec les bons arguments
-> Vérifier sur la page de listing que le nouveau blueprint apparaît bien
-> Vérifier en base que les données sont bonnes

Règle métier à vérifier
On ne doit pas pouvoir envoyer un schéma qui aurait un ensemble de sujets cochés sans taux de maîtrise et sans avoir sélectionné une attestation.