### PR TITLE
[FEATURE] Récompense l'utilisateur qui a rempli l'exigence de sujets cappés dans un Parcours Combinés (PIX-21718).

### DIFF
--- a/api/src/quest/domain/usecases/update-combined-course-progress.js
+++ b/api/src/quest/domain/usecases/update-combined-course-progress.js
@@ -10,6 +10,7 @@ export async function updateCombinedCourseProgress({
   organizationLearnerParticipationRepository,
   combinedCourseDetailsService,
   rewardRepository,
+  successRepository,
 }) {
   const combinedCourse = await combinedCourseRepository.getByCode({ code });
   const organizationLearnerId = await organizationLearnerPrescriptionRepository.findIdByUserIdAndOrganizationId({
@@ -44,6 +45,17 @@ export async function updateCombinedCourseProgress({
   const isCombinedCourseCompleted = await updatedCombinedCourseDetails.items.every((item) => item.isCompleted);
 
   if (isCombinedCourseCompleted) {
+    const success = await successRepository.find({
+      userId,
+      campaignParticipationIds: updatedCombinedCourseDetails.quest.findCampaignParticipationIdsContributingToQuest(
+        updatedCombinedCourseDetails.dataForQuest,
+      ),
+      targetProfileIds:
+        updatedCombinedCourseDetails.quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(
+          updatedCombinedCourseDetails.dataForQuest,
+        ),
+    });
+    updatedCombinedCourseDetails.dataForQuest.success = success;
     updatedCombinedCourseDetails.participation.complete();
     const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromCombinedCourse(
       updatedCombinedCourseDetails.participation,

--- a/api/tests/quest/integration/domain/usecases/update-combined-course-progress_test.js
+++ b/api/tests/quest/integration/domain/usecases/update-combined-course-progress_test.js
@@ -12,6 +12,7 @@ import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { repositories } from '../../../../../src/quest/infrastructure/repositories/index.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | Quest | Domain | UseCases | update-combined-course-progress', function () {
   let clock;
@@ -97,9 +98,60 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course-progr
           userId,
           organizationId,
         } = databaseBuilder.factory.buildOrganizationLearner();
+        const skillId = 'web1';
+        const tubeId = 'recTube1';
+        const competenceId = 'recAbe382T0e1337';
+        const competence = {
+          id: competenceId,
+          areaId: 'recvoGdo7z2z7pXWa',
+        };
+        const area = {
+          id: 'recvoGdo7z2z7pXWa',
+          competenceIds: [competenceId],
+        };
+        const learningContent = [
+          {
+            ...area,
+            competences: [
+              {
+                ...competence,
+                tubes: [
+                  {
+                    id: tubeId,
+                    skills: [
+                      {
+                        id: skillId,
+                        level: 1,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        databaseBuilder.factory.buildKnowledgeElement({
+          skillId,
+          competenceId,
+          userId,
+        });
+        const campaignId = databaseBuilder.factory.buildCampaign().id;
+        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId });
         const reward = databaseBuilder.factory.buildAttestation();
         const { id: rewardQuestId } = databaseBuilder.factory.buildQuestForCombinedCourse({
-          successRequirements: [CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }).toDTO()],
+          successRequirements: [
+            CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }).toDTO(),
+            CombinedCourseBlueprint.buildRequirementForCombinedCourse({ campaignId }).toDTO(),
+            {
+              requirement_type: 'cappedTubes',
+              data: {
+                threshold: 100,
+                cappedTubes: [{ tubeId, level: 1 }],
+              },
+            },
+          ],
           rewardType: REWARD_TYPES.ATTESTATION,
           rewardId: reward.id,
         });
@@ -124,6 +176,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course-progr
           updatedAt: new Date('2022-01-01'),
           status: OrganizationLearnerParticipationStatuses.STARTED,
         });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, userId });
         await databaseBuilder.commit();
 
         await usecases.updateCombinedCourseProgress({ userId, code });


### PR DESCRIPTION
## 🪧 Problème

Bien que l'on puisse créé un parcours combiné avec une récompense basée sur le pourcentage d'atteinte de sujets cappés, la récompense n'est pas donnée en fin de parcours à l'utilisateur répondant aux critères car les connaissances acquises ne sont pas encore vérifiées.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌈 Proposition

On ajoute les critères de succès obtenus par l'utilisateur en fin de parcours combinés.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ✊ Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Sur Pix Admin, créer un modèle de parcours combiné contenant une attestation et des sujets cappés correspondant aux sujets présents dans le profil cible choisi.
Sur Pix Orga, créer un parcours combiné à partir du modèle précédent.
Sur Pix App, jouer l'intégralité du parcours combiné.
Constater l'obtention de l'attestation en fin de parcours combiné