### PR TITLE
[FEATURE] Création de la route pour récupérer les prescrits dans Pix Admin (PIX-23150)

### DIFF
--- a/api/src/prescription/organization-learner/application/learner-list-controller.js
+++ b/api/src/prescription/organization-learner/application/learner-list-controller.js
@@ -1,5 +1,6 @@
 import { divisionSerializer } from '../../campaign/infrastructure/serializers/jsonapi/division-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as adminOrganizationLearnerSerializer from '../infrastructure/serializers/jsonapi/admin-organization-learner-serializer.js';
 import { organizationParticipantsSerializer } from '../infrastructure/serializers/jsonapi/organization-participants-serializer.js';
 import { mapCertificabilityByLabel } from './../../shared/application/helpers.js';
 
@@ -25,12 +26,22 @@ const findPaginatedFilteredParticipants = async function (
   return dependencies.organizationParticipantsSerializer.serialize(results);
 };
 
+const findOrganizationLearnersForAdmin = async function (
+  request,
+  _,
+  dependencies = { adminOrganizationLearnerSerializer },
+) {
+  const { page, filter } = request.query;
+  const { learners, pagination } = await usecases.findOrganizationLearnersForAdmin({ page, filter });
+  return dependencies.adminOrganizationLearnerSerializer.serialize({ learners, pagination });
+};
+
 const getDivisions = async function (request) {
   const organizationId = request.params.id;
   const divisions = await usecases.findDivisionsByOrganization({ organizationId });
   return divisionSerializer.serialize(divisions);
 };
 
-const learnerListController = { findPaginatedFilteredParticipants, getDivisions };
+const learnerListController = { findPaginatedFilteredParticipants, findOrganizationLearnersForAdmin, getDivisions };
 
 export { learnerListController };

--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -49,6 +49,41 @@ const register = async function (server) {
     },
     {
       method: 'GET',
+      path: '/api/admin/organization-learners',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          query: Joi.object({
+            page: Joi.object({
+              size: Joi.number().integer().empty(''),
+              number: Joi.number().integer().empty(''),
+            }).default({}),
+            filter: Joi.object({
+              fullName: Joi.string().empty(''),
+              organizationId: Joi.number().integer().empty(''),
+            }).default({}),
+          }),
+        },
+        handler: learnerListController.findOrganizationLearnersForAdmin,
+        tags: ['api', 'admin', 'organization-learners'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés sur PixAdmin avec le rôle SuperAdmin, Certif, Support et Métier',
+          `- Récupération de tous les prescrits filtrables selon le nom et l'organizationId`,
+        ],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/organizations/{id}/divisions',
       config: {
         pre: [

--- a/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerOverviewForAdmin.js
+++ b/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerOverviewForAdmin.js
@@ -1,0 +1,31 @@
+class OrganizationLearnerOverviewForAdmin {
+  constructor({
+    id,
+    firstName,
+    lastName,
+    birthdate,
+    division,
+    group,
+    nationalStudentId,
+    organizationId,
+    organizationName,
+    userId,
+    updatedAt,
+    isDisabled,
+  } = {}) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.birthdate = birthdate;
+    this.division = division;
+    this.group = group;
+    this.nationalStudentId = nationalStudentId;
+    this.organizationId = organizationId;
+    this.organizationName = organizationName;
+    this.userId = userId;
+    this.updatedAt = updatedAt;
+    this.isDisabled = isDisabled;
+  }
+}
+
+export { OrganizationLearnerOverviewForAdmin };

--- a/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-for-admin.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-for-admin.js
@@ -1,0 +1,5 @@
+const findOrganizationLearnersForAdmin = async function ({ page, filter, organizationLearnerRepository }) {
+  return organizationLearnerRepository.findPaginatedLearnersForAdmin({ page, filter });
+};
+
+export { findOrganizationLearnersForAdmin };

--- a/api/src/prescription/organization-learner/domain/usecases/find-paginated-organization-learners.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-paginated-organization-learners.js
@@ -4,7 +4,7 @@ const findPaginatedOrganizationLearners = async function ({
   filter,
   organizationLearnerRepository,
 }) {
-  return organizationLearnerRepository.findPaginatedLearners({ organizationId, page, filter });
+  return organizationLearnerRepository.findPaginatedLearnersByOrganizationId({ organizationId, page, filter });
 };
 
 export { findPaginatedOrganizationLearners };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -93,6 +93,7 @@ import { findAssociationBetweenUserAndOrganizationLearner } from './find-associa
 import { findDivisionsByOrganization } from './find-divisions-by-organization.js';
 import { findGroupsByOrganization } from './find-groups-by-organization.js';
 import { findOrganizationLearnersByUserId } from './find-organization-learners-by-user-id.js';
+import { findOrganizationLearnersForAdmin } from './find-organization-learners-for-admin.js';
 import { findOrganizationLearnersWithOrganizationByUserId } from './find-organization-learners-with-organization.js';
 import { findPaginatedFilteredAttestationParticipantsStatus } from './find-paginated-filtered-attestation-participants-status.js';
 import { findPaginatedFilteredParticipants } from './find-paginated-filtered-participants.js';
@@ -124,6 +125,7 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedFilteredScoParticipants,
   findPaginatedFilteredSupParticipants,
   findPaginatedOrganizationLearners,
+  findOrganizationLearnersForAdmin,
   generateOrganizationLearnersUsernameAndTemporaryPassword,
   generateResetOrganizationLearnersPasswordCsvContent,
   generateUsername,

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -12,6 +12,7 @@ import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/do
 import { ParticipantRepartition } from '../../domain/models/ParticipantRepartition.js';
 import { AttestationParticipantStatus } from '../../domain/read-models/AttestationParticipantStatus.js';
 import { OrganizationLearner } from '../../domain/read-models/OrganizationLearner.js';
+import { OrganizationLearnerOverviewForAdmin } from '../../domain/read-models/OrganizationLearnerOverviewForAdmin.js';
 
 function _buildIsCertifiable(queryBuilder, organizationLearnerId, knexConn) {
   queryBuilder
@@ -123,6 +124,46 @@ async function findPaginatedLearnersByOrganizationId({ organizationId, page, fil
   const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const learners = results.map((learner) => new OrganizationLearner(learner));
+
+  return { learners, pagination };
+}
+
+async function findPaginatedLearnersForAdmin({ page, filter }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const query = knexConn
+    .select(
+      'view-active-organization-learners.id as id',
+      'firstName',
+      'lastName',
+      'birthdate',
+      'division',
+      'group',
+      'nationalStudentId',
+      'userId',
+      'organizationId',
+      'organizations.name as organizationName',
+      'view-active-organization-learners.updatedAt as updatedAt',
+      'isDisabled',
+    )
+    .from('view-active-organization-learners')
+    .innerJoin('organizations', 'organizations.id', 'view-active-organization-learners.organizationId')
+    .orderByRaw('LOWER("firstName") ASC')
+    .orderByRaw('LOWER("lastName") ASC');
+
+  if (filter) {
+    const { fullName, organizationId } = filter;
+    if (fullName) {
+      filterByFullName(query, fullName, 'firstName', 'lastName');
+    }
+    if (organizationId) {
+      query.where({ organizationId });
+    }
+  }
+
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
+
+  const learners = results.map((learner) => new OrganizationLearnerOverviewForAdmin(learner));
 
   return { learners, pagination };
 }
@@ -516,6 +557,7 @@ export {
   findIdByUserIdAndOrganizationId,
   findPaginatedAttestationStatusForOrganizationLearnersAndKey,
   findPaginatedLearnersByOrganizationId,
+  findPaginatedLearnersForAdmin,
   findUserIdsFromFilters,
   get,
   getAttestationsForOrganizationLearnersAndKey,

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -92,7 +92,7 @@ async function get({ organizationLearnerId }) {
   throw new NotFoundError(`Student not found for ID ${organizationLearnerId}`);
 }
 
-async function findPaginatedLearners({ organizationId, page, filter }) {
+async function findPaginatedLearnersByOrganizationId({ organizationId, page, filter }) {
   const knexConn = DomainTransaction.getConnection();
 
   const query = knexConn
@@ -515,7 +515,7 @@ export {
   findByUserId,
   findIdByUserIdAndOrganizationId,
   findPaginatedAttestationStatusForOrganizationLearnersAndKey,
-  findPaginatedLearners,
+  findPaginatedLearnersByOrganizationId,
   findUserIdsFromFilters,
   get,
   getAttestationsForOrganizationLearnersAndKey,

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/admin-organization-learner-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/admin-organization-learner-serializer.js
@@ -1,0 +1,25 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function ({ learners, pagination }) {
+  const result = new Serializer('admin-organization-learner', {
+    attributes: [
+      'firstName',
+      'lastName',
+      'birthdate',
+      'division',
+      'group',
+      'nationalStudentId',
+      'organizationId',
+      'organizationName',
+      'userId',
+      'updatedAt',
+      'isDisabled',
+    ],
+    meta: pagination,
+  }).serialize(learners);
+  return result;
+};
+
+export { serialize };

--- a/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
@@ -51,6 +51,35 @@ describe('Acceptance | Application | learner-list-route', function () {
     });
   });
 
+  describe('GET /api/admin/organization-learners', function () {
+    it('should return a list of organization learners', async function () {
+      //given
+      const superAdminId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Annie', organizationId });
+      databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Annie-Marie', organizationId });
+      databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Simon', organizationId });
+      databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Annie', organizationId: otherOrganizationId });
+      await databaseBuilder.commit();
+
+      const params =
+        '?filter[fullName]=Annie' + '&page[number]=1&page[size]=25' + `&filter[organizationId]=${organizationId}`;
+      const request = {
+        method: 'GET',
+        url: `/api/admin/organization-learners${params}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdminId }),
+      };
+      //when
+      const response = await server.inject(request);
+
+      //then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.length).to.equal(2);
+      expect(response.result.data[0].type).to.equal('admin-organization-learners');
+    });
+  });
+
   describe('GET /api/organizations/{organizationId}/divisions', function () {
     it('should return the divisions', async function () {
       // given

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-for-admin_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-for-admin_test.js
@@ -1,0 +1,81 @@
+import { OrganizationLearnerOverviewForAdmin } from '../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerOverviewForAdmin.js';
+import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | UseCases | find-paginated-filtered-organization-learners-for-admin', function () {
+  it('should return paginated organization learners filtered by name', async function () {
+    const learner = databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Jean-René',
+      lastName: 'Michel',
+    });
+    const learner2 = databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Jeanne-Michelle',
+      lastName: 'René',
+    });
+    const learner3 = databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Michel',
+      lastName: 'michel',
+    });
+    databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Jean',
+      lastName: 'Dion',
+    });
+    await databaseBuilder.commit();
+
+    const result = await usecases.findOrganizationLearnersForAdmin({
+      page: {
+        size: 2,
+        number: 1,
+      },
+      filter: { fullName: 'michel' },
+    });
+    const result2 = await usecases.findOrganizationLearnersForAdmin({
+      page: {
+        size: 2,
+        number: 2,
+      },
+      filter: { fullName: 'michel' },
+    });
+
+    const learners = result.learners;
+    const learners2 = result2.learners;
+
+    expect(learners).lengthOf(2);
+    expect(learners[0]).to.be.an.instanceOf(OrganizationLearnerOverviewForAdmin);
+    expect(learners[1]).to.be.an.instanceOf(OrganizationLearnerOverviewForAdmin);
+    expect(learners[0].id).to.be.equal(learner.id);
+    expect(learners[1].id).to.be.equal(learner2.id);
+
+    expect(learners2).lengthOf(1);
+    expect(learners2[0]).to.be.an.instanceOf(OrganizationLearnerOverviewForAdmin);
+    expect(learners2[0].id).to.be.equal(learner3.id);
+  });
+
+  it('should return paginated organization learners filtered by organizationId', async function () {
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const learner = databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Jean-René',
+      lastName: 'Michel',
+      organizationId,
+    });
+    databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Jean',
+      lastName: 'Dion',
+    });
+    await databaseBuilder.commit();
+
+    const result = await usecases.findOrganizationLearnersForAdmin({
+      page: {
+        size: 2,
+        number: 1,
+      },
+      filter: { organizationId },
+    });
+    const learners = result.learners;
+
+    expect(learners).lengthOf(1);
+    expect(learners[0]).to.be.an.instanceOf(OrganizationLearnerOverviewForAdmin);
+    expect(learners[0].id).to.be.equal(learner.id);
+  });
+});

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -495,7 +495,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
     });
   });
 
-  describe('#findPaginatedLearners', function () {
+  describe('#findPaginatedLearnersByOrganizationId', function () {
     let organizationId;
 
     beforeEach(async function () {
@@ -518,7 +518,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
       await databaseBuilder.commit();
 
-      const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
+      const result = await organizationLearnerRepository.findPaginatedLearnersByOrganizationId({ organizationId });
 
       expect(result.learners).lengthOf(1);
       expect(result.learners[0]).instanceOf(OrganizationLearner);
@@ -540,7 +540,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
       await databaseBuilder.commit();
 
-      const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
+      const result = await organizationLearnerRepository.findPaginatedLearnersByOrganizationId({ organizationId });
 
       expect(result.learners).lengthOf(0);
     });
@@ -554,7 +554,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
       await databaseBuilder.commit();
 
-      const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
+      const result = await organizationLearnerRepository.findPaginatedLearnersByOrganizationId({ organizationId });
 
       expect(result.learners).lengthOf(0);
     });
@@ -572,7 +572,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
       await databaseBuilder.commit();
 
-      const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
+      const result = await organizationLearnerRepository.findPaginatedLearnersByOrganizationId({ organizationId });
 
       expect(result.learners).lengthOf(2);
     });
@@ -604,7 +604,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
         await databaseBuilder.commit();
 
-        const result = await organizationLearnerRepository.findPaginatedLearners({
+        const result = await organizationLearnerRepository.findPaginatedLearnersByOrganizationId({
           organizationId,
         });
 
@@ -629,7 +629,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
         await databaseBuilder.commit();
 
-        const result = await organizationLearnerRepository.findPaginatedLearners({
+        const result = await organizationLearnerRepository.findPaginatedLearnersByOrganizationId({
           organizationId,
         });
 
@@ -653,7 +653,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
         await databaseBuilder.commit();
 
-        const result = await organizationLearnerRepository.findPaginatedLearners({
+        const result = await organizationLearnerRepository.findPaginatedLearnersByOrganizationId({
           organizationId,
           page: {
             size: 1,
@@ -690,7 +690,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
           await databaseBuilder.commit();
 
-          const result = await organizationLearnerRepository.findPaginatedLearners({
+          const result = await organizationLearnerRepository.findPaginatedLearnersByOrganizationId({
             organizationId,
             page: {
               size: 1,

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1,6 +1,7 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { AttestationParticipantStatus } from '../../../../../../src/prescription/organization-learner/domain/read-models/AttestationParticipantStatus.js';
 import { OrganizationLearner } from '../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearner.js';
+import { OrganizationLearnerOverviewForAdmin } from '../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerOverviewForAdmin.js';
 import { repositories } from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/index.js';
 import { User } from '../../../../../../src/profile/domain/models/User.js';
 import { NotFoundError, OrganizationLearnerNotFound } from '../../../../../../src/shared/domain/errors.js';
@@ -707,6 +708,223 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
           });
           expect(result.learners).to.have.lengthOf(1);
           expect(result.learners[0].id).to.equal(rogueLearner.id);
+        });
+      });
+    });
+  });
+
+  describe('#findPaginatedLearnersForAdmin', function () {
+    let organization;
+
+    beforeEach(async function () {
+      organization = databaseBuilder.factory.buildOrganization();
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return disabled learner by default', async function () {
+      const userId = databaseBuilder.factory.buildUser().id;
+      const learner = databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'afirstname',
+        lastName: 'lastname',
+        birthdate: '2000-01-01',
+        division: '3eB',
+        group: 'AB2',
+        nationalStudentId: '12345678910',
+        userId,
+        organizationId: organization.id,
+        updatedAt: '2026-01-01',
+        isDisabled: true,
+      });
+      const learner2 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        isDisabled: false,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({ page: {} });
+
+      expect(result.learners).lengthOf(2);
+      expect(result.learners[0]).instanceOf(OrganizationLearnerOverviewForAdmin);
+      expect(result.learners[0]).to.be.deep.equal({
+        id: learner.id,
+        firstName: 'afirstname',
+        lastName: 'lastname',
+        birthdate: '2000-01-01',
+        division: '3eB',
+        group: 'AB2',
+        nationalStudentId: '12345678910',
+        userId,
+        organizationId: organization.id,
+        organizationName: organization.name,
+        updatedAt: new Date('2026-01-01'),
+        isDisabled: true,
+      });
+      expect(result.learners[1]).instanceOf(OrganizationLearnerOverviewForAdmin);
+      expect(result.learners[1].id).to.be.equal(learner2.id);
+    });
+
+    it('should not return deleted learner', async function () {
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+        deletedAt: new Date(),
+        deletedBy: userId,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({ page: {} });
+
+      expect(result.learners).lengthOf(0);
+    });
+
+    it('retrieve all active learners from specific organizationId', async function () {
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+      });
+
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+      });
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: otherOrganizationId,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+        filter: { organizationId: organization.id },
+        page: {},
+      });
+
+      expect(result.learners).lengthOf(2);
+    });
+
+    context('ordered learners without case sensitive', function () {
+      let firstLearner;
+
+      beforeEach(async function () {
+        firstLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'toto',
+          lastName: 'Gilgamesh',
+        });
+        await databaseBuilder.commit();
+      });
+
+      it('orders by firstName', async function () {
+        const secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Tata',
+          lastName: 'Gilgamesh',
+        });
+        const thirdLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Toto',
+          lastName: 'Gulgamesh',
+        });
+
+        await databaseBuilder.commit();
+
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({ page: {} });
+
+        expect(result.learners).lengthOf(3);
+        expect(result.learners[0].id).to.equal(secondLearner.id);
+        expect(result.learners[1].id).to.equal(firstLearner.id);
+        expect(result.learners[2].id).to.equal(thirdLearner.id);
+      });
+
+      it('orders by lastName when firstName are identical', async function () {
+        const secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Toto',
+          lastName: 'Auberto',
+        });
+
+        const thirdLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Toto',
+          lastName: 'auberti',
+        });
+
+        await databaseBuilder.commit();
+
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({ page: {} });
+
+        expect(result.learners).lengthOf(3);
+        expect(result.learners[0].id).to.equal(thirdLearner.id);
+        expect(result.learners[1].id).to.equal(secondLearner.id);
+        expect(result.learners[2].id).to.equal(firstLearner.id);
+      });
+    });
+
+    context('Pagination', function () {
+      it('retrieve paginated all active learners', async function () {
+        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId: organization.id,
+        });
+        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId: organization.id,
+        });
+
+        await databaseBuilder.commit();
+
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+          page: {
+            size: 1,
+            number: 1,
+          },
+        });
+
+        expect(result.pagination).to.deep.equal({
+          page: 1,
+          pageSize: 1,
+          rowCount: 2,
+          pageCount: 2,
+        });
+      });
+
+      context('Filtering', function () {
+        it('retrieve filtered and paginated learners', async function () {
+          const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+            organizationId: otherOrganizationId,
+            firstName: 'Zoé',
+            lastName: 'De Ségazan',
+          });
+          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+            organizationId: organization.id,
+            firstName: 'Zoé',
+          });
+
+          const learner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+            organizationId: organization.id,
+            firstName: 'Zoé',
+            lastName: 'De Ségazan',
+          });
+
+          await databaseBuilder.commit();
+
+          const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+            page: {
+              size: 1,
+              number: 1,
+            },
+            filter: { organizationId: organization.id, fullName: 'Zoé De Ségazan' },
+          });
+
+          expect(result.pagination).to.deep.equal({
+            page: 1,
+            pageSize: 1,
+            rowCount: 1,
+            pageCount: 1,
+          });
+          expect(result.learners).to.have.lengthOf(1);
+          expect(result.learners[0].id).to.equal(learner.id);
         });
       });
     });

--- a/api/tests/prescription/organization-learner/unit/application/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/learner-list-route_test.js
@@ -88,4 +88,58 @@ describe('Unit | Application | Routes | Learner List', function () {
       });
     });
   });
+  describe('GET /api/admin/organization-learners', function () {
+    it('should return error 403 when user is not admin', async function () {
+      //given
+      sinon.stub(learnerListController, 'findOrganizationLearnersForAdmin');
+      sinon
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          securityPreHandlers.checkAdminMemberHasRoleCertif,
+          securityPreHandlers.checkAdminMemberHasRoleSupport,
+          securityPreHandlers.checkAdminMemberHasRoleMetier,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover(),
+        );
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      //when
+      const response = await httpTestServer.request('GET', '/api/admin/organization-learners', null);
+
+      //then
+      expect(response.statusCode).to.be.equal(403);
+      sinon.assert.notCalled(learnerListController.findOrganizationLearnersForAdmin);
+    });
+    it('should return error 400 when filters are invalid', async function () {
+      //given
+      sinon.stub(learnerListController, 'findOrganizationLearnersForAdmin');
+      sinon
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          securityPreHandlers.checkAdminMemberHasRoleCertif,
+          securityPreHandlers.checkAdminMemberHasRoleSupport,
+          securityPreHandlers.checkAdminMemberHasRoleMetier,
+        ])
+        .callsFake(() => (request, h) => h.response().code(200));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      //when
+      const response = await httpTestServer.request('GET', '/api/admin/organization-learners?filter[wrongFilter]=true');
+
+      //then
+      expect(response.statusCode).to.be.equal(400);
+      sinon.assert.notCalled(learnerListController.findOrganizationLearnersForAdmin);
+    });
+  });
 });

--- a/api/tests/prescription/organization-learner/unit/application/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/learner-list-route_test.js
@@ -6,7 +6,7 @@ import { securityPreHandlers } from '../../../../../src/shared/application/secur
 import { expect } from '../../../../test-helper.js';
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 
-describe('Integration | Application | Routes | Learner List', function () {
+describe('Unit | Application | Routes | Learner List', function () {
   describe('GET /api/organizations/{organizationId}/participants', function () {
     const method = 'GET';
     const url = '/api/organizations/1/participants';
@@ -30,7 +30,7 @@ describe('Integration | Application | Routes | Learner List', function () {
       expect(learnerListController.findPaginatedFilteredParticipants).to.have.been.calledOnce;
     });
 
-    it('should return HTTP code 400 when user not belongs to the organization', async function () {
+    it('should return HTTP code 403 when user not belongs to the organization', async function () {
       //given
       sinon
         .stub(securityPreHandlers, 'checkUserBelongsToOrganization')

--- a/api/tests/prescription/organization-learner/unit/domain/read-models/OrganizationLearnerOverviewForAdmin_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/read-models/OrganizationLearnerOverviewForAdmin_test.js
@@ -1,0 +1,43 @@
+import { OrganizationLearnerOverviewForAdmin } from '../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerOverviewForAdmin.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Read-models | OrganizationLearnerOverviewForAdmin', function () {
+  describe('#constructor', function () {
+    let validArguments;
+
+    beforeEach(function () {
+      validArguments = {
+        id: 1,
+        firstName: 'John',
+        lastName: 'Doe',
+        birthdate: '2000-10-15',
+        division: '3A',
+        group: 'L1',
+        nationalStudentId: '123456ABCDE',
+        organizationId: 1,
+        organizationName: 'School',
+        userId: 1,
+        updatedAt: new Date('2020-09-08'),
+        isDisabled: false,
+      };
+    });
+    it('should build a valid learner', function () {
+      const learner = new OrganizationLearnerOverviewForAdmin(validArguments);
+      expect(learner).to.be.an.instanceof(OrganizationLearnerOverviewForAdmin);
+      expect(learner).to.be.deep.equal({
+        id: 1,
+        firstName: 'John',
+        lastName: 'Doe',
+        birthdate: '2000-10-15',
+        division: '3A',
+        group: 'L1',
+        nationalStudentId: '123456ABCDE',
+        organizationId: 1,
+        organizationName: 'School',
+        userId: 1,
+        updatedAt: new Date('2020-09-08'),
+        isDisabled: false,
+      });
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/find-paginated-organization-learners_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/find-paginated-organization-learners_test.js
@@ -9,7 +9,7 @@ describe('Unit | UseCase | find-paginated-organisation-learners', function () {
     const organizationId = 1234;
 
     const organizationLearnerRepository = {
-      findPaginatedLearners: sinon.stub(),
+      findPaginatedLearnersByOrganizationId: sinon.stub(),
     };
 
     // when
@@ -21,7 +21,7 @@ describe('Unit | UseCase | find-paginated-organisation-learners', function () {
     });
 
     // then
-    expect(organizationLearnerRepository.findPaginatedLearners).to.have.been.calledWithExactly({
+    expect(organizationLearnerRepository.findPaginatedLearnersByOrganizationId).to.have.been.calledWithExactly({
       organizationId,
       page: { size: 1, number: 1 },
       filter: { 'Libellé classe': ['div'] },

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/admin-organization-learner-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/admin-organization-learner-serializer_test.js
@@ -1,0 +1,88 @@
+import { OrganizationLearnerOverviewForAdmin } from '../../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerOverviewForAdmin.js';
+import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/admin-organization-learner-serializer.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | admin-organization-learner-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an OrganizationLearnerOverviewForAdmin model object into JSON API data', function () {
+      // given
+      const pagination = { page: 1, pageSize: 1, rowCount: 2, pageCount: 2 };
+      const organizationLearners = [
+        new OrganizationLearnerOverviewForAdmin({
+          id: 1,
+          firstName: 'John',
+          lastName: 'Doe',
+          birthdate: '2000-10-15',
+          division: '3A',
+          group: 'L1',
+          nationalStudentId: '123456ABCDE',
+          organizationId: 1,
+          organizationName: 'School',
+          userId: 1,
+          updatedAt: new Date('2020-09-08'),
+          isDisabled: false,
+        }),
+        new OrganizationLearnerOverviewForAdmin({
+          id: 2,
+          firstName: 'Jane',
+          lastName: 'Do',
+          birthdate: '2000-10-15',
+          division: '3A',
+          group: 'L1',
+          nationalStudentId: '223456ABCDE',
+          organizationId: 1,
+          organizationName: 'School',
+          userId: 1,
+          updatedAt: new Date('2020-09-08'),
+          isDisabled: true,
+        }),
+      ];
+
+      const expectedSerializedLearner = {
+        meta: { page: 1, pageSize: 1, rowCount: 2, pageCount: 2 },
+        data: [
+          {
+            type: 'admin-organization-learners',
+            id: '1',
+            attributes: {
+              'first-name': 'John',
+              'last-name': 'Doe',
+              birthdate: '2000-10-15',
+              division: '3A',
+              group: 'L1',
+              'national-student-id': '123456ABCDE',
+              'organization-id': 1,
+              'organization-name': 'School',
+              'user-id': 1,
+              'updated-at': new Date('2020-09-08'),
+              'is-disabled': false,
+            },
+          },
+          {
+            type: 'admin-organization-learners',
+            id: '2',
+            attributes: {
+              'first-name': 'Jane',
+              'last-name': 'Do',
+              birthdate: '2000-10-15',
+              division: '3A',
+              group: 'L1',
+              'national-student-id': '223456ABCDE',
+              'organization-id': 1,
+              'organization-name': 'School',
+              'user-id': 1,
+              'updated-at': new Date('2020-09-08'),
+              'is-disabled': true,
+            },
+          },
+        ],
+      };
+
+      // when
+      const json = serializer.serialize({ learners: organizationLearners, pagination });
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedLearner);
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

Le support ne peut pas rechercher des prescrits sans utiliser metabase. Il n’existe pas encore de routes de récupération des prescrits pour Pix Admin.

## 🌈 Proposition

Créer la route dans l’API. Investiguer pour utiliser le modèle OrganizationLearners et le repository déjà existants et voir s’ils ont besoin d'être modifiés.

La route ne devra pas retourner de prescrits deleted (mais les désactivés sont retournés).

## ✊ Remarques

Aucune limite de récupération n'a été fixée dans la requête car il existe apparemment un comportement défini pour ça.

## 🎉 Pour tester
Tests au vert.

Faire un curl vers la route pour vérifier qu’elle renvoie les bonnes infos.

```
ACCESS_TOKEN=$(curl -X 'POST' -s  'https://api-pr16614.review.pix.fr/api/token' -d 'grant_type=password&username=superadmin@example.net&password=pix123' | jq -r ".access_token")

curl -H "Authorization: Bearer $ACCESS_TOKEN" "https://api-pr16614.review.pix.fr/api/admin/organization-learners?page%5Bnumber%5D=1&page%5Bsize%5D=50&filter%5BfullName%5D=Zoro&filter%5BorganizationId%5D=9001" | jq
```