### PR TITLE
[FEATURE] Harmoniser les appels à l'api legalDocuments depuis la route api/admin/users/{id} (PIX-23262)

### DIFF
--- a/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
+++ b/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
@@ -60,10 +60,13 @@ class UserDetailsForAdmin {
       : null;
   }
 
-  set tosStatus({ pixAppTosStatus }) {
+  set tosStatus({ pixAppTosStatus, pixOrgaTosStatus }) {
     this.cgu = pixAppTosStatus.status === STATUS.ACCEPTED || pixAppTosStatus.status === STATUS.UPDATE_REQUESTED;
     this.pixAppTermsOfServiceAccepted = pixAppTosStatus.status === STATUS.ACCEPTED;
     this.lastPixAppTermsOfServiceValidatedAt = pixAppTosStatus.acceptedAt;
+
+    this.pixOrgaTermsOfServiceAccepted = pixOrgaTosStatus.status === STATUS.ACCEPTED;
+    this.lastPixOrgaTermsOfServiceValidatedAt = pixOrgaTosStatus.acceptedAt;
   }
 }
 

--- a/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
+++ b/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
@@ -60,7 +60,7 @@ class UserDetailsForAdmin {
       : null;
   }
 
-  set tosStatus({ pixAppTosStatus, pixOrgaTosStatus }) {
+  setTosStatus({ pixAppTosStatus, pixOrgaTosStatus }) {
     this.cgu = pixAppTosStatus.status === STATUS.ACCEPTED || pixAppTosStatus.status === STATUS.UPDATE_REQUESTED;
     this.pixAppTermsOfServiceAccepted = pixAppTosStatus.status === STATUS.ACCEPTED;
     this.lastPixAppTermsOfServiceValidatedAt = pixAppTosStatus.acceptedAt;

--- a/api/src/identity-access-management/domain/usecases/get-user-details-for-admin.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-user-details-for-admin.usecase.js
@@ -10,7 +10,7 @@ const getUserDetailsForAdmin = async function ({ userId, userRepository, legalDo
 
   const pixAppTosStatus = await legalDocumentApiRepository.getPixAppTosStatus({ userId });
   const pixOrgaTosStatus = await legalDocumentApiRepository.getPixOrgaTosStatus({ userId });
-  userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
+  userDetailsForAdmin.setTosStatus({ pixAppTosStatus, pixOrgaTosStatus });
 
   return userDetailsForAdmin;
 };

--- a/api/src/identity-access-management/domain/usecases/get-user-details-for-admin.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-user-details-for-admin.usecase.js
@@ -9,7 +9,8 @@ const getUserDetailsForAdmin = async function ({ userId, userRepository, legalDo
   const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userId);
 
   const pixAppTosStatus = await legalDocumentApiRepository.getPixAppTosStatus({ userId });
-  userDetailsForAdmin.tosStatus = { pixAppTosStatus };
+  const pixOrgaTosStatus = await legalDocumentApiRepository.getPixOrgaTosStatus({ userId });
+  userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
 
   return userDetailsForAdmin;
 };

--- a/api/src/identity-access-management/infrastructure/repositories/legal-document-api.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/legal-document-api.repository.js
@@ -20,6 +20,9 @@ const getPixOrgaTosStatus = async ({ userId, dependencies = { legalDocumentApi }
   });
 };
 
-const legalDocumentApiRepository = { acceptPixAppTos, acceptPixOrgaTos, getPixAppTosStatus, getPixOrgaTosStatus };
-
-export { legalDocumentApiRepository };
+export const legalDocumentApiRepository = {
+  acceptPixAppTos,
+  acceptPixOrgaTos,
+  getPixAppTosStatus,
+  getPixOrgaTosStatus,
+};

--- a/api/src/identity-access-management/infrastructure/repositories/legal-document-api.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/legal-document-api.repository.js
@@ -12,6 +12,14 @@ const getPixAppTosStatus = async ({ userId, dependencies = { legalDocumentApi } 
   return dependencies.legalDocumentApi.getLegalDocumentStatusByUserId({ userId, service: 'pix-app', type: 'TOS' });
 };
 
-const legalDocumentApiRepository = { acceptPixAppTos, acceptPixOrgaTos, getPixAppTosStatus };
+const getPixOrgaTosStatus = async ({ userId, dependencies = { legalDocumentApi } }) => {
+  return dependencies.legalDocumentApi.getLegalDocumentStatusByUserId({
+    userId,
+    service: 'pix-orga',
+    type: 'TOS',
+  });
+};
+
+const legalDocumentApiRepository = { acceptPixAppTos, acceptPixOrgaTos, getPixAppTosStatus, getPixOrgaTosStatus };
 
 export { legalDocumentApiRepository };

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -1,5 +1,4 @@
 import { InvalidOrAlreadyUsedEmailError } from '../../../identity-access-management/domain/errors.js';
-import * as legalDocumentApi from '../../../legal-documents/application/api/legal-documents-api.js';
 import * as organizationFeaturesApi from '../../../organizational-entities/application/api/organization-features-api.js';
 import { Organization } from '../../../organizational-entities/domain/models/Organization.js';
 import { OrganizationLearnerForAdmin } from '../../../prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js';
@@ -120,12 +119,6 @@ const getUserDetailsForAdmin = async function (userId) {
     throw new UserNotFoundError(`User not found for ID ${userId}`);
   }
 
-  const pixOrgaLegalDocumentStatus = await legalDocumentApi.getLegalDocumentStatusByUserId({
-    userId,
-    service: 'pix-orga',
-    type: 'TOS',
-  });
-
   const lastUserApplicationConnectionsDTO = await knexConn('last-user-application-connections').where({ userId });
 
   const authenticationMethodsDTO = await knexConn('authentication-methods')
@@ -161,7 +154,6 @@ const getUserDetailsForAdmin = async function (userId) {
 
   return _fromKnexDTOToUserDetailsForAdmin({
     userDTO,
-    pixOrgaLegalDocumentStatus,
     organizationLearnersDTO,
     authenticationMethodsDTO,
     pixAdminRolesDTO,
@@ -498,7 +490,6 @@ export {
 
 function _fromKnexDTOToUserDetailsForAdmin({
   userDTO,
-  pixOrgaLegalDocumentStatus,
   organizationLearnersDTO,
   authenticationMethodsDTO,
   pixAdminRolesDTO,
@@ -558,11 +549,9 @@ function _fromKnexDTOToUserDetailsForAdmin({
     lastName: userDTO.lastName,
     username: userDTO.username,
     email: userDTO.email,
-    pixOrgaTermsOfServiceAccepted: pixOrgaLegalDocumentStatus.status === 'accepted',
     pixCertifTermsOfServiceAccepted: userDTO.pixCertifTermsOfServiceAccepted,
     lang: userDTO.lang,
     locale: userDTO.locale,
-    lastPixOrgaTermsOfServiceValidatedAt: pixOrgaLegalDocumentStatus.acceptedAt,
     lastPixCertifTermsOfServiceValidatedAt: userDTO.lastPixCertifTermsOfServiceValidatedAt,
     lastLoggedAt: userDTO.lastLoggedAt,
     emailConfirmedAt: userDTO.emailConfirmedAt,

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -9,8 +9,6 @@ import { LastUserApplicationConnection } from '../../../../../src/identity-acces
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { UserDetailsForAdmin } from '../../../../../src/identity-access-management/domain/models/UserDetailsForAdmin.js';
 import * as userRepository from '../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
-import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
-import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import { Organization } from '../../../../../src/organizational-entities/domain/models/Organization.js';
 import { IMPORT_KEY_FIELD } from '../../../../../src/prescription/learner-management/domain/constants.js';
 import { OrganizationLearnerForAdmin } from '../../../../../src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js';
@@ -1106,22 +1104,6 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.factory.buildUserLogin({ userId: userInDB.id, lastLoggedAt });
         await databaseBuilder.commit();
 
-        const { PIX_ORGA } = LegalDocumentService.VALUES;
-        const { TOS } = LegalDocumentType.VALUES;
-
-        const service = PIX_ORGA;
-        const type = TOS;
-
-        const documentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
-          service,
-          type,
-          versionAt: new Date('2024-02-01'),
-        });
-        const documentVersionUserAcceptance = databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
-          userId: userInDB.id,
-          legalDocumentVersionId: documentVersion.id,
-          acceptedAt: new Date('2024-03-01'),
-        });
         await databaseBuilder.commit();
 
         // when
@@ -1137,10 +1119,6 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(userDetailsForAdmin.updatedAt).to.deep.equal(createdAt);
         expect(userDetailsForAdmin.lang).to.equal('en');
         expect(userDetailsForAdmin.locale).to.equal('en');
-        expect(userDetailsForAdmin.pixOrgaTermsOfServiceAccepted).equals(true);
-        expect(userDetailsForAdmin.lastPixOrgaTermsOfServiceValidatedAt).to.deep.equal(
-          documentVersionUserAcceptance.acceptedAt,
-        );
         expect(userDetailsForAdmin.lastPixCertifTermsOfServiceValidatedAt).to.deep.equal(lastLoggedAt);
         expect(userDetailsForAdmin.lastLoggedAt).to.deep.equal(lastLoggedAt);
         expect(userDetailsForAdmin.emailConfirmedAt).to.deep.equal(emailConfirmedAt);

--- a/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
@@ -45,8 +45,8 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
     });
 
     context('terms of service', function () {
-      context('when the user TOS status is ACCEPTED', function () {
-        it('returns the userDetailsForAdmin with accepted Pix App TOS status', async function () {
+      context('when the user TOS statuses are ACCEPTED for pix app and pix orga', function () {
+        it('returns the userDetailsForAdmin with accepted Pix App and Pix Orga TOS status', async function () {
           // given
           const user = domainBuilder.buildUser({
             cgu: false, // irrelevant data to enlighten the fact that values come now from tosStatus
@@ -54,24 +54,36 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
             lastPixAppTermsOfServiceValidatedAt: null,
           });
 
-          const acceptedAt = new Date('2025-01-15');
+          const pixAppTosAcceptedAt = new Date('2025-01-15');
+          const pixOrgaTosAcceptedAt = new Date('2026-01-15');
           const userDetailsForAdmin = new UserDetailsForAdmin({
             userId: user.id,
           });
-          const pixAppTosStatus = { status: STATUS.ACCEPTED, documentPath: '/tos/v2.pdf', acceptedAt: acceptedAt };
+          const pixAppTosStatus = {
+            status: STATUS.ACCEPTED,
+            documentPath: '/tos/v2.pdf',
+            acceptedAt: pixAppTosAcceptedAt,
+          };
+          const pixOrgaTosStatus = {
+            status: STATUS.ACCEPTED,
+            documentPath: '/tos/v4.pdf',
+            acceptedAt: pixOrgaTosAcceptedAt,
+          };
 
           // when
-          userDetailsForAdmin.tosStatus = { pixAppTosStatus };
+          userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
 
           // then
           expect(userDetailsForAdmin.cgu).to.be.true;
-          expect(userDetailsForAdmin.lastPixAppTermsOfServiceValidatedAt).to.deep.equal(acceptedAt);
+          expect(userDetailsForAdmin.lastPixAppTermsOfServiceValidatedAt).to.deep.equal(pixAppTosAcceptedAt);
+          expect(userDetailsForAdmin.lastPixOrgaTermsOfServiceValidatedAt).to.deep.equal(pixOrgaTosAcceptedAt);
           expect(userDetailsForAdmin.pixAppTermsOfServiceAccepted).to.equal(true);
+          expect(userDetailsForAdmin.pixOrgaTermsOfServiceAccepted).to.equal(true);
         });
       });
 
-      context('when the user TOS status is REQUESTED', function () {
-        it('returns the user with not accepted Pix App TOS status', function () {
+      context('when the user TOS statuses are REQUESTED for Pix App and ACCEPTED for Pix Orga', function () {
+        it('returns the user with not accepted Pix App TOS status and accepted Pix Orga TOS status', function () {
           // given
           const user = domainBuilder.buildUser({
             cgu: true, // irrelevant data to enlighten the fact that values come now from tosStatus
@@ -81,10 +93,16 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
           const userDetailsForAdmin = new UserDetailsForAdmin({
             userId: user.id,
           });
+          const pixOrgaTosAcceptedAt = new Date('2026-01-15');
           const pixAppTosStatus = { status: STATUS.REQUESTED, acceptedAt: null };
+          const pixOrgaTosStatus = {
+            status: STATUS.ACCEPTED,
+            documentPath: '/tos/v4.pdf',
+            acceptedAt: pixOrgaTosAcceptedAt,
+          };
 
           // when
-          userDetailsForAdmin.tosStatus = { pixAppTosStatus };
+          userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
 
           // then
           expect(userDetailsForAdmin.cgu).to.be.false;
@@ -93,8 +111,8 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
         });
       });
 
-      context('when the user TOS status is UPDATE-REQUESTED', function () {
-        it('returns the user with update-requested TOS status', function () {
+      context('when the user TOS statuses for Pix App and Pix Orga are UPDATE-REQUESTED', function () {
+        it('returns the user with update-requested Pix Orga and Pix App TOS statuses', function () {
           // given
           const user = domainBuilder.buildUser({
             cgu: false, // irrelevant data to enlighten the fact that values come now from tosStatus
@@ -105,18 +123,21 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
             userId: user.id,
           });
           const pixAppTosStatus = { status: STATUS.UPDATE_REQUESTED, acceptedAt: null };
+          const pixOrgaTosStatus = { status: STATUS.UPDATE_REQUESTED, acceptedAt: null };
 
           // when
-          userDetailsForAdmin.tosStatus = { pixAppTosStatus };
+          userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
 
           // then
           expect(userDetailsForAdmin.cgu).to.be.true;
           expect(userDetailsForAdmin.lastPixAppTermsOfServiceValidatedAt).to.be.null;
+          expect(userDetailsForAdmin.lastPixOrgaTermsOfServiceValidatedAt).to.be.null;
           expect(userDetailsForAdmin.pixAppTermsOfServiceAccepted).to.be.false;
+          expect(userDetailsForAdmin.pixOrgaTermsOfServiceAccepted).to.be.false;
         });
       });
 
-      context('when the user TOS status is NOT-APPLICABLE', function () {
+      context('when the user Pix App TOS status is NOT-APPLICABLE', function () {
         it('returns the user with update-requested TOS status', function () {
           // given
           const user = domainBuilder.buildUser({
@@ -128,9 +149,10 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
             userId: user.id,
           });
           const pixAppTosStatus = { status: STATUS.NOT_APPLICABLE, acceptedAt: null };
+          const pixOrgaTosStatus = { status: STATUS.REQUESTED, acceptedAt: null };
 
           // when
-          userDetailsForAdmin.tosStatus = { pixAppTosStatus };
+          userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
 
           // then
           expect(userDetailsForAdmin.cgu).to.be.false;

--- a/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
@@ -71,7 +71,7 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
           };
 
           // when
-          userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
+          userDetailsForAdmin.setTosStatus({ pixAppTosStatus, pixOrgaTosStatus });
 
           // then
           expect(userDetailsForAdmin.cgu).to.be.true;
@@ -102,7 +102,7 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
           };
 
           // when
-          userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
+          userDetailsForAdmin.setTosStatus({ pixAppTosStatus, pixOrgaTosStatus });
 
           // then
           expect(userDetailsForAdmin.cgu).to.be.false;
@@ -126,7 +126,7 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
           const pixOrgaTosStatus = { status: STATUS.UPDATE_REQUESTED, acceptedAt: null };
 
           // when
-          userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
+          userDetailsForAdmin.setTosStatus({ pixAppTosStatus, pixOrgaTosStatus });
 
           // then
           expect(userDetailsForAdmin.cgu).to.be.true;
@@ -152,7 +152,7 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
           const pixOrgaTosStatus = { status: STATUS.REQUESTED, acceptedAt: null };
 
           // when
-          userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
+          userDetailsForAdmin.setTosStatus({ pixAppTosStatus, pixOrgaTosStatus });
 
           // then
           expect(userDetailsForAdmin.cgu).to.be.false;

--- a/api/tests/identity-access-management/unit/infrastructure/repositories/legal-document-api.repository.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/repositories/legal-document-api.repository.test.js
@@ -26,6 +26,30 @@ describe('Unit | Identity Access Management | Infrastructure | Repositories | le
       });
     });
   });
+
+  describe('#acceptPixAppTos', function () {
+    it('accepts terms of service', async function () {
+      // given
+      const dependencies = {
+        legalDocumentApi: {
+          acceptLegalDocumentByUserId: sinon.stub().resolves(),
+        },
+      };
+
+      const userId = Symbol('userId');
+
+      // when
+      await legalDocumentApiRepository.acceptPixAppTos({ userId, dependencies });
+
+      // then
+      expect(dependencies.legalDocumentApi.acceptLegalDocumentByUserId).to.have.been.calledWithExactly({
+        userId,
+        service: 'pix-app',
+        type: 'TOS',
+      });
+    });
+  });
+
   describe('#getPixAppTosStatus', function () {
     it('returns the TOS status', async function () {
       // given
@@ -44,6 +68,29 @@ describe('Unit | Identity Access Management | Infrastructure | Repositories | le
       expect(dependencies.legalDocumentApi.getLegalDocumentStatusByUserId).to.have.been.calledWithExactly({
         userId,
         service: 'pix-app',
+        type: 'TOS',
+      });
+    });
+  });
+
+  describe('#getPixOrgaTosStatus', function () {
+    it('returns the Pix Orga TOS status', async function () {
+      // given
+      const dependencies = {
+        legalDocumentApi: {
+          getLegalDocumentStatusByUserId: sinon.stub().resolves(),
+        },
+      };
+
+      const userId = Symbol('userId');
+
+      // when
+      await legalDocumentApiRepository.getPixOrgaTosStatus({ userId, dependencies });
+
+      // then
+      expect(dependencies.legalDocumentApi.getLegalDocumentStatusByUserId).to.have.been.calledWithExactly({
+        userId,
+        service: 'pix-orga',
         type: 'TOS',
       });
     });

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
@@ -47,7 +47,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
         documentPath: '/tos/v4.pdf',
         acceptedAt: pixOrgaTosAcceptedAt,
       };
-      userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
+      userDetailsForAdmin.setTosStatus({ pixAppTosStatus, pixOrgaTosStatus });
 
       // when
       const json = serializer.serialize(userDetailsForAdmin);

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
@@ -39,9 +39,15 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
           }),
         ],
       });
-      const acceptedAt = new Date('2024-03-01');
-      const pixAppTosStatus = { status: STATUS.ACCEPTED, documentPath: '/tos/v2.pdf', acceptedAt: acceptedAt };
-      userDetailsForAdmin.tosStatus = { pixAppTosStatus };
+      const pixAppTosAcceptedAt = new Date('2024-03-01');
+      const pixOrgaTosAcceptedAt = new Date('2025-06-07');
+      const pixAppTosStatus = { status: STATUS.ACCEPTED, documentPath: '/tos/v2.pdf', acceptedAt: pixAppTosAcceptedAt };
+      const pixOrgaTosStatus = {
+        status: STATUS.ACCEPTED,
+        documentPath: '/tos/v4.pdf',
+        acceptedAt: pixOrgaTosAcceptedAt,
+      };
+      userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
 
       // when
       const json = serializer.serialize(userDetailsForAdmin);
@@ -61,8 +67,8 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
             'pix-certif-terms-of-service-accepted': userDetailsForAdmin.pixCertifTermsOfServiceAccepted,
             lang: 'fr',
             locale: 'fr-FR',
-            'last-pix-app-terms-of-service-validated-at': acceptedAt,
-            'last-pix-orga-terms-of-service-validated-at': now,
+            'last-pix-app-terms-of-service-validated-at': pixAppTosAcceptedAt,
+            'last-pix-orga-terms-of-service-validated-at': pixOrgaTosAcceptedAt,
             'last-pix-certif-terms-of-service-validated-at': now,
             'last-logged-at': now,
             'email-confirmed-at': now,

--- a/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
@@ -8,13 +8,11 @@ const buildUserDetailsForAdmin = function ({
   email = 'louis.philippe@example.net',
   username = 'jean.bono1234',
   pixCertifTermsOfServiceAccepted = false,
-  pixOrgaTermsOfServiceAccepted = false,
   isAuthenticatedFromGAR = false,
   createdAt,
   updatedAt,
   lang = 'fr',
   locale,
-  lastPixOrgaTermsOfServiceValidatedAt,
   lastPixCertifTermsOfServiceValidatedAt,
   lastLoggedAt,
   emailConfirmedAt,
@@ -26,6 +24,7 @@ const buildUserDetailsForAdmin = function ({
   isPixAgent = false,
   lastApplicationConnections,
   pixAppTosStatus = { status: STATUS.ACCEPTED, acceptedAt: null },
+  pixOrgaTosStatus = { status: STATUS.ACCEPTED, acceptedAt: null },
 } = {}) {
   const userDetailsForAdmin = new UserDetailsForAdmin({
     id,
@@ -33,13 +32,11 @@ const buildUserDetailsForAdmin = function ({
     lastName,
     email,
     username,
-    pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted,
     createdAt,
     updatedAt,
     lang,
     locale,
-    lastPixOrgaTermsOfServiceValidatedAt,
     lastPixCertifTermsOfServiceValidatedAt,
     lastLoggedAt,
     emailConfirmedAt,
@@ -52,7 +49,7 @@ const buildUserDetailsForAdmin = function ({
     isPixAgent,
     lastApplicationConnections,
   });
-  userDetailsForAdmin.tosStatus = { pixAppTosStatus };
+  userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
   return userDetailsForAdmin;
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
@@ -49,7 +49,7 @@ const buildUserDetailsForAdmin = function ({
     isPixAgent,
     lastApplicationConnections,
   });
-  userDetailsForAdmin.tosStatus = { pixAppTosStatus, pixOrgaTosStatus };
+  userDetailsForAdmin.setTosStatus({ pixAppTosStatus, pixOrgaTosStatus });
   return userDetailsForAdmin;
 };
 


### PR DESCRIPTION
## 🪧 Problème

Dans Pix Admin, il faut harmoniser l'implémentation des cgu Pix Orga avec celle des cgu Pix App sur la route `/api/admin/users/{userId}`

## 🌈 Proposition

Appeler les CGU Pix Orga depuis le `legalDocumentApiRepository` et rajouter un setter au modèle `UserDetailsFromAdmin`

## ✊ Remarques

ras 

## 🎉 Pour tester

- Depuis Pix Admin, en tant qu'administrateur, chercher Ornella Accès et afficher sa page.
- Vérifier que la route `/api/admin/users/{userId}` renvoie bien :
-- `pix-orga-terms-of-service-accepted = true`
-- `last-pix-orga-terms-of-service-validated-at = 2026-06-22T06:50:03.429Z`

Non régression : 
- Connectez vous avec `orgacces@example.net` sur Pix App et rafraîchissez la page de cette utilisatrice sur Pix Admin.
- Vérifier que la route `/admin/user/{userId}` renvoie : 
-- `cgu= true`
-- `pix-app-terms-of-service-accepted = true`;
-- `pix-app-terms-of-service-accepted = true`;

- Refaites la première partie du test avec un utilisateur n'ayant pas de compte ou de connexion sur Pix Orga (`harry-cover@example.net`)/
- Vérifier que la route `/api/admin/users/{userId}` renvoie bien :
-- `pix-orga-terms-of-service-accepted = false`
-- `last-pix-orga-terms-of-service-validated-at = null`
