### PR TITLE
[TECH] Récupération des challenges anglais non joués en certif coeur (PIX-23293).

### DIFF
--- a/api/scripts/certification/duplicate-english-core-calibration-with-new-ids.js
+++ b/api/scripts/certification/duplicate-english-core-calibration-with-new-ids.js
@@ -27,12 +27,10 @@ export class DuplicateEnglishCoreCalibrationWithNewIds extends Script {
       .join('certification_versions', 'certification_versions.id', 'certification-frameworks-challenges.versionId')
       .join(
         { lc_challenges: 'learningcontent.challenges' },
-        'lc_challenges.id',
-        'certification-frameworks-challenges.challengeId',
+        knex.raw('lc_challenges.id = "certification-frameworks-challenges"."challengeId" || \'-EN\''),
       )
       .where('certification_versions.scope', 'CORE')
       .whereNull('certification_versions.expirationDate')
-      .whereRaw('?=ANY(??)', ['en', 'lc_challenges.locales'])
       .select(
         'certification-frameworks-challenges.challengeId',
         'certification-frameworks-challenges.discriminant',

--- a/api/scripts/certification/duplicate-english-core-calibration-with-new-ids.js
+++ b/api/scripts/certification/duplicate-english-core-calibration-with-new-ids.js
@@ -1,7 +1,6 @@
 import { knex } from '../../db/knex-database-connection.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
 
 export class DuplicateEnglishCoreCalibrationWithNewIds extends Script {
   constructor() {
@@ -47,14 +46,22 @@ export class DuplicateEnglishCoreCalibrationWithNewIds extends Script {
       versionId: challenge.versionId,
     }));
 
-    if (!dryRun) {
-      const knexConnection = DomainTransaction.getConnection();
-      await knexConnection.batchInsert('certification-frameworks-challenges', newChallenges);
-    }
+    const trx = await knex.transaction();
 
-    logger.info(
-      `${newChallenges.length} challenges have been added to current version ${dryRun ? '(dry run)' : ''}. Youpi Yo Youpi Yay`,
-    );
+    try {
+      await trx.batchInsert('certification-frameworks-challenges', newChallenges);
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(`${newChallenges.length} challenges would have been added to current version`);
+        return;
+      } else {
+        await trx.commit();
+        logger.info(`${newChallenges.length} challenges have been added to current version. Youpi.`);
+      }
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
   }
 }
 

--- a/api/scripts/certification/duplicate-english-core-calibration-with-new-ids.js
+++ b/api/scripts/certification/duplicate-english-core-calibration-with-new-ids.js
@@ -1,0 +1,63 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+export class DuplicateEnglishCoreCalibrationWithNewIds extends Script {
+  constructor() {
+    super({
+      description:
+        'This script will duplicate English calibration for current core version with new ids as current ids are no longer attached to lcms challenges',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info(`Script execution started`);
+
+    const englishChallenges = await knex('certification-frameworks-challenges')
+      .join('certification_versions', 'certification_versions.id', 'certification-frameworks-challenges.versionId')
+      .join(
+        { lc_challenges: 'learningcontent.challenges' },
+        'lc_challenges.id',
+        'certification-frameworks-challenges.challengeId',
+      )
+      .where('certification_versions.scope', 'CORE')
+      .whereNull('certification_versions.expirationDate')
+      .whereRaw('?=ANY(??)', ['en', 'lc_challenges.locales'])
+      .select(
+        'certification-frameworks-challenges.challengeId',
+        'certification-frameworks-challenges.discriminant',
+        'certification-frameworks-challenges.difficulty',
+        'certification-frameworks-challenges.versionId',
+      );
+
+    logger.info(`Found ${englishChallenges.length} English challenges in current CORE version`);
+
+    const newChallenges = englishChallenges.map((challenge) => ({
+      challengeId: `${challenge.challengeId}-EN`,
+      discriminant: challenge.discriminant,
+      difficulty: challenge.difficulty,
+      versionId: challenge.versionId,
+    }));
+
+    if (!dryRun) {
+      const knexConnection = DomainTransaction.getConnection();
+      await knexConnection.batchInsert('certification-frameworks-challenges', newChallenges);
+    }
+
+    logger.info(
+      `${newChallenges.length} challenges have been added to current version ${dryRun ? '(dry run)' : ''}. Youpi Yo Youpi Yay`,
+    );
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, DuplicateEnglishCoreCalibrationWithNewIds);

--- a/api/tests/integration/scripts/certification/duplicate-english-core-calibration-with-new-ids_test.js
+++ b/api/tests/integration/scripts/certification/duplicate-english-core-calibration-with-new-ids_test.js
@@ -1,0 +1,144 @@
+import sinon from 'sinon';
+
+import { DuplicateEnglishCoreCalibrationWithNewIds } from '../../../../scripts/certification/duplicate-english-core-calibration-with-new-ids.js';
+import { expect } from '../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../tooling/databases.js';
+
+describe('Integration | Scripts | Certification | duplicate-english-core-calibration-with-new-ids', function () {
+  let script;
+  let logger;
+
+  beforeEach(function () {
+    script = new DuplicateEnglishCoreCalibrationWithNewIds();
+    logger = { info: sinon.stub(), warn: sinon.stub() };
+  });
+
+  describe('#handle', function () {
+    context('when dryRun is false', function () {
+      it('should insert duplicates with -EN suffix for English challenges of the current CORE version', async function () {
+        // given
+        const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
+          scope: 'CORE',
+          expirationDate: null,
+        });
+
+        const { id: challengeId } = databaseBuilder.factory.learningContent.buildChallenge({
+          id: 'challengeEn1',
+          locales: ['en'],
+        });
+
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          challengeId,
+          versionId,
+          discriminant: 1.5,
+          difficulty: 2.5,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: false } });
+
+        // then
+        const insertedChallenge = await knex('certification-frameworks-challenges')
+          .where({ challengeId: `${challengeId}-EN`, versionId })
+          .first();
+
+        expect(insertedChallenge).to.exist;
+        expect(insertedChallenge.discriminant).to.equal(1.5);
+        expect(insertedChallenge.difficulty).to.equal(2.5);
+      });
+
+      it('should not duplicate non-English challenges', async function () {
+        // given
+        const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
+          scope: 'CORE',
+          expirationDate: null,
+        });
+
+        const { id: frenchChallengeId } = databaseBuilder.factory.learningContent.buildChallenge({
+          id: 'challengeFr1',
+          locales: ['fr'],
+        });
+
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          challengeId: frenchChallengeId,
+          versionId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: false } });
+
+        // then
+        const insertedChallenge = await knex('certification-frameworks-challenges')
+          .where({ challengeId: `${frenchChallengeId}-EN` })
+          .first();
+
+        expect(insertedChallenge).to.not.exist;
+      });
+
+      it('should not duplicate English challenges from an expired CORE version', async function () {
+        // given
+        const { id: expiredVersionId } = databaseBuilder.factory.buildCertificationVersion({
+          scope: 'CORE',
+          expirationDate: new Date('2025-01-01'),
+        });
+
+        const { id: challengeId } = databaseBuilder.factory.learningContent.buildChallenge({
+          id: 'challengeEnExpired',
+          locales: ['en'],
+        });
+
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          challengeId,
+          versionId: expiredVersionId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: false } });
+
+        // then
+        const insertedChallenge = await knex('certification-frameworks-challenges')
+          .where({ challengeId: `${challengeId}-EN` })
+          .first();
+
+        expect(insertedChallenge).to.not.exist;
+      });
+    });
+
+    context('when dryRun is true', function () {
+      it('should not modify the database', async function () {
+        // given
+        const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
+          scope: 'CORE',
+          expirationDate: null,
+        });
+
+        const { id: challengeId } = databaseBuilder.factory.learningContent.buildChallenge({
+          id: 'challengeEn1',
+          locales: ['en'],
+        });
+
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          challengeId,
+          versionId,
+        });
+
+        await databaseBuilder.commit();
+
+        const { count: countBefore } = await knex('certification-frameworks-challenges').count('id as count').first();
+
+        // when
+        await script.handle({ logger, options: { dryRun: true } });
+
+        // then
+        const { count: countAfter } = await knex('certification-frameworks-challenges').count('id as count').first();
+        expect(Number(countAfter)).to.equal(Number(countBefore));
+      });
+    });
+  });
+});

--- a/api/tests/integration/scripts/certification/duplicate-english-core-calibration-with-new-ids_test.js
+++ b/api/tests/integration/scripts/certification/duplicate-english-core-calibration-with-new-ids_test.js
@@ -142,5 +142,45 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
         expect(Number(countAfter)).to.equal(Number(countBefore));
       });
     });
+
+    context('when an error occurs during insertion', function () {
+      afterEach(function () {
+        sinon.restore();
+      });
+
+      it('should rollback the transaction and rethrow the error', async function () {
+        // given
+        const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
+          scope: 'CORE',
+          expirationDate: null,
+        });
+
+        const baseId = 'challengeEnError';
+
+        databaseBuilder.factory.learningContent.buildChallenge({
+          id: `${baseId}-EN`,
+        });
+
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          challengeId: baseId,
+          versionId,
+          discriminant: 1.5,
+          difficulty: 2.5,
+        });
+
+        await databaseBuilder.commit();
+
+        const dbError = new Error('DB insertion error');
+        const fakeTrx = {
+          batchInsert: sinon.stub().rejects(dbError),
+          rollback: sinon.stub().resolves(),
+        };
+        sinon.stub(knex, 'transaction').resolves(fakeTrx);
+
+        // when / then
+        await expect(script.handle({ logger, options: { dryRun: false } })).to.be.rejectedWith('DB insertion error');
+        expect(fakeTrx.rollback).to.have.been.calledOnce;
+      });
+    });
   });
 });

--- a/api/tests/integration/scripts/certification/duplicate-english-core-calibration-with-new-ids_test.js
+++ b/api/tests/integration/scripts/certification/duplicate-english-core-calibration-with-new-ids_test.js
@@ -15,20 +15,21 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
 
   describe('#handle', function () {
     context('when dryRun is false', function () {
-      it('should insert duplicates with -EN suffix for English challenges of the current CORE version', async function () {
+      it('should insert duplicates with -EN suffix for challenges that have a -EN counterpart in LCMS', async function () {
         // given
         const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
           scope: 'CORE',
           expirationDate: null,
         });
 
-        const { id: challengeId } = databaseBuilder.factory.learningContent.buildChallenge({
-          id: 'challengeEn1',
-          locales: ['en'],
+        const baseId = 'challengeEn1';
+
+        databaseBuilder.factory.learningContent.buildChallenge({
+          id: `${baseId}-EN`,
         });
 
         databaseBuilder.factory.buildCertificationFrameworksChallenge({
-          challengeId,
+          challengeId: baseId,
           versionId,
           discriminant: 1.5,
           difficulty: 2.5,
@@ -41,7 +42,7 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
 
         // then
         const insertedChallenge = await knex('certification-frameworks-challenges')
-          .where({ challengeId: `${challengeId}-EN`, versionId })
+          .where({ challengeId: `${baseId}-EN`, versionId })
           .first();
 
         expect(insertedChallenge).to.exist;
@@ -49,20 +50,19 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
         expect(insertedChallenge.difficulty).to.equal(2.5);
       });
 
-      it('should not duplicate non-English challenges', async function () {
+      it('should not duplicate challenges that have no corresponding -EN entry in LCMS', async function () {
         // given
         const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
           scope: 'CORE',
           expirationDate: null,
         });
 
-        const { id: frenchChallengeId } = databaseBuilder.factory.learningContent.buildChallenge({
+        databaseBuilder.factory.learningContent.buildChallenge({
           id: 'challengeFr1',
-          locales: ['fr'],
         });
 
         databaseBuilder.factory.buildCertificationFrameworksChallenge({
-          challengeId: frenchChallengeId,
+          challengeId: 'challengeFr1',
           versionId,
         });
 
@@ -73,26 +73,27 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
 
         // then
         const insertedChallenge = await knex('certification-frameworks-challenges')
-          .where({ challengeId: `${frenchChallengeId}-EN` })
+          .where({ challengeId: 'challengeFr1-EN' })
           .first();
 
         expect(insertedChallenge).to.not.exist;
       });
 
-      it('should not duplicate English challenges from an expired CORE version', async function () {
+      it('should not duplicate challenges from an expired CORE version', async function () {
         // given
         const { id: expiredVersionId } = databaseBuilder.factory.buildCertificationVersion({
           scope: 'CORE',
           expirationDate: new Date('2025-01-01'),
         });
 
-        const { id: challengeId } = databaseBuilder.factory.learningContent.buildChallenge({
-          id: 'challengeEnExpired',
-          locales: ['en'],
+        const baseId = 'challengeEnExpired';
+
+        databaseBuilder.factory.learningContent.buildChallenge({
+          id: `${baseId}-EN`,
         });
 
         databaseBuilder.factory.buildCertificationFrameworksChallenge({
-          challengeId,
+          challengeId: baseId,
           versionId: expiredVersionId,
         });
 
@@ -103,7 +104,7 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
 
         // then
         const insertedChallenge = await knex('certification-frameworks-challenges')
-          .where({ challengeId: `${challengeId}-EN` })
+          .where({ challengeId: `${baseId}-EN` })
           .first();
 
         expect(insertedChallenge).to.not.exist;
@@ -118,13 +119,14 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
           expirationDate: null,
         });
 
-        const { id: challengeId } = databaseBuilder.factory.learningContent.buildChallenge({
-          id: 'challengeEn1',
-          locales: ['en'],
+        const baseId = 'challengeEn1';
+
+        databaseBuilder.factory.learningContent.buildChallenge({
+          id: `${baseId}-EN`,
         });
 
         databaseBuilder.factory.buildCertificationFrameworksChallenge({
-          challengeId,
+          challengeId: baseId,
           versionId,
         });
 


### PR DESCRIPTION
## 🪧 Problème

Depuis le 19 mars 2026, la majorité des épreuves du référentiel Pix transverse en anglais ont été périmées.

Elles n'étaient donc plus jouables en certification car l’algo ne pouvait les sélectionner. La qualité des certifications passées en anglais depuis cette date étaient donc fortement dégradées.

Les certifications en anglais ont été bloquées depuis #16610 en attendant de pouvoir trouver une solution pérenne pour rétablir la qualité du référentiel de certification Pix transverse en anglais.

## 🌈 Proposition

Création d'un script qui : 
- retrouve la liste des épreuves initialement incluses dans le référentiel Pix transverse en anglais avant la vague de péremption du 19/03
- modifie les ID des challenges de la version actuelle du référentiel de certification Pix transverse en anglais
- ajoute les challenges modifiés à ceux associés à la version actuelle

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

(Peut être exécuté en local pour plus de facilité à modifier certains éléments en BDD)

- Remplacer le tableau des locales d'un ou plusieurs challenges dans LCMS associés par `["en"]`
- Exécuter le script avec :

```bash
scalingo -a pix-api-review-pr16621 run "node scripts/certification/duplicate-english-core-calibration-with-new-ids.js --dryRun=true"
```

Vérifier que des challenges seraient ajoutés à la calibration existante.
Passer le dryRun à false et vérifier en BDD que les challenges ont bien été insérés en BDD avec pour nouveau challengeId : `<ancien_challengeId>-EN`