### PR TITLE
[TECH] Ne pas faire les clics sur la liste déroulante du choix de langue en entrée de certif tant que la liste est désactivée pendant le rétablissement de la certification anglaise

### DIFF
--- a/high-level-tests/e2e-playwright/pages/pix-app/CertificationAccessCodePage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/CertificationAccessCodePage.ts
@@ -8,8 +8,9 @@ export class CertificationAccessCodePage {
     const languageDropdown = this.page.getByRole('button', { name: 'Langue de certification' });
 
     if (await languageDropdown.isVisible()) {
-      await languageDropdown.click();
-      await this.page.getByRole('option', { name: 'français - FR' }).click();
+      // TODO UNCOMMENT ME WHEN ENGLISH CERTIF FIXED
+      // await languageDropdown.click();
+      // await this.page.getByRole('option', { name: 'français - FR' }).click();
 
       const languageConfirmationCheckbox = this.page.getByRole('checkbox', {
         name: /Je confirme être à l'aise dans la langue sélectionnée/,


### PR DESCRIPTION
## 🪧 Problème

E2E KOs car ils essayent de cliquer sur la dropdown qui a été désactivée pendant le rétablissement de la certification anglaise

## 🌈 Proposition

Commenter du code (décommenter le moment venu)

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
E2E verts : ✅ 
