### PR TITLE
[FEATURE] Afficher l'organisation lié à un centre de certification (PIX-22631)

### DIFF
--- a/admin/app/adapters/attached-organization.js
+++ b/admin/app/adapters/attached-organization.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class AttachedOrganizationAdapter extends ApplicationAdapter {
+  urlForQuery(query) {
+    const { certificationCenterId } = query;
+    delete query.certificationCenterId;
+    return `${this.host}/${this.namespace}/admin/certification-centers/${certificationCenterId}/organizations`;
+  }
+}

--- a/admin/app/components/certification-centers/attached-organizations.gjs
+++ b/admin/app/components/certification-centers/attached-organizations.gjs
@@ -1,0 +1,35 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
+
+<template>
+  {{#if @attachedOrganizations.length}}
+    <PixTable
+      @variant="admin"
+      @caption={{t "components.certification-centers.attached-organizations.table.caption"}}
+      @data={{@attachedOrganizations}}
+    >
+      <:columns as |attachedOrganization context|>
+        <PixTableColumn @context={{context}}>
+          <:header>{{t "components.certification-centers.attached-organizations.table.headers.id"}}</:header>
+          <:cell>
+            <LinkTo @route="authenticated.organizations.get" @model={{attachedOrganization.id}}>
+              {{attachedOrganization.id}}
+            </LinkTo>
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>{{t "components.certification-centers.attached-organizations.table.headers.name"}}</:header>
+          <:cell>{{attachedOrganization.name}}</:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>{{t "components.certification-centers.attached-organizations.table.headers.external-id"}}</:header>
+          <:cell>{{attachedOrganization.externalId}}</:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  {{else}}
+    <p>{{t "components.certification-centers.attached-organizations.empty"}}</p>
+  {{/if}}
+</template>

--- a/admin/app/models/attached-organization.js
+++ b/admin/app/models/attached-organization.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AttachedOrganization extends Model {
+  @attr('string') name;
+  @attr('string') externalId;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -91,6 +91,7 @@ Router.map(function () {
       this.route('get', { path: '/:certification_center_id' }, function () {
         this.route('team', { path: '/' });
         this.route('invitations');
+        this.route('attached-organizations');
       });
       this.route('list');
       this.route('new');

--- a/admin/app/routes/authenticated/certification-centers/get/attached-organizations.js
+++ b/admin/app/routes/authenticated/certification-centers/get/attached-organizations.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AuthenticatedCertificationCentersGetAttachedOrganizationsRoute extends Route {
+  @service store;
+
+  async model() {
+    const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
+
+    return this.store.query('attached-organization', { certificationCenterId: certificationCenter.id });
+  }
+}

--- a/admin/app/templates/authenticated/certification-centers/get.gjs
+++ b/admin/app/templates/authenticated/certification-centers/get.gjs
@@ -1,5 +1,6 @@
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { LinkTo } from '@ember/routing';
+import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import Breadcrumb from 'pix-admin/components/certification-centers/breadcrumb';
 import Information from 'pix-admin/components/certification-centers/information';
@@ -18,13 +19,23 @@ import Information from 'pix-admin/components/certification-centers/information'
     />
 
     {{#unless @model.certificationCenter.isArchived}}
-      <PixTabs @variant="primary" @ariaLabel="Navigation de la section centre de certification" class="navigation">
+      <PixTabs
+        @variant="primary"
+        @ariaLabel={{t "pages.certification-centers.get.navbar.aria-label"}}
+        class="navigation"
+      >
         <LinkTo @route="authenticated.certification-centers.get.team">
-          Équipe ({{@model.certificationCenter.certificationCenterMemberships.length}})
+          {{t "pages.certification-centers.get.navbar.team"}}
+          ({{@model.certificationCenter.certificationCenterMemberships.length}})
         </LinkTo>
 
         <LinkTo @route="authenticated.certification-centers.get.invitations">
-          Invitations ({{@model.certificationCenter.certificationCenterInvitations.length}})
+          {{t "pages.certification-centers.get.navbar.invitations"}}
+          ({{@model.certificationCenter.certificationCenterInvitations.length}})
+        </LinkTo>
+
+        <LinkTo @route="authenticated.certification-centers.get.attached-organizations">
+          {{t "pages.certification-centers.get.navbar.attached-organizations"}}
         </LinkTo>
       </PixTabs>
     {{/unless}}

--- a/admin/app/templates/authenticated/certification-centers/get/attached-organizations.gjs
+++ b/admin/app/templates/authenticated/certification-centers/get/attached-organizations.gjs
@@ -1,0 +1,3 @@
+import AttachedOrganizations from 'pix-admin/components/certification-centers/attached-organizations';
+
+<template><AttachedOrganizations @attachedOrganizations={{@model}} /></template>

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -1,5 +1,6 @@
 import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
@@ -258,7 +259,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
     });
 
     module('tab navigation', function () {
-      test('should show Équipe and Invitations tab', async function (assert) {
+      test('should show Équipe, Invitations tab and Attached Orga tabs', async function (assert) {
         // given
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const certificationCenter = server.create('certification-center', {
@@ -275,11 +276,30 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         // then
         const certificationCenterNavigation = within(
           screen.getByRole('navigation', {
-            name: 'Navigation de la section centre de certification',
+            name: t('pages.certification-centers.get.navbar.aria-label'),
           }),
         );
-        assert.dom(certificationCenterNavigation.getByRole('link', { name: /Équipe/ })).exists();
-        assert.dom(certificationCenterNavigation.getByRole('link', { name: /Invitations/ })).exists();
+        assert
+          .dom(
+            certificationCenterNavigation.getByRole('link', {
+              name: (text) => text.includes(t('pages.certification-centers.get.navbar.team')),
+            }),
+          )
+          .exists();
+        assert
+          .dom(
+            certificationCenterNavigation.getByRole('link', {
+              name: (text) => text.includes(t('pages.certification-centers.get.navbar.invitations')),
+            }),
+          )
+          .exists();
+        assert
+          .dom(
+            certificationCenterNavigation.getByRole('link', {
+              name: t('pages.certification-centers.get.navbar.attached-organizations'),
+            }),
+          )
+          .exists();
       });
 
       test('should display the number of active members in the Équipe tab', async function (assert) {

--- a/admin/tests/acceptance/authenticated/certification-centers/get/attached-organizations-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get/attached-organizations-test.js
@@ -1,0 +1,47 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupIntl from 'pix-admin/tests/helpers/setup-intl';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+module('Acceptance | Organizations | Attached Organizations Page', function (hooks) {
+  setupApplicationTest(hooks);
+  setupIntl(hooks);
+  setupMirage(hooks);
+
+  module('when user has role "SUPER_ADMIN"', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    });
+
+    test('clicking the ID cell redirects to the attached organization details page', async function (assert) {
+      // given
+      const organizationToAttach = this.server.create('organization', {
+        id: '56',
+        name: 'Organization to attach',
+        externalId: 'EXT456',
+        features: { PLACES_MANAGEMENT: { active: false } },
+      });
+      const certificationCenterId = this.server.create('certification-center', {
+        name: 'Certification Center with attached organization',
+      }).id;
+
+      this.server.create('attached-organization', {
+        id: organizationToAttach.id,
+        certificationCenterId,
+        name: organizationToAttach.name,
+        externalId: organizationToAttach.externalId,
+      });
+
+      const screen = await visit(`/certification-centers/${certificationCenterId}/attached-organizations`);
+
+      // when
+      await click(screen.getByRole('link', { name: organizationToAttach.id }));
+
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${organizationToAttach.id}/details`);
+    });
+  });
+});

--- a/admin/tests/integration/components/certification-centers/attached-organizations-test.gjs
+++ b/admin/tests/integration/components/certification-centers/attached-organizations-test.gjs
@@ -1,0 +1,86 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import AttachedOrganizations from 'pix-admin/components/certification-centers/attached-organizations';
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+
+module('Integration | Component | certification-centers/attached-organizations', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when there is no attached organizations', function () {
+    test('it displays an empty message', async function (assert) {
+      // given
+      const attachedOrganizations = [];
+
+      // when
+      const screen = await render(
+        <template><AttachedOrganizations @attachedOrganizations={{attachedOrganizations}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('components.certification-centers.attached-organizations.empty'))).exists();
+    });
+  });
+
+  module('when there are attached organizations', function () {
+    test('it displays the table with caption and column headers', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('attached-organization', {
+        id: '123',
+        name: 'Organization Pix',
+        externalId: 'EXT-456',
+      });
+      const attachedOrganizations = [organization];
+
+      // when
+      const screen = await render(
+        <template><AttachedOrganizations @attachedOrganizations={{attachedOrganizations}} /></template>,
+      );
+
+      // then
+      assert.dom(
+        screen.getByRole('table', { name: t('components.certification-centers.attached-organizations.table.caption') }),
+      );
+
+      assert.dom(
+        screen.getByRole('columnheader', {
+          name: t('components.certification-centers.attached-organizations.table.headers.id'),
+        }),
+      );
+      assert.dom(
+        screen.getByRole('columnheader', {
+          name: t('components.certification-centers.attached-organizations.table.headers.name'),
+        }),
+      );
+      assert.dom(
+        screen.getByRole('columnheader', {
+          name: t('components.certification-centers.attached-organizations.table.headers.external-id'),
+        }),
+      );
+
+      assert.dom(screen.getByRole('cell', { name: '123' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Organization Pix' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'EXT-456' })).exists();
+    });
+
+    test('it displays a link to the organization page', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('attached-organization', {
+        id: '123',
+        name: 'Organization Pix',
+        externalId: 'EXT-456',
+      });
+      const attachedOrganizations = [organization];
+
+      // when
+      const screen = await render(
+        <template><AttachedOrganizations @attachedOrganizations={{attachedOrganizations}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('link', { name: '123' })).hasAttribute('href', '/organizations/123');
+    });
+  });
+});

--- a/admin/tests/mirage/factories.js
+++ b/admin/tests/mirage/factories.js
@@ -1,6 +1,7 @@
 // This file imports and exports all factories for explicit registration in config.js
 
 import attachedCertificationCenter from './factories/attached-certification-center';
+import attachedOrganization from './factories/attached-organization';
 import badge from './factories/badge';
 import certificationCandidate from './factories/certification-candidate';
 import certificationCenter from './factories/certification-center';
@@ -17,6 +18,7 @@ import user from './factories/user';
 
 export default {
   attachedCertificationCenter,
+  attachedOrganization,
   badge,
   certificationCandidate,
   certificationCenter,

--- a/admin/tests/mirage/factories/attached-organization.js
+++ b/admin/tests/mirage/factories/attached-organization.js
@@ -1,0 +1,3 @@
+import { Factory } from 'miragejs';
+
+export default Factory.extend({});

--- a/admin/tests/mirage/handlers/certification-centers.js
+++ b/admin/tests/mirage/handlers/certification-centers.js
@@ -13,4 +13,9 @@ function findPaginatedFilteredCertificationCenters(schema) {
   return json;
 }
 
-export { findPaginatedFilteredCertificationCenters };
+function findCertificationCenterAttachedOrganizations(schema, request) {
+  const certificationCenterId = request.params.id;
+  return schema.attachedOrganizations.where({ certificationCenterId });
+}
+
+export { findCertificationCenterAttachedOrganizations, findPaginatedFilteredCertificationCenters };

--- a/admin/tests/mirage/models.js
+++ b/admin/tests/mirage/models.js
@@ -5,6 +5,7 @@ import administrationTeam from './models/administration-team';
 import area from './models/area';
 import attachableTargetProfile from './models/attachable-target-profile';
 import attachedCertificationCenter from './models/attached-certification-center';
+import attachedOrganization from './models/attached-organization';
 import attestation from './models/attestation.js';
 import authenticationMethod from './models/authentication-method';
 import autonomousCourse from './models/autonomous-course';
@@ -81,6 +82,7 @@ export default {
   area,
   attachableTargetProfile,
   attachedCertificationCenter,
+  attachedOrganization,
   attestation,
   authenticationMethod,
   autonomousCourse,

--- a/admin/tests/mirage/models/attached-organization.js
+++ b/admin/tests/mirage/models/attached-organization.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend();

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -11,7 +11,10 @@ import {
 } from './handlers/autonomous-courses';
 import { updateBadgeCriterion } from './handlers/badge-criteria';
 import { findPaginatedFilteredCampaignParticipations } from './handlers/campaign-participations';
-import { findPaginatedFilteredCertificationCenters } from './handlers/certification-centers';
+import {
+  findCertificationCenterAttachedOrganizations,
+  findPaginatedFilteredCertificationCenters,
+} from './handlers/certification-centers';
 import { attachCombinedCourseBlueprintToOrganizations } from './handlers/combined-course-blueprint.js';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';
 import { findFrameworkAreas } from './handlers/frameworks';
@@ -347,6 +350,7 @@ export default function routes() {
 
     return certificationCenterMembership;
   });
+  this.get('/admin/certification-centers/:id/organizations', findCertificationCenterAttachedOrganizations);
 
   this.get('/admin/users/:id/certification-courses', (schema, request) => {
     const userId = request.params.id;

--- a/admin/tests/unit/adapters/attached-organization-test.js
+++ b/admin/tests/unit/adapters/attached-organization-test.js
@@ -1,0 +1,26 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Adapter | AttachedOrganization', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:attached-organization');
+  });
+
+  module('#urlForQuery', function () {
+    test('it builds the correct URL from certificationCenterId and removes certificationCenterId from the query object', function (assert) {
+      // given
+      const query = { certificationCenterId: 10 };
+
+      // when
+      const url = adapter.urlForQuery(query);
+
+      // then
+      assert.ok(url.endsWith('/admin/certification-centers/10/organizations'));
+      assert.strictEqual(query.certificationCenterId, undefined);
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/certification-centers/get/attached-organizations-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get/attached-organizations-test.js
@@ -1,0 +1,30 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/certification-centers/get/attached-organizations', function (hooks) {
+  setupTest(hooks);
+
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/certification-centers/get/attached-organizations');
+  });
+
+  module('#model', function () {
+    test('it queries an attached-organization store model with the certificationId parameter from the parent route and returns it', async function (assert) {
+      // given
+      const organizations = [{ id: '1', name: 'Orga' }];
+      const certificationCenter = { id: '17' };
+      route.modelFor = sinon.stub().returns({ certificationCenter });
+      route.store = { query: sinon.stub().resolves(organizations) };
+
+      // when
+      const result = await route.model();
+
+      // then
+      sinon.assert.calledWith(route.store.query, 'attached-organization', { certificationCenterId: '17' });
+      assert.strictEqual(result, organizations);
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -461,6 +461,17 @@
       }
     },
     "certification-centers": {
+      "attached-organizations": {
+        "empty": "No organisation attached.",
+        "table": {
+          "caption": "Organisation attached to the certification center.",
+          "headers": {
+            "external-id": "External ID",
+            "id": "ID of the organisation",
+            "name": "Name of the attached organisation"
+          }
+        }
+      },
       "invitations": {
         "table": {
           "caption": "Liste des invitations envoyées pour rejoindre un centre de certification. Contient une adresse e-mail de l'utilisateur, le rôle que l'on souhaite lui attribuer, la date de dernier envoi de l'invitation et des actions permettent de renvoyer l'invitation ou de la supprimer."
@@ -1402,6 +1413,12 @@
           "external-id": "External identifier",
           "type": "Type"
         }
+      },
+      "navbar": {
+        "aria-label": "Certification center navigation section",
+        "attached-organizations": "Attached organization",
+        "invitations": "Invitations",
+        "team": "Team"
       },
       "notifications": {
         "failure": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -468,6 +468,17 @@
       }
     },
     "certification-centers": {
+      "attached-organizations": {
+        "empty": "Aucune organisation rattachée.",
+        "table": {
+          "caption": "Organisation rattachée au centre de certification.",
+          "headers": {
+            "external-id": "Identifiant externe",
+            "id": "ID de l'organisation",
+            "name": "Nom de l'organisation rattachée"
+          }
+        }
+      },
       "invitations": {
         "table": {
           "caption": "Liste des invitations envoyées pour rejoindre un centre de certification. Contient une adresse e-mail de l'utilisateur, le rôle que l'on souhaite lui attribuer, la date de dernier envoi de l'invitation et des actions permettent de renvoyer l'invitation ou de la supprimer."
@@ -1394,6 +1405,14 @@
         "question": "Êtes-vous sûr de vouloir archiver ce centre de certification?",
         "title": "Archiver le centre de certification {certificationCenterName}",
         "warning": "Cette action est irréversible."
+      },
+      "get": {
+        "navbar": {
+          "aria-label": "Navigation de la section centre de certification",
+          "attached-organizations": "Lien orga",
+          "invitations": "Invitations",
+          "team": "Équipe"
+        }
       },
       "information-view": {
         "habilitations": {

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -5,7 +5,7 @@ import { getLatestParticipationSharedForOneLearner } from './helpers/get-latest-
 
 const { SHARED, STARTED } = CampaignParticipationStatuses;
 
-const TIMEOUT = 3000;
+const TIMEOUT = 6000;
 
 const getParticipationsActivityByDate = async function (campaignId) {
   const knexConn = DomainTransaction.getConnection();


### PR DESCRIPTION
## 🪧 Problème
Sur la page d'un centre de certification, on veut pouvoir visualiser son organisation rattachée.

## 🌈 Proposition
Ajouter un nouvel onglet **Lien orga** qui affichera les infos basiques de l'organisation rattachée.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
Sur Pix Admin, connecté avec n'importe quel rôle:
- trouver le centre de certification _Lycée 1 de l'Académie de Versailles_ et naviguer sur sa page
- constater le nouvel onglet **Lien Orga** et naviguer dessus
- constater qu'on affiche bien son organisation rattachée
- naviguer vers un autre centre de certif
- constater qu'il n'y a pas d'orga rattachée
