### PR TITLE
[TECH] :recycle: Exploration d'une règle pour forcer la forme de déclaration de function (pix-23385)

### DIFF
--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -79,6 +79,12 @@ export default defineConfig([
       ...i18nJsonPlugin.configs.recommended.rules,
     },
   },
+  {
+    files: ['src/certification/configuration/**/*.{js,mjs}'],
+    rules: {
+      'func-style': ['error', 'declaration'],
+    },
+  },
   // Ignored files
   globalIgnores(['tests/integration/tooling/db-schemalint.cjs']),
 ]);

--- a/api/src/certification/configuration/application/attach-target-profile-controller.js
+++ b/api/src/certification/configuration/application/attach-target-profile-controller.js
@@ -1,7 +1,7 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as complementaryCertificationBadgeSerializer from '../infrastructure/serializers/complementary-certification-badge-serializer.js';
 
-const attachTargetProfile = async function (request, h, dependencies = { complementaryCertificationBadgeSerializer }) {
+async function attachTargetProfile(request, h, dependencies = { complementaryCertificationBadgeSerializer }) {
   const { userId } = request.auth.credentials;
   const { complementaryCertificationId } = request.params;
   const { targetProfileId, notifyOrganizations, complementaryCertificationBadges } =
@@ -25,9 +25,8 @@ const attachTargetProfile = async function (request, h, dependencies = { complem
   }
 
   return h.response().code(204);
-};
+}
 
-const attachTargetProfileController = {
+export const attachTargetProfileController = {
   attachTargetProfile,
 };
-export { attachTargetProfileController };

--- a/api/src/certification/configuration/application/attach-target-profile-route.js
+++ b/api/src/certification/configuration/application/attach-target-profile-route.js
@@ -5,7 +5,7 @@ import { identifiersType } from '../../../shared/domain/types/identifiers-type.j
 import { erreurDoc } from '../../../shared/infrastructure/open-api-doc/pole-emploi/erreur-doc.js';
 import { attachTargetProfileController } from './attach-target-profile-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'PUT',
@@ -74,6 +74,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const attachTargetProfileRoute = { name: 'certification/configuration/attach-target-profile-api', register };

--- a/api/src/certification/configuration/application/certification-framework-controller.js
+++ b/api/src/certification/configuration/application/certification-framework-controller.js
@@ -2,12 +2,12 @@ import { usecases } from '../domain/usecases/index.js';
 import * as certificationFrameworkSerializer from '../infrastructure/serializers/certification-framework-serializer.js';
 import * as frameworkHistorySerializer from '../infrastructure/serializers/framework-history-serializer.js';
 
-const findCertificationFrameworks = async function () {
+async function findCertificationFrameworks() {
   const frameworks = await usecases.findCertificationFrameworks();
   return certificationFrameworkSerializer.serialize(frameworks);
-};
+}
 
-const getFrameworkHistory = async function (request) {
+async function getFrameworkHistory(request) {
   const framework = request.params.framework;
 
   const frameworkHistory = await usecases.getFrameworkHistory({
@@ -15,20 +15,18 @@ const getFrameworkHistory = async function (request) {
   });
 
   return frameworkHistorySerializer.serialize({ scope: framework, frameworkHistory });
-};
+}
 
-const getTargetProfileHistory = async function (request) {
+async function getTargetProfileHistory(request) {
   const framework = request.params.framework;
   const certificationFramework = await usecases.getComplementaryCertificationTargetProfileHistory({
     complementaryCertificationKey: framework,
   });
   return certificationFrameworkSerializer.serializeWithTargetProfilesHistory(certificationFramework);
-};
+}
 
-const certificationFrameworkController = {
+export const certificationFrameworkController = {
   findCertificationFrameworks,
   getFrameworkHistory,
   getTargetProfileHistory,
 };
-
-export { certificationFrameworkController };

--- a/api/src/certification/configuration/application/certification-framework-route.js
+++ b/api/src/certification/configuration/application/certification-framework-route.js
@@ -4,7 +4,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { Frameworks } from '../../shared/domain/models/Frameworks.js';
 import { certificationFrameworkController } from './certification-framework-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -93,7 +93,7 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const certificationFrameworkRoute = {
   name: 'certification/configuration/certification-frameworks-api',

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -8,7 +8,7 @@ import { certificationVersionController } from './certification-version-controll
 
 const Joi = BaseJoi.extend(JoiDate);
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -145,6 +145,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const certificationVersionRoute = { name: 'certification/configuration/certification-versions-api', register };

--- a/api/src/certification/configuration/application/complementary-certification-controller.js
+++ b/api/src/certification/configuration/application/complementary-certification-controller.js
@@ -2,28 +2,27 @@ import { usecases } from '../domain/usecases/index.js';
 import * as attachableTargetProfilesSerializer from '../infrastructure/serializers/attachable-target-profiles-serializer.js';
 import * as complementaryCertificationSerializer from '../infrastructure/serializers/complementary-certification-serializer.js';
 
-const findComplementaryCertifications = async function () {
+async function findComplementaryCertifications() {
   const complementaryCertifications = await usecases.findComplementaryCertifications();
   return complementaryCertificationSerializer.serialize(complementaryCertifications);
-};
+}
 
-const searchAttachableTargetProfilesForComplementaryCertifications = async function (request) {
+async function searchAttachableTargetProfilesForComplementaryCertifications(request) {
   const searchTerm = request.query.searchTerm;
   const attachableTargetProfiles = await usecases.searchAttachableTargetProfiles({ searchTerm });
   return attachableTargetProfilesSerializer.serialize(attachableTargetProfiles);
-};
+}
 
-const getComplementaryCertificationTargetProfileHistory = async function (request) {
+async function getComplementaryCertificationTargetProfileHistory(request) {
   const complementaryCertificationKey = request.params.complementaryCertificationKey;
   const complementaryCertification = await usecases.getComplementaryCertificationTargetProfileHistory({
     complementaryCertificationKey,
   });
   return complementaryCertificationSerializer.serializeForAdmin(complementaryCertification);
-};
+}
 
-const complementaryCertificationController = {
+export const complementaryCertificationController = {
   findComplementaryCertifications,
   getComplementaryCertificationTargetProfileHistory,
   searchAttachableTargetProfilesForComplementaryCertifications,
 };
-export { complementaryCertificationController };

--- a/api/src/certification/configuration/application/complementary-certification-route.js
+++ b/api/src/certification/configuration/application/complementary-certification-route.js
@@ -7,7 +7,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { ComplementaryCertificationKeys } from '../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { complementaryCertificationController } from './complementary-certification-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -91,7 +91,7 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const complementaryCertificationRoute = {
   name: 'certification/configuration/complementary-certifications-api',

--- a/api/src/certification/configuration/application/sco-blocked-access-dates-controller.js
+++ b/api/src/certification/configuration/application/sco-blocked-access-dates-controller.js
@@ -8,19 +8,19 @@ import { serialize } from '../infrastructure/serializers/sco-blocked-access-date
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-const updateScoBlockedAccessDate = async function (request, h) {
+async function updateScoBlockedAccessDate(request, h) {
   const scoOrganizationTagName = request.params.key;
   const dateString = request.payload.data.attributes.value;
   const reopeningDate = dayjs.tz(dateString, 'Europe/Paris').toDate();
   await usecases.updateScoBlockedAccessDate({ scoOrganizationTagName, reopeningDate });
   return h.response().code(200);
-};
+}
 
-const getScoBlockedAccessDates = async function (request, h) {
+async function getScoBlockedAccessDates(request, h) {
   const scoBlockedAccessDates = await usecases.getScoBlockedAccessDates();
 
   return h.response(await serialize(scoBlockedAccessDates)).code(200);
-};
+}
 
 export const scoBlockedAccessDatesController = {
   updateScoBlockedAccessDate,

--- a/api/src/certification/configuration/application/sco-blocked-access-dates-route.js
+++ b/api/src/certification/configuration/application/sco-blocked-access-dates-route.js
@@ -7,7 +7,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { ScoOrganizationTagName } from '../domain/models/ScoOrganizationTagName.js';
 import { scoBlockedAccessDatesController } from './sco-blocked-access-dates-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'PATCH',
@@ -64,7 +64,7 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const scoBlockedAccessDatesRoute = {
   name: 'certification/configuration/sco-blocked-access-dates-api',

--- a/api/src/certification/configuration/application/sco-whitelist-controller.js
+++ b/api/src/certification/configuration/application/sco-whitelist-controller.js
@@ -2,13 +2,13 @@ import { usecases } from '../domain/usecases/index.js';
 import { extractExternalIds } from '../infrastructure/serializers/csv/sco-whitelist-csv-parser.js';
 import { serialize } from '../infrastructure/serializers/csv/sco-whitelist-csv-serializer.js';
 
-const importScoWhitelist = async function (request, h, dependencies = { extractExternalIds }) {
+async function importScoWhitelist(request, h, dependencies = { extractExternalIds }) {
   const externalIds = await dependencies.extractExternalIds(request.payload.path);
   await usecases.importScoWhitelist({ externalIds });
   return h.response().created();
-};
+}
 
-const exportScoWhitelist = async function (request, h) {
+async function exportScoWhitelist(request, h) {
   const whitelist = await usecases.exportScoWhitelist();
 
   return h
@@ -16,7 +16,7 @@ const exportScoWhitelist = async function (request, h) {
     .header('Content-Type', 'text/csv; charset=utf-8')
     .header('content-disposition', 'filename=sco-whitelist')
     .code(200);
-};
+}
 
 export const scoWhitelistController = {
   importScoWhitelist,

--- a/api/src/certification/configuration/application/sco-whitelist-route.js
+++ b/api/src/certification/configuration/application/sco-whitelist-route.js
@@ -3,7 +3,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { MAX_FILE_SIZE_UPLOAD } from '../../../shared/domain/constants.js';
 import { scoWhitelistController } from './sco-whitelist-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'POST',
@@ -58,6 +58,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const scoWhitelistRoute = { name: 'certification/configuration/sco-whitelist-api', register };

--- a/api/src/certification/configuration/domain/services/get-version-number.js
+++ b/api/src/certification/configuration/domain/services/get-version-number.js
@@ -1,5 +1,4 @@
 export function getVersionNumber(date = new Date()) {
-  const pad = (n) => String(n).padStart(2, '0');
   return (
     date.getUTCFullYear().toString() +
     pad(date.getUTCMonth() + 1) +
@@ -8,4 +7,8 @@ export function getVersionNumber(date = new Date()) {
     pad(date.getUTCMinutes()) +
     pad(date.getSeconds())
   );
+}
+
+function pad(n) {
+  return String(n).padStart(2, '0');
 }

--- a/api/src/certification/configuration/domain/usecases/attach-badges.js
+++ b/api/src/certification/configuration/domain/usecases/attach-badges.js
@@ -17,7 +17,7 @@ import { BadgeToAttach } from '../models/BadgeToAttach.js';
  * @param {Array<ComplementaryCertificationBadge>} params.complementaryCertificationBadgesToAttachDTO
  * @param {ComplementaryCertificationBadgesRepository} params.complementaryCertificationBadgesRepository
  */
-const attachBadges = async function ({
+export async function attachBadges({
   complementaryCertification,
   userId,
   targetProfileIdToDetach,
@@ -66,9 +66,7 @@ const attachBadges = async function ({
       complementaryCertificationBadges,
     });
   });
-};
-
-export { attachBadges };
+}
 
 function _isRequiredInformationMissing(complementaryCertificationBadgesToAttachDTO) {
   return complementaryCertificationBadgesToAttachDTO.some(

--- a/api/src/certification/configuration/domain/usecases/export-sco-whitelist.js
+++ b/api/src/certification/configuration/domain/usecases/export-sco-whitelist.js
@@ -8,6 +8,6 @@
  * @param {CenterRepository} params.centerRepository
  * @returns {Promise<Array<Center>>}
  */
-export const exportScoWhitelist = async ({ centerRepository }) => {
+export async function exportScoWhitelist({ centerRepository }) {
   return centerRepository.getWhitelist();
-};
+}

--- a/api/src/certification/configuration/domain/usecases/find-certification-frameworks.js
+++ b/api/src/certification/configuration/domain/usecases/find-certification-frameworks.js
@@ -5,7 +5,7 @@ import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
  * @param {VersionRepository} params.versionRepository
  * @returns {Promise<Array<{id: string, name: string, versionStartDate: Date|null}>>}
  */
-const findCertificationFrameworks = async function ({ versionRepository }) {
+export async function findCertificationFrameworks({ versionRepository }) {
   const frameworksWithVersions = [];
   for (const framework of Object.values(Frameworks)) {
     if (framework === Frameworks.CLEA) {
@@ -28,6 +28,4 @@ const findCertificationFrameworks = async function ({ versionRepository }) {
   }
 
   return frameworksWithVersions;
-};
-
-export { findCertificationFrameworks };
+}

--- a/api/src/certification/configuration/domain/usecases/find-complementary-certifications.js
+++ b/api/src/certification/configuration/domain/usecases/find-complementary-certifications.js
@@ -6,8 +6,6 @@
  * @param {object} params
  * @param {ComplementaryCertificationRepository} params.complementaryCertificationRepository
  */
-const findComplementaryCertifications = function ({ complementaryCertificationRepository }) {
+export function findComplementaryCertifications({ complementaryCertificationRepository }) {
   return complementaryCertificationRepository.findAll();
-};
-
-export { findComplementaryCertifications };
+}

--- a/api/src/certification/configuration/domain/usecases/get-complementary-certification-for-target-profile-attachment.js
+++ b/api/src/certification/configuration/domain/usecases/get-complementary-certification-for-target-profile-attachment.js
@@ -1,10 +1,8 @@
-const getComplementaryCertificationForTargetProfileAttachmentRepository = async function ({
+export async function getComplementaryCertificationForTargetProfileAttachmentRepository({
   complementaryCertificationId,
   complementaryCertificationForTargetProfileAttachmentRepository,
 }) {
   return complementaryCertificationForTargetProfileAttachmentRepository.getById({
     complementaryCertificationId,
   });
-};
-
-export { getComplementaryCertificationForTargetProfileAttachmentRepository };
+}

--- a/api/src/certification/configuration/domain/usecases/get-complementary-certification-target-profile-history.js
+++ b/api/src/certification/configuration/domain/usecases/get-complementary-certification-target-profile-history.js
@@ -12,7 +12,7 @@ import { ComplementaryCertificationTargetProfileHistory } from '../models/Comple
  *
  * @returns {Promise<ComplementaryCertificationTargetProfileHistory>} all target profiles than were applicable for this complementary certification
  */
-const getComplementaryCertificationTargetProfileHistory = async function ({
+export async function getComplementaryCertificationTargetProfileHistory({
   complementaryCertificationKey,
   targetProfileHistoryRepository,
   complementaryCertificationForTargetProfileAttachmentRepository,
@@ -40,6 +40,4 @@ const getComplementaryCertificationTargetProfileHistory = async function ({
       ...detachedTargetProfileHistoryByComplementaryCertification,
     ],
   });
-};
-
-export { getComplementaryCertificationTargetProfileHistory };
+}

--- a/api/src/certification/configuration/domain/usecases/get-sco-blocked-access-dates.js
+++ b/api/src/certification/configuration/domain/usecases/get-sco-blocked-access-dates.js
@@ -7,7 +7,6 @@
  * @param {ScoBlockedAccessDatesRepository} paramsScoBlockedAccessDatesRepository
  * @returns {Promise<Array<ScoBlockedAccessDate>>}
  */
-
-export const getScoBlockedAccessDates = async ({ ScoBlockedAccessDatesRepository }) => {
+export async function getScoBlockedAccessDates({ ScoBlockedAccessDatesRepository }) {
   return ScoBlockedAccessDatesRepository.getScoBlockedAccessDates();
-};
+}

--- a/api/src/certification/configuration/domain/usecases/get-version-by-id.js
+++ b/api/src/certification/configuration/domain/usecases/get-version-by-id.js
@@ -14,12 +14,12 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
  * @param {LearningContentRepository} params.learningContentRepository
  * @param {VersionRepository} params.versionRepository
  */
-export const getVersionById = async ({
+export async function getVersionById({
   id,
   frameworkChallengesRepository,
   learningContentRepository,
   versionRepository,
-}) => {
+}) {
   const version = await versionRepository.getById({ id });
 
   if (!version) {
@@ -38,4 +38,4 @@ export const getVersionById = async ({
     version,
     areas: frameworkAreas,
   };
-};
+}

--- a/api/src/certification/configuration/domain/usecases/import-sco-whitelist.js
+++ b/api/src/certification/configuration/domain/usecases/import-sco-whitelist.js
@@ -26,7 +26,7 @@ export const importScoWhitelist = withTransaction(
   },
 );
 
-const _getCSVLineNumbersWithError = ({ externalIds, updatedExternalIds }) => {
+function _getCSVLineNumbersWithError({ externalIds, updatedExternalIds }) {
   const uniqueExternalIds = [...new Set(externalIds)];
   const externalIdsOnError = uniqueExternalIds.filter((externalId) => {
     return !updatedExternalIds.includes(externalId);
@@ -49,4 +49,4 @@ const _getCSVLineNumbersWithError = ({ externalIds, updatedExternalIds }) => {
   }
 
   return [];
-};
+}

--- a/api/src/certification/configuration/domain/usecases/search-attachable-target-profiles.js
+++ b/api/src/certification/configuration/domain/usecases/search-attachable-target-profiles.js
@@ -8,8 +8,6 @@
  * @param {string} [params.searchTerm]
  * @param {AttachableTargetProfileRepository} params.attachableTargetProfileRepository
  */
-const searchAttachableTargetProfiles = async function ({ searchTerm, attachableTargetProfileRepository }) {
+export async function searchAttachableTargetProfiles({ searchTerm, attachableTargetProfileRepository }) {
   return attachableTargetProfileRepository.find({ searchTerm });
-};
-
-export { searchAttachableTargetProfiles };
+}

--- a/api/src/certification/configuration/domain/usecases/update-version.js
+++ b/api/src/certification/configuration/domain/usecases/update-version.js
@@ -11,7 +11,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
  * @param {string} params.comments
  * @param {VersionRepository} params.versionRepository
  */
-export const updateVersion = async ({ id, comments, versionRepository }) => {
+export async function updateVersion({ id, comments, versionRepository }) {
   const version = await versionRepository.getById({ id });
 
   if (!version) {
@@ -20,4 +20,4 @@ export const updateVersion = async ({ id, comments, versionRepository }) => {
 
   version.update({ comments });
   return versionRepository.update({ version });
-};
+}

--- a/api/src/certification/configuration/infrastructure/repositories/attachable-target-profiles-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/attachable-target-profiles-repository.js
@@ -8,7 +8,7 @@ import { AttachableTargetProfile } from '../../domain/models/AttachableTargetPro
  * @param {string} [params.searchTerm]
  * @returns {Promise<Array<AttachableTargetProfile>>}
  */
-const find = async function ({ searchTerm } = {}) {
+export async function find({ searchTerm } = {}) {
   const knexConn = DomainTransaction.getConnection();
   const targetProfiles = await knexConn('target-profiles')
     .select('target-profiles.id', 'target-profiles.name')
@@ -22,9 +22,7 @@ const find = async function ({ searchTerm } = {}) {
     .orderBy('target-profiles.id', 'DESC');
 
   return _toDomain(targetProfiles);
-};
-
-export { find };
+}
 
 function _searchByCriteria({ builder, searchTerm }) {
   if (!isBlank(searchTerm)) {

--- a/api/src/certification/configuration/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/center-repository.js
@@ -8,7 +8,7 @@ import { CenterTypes } from '../../domain/models/CenterTypes.js';
  * @param {Array<string>} params.externalIds
  * @returns {Promise<Array<number>>} - number of rows affected
  */
-export const addToWhitelistByExternalIds = async ({ externalIds }) => {
+export async function addToWhitelistByExternalIds({ externalIds }) {
   const knexConn = DomainTransaction.getConnection();
   const updatedLines = await knexConn('certification-centers')
     .update({
@@ -24,29 +24,29 @@ export const addToWhitelistByExternalIds = async ({ externalIds }) => {
 
   const updatedExternalIds = updatedLines.map((line) => line.externalId);
   return updatedExternalIds;
-};
+}
 
 /**
  * @returns {Promise<number>}
  */
-export const resetWhitelist = async () => {
+export async function resetWhitelist() {
   const knexConn = DomainTransaction.getConnection();
   return knexConn('certification-centers')
     .update({ isScoBlockedAccessWhitelist: false, updatedAt: knexConn.fn.now() })
     .where({ type: CenterTypes.SCO });
-};
+}
 
 /**
  * @returns {Promise<Array<Center>>}
  */
-export const getWhitelist = async () => {
+export async function getWhitelist() {
   const knexConn = DomainTransaction.getConnection();
   const data = await knexConn('certification-centers')
     .select('id', 'type', 'externalId')
     .where({ isScoBlockedAccessWhitelist: true });
 
   return data.map(_toDomain);
-};
+}
 
 /**
  * @param {object} data
@@ -55,6 +55,6 @@ export const getWhitelist = async () => {
  * @param {CenterTypes} data.type
  * @returns {Center}
  */
-const _toDomain = ({ id, externalId, type }) => {
+function _toDomain({ id, externalId, type }) {
   return new Center({ id, externalId, type });
-};
+}

--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js
@@ -6,7 +6,7 @@ function _toDomain(row) {
   return new ComplementaryCertificationForTargetProfileAttachment(row);
 }
 
-const getById = async function ({ complementaryCertificationId }) {
+export async function getById({ complementaryCertificationId }) {
   const knexConn = DomainTransaction.getConnection();
   const complementaryCertification = await knexConn
     .from('complementary-certifications')
@@ -18,7 +18,7 @@ const getById = async function ({ complementaryCertificationId }) {
   }
 
   return _toDomain(complementaryCertification);
-};
+}
 
 /**
  * @function
@@ -28,7 +28,7 @@ const getById = async function ({ complementaryCertificationId }) {
  * @returns {Promise<ComplementaryCertificationForTargetProfileAttachment>}
  * @throws {NotFoundError}
  */
-const getByKey = async function ({ complementaryCertificationKey }) {
+export async function getByKey({ complementaryCertificationKey }) {
   const knexConn = DomainTransaction.getConnection();
   const complementaryCertification = await knexConn
     .from('complementary-certifications')
@@ -40,6 +40,4 @@ const getByKey = async function ({ complementaryCertificationKey }) {
   }
 
   return _toDomain(complementaryCertification);
-};
-
-export { getById, getByKey };
+}

--- a/api/src/certification/configuration/infrastructure/repositories/organization-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/organization-repository.js
@@ -1,6 +1,6 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
-const getOrganizationUserEmailByCampaignTargetProfileId = async function (targetProfileId) {
+export async function getOrganizationUserEmailByCampaignTargetProfileId(targetProfileId) {
   const knexConn = DomainTransaction.getConnection();
 
   return knexConn('campaigns')
@@ -10,6 +10,4 @@ const getOrganizationUserEmailByCampaignTargetProfileId = async function (target
     .where({ targetProfileId })
     .distinct()
     .pluck('users.email');
-};
-
-export { getOrganizationUserEmailByCampaignTargetProfileId };
+}

--- a/api/src/certification/configuration/infrastructure/repositories/sco-blocked-access-dates-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/sco-blocked-access-dates-repository.js
@@ -6,7 +6,7 @@ import { ScoBlockedAccessDate } from '../../domain/models/ScoBlockedAccessDate.j
 /**
  * @returns {Promise<Array<ScoBlockedAccessDate>>}
  */
-export const getScoBlockedAccessDates = async () => {
+export async function getScoBlockedAccessDates() {
   const knexConn = DomainTransaction.getConnection();
   const data = await knexConn('certification_sco_blocked_access_dates').select(
     'scoOrganizationTagName',
@@ -17,13 +17,13 @@ export const getScoBlockedAccessDates = async () => {
   } else {
     throw new NotFoundError(`No ScoBlockedAccessDate found.`);
   }
-};
+}
 
 /**
  * @returns {Promise<ScoBlockedAccessDate>}
  * @throws {NotFoundError} if ScoBlockedAccessDate does not exist
  */
-export const getScoBlockedAccessDateByKey = async (scoOrganizationTagName) => {
+export async function getScoBlockedAccessDateByKey(scoOrganizationTagName) {
   const knexConn = DomainTransaction.getConnection();
   const data = await knexConn('certification_sco_blocked_access_dates')
     .select('scoOrganizationTagName', 'reopeningDate')
@@ -34,19 +34,19 @@ export const getScoBlockedAccessDateByKey = async (scoOrganizationTagName) => {
   } else {
     throw new NotFoundError(`ScoBlockedAccessDate ${scoOrganizationTagName} does not exist.`);
   }
-};
+}
 
 /**
  * @param {object} params
  * @param {ScoBlockedAccessDate} params.scoBlockedAccessDate
  */
-export const updateScoBlockedAccessDate = async (scoBlockedAccessDate) => {
+export async function updateScoBlockedAccessDate(scoBlockedAccessDate) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('certification_sco_blocked_access_dates')
     .update({ reopeningDate: scoBlockedAccessDate.reopeningDate })
     .where({ scoOrganizationTagName: scoBlockedAccessDate.scoOrganizationTagName });
-};
+}
 
-const _toDomain = ({ scoOrganizationTagName, reopeningDate }) => {
+function _toDomain({ scoOrganizationTagName, reopeningDate }) {
   return new ScoBlockedAccessDate({ scoOrganizationTagName, reopeningDate });
-};
+}

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -115,7 +115,7 @@ export async function deleteVersion(id) {
   await knexConn('certification_versions').where({ id }).del();
 }
 
-const _toFrameworkHistoryEntry = ({ id, startDate, expirationDate, assessmentDuration, challengesConfiguration }) => {
+function _toFrameworkHistoryEntry({ id, startDate, expirationDate, assessmentDuration, challengesConfiguration }) {
   return new FrameworkHistoryEntry({
     id,
     startDate,
@@ -123,9 +123,9 @@ const _toFrameworkHistoryEntry = ({ id, startDate, expirationDate, assessmentDur
     assessmentDuration,
     maximumAssessmentLength: challengesConfiguration.maximumAssessmentLength,
   });
-};
+}
 
-const _toDomain = ({
+function _toDomain({
   id,
   scope,
   startDate,
@@ -136,7 +136,7 @@ const _toDomain = ({
   competencesScoringConfiguration,
   challengesConfiguration,
   comments,
-}) => {
+}) {
   return new Version({
     id,
     scope,
@@ -157,4 +157,4 @@ const _toDomain = ({
       defaultProbabilityToPickChallenge: challengesConfiguration.defaultProbabilityToPickChallenge,
     }),
   });
-};
+}

--- a/api/src/certification/configuration/infrastructure/serializers/attachable-target-profiles-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/attachable-target-profiles-serializer.js
@@ -2,10 +2,8 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function (targetProfiles) {
+export function serialize(targetProfiles) {
   return new Serializer('attachable-target-profile', {
     attributes: ['name'],
   }).serialize(targetProfiles);
-};
-
-export { serialize };
+}

--- a/api/src/certification/configuration/infrastructure/serializers/certification-version-detail-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/certification-version-detail-serializer.js
@@ -2,7 +2,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-export const serialize = ({ version, areas }) => {
+export function serialize({ version, areas }) {
   const data = {
     id: version.id,
     startDate: version.startDate,
@@ -50,4 +50,4 @@ export const serialize = ({ version, areas }) => {
       },
     },
   }).serialize(data);
-};
+}

--- a/api/src/certification/configuration/infrastructure/serializers/complementary-certification-badge-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/complementary-certification-badge-serializer.js
@@ -5,7 +5,7 @@ import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-ut
 
 const { Deserializer } = jsonapiSerializer;
 
-const deserialize = async function (json) {
+export async function deserialize(json) {
   const deserialize = new Deserializer({ keyForAttribute: 'camelCase' });
 
   const deserializedComplementaryCertification = await deserialize.deserialize(json);
@@ -21,6 +21,4 @@ const deserialize = async function (json) {
   );
 
   return deserializedComplementaryCertification;
-};
-
-export { deserialize };
+}

--- a/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-parser.js
+++ b/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-parser.js
@@ -7,7 +7,7 @@ import { getDataBuffer } from '../../../../../shared/infrastructure/utils/buffer
 import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 import { ScoWhitelistCsvHeader } from './sco-whitelist-csv-header.js';
 
-export const extractExternalIds = async (file) => {
+export async function extractExternalIds(file) {
   const stream = createReadStream(file);
   const buffer = await getDataBuffer(stream);
   try {
@@ -18,10 +18,10 @@ export const extractExternalIds = async (file) => {
   } finally {
     fs.unlink(file);
   }
-};
+}
 
-const _extractIds = (buffer) => {
+function _extractIds(buffer) {
   const columns = new ScoWhitelistCsvHeader();
   const campaignIdsCsv = new CsvParser(buffer, columns);
   return campaignIdsCsv.parse();
-};
+}

--- a/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-serializer.js
@@ -5,6 +5,6 @@ import { getCsvContent } from '../../../../../shared/infrastructure/utils/csv/wr
  * @param {Array<Center>} params.centers
  * @returns {Promise<string>}
  */
-export const serialize = async ({ centers }) => {
+export async function serialize({ centers }) {
   return getCsvContent({ data: centers, fileHeaders: [{ label: 'externalId', value: 'externalId' }] });
-};
+}

--- a/api/src/certification/configuration/infrastructure/serializers/framework-history-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/framework-history-serializer.js
@@ -2,11 +2,9 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function ({ scope, frameworkHistory }) {
+export function serialize({ scope, frameworkHistory }) {
   return new Serializer('framework-history', {
     id: 'scope',
     attributes: ['scope', 'history'],
   }).serialize({ scope, history: frameworkHistory });
-};
-
-export { serialize };
+}

--- a/api/src/certification/configuration/infrastructure/serializers/sco-blocked-access-dates-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/sco-blocked-access-dates-serializer.js
@@ -2,7 +2,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-export const serialize = function (scoBlockedAccessDate) {
+export function serialize(scoBlockedAccessDate) {
   return new Serializer('sco-blocked-access-dates', {
     attributes: ['reopeningDate'],
     transform: (record) => {
@@ -12,4 +12,4 @@ export const serialize = function (scoBlockedAccessDate) {
       };
     },
   }).serialize(scoBlockedAccessDate);
-};
+}


### PR DESCRIPTION
## 🪧 Problème

Nous avons des déclarations de fonctions et d'export très disparate. C'est gênant pour la lecture (perte de temps lié à une forme de contexte switching)


## 🌈 Proposition

Ajouter une règle eslint pour forcer à déclarer les fonctions d'une certaine manières (et les exports aussi)

## ✊ Remarques

Pour éviter l'énorme PR, je suis parti d'un sous contexte de certification uniquement : `src/certification/configuration`. L'idée sera d'élargir au fur et à mesure.

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
