### PR TITLE
[FEATURE] Bloquer le bouton de création de version d'une certification si un brouillon est déjà en cours d'élaboration (PIX-23273)

### DIFF
--- a/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/item/framework/framework-history.gjs
@@ -24,15 +24,13 @@ export default class FrameworkHistory extends Component {
   @service intl;
   @service pixToast;
 
-  @tracked frameworkHistory = [];
   @tracked selectedVersion = null;
   @tracked selectedVersionStatus = null;
   @tracked showDeletionConfirmationModal = false;
   @tracked showVersionDetailModal = false;
 
-  constructor() {
-    super(...arguments);
-    this.frameworkHistory = this.args.frameworkHistory?.history.sort(sortByStartDateNullFirst) ?? [];
+  get frameworkHistory() {
+    return this.args.frameworkHistory?.history.sort(sortByStartDateNullFirst) ?? [];
   }
 
   get hasHistory() {
@@ -66,10 +64,9 @@ export default class FrameworkHistory extends Component {
 
   @action
   async deleteVersion() {
-    const selectionVersionId = parseInt(this.selectedVersion.id);
     try {
       await this.selectedVersion.destroyRecord();
-      this.frameworkHistory = this.frameworkHistory.filter(({ id }) => id !== selectionVersionId);
+      await this.store.queryRecord('framework-history', this.args.frameworkKey);
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('components.certification-frameworks.deletion-modal.success-message'),
       });

--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -16,14 +16,13 @@ export default class Header extends Component {
   }
 
   get canCreateVersion() {
-    return this.args.frameworkHistory?.history?.some((history) => history.status === 'DRAFT');
+    return this.args.frameworkHistory?.hasDraft;
   }
 
   get activeCertificationVersionId() {
+    const activeVersion = this.args.frameworkHistory?.activeHistory;
     return {
-      activeVersionId: this.args.frameworkHistory?.history.find(
-        (frameworkHistory) => frameworkHistory.status == 'ACTIVE',
-      )?.id,
+      activeVersionId: activeVersion?.id,
     };
   }
 

--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -1,8 +1,10 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
 
 export default class Header extends Component {
   @service intl;
@@ -14,9 +16,7 @@ export default class Header extends Component {
   }
 
   get canCreateVersion() {
-    if (this.router.currentRouteName.startsWith('authenticated.certification-frameworks.item.frameworks.new'))
-      return false;
-    return this.currentUser.adminMember.isSuperAdmin && this.args.certificationFramework?.name !== 'CLEA';
+    return this.args.frameworkHistory?.history?.some((history) => history.status === 'DRAFT');
   }
 
   get activeCertificationVersionId() {
@@ -51,15 +51,24 @@ export default class Header extends Component {
         </span>
       </h1>
 
-      {{#if this.canCreateVersion}}
-        <PixButtonLink
-          class="framework__creation-button"
-          @route="authenticated.certification-frameworks.item.frameworks.new"
-          @query={{this.activeCertificationVersionId}}
-          @iconBefore="add"
-        >
-          {{t "components.certification-frameworks.item.frameworks.create-button"}}
-        </PixButtonLink>
+      {{#if @showCreationVersionButton}}
+        <PixTooltip @hide={{not this.canCreateVersion}} @position="bottom" @isWide={{true}}>
+          <:triggerElement>
+            <PixButtonLink
+              class="framework__creation-button"
+              @route="authenticated.certification-frameworks.item.frameworks.new"
+              @query={{this.activeCertificationVersionId}}
+              @iconBefore="add"
+              @isDisabled={{this.canCreateVersion}}
+            >
+              {{t "components.certification-frameworks.item.frameworks.create-button"}}
+            </PixButtonLink>
+          </:triggerElement>
+
+          <:tooltip>
+            {{t "components.certification-frameworks.item.frameworks.create-button-cancel-tooltip"}}
+          </:tooltip>
+        </PixTooltip>
       {{/if}}
     </div>
   </template>

--- a/admin/app/controllers/authenticated/certification-frameworks/item.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/item.js
@@ -1,0 +1,18 @@
+import Controller from '@ember/controller';
+import { service } from '@ember/service';
+
+export default class CertificationFrameworkItem extends Controller {
+  @service router;
+  @service currentUser;
+
+  get showCreationVersionButton() {
+    if (
+      this.currentUser.adminMember.isSuperAdmin &&
+      this.router.currentRouteName === 'authenticated.certification-frameworks.item.frameworks.index' &&
+      this.model.certificationFramework?.name !== 'CLEA'
+    ) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/admin/app/models/framework-history.js
+++ b/admin/app/models/framework-history.js
@@ -2,4 +2,12 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FrameworkHistory extends Model {
   @attr() history;
+
+  get hasDraft() {
+    return this.history?.some((version) => version.status === 'DRAFT');
+  }
+
+  get activeHistory() {
+    return this.history?.find((version) => version.status === 'ACTIVE') ?? null;
+  }
 }

--- a/admin/app/templates/authenticated/certification-frameworks/item.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item.gjs
@@ -8,6 +8,7 @@ import Header from 'pix-admin/components/certification-frameworks/item/header';
     <Header
       @certificationFramework={{@model.currentCertificationFramework}}
       @frameworkHistory={{@model.frameworkHistory}}
+      @showCreationVersionButton={{@controller.showCreationVersionButton}}
     />
 
     <section class="page-body certification-framework">

--- a/admin/tests/acceptance/authenticated/certification-frameworks/item-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/item-test.js
@@ -1,12 +1,12 @@
 import { visit, within } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
 import { module, test } from 'qunit';
 
-module('Acceptance | Complementary certifications | Complementary certification | Item', function (hooks) {
+module('Acceptance | Certification Frameworks | Item', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -88,7 +88,7 @@ module('Acceptance | Complementary certifications | Complementary certification 
     assert.strictEqual(currentURL(), '/certification-frameworks/CLEA/target-profile');
   });
 
-  test('it should display the create button on new version page', async function (assert) {
+  test('it should display the create-button', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     server.create('certification-framework', { id: 'DROIT', name: 'DROIT' });
@@ -104,5 +104,72 @@ module('Acceptance | Complementary certifications | Complementary certification 
     assert
       .dom(screen.queryByRole('link', { name: t('components.certification-frameworks.item.frameworks.create-button') }))
       .exists();
+  });
+
+  test("it shouln't possible to create 2 certification-version with status DRAFT", async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+    server.create('certification-framework', { id: 'DROIT', name: 'DROIT' });
+    server.create('framework-history', {
+      id: 'DROIT',
+      history: [
+        {
+          id: 13,
+          startDate: new Date('2023-10-10'),
+          expirationDate: null,
+          assessmentDuration: 90,
+          maximumAssessmentLength: 32,
+          status: 'ACTIVE',
+        },
+        {
+          id: 14,
+          startDate: null,
+          expirationDate: null,
+          assessmentDuration: 90,
+          maximumAssessmentLength: 32,
+          status: 'DRAFT',
+        },
+      ],
+    });
+
+    server.create('certification-version', { id: 13 });
+    server.create('certification-version', { id: 14 });
+
+    // when
+    const screen = await visit('/certification-frameworks/DROIT/');
+
+    const button = await screen.findByRole('link', {
+      name: t('components.certification-frameworks.item.frameworks.create-button'),
+      exact: false,
+    });
+
+    // then
+    assert.strictEqual(button.getAttribute('aria-disabled'), 'true');
+
+    const rows = await screen.findAllByRole('row');
+    const [, row1] = rows;
+
+    assert.strictEqual(rows.length, 3);
+    assert.dom(await screen.getByRole('cell', { name: "En cours d'édition" })).exists();
+    assert.dom(await screen.getByRole('cell', { name: 'Actif' })).exists();
+
+    const deleteButton = within(row1).getByRole('button', {
+      name: t('components.certification-frameworks.item.frameworks.history.table.actions.delete'),
+    });
+
+    await click(deleteButton);
+
+    const confirmButton = await screen.findByRole('button', {
+      name: t('components.certification-frameworks.deletion-modal.action-button'),
+    });
+
+    await click(confirmButton);
+
+    assert.strictEqual(button.getAttribute('aria-disabled'), 'false');
+    const rowsAfterDelete = await screen.findAllByRole('row');
+    assert.strictEqual(rowsAfterDelete.length, 2);
+    assert.dom(await screen.queryByRole('cell', { name: "En cours d'édition" })).doesNotExist();
+    assert.dom(await screen.getByRole('cell', { name: 'Actif' })).exists();
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework/framework-history-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import FrameworkHistory from 'pix-admin/components/certification-frameworks/item/framework/framework-history';
 import { module, test } from 'qunit';
@@ -188,9 +188,9 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       assert.dom(screen.getAllByRole('button', { name: deleteButtonName })[2]).hasAttribute('aria-disabled');
     });
 
-    test('it should be possible to delete a DRAFT version', async function (assert) {
+    test('it should be possible to only delete a DRAFT version', async function (assert) {
       // given
-      const certificationVersion = store.createRecord('certification-version', { id: archivedFrameworkItem.id });
+      const certificationVersion = store.createRecord('certification-version', { id: draftFrameworkItem.id });
       sinon.stub(store, 'findRecord').resolves(certificationVersion);
       sinon.stub(certificationVersion, 'destroyRecord').resolves();
       const frameworkHistory = store.createRecord('framework-history', {
@@ -198,16 +198,27 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       });
 
       const screen = await render(
-        <template><FrameworkHistory @frameworkKey="CORE" @frameworkHistory={{frameworkHistory}} /></template>,
+        <template>
+          <FrameworkHistory
+            @frameworkKey="CORE"
+            @frameworkHistory={{frameworkHistory}}
+            @showCreationVersionButton={{true}}
+          />
+        </template>,
       );
 
-      // when
-      await click(screen.getAllByRole('button', { name: deleteButtonName })[0]);
-      await click(screen.getByText('Confirmer la suppression'));
+      const [, row1, row2, row3] = await screen.getAllByRole('row');
 
-      // then
-      assert.strictEqual(screen.getAllByRole('row').length, 3);
-      assert.dom(screen.queryByRole('cell', { name: `${archivedFrameworkItem.id}` })).doesNotExist();
+      const draftDeleteButton = within(row1).getByRole('button', { name: deleteButtonName });
+      const activeDeleteButton = within(row2).getByRole('button', { name: deleteButtonName });
+      const archivedDeleteButton = within(row3).getByRole('button', { name: deleteButtonName });
+
+      assert.dom(draftDeleteButton).doesNotHaveAttribute('aria-disabled');
+      assert.dom(activeDeleteButton).hasAttribute('aria-disabled');
+      assert.dom(archivedDeleteButton).hasAttribute('aria-disabled');
+
+      await click(draftDeleteButton);
+      await click(screen.getByText('Confirmer la suppression'));
     });
 
     module('when deletion is a success', function () {
@@ -215,6 +226,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
         sinon.stub(pixToast, 'sendSuccessNotification');
         const certificationVersion = store.createRecord('certification-version', { id: archivedFrameworkItem.id });
         sinon.stub(store, 'findRecord').resolves(certificationVersion);
+        sinon.stub(store, 'queryRecord').resolves();
         sinon.stub(certificationVersion, 'destroyRecord').resolves();
         const frameworkHistory = store.createRecord('framework-history', {
           history: [draftFrameworkItem, activeFrameworkItem, archivedFrameworkItem],
@@ -242,6 +254,7 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
 
         const certificationVersion = store.createRecord('certification-version', { id: archivedFrameworkItem.id });
         sinon.stub(store, 'findRecord').resolves(certificationVersion);
+        sinon.stub(store, 'queryRecord').rejects();
         sinon.stub(certificationVersion, 'destroyRecord').rejects();
 
         const screen = await render(

--- a/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
@@ -1,5 +1,6 @@
 import { render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
 import Header from 'pix-admin/components/certification-frameworks/item/header';
 import { module, test } from 'qunit';
 
@@ -24,7 +25,11 @@ module('Integration | Component | certification-frameworks/item/header', functio
     currentUser.adminMember = { isSuperAdmin: false };
     const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
     // when
-    const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
+    const screen = await render(
+      <template>
+        <Header @certificationFramework={{certificationFramework}} @showCreationVersionButton={{true}} />
+      </template>,
+    );
 
     // then
     const nav = screen.getByRole('navigation');
@@ -32,69 +37,102 @@ module('Integration | Component | certification-frameworks/item/header', functio
     assert.ok(screen.getByRole('heading', { name: t('components.certification-frameworks.labels.DROIT'), level: 1 }));
   });
 
-  module('#canCreateVersion', function () {
-    test('it should display the create button when user is super admin and framework is not CLEA', async function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isSuperAdmin: true };
-      const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
+  test('it should display create button when there is no draft version', async function (assert) {
+    const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
 
-      // when
-      const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
+    const frameworkHistory = store.createRecord('framework-history', { history: [] });
 
-      // then
-      assert.dom(screen.getByText(t('components.certification-frameworks.item.frameworks.create-button'))).exists();
+    // when
+    const screen = await render(
+      <template>
+        <Header
+          @certificationFramework={{certificationFramework}}
+          @frameworkHistory={{frameworkHistory}}
+          @showCreationVersionButton={{true}}
+        />
+      </template>,
+    );
+
+    const button = screen.getByText(t('components.certification-frameworks.item.frameworks.create-button'));
+    // then
+    assert.strictEqual(button.getAttribute('aria-disabled'), 'false');
+  });
+
+  test('it should hide create button when showCreationVersionButton is false', async function (assert) {
+    const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
+
+    const frameworkHistory = store.createRecord('framework-history', { history: [] });
+
+    // when
+    const screen = await render(
+      <template>
+        <Header
+          @certificationFramework={{certificationFramework}}
+          @frameworkHistory={{frameworkHistory}}
+          @showCreationVersionButton={{false}}
+        />
+      </template>,
+    );
+
+    // then
+    assert
+      .dom(screen.queryByText(t('components.certification-frameworks.item.frameworks.create-button')))
+      .doesNotExist();
+  });
+
+  test('it should disable the create button when there is a draft version', async function (assert) {
+    // given
+    this.owner.lookup('service:router');
+    const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
+
+    const frameworkItem1 = {
+      id: 456,
+      startDate: new Date('2023-10-10'),
+      expirationDate: null,
+      assessmentDuration: 90,
+      maximumAssessmentLength: 32,
+      status: 'ACTIVE',
+    };
+
+    const frameworkItem2 = {
+      id: 123,
+      startDate: new Date('2020-01-01'),
+      expirationDate: new Date('2021-06-15'),
+      assessmentDuration: 105,
+      maximumAssessmentLength: 32,
+      status: 'ARCHIVED',
+    };
+    const frameworkItem3 = {
+      id: 999,
+      startDate: null,
+      expirationDate: null,
+      assessmentDuration: 90,
+      maximumAssessmentLength: 32,
+      status: 'DRAFT',
+    };
+
+    const frameworkHistory = store.createRecord('framework-history', {
+      history: [frameworkItem1, frameworkItem2, frameworkItem3],
     });
 
-    test('it should not display the create button when user is not super admin', async function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isSuperAdmin: false };
-      const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
+    // when
+    const screen = await render(
+      <template>
+        <Header
+          @certificationFramework={{certificationFramework}}
+          @frameworkHistory={{frameworkHistory}}
+          @showCreationVersionButton={{true}}
+        />
+      </template>,
+    );
 
-      // when
-      const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
+    const button = screen.getByText(t('components.certification-frameworks.item.frameworks.create-button'));
+    // then
+    assert.strictEqual(button.getAttribute('aria-disabled'), 'true');
 
-      // then
-      assert
-        .dom(screen.queryByText(t('components.certification-frameworks.item.frameworks.create-button')))
-        .doesNotExist();
-    });
-
-    test('it should not display the create button for CLEA even if user is super admin', async function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isSuperAdmin: true };
-      const cleaFramework = store.createRecord('certification-framework', { id: 'CLEA', name: 'CLEA' });
-
-      // when
-      const screen = await render(<template><Header @certificationFramework={{cleaFramework}} /></template>);
-
-      // then
-      assert
-        .dom(screen.queryByText(t('components.certification-frameworks.item.frameworks.create-button')))
-        .doesNotExist();
-    });
-
-    test('it should not display the create button on new version page', async function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isSuperAdmin: true };
-      const serviceRouter = this.owner.lookup('service:router');
-      serviceRouter.currentRouteName = 'authenticated.certification-frameworks.item.frameworks.new';
-      const certificationFramework = store.createRecord('certification-framework', { id: 'DROIT', name: 'DROIT' });
-
-      // when
-      const screen = await render(<template><Header @certificationFramework={{certificationFramework}} /></template>);
-
-      // then
-      assert
-        .dom(
-          screen.queryByRole('button', {
-            name: t('components.certification-frameworks.item.frameworks.create-button'),
-          }),
-        )
-        .doesNotExist();
-    });
+    await triggerEvent(button, 'mouseenter');
+    assert
+      .dom(screen.getByText(t('components.certification-frameworks.item.frameworks.create-button-cancel-tooltip')))
+      .exists();
   });
 });

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -112,6 +112,18 @@ export default function routes() {
     return certificationVersion.update(params.data.attributes);
   });
 
+  this.delete('/admin/certification-versions/:id', (schema, request) => {
+    const certificationVersions = schema.certificationVersions.all();
+    const certificationVersionToDelete = certificationVersions.filter((version) => version.id === request.params.id);
+    certificationVersionToDelete.destroy();
+
+    const frameworkHistory = schema.frameworkHistories.first();
+
+    frameworkHistory.update({
+      history: frameworkHistory.attrs.history.filter((version) => version.id !== Number(request.params.id)),
+    });
+  });
+
   this.get('/admin/certification-frameworks', (schema) => {
     return schema.certificationFrameworks.all();
   });

--- a/admin/tests/unit/models/framework-history-test.js
+++ b/admin/tests/unit/models/framework-history-test.js
@@ -1,0 +1,79 @@
+import { setupTest } from 'ember-qunit';
+import setupIntl from 'pix-admin/tests/helpers/setup-intl';
+import { module, test } from 'qunit';
+
+module('Unit | Model | framework-history', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  let store;
+
+  hooks.beforeEach(async function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('#hasDraft', function () {
+    test('it should return true when there is a draft version', function (assert) {
+      // given
+      store.createRecord('certification-version', { id: 12, status: 'DRAFT' });
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [
+          {
+            id: 12,
+            status: 'DRAFT',
+          },
+        ],
+      });
+
+      assert.true(frameworkHistory.hasDraft);
+    });
+    test('it should return false when there is no draft version', function (assert) {
+      // given
+      store.createRecord('certification-version', { id: 13, status: 'ACTIVE' });
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [
+          {
+            id: 13,
+            status: 'ACTIVE',
+          },
+        ],
+      });
+
+      assert.false(frameworkHistory.hasDraft);
+    });
+  });
+
+  module('#activeHistory', function () {
+    test('it should return the activeHistory when there is an active version', function (assert) {
+      // given
+      store.createRecord('certification-version', { id: 12, status: 'ACTIVE' });
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [
+          {
+            id: 12,
+            status: 'ACTIVE',
+          },
+        ],
+      });
+
+      assert.deepEqual(frameworkHistory.activeHistory, {
+        id: 12,
+        status: 'ACTIVE',
+      });
+    });
+    test('it should return null when there is an active version', function (assert) {
+      // given
+      store.createRecord('certification-version', { id: 13, status: 'DRAFT' });
+      const frameworkHistory = store.createRecord('framework-history', {
+        history: [
+          {
+            id: 13,
+            status: 'DRAFT',
+          },
+        ],
+      });
+
+      assert.strictEqual(frameworkHistory.activeHistory, null);
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -496,6 +496,7 @@
         "certification-framework": "Certification framework",
         "frameworks": {
           "create-button": "Create a new version of the certification framework",
+          "create-button-cancel-tooltip": "It is not possible to create a new version for this scope as a draft version already exists",
           "details": {
             "title": "Current certification framework details"
           },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -503,6 +503,7 @@
         "certification-framework": "Référentiel de certification",
         "frameworks": {
           "create-button": "Créer une nouvelle version du référentiel",
+          "create-button-cancel-tooltip": "Il est impossible de créer une nouvelle version pour ce scope car une version en cours d'édition existe déjà.",
           "details": {
             "empty-current-framework": "Le référentiel de certification actuel est vide.",
             "title": "Détails du référentiel de certification actuel"


### PR DESCRIPTION
## 🪧 Problème

Notre règle métier est que l'on de peut pas créer de nouvelle version si un brouillon est déjà en cours.

## 🌈 Proposition

Faire un blocage sur le boutton de cration

## ✊ Remarques

ras

## 🎉 Pour tester

Créer une version dans un scope puis voir que le boutton de création d'une version est bien disabled.

Lorsque l'on supprime la version draft le boutton doit se mettre à jour
