### PR TITLE
[FEATURE] Permettre de réinitialiser les résultats d'une campagne de type moteur de recommandation (PIX-23021)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -1,6 +1,9 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixStars from '@1024pix/pix-ui/components/pix-stars';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -15,6 +18,7 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
   @service media;
 
   @tracked stagedMessageContentShowMoreEnabled = false;
+  @tracked isResetModalVisible = false;
 
   get masteryRatePercentage() {
     return Math.round(this.args.campaignParticipationResult.masteryRate * 100);
@@ -56,6 +60,11 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
 
   @action toggleStagedMessage() {
     this.stagedMessageContentShowMoreEnabled = !this.stagedMessageContentShowMoreEnabled;
+  }
+
+  @action
+  toggleResetModalVisibility() {
+    this.isResetModalVisible = !this.isResetModalVisible;
   }
 
   <template>
@@ -108,6 +117,54 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
           <PixButtonLink @route="authentication.login" @size="small" @variant="secondary-white">
             {{t "pages.skill-review.actions.back-to-pix"}}
           </PixButtonLink>
+          {{#if @campaignParticipationResult.canReset}}
+            <PixButton
+              @iconBefore="refresh"
+              @variant="tertiary-white"
+              @triggerAction={{this.toggleResetModalVisibility}}
+            >
+              {{t "pages.skill-review.hero.retry.actions.reset"}}
+            </PixButton>
+            <PixModal
+              class="evaluation-results-hero-recommendation-engine-reset-modal"
+              @title={{t "pages.skill-review.reset.button"}}
+              @showModal={{this.isResetModalVisible}}
+              @onCloseButtonClick={{this.toggleResetModalVisibility}}
+            >
+              <:content>
+                <p class="evaluation-results-hero-recommendation-engine-reset-modal__text">
+                  {{t
+                    "pages.skill-review.reset.modal.text"
+                    targetProfileName=@campaign.targetProfileName
+                    htmlSafe=true
+                  }}
+                </p>
+                <PixNotificationAlert @type="warning">{{t
+                    "pages.skill-review.reset.modal.warning-text"
+                  }}</PixNotificationAlert>
+              </:content>
+              <:footer>
+                <ul class="reset-campaign-participation-modal__footer">
+                  <li>
+                    <PixButton @variant="secondary" @triggerAction={{this.toggleResetModalVisibility}}>
+                      {{t "common.actions.cancel"}}
+                    </PixButton>
+                  </li>
+                  <li>
+                    <PixButtonLink
+                      @route="campaigns.entry-point"
+                      @model={{@campaign.code}}
+                      @query={{hash reset=true}}
+                      @variant="error"
+                    >
+                      {{t "common.actions.confirm"}}
+                    </PixButtonLink>
+                  </li>
+                </ul>
+              </:footer>
+            </PixModal>
+
+          {{/if}}
         </div>
       </div>
     </div>

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -91,13 +91,19 @@
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
-    gap: var(--pix-spacing-4x);
+    gap: var(--pix-spacing-3x);
     align-items: flex-start;
     width: 100%;
 
     .pix-button {
       width: 100%;
     }
+  }
+}
+
+.evaluation-results-hero-recommendation-engine-reset-modal {
+  &__text {
+    margin-bottom: var(--pix-spacing-4x);
   }
 }
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click, settled } from '@ember/test-helpers';
 import { tracked } from '@glimmer/tracking';
@@ -8,6 +8,7 @@ import { module, test } from 'qunit';
 
 import { stubCurrentUserService } from '../../../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+import { waitForDialog } from '../../../../../../helpers/wait-for';
 
 module(
   'Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | EvaluationResultsHeroRecommendationEngine',
@@ -363,6 +364,59 @@ module(
       // then
       assert.dom(screen.getByRole('link', { name: t('pages.skill-review.actions.back-to-pix') })).exists();
       assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).doesNotExist();
+    });
+
+    module('when campaign can be reset', function (hooks) {
+      hooks.beforeEach(async function () {
+        stubCurrentUserService(this.owner, { firstName: 'Hermione' });
+      });
+
+      test('it should display a reset button', async function (assert) {
+        // given
+        const campaign = { organizationId: 1, hasCustomResultPageButton: false };
+        const campaignParticipationResult = { masteryRate: 0.75, canReset: true };
+
+        // when
+        const screen = await render(
+          <template>
+            <EvaluationResultsHeroRecommendationEngine
+              @campaign={{campaign}}
+              @campaignParticipationResult={{campaignParticipationResult}}
+              @hasTrainings={{false}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button', { name: t('pages.skill-review.reset.button') })).exists();
+      });
+
+      module('when clicking on the reset button', function () {
+        test('it should display a confirmation modal with a reset confirm button', async function (assert) {
+          // given
+          const campaign = { organizationId: 1, hasCustomResultPageButton: false };
+          const campaignParticipationResult = { masteryRate: 0.75, canReset: true };
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+                @hasTrainings={{false}}
+              />
+            </template>,
+          );
+
+          await click(screen.getByRole('button', { name: t('pages.skill-review.reset.button') }));
+
+          await waitForDialog();
+          assert.dom(screen.getByRole('dialog', { name: t('pages.skill-review.reset.button') })).exists();
+
+          const resetConfirmationDialog = screen.getByRole('dialog', { name: t('pages.skill-review.reset.button') });
+          assert.dom(within(resetConfirmationDialog).getByText(t('common.actions.confirm'))).exists();
+        });
+      });
     });
   },
 );


### PR DESCRIPTION
## 🪧 Problème

Actuellement, on ne peut pas réinitialiser les résultats d'une campagne de type moteur de recommandation. Cela pose problème pour des tests car oblige à recréer des campagnes.

## 🌈 Proposition

Ajouter un bouton pour le faire.

## ✊ Remarques

- Sur la page de résultat initiale, une modale de confirmation est affichée lors du clic sur le bouton. J'ai repris le même fonctionnement.

## 🎉 Pour tester
- Se connecter avec le compte `dave-comp@example.net`
- Passer la campagne avec le code `EDUMULTIP`
- Une fois arrivée sur la page de résultat, constater qu'un bouton `Remettre à zero et tout retenter`s'affiche
- Cliquer sur le bouton, une modale devrait s'afficher
- Cliquer sur confirmer. Les résultats de la campagne devraient être réinitialisés 🚀 