### PR TITLE
[BUGFIX] Écouter les erreurs pg-boss côté client pour éviter le crash du web

### DIFF
--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -50,19 +50,6 @@ export class JobClient {
             persistWarnings: config.pgBoss.persistWarnings,
             warningRetentionDays: 30,
           });
-
-      this.#pgBoss.on('error', (err) => {
-        logger.error({ event: 'pg-boss-error', err }, 'PGBOSS ERROR');
-      });
-      this.#pgBoss.on('warning', ({ message, data }) => {
-        logger.warn({ event: 'pg-boss-warning', data }, message);
-      });
-      this.#pgBoss.on('wip', (data) => {
-        logger.info({ event: 'pg-boss-wip', data }, 'PGBOSS WIP');
-      });
-
-      await this.#pgBoss.start();
-      await this.#registerJobs(jobGroups);
     } else {
       this.#pgBoss = pgBossFactory
         ? pgBossFactory()
@@ -72,7 +59,22 @@ export class JobClient {
             supervise: false,
             schedule: false,
           });
-      await this.#pgBoss.start();
+    }
+
+    this.#pgBoss.on('error', (err) => {
+      logger.error({ event: 'pg-boss-error', err }, 'PGBOSS ERROR');
+    });
+    this.#pgBoss.on('warning', ({ message, data }) => {
+      logger.warn({ event: 'pg-boss-warning', data }, message);
+    });
+    this.#pgBoss.on('wip', (data) => {
+      logger.info({ event: 'pg-boss-wip', data }, 'PGBOSS WIP');
+    });
+
+    await this.#pgBoss.start();
+
+    if (worker) {
+      await this.#registerJobs(jobGroups);
     }
 
     this.#isInitialized = true;

--- a/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
+++ b/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
@@ -45,6 +45,21 @@ class FakePgBoss {
 }
 
 describe('Unit | JobClient', function () {
+  context('#initialize', function () {
+    it('registers an error listener on the client instance to prevent process crash', async function () {
+      // given
+      const pgBossStub = new FakePgBoss();
+      sinon.stub(pgBossStub, 'on');
+
+      // when
+      const jobClient = new JobClient();
+      await jobClient.initialize({ jobGroups: [JobGroup.DEFAULT], worker: false }, () => pgBossStub);
+
+      // then
+      expect(pgBossStub.on).to.have.been.calledWith('error');
+    });
+  });
+
   context('#registerJobs', function () {
     it('should register AuditLoggingJob', async function () {
       // given


### PR DESCRIPTION
## 🪧 Problème

Le process **web** de l'API crashe par intermittence sur l'environnement integration, avec ce type d'erreur fatale :

```
Error: Connection terminated due to connection timeout
at /app/node_modules/pg-pool/index.js:45:11
at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
at async Db.executeSql (file:///app/node_modules/pg-boss/dist/db.js:43:16)
at async #onPoll (file:///app/node_modules/pg-boss/dist/bam.js:57:30)
Emitted 'error' event on PgBoss instance at:
at Bam.<anonymous> (file:///app/node_modules/pg-boss/dist/index.js:70:43)
at Bam.emit (node:events:509:28)
at #onPoll (file:///app/node_modules/pg-boss/dist/bam.js:63:18)
at process.processTicksAndRejections (node:internal/process/task_queues:104:5) {
[cause]: Error: Connection terminated unexpectedly
at Connection.<anonymous> (/app/node_modules/pg/lib/client.js:180:73)
at Object.onceWrapper (node:events:630:28)
at Connection.emit (node:events:509:28)
at Socket.<anonymous> (/app/node_modules/pg/lib/connection.js:61:12)
at Socket.emit (node:events:509:28)
at TCP.<anonymous> (node:net:350:12)
```
## 🌈 Proposition

Déplacer l'enregistrement des listeners `error` / `warning` / `wip` **hors** du `if (worker)`, pour qu'ils soient attachés dans les deux modes (worker **et** client).

Résultat : une coupure de connexion pendant un poll Bam est désormais **loggée** (`PGBOSS ERROR`) au lieu de tuer le process.

