### PR TITLE
[TECH] Supprimer les scripts preinstall inutiles + rétablir la vérification version de Node.js

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/admin/.npmrc
+++ b/admin/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/admin/package.json
+++ b/admin/package.json
@@ -33,7 +33,6 @@
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "lint:translations": "eslint --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "lint:translations:fix": "npm run lint:translations -- --fix",
-    "preinstall": "npx check-engine",
     "dev": "ember serve --proxy http://localhost:3000",
     "start": "npm run dev",
     "test": "ember test",

--- a/api/.npmrc
+++ b/api/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/audit-logger/.npmrc
+++ b/audit-logger/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/audit-logger/package.json
+++ b/audit-logger/package.json
@@ -17,7 +17,6 @@
     "lint": "eslint . --cache --cache-strategy content",
     "lint:fix": "eslint --fix . --cache --cache-strategy content",
     "postdeploy": "DEBUG=knex:* npm run db:migrate",
-    "preinstall": "npx check-engine",
     "test": "NODE_ENV=test npm run db:prepare && vitest",
     "test:ci": "NODE_ENV=test npm run db:prepare && vitest",
     "test:watch": "NODE_ENV=test npm run db:prepare && vitest --watch",

--- a/certif/.npmrc
+++ b/certif/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/certif/package.json
+++ b/certif/package.json
@@ -33,7 +33,6 @@
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "lint:translations": "eslint --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "lint:translations:fix": "npm run lint:translations -- --fix",
-    "preinstall": "npx check-engine",
     "dev": "ember serve --proxy http://localhost:3000",
     "start": "npm run dev",
     "test": "ember test",

--- a/high-level-tests/e2e-playwright/.npmrc
+++ b/high-level-tests/e2e-playwright/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/high-level-tests/e2e/.npmrc
+++ b/high-level-tests/e2e/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -27,7 +27,6 @@
     "cy:test:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test run-p start:api start:mon-pix start:orga cy:open",
     "db:empty": "cd ../../api && npm run db:empty",
     "db:initialize": "cd ../../api && npm run db:prepare",
-    "preinstall": "npx check-engine",
     "start:api": "cd ../../api && DATABASE_URL=postgresql://postgres@localhost/pix_test npm run start:watch",
     "start:mon-pix": "cd ../../mon-pix && npm start",
     "start:orga": "cd ../../orga && npm start",

--- a/junior/.npmrc
+++ b/junior/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/junior/package.json
+++ b/junior/package.json
@@ -29,7 +29,6 @@
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "lint:translations": "eslint --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "lint:translations:fix": "npm run lint:translations -- --fix",
-    "preinstall": "npx check-engine",
     "dev": "ember serve --proxy http://localhost:3000",
     "start": "npm run dev",
     "test": "ember test",

--- a/mon-pix/.npmrc
+++ b/mon-pix/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -32,7 +32,6 @@
     "lint:translations": "eslint --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "lint:translations:fix": "npm run lint:translations -- --fix",
     "build": "ember build --environment $BUILD_ENVIRONMENT",
-    "preinstall": "npx check-engine",
     "dev": "ember serve --proxy http://localhost:3000",
     "start": "ember serve --proxy http://localhost:3000 --live-reload false",
     "test": "ember test",

--- a/orga/.npmrc
+++ b/orga/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/orga/package.json
+++ b/orga/package.json
@@ -32,7 +32,6 @@
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "lint:translations": "eslint --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "lint:translations:fix": "npm run lint:translations -- --fix",
-    "preinstall": "npx check-engine",
     "dev": "vite",
     "start": "vite",
     "test": "ember exam --path dist --config-file ./testem.cjs",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "lint:scripts": "eslint --ignore-pattern **/compose.yaml scripts",
     "lint:yaml": "eslint --fix .circleci/*.yml .github/**/*.yaml",
     "lint:docs": "find ./docs -type f -name '*.md' | xargs -L1 markdown-link-check --quiet --config ./docs/link--check-config.json ",
-    "preinstall": "npx check-engine",
     "dev:team-certif": "run-p --print-label dev:api dev:mon-pix dev:certif dev:admin",
     "dev:admin": "cd admin && npm run dev",
     "dev:api": "cd api && npm run dev",


### PR DESCRIPTION
## 🪧 Problème

La PR #15762 a désactivé, pour des raisons de sécurité, l’exécution des scripts `preinstall`. Mais certains scripts `preinstall` sont encore présents dans les fichiers `package.json`. Laisser ces scripts fait penser à tort qu’ils sont exécutés et ont un effet.

## 🌈 Proposition

* Supprimer tous les scripts `preinstall` de tous les fichiers `package.json`
* Faire que le non-respect des contraintes édictées dans les fichiers `package.json` avec la propriété `engines.node` génère une erreur avec le builtin Node.js `engine-strict=true` dans les fichiers `.npmrc` qui permet de remplacer à l’identique la fonctionnalité assurée anciennement par  `npx check-engine`, cf. https://docs.npmjs.com/cli/v11/using-npm/config#engine-strict : 
   > If set to true, then npm will stubbornly refuse to install (or even consider installing) any package that claims to not be compatible with the current Node.js version.

## ✊ Remarques

RAS

## 🎉 Pour tester

* Vérifier que les modifications ont bien été appliquées de manière uniforme et globale sur tous les fichiers `package.json` et `.npmrc`
* Modifier la propriété ` engines.node` du fichier `package.json` de n’importe quelle application du monorepo et constater que la commande `npm ci` refuse d’installer quoi que ce soit et renvoie un code d’erreur

Exemple si on met la contrainte suivante : 
```json
"engines": {
    "node": "^29.15.0"
  }
```

et que le fichier `.nvmrc` contient : 
```
24.15.0
```

```shell
cd api/
Found '1024pix/pix/api/.nvmrc' with version <24.15.0>
Now using node v24.15.0 (npm v11.12.1)

1024pix/pix/api$ npm ci
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: pix-api@5.436.0
npm error notsup Not compatible with your version of node/npm: pix-api@5.436.0
npm error notsup Required: {"node":"^29.15.0"}
npm error notsup Actual:   {"node":"v24.15.0","npm":"11.12.1"}

1024pix/pix/api$ echo $?
1
```