### PR TITLE
[FEATURE] Pouvoir enregistrer un NPS pour le moteur de recommandation (PIX-23302)

### DIFF
--- a/api/db/database-builder/factory/build-user-campaign-survey.js
+++ b/api/db/database-builder/factory/build-user-campaign-survey.js
@@ -1,0 +1,14 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildUserCampaignSurvey({
+  id = databaseBuffer.getNextId(),
+  userId,
+  campaignId,
+  satisfactionScore = 3,
+  createdAt = new Date(),
+} = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'user-campaign-surveys',
+    values: { id, userId, campaignId, satisfactionScore, createdAt },
+  });
+}

--- a/api/src/devcomp/application/user-campaign-surveys/user-campaign-survey-controller.js
+++ b/api/src/devcomp/application/user-campaign-surveys/user-campaign-survey-controller.js
@@ -1,0 +1,12 @@
+import { usecases } from '../../domain/usecases/index.js';
+
+async function saveUserCampaignSurvey(request, h) {
+  const { userId } = request.auth.credentials;
+  const { 'campaign-id': campaignId, 'satisfaction-score': satisfactionScore } = request.payload.data.attributes;
+
+  const id = await usecases.saveUserCampaignSurvey({ userId, campaignId, satisfactionScore });
+
+  return h.response({ data: { id: String(id), type: 'user-campaign-surveys' } }).created();
+}
+
+export const userCampaignSurveyController = { saveUserCampaignSurvey };

--- a/api/src/devcomp/application/user-campaign-surveys/user-campaign-survey-route.js
+++ b/api/src/devcomp/application/user-campaign-surveys/user-campaign-survey-route.js
@@ -1,0 +1,33 @@
+import Joi from 'joi';
+
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { userCampaignSurveyController } from './user-campaign-survey-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/user-campaign-surveys',
+      config: {
+        handler: userCampaignSurveyController.saveUserCampaignSurvey,
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              type: Joi.string().valid('user-campaign-surveys').required(),
+              attributes: Joi.object({
+                'campaign-id': identifiersType.campaignId.required(),
+                'satisfaction-score': Joi.number().integer().min(1).max(5).required(),
+              }).required(),
+            }).required(),
+          }).required(),
+        },
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés**\n- Enregistre le NPS d'un utilisateur pour une campagne",
+        ],
+        tags: ['api', 'user-campaign-surveys'],
+      },
+    },
+  ]);
+};
+
+export const userCampaignSurveyRoute = { name: 'devcomp/user-campaign-surveys-api', register };

--- a/api/src/devcomp/domain/models/UserCampaignSurvey.js
+++ b/api/src/devcomp/domain/models/UserCampaignSurvey.js
@@ -1,0 +1,31 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+const SATISFACTION_SCORE_MIN = 1;
+const SATISFACTION_SCORE_MAX = 5;
+
+export class UserCampaignSurvey {
+  constructor({ userId, campaignId, satisfactionScore }) {
+    assertNotNullOrUndefined(userId, 'The userId is required for a UserCampaignSurvey');
+    assertNotNullOrUndefined(campaignId, 'The campaignId is required for a UserCampaignSurvey');
+    assertNotNullOrUndefined(satisfactionScore, 'The satisfactionScore is required for a UserCampaignSurvey');
+
+    this.#assertSatisfactionScoreIsValid(satisfactionScore);
+
+    this.userId = userId;
+    this.campaignId = campaignId;
+    this.satisfactionScore = satisfactionScore;
+  }
+
+  #assertSatisfactionScoreIsValid(satisfactionScore) {
+    if (
+      !Number.isInteger(satisfactionScore) ||
+      satisfactionScore < SATISFACTION_SCORE_MIN ||
+      satisfactionScore > SATISFACTION_SCORE_MAX
+    ) {
+      throw new DomainError(
+        `The satisfactionScore must be an integer between ${SATISFACTION_SCORE_MIN} and ${SATISFACTION_SCORE_MAX}`,
+      );
+    }
+  }
+}

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -42,6 +42,7 @@ import { getUserModuleStatuses } from './get-user-module-statuses.js';
 import { handleTrainingRecommendation } from './handle-training-recommendation.js';
 import { promptToLLMChat } from './prompt-to-llm-chat.js';
 import { recordPassageEvents } from './record-passage-events.js';
+import { saveUserCampaignSurvey } from './save-user-campaign-survey.js';
 import { saveUserRelevanceFeedbackOnRecommendedTraining } from './save-user-relevance-feedback-on-recommended-training.js';
 import { startEmbedLlmChat } from './start-embed-llm-chat.js';
 import { terminatePassage } from './terminate-passage.js';
@@ -95,6 +96,7 @@ const usecasesWithoutInjectedDependencies = {
   handleTrainingRecommendation,
   promptToLLMChat,
   recordPassageEvents,
+  saveUserCampaignSurvey,
   saveUserRelevanceFeedbackOnRecommendedTraining,
   startEmbedLlmChat,
   terminatePassage,

--- a/api/src/devcomp/domain/usecases/save-user-campaign-survey.js
+++ b/api/src/devcomp/domain/usecases/save-user-campaign-survey.js
@@ -1,0 +1,6 @@
+import { UserCampaignSurvey } from '../models/UserCampaignSurvey.js';
+
+export async function saveUserCampaignSurvey({ userId, campaignId, satisfactionScore, userCampaignSurveyRepository }) {
+  const survey = new UserCampaignSurvey({ userId, campaignId, satisfactionScore });
+  return userCampaignSurveyRepository.save(survey);
+}

--- a/api/src/devcomp/infrastructure/repositories/index.js
+++ b/api/src/devcomp/infrastructure/repositories/index.js
@@ -10,6 +10,7 @@ import * as trainingRepository from './training-repository.js';
 import * as trainingTriggerRepository from './training-trigger-repository.js';
 import * as tutorialEvaluationRepository from './tutorial-evaluation-repository.js';
 import * as tutorialRepository from './tutorial-repository.js';
+import * as userCampaignSurveyRepository from './user-campaign-survey-repository.js';
 import * as userRecommendedTrainingRepository from './user-recommended-training-repository.js';
 import * as userSavedTutorialRepository from './user-saved-tutorial-repository.js';
 
@@ -23,6 +24,7 @@ const repositoriesWithoutInjectedDependencies = {
   trainingRepository,
   trainingTriggerRepository,
   userRecommendedTrainingRepository,
+  userCampaignSurveyRepository,
   userSavedTutorialRepository,
   tutorialRepository,
   tutorialEvaluationRepository,

--- a/api/src/devcomp/infrastructure/repositories/user-campaign-survey-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-campaign-survey-repository.js
@@ -1,0 +1,16 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
+import { isUniqConstraintViolated } from '../../../shared/infrastructure/utils/knex-utils.js';
+
+export async function save(userCampaignSurvey) {
+  const knexConn = DomainTransaction.getConnection();
+  try {
+    const [result] = await knexConn('user-campaign-surveys').insert(userCampaignSurvey).returning('id');
+    return result.id;
+  } catch (error) {
+    if (isUniqConstraintViolated(error)) {
+      throw new AlreadyExistingEntityError('User has already submitted a survey for this campaign');
+    }
+    throw error;
+  }
+}

--- a/api/src/devcomp/routes.js
+++ b/api/src/devcomp/routes.js
@@ -6,6 +6,7 @@ import { passageEventRoute } from './application/passage-events/passage-event-ro
 import { passageRoute } from './application/passages/passage-route.js';
 import { trainingRoute } from './application/trainings/training-route.js';
 import { tutorialEvaluationsRoute } from './application/tutorial-evaluations/tutorial-evaluations-route.js';
+import { userCampaignSurveyRoute } from './application/user-campaign-surveys/user-campaign-survey-route.js';
 import { userTrainingsRoute } from './application/user-trainings/user-trainings-route.js';
 import { userTutorialsRoute } from './application/user-tutorials/user-tutorials-route.js';
 
@@ -17,6 +18,7 @@ const devcompRoutes = [
   passageRoute,
   passageEventRoute,
   trainingRoute,
+  userCampaignSurveyRoute,
   userTutorialsRoute,
   tutorialEvaluationsRoute,
   userTrainingsRoute,

--- a/api/tests/devcomp/acceptance/application/user-campaign-surveys/user-campaign-survey-route_test.js
+++ b/api/tests/devcomp/acceptance/application/user-campaign-surveys/user-campaign-survey-route_test.js
@@ -1,0 +1,42 @@
+import { createServer } from '../../../../../server.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
+
+describe('Acceptance | API | user-campaign-surveys', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/user-campaign-surveys', function () {
+    it('should return 201 and store the survey', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/user-campaign-surveys',
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        payload: {
+          data: {
+            type: 'user-campaign-surveys',
+            attributes: {
+              'campaign-id': campaignId,
+              'satisfaction-score': 4,
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      expect(response.result.data.type).to.equal('user-campaign-surveys');
+      expect(response.result.data.id).to.be.a('string');
+    });
+  });
+});

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-campaign-survey-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-campaign-survey-repository_test.js
@@ -1,0 +1,66 @@
+import { UserCampaignSurvey } from '../../../../../src/devcomp/domain/models/UserCampaignSurvey.js';
+import * as userCampaignSurveyRepository from '../../../../../src/devcomp/infrastructure/repositories/user-campaign-survey-repository.js';
+import { AlreadyExistingEntityError } from '../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+describe('Integration | Infrastructure | Repository | userCampaignSurveyRepository', function () {
+  let userId, campaignId;
+
+  beforeEach(async function () {
+    userId = databaseBuilder.factory.buildUser().id;
+    campaignId = databaseBuilder.factory.buildCampaign().id;
+    await databaseBuilder.commit();
+  });
+
+  describe('#save', function () {
+    it('should store the survey in the database', async function () {
+      // given
+      const survey = new UserCampaignSurvey({ userId, campaignId, satisfactionScore: 4 });
+
+      // when
+      await userCampaignSurveyRepository.save(survey);
+
+      // then
+      const rows = await knex('user-campaign-surveys').where({ userId, campaignId });
+      expect(rows).to.have.lengthOf(1);
+      expect(rows[0].satisfactionScore).to.equal(4);
+    });
+
+    it('should return the created id', async function () {
+      // given
+      const anotherUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserCampaignSurvey({ userId: anotherUserId, campaignId, satisfactionScore: 3 });
+      await databaseBuilder.commit();
+
+      const survey = new UserCampaignSurvey({ userId, campaignId, satisfactionScore: 2 });
+
+      // when
+      const id = await userCampaignSurveyRepository.save(survey);
+
+      // then
+      const row = await knex('user-campaign-surveys').where({ id }).first();
+      expect(row).to.exist;
+      expect(row.userId).to.equal(userId);
+      expect(row.campaignId).to.equal(campaignId);
+      expect(row.satisfactionScore).to.equal(2);
+    });
+
+    context('when the user has already answered the survey for this campaign', function () {
+      it('should throw an error', async function () {
+        // given
+        databaseBuilder.factory.buildUserCampaignSurvey({ userId, campaignId, satisfactionScore: 3 });
+        await databaseBuilder.commit();
+
+        const survey = new UserCampaignSurvey({ userId, campaignId, satisfactionScore: 4 });
+
+        // when
+        const error = await catchErr(userCampaignSurveyRepository.save)(survey);
+
+        // then
+        expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/UserCampaignSurvey_test.js
+++ b/api/tests/devcomp/unit/domain/models/UserCampaignSurvey_test.js
@@ -1,0 +1,81 @@
+import { UserCampaignSurvey } from '../../../../../src/devcomp/domain/models/UserCampaignSurvey.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
+
+describe('Unit | Devcomp | Domain | Models | UserCampaignSurvey', function () {
+  describe('#constructor', function () {
+    it('should create a UserCampaignSurvey with valid attributes', function () {
+      // given
+      const userId = 1;
+      const campaignId = 2;
+      const satisfactionScore = 3;
+
+      // when
+      const survey = new UserCampaignSurvey({ userId, campaignId, satisfactionScore });
+
+      // then
+      expect(survey.userId).to.equal(userId);
+      expect(survey.campaignId).to.equal(campaignId);
+      expect(survey.satisfactionScore).to.equal(satisfactionScore);
+    });
+
+    describe('if userId is missing', function () {
+      it('should throw a DomainError', function () {
+        // when
+        const error = catchErrSync(() => new UserCampaignSurvey({ campaignId: 1, satisfactionScore: 3 }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The userId is required for a UserCampaignSurvey');
+      });
+    });
+
+    describe('if campaignId is missing', function () {
+      it('should throw a DomainError', function () {
+        // when
+        const error = catchErrSync(() => new UserCampaignSurvey({ userId: 1, satisfactionScore: 3 }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The campaignId is required for a UserCampaignSurvey');
+      });
+    });
+
+    describe('if satisfactionScore is missing', function () {
+      it('should throw a DomainError', function () {
+        // when
+        const error = catchErrSync(() => new UserCampaignSurvey({ userId: 1, campaignId: 2 }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The satisfactionScore is required for a UserCampaignSurvey');
+      });
+    });
+
+    describe('if satisfactionScore is out of range', function () {
+      [0, 6, -1, 100].forEach((satisfactionScore) => {
+        it(`should throw a DomainError for satisfactionScore ${satisfactionScore}`, function () {
+          // when
+          const error = catchErrSync(() => new UserCampaignSurvey({ userId: 1, campaignId: 2, satisfactionScore }))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The satisfactionScore must be an integer between 1 and 5');
+        });
+      });
+
+      it('should throw a DomainError for a non-integer score', function () {
+        // given
+        const satisfactionScore = 2.5;
+
+        // when
+        const error = catchErrSync(() => new UserCampaignSurvey({ userId: 1, campaignId: 2, satisfactionScore }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The satisfactionScore must be an integer between 1 and 5');
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/save-user-campaign-survey_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/save-user-campaign-survey_test.js
@@ -1,0 +1,36 @@
+import sinon from 'sinon';
+
+import { UserCampaignSurvey } from '../../../../../src/devcomp/domain/models/UserCampaignSurvey.js';
+import { saveUserCampaignSurvey } from '../../../../../src/devcomp/domain/usecases/save-user-campaign-survey.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | save-user-campaign-survey', function () {
+  it('should save a UserCampaignSurvey and return its id', async function () {
+    // given
+    const userId = 1;
+    const campaignId = 2;
+    const satisfactionScore = 4;
+    const createdId = 99;
+
+    const userCampaignSurveyRepository = {
+      save: sinon.stub().resolves(createdId),
+    };
+
+    // when
+    const result = await saveUserCampaignSurvey({
+      userId,
+      campaignId,
+      satisfactionScore,
+      userCampaignSurveyRepository,
+    });
+
+    // then
+    expect(userCampaignSurveyRepository.save).to.have.been.calledOnce;
+    const savedArg = userCampaignSurveyRepository.save.firstCall.args[0];
+    expect(savedArg).to.be.instanceOf(UserCampaignSurvey);
+    expect(savedArg.userId).to.equal(userId);
+    expect(savedArg.campaignId).to.equal(campaignId);
+    expect(savedArg.satisfactionScore).to.equal(satisfactionScore);
+    expect(result).to.equal(createdId);
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-user-campaign-survey.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-campaign-survey.js
@@ -1,0 +1,5 @@
+import { UserCampaignSurvey } from '../../../../src/devcomp/domain/models/UserCampaignSurvey.js';
+
+export function buildUserCampaignSurvey({ userId = 1, campaignId = 1, satisfactionScore = 3 } = {}) {
+  return new UserCampaignSurvey({ userId, campaignId, satisfactionScore });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -152,6 +152,7 @@ import { buildTube } from './build-tube.js';
 import { buildTutorial } from './build-tutorial.js';
 import { buildTutorialForUser } from './build-tutorial-for-user.js';
 import { buildUser } from './build-user.js';
+import { buildUserCampaignSurvey } from './build-user-campaign-survey.js';
 import { buildUserCompetence } from './build-user-competence.js';
 import { buildUserDetailsForAdmin } from './build-user-details-for-admin.js';
 import { buildUserOrgaSettings } from './build-user-orga-settings.js';
@@ -526,6 +527,7 @@ export {
   buildTutorial,
   buildTutorialForUser,
   buildUser,
+  buildUserCampaignSurvey,
   buildUserCompetence,
   buildUserDetailsForAdmin,
   buildUserOrgaSettings,


### PR DESCRIPTION
##  🪧 Problème
Les campagnes du moteur de recommandations Pix permettent de proposer un NPS (Net Promoter Score) aux utilisateurs à la fin de leur parcours. Il n'existait pas de route API pour enregistrer cette réponse.

## 🌈 Proposition
Ajouter une route POST /api/user-campaign-surveys permettant à un utilisateur authentifié d'enregistrer son score de satisfaction (1–5) pour une campagne donnée (dans le cadre du moteur de recommandations).

 ## ✊ Remarques
- Un utilisateur ne peut soumettre qu'une seule réponse par campagne
- La PR pour [la création de table](https://github.com/1024pix/pix/pull/16623) a été mergée, pensez à faire un fetch et rebase de ka branche `dev`

 ## 🎉 Pour tester
- Test verts
- En local, lancer la migration `npm run db:migrate`
- Reconstruire les seeds si ça n'a pas été fait récemment
- Lancer, en local, une instance API
- Lancer la commande suivante dans le terminal
```
TOKEN=$(curl -s -X POST http://localhost:3000/api/token -H "Content-Type: application/x-www-form-urlencoded" -H "x-forwarded-proto: https" -H "x-forwarded-host: app.pix.fr" -d "grant_type=password&username=superadmin@example.net&password=pix123" | jq -r '.access_token')
curl -s -X POST http://localhost:3000/api/user-campaign-surveys -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/vnd.api+json" -H "x-forwarded-proto: https" -H "x-forwarded-host: app.pix.fr" -d '{"data":{"type":"user-campaign-surveys","attributes":{"campaign-id":6001,"satisfaction-score":4}}}'
```
- Aller checker qu'il y a des enregistrements dans la table `user-campaign-surveys`