### PR TITLE
[TECH] Ajout de la propriété `competenceId` aux configurations de niveau par compétence (PIX-21753).

### DIFF
--- a/api/scripts/certification/add-competence-ids-to-scoring-configurations.js
+++ b/api/scripts/certification/add-competence-ids-to-scoring-configurations.js
@@ -1,0 +1,69 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
+
+export class AddCompetenceIdsToScoringConfigurations extends Script {
+  constructor() {
+    super({
+      description:
+        'This script will add competence ids to jsonb scoring configurations as competence code retrieval is error prone',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info(`Script execution started`);
+
+    const competenceList = await competenceRepository.listPixCompetencesOnly();
+    const competenceIdByIndex = Object.fromEntries(
+      competenceList.map((competence) => [competence.index, competence.id]),
+    );
+
+    const coreConfigurations = await knex('certification_versions')
+      .select('id', 'competencesScoringConfiguration')
+      .whereNotNull('competencesScoringConfiguration')
+      .whereRaw('"competencesScoringConfiguration"::text != \'null\'');
+
+    let updatedConfigurationsCount = 0;
+    for (const configuration of coreConfigurations) {
+      const competencesScoringConfiguration = configuration.competencesScoringConfiguration;
+
+      const updatedConfig = competencesScoringConfiguration.map((entry) => {
+        const competenceId = competenceIdByIndex[entry.competence];
+        if (!competenceId) {
+          logger.warn(
+            `No competence found for index "${entry.competence}" in certification_version ${configuration.id}`,
+          );
+          return entry;
+        }
+        return { ...entry, competenceId };
+      });
+
+      if (!dryRun) {
+        const knexConnection = DomainTransaction.getConnection();
+        await knexConnection('certification_versions')
+          .where('id', configuration.id)
+          .update({
+            competencesScoringConfiguration: JSON.stringify(updatedConfig),
+          });
+      }
+      updatedConfigurationsCount++;
+    }
+
+    logger.info(
+      `${updatedConfigurationsCount} certification_versions rows processed ${dryRun ? '(dry run)' : ''}. Youpi Yo Youpi Yay`,
+    );
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, AddCompetenceIdsToScoringConfigurations);

--- a/api/tests/integration/scripts/certification/add-competence-ids-to-scoring-configurations_test.js
+++ b/api/tests/integration/scripts/certification/add-competence-ids-to-scoring-configurations_test.js
@@ -1,0 +1,130 @@
+import sinon from 'sinon';
+
+import { AddCompetenceIdsToScoringConfigurations } from '../../../../scripts/certification/add-competence-ids-to-scoring-configurations.js';
+import { PIX_ORIGIN } from '../../../../src/shared/domain/constants.js';
+import { expect } from '../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../tooling/databases.js';
+
+describe('Integration | Scripts | Certification | add-competence-ids-to-scoring-configurations', function () {
+  let script;
+  let logger;
+
+  const competence11 = {
+    id: 'recCompetence11',
+    index: '1.1',
+    origin: PIX_ORIGIN,
+    name_i18n: { fr: 'Compétence 1.1' },
+    description_i18n: { fr: 'Description 1.1' },
+    areaId: 'recArea1',
+    skillIds: [],
+    thematicIds: [],
+  };
+
+  const competence12 = {
+    id: 'recCompetence12',
+    index: '1.2',
+    origin: PIX_ORIGIN,
+    name_i18n: { fr: 'Compétence 1.2' },
+    description_i18n: { fr: 'Description 1.2' },
+    areaId: 'recArea1',
+    skillIds: [],
+    thematicIds: [],
+  };
+
+  beforeEach(function () {
+    script = new AddCompetenceIdsToScoringConfigurations();
+    logger = { info: sinon.stub(), warn: sinon.stub() };
+  });
+
+  describe('#handle', function () {
+    context('when dryRun is false', function () {
+      it('should add competenceId to each entry in competencesScoringConfiguration', async function () {
+        // given
+        databaseBuilder.factory.learningContent.build({
+          competences: [competence11, competence12],
+        });
+
+        const scoringConfig = [
+          {
+            competence: '1.1',
+            values: [{ bounds: { min: -10, max: 0 }, competenceLevel: 0 }],
+          },
+          {
+            competence: '1.2',
+            values: [{ bounds: { min: 0, max: 10 }, competenceLevel: 1 }],
+          },
+        ];
+        const { id } = databaseBuilder.factory.buildCertificationVersion({
+          competencesScoringConfiguration: scoringConfig,
+        });
+
+        const invalidVersion = databaseBuilder.factory.buildCertificationVersion({
+          competencesScoringConfiguration: [],
+        });
+        // competencesScoringConfiguration is overwritten as to simulate a null vale
+        invalidVersion.competencesScoringConfiguration = null;
+
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: false } });
+
+        // then
+        const { competencesScoringConfiguration } = await knex('certification_versions').where({ id }).first();
+        expect(competencesScoringConfiguration).to.deep.equal([
+          {
+            competence: '1.1',
+            competenceId: 'recCompetence11',
+            values: [{ bounds: { min: -10, max: 0 }, competenceLevel: 0 }],
+          },
+          {
+            competence: '1.2',
+            competenceId: 'recCompetence12',
+            values: [{ bounds: { min: 0, max: 10 }, competenceLevel: 1 }],
+          },
+        ]);
+      });
+    });
+
+    context('when dryRun is true', function () {
+      it('should not modify the database', async function () {
+        // given
+        databaseBuilder.factory.learningContent.build({ competences: [competence11] });
+
+        const scoringConfig = [{ competence: '1.1', values: [] }];
+        const { id } = databaseBuilder.factory.buildCertificationVersion({
+          competencesScoringConfiguration: scoringConfig,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: true } });
+
+        // then
+        const { competencesScoringConfiguration } = await knex('certification_versions').where({ id }).first();
+        expect(competencesScoringConfiguration).to.deep.equal(scoringConfig);
+      });
+    });
+
+    context('when a competence index is not found in the learning content', function () {
+      it('should log a warning and leave the entry without competenceId', async function () {
+        // given
+        databaseBuilder.factory.learningContent.build({ competences: [competence11] });
+
+        const scoringConfig = [{ competence: '9.9', values: [] }];
+        const { id } = databaseBuilder.factory.buildCertificationVersion({
+          competencesScoringConfiguration: scoringConfig,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: false } });
+
+        // then
+        expect(logger.warn).to.have.been.calledOnce;
+        const { competencesScoringConfiguration } = await knex('certification_versions').where({ id }).first();
+        expect(competencesScoringConfiguration[0]).not.to.have.property('competenceId');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

Les configurations de scores par compétences ne contiennent que les code (ex: 1.1, 1.2, etc). Cela ne posait pas de problème lorsque l’on avait uniquement à traiter des niveaux par compétence pour le référentiel coeur mais va poser problème si l’on veut faire la même chose avec les référentiels Pix+ puisque des compétences issus de référentiels différents peuvent avoir le même code.

## 🌈 Proposition

Ajout d'un script pour intégrer aux jsonb des différentes configurations les ID de compétences manquants

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

```
scalingo -a pix-api-review-pr16601 run "node scripts/certification/add-competence-ids-to-scoring-configurations.js --dryRun=true"
```

Vérifier que des configurations seraient modifiées.
Passer le dryRun à false et vérifier en BDD  que les configurations ont bien été modifiées.