### PR TITLE
[FEATURE] Créer la table user-campaign-surveys pour stocker le NPS (PIX-23301).

### DIFF
--- a/api/db/migrations/20260624112002_create-user-campaign-surveys.js
+++ b/api/db/migrations/20260624112002_create-user-campaign-surveys.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'user-campaign-surveys';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.integer('userId').unsigned().notNullable().references('users.id');
+    table.integer('campaignId').unsigned().notNullable().references('campaigns.id');
+    table.smallint('satisfactionScore').notNullable().comment('satisfaction score from 1 to 5');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.unique(['userId', 'campaignId']);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}


### PR DESCRIPTION
## 🪧 Problème
Une nouvelle fonctionnalité arrive lors de cette canicule intense. C'est celle du stockage du NPS pour le moteur de recommandations. On a besoin d'une table pour stocker cette information

## 🌈 Proposition
Créer la table `user-campaign-surveys`

## ✊ Remarques
Ajout d'un contrainte d'unicité pour le couple `userId` et `campaignId`

## 🎉 Pour tester
- lancer la migration en local `npm run db:migrate`
- constater la présence de la table
- lancer un `npm run db:rollback:latest`
- constater que la table a disparu 🏜️ 

