### PR TITLE
[FEATURE] Améliorer la modale d'une campagne de type moteur de recommandation (PIX-22963)

### DIFF
--- a/mon-pix/app/app.js
+++ b/mon-pix/app/app.js
@@ -1,5 +1,6 @@
 import './deprecation-workflow';
 import '@1024pix/epreuves-components';
+import '@formatjs/intl-durationformat/polyfill.js';
 
 import Application from '@ember/application';
 import setupInspector from '@embroider/legacy-inspector-support/ember-source-4.12';

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -12,10 +12,12 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
+import Training from 'mon-pix/models/training';
 
 import RegistrationCardTag from './registration-card-tag';
 
 export default class CardModal extends Component {
+  @service locale;
   @service store;
 
   @tracked isTrainingRecommendationRelevant = null;
@@ -25,6 +27,10 @@ export default class CardModal extends Component {
   constructor(...args) {
     super(...args);
     this.isTrainingRecommendationRelevant = this.args.training.isRelevant ?? null;
+  }
+
+  get formattedDuration() {
+    return Training.formatDuration({ locale: this.locale.currentLanguage, duration: this.args.training.duration });
   }
 
   get isPositiveFeedback() {
@@ -77,8 +83,7 @@ export default class CardModal extends Component {
                 <PixIcon @name="time" @ariaHidden={{true}} />
                 <dt>{{t "pages.skill-review.recommended-engine.modal.duration"}}</dt>
                 <dd class="results-recommendation-engine-training-card-modal-section__time-information--bold">
-                  <span>{{@training.formattedDays}}</span>
-                  <span>{{@training.formattedTime}}</span>
+                  <span>{{this.formattedDuration}}</span>
                 </dd>
               </dl>
             {{/if}}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -92,7 +92,7 @@ export default class CardModal extends Component {
           </div>
         </div>
 
-        <PixAccordions {{on "click" (fn this.onModalAccordionClick "OBJECTIVES")}}>
+        <PixAccordions @isV2Version={{true}} {{on "click" (fn this.onModalAccordionClick "OBJECTIVES")}}>
           <:title>
             <h2>{{t "pages.skill-review.recommended-engine.modal.objectives"}}</h2>
           </:title>
@@ -112,7 +112,7 @@ export default class CardModal extends Component {
             </ul>
           </:content>
         </PixAccordions>
-        <PixAccordions {{on "click" (fn this.onModalAccordionClick "PROGRAM")}}>
+        <PixAccordions @isV2Version={{true}} {{on "click" (fn this.onModalAccordionClick "PROGRAM")}}>
           <:title>
             <h2>{{t "pages.skill-review.recommended-engine.modal.program"}}</h2>
           </:title>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -4,12 +4,14 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import Training from 'mon-pix/models/training';
 
 import CardModal from './card-modal';
 import RegistrationCardTag from './registration-card-tag';
 
 export default class Card extends Component {
   @service intl;
+  @service locale;
 
   @tracked modalIsOpen = false;
 
@@ -17,6 +19,10 @@ export default class Card extends Component {
     const deliveryMode = this.args.training.deliveryMode === 'onSite' ? 'on-site' : this.args.training.deliveryMode;
 
     return this.intl.t(`pages.skill-review.recommended-engine.training-card.delivery-mode.${deliveryMode}`);
+  }
+
+  get formattedDuration() {
+    return Training.formatDuration({ locale: this.locale.currentLanguage, duration: this.args.training.duration });
   }
 
   get illustrationPath() {
@@ -66,7 +72,7 @@ export default class Card extends Component {
         <ul class="results-recommendation-engine-training-card-content__details"><li>{{this.type}}</li>
           <li>{{this.deliveryMode}}</li>
           {{#if @training.hasDuration}}
-            <li>{{@training.formattedDuration}}</li>
+            <li>{{this.formattedDuration}}</li>
           {{/if}}
         </ul>
       </section>

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -1,4 +1,3 @@
-import { service } from '@ember/service';
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Training extends Model {
@@ -69,35 +68,4 @@ export default class Training extends Model {
 
     return days ? result : resultWithWhitespaceRemoved;
   }
-
-  get formattedDuration() {
-    const daysPart = this.formattedDays;
-    const timePart = this.formattedTime;
-
-    if (daysPart && timePart)
-      return `${daysPart} ${this.intl.t('pages.skill-review.recommended-engine.training-card.duration.and')} ${timePart}`;
-    return daysPart || timePart;
-  }
-
-  get formattedDays() {
-    const { days } = this.duration;
-
-    return days
-      ? `${days} ${this.intl.t('pages.skill-review.recommended-engine.training-card.duration.days', { count: days })}`
-      : '';
-  }
-
-  get formattedTime() {
-    const { hours, minutes } = this.duration;
-
-    const formattedHours = hours
-      ? `${hours}${this.intl.t('pages.skill-review.recommended-engine.training-card.duration.hours')}`
-      : '';
-    const formattedMinutes = minutes
-      ? `${minutes}${this.intl.t('pages.skill-review.recommended-engine.training-card.duration.minutes')}`
-      : '';
-    return [formattedHours, formattedMinutes].filter(Boolean).join('');
-  }
-
-  @service intl;
 }

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -50,6 +50,26 @@ export default class Training extends Model {
     return this.duration.days || this.duration.hours || this.duration.minutes;
   }
 
+  static formatDuration({ locale, duration }) {
+    const { days, hours, minutes } = duration || {};
+
+    if (!days && !hours && !minutes) {
+      return '';
+    }
+
+    let options = { style: 'narrow' };
+
+    if (days) {
+      options = { style: 'long', ...(hours && { hours: 'narrow' }), ...(minutes && { minutes: 'narrow' }) };
+    }
+
+    const formatter = new Intl.DurationFormat(locale, options);
+    const result = formatter.format({ days, hours, minutes });
+    const resultWithWhitespaceRemoved = result.replaceAll(' ', '');
+
+    return days ? result : resultWithWhitespaceRemoved;
+  }
+
   get formattedDuration() {
     const daysPart = this.formattedDays;
     const timePart = this.formattedTime;

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -206,6 +206,8 @@
       display: flex;
       flex-direction: column;
       font-weight: var(--pix-font-bold);
+      text-align: center;
+      text-wrap: balance;
     }
   }
 }

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -243,6 +243,30 @@
       outline-offset: -3px;
     }
 
+    .pix-icon-button {
+      &:not([aria-disabled='true']) {
+        &:hover:enabled {
+          color: var(--pix-neutral-800);
+          background-color: var(--pix-neutral-100);
+          outline: 0;
+        }
+
+        &:focus:enabled:not(.selected){
+          color: var(--pix-neutral-800);
+          background-color: var(--pix-neutral-0);
+          outline: 1px solid var(--pix-neutral-800);
+          outline-offset: -3px;
+        }
+
+        &:active:enabled {
+          color: var(--pix-neutral-800);
+          background-color: var(--pix-neutral-100);
+          outline: 0;
+        }
+      }
+
+    }
+
     legend {
       @extend %pix-body-m;
 

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -30,6 +30,7 @@
         "@embroider/util": "^1.13.5",
         "@embroider/webpack": "^4.1.2",
         "@formatjs/intl": "^4.1.11",
+        "@formatjs/intl-durationformat": "^0.10.15",
         "@glimmer/component": "^1.1.2",
         "@sentry/ember": "^10.53.1",
         "@testing-library/user-event": "^14.6.1",
@@ -6327,6 +6328,13 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@formatjs/bigdecimal": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/bigdecimal/-/bigdecimal-0.2.6.tgz",
+      "integrity": "sha512-aPzKsGQOkQRHUEbyO/ZtYfr4EqaBQnSs6U4tzTla1xBnIdEHgY2GqEqso28UMwWRkzKqqTj5+/6BmuOsRkfn2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@formatjs/fast-memoize": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.5.tgz",
@@ -6362,6 +6370,34 @@
         "@formatjs/icu-messageformat-parser": "3.5.9",
         "intl-messageformat": "11.2.6"
       }
+    },
+    "node_modules/@formatjs/intl-durationformat": {
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-durationformat/-/intl-durationformat-0.10.15.tgz",
+      "integrity": "sha512-3W636wOl2pOVKR2+aFC+2BMOHA/FYsHZfKTr/cT1OG0YIXI2hhGrBH2+EFmqEzzClRi5BlPvwE6LlLN2dikdDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/bigdecimal": "0.2.6",
+        "@formatjs/intl-localematcher": "0.8.10"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.10.tgz",
+      "integrity": "sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher/node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+      "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@glimmer/component": {
       "version": "1.1.2",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -61,6 +61,7 @@
     "@embroider/util": "^1.13.5",
     "@embroider/webpack": "^4.1.2",
     "@formatjs/intl": "^4.1.11",
+    "@formatjs/intl-durationformat": "^0.10.15",
     "@glimmer/component": "^1.1.2",
     "@sentry/ember": "^10.53.1",
     "@testing-library/user-event": "^14.6.1",

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -22,9 +22,13 @@ module(
 
       // then
       const trainingTitle = screen.getAllByText(training.title);
+      const button = screen.getByRole('button', {
+        name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
+      });
+
       assert.strictEqual(trainingTitle.length, 2);
       assert.dom(screen.getByText('Webinaire')).exists();
-      assert.dom(screen.getByText('1 jour et 2h')).exists();
+      assert.dom(within(button).getByText('1 jour et 2h')).exists();
     });
 
     module('when delivery mode is hybrid', function () {
@@ -184,7 +188,10 @@ module(
           const screen = await render(<template><TrainingCard @training={{training}} /></template>);
 
           // then
-          assert.dom(screen.getByText('3 jours et 1h')).exists();
+          const button = screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
+          });
+          assert.dom(within(button).getByText('3 jours et 1h')).exists();
         });
       });
     });

--- a/mon-pix/tests/unit/models/training-test.js
+++ b/mon-pix/tests/unit/models/training-test.js
@@ -1,61 +1,60 @@
 import { setupTest } from 'ember-qunit';
+import Training from 'mon-pix/models/training';
 import { module, test } from 'qunit';
-
-import setupIntl from '../../helpers/setup-intl';
 
 module('Unit | Model | training', function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks);
 
-  let store;
-
-  hooks.beforeEach(function () {
-    store = this.owner.lookup('service:store');
-  });
-
-  module('#formattedDuration', function () {
-    module('when training has only days duration', function () {
-      test('it returns days only', async function (assert) {
+  module('#formatDuration', function () {
+    module('when training does not have duration', function () {
+      test('it returns an empty string', function (assert) {
         // given
-        const training = store.createRecord('training', {
-          type: 'modulix',
-          duration: {
-            days: 3,
-          },
-        });
+        const duration = null;
 
         // when
-        const displayedDuration = training.formattedDuration;
+        const displayedDuration = Training.formatDuration({ locale: 'fr-FR', duration });
 
         // then
-        assert.strictEqual(displayedDuration, '3 jours');
+        assert.strictEqual(displayedDuration, '');
+      });
+    });
+
+    module('when training has only days duration', function () {
+      test('it returns days only', function (assert) {
+        // given
+        const duration = {
+          days: 3,
+        };
+
+        // when
+        const displayedDuration = Training.formatDuration({ locale: 'fr-FR', duration });
+
+        // then
+        assert.strictEqual(displayedDuration, '3\u00A0jours');
       });
     });
   });
 
   module('when training has days and hours duration', function () {
-    test('it displays complete duration', async function (assert) {
+    test('it displays complete duration', function (assert) {
       // given
-      const training = store.createRecord('training', { type: 'modulix', duration: { days: 3, hours: 1, minutes: 0 } });
+      const duration = { days: 3, hours: 1, minutes: 0 };
 
       // when
-      const displayedDuration = training.formattedDuration;
+      const displayedDuration = Training.formatDuration({ locale: 'fr-FR', duration });
 
       // then
-      assert.strictEqual(displayedDuration, '3 jours et 1h');
+      assert.strictEqual(displayedDuration, '3\u00A0jours et 1h');
     });
   });
 
   module('when training has minutes and hours duration', function () {
-    test('it displays complete duration', async function (assert) {
+    test('it displays complete duration', function (assert) {
       // given
-      const training = store.createRecord('training', {
-        type: 'modulix',
-        duration: { days: 0, hours: 1, minutes: 30 },
-      });
+      const duration = { days: 0, hours: 1, minutes: 30 };
 
       // when
-      const displayedDuration = training.formattedDuration;
+      const displayedDuration = Training.formatDuration({ locale: 'fr-FR', duration });
 
       // then
       assert.strictEqual(displayedDuration, '1h30min');


### PR DESCRIPTION
## 🪧 Problème

Lors de la review de la PR https://github.com/1024pix/pix/pull/16325, nous avons lister des retours à traiter.

## 🌈 Proposition

Les faire.

## ✊ Remarques

- Une librairie `@formatjs/intl-durationformat` a été ajouté pour gérer le polyfill de l'API durationFormat. 
- L'affichage de la durée  dans la modale a été mise à jour. On a maintenant la même chose des 2 côtés.
- Le PixAccordions a bien été mis à jour pour avoir le nouveau design ✨ 

## 🎉 Pour tester
- Se connecter avec le compte `dave-comp@example.net`
- Passer la campagne avec le code `EDUMULTIP` pour arriver sur la page de résultat.
- Vérifier qu'il n'y a pas de régressions sur les durées des CFs affichées.
- Cliquer sur une carte de CF
- Constater que le composant PixAccordions a bien le nouveau design et que la durée s'affiche bien 🚀 

### Test du polyfill
- Utiliser lambdatest avec une version de firefox < 136 (ex: 130)
- Refaire les tests plus haut pour vérifier que la durée s'affiche bien sur la carte et dans la modale.
- Constater que le polyfill fonctionne bien 🎉 
