### PR TITLE
[TECH] Supprime les chargements de attestations depuis le service currentUser

### DIFF
--- a/mon-pix/app/components/attestations/content.gjs
+++ b/mon-pix/app/components/attestations/content.gjs
@@ -10,7 +10,6 @@ import AttestationCard from './card';
 
 export default class AttestationContent extends Component {
   @service session;
-  @service currentUser;
   @service fileSaver;
   @service pixMetrics;
   @service intl;
@@ -45,7 +44,7 @@ export default class AttestationContent extends Component {
       </UiPageTitle>
 
       <ul class="attestation-list">
-        {{#each this.currentUser.attestationsDetails as |attestationDetail|}}
+        {{#each @attestationsDetails as |attestationDetail|}}
           <li>
             <AttestationCard
               @type={{attestationDetail.type}}

--- a/mon-pix/app/components/global/app-navigation.gjs
+++ b/mon-pix/app/components/global/app-navigation.gjs
@@ -4,6 +4,7 @@ import PixNavigationButton from '@1024pix/pix-ui/components/pix-navigation-butto
 import PixNavigationSeparator from '@1024pix/pix-ui/components/pix-navigation-separator';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import PixLogo from '../pix-logo';
@@ -12,7 +13,35 @@ export default class AppNavigation extends Component {
   @service currentDomain;
   @service currentUser;
   @service media;
+  @service store;
   @service url;
+
+  @tracked _hasAttestations = false;
+
+  constructor(owner, args) {
+    super(owner, args);
+    if (!this.currentUser.user) return;
+
+    const cacheKey = `pix-has-attestations-${this.currentUser.user.id}`;
+    if (localStorage.getItem(cacheKey) === 'true') {
+      this._hasAttestations = true;
+      return;
+    }
+
+    this._loadAttestationVisibility(cacheKey);
+  }
+
+  async _loadAttestationVisibility(cacheKey) {
+    try {
+      const attestations = await this.store.findAll('attestation-detail');
+      if (attestations.length > 0) {
+        localStorage.setItem(cacheKey, 'true');
+        this._hasAttestations = true;
+      }
+    } catch {
+      // silently fail — don't show the link
+    }
+  }
 
   get showAssessmentsNavItem() {
     return this.currentUser.user.hasAssessmentParticipations;
@@ -23,7 +52,7 @@ export default class AppNavigation extends Component {
   }
 
   get showAttestationNavItem() {
-    return this.currentUser.hasAttestationsDetails;
+    return this._hasAttestations;
   }
 
   <template>

--- a/mon-pix/app/routes/authenticated/attestations.js
+++ b/mon-pix/app/routes/authenticated/attestations.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AttestationsRoute extends Route {
+  @service store;
+
+  model() {
+    return this.store.findAll('attestation-detail');
+  }
+}

--- a/mon-pix/app/services/current-user.js
+++ b/mon-pix/app/services/current-user.js
@@ -5,38 +5,18 @@ export default class CurrentUserService extends Service {
   @service store;
 
   #user;
-  #attestationsDetails = [];
 
   get user() {
     return this.#user;
-  }
-
-  get attestationsDetails() {
-    return this.#attestationsDetails;
-  }
-
-  get hasAttestationsDetails() {
-    return this.#attestationsDetails.length > 0;
   }
 
   async load() {
     if (this.session.isAuthenticated) {
       try {
         this.#user = await this.store.queryRecord('user', { me: true });
-        await this.loadAttestationDetails();
       } catch {
         this.#user = null;
         return this.session.invalidate();
-      }
-    }
-  }
-
-  async loadAttestationDetails() {
-    if (this.session.isAuthenticated) {
-      try {
-        this.#attestationsDetails = await this.store.findAll('attestation-detail');
-      } catch {
-        this.#attestationsDetails = [];
       }
     }
   }

--- a/mon-pix/app/templates/authenticated/attestations.gjs
+++ b/mon-pix/app/templates/authenticated/attestations.gjs
@@ -5,5 +5,5 @@ import Content from 'mon-pix/components/attestations/content';
 <template>
   {{pageTitle (t "pages.attestations.title")}}
 
-  <Content />
+  <Content @attestationsDetails={{@model}} />
 </template>

--- a/mon-pix/tests/acceptance/authenticated/attestations-test.js
+++ b/mon-pix/tests/acceptance/authenticated/attestations-test.js
@@ -1,6 +1,7 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, within } from '@1024pix/ember-testing-library';
 import { currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -28,6 +29,47 @@ module('Acceptance | Authenticated | Attestations', function (hooks) {
       await visit('/mes-attestations');
       // then
       assert.strictEqual(currentURL(), '/mes-attestations');
+    });
+
+    module('when user has attestations', function (hooks) {
+      hooks.beforeEach(function () {
+        server.get('/users/:id/attestation-details', () => ({
+          data: [
+            {
+              id: '1',
+              type: 'attestation-details',
+              attributes: { type: 'SIXTH_GRADE', 'obtained-at': '2025-01-15' },
+            },
+            {
+              id: '2',
+              type: 'attestation-details',
+              attributes: { type: 'PARENTHOOD', 'obtained-at': '2025-03-20' },
+            },
+          ],
+        }));
+      });
+
+      test('displays the attestation cards', async function (assert) {
+        // when
+        const screen = await visit('/mes-attestations');
+        const main = within(screen.getByRole('main'));
+
+        // then
+        assert.dom(main.getByRole('heading', { name: t('pages.attestations.title') })).exists();
+        assert.strictEqual(main.getAllByRole('listitem').length, 2);
+      });
+    });
+
+    module('when user has no attestations', function () {
+      test('displays an empty list', async function (assert) {
+        // when
+        const screen = await visit('/mes-attestations');
+        const main = within(screen.getByRole('main'));
+
+        // then
+        assert.dom(main.getByRole('heading', { name: t('pages.attestations.title') })).exists();
+        assert.strictEqual(main.queryAllByRole('listitem').length, 0);
+      });
     });
   });
 

--- a/mon-pix/tests/integration/components/attestations/content-test.gjs
+++ b/mon-pix/tests/integration/components/attestations/content-test.gjs
@@ -1,0 +1,114 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import AttestationContent from 'mon-pix/components/attestations/content';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Attestations | content', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    class SessionStub extends Service {
+      data = { authenticated: { access_token: 'token', user_id: '1' } };
+    }
+
+    class FileSaverStub extends Service {
+      save = sinon.stub().resolves();
+    }
+
+    class PixMetricsStub extends Service {
+      trackEvent = sinon.stub();
+    }
+
+    this.owner.register('service:session', SessionStub);
+    this.owner.register('service:fileSaver', FileSaverStub);
+    this.owner.register('service:pixMetrics', PixMetricsStub);
+  });
+
+  test('it renders attestation cards for each attestation detail', async function (assert) {
+    // given
+    const attestationsDetails = [
+      { type: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') },
+      { type: 'PARENTHOOD', obtainedAt: new Date('2025-03-20') },
+    ];
+
+    // when
+    const screen = await render(
+      <template><AttestationContent @attestationsDetails={{attestationsDetails}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('heading', { level: 1 })).hasText(t('pages.attestations.title'));
+    assert.strictEqual(screen.getAllByRole('listitem').length, 2);
+  });
+
+  test('it renders an empty list when there are no attestation details', async function (assert) {
+    // given
+    const attestationsDetails = [];
+
+    // when
+    const screen = await render(
+      <template><AttestationContent @attestationsDetails={{attestationsDetails}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('heading', { level: 1 })).hasText(t('pages.attestations.title'));
+    assert.dom(screen.getByRole('list')).exists();
+    assert.strictEqual(screen.queryAllByRole('listitem').length, 0);
+  });
+
+  test('clicking download calls fileSaver with the correct url and token', async function (assert) {
+    // given
+    const fileSaverSaveStub = sinon.stub().resolves();
+    class FileSaverStub extends Service {
+      save = fileSaverSaveStub;
+    }
+    this.owner.register('service:fileSaver', FileSaverStub);
+
+    const attestationsDetails = [{ type: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') }];
+
+    const screen = await render(
+      <template><AttestationContent @attestationsDetails={{attestationsDetails}} /></template>,
+    );
+
+    // when
+    await click(screen.getByRole('button', { name: t('pages.certificate.actions.download-attestation') }));
+
+    // then
+    sinon.assert.calledOnce(fileSaverSaveStub);
+    const { url, token } = fileSaverSaveStub.firstCall.args[0];
+    assert.strictEqual(url, '/api/users/1/attestations/SIXTH_GRADE');
+    assert.strictEqual(token, 'token');
+  });
+
+  test('clicking download sends metrics', async function (assert) {
+    // given
+    const trackEventStub = sinon.stub();
+    class PixMetricsStub extends Service {
+      trackEvent = trackEventStub;
+    }
+    this.owner.register('service:pixMetrics', PixMetricsStub);
+
+    const attestationsDetails = [{ type: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') }];
+
+    const screen = await render(
+      <template><AttestationContent @attestationsDetails={{attestationsDetails}} /></template>,
+    );
+
+    // when
+    await click(screen.getByRole('button', { name: t('pages.certificate.actions.download-attestation') }));
+
+    // then
+    sinon.assert.calledOnce(trackEventStub);
+    sinon.assert.calledWith(trackEventStub, 'Clic sur le bouton Télécharger (attestation)', {
+      disabled: true,
+      category: 'Page Mes Attestations',
+      action: 'Cliquer sur le bouton Télécharger (attestation)',
+    });
+    assert.ok(true);
+  });
+});

--- a/mon-pix/tests/integration/components/global/app-navigation-test.gjs
+++ b/mon-pix/tests/integration/components/global/app-navigation-test.gjs
@@ -1,8 +1,10 @@
 import { render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { settled } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import AppNavigation from 'mon-pix/components/global/app-navigation';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -73,6 +75,91 @@ module('Integration | Component | Global | App Navigation', function (hooks) {
           // then
           const nav = screen.getByLabelText('navigation principale');
           assert.dom(within(nav).getByRole('link', { name: t('navigation.main.trainings') })).exists();
+        });
+      });
+
+      module('attestation nav item', function (hooks) {
+        const userId = '123';
+        const cacheKey = `pix-has-attestations-${userId}`;
+
+        hooks.afterEach(function () {
+          localStorage.removeItem(cacheKey);
+        });
+
+        module('when localStorage has the cache set', function (hooks) {
+          hooks.beforeEach(function () {
+            localStorage.setItem(cacheKey, 'true');
+          });
+
+          test('it shows the attestation nav item without calling the store', async function (assert) {
+            // given
+            const findAllStub = sinon.stub();
+            class StoreStub extends Service {
+              findAll = findAllStub;
+            }
+            this.owner.register('service:store', StoreStub);
+            stubCurrentUserService(
+              this.owner,
+              { id: userId, firstName: 'Banana', lastName: 'Split', email: 'banana.split@example.net' },
+              { withStoreStubbed: true },
+            );
+
+            // when
+            const screen = await render(<template><AppNavigation /></template>);
+
+            // then
+            const nav = screen.getByLabelText('navigation principale');
+            assert.dom(within(nav).getByRole('link', { name: t('navigation.main.attestations') })).exists();
+            sinon.assert.notCalled(findAllStub);
+          });
+        });
+
+        module('when localStorage does not have the cache', function () {
+          test('shows the attestation nav item when user has attestations and caches the result', async function (assert) {
+            // given
+            const findAllStub = sinon.stub().resolves([{ id: '1' }]);
+            class StoreStub extends Service {
+              findAll = findAllStub;
+            }
+            this.owner.register('service:store', StoreStub);
+            stubCurrentUserService(
+              this.owner,
+              { id: userId, firstName: 'Banana', lastName: 'Split', email: 'banana.split@example.net' },
+              { withStoreStubbed: true },
+            );
+
+            // when
+            const screen = await render(<template><AppNavigation /></template>);
+            await settled();
+
+            // then
+            const nav = screen.getByLabelText('navigation principale');
+            assert.dom(within(nav).getByRole('link', { name: t('navigation.main.attestations') })).exists();
+            assert.strictEqual(localStorage.getItem(cacheKey), 'true');
+          });
+
+          test('does not show the attestation nav item when user has no attestations', async function (assert) {
+            // given
+            const findAllStub = sinon.stub().resolves([]);
+            class StoreStub extends Service {
+              findAll = findAllStub;
+            }
+            this.owner.register('service:store', StoreStub);
+            stubCurrentUserService(
+              this.owner,
+              { id: userId, firstName: 'Banana', lastName: 'Split', email: 'banana.split@example.net' },
+              { withStoreStubbed: true },
+            );
+
+            // when
+            const screen = await render(<template><AppNavigation /></template>);
+            await settled();
+
+            // then
+            const nav = screen.getByLabelText('navigation principale');
+            assert.dom(within(nav).queryByRole('link', { name: t('navigation.main.attestations') })).doesNotExist();
+            assert.strictEqual(localStorage.getItem(cacheKey), null);
+          });
         });
       });
     });

--- a/mon-pix/tests/unit/services/current-user-test.js
+++ b/mon-pix/tests/unit/services/current-user-test.js
@@ -15,7 +15,6 @@ module('Unit | Service | current-user', function (hooks) {
       sessionStub = Service.create({ isAuthenticated: true });
       storeStub = Service.create({
         queryRecord: sinon.stub().resolves(user),
-        findAll: sinon.stub().resolves(),
       });
     });
 
@@ -72,45 +71,6 @@ module('Unit | Service | current-user', function (hooks) {
 
       // Then
       assert.strictEqual(result, 'invalidate');
-    });
-  });
-
-  module('loadAttestationDetails', function (hooks) {
-    hooks.beforeEach(function () {
-      sessionStub = Service.create({ isAuthenticated: true });
-      storeStub = Service.create({
-        findAll: sinon.stub().rejects(),
-      });
-    });
-
-    test('should set attestation detail user', async function (assert) {
-      // Given
-      const currentUser = this.owner.lookup('service:currentUser');
-      const expectedResult = [Symbol('attestation-detail')];
-      currentUser.set('store', storeStub);
-      currentUser.set('session', sessionStub);
-
-      storeStub.findAll.withArgs('attestation-detail').resolves(expectedResult);
-      // When
-      await currentUser.loadAttestationDetails();
-
-      // Then
-      assert.strictEqual(currentUser.attestationsDetails, expectedResult);
-      assert.true(currentUser.hasAttestationsDetails);
-    });
-
-    test('should set to false attesation details', async function (assert) {
-      // Given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.set('store', storeStub);
-      currentUser.set('session', sessionStub);
-
-      storeStub.findAll.withArgs('attestation-detail').resolves([]);
-      // When
-      await currentUser.loadAttestationDetails();
-
-      // Then
-      assert.false(currentUser.hasAttestationsDetails);
     });
   });
 });


### PR DESCRIPTION
## 🪧 Problème

Le service currentUser charge les attestations de l'utilisateur afin de pouvoir afficher l'entrée de menu "Mes attestations". Cela représente 1M de requêtes par semaine. 

## 🌈 Proposition

1/ Charger directement les données dans le composant de menu. Cela évite de faire la requête sur les pages où le menu n'est pas présent.
2/ Stocker dans le localStorage que l'utilisateur a le droit de voir l'onglet "Mes attestations" car on ne peut pas supprimer une attestation.

## ✊ Remarques

Le délai d'affichage est quasi imperceptible mais ça génère un petit layout shifting dans le menu.

## 🎉 Pour tester

- Se connecter avec l'utilisateur all-attestations et constater la présence du menu "Mes attestations"