### PR TITLE
[FEATURE] Bloquer le passage des certifs en EN (PIX-23288).

### DIFF
--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -15,7 +15,7 @@ import { AlgorithmEngineVersion } from './AlgorithmEngineVersion.js';
 
 const Joi = BaseJoi.extend(JoiDate);
 
-export const V3_CERTIFICATION_AVAILABLE_LOCALES = ['fr-fr', 'fr', 'en'];
+export const V3_CERTIFICATION_AVAILABLE_LOCALES = ['fr-fr', 'fr'];
 
 export class CertificationCourse {
   /**

--- a/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
@@ -275,7 +275,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
     it('should be true if user language is available for certification', function () {
       // given
       const user = domainBuilder.buildUser({
-        lang: 'en',
+        lang: 'fr-fr',
       });
 
       // when

--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -72,10 +72,6 @@ export default class CertificationStarter extends Component {
         value: VALID_CERTIFICATION_LOCALES.FRENCH,
         label: this.intl.t('pages.certification-start.language-selector.options.french'),
       },
-      {
-        value: VALID_CERTIFICATION_LOCALES.ENGLISH,
-        label: this.intl.t('pages.certification-start.language-selector.options.english'),
-      },
     ];
   }
 
@@ -207,10 +203,15 @@ export default class CertificationStarter extends Component {
             @options={{this.languageOptions}}
             @hideDefaultOption={{true}}
             @iconName="language"
+            @isDisabled={{true}}
           >
             <:label>{{t "pages.certification-start.language-selector.label"}}</:label>
             <:default as |language|>{{language.label}}</:default>
           </PixSelect>
+
+          <PixNotificationAlert @withIcon={{true}} @type="error" class="create-attestations__errors">
+            <p>{{t "pages.certification-start.language-selector.warning-message"}}</p>
+          </PixNotificationAlert>
 
           <PixCheckbox
             @class="certification-start-form__lang-confirm-checkbox"

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -114,7 +114,7 @@ module('Integration | Component | certification-starter', function (hooks) {
           );
         });
 
-        test('should be possible to update the selected language', async function (assert) {
+        test('should display the language selector as disabled', async function (assert) {
           // given
           const currentDomainService = this.owner.lookup('service:currentDomain');
           sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
@@ -125,16 +125,29 @@ module('Integration | Component | certification-starter', function (hooks) {
             }),
           });
 
+          // when
           const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
 
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Langue de certification' })).hasAttribute('aria-disabled');
+        });
+
+        test('should display a warning message about English being unavailable', async function (assert) {
+          // given
+          const currentDomainService = this.owner.lookup('service:currentDomain');
+          sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
+          const store = this.owner.lookup('service:store');
+          this.set('model', {
+            certificationCandidate: store.createRecord('certification-candidate', {
+              hasStartedTest: false,
+            }),
+          });
+
           // when
-          await click(screen.getByRole('button', { name: 'Langue de certification' }));
-          await click(screen.getByText('anglais - EN'));
+          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
 
           // then
-          assert.ok(
-            screen.getByRole('button', { name: 'Langue de certification' }).textContent.includes('anglais - EN'),
-          );
+          assert.ok(screen.getByText(t('pages.certification-start.language-selector.warning-message')));
         });
 
         module('when the language confirmation checkbox is not checked and code filled', function () {
@@ -426,8 +439,6 @@ module('Integration | Component | certification-starter', function (hooks) {
             }),
             'ABC123',
           );
-          await click(screen.getByRole('button', { name: 'Langue de certification' }));
-          await click(screen.getByText('anglais - EN'));
           await click(
             screen.getByRole('checkbox', {
               name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
@@ -442,7 +453,7 @@ module('Integration | Component | certification-starter', function (hooks) {
           sinon.assert.calledWithExactly(createRecordStub, 'certification-course', {
             accessCode: 'ABC123',
             sessionId: 123,
-            locale: 'en',
+            locale: 'fr',
           });
 
           sinon.assert.calledOnce(certificationCourse.save);

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -977,7 +977,8 @@
         "options": {
           "english": "Englisch - EN",
           "french": "Französisch - FR"
-        }
+        },
+        "warning-message": "Aufgrund eines technischen Problems ist die Pix-Zertifizierung vorübergehend nicht auf Englisch verfügbar. Wir entschuldigen uns für die Unannehmlichkeiten."
       },
       "link-to-user-certification": "Meine Zertifizierungen ansehen",
       "non-eligible-subscription": "Du bist nicht für {subscriptionLabel} qualifiziert. Du aknnst dennoch deine Pix-Zertifizierung ablegen.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -977,7 +977,8 @@
         "options": {
           "english": "English - EN",
           "french": "French - FR"
-        }
+        },
+        "warning-message": "Due to technical problems, the Pix Certification is momentarily unavailable in English. We apologize for any inconvenience caused."
       },
       "link-to-user-certification": "See my certificates",
       "non-eligible-subscription": "You are not eligible to {subscriptionLabel}. However, you can still take your Pix Certification.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -977,7 +977,8 @@
         "options": {
           "english": "inglés - EN",
           "french": "francés - FR"
-        }
+        },
+        "warning-message": "Debido a un problema técnico, la Certificación Pix no está disponible temporalmente en inglés. Nos disculpamos por las molestias ocasionadas."
       },
       "link-to-user-certification": "Ver mis certificaciones",
       "non-eligible-subscription": "No eres elegible para {subscriptionLabel}. Sin embargo, puedes presentarte a la certificación Pix.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -977,7 +977,8 @@
         "options": {
           "english": "anglais - EN",
           "french": "français - FR"
-        }
+        },
+        "warning-message": "Suite un à problème technique, la Certification Pix est momentanément indisponible en anglais. Nous nous excusons pour la gêne occassionnée."
       },
       "link-to-user-certification": "Voir mes certifications",
       "non-eligible-subscription": "Vous n'êtes pas éligible à {subscriptionLabel}. Vous pouvez néanmoins passer votre certification Pix.",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -977,7 +977,8 @@
         "options": {
           "english": "inglese - EN",
           "french": "francese - FR"
-        }
+        },
+        "warning-message": "A causa di un problema tecnico, la Certificazione Pix è temporaneamente non disponibile in inglese. Ci scusiamo per l'inconveniente."
       },
       "link-to-user-certification": "Vedi le mie certificazioni",
       "non-eligible-subscription": "Non si ha diritto a {subscriptionLabel}. È tuttavia possibile ottenere la certificazione Pix.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -977,7 +977,8 @@
         "options": {
           "english": "Engels - EN",
           "french": "Frans - FR"
-        }
+        },
+        "warning-message": "Vanwege een technisch probleem is de Pix-certificering tijdelijk niet beschikbaar in het Engels. Onze excuses voor het ongemak."
       },
       "link-to-user-certification": "Bekijk mijn certificaten",
       "non-eligible-subscription": "Je komt niet in aanmerking voor {subscriptionLabel}. Je kunt echter wel je Pix-certificering behalen.",


### PR DESCRIPTION
## 🪧 Problème

La Certification Pix est normalement disponible en EN si les candidats se connectent via [pix.org](http://pix.org/) et sélectionnent la langue anglaise sur l'écran de saisie du code d’accès candidat.

Depuis le 19/03/2026, le passage a Phrase a fortement dégradé la qualité de la Certification Pix en EN.

## 🌈 Proposition

En attendant la réparation de la langue anglaise en Certification Pix :

- supprimer l’option pour choisir l’anglais dans la drop down de l'écran d’entrée en session
- afficher un message au candidat sur l'écran de saisie du code d’accès candidat sur [pix.org](http://pix.org/)

## 🎉 Pour tester

- Se connecter sur PixApp en RA et en .org
- Aller sur l'écran de réconcialiation
- Constater que le selecteur de langue est disabled et que le message de prévention est affiché.
