### PR TITLE
[TECH] Exporter les serializers avec des exports nommés

### DIFF
--- a/api/knip.jsonc
+++ b/api/knip.jsonc
@@ -1,7 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "entry": ["**/scripts/**/*.js", "**/*job-controller.js", "datamart/**/*.js", "db/**/*.js", "tests/**/*.{cjs,js}"],
-  "exclude": ["exports"],
   "ignoreDependencies": [
     "mocha-junit-reporter", // used by .circleci/config.yml
     "pg-query-stream", // https://knexjs.org/guide/interfaces.html#streams

--- a/api/src/announcements/application/announcement-controller.js
+++ b/api/src/announcements/application/announcement-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as announcementSerializer from '../infrastructure/serializers/jsonapi/announcement-serializer.js';
+import { announcementSerializer } from '../infrastructure/serializers/jsonapi/announcement-serializer.js';
 
 const get = async (request, h, dependencies = { announcementSerializer }) => {
   const { name } = request.params;

--- a/api/src/announcements/infrastructure/serializers/jsonapi/announcement-serializer.js
+++ b/api/src/announcements/infrastructure/serializers/jsonapi/announcement-serializer.js
@@ -7,4 +7,4 @@ const serialize = (announcement) =>
     attributes: ['content'],
   }).serialize(announcement);
 
-export { serialize };
+export const announcementSerializer = { serialize };

--- a/api/src/banner/application/banner-controller.js
+++ b/api/src/banner/application/banner-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as informationBannerSerializer from '../infrastructure/serializers/jsonapi/information-banner-serializer.js';
+import { informationBannerSerializer } from '../infrastructure/serializers/jsonapi/information-banner-serializer.js';
 
 const getInformationBanner = async function (request) {
   const { target: id } = request.params;

--- a/api/src/banner/infrastructure/serializers/jsonapi/information-banner-serializer.js
+++ b/api/src/banner/infrastructure/serializers/jsonapi/information-banner-serializer.js
@@ -13,4 +13,4 @@ const serialize = function (informationBanner) {
   }).serialize(informationBanner);
 };
 
-export { serialize };
+export const informationBannerSerializer = { serialize };

--- a/api/src/certification/enrolment/application/certification-candidate-controller.js
+++ b/api/src/certification/enrolment/application/certification-candidate-controller.js
@@ -1,7 +1,7 @@
 import { normalize } from '../../../shared/infrastructure/utils/string-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as candidateSerializer from '../infrastructure/serializers/candidate-serializer.js';
-import * as timelineSerializer from '../infrastructure/serializers/timeline-serializer.js';
+import { candidateSerializer } from '../infrastructure/serializers/candidate-serializer.js';
+import { timelineSerializer } from '../infrastructure/serializers/timeline-serializer.js';
 
 const addCandidate = async function (request, h, dependencies = { candidateSerializer }) {
   const sessionId = request.params.sessionId;

--- a/api/src/certification/enrolment/application/certification-center-controller.js
+++ b/api/src/certification/enrolment/application/certification-center-controller.js
@@ -1,6 +1,6 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as divisionSerializer from '../infrastructure/serializers/division-serializer.js';
-import * as studentCertificationSerializer from '../infrastructure/serializers/student-certification-serializer.js';
+import { divisionSerializer } from '../infrastructure/serializers/division-serializer.js';
+import { studentCertificationSerializer } from '../infrastructure/serializers/student-certification-serializer.js';
 
 const getStudents = async function (request) {
   const certificationCenterId = request.params.certificationCenterId;

--- a/api/src/certification/enrolment/application/enrolment-controller.js
+++ b/api/src/certification/enrolment/application/enrolment-controller.js
@@ -1,7 +1,7 @@
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
 import { usecases } from '../domain/usecases/index.js';
 import { fillCandidatesImportSheet } from '../infrastructure/candidates-import/fill-candidates-import-sheet.js';
-import * as candidateSerializer from '../infrastructure/serializers/candidate-serializer.js';
+import { candidateSerializer } from '../infrastructure/serializers/candidate-serializer.js';
 
 const enrolStudentsToSession = async function (request, h, dependencies = { candidateSerializer }) {
   const sessionId = request.params.sessionId;

--- a/api/src/certification/enrolment/application/session-controller.js
+++ b/api/src/certification/enrolment/application/session-controller.js
@@ -1,7 +1,7 @@
 import { normalize } from '../../../shared/infrastructure/utils/string-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import { serializeForParticipation } from '../infrastructure/serializers/candidate-serializer.js';
-import * as sessionSerializer from '../infrastructure/serializers/session-serializer.js';
+import { candidateSerializer } from '../infrastructure/serializers/candidate-serializer.js';
+import { sessionSerializer } from '../infrastructure/serializers/session-serializer.js';
 import { services } from './services/index.js';
 
 const createSession = async function (request, _h, dependencies = { sessionSerializer }) {
@@ -57,7 +57,7 @@ const createCandidateParticipation = async function (request, h) {
     normalizeStringFnc: normalize,
   });
 
-  return h.response(serializeForParticipation(candidate)).created();
+  return h.response(candidateSerializer.serializeForParticipation(candidate)).created();
 };
 
 const sessionController = {

--- a/api/src/certification/enrolment/application/session-mass-import-controller.js
+++ b/api/src/certification/enrolment/application/session-mass-import-controller.js
@@ -1,7 +1,7 @@
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
 import * as csvHelpers from '../../shared/application/helpers/csvHelpers.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as csvSerializer from '../infrastructure/serializers/csv/sessions-csv-serializer.js';
+import { sessionsCsvSerializer } from '../infrastructure/serializers/csv/sessions-csv-serializer.js';
 import { getCsvHeaders } from '../infrastructure/utils/sessions-import.js';
 
 const createSessions = async function (request, h) {
@@ -16,7 +16,11 @@ const createSessions = async function (request, h) {
   return h.response().code(201);
 };
 
-const validateSessions = async function (request, h, dependencies = { csvHelpers, csvSerializer }) {
+const validateSessions = async function (
+  request,
+  h,
+  dependencies = { csvHelpers, csvSerializer: sessionsCsvSerializer },
+) {
   const i18n = getI18nFromRequest(request);
 
   const certificationCenterId = request.params.certificationCenterId;

--- a/api/src/certification/enrolment/application/user-controller.js
+++ b/api/src/certification/enrolment/application/user-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as userCertificationEligibilitySerializer from '../infrastructure/serializers/user-certification-eligibility-serializer.js';
+import { userCertificationEligibilitySerializer } from '../infrastructure/serializers/user-certification-eligibility-serializer.js';
 
 const isCertifiable = async function (request) {
   const userId = request.auth.credentials.userId;

--- a/api/src/certification/enrolment/infrastructure/serializers/candidate-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/candidate-serializer.js
@@ -6,7 +6,7 @@ import { Subscription } from '../../domain/models/Subscription.js';
 
 const { Deserializer, Serializer } = jsonapiSerializer;
 
-export async function deserialize(json) {
+async function deserialize(json) {
   const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
   const deserializedCandidate = await deserializer.deserialize(json);
   deserializedCandidate.birthINSEECode = deserializedCandidate.birthInseeCode;
@@ -30,14 +30,14 @@ export async function deserialize(json) {
   });
 }
 
-export function deserializeForEdition({ candidateId, candidateData }) {
+function deserializeForEdition({ candidateId, candidateData }) {
   return new EditedCandidate({
     id: candidateId,
     accessibilityAdjustmentNeeded: candidateData['accessibility-adjustment-needed'],
   });
 }
 
-export const serializeForParticipation = function (candidate) {
+const serializeForParticipation = function (candidate) {
   return new Serializer('certification-candidate', {
     attributes: [
       'firstName',
@@ -52,11 +52,11 @@ export const serializeForParticipation = function (candidate) {
   }).serialize(candidate);
 };
 
-export function serializeId(candidateId) {
+function serializeId(candidateId) {
   return new Serializer('certification-candidate', {}).serialize({ id: candidateId });
 }
 
-export function serialize(candidates) {
+function serialize(candidates) {
   return new Serializer('certification-candidate', {
     attributes: [
       'firstName',
@@ -84,8 +84,17 @@ export function serialize(candidates) {
   }).serialize(candidates);
 }
 
-export function serializeForSession(candidates) {
+function serializeForSession(candidates) {
   return new Serializer('certification-candidate', {
     attributes: ['firstName', 'lastName', 'birthdate', 'subscription'],
   }).serialize(candidates);
 }
+
+export const candidateSerializer = {
+  deserialize,
+  deserializeForEdition,
+  serializeForParticipation,
+  serializeId,
+  serialize,
+  serializeForSession,
+};

--- a/api/src/certification/enrolment/infrastructure/serializers/csv/sessions-csv-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/csv/sessions-csv-serializer.js
@@ -269,4 +269,4 @@ function _generateUniqueKey({ address, room, date, time }) {
   return address + room + date + time;
 }
 
-export { deserializeForSessionsImport };
+export const sessionsCsvSerializer = { deserializeForSessionsImport };

--- a/api/src/certification/enrolment/infrastructure/serializers/division-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/division-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (divisions) {
   }).serialize(divisions);
 };
 
-export { serialize };
+export const divisionSerializer = { serialize };

--- a/api/src/certification/enrolment/infrastructure/serializers/session-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/session-serializer.js
@@ -4,7 +4,7 @@ import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
 
 const { Serializer } = jsonapiSerializer;
 
-export function serialize(session) {
+function serialize(session) {
   return new Serializer('session-enrolment', {
     transform: function (session) {
       return { ...session, status: session.status, invigilatorPassword: session.invigilatorPassword };
@@ -34,7 +34,7 @@ export function serialize(session) {
   }).serialize(session);
 }
 
-export function deserialize(json) {
+function deserialize(json) {
   const attributes = json.data.attributes;
 
   return new SessionEnrolment({
@@ -49,3 +49,5 @@ export function deserialize(json) {
     description: attributes.description,
   });
 }
+
+export const sessionSerializer = { serialize, deserialize };

--- a/api/src/certification/enrolment/infrastructure/serializers/student-certification-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/student-certification-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (students, pagination) {
   }).serialize(students);
 };
 
-export { serialize };
+export const studentCertificationSerializer = { serialize };

--- a/api/src/certification/enrolment/infrastructure/serializers/timeline-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/timeline-serializer.js
@@ -1,9 +1,11 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 const { Serializer } = jsonapiSerializer;
 
-export const serialize = function (timeline) {
+const serialize = function (timeline) {
   return new Serializer('certification-candidate-timeline', {
     id: 'certificationCandidateId',
     attributes: ['events'],
   }).serialize(timeline);
 };
+
+export const timelineSerializer = { serialize };

--- a/api/src/certification/enrolment/infrastructure/serializers/user-certification-eligibility-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/user-certification-eligibility-serializer.js
@@ -33,4 +33,4 @@ const serialize = function (userCertificationEligibility) {
   }).serialize(userCertificationEligibility);
 };
 
-export { serialize };
+export const userCertificationEligibilitySerializer = { serialize };

--- a/api/src/certification/results/application/certification-reports-controller.js
+++ b/api/src/certification/results/application/certification-reports-controller.js
@@ -1,4 +1,4 @@
-import * as certificationReportSerializer from '../../shared/infrastructure/serializers/jsonapi/certification-report-serializer.js';
+import { certificationReportSerializer } from '../../shared/infrastructure/serializers/jsonapi/certification-report-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 
 const getCertificationReports = async function (request, h, dependencies = { certificationReportSerializer }) {

--- a/api/src/certification/session-management/application/finalize-controller.js
+++ b/api/src/certification/session-management/application/finalize-controller.js
@@ -1,5 +1,5 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import * as certificationReportSerializer from '../../shared/infrastructure/serializers/jsonapi/certification-report-serializer.js';
+import { certificationReportSerializer } from '../../shared/infrastructure/serializers/jsonapi/certification-report-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 
 const finalize = async function (request, h, dependencies = { certificationReportSerializer }) {

--- a/api/src/certification/shared/infrastructure/serializers/jsonapi/certification-report-serializer.js
+++ b/api/src/certification/shared/infrastructure/serializers/jsonapi/certification-report-serializer.js
@@ -28,4 +28,4 @@ const deserialize = async function (jsonApiData) {
   return new CertificationReport(deserializedReport);
 };
 
-export { deserialize, serialize };
+export const certificationReportSerializer = { deserialize, serialize };

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
@@ -1,6 +1,6 @@
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases as devcompUsecases } from '../../domain/usecases/index.js';
-import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
+import { trainingSerializer } from '../../infrastructure/serializers/jsonapi/training-serializer.js';
 
 const findTrainings = async function (request, h, dependencies = { trainingSerializer }) {
   const { userId } = request.auth.credentials;

--- a/api/src/devcomp/application/modules-metadata/module-metadata-controller.js
+++ b/api/src/devcomp/application/modules-metadata/module-metadata-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as moduleMetadataSerializer from '../../infrastructure/serializers/jsonapi/module-metadata-serializer.js';
+import { moduleMetadataSerializer } from '../../infrastructure/serializers/jsonapi/module-metadata-serializer.js';
 
 async function getAllModulesMetadata() {
   const modulesMetadata = await usecases.getModuleMetadataList();

--- a/api/src/devcomp/application/trainings/training-controller.js
+++ b/api/src/devcomp/application/trainings/training-controller.js
@@ -1,9 +1,9 @@
 import * as targetProfileSummaryForAdminSerializer from '../../../prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../../domain/usecases/index.js';
-import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
-import * as trainingSummarySerializer from '../../infrastructure/serializers/jsonapi/training-summary-serializer.js';
-import * as trainingTriggerSerializer from '../../infrastructure/serializers/jsonapi/training-trigger-serializer.js';
+import { trainingSerializer } from '../../infrastructure/serializers/jsonapi/training-serializer.js';
+import { trainingSummarySerializer } from '../../infrastructure/serializers/jsonapi/training-summary-serializer.js';
+import { trainingTriggerSerializer } from '../../infrastructure/serializers/jsonapi/training-trigger-serializer.js';
 
 const findPaginatedTrainingSummaries = async function (request, h, dependencies = { trainingSummarySerializer }) {
   const { filter, page } = request.query;

--- a/api/src/devcomp/application/trainings/training-controller.js
+++ b/api/src/devcomp/application/trainings/training-controller.js
@@ -1,4 +1,4 @@
-import * as targetProfileSummaryForAdminSerializer from '../../../prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js';
+import { targetProfileSummaryForAdminSerializer } from '../../../prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { trainingSerializer } from '../../infrastructure/serializers/jsonapi/training-serializer.js';

--- a/api/src/devcomp/application/tutorial-evaluations/tutorial-evaluations-controller.js
+++ b/api/src/devcomp/application/tutorial-evaluations/tutorial-evaluations-controller.js
@@ -1,6 +1,6 @@
 import { TutorialEvaluation } from '../../domain/models/TutorialEvaluation.js';
 import { usecases } from '../../domain/usecases/index.js';
-import * as tutorialEvaluationSerializer from '../../infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js';
+import { tutorialEvaluationSerializer } from '../../infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js';
 
 const evaluate = async function (request, h, dependencies = { tutorialEvaluationSerializer }) {
   const { userId } = request.auth.credentials;

--- a/api/src/devcomp/application/user-trainings/user-trainings-controller.js
+++ b/api/src/devcomp/application/user-trainings/user-trainings-controller.js
@@ -1,6 +1,6 @@
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases as devcompUsecases } from '../../domain/usecases/index.js';
-import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
+import { trainingSerializer } from '../../infrastructure/serializers/jsonapi/training-serializer.js';
 
 const findPaginatedUserRecommendedTrainings = async function (
   request,

--- a/api/src/devcomp/application/user-tutorials/user-tutorials-controller.js
+++ b/api/src/devcomp/application/user-tutorials/user-tutorials-controller.js
@@ -2,8 +2,8 @@ import { getBaseLocale } from '../../../shared/domain/services/locale-service.js
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as userSavedTutorialRepository from '../../infrastructure/repositories/user-saved-tutorial-repository.js';
-import * as tutorialSerializer from '../../infrastructure/serializers/jsonapi/tutorial-serializer.js';
-import * as userSavedTutorialSerializer from '../../infrastructure/serializers/jsonapi/user-saved-tutorial-serializer.js';
+import { tutorialSerializer } from '../../infrastructure/serializers/jsonapi/tutorial-serializer.js';
+import { userSavedTutorialSerializer } from '../../infrastructure/serializers/jsonapi/user-saved-tutorial-serializer.js';
 
 const add = async function (request, h, dependencies = { userSavedTutorialSerializer }) {
   const { userId } = request.auth.credentials;

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js
@@ -15,4 +15,4 @@ function serialize(correctionResponse) {
   }).serialize(correctionResponse);
 }
 
-export { serialize };
+export const correctionResponseSerializer = { serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
@@ -33,4 +33,4 @@ function serialize(elementAnswer) {
   }).serialize(elementAnswer);
 }
 
-export { serialize };
+export const elementAnswerSerializer = { serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (moduleMetadataList) {
   }).serialize(moduleMetadataList);
 };
 
-export { serialize };
+export const moduleMetadataSerializer = { serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -51,4 +51,4 @@ function serialize(module) {
   }).serialize(module);
 }
 
-export { serialize };
+export const moduleSerializer = { serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js
@@ -13,4 +13,4 @@ const deserialize = async function (payload) {
   });
 };
 
-export { deserialize };
+export const passageEventSerializer = { deserialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/passage-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/passage-serializer.js
@@ -8,4 +8,4 @@ function serialize(passage) {
   }).serialize(passage);
 }
 
-export { serialize };
+export const passageSerializer = { serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -151,4 +151,4 @@ const deserialize = function (payload) {
   }).deserialize(payload);
 };
 
-export { deserialize, serialize, serializeForAdmin };
+export const trainingSerializer = { deserialize, serialize, serializeForAdmin };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer.js
@@ -16,4 +16,4 @@ const serialize = function (trainingSummaries, meta) {
   }).serialize(trainingSummaries);
 };
 
-export { serialize };
+export const trainingSummarySerializer = { serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-trigger-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-trigger-serializer.js
@@ -53,4 +53,4 @@ const deserialize = function (payload) {
   }).deserialize(payload);
 };
 
-export { deserialize, serialize };
+export const trainingTriggerSerializer = { deserialize, serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js
@@ -21,4 +21,4 @@ const deserialize = function (json) {
   });
 };
 
-export { deserialize, serialize };
+export const tutorialEvaluationSerializer = { deserialize, serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/tutorial-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/tutorial-serializer.js
@@ -31,4 +31,4 @@ const serialize = function (tutorial = {}, pagination) {
   }).serialize(tutorial);
 };
 
-export { serialize };
+export const tutorialSerializer = { serialize };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/user-saved-tutorial-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/user-saved-tutorial-serializer.js
@@ -19,4 +19,4 @@ const deserialize = function (json) {
   });
 };
 
-export { deserialize, serialize };
+export const userSavedTutorialSerializer = { deserialize, serialize };

--- a/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
+++ b/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
@@ -1,8 +1,8 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as elementAnswerSerializer from '../serializers/jsonapi/element-answer-serializer.js';
-import * as moduleSerializer from '../serializers/jsonapi/module-serializer.js';
-import * as passageEventSerializer from '../serializers/jsonapi/passage-event-serializer.js';
-import * as passageSerializer from '../serializers/jsonapi/passage-serializer.js';
+import { elementAnswerSerializer } from '../serializers/jsonapi/element-answer-serializer.js';
+import { moduleSerializer } from '../serializers/jsonapi/module-serializer.js';
+import { passageEventSerializer } from '../serializers/jsonapi/passage-event-serializer.js';
+import { passageSerializer } from '../serializers/jsonapi/passage-serializer.js';
 
 const dependencies = {
   usecases,

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -7,8 +7,8 @@ import {
   getChallengeLocale,
 } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
-import * as answerSerializer from '../../infrastructure/serializers/jsonapi/answer-serializer.js';
-import * as correctionSerializer from '../../infrastructure/serializers/jsonapi/correction-serializer.js';
+import { answerSerializer } from '../../infrastructure/serializers/jsonapi/answer-serializer.js';
+import { correctionSerializer } from '../../infrastructure/serializers/jsonapi/correction-serializer.js';
 
 async function save(request, h, dependencies = { answerSerializer, assessmentRepository, certificationEvaluationApi }) {
   const answer = dependencies.answerSerializer.deserialize(request.payload);

--- a/api/src/evaluation/application/api/challenge-to-play-api.js
+++ b/api/src/evaluation/application/api/challenge-to-play-api.js
@@ -1,5 +1,5 @@
 import * as challengeToPlayRepository from '../../infrastructure/repositories/challenge-to-play-repository.js';
-import * as challengeToPlaySerializer from '../../infrastructure/serializers/jsonapi/challenge-to-play-serializer.js';
+import { challengeToPlaySerializer } from '../../infrastructure/serializers/jsonapi/challenge-to-play-serializer.js';
 
 /**
  * @function

--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -16,7 +16,7 @@ import {
 } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { Answer } from '../../domain/models/Answer.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
-import * as competenceEvaluationSerializer from '../../infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
+import { competenceEvaluationSerializer } from '../../infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
 
 async function shareProfileRewardWithOrganization(campaignParticipationId, userId) {
   const questResults = await questUsecases.getQuestResultsForCampaignParticipation({

--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -8,7 +8,7 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { AssessmentDtoFactory } from '../../../shared/domain/models/AssessmentDtoFactory.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
-import * as assessmentSerializer from '../../../shared/infrastructure/serializers/jsonapi/assessment-serializer.js';
+import { assessmentSerializer } from '../../../shared/infrastructure/serializers/jsonapi/assessment-serializer.js';
 import * as llmChatSerializer from '../../../shared/infrastructure/serializers/llm-chat-serializer.js';
 import {
   extractUserIdFromRequest,

--- a/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
+++ b/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
@@ -1,7 +1,7 @@
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
-import * as autonomousCoursePaginatedListSerializer from '../../infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js';
-import * as autonomousCourseSerializer from '../../infrastructure/serializers/jsonapi/autonomous-course-serializer.js';
+import { autonomousCoursePaginatedListSerializer } from '../../infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js';
+import { autonomousCourseSerializer } from '../../infrastructure/serializers/jsonapi/autonomous-course-serializer.js';
 
 const save = async (request, h, dependencies = { usecases, autonomousCourseSerializer }) => {
   const userId = extractUserIdFromRequest(request);

--- a/api/src/evaluation/application/autonomous-courses/autonomous-course-target-profile-controller.js
+++ b/api/src/evaluation/application/autonomous-courses/autonomous-course-target-profile-controller.js
@@ -1,10 +1,10 @@
 import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
-import * as AutonomousCourseTargetProfilesSerializer from '../../infrastructure/serializers/jsonapi/autonomous-course-target-profiles-serializer.js';
+import { autonomousCourseTargetProfilesSerializer } from '../../infrastructure/serializers/jsonapi/autonomous-course-target-profiles-serializer.js';
 
 const get = function (
   request,
   h,
-  dependencies = { usecases, autonomousCourseTargetProfilesSerializer: AutonomousCourseTargetProfilesSerializer },
+  dependencies = { usecases, autonomousCourseTargetProfilesSerializer: autonomousCourseTargetProfilesSerializer },
 ) {
   return dependencies.usecases
     .getAutonomousCourseTargetProfiles()

--- a/api/src/evaluation/application/badge-criteria/badge-criteria-controller.js
+++ b/api/src/evaluation/application/badge-criteria/badge-criteria-controller.js
@@ -1,5 +1,5 @@
 import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
-import * as badgeCriterionSerializer from '../../infrastructure/serializers/jsonapi/badge-criterion-serializer.js';
+import { badgeCriterionSerializer } from '../../infrastructure/serializers/jsonapi/badge-criterion-serializer.js';
 
 const updateCriterion = async (request, h, dependencies = { usecases, badgeCriterionSerializer }) => {
   const badgeCriterionId = request.params.badgeCriterionId;

--- a/api/src/evaluation/application/challenges/challenge-controller.js
+++ b/api/src/evaluation/application/challenges/challenge-controller.js
@@ -1,5 +1,5 @@
 import * as challengeToPlayRepository from '../../infrastructure/repositories/challenge-to-play-repository.js';
-import * as challengeToPlaySerializer from '../../infrastructure/serializers/jsonapi/challenge-to-play-serializer.js';
+import { challengeToPlaySerializer } from '../../infrastructure/serializers/jsonapi/challenge-to-play-serializer.js';
 
 async function get(request, h, dependencies = { challengeToPlayRepository, challengeToPlaySerializer }) {
   const challengeToPlay = await dependencies.challengeToPlayRepository.get(request.params.id);

--- a/api/src/evaluation/application/competence-evaluations/competence-evaluation-controller.js
+++ b/api/src/evaluation/application/competence-evaluations/competence-evaluation-controller.js
@@ -1,6 +1,6 @@
 import { evaluationUsecases as usecases } from '../../../evaluation/domain/usecases/index.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import * as competenceEvaluationSerializer from '../../infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
+import { competenceEvaluationSerializer } from '../../infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
 
 const startOrResume = async function (request, h, dependencies = { competenceEvaluationSerializer }) {
   const userId = request.auth.credentials.userId;

--- a/api/src/evaluation/application/courses/course-controller.js
+++ b/api/src/evaluation/application/courses/course-controller.js
@@ -1,4 +1,4 @@
-import * as courseSerializer from '../../../shared/infrastructure/serializers/jsonapi/course-serializer.js';
+import { courseSerializer } from '../../../shared/infrastructure/serializers/jsonapi/course-serializer.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as courseService from '../../domain/services/course-service.js';
 

--- a/api/src/evaluation/application/feedbacks/feedback-controller.js
+++ b/api/src/evaluation/application/feedbacks/feedback-controller.js
@@ -1,7 +1,7 @@
 import { evaluationUsecases as usecases } from '../../../evaluation/domain/usecases/index.js';
-import * as feedBackSerializer from '../../infrastructure/serializers/jsonapi/feedback-serializer.js';
+import { feedbackSerializer } from '../../infrastructure/serializers/jsonapi/feedback-serializer.js';
 
-const save = async function (request, h, dependencies = { feedBackSerializer, usecases }) {
+const save = async function (request, h, dependencies = { feedBackSerializer: feedbackSerializer, usecases }) {
   const newUserAgent = request.headers['user-agent'].slice(0, 255);
   const feedback = await dependencies.feedBackSerializer.deserialize(request.payload, newUserAgent);
 

--- a/api/src/evaluation/application/pre-handlers/assessment-authorization.js
+++ b/api/src/evaluation/application/pre-handlers/assessment-authorization.js
@@ -1,5 +1,5 @@
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
-import * as validationErrorSerializer from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
+import { validationErrorSerializer } from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
 const verify = function (request, h, dependencies = { assessmentRepository, validationErrorSerializer }) {

--- a/api/src/evaluation/application/progressions/progression-controller.js
+++ b/api/src/evaluation/application/progressions/progression-controller.js
@@ -1,5 +1,5 @@
 import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
-import * as ProgressionSerializer from '../../infrastructure/serializers/jsonapi/progression-serializer.js';
+import { progressionSerializer } from '../../infrastructure/serializers/jsonapi/progression-serializer.js';
 
 const get = function (request) {
   const userId = request.auth.credentials.userId;
@@ -11,7 +11,7 @@ const get = function (request) {
       progressionId,
       userId,
     })
-    .then(ProgressionSerializer.serialize);
+    .then(progressionSerializer.serialize);
 };
 
 const progressionController = { get };

--- a/api/src/evaluation/application/scorecards/scorecard-controller.js
+++ b/api/src/evaluation/application/scorecards/scorecard-controller.js
@@ -1,7 +1,7 @@
 // TODO Bounded context violation
 import { usecases as devCompUsecases } from '../../../devcomp/domain/usecases/index.js';
 // TODO Bounded context violation
-import * as tutorialSerializer from '../../../devcomp/infrastructure/serializers/jsonapi/tutorial-serializer.js';
+import { tutorialSerializer } from '../../../devcomp/infrastructure/serializers/jsonapi/tutorial-serializer.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../shared/domain/errors.js';
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { Scorecard } from '../../domain/models/Scorecard.js';

--- a/api/src/evaluation/application/scorecards/scorecard-controller.js
+++ b/api/src/evaluation/application/scorecards/scorecard-controller.js
@@ -6,7 +6,7 @@ import { UserNotAuthorizedToAccessEntityError } from '../../../shared/domain/err
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { Scorecard } from '../../domain/models/Scorecard.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
-import * as scorecardSerializer from '../../infrastructure/serializers/jsonapi/scorecard-serializer.js';
+import { scorecardSerializer } from '../../infrastructure/serializers/jsonapi/scorecard-serializer.js';
 
 const getScorecard = function (request, h, dependencies = { scorecardSerializer }) {
   const locale = getChallengeLocale(request);

--- a/api/src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js
+++ b/api/src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js
@@ -1,8 +1,12 @@
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import { clearLog, startLogging } from '../../domain/services/smart-random-log-service.js';
-import * as algorithmSimulatorSerializer from '../../infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js';
+import { smartRandomSimulatorSerializer } from '../../infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js';
 
-const getNextChallenge = async function (request, h, dependencies = { algorithmSimulatorSerializer }) {
+const getNextChallenge = async function (
+  request,
+  h,
+  dependencies = { algorithmSimulatorSerializer: smartRandomSimulatorSerializer },
+) {
   const deserializedPayload = await dependencies.algorithmSimulatorSerializer.deserialize(request.payload);
 
   try {

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -52,11 +52,11 @@ const deserialize = function (payload) {
   });
 };
 
-export { deserialize, serialize };
-
 function _cleanValue(value) {
   if (value) {
     return value.replaceAll('\u0000', '');
   }
   return '';
 }
+
+export const answerSerializer = { deserialize, serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (autonomousCourses, meta) {
   }).serialize(autonomousCourses);
 };
 
-export { serialize };
+export const autonomousCoursePaginatedListSerializer = { serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js
@@ -16,4 +16,4 @@ const deserialize = function (payload) {
   }).deserialize(payload);
 };
 
-export { deserialize, serialize, serializeId };
+export const autonomousCourseSerializer = { deserialize, serialize, serializeId };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-target-profiles-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-target-profiles-serializer.js
@@ -7,4 +7,4 @@ const serialize = function (autonomousCourseTargetProfiles) {
   }).serialize(autonomousCourseTargetProfiles);
 };
 
-export { serialize };
+export const autonomousCourseTargetProfilesSerializer = { serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/badge-criterion-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/badge-criterion-serializer.js
@@ -21,4 +21,4 @@ const deserialize = async function (payload) {
   return new BadgeCriterion({ ...deserializedPayload });
 };
 
-export { deserialize };
+export const badgeCriterionSerializer = { deserialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/challenge-to-play-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/challenge-to-play-serializer.js
@@ -56,4 +56,4 @@ const serialize = function (challenges) {
   return new Serializer('challenge', config).serialize(challenges);
 };
 
-export { config, serialize };
+export const challengeToPlaySerializer = { config, serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js
@@ -26,4 +26,4 @@ const serialize = function (competenceEvaluations) {
   }).serialize(competenceEvaluations);
 };
 
-export { serialize };
+export const competenceEvaluationSerializer = { serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js
@@ -52,4 +52,4 @@ const serialize = function (correction) {
   }).serialize(correction);
 };
 
-export { serialize };
+export const correctionSerializer = { serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/feedback-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/feedback-serializer.js
@@ -30,4 +30,4 @@ const deserialize = function (json, userAgent) {
     });
 };
 
-export { deserialize, serialize };
+export const feedbackSerializer = { deserialize, serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/progression-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/progression-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (progression) {
   }).serialize(progression);
 };
 
-export { serialize };
+export const progressionSerializer = { serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/scorecard-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/scorecard-serializer.js
@@ -60,4 +60,4 @@ const serialize = function (scorecard = {}) {
   }).serialize(scorecard);
 };
 
-export { serialize };
+export const scorecardSerializer = { serialize };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js
@@ -28,4 +28,4 @@ const deserialize = async function (payload) {
   });
 };
 
-export { deserialize };
+export const smartRandomSimulatorSerializer = { deserialize };

--- a/api/src/identity-access-management/application/account-recovery/account-recovery.controller.js
+++ b/api/src/identity-access-management/application/account-recovery/account-recovery.controller.js
@@ -1,6 +1,6 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../../domain/usecases/index.js';
-import * as studentInformationForAccountRecoverySerializer from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
+import { studentInformationForAccountRecoverySerializer } from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
 
 const checkAccountRecoveryDemand = async function (
   request,

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
@@ -1,7 +1,7 @@
 import { getForwardedOrigin, RequestedApplication } from '../../../shared/infrastructure/utils/network.js';
 import { oidcAuthenticationServiceRegistry, usecases } from '../../domain/usecases/index.js';
 import { addOidcProviderValidator } from '../../domain/validators/add-oidc-provider.validator.js';
-import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
+import { oidcIdentityProvidersSerializer } from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
 
 /**
  * @param request
@@ -36,7 +36,7 @@ async function createInBatch(request, h) {
  */
 async function getAllIdentityProvidersForAdmin(request, h) {
   const identityProviders = await usecases.getAllIdentityProviders();
-  return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
+  return h.response(oidcIdentityProvidersSerializer.serialize(identityProviders)).code(200);
 }
 
 /**

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -4,8 +4,8 @@ import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { getForwardedOrigin, RequestedApplication } from '../../../shared/infrastructure/utils/network.js';
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
-import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
-import * as userOidcAuthenticationRequestSerializer from '../../infrastructure/serializers/jsonapi/user-oidc-authentication-request.serializer.js';
+import { oidcIdentityProvidersSerializer } from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
+import { userOidcAuthenticationRequestSerializer } from '../../infrastructure/serializers/jsonapi/user-oidc-authentication-request.serializer.js';
 
 /**
  * @typedef {function} authenticateOidcUser
@@ -129,10 +129,10 @@ async function getIdentityProvidersByRequestedApplication(request, h) {
 
     const identityProviders = await usecases.getIdentityProvidersByRequestedApplication({ requestedApplication });
 
-    return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
+    return h.response(oidcIdentityProvidersSerializer.serialize(identityProviders)).code(200);
   } catch (error) {
     logger.error(error, `Error getting identity providers.`);
-    return h.response(oidcProviderSerializer.serialize([])).code(200);
+    return h.response(oidcIdentityProvidersSerializer.serialize([])).code(200);
   }
 }
 

--- a/api/src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.controller.js
+++ b/api/src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as studentInformationForAccountRecoverySerializer from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
+import { studentInformationForAccountRecoverySerializer } from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
 
 async function checkScoAccountRecovery(request, h, dependencies = { studentInformationForAccountRecoverySerializer }) {
   const studentInformation = await dependencies.studentInformationForAccountRecoverySerializer.deserialize(

--- a/api/src/identity-access-management/application/password/password.controller.js
+++ b/api/src/identity-access-management/application/password/password.controller.js
@@ -1,6 +1,6 @@
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
-import * as userSerializer from '../../infrastructure/serializers/jsonapi/user-serializer.js';
+import { userSerializer } from '../../infrastructure/serializers/jsonapi/user-serializer.js';
 
 const checkResetDemand = async function (request, h, dependencies = { userSerializer }) {
   const temporaryKey = request.params.temporaryKey;

--- a/api/src/identity-access-management/application/user/user-existence-verification-pre-handler.js
+++ b/api/src/identity-access-management/application/user/user-existence-verification-pre-handler.js
@@ -1,8 +1,12 @@
 import { UserNotFoundError } from '../../../shared/domain/errors.js';
-import * as errorSerializer from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
+import { validationErrorSerializer } from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
 import * as userRepository from '../../infrastructure/repositories/user.repository.js';
 
-const verifyById = function (request, h, dependencies = { userRepository, errorSerializer }) {
+const verifyById = function (
+  request,
+  h,
+  dependencies = { userRepository, errorSerializer: validationErrorSerializer },
+) {
   return dependencies.userRepository.get(request.params.id).catch((err) => {
     if (err instanceof UserNotFoundError) {
       const serializedError = dependencies.errorSerializer.serialize(new UserNotFoundError().getErrorMessage());

--- a/api/src/identity-access-management/application/user/user.admin.controller.js
+++ b/api/src/identity-access-management/application/user/user.admin.controller.js
@@ -1,9 +1,9 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../../domain/usecases/index.js';
-import * as userAnonymizedDetailsForAdminSerializer from '../../infrastructure/serializers/jsonapi/user-anonymized-details-for-admin.serializer.js';
-import * as userDetailsForAdminSerializer from '../../infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js';
-import * as userForAdminSerializer from '../../infrastructure/serializers/jsonapi/user-for-admin.serializer.js';
-import * as userLoginSerializer from '../../infrastructure/serializers/jsonapi/user-login-serializer.js';
+import { userAnonymizedDetailsForAdminSerializer } from '../../infrastructure/serializers/jsonapi/user-anonymized-details-for-admin.serializer.js';
+import { userDetailsForAdminSerializer } from '../../infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js';
+import { userForAdminSerializer } from '../../infrastructure/serializers/jsonapi/user-for-admin.serializer.js';
+import { userLoginSerializer } from '../../infrastructure/serializers/jsonapi/user-login-serializer.js';
 
 /**
  *

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -2,11 +2,11 @@ import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js'
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { authenticationMethodsSerializer } from '../../infrastructure/serializers/jsonapi/authentication-methods.serializer.js';
-import * as certificationPointOfContactSerializer from '../../infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js';
+import { certificationPointOfContactSerializer } from '../../infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js';
 import { emailVerificationSerializer } from '../../infrastructure/serializers/jsonapi/email-verification.serializer.js';
-import * as updateEmailSerializer from '../../infrastructure/serializers/jsonapi/update-email.serializer.js';
+import { updateEmailSerializer } from '../../infrastructure/serializers/jsonapi/update-email.serializer.js';
 import { userAccountInfoSerializer } from '../../infrastructure/serializers/jsonapi/user-account-info.serializer.js';
-import * as userSerializer from '../../infrastructure/serializers/jsonapi/user-serializer.js';
+import { userSerializer } from '../../infrastructure/serializers/jsonapi/user-serializer.js';
 import { userWithActivitySerializer } from '../../infrastructure/serializers/jsonapi/user-with-activity.serializer.js';
 
 const acceptPixCertifTermsOfService = async function (request, h) {

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js
@@ -80,4 +80,4 @@ const serialize = function (certificationPointOfContact) {
   }).serialize(certificationPointOfContact);
 };
 
-export { serialize };
+export const certificationPointOfContactSerializer = { serialize };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js
@@ -30,4 +30,4 @@ const serialize = function (oidcIdentityProviders) {
   }).serialize(oidcIdentityProviders);
 };
 
-export { serialize };
+export const oidcIdentityProvidersSerializer = { serialize };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js
@@ -29,4 +29,4 @@ const deserialize = async function (studentInformationForAccountRecovery) {
     .then((studentInformation) => studentInformation);
 };
 
-export { deserialize, serialize, serializeAccountRecovery };
+export const studentInformationForAccountRecoverySerializer = { deserialize, serialize, serializeAccountRecovery };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/update-email.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/update-email.serializer.js
@@ -8,4 +8,4 @@ const serialize = function (newEmail) {
   }).serialize(newEmail);
 };
 
-export { serialize };
+export const updateEmailSerializer = { serialize };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin.serializer.js
@@ -24,4 +24,4 @@ const serialize = function (usersAnonymizedDetailsForAdmin) {
   }).serialize(usersAnonymizedDetailsForAdmin);
 };
 
-export { serialize };
+export const userAnonymizedDetailsForAdminSerializer = { serialize };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js
@@ -181,4 +181,4 @@ const deserialize = function (json) {
   });
 };
 
-export { deserialize, serialize, serializeForUpdate };
+export const userDetailsForAdminSerializer = { deserialize, serialize, serializeForUpdate };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-for-admin.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-for-admin.serializer.js
@@ -65,4 +65,4 @@ const serialize = function (users, meta) {
   }).serialize(users);
 };
 
-export { serialize };
+export const userForAdminSerializer = { serialize };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-login-serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-login-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (usersAnonymizedDetailsForAdmin) {
   }).serialize(usersAnonymizedDetailsForAdmin);
 };
 
-export { serialize };
+export const userLoginSerializer = { serialize };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-oidc-authentication-request.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-oidc-authentication-request.serializer.js
@@ -14,4 +14,4 @@ const serialize = function (authenticationContent) {
   }).serialize(authenticationContent);
 };
 
-export { serialize };
+export const userOidcAuthenticationRequestSerializer = { serialize };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-serializer.js
@@ -89,4 +89,5 @@ const deserialize = function (json) {
 /**
  * @typedef UserSerializer
  */
-export { deserialize, serialize };
+
+export const userSerializer = { deserialize, serialize };

--- a/api/src/learning-content/application/frameworks-controller.js
+++ b/api/src/learning-content/application/frameworks-controller.js
@@ -1,7 +1,7 @@
 import { getChallengeLocale } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as frameworkAreasSerializer from '../infrastructure/serializers/framework-areas-serializer.js';
-import * as frameworkSerializer from '../infrastructure/serializers/framework-serializer.js';
+import { frameworkAreasSerializer } from '../infrastructure/serializers/framework-areas-serializer.js';
+import { frameworkSerializer } from '../infrastructure/serializers/framework-serializer.js';
 
 const getFrameworks = async function (request, h, dependencies = { frameworkSerializer }) {
   const frameworks = await usecases.getFrameworks();

--- a/api/src/learning-content/infrastructure/serializers/framework-areas-serializer.js
+++ b/api/src/learning-content/infrastructure/serializers/framework-areas-serializer.js
@@ -39,4 +39,4 @@ const serialize = function (areas, { withoutThematics = false } = {}) {
   }).serialize(areas);
 };
 
-export { serialize };
+export const frameworkAreasSerializer = { serialize };

--- a/api/src/learning-content/infrastructure/serializers/framework-serializer.js
+++ b/api/src/learning-content/infrastructure/serializers/framework-serializer.js
@@ -20,4 +20,4 @@ const serialize = function (frameworks) {
   }).serialize(frameworks);
 };
 
-export { serialize };
+export const frameworkSerializer = { serialize };

--- a/api/src/llm/application/pre-handlers/index.js
+++ b/api/src/llm/application/pre-handlers/index.js
@@ -1,6 +1,6 @@
 import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
-import * as errorSerializer from '../../../shared/infrastructure/serializers/jsonapi/error-serializer.js';
+import { errorSerializer } from '../../../shared/infrastructure/serializers/jsonapi/error-serializer.js';
 
 export async function checkLLMChatIsEnabled(request, h) {
   try {

--- a/api/src/organizational-entities/application/administration-team/administration-team.admin.controller.js
+++ b/api/src/organizational-entities/application/administration-team/administration-team.admin.controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as administrationTeamSerializer from '../../infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js';
+import { administrationTeamSerializer } from '../../infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js';
 
 const findAllAdministrationTeams = async function (request, h, dependencies = { administrationTeamSerializer }) {
   const administrationTeams = await usecases.findAllAdministrationTeams();

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
@@ -5,8 +5,8 @@ import {
   deserializeForCertificationCenterBatchArchive,
   requiredFieldNamesForCertificationCenterBatchArchive,
 } from '../../infrastructure/serializers/csv/certification-center-archive-csv-serializer.js';
-import * as certificationCenterSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
-import * as certificationCenterForAdminSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js';
+import { certificationCenterSerializer } from '../../infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
+import { certificationCenterForAdminSerializer } from '../../infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js';
 import { attachedOrganizationSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/attached-organization.serializer.js';
 
 const archiveCertificationCenter = async function (request, h) {

--- a/api/src/organizational-entities/application/network/network.admin.controller.js
+++ b/api/src/organizational-entities/application/network/network.admin.controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as networkSerializer from '../../infrastructure/serializers/jsonapi/network/network.serializer.js';
+import { networkSerializer } from '../../infrastructure/serializers/jsonapi/network/network.serializer.js';
 
 const findAllFilteredNetworks = async function (request, h, dependencies = { networkSerializer }) {
   const { filter, page } = request.query;

--- a/api/src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.controller.js
+++ b/api/src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as organizationLearnerTypeSerializer from '../../infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js';
+import { organizationLearnerTypeSerializer } from '../../infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js';
 
 const findAllOrganizationLearnerTypes = async function (
   request,

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -11,11 +11,11 @@ import {
   deserializeForOrganizationsImport,
   requiredFieldNamesForOrganizationsImport,
 } from '../../infrastructure/serializers/csv/organizations-csv-serializer.js';
-import * as certificationCenterSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
-import * as organizationSerializer from '../../infrastructure/serializers/jsonapi/organization-serializer.js';
+import { certificationCenterSerializer } from '../../infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
+import { organizationSerializer } from '../../infrastructure/serializers/jsonapi/organization-serializer.js';
 import { organizationForAdminSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js';
-import * as organizationPlacesStatisticsSerializer from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js';
-import * as organizationStatisticsSerializer from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js';
+import { organizationPlacesStatisticsSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js';
+import { organizationStatisticsSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js';
 
 const ADD_TAGS_TO_ORGANIZATIONS_HEADER = organizationTagCsvParser.CSV_HEADER;
 

--- a/api/src/organizational-entities/application/tag/tag.admin.controller.js
+++ b/api/src/organizational-entities/application/tag/tag.admin.controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as tagSerializer from '../../infrastructure/serializers/jsonapi/tag-serializer.js';
+import { tagSerializer } from '../../infrastructure/serializers/jsonapi/tag-serializer.js';
 
 const findAllTags = async function (request, h, dependencies = { tagSerializer }) {
   const organizationsTags = await usecases.findAllTags();

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (administrationTeam) {
   }).serialize(administrationTeam);
 };
 
-export { serialize };
+export const administrationTeamSerializer = { serialize };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js
@@ -76,4 +76,4 @@ const serialize = function (certificationCenter) {
   }).serialize({ ...certificationCenter });
 };
 
-export { deserialize, serialize };
+export const certificationCenterForAdminSerializer = { deserialize, serialize };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js
@@ -17,4 +17,4 @@ const serialize = function (certificationCenters, meta) {
   }).serialize(certificationCenters);
 };
 
-export { serialize };
+export const certificationCenterSerializer = { serialize };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/network/network.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/network/network.serializer.js
@@ -18,4 +18,4 @@ const deserialize = function (json) {
   };
 };
 
-export { deserialize, serialize };
+export const networkSerializer = { deserialize, serialize };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (organizationLearnerType) {
   }).serialize(organizationLearnerType);
 };
 
-export { serialize };
+export const organizationLearnerTypeSerializer = { serialize };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -72,4 +72,4 @@ const deserialize = function (json) {
   return organization;
 };
 
-export { deserialize, serialize };
+export const organizationSerializer = { deserialize, serialize };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js
@@ -8,4 +8,4 @@ const serialize = function (places) {
   }).serialize(places);
 };
 
-export { serialize };
+export const organizationPlacesStatisticsSerializer = { serialize };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js
@@ -8,4 +8,4 @@ const serialize = function (statistics) {
   }).serialize(statistics);
 };
 
-export { serialize };
+export const organizationStatisticsSerializer = { serialize };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/tag-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/tag-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (tags) {
   }).serialize(tags);
 };
 
-export { serialize };
+export const tagSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/application/admin-campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/admin-campaign-participation-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as campaignParticipationForUserManagementSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer.js';
+import { campaignParticipationForUserManagementSerializer } from '../infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer.js';
 
 const findCampaignParticipationsForUserManagement = async function (
   request,

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -1,5 +1,5 @@
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
-import * as campaignResultLevelsPerTubesAndCompetencesSerializer from '../../campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
+import { campaignResultLevelsPerTubesAndCompetencesSerializer } from '../../campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as anonymisedCampaignAssessmentSerializer from '../infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js';
 import * as availableCampaignParticipationsSerializer from '../infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -1,16 +1,16 @@
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { campaignResultLevelsPerTubesAndCompetencesSerializer } from '../../campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as anonymisedCampaignAssessmentSerializer from '../infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js';
-import * as availableCampaignParticipationsSerializer from '../infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';
-import * as campaignAssessmentParticipationResultSerializer from '../infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer.js';
-import * as campaignAssessmentParticipationSerializer from '../infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js';
-import * as campaignParticipationOverviewSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
-import * as campaignParticipationSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
-import * as campaignParticipationStatisticsSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-statistics-serializer.js';
-import * as campaignProfileSerializer from '../infrastructure/serializers/jsonapi/campaign-profile-serializer.js';
-import * as participantResultSerializer from '../infrastructure/serializers/jsonapi/participant-result-serializer.js';
-import * as participationForCampaignManagementSerializer from '../infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js';
+import { anonymisedCampaignAssessmentSerializer } from '../infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js';
+import { availableCampaignParticipationSerializer } from '../infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';
+import { campaignAssessmentParticipationResultSerializer } from '../infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer.js';
+import { campaignAssessmentParticipationSerializer } from '../infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js';
+import { campaignParticipationOverviewSerializer } from '../infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
+import { campaignParticipationSerializer } from '../infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
+import { campaignParticipationStatisticsSerializer } from '../infrastructure/serializers/jsonapi/campaign-participation-statistics-serializer.js';
+import { campaignProfileSerializer } from '../infrastructure/serializers/jsonapi/campaign-profile-serializer.js';
+import { participantResultSerializer } from '../infrastructure/serializers/jsonapi/participant-result-serializer.js';
+import { participationForCampaignManagementSerializer } from '../infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js';
 
 const getUserCampaignParticipationToCampaign = function (
   request,
@@ -132,7 +132,7 @@ const updateParticipantExternalId = async function (request, h) {
 const getCampaignParticipationsForOrganizationLearner = async function (
   request,
   h,
-  dependencies = { availableCampaignParticipationsSerializer },
+  dependencies = { availableCampaignParticipationsSerializer: availableCampaignParticipationSerializer },
 ) {
   const { campaignId, organizationLearnerId } = request.params;
   const availableCampaignParticipations = await usecases.getCampaignParticipationsForOrganizationLearner({

--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -1,8 +1,8 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as campaignParticipationSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
-import * as sharedProfileForCampaignSerializer from '../infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js';
+import { campaignParticipationSerializer } from '../infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
+import { sharedProfileForCampaignSerializer } from '../infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js';
 
 const save = async function (request, h, dependencies = { campaignParticipationSerializer }) {
   const userId = request.auth.credentials.userId;

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (anonymisedCampaignAssessment, meta) {
   }).serialize(anonymisedCampaignAssessment);
 };
 
-export { serialize };
+export const anonymisedCampaignAssessmentSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (availableCampaignParticipation, meta) {
   }).serialize(availableCampaignParticipation);
 };
 
-export { serialize };
+export const availableCampaignParticipationSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer.js
@@ -16,4 +16,4 @@ const serialize = function (campaignAssessmentParticipationResult) {
   }).serialize(campaignAssessmentParticipationResult);
 };
 
-export { serialize };
+export const campaignAssessmentParticipationResultSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js
@@ -55,4 +55,4 @@ const serialize = function (campaignAssessmentParticipation) {
   }).serialize(campaignAssessmentParticipation);
 };
 
-export { serialize };
+export const campaignAssessmentParticipationSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer.js
@@ -19,4 +19,4 @@ const serialize = function (campaignParticipation) {
   }).serialize(campaignParticipation);
 };
 
-export { serialize };
+export const campaignParticipationForUserManagementSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
@@ -22,4 +22,4 @@ const serialize = function (campaignParticipationOverviews) {
   }).serialize(campaignParticipationOverviews);
 };
 
-export { serialize };
+export const campaignParticipationOverviewSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -70,4 +70,4 @@ const deserialize = async function (json) {
   return campaignParticipation;
 };
 
-export { deserialize, serialize };
+export const campaignParticipationSerializer = { deserialize, serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-statistics-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-statistics-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (statistics) {
   }).serialize(statistics);
 };
 
-export { serialize };
+export const campaignParticipationStatisticsSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-profile-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-profile-serializer.js
@@ -30,4 +30,4 @@ const serialize = function (campaignProfile) {
   }).serialize(campaignProfile);
 };
 
-export { serialize };
+export const campaignProfileSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -63,11 +63,11 @@ const serialize = function (results) {
   }).serialize(results);
 };
 
-export { serialize };
-
 function transform(record) {
   return {
     ...record,
     campaignParticipationBadges: record.badgeResults,
   };
 }
+
+export const participantResultSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js
@@ -21,4 +21,4 @@ const serialize = function (participationsForCampaignManagement, meta) {
   }).serialize(participationsForCampaignManagement);
 };
 
-export { serialize };
+export const participationForCampaignManagementSerializer = { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js
@@ -34,4 +34,4 @@ const serialize = function (sharedProfileForCampaign = {}) {
   }).serialize(sharedProfileForCampaign);
 };
 
-export { serialize };
+export const sharedProfileForCampaignSerializer = { serialize };

--- a/api/src/prescription/campaign/application/campaign-administration-controller.js
+++ b/api/src/prescription/campaign/application/campaign-administration-controller.js
@@ -11,8 +11,8 @@ import { getDataBuffer } from '../../learner-management/infrastructure/utils/buf
 import { CAMPAIGNS_HEADER } from '../domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as csvCampaignsIdsParser from '../infrastructure/serializers/csv/csv-campaigns-ids-parser.js';
-import * as campaignManagementSerializer from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
-import * as campaignReportSerializer from '../infrastructure/serializers/jsonapi/campaign-report-serializer.js';
+import { campaignManagementSerializer } from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
+import { campaignReportSerializer } from '../infrastructure/serializers/jsonapi/campaign-report-serializer.js';
 
 const getTemplateForCreateCampaigns = (request, h) => {
   const fields = CAMPAIGNS_HEADER.columns.map(({ name }) => name);

--- a/api/src/prescription/campaign/application/campaign-controller.js
+++ b/api/src/prescription/campaign/application/campaign-controller.js
@@ -1,9 +1,9 @@
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as campaignResultLevelsPerTubesAndCompetencesSerializer from '../infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
-import * as divisionSerializer from '../infrastructure/serializers/jsonapi/division-serializer.js';
-import * as groupSerializer from '../infrastructure/serializers/jsonapi/group-serializer.js';
-import * as presentationStepsSerializer from '../infrastructure/serializers/jsonapi/presentation-steps-serializer.js';
+import { campaignResultLevelsPerTubesAndCompetencesSerializer } from '../infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
+import { divisionSerializer } from '../infrastructure/serializers/jsonapi/division-serializer.js';
+import { groupSerializer } from '../infrastructure/serializers/jsonapi/group-serializer.js';
+import { presentationStepsSerializer } from '../infrastructure/serializers/jsonapi/presentation-steps-serializer.js';
 
 const division = async function (request) {
   const { userId } = request.auth.credentials;

--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -2,11 +2,11 @@ import stream from 'node:stream';
 
 import { escapeFileName, getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as campaignDetailsManagementSerializer from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
-import * as campaignParticipantsActivitySerializer from '../infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js';
-import * as campaignReportSerializer from '../infrastructure/serializers/jsonapi/campaign-report-serializer.js';
-import * as campaignToJoinSerializer from '../infrastructure/serializers/jsonapi/campaign-to-join-serializer.js';
-import * as targetProfileSerializer from '../infrastructure/serializers/jsonapi/target-profile-serializer.js';
+import { campaignManagementSerializer } from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
+import { campaignParticipantActivitySerializer } from '../infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js';
+import { campaignReportSerializer } from '../infrastructure/serializers/jsonapi/campaign-report-serializer.js';
+import { campaignToJoinSerializer } from '../infrastructure/serializers/jsonapi/campaign-to-join-serializer.js';
+import { targetProfileSerializer } from '../infrastructure/serializers/jsonapi/target-profile-serializer.js';
 
 const { PassThrough } = stream;
 
@@ -40,7 +40,7 @@ const getById = async function (
 const getCampaignDetails = async function (request) {
   const { campaignId } = request.params;
   const campaign = await usecases.getCampaignManagement({ campaignId });
-  return campaignDetailsManagementSerializer.serialize(campaign);
+  return campaignManagementSerializer.serialize(campaign);
 };
 
 const getTargetProfile = async function (request, _, dependencies = { targetProfileSerializer }) {
@@ -119,7 +119,7 @@ const getCsvProfilesCollectionResults = async function (request, h) {
 const findParticipantsActivity = async function (
   request,
   h,
-  dependencies = { campaignParticipantsActivitySerializer },
+  dependencies = { campaignParticipantsActivitySerializer: campaignParticipantActivitySerializer },
 ) {
   const { campaignId } = request.params;
 

--- a/api/src/prescription/campaign/application/campaign-results-controller.js
+++ b/api/src/prescription/campaign/application/campaign-results-controller.js
@@ -1,9 +1,9 @@
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { certificabilityByLabel } from '../../shared/application/helpers.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as campaignAssessmentResultMinimalSerializer from '../infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js';
-import * as campaignCollectiveResultSerializer from '../infrastructure/serializers/jsonapi/campaign-collective-result-serializer.js';
-import * as campaignProfilesCollectionParticipationSummarySerializer from '../infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer.js';
+import { campaignAssessmentResultMinimalSerializer } from '../infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js';
+import { campaignCollectiveResultSerializer } from '../infrastructure/serializers/jsonapi/campaign-collective-result-serializer.js';
+import { campaignProfilesCollectionParticipationSummarySerializer } from '../infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer.js';
 
 const findAssessmentParticipationResults = async function (
   request,

--- a/api/src/prescription/campaign/application/campaign-stats-controller.js
+++ b/api/src/prescription/campaign/application/campaign-stats-controller.js
@@ -1,9 +1,9 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as badgeAcquisitionsStatisticsSerializer from '../infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js';
-import * as participationsByStageSerializer from '../infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js';
-import * as participationsByDaySerializer from '../infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer.js';
-import * as participationsByStatusSerializer from '../infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js';
-import * as participationsCountByMasteryRateSerializer from '../infrastructure/serializers/jsonapi/participations-count-by-mastery-rate.js';
+import { badgeAcquisitionsStatisticsSerializer } from '../infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js';
+import { campaignParticipationsCountByStageSerializer } from '../infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js';
+import { campaignParticipationsCountsByDaySerializer } from '../infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer.js';
+import { campaignParticipationsCountsByStatusSerializer } from '../infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js';
+import { participationsCountByMasteryRateSerializer } from '../infrastructure/serializers/jsonapi/participations-count-by-mastery-rate.js';
 
 const getParticipationsByStage = async function (request) {
   const { userId } = request.auth.credentials;
@@ -11,7 +11,7 @@ const getParticipationsByStage = async function (request) {
 
   const participationsByStage = await usecases.getCampaignParticipationsCountByStage({ userId, campaignId });
 
-  return participationsByStageSerializer.serialize({
+  return campaignParticipationsCountByStageSerializer.serialize({
     campaignId,
     data: participationsByStage,
   });
@@ -23,7 +23,7 @@ const getParticipationsByStatus = async function (request) {
 
   const participantsCounts = await usecases.getCampaignParticipationsCountsByStatus({ userId, campaignId });
 
-  return participationsByStatusSerializer.serialize({
+  return campaignParticipationsCountsByStatusSerializer.serialize({
     campaignId,
     ...participantsCounts,
   });
@@ -34,7 +34,7 @@ const getParticipationsByDay = async function (request) {
 
   const participantsCounts = await usecases.getCampaignParticipationsActivityByDay({ userId, campaignId });
 
-  return participationsByDaySerializer.serialize({
+  return campaignParticipationsCountsByDaySerializer.serialize({
     campaignId,
     ...participantsCounts,
   });

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js
@@ -15,4 +15,4 @@ const serialize = (model) =>
     },
   }).serialize(model);
 
-export { serialize };
+export const badgeAcquisitionsStatisticsSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js
@@ -27,4 +27,4 @@ const serialize = function ({ participations, pagination }) {
   }).serialize(participations);
 };
 
-export { serialize };
+export const campaignAssessmentResultMinimalSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-collective-result-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-collective-result-serializer.js
@@ -20,4 +20,4 @@ const serialize = function (results) {
   }).serialize(results);
 };
 
-export { serialize };
+export const campaignCollectiveResultSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-management-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-management-serializer.js
@@ -39,4 +39,4 @@ const serialize = function (campaignManagement, meta) {
   }).serialize(campaignManagement);
 };
 
-export { serialize };
+export const campaignManagementSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js
@@ -17,4 +17,4 @@ const serialize = function ({ campaignParticipantsActivities, pagination }) {
   }).serialize(campaignParticipantsActivities);
 };
 
-export { serialize };
+export const campaignParticipantActivitySerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js
@@ -12,4 +12,4 @@ const serialize = function (model) {
   }).serialize(model);
 };
 
-export { serialize };
+export const campaignParticipationsCountByStageSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer.js
@@ -15,4 +15,4 @@ const serialize = function (model) {
   }).serialize(model);
 };
 
-export { serialize };
+export const campaignParticipationsCountsByDaySerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (model) {
   }).serialize(model);
 };
 
-export { serialize };
+export const campaignParticipationsCountsByStatusSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer.js
@@ -20,4 +20,4 @@ const serialize = function ({ data, pagination }) {
   }).serialize(data);
 };
 
-export { serialize };
+export const campaignProfilesCollectionParticipationSummarySerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -105,4 +105,4 @@ const serialize = function (campaignReports, meta) {
   }).serialize(campaignReports);
 };
 
-export { serialize };
+export const campaignReportSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
@@ -46,4 +46,4 @@ const serialize = function (results, isCampaignParticipation = false) {
   }).serialize(results);
 };
 
-export { serialize };
+export const campaignResultLevelsPerTubesAndCompetencesSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
@@ -39,4 +39,4 @@ const serialize = function (campaignsToJoin) {
   }).serialize(campaignsToJoin);
 };
 
-export { serialize };
+export const campaignToJoinSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/division-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/division-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (divisions) {
   }).serialize(divisions);
 };
 
-export { serialize };
+export const divisionSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/group-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/group-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (groups) {
   }).serialize(groups);
 };
 
-export { serialize };
+export const groupSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate.js
@@ -9,4 +9,4 @@ const serialize = function (model) {
   }).serialize(model);
 };
 
-export { serialize };
+export const participationsCountByMasteryRateSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/presentation-steps-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/presentation-steps-serializer.js
@@ -16,4 +16,4 @@ const serialize = function (presentationSteps) {
   }).serialize(presentationSteps);
 };
 
-export { serialize };
+export const presentationStepsSerializer = { serialize };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (targetProfiles, meta) {
   }).serialize(targetProfiles);
 };
 
-export { serialize };
+export const targetProfileSerializer = { serialize };

--- a/api/src/prescription/learner-management/application/organization-import-controller.js
+++ b/api/src/prescription/learner-management/application/organization-import-controller.js
@@ -1,6 +1,6 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as organizationImportDetailSerializer from '../infrastructure/serializers/jsonapi/organization-import-detail-serializer.js';
-import * as organizationLearnerImportFormatSerializer from '../infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js';
+import { organizationImportDetailSerializer } from '../infrastructure/serializers/jsonapi/organization-import-detail-serializer.js';
+import { organizationLearnerImportFormatSerializer } from '../infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js';
 
 const getOrganizationImportStatus = async function (request, h, dependencies = { organizationImportDetailSerializer }) {
   const { organizationId } = request.params;

--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -1,7 +1,7 @@
 import { CLIENTS, PIX_ADMIN, PIX_ORGA } from '../../../shared/domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as organizationLearnerFilterSerializer from '../infrastructure/serializers/jsonapi/organization-learner-filter-serializer.js';
-import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
+import { organizationLearnerFilterSerializer } from '../infrastructure/serializers/jsonapi/organization-learner-filter-serializer.js';
+import { scoOrganizationLearnerSerializer } from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 
 const deleteOrganizationLearners = async function (request, h) {
   const authenticatedUserId = request.auth.credentials.userId;

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -5,7 +5,7 @@ import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js'
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { usecases } from '../domain/usecases/index.js';
 import { FregataParser } from '../infrastructure/serializers/csv/parsers/fregata-parser.js';
-import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
+import { scoOrganizationLearnerSerializer } from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 
 const INVALID_FILE_EXTENSION_ERROR = 'INVALID_FILE_EXTENSION';
 

--- a/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-detail-serializer.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-detail-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (organizationImportDetail, meta) {
   }).serialize(organizationImportDetail);
 };
 
-export { serialize };
+export const organizationImportDetailSerializer = { serialize };

--- a/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-filter-serializer.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-filter-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (filters) {
   }).serialize(filters);
 };
 
-export { serialize };
+export const organizationLearnerFilterSerializer = { serialize };

--- a/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (organizationLearnerImportFormat, meta) {
   }).serialize(organizationLearnerImportFormat);
 };
 
-export { serialize };
+export const organizationLearnerImportFormatSerializer = { serialize };

--- a/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js
@@ -39,4 +39,9 @@ const serializeCredentialsForDependent = function (scoOrganizationLearner) {
   }).serialize(scoOrganizationLearner);
 };
 
-export { serializeCredentialsForDependent, serializeExternal, serializeIdentity, serializeWithUsernameGeneration };
+export const scoOrganizationLearnerSerializer = {
+  serializeCredentialsForDependent,
+  serializeExternal,
+  serializeIdentity,
+  serializeWithUsernameGeneration,
+};

--- a/api/src/prescription/organization-learner/application/learner-activity-controller.js
+++ b/api/src/prescription/organization-learner/application/learner-activity-controller.js
@@ -1,6 +1,6 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as organizationLearnerActivitySerializer from '../infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js';
-import * as organizationLearnerSerializer from '../infrastructure/serializers/jsonapi/organization-learner-serializer.js';
+import { organizationLearnerActivitySerializer } from '../infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js';
+import { organizationLearnerSerializer } from '../infrastructure/serializers/jsonapi/organization-learner-serializer.js';
 
 const getLearner = async function (request, h, dependencies = { organizationLearnerSerializer }) {
   const organizationLearnerId = request.params.id;

--- a/api/src/prescription/organization-learner/application/learner-list-controller.js
+++ b/api/src/prescription/organization-learner/application/learner-list-controller.js
@@ -1,6 +1,6 @@
 import { divisionSerializer } from '../../campaign/infrastructure/serializers/jsonapi/division-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as organizationParticipantsSerializer from '../infrastructure/serializers/jsonapi/organization-participants-serializer.js';
+import { organizationParticipantsSerializer } from '../infrastructure/serializers/jsonapi/organization-participants-serializer.js';
 import { mapCertificabilityByLabel } from './../../shared/application/helpers.js';
 
 const findPaginatedFilteredParticipants = async function (

--- a/api/src/prescription/organization-learner/application/learner-list-controller.js
+++ b/api/src/prescription/organization-learner/application/learner-list-controller.js
@@ -1,4 +1,4 @@
-import * as divisionSerializer from '../../campaign/infrastructure/serializers/jsonapi/division-serializer.js';
+import { divisionSerializer } from '../../campaign/infrastructure/serializers/jsonapi/division-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as organizationParticipantsSerializer from '../infrastructure/serializers/jsonapi/organization-participants-serializer.js';
 import { mapCertificabilityByLabel } from './../../shared/application/helpers.js';

--- a/api/src/prescription/organization-learner/application/organization-learners-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-controller.js
@@ -1,7 +1,7 @@
 import { NoProfileRewardsFoundError } from '../../../profile/domain/errors.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as analysisByTubesSerializer from '../infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
-import * as attestationParticipantStatusSerializer from '../infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js';
+import { analysisByTubesSerializer } from '../infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
+import { attestationParticipantsStatusSerializer } from '../infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js';
 
 const getAttestationPdfFromFilters = async function (request, h) {
   const organizationId = request.params.organizationId;
@@ -33,7 +33,7 @@ const getAnalysisByTubes = async function (request, h, dependencies = { analysis
 const getAttestationParticipantsStatus = async function (
   request,
   h,
-  dependencies = { attestationParticipantStatusSerializer },
+  dependencies = { attestationParticipantStatusSerializer: attestationParticipantsStatusSerializer },
 ) {
   const { organizationId, attestationKey } = request.params;
   const { filter, page } = request.query;

--- a/api/src/prescription/organization-learner/application/organization-to-join-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-to-join-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as organizationsToJoinSerializer from '../infrastructure/serializers/jsonapi/organizations-to-join-serializer.js';
+import { organizationsToJoinSerializer } from '../infrastructure/serializers/jsonapi/organizations-to-join-serializer.js';
 
 const getOrganization = async function (request, h, dependencies = { organizationsToJoinSerializer }) {
   const { code } = request.params;

--- a/api/src/prescription/organization-learner/application/registration-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/registration-organization-learner-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as organizationLearnerIdentitySerializer from '../infrastructure/serializers/jsonapi/organization-learner-identity-serializer.js';
+import { organizationLearnerIdentitySerializer } from '../infrastructure/serializers/jsonapi/organization-learner-identity-serializer.js';
 
 const findAssociation = async function (request, h, dependencies = { organizationLearnerIdentitySerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;

--- a/api/src/prescription/organization-learner/application/sco-learner-list-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-learner-list-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as scoOrganizationParticipantsSerializer from '../infrastructure/serializers/jsonapi/sco-organization-participants-serializer.js';
+import { scoOrganizationParticipantsSerializer } from '../infrastructure/serializers/jsonapi/sco-organization-participants-serializer.js';
 import { mapCertificabilityByLabel } from './../../shared/application/helpers.js';
 
 const findPaginatedFilteredScoParticipants = async function (

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
@@ -4,7 +4,7 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
 import { getForwardedOrigin, RequestedApplication } from '../../../shared/infrastructure/utils/network.js';
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
-import * as scoOrganizationLearnerSerializer from '../../learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
+import { scoOrganizationLearnerSerializer } from '../../learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 
 const createUserAndReconcileToOrganizationLearnerFromExternalUser = async function (

--- a/api/src/prescription/organization-learner/application/sup-learner-list-controller.js
+++ b/api/src/prescription/organization-learner/application/sup-learner-list-controller.js
@@ -1,4 +1,4 @@
-import * as groupSerializer from '../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/group-serializer.js';
+import { groupSerializer } from '../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/group-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as supOrganizationParticipantsSerializer from '../infrastructure/serializers/jsonapi/sup-organization-participants-serializer.js';
 import { mapCertificabilityByLabel } from './../../shared/application/helpers.js';

--- a/api/src/prescription/organization-learner/application/sup-learner-list-controller.js
+++ b/api/src/prescription/organization-learner/application/sup-learner-list-controller.js
@@ -1,6 +1,6 @@
 import { groupSerializer } from '../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/group-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as supOrganizationParticipantsSerializer from '../infrastructure/serializers/jsonapi/sup-organization-participants-serializer.js';
+import { supOrganizationParticipantsSerializer } from '../infrastructure/serializers/jsonapi/sup-organization-participants-serializer.js';
 import { mapCertificabilityByLabel } from './../../shared/application/helpers.js';
 
 const findPaginatedFilteredSupParticipants = async function (

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js
@@ -20,4 +20,4 @@ const serialize = function (analysisByTubes) {
   }).serialize(analysisByTubes);
 };
 
-export { serialize };
+export const analysisByTubesSerializer = { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js
@@ -10,4 +10,4 @@ const serialize = function ({ attestationParticipantsStatus, pagination }) {
   }).serialize(attestationParticipantsStatus);
 };
 
-export { serialize };
+export const attestationParticipantsStatusSerializer = { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js
@@ -33,4 +33,4 @@ const serialize = function (organizationLearnerActivity) {
   }).serialize(organizationLearnerActivity);
 };
 
-export { serialize };
+export const organizationLearnerActivitySerializer = { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-identity-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-identity-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (organizationLearnerIdentity) {
   }).serialize(organizationLearnerIdentity);
 };
 
-export { serialize };
+export const organizationLearnerIdentitySerializer = { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-serializer.js
@@ -18,4 +18,4 @@ const serialize = function (organizationLearner) {
   }).serialize(organizationLearner);
 };
 
-export { serialize };
+export const organizationLearnerSerializer = { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-participants-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-participants-serializer.js
@@ -21,4 +21,4 @@ const serialize = function ({ organizationParticipants, meta }) {
   }).serialize(organizationParticipants);
 };
 
-export { serialize };
+export const organizationParticipantsSerializer = { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organizations-to-join-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organizations-to-join-serializer.js
@@ -25,4 +25,4 @@ const serialize = function (organizations) {
   }).serialize(organizations);
 };
 
-export { serialize };
+export const organizationsToJoinSerializer = { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/sco-organization-participants-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/sco-organization-participants-serializer.js
@@ -28,4 +28,4 @@ const serialize = function ({ scoOrganizationParticipants, meta }) {
   }).serialize(scoOrganizationParticipants);
 };
 
-export { serialize };
+export const scoOrganizationParticipantsSerializer = { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/sup-organization-participants-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/sup-organization-participants-serializer.js
@@ -23,4 +23,4 @@ const serialize = function ({ supOrganizationParticipants, meta }) {
   }).serialize(supOrganizationParticipants);
 };
 
-export { serialize };
+export const supOrganizationParticipantsSerializer = { serialize };

--- a/api/src/prescription/organization-place/application/organization-place-controller.js
+++ b/api/src/prescription/organization-place/application/organization-place-controller.js
@@ -1,8 +1,8 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as dataOrganizationPlacesStatisticsSerializer from '../infrastructure/serializers/json/data-organization-places-statistics-serializer.js';
-import * as organizationPlacesLotManagementSerializer from '../infrastructure/serializers/jsonapi/organization-places-lot-management-serializer.js';
-import * as organizationPlacesLotsSerializer from '../infrastructure/serializers/jsonapi/organization-places-lots-serializer.js';
-import * as organizationPlacesStatisticsSerializer from '../infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js';
+import { organizationPlacesLotManagementSerializer } from '../infrastructure/serializers/jsonapi/organization-places-lot-management-serializer.js';
+import { organizationPlacesLotsSerializer } from '../infrastructure/serializers/jsonapi/organization-places-lots-serializer.js';
+import { organizationPlacesStatisticsSerializer } from '../infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js';
 
 const createOrganizationPlacesLot = async function (
   request,

--- a/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-lot-management-serializer.js
+++ b/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-lot-management-serializer.js
@@ -20,4 +20,4 @@ const deserialize = function (json) {
   };
 };
 
-export { deserialize, serialize };
+export const organizationPlacesLotManagementSerializer = { deserialize, serialize };

--- a/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-lots-serializer.js
+++ b/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-lots-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (places) {
   }).serialize(places);
 };
 
-export { serialize };
+export const organizationPlacesLotsSerializer = { serialize };

--- a/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js
+++ b/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (places) {
   }).serialize(places);
 };
 
-export { serialize };
+export const organizationPlacesStatisticsSerializer = { serialize };

--- a/api/src/prescription/target-profile/application/admin-target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-controller.js
@@ -6,11 +6,11 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { escapeFileName } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { stageUsecases } from '../../stages/domain/usecases/index.js';
 import { usecases as prescriptionTargetProfileUsecases } from '../domain/usecases/index.js';
-import * as targetProfileAttachOrganizationSerializer from '../infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js';
-import * as targetProfileDetachOrganizationsSerializer from '../infrastructure/serializers/jsonapi/target-profile-detach-organizations-serializer.js';
-import * as targetProfileForAdminSerializer from '../infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js';
-import * as targetProfileSerializer from '../infrastructure/serializers/jsonapi/target-profile-serializer.js';
-import * as targetProfileSummaryForAdminSerializer from '../infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js';
+import { targetProfileAttachOrganizationSerializer } from '../infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js';
+import { targetProfileDetachOrganizationsSerializer } from '../infrastructure/serializers/jsonapi/target-profile-detach-organizations-serializer.js';
+import { targetProfileForAdminSerializer } from '../infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js';
+import { targetProfileSerializer } from '../infrastructure/serializers/jsonapi/target-profile-serializer.js';
+import { targetProfileSummaryForAdminSerializer } from '../infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js';
 import * as learningContentPDFPresenter from './presenter/pdf/learning-content-pdf-presenter.js';
 
 const getTargetProfileForAdmin = async function (request, h, dependencies = { targetProfileForAdminSerializer }) {

--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -1,8 +1,8 @@
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as frameworkWithSkillsSerializer from '../infrastructure/serializers/jsonapi/framework-with-skills-serializer.js';
-import * as targetProfileForSpecifierSerializer from '../infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js';
-import * as targetProfileOverviewSerializer from '../infrastructure/serializers/jsonapi/target-profile-overview-serializer.js';
+import { frameworkWithSkillsSerializer } from '../infrastructure/serializers/jsonapi/framework-with-skills-serializer.js';
+import { targetProfileForSpecifierSerializer } from '../infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js';
+import { targetProfileOverviewSerializer } from '../infrastructure/serializers/jsonapi/target-profile-overview-serializer.js';
 
 const findTargetProfiles = async function (request, h, dependencies = { targetProfileForSpecifierSerializer }) {
   const organizationId = request.params.organizationId;

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/framework-with-skills-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/framework-with-skills-serializer.js
@@ -43,4 +43,4 @@ const serialize = function (frameworks) {
   }).serialize(frameworks);
 };
 
-export { serialize };
+export const frameworkWithSkillsSerializer = { serialize };

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (model) {
   }).serialize(model);
 };
 
-export { serialize };
+export const targetProfileAttachOrganizationSerializer = { serialize };

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-detach-organizations-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-detach-organizations-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (model) {
   }).serialize(model);
 };
 
-export { serialize };
+export const targetProfileDetachOrganizationsSerializer = { serialize };

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -108,4 +108,4 @@ const serialize = function ({ targetProfile, filter }) {
   }).serialize(targetProfile);
 };
 
-export { serialize };
+export const targetProfileForAdminSerializer = { serialize };

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js
@@ -18,4 +18,4 @@ const serialize = function (targetProfiles, meta) {
   }).serialize(targetProfiles);
 };
 
-export { serialize };
+export const targetProfileForSpecifierSerializer = { serialize };

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-overview-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-overview-serializer.js
@@ -50,4 +50,4 @@ const serialize = function (targetProfiles) {
   }).serialize(targetProfiles);
 };
 
-export { serialize };
+export const targetProfileOverviewSerializer = { serialize };

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -31,4 +31,4 @@ const deserialize = function (json) {
   return deserializedData;
 };
 
-export { deserialize, serialize, serializeId };
+export const targetProfileSerializer = { deserialize, serialize, serializeId };

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (targetProfileSummaries, meta) {
   }).serialize(targetProfileSummaries);
 };
 
-export { serialize };
+export const targetProfileSummaryForAdminSerializer = { serialize };

--- a/api/src/profile/application/attestation-controller.js
+++ b/api/src/profile/application/attestation-controller.js
@@ -1,7 +1,7 @@
 import { FRENCH_FRANCE } from '../../shared/domain/services/locale-service.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as attestationSerializer from '../infrastructure/serializers/jsonapi/attestation-detail-serializer.js';
-import * as attestationAdminSerializer from '../infrastructure/serializers/jsonapi/attestation-serializer.js';
+import { attestationDetailSerializer } from '../infrastructure/serializers/jsonapi/attestation-detail-serializer.js';
+import { attestationSerializer } from '../infrastructure/serializers/jsonapi/attestation-serializer.js';
 import * as pdfWithFormSerializer from '../infrastructure/serializers/pdf/pdf-with-form-serializer.js';
 
 const getUserAttestation = async function (request, h, dependencies = { pdfWithFormSerializer }) {
@@ -20,7 +20,11 @@ const getUserAttestation = async function (request, h, dependencies = { pdfWithF
   return h.response(buffer).header('Content-Type', 'application/pdf');
 };
 
-const getUserAttestationsDetails = async function (request, _, dependencies = { attestationSerializer }) {
+const getUserAttestationsDetails = async function (
+  request,
+  _,
+  dependencies = { attestationSerializer: attestationDetailSerializer },
+) {
   const userId = request.auth.credentials.userId;
 
   const profileRewards = await usecases.getProfileRewardsByUserId({ userId });
@@ -28,7 +32,7 @@ const getUserAttestationsDetails = async function (request, _, dependencies = { 
   return usecases.getAttestationDetails({ profileRewards }).then(dependencies.attestationSerializer.serialize);
 };
 
-const getAll = async function (request, _, dependencies = { attestationAdminSerializer }) {
+const getAll = async function (request, _, dependencies = { attestationAdminSerializer: attestationSerializer }) {
   const attestations = await usecases.getAllAttestations();
   return dependencies.attestationAdminSerializer.serialize(attestations);
 };

--- a/api/src/profile/application/profile-controller.js
+++ b/api/src/profile/application/profile-controller.js
@@ -1,6 +1,6 @@
 import { getChallengeLocale } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as profileSerializer from '../infrastructure/serializers/jsonapi/profile-serializer.js';
+import { profileSerializer } from '../infrastructure/serializers/jsonapi/profile-serializer.js';
 
 const getProfile = function (request, h, dependencies = { profileSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;

--- a/api/src/profile/infrastructure/serializers/jsonapi/attestation-detail-serializer.js
+++ b/api/src/profile/infrastructure/serializers/jsonapi/attestation-detail-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (attestationDetail) {
   }).serialize(attestationDetail);
 };
 
-export { serialize };
+export const attestationDetailSerializer = { serialize };

--- a/api/src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js
+++ b/api/src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (attestations) {
   }).serialize(attestations);
 };
 
-export { serialize };
+export const attestationSerializer = { serialize };

--- a/api/src/profile/infrastructure/serializers/jsonapi/profile-serializer.js
+++ b/api/src/profile/infrastructure/serializers/jsonapi/profile-serializer.js
@@ -53,4 +53,4 @@ const serialize = function (profile = {}) {
   }).serialize(profile);
 };
 
-export { serialize };
+export const profileSerializer = { serialize };

--- a/api/src/quest/application/attestation-controller.js
+++ b/api/src/quest/application/attestation-controller.js
@@ -1,6 +1,6 @@
 import { Readable } from 'node:stream';
 
-import * as attestationSerializer from '../../profile/infrastructure/serializers/jsonapi/attestation-serializer.js';
+import { attestationSerializer } from '../../profile/infrastructure/serializers/jsonapi/attestation-serializer.js';
 import { BadRequestError } from '../../shared/application/errors/http-errors.js';
 import { usecases } from '../domain/usecases/index.js';
 

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -1,10 +1,10 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as adminCombinedCourseBlueprintDetailsSerializer from '../infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js';
-import * as combinedCourseBlueprintForCreationSerializer from '../infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js';
-import * as combinedCourseBlueprintForUpdateSerializer from '../infrastructure/serializers/combined-course-blueprint-for-update-serializer.js';
-import * as combinedCourseBlueprintOrganizationSerializer from '../infrastructure/serializers/combined-course-blueprint-organization-serializer.js';
-import * as combinedCourseBlueprintOverviewSerializer from '../infrastructure/serializers/combined-course-blueprint-overview-serializer.js';
-import * as combinedCourseBlueprintSerializer from '../infrastructure/serializers/combined-course-blueprint-serializer.js';
+import { adminCombinedCourseBlueprintDetailsSerializer } from '../infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js';
+import { combinedCourseBlueprintForCreationSerializer } from '../infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js';
+import { combinedCourseBlueprintForUpdateSerializer } from '../infrastructure/serializers/combined-course-blueprint-for-update-serializer.js';
+import { combinedCourseBlueprintOrganizationSerializer } from '../infrastructure/serializers/combined-course-blueprint-organization-serializer.js';
+import { combinedCourseBlueprintOverviewSerializer } from '../infrastructure/serializers/combined-course-blueprint-overview-serializer.js';
+import { combinedCourseBlueprintSerializer } from '../infrastructure/serializers/combined-course-blueprint-serializer.js';
 
 const findAll = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
   const combinedCourseBlueprints = await usecases.findCombinedCourseBlueprints();

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -3,15 +3,15 @@ import { createReadStream } from 'node:fs';
 import { getDataBuffer } from '../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
 import { getChallengeLocale } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as campaignTypeCombinedCourseSerializer from '../infrastructure/serializers/campaign-type-combined-course-serializer.js';
-import * as combinedCourseDetailsSerializer from '../infrastructure/serializers/combined-course-details-serializer.js';
-import * as combinedCourseForCreationSerializer from '../infrastructure/serializers/combined-course-for-creation-serializer.js';
-import * as combinedCourseListSerializer from '../infrastructure/serializers/combined-course-list-serializer.js';
-import * as combinedCourseParticipationDetailSerializer from '../infrastructure/serializers/combined-course-participation-detail-serializer.js';
-import * as combinedCourseParticipationSerializer from '../infrastructure/serializers/combined-course-participation-serializer.js';
-import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
-import * as combinedCourseStatisticsSerializer from '../infrastructure/serializers/combined-course-statistics-serializer.js';
-import * as courseSerializer from '../infrastructure/serializers/course-serializer.js';
+import { campaignTypeCombinedCourseSerializer } from '../infrastructure/serializers/campaign-type-combined-course-serializer.js';
+import { combinedCourseDetailsSerializer } from '../infrastructure/serializers/combined-course-details-serializer.js';
+import { combinedCourseForCreationSerializer } from '../infrastructure/serializers/combined-course-for-creation-serializer.js';
+import { combinedCourseListSerializer } from '../infrastructure/serializers/combined-course-list-serializer.js';
+import { combinedCourseParticipationDetailSerializer } from '../infrastructure/serializers/combined-course-participation-detail-serializer.js';
+import { combinedCourseParticipationSerializer } from '../infrastructure/serializers/combined-course-participation-serializer.js';
+import { combinedCourseSerializer } from '../infrastructure/serializers/combined-course-serializer.js';
+import { combinedCourseStatisticsSerializer } from '../infrastructure/serializers/combined-course-statistics-serializer.js';
+import { courseSerializer } from '../infrastructure/serializers/course-serializer.js';
 
 const getByCode = async function (request, _, dependencies = { combinedCourseSerializer }) {
   const { code } = request.query.filter;

--- a/api/src/quest/application/pre-handlers/display-catalogue.js
+++ b/api/src/quest/application/pre-handlers/display-catalogue.js
@@ -1,6 +1,6 @@
 import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
-import * as errorSerializer from '../../../shared/infrastructure/serializers/jsonapi/error-serializer.js';
+import { errorSerializer } from '../../../shared/infrastructure/serializers/jsonapi/error-serializer.js';
 
 export async function checkDisplayCatalogueIsEnabled(request, h) {
   const isEnabled = await featureToggles.get('displayCatalogue');

--- a/api/src/quest/application/quest-controller.js
+++ b/api/src/quest/application/quest-controller.js
@@ -2,7 +2,7 @@ import { generateCSVTemplate } from '../../shared/infrastructure/serializers/csv
 import { extractUserIdFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { QUEST_HEADER } from '../domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as questResultSerializer from '../infrastructure/serializers/quest-result-serializer.js';
+import { questResultSerializer } from '../infrastructure/serializers/quest-result-serializer.js';
 
 const getQuestResults = async function (request, h, dependencies = { questResultSerializer }) {
   const { campaignParticipationId } = request.params;

--- a/api/src/quest/application/verified-code-controller.js
+++ b/api/src/quest/application/verified-code-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as verifiedCodeSerializer from '../infrastructure/serializers/verified-code-serializer.js';
+import { verifiedCodeSerializer } from '../infrastructure/serializers/verified-code-serializer.js';
 
 const get = async function (request, h, dependencies = { verifiedCodeSerializer }) {
   const { code } = request.params;

--- a/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js
@@ -18,4 +18,4 @@ const serialize = function (adminCombinedCourseBlueprintDetails) {
   }).serialize(adminCombinedCourseBlueprintDetails);
 };
 
-export { serialize };
+export const adminCombinedCourseBlueprintDetailsSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/campaign-type-combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/campaign-type-combined-course-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (campaign) {
   }).serialize(campaign);
 };
 
-export { serialize };
+export const campaignTypeCombinedCourseSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js
@@ -28,4 +28,4 @@ const deserialize = async function (payload) {
   });
 };
 
-export { deserialize, serialize };
+export const combinedCourseBlueprintForCreationSerializer = { deserialize, serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-for-update-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-for-update-serializer.js
@@ -11,4 +11,4 @@ const deserialize = async function (payload) {
   return new CombinedCourseBlueprintForUpdate(deserializedData);
 };
 
-export { deserialize };
+export const combinedCourseBlueprintForUpdateSerializer = { deserialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-organization-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-organization-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (model) {
   }).serialize(model);
 };
 
-export { serialize };
+export const combinedCourseBlueprintOrganizationSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js
@@ -17,4 +17,4 @@ const serialize = function (combinedCourseBlueprint) {
   }).serialize(combinedCourseBlueprint);
 };
 
-export { serialize };
+export const combinedCourseBlueprintOverviewSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (combinedCourseBlueprint) {
   }).serialize(combinedCourseBlueprint);
 };
 
-export { serialize };
+export const combinedCourseBlueprintSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
@@ -36,4 +36,4 @@ const serialize = function (combinedCourse) {
   }).serialize(combinedCourse);
 };
 
-export { serialize };
+export const combinedCourseDetailsSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-for-creation-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-for-creation-serializer.js
@@ -8,4 +8,4 @@ const deserialize = function (payload) {
   return new CombinedCourseForCreation({ organizationId, name, blueprintId });
 };
 
-export { deserialize };
+export const combinedCourseForCreationSerializer = { deserialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-list-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-list-serializer.js
@@ -9,4 +9,4 @@ const serialize = function (combinedCourse, meta) {
   }).serialize(combinedCourse);
 };
 
-export { serialize };
+export const combinedCourseListSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-participation-detail-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-participation-detail-serializer.js
@@ -32,4 +32,4 @@ const serialize = function (combinedCourseParticipation) {
   }).serialize(combinedCourseParticipation);
 };
 
-export { serialize };
+export const combinedCourseParticipationDetailSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-participation-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-participation-serializer.js
@@ -22,4 +22,4 @@ const serialize = function (combinedCourseParticipations, meta) {
   }).serialize(combinedCourseParticipations);
 };
 
-export { serialize };
+export const combinedCourseParticipationSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -47,4 +47,4 @@ const serialize = function (combinedCourse) {
   }).serialize(combinedCourse);
 };
 
-export { serialize };
+export const combinedCourseSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-statistics-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-statistics-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (combinedCourseStatistics) {
   }).serialize(combinedCourseStatistics);
 };
 
-export { serialize };
+export const combinedCourseStatisticsSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/course-serializer.js
@@ -16,4 +16,4 @@ const serialize = function (courseItems) {
   }).serialize(courseItems);
 };
 
-export { serialize };
+export const courseSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/quest-result-serializer.js
+++ b/api/src/quest/infrastructure/serializers/quest-result-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (questResult) {
   }).serialize(questResult);
 };
 
-export { serialize };
+export const questResultSerializer = { serialize };

--- a/api/src/quest/infrastructure/serializers/verified-code-serializer.js
+++ b/api/src/quest/infrastructure/serializers/verified-code-serializer.js
@@ -28,4 +28,4 @@ const serialize = function (verifiedCode) {
   }).serialize(verifiedCode);
 };
 
-export { serialize };
+export const verifiedCodeSerializer = { serialize };

--- a/api/src/school/application/activity-answer-controller.js
+++ b/api/src/school/application/activity-answer-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../school/domain/usecases/index.js';
-import * as activityAnswerSerializer from '../infrastructure/serializers/activity-answer-serializer.js';
+import { activityAnswerSerializer } from '../infrastructure/serializers/activity-answer-serializer.js';
 
 const save = async function (request, h, dependencies = { activityAnswerSerializer }) {
   const { activityAnswer, assessmentId, isPreview } = dependencies.activityAnswerSerializer.deserialize(

--- a/api/src/school/application/assessment-controller.js
+++ b/api/src/school/application/assessment-controller.js
@@ -1,7 +1,7 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as activitySerializer from '../infrastructure/serializers/activity-serializer.js';
-import * as assessmentSerializer from '../infrastructure/serializers/assessment-serializer.js';
-import * as challengeSerializer from '../infrastructure/serializers/challenge-serializer.js';
+import { activitySerializer } from '../infrastructure/serializers/activity-serializer.js';
+import { assessmentSerializer } from '../infrastructure/serializers/assessment-serializer.js';
+import { challengeSerializer } from '../infrastructure/serializers/challenge-serializer.js';
 
 const getNextChallengeForPix1d = async function (request, h, dependencies = { challengeSerializer }) {
   const assessmentId = request.params.id;

--- a/api/src/school/application/challenge-controller.js
+++ b/api/src/school/application/challenge-controller.js
@@ -1,5 +1,5 @@
 import * as challengeToPlayApi from '../../evaluation/application/api/challenge-to-play-api.js';
-import * as challengeSerializer from '../infrastructure/serializers/challenge-serializer.js';
+import { challengeSerializer } from '../infrastructure/serializers/challenge-serializer.js';
 
 async function get(request, h, dependencies = { challengeToPlayApi, challengeSerializer }) {
   const challengeToPlay = await challengeToPlayApi.get(request.params.id);

--- a/api/src/school/application/mission-controller.js
+++ b/api/src/school/application/mission-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as missionSerializer from '../infrastructure/serializers/mission-serializer.js';
+import { missionSerializer } from '../infrastructure/serializers/mission-serializer.js';
 
 const getById = async function (request, h, dependencies = { missionSerializer }) {
   const { id: organizationId, missionId } = request.params;

--- a/api/src/school/application/mission-learner-controller.js
+++ b/api/src/school/application/mission-learner-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as missionLearnerSerializer from '../infrastructure/serializers/mission-learner-serializer.js';
+import { missionLearnerSerializer } from '../infrastructure/serializers/mission-learner-serializer.js';
 
 const findPaginatedMissionLearners = async function (request) {
   const { organizationId, missionId } = request.params;

--- a/api/src/school/application/organization-learner-controller.js
+++ b/api/src/school/application/organization-learner-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as organizationLearnerSerializer from '../infrastructure/serializers/organization-learner.js';
+import { organizationLearnerSerializer } from '../infrastructure/serializers/organization-learner.js';
 
 const getById = async function (request) {
   const organizationLearnerId = request.params.id;

--- a/api/src/school/application/school-controller.js
+++ b/api/src/school/application/school-controller.js
@@ -1,6 +1,6 @@
 import { divisionSerializer } from '../../prescription/campaign/infrastructure/serializers/jsonapi/division-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as schoolSerializer from '../infrastructure/serializers/school-serializer.js';
+import { schoolSerializer } from '../infrastructure/serializers/school-serializer.js';
 
 const getSchool = async function (request) {
   const { code } = request.query;

--- a/api/src/school/application/school-controller.js
+++ b/api/src/school/application/school-controller.js
@@ -1,4 +1,4 @@
-import * as divisionSerializer from '../../prescription/campaign/infrastructure/serializers/jsonapi/division-serializer.js';
+import { divisionSerializer } from '../../prescription/campaign/infrastructure/serializers/jsonapi/division-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as schoolSerializer from '../infrastructure/serializers/school-serializer.js';
 

--- a/api/src/school/infrastructure/serializers/activity-answer-serializer.js
+++ b/api/src/school/infrastructure/serializers/activity-answer-serializer.js
@@ -34,8 +34,8 @@ const deserialize = function (payload) {
   };
 };
 
-export { deserialize, serialize };
-
 function _cleanValue(value) {
   return value?.replaceAll('\u0000', '');
 }
+
+export const activityAnswerSerializer = { deserialize, serialize };

--- a/api/src/school/infrastructure/serializers/activity-serializer.js
+++ b/api/src/school/infrastructure/serializers/activity-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (activity) {
   }).serialize(activity);
 };
 
-export { serialize };
+export const activitySerializer = { serialize };

--- a/api/src/school/infrastructure/serializers/assessment-serializer.js
+++ b/api/src/school/infrastructure/serializers/assessment-serializer.js
@@ -6,4 +6,4 @@ const serialize = function (assessment) {
   }).serialize(assessment);
 };
 
-export { serialize };
+export const assessmentSerializer = { serialize };

--- a/api/src/school/infrastructure/serializers/challenge-serializer.js
+++ b/api/src/school/infrastructure/serializers/challenge-serializer.js
@@ -44,4 +44,4 @@ const serialize = function (challenges) {
   }).serialize(challenges);
 };
 
-export { serialize };
+export const challengeSerializer = { serialize };

--- a/api/src/school/infrastructure/serializers/mission-learner-serializer.js
+++ b/api/src/school/infrastructure/serializers/mission-learner-serializer.js
@@ -7,4 +7,4 @@ const serialize = function ({ missionLearners, pagination }) {
   }).serialize(missionLearners);
 };
 
-export { serialize };
+export const missionLearnerSerializer = { serialize };

--- a/api/src/school/infrastructure/serializers/mission-serializer.js
+++ b/api/src/school/infrastructure/serializers/mission-serializer.js
@@ -18,4 +18,5 @@ const serialize = function (missions) {
     ],
   }).serialize(missions);
 };
-export { serialize };
+
+export const missionSerializer = { serialize };

--- a/api/src/school/infrastructure/serializers/organization-learner.js
+++ b/api/src/school/infrastructure/serializers/organization-learner.js
@@ -21,4 +21,4 @@ const serialize = function (organizationLearner) {
   }).serialize(organizationLearner);
 };
 
-export { serialize };
+export const organizationLearnerSerializer = { serialize };

--- a/api/src/school/infrastructure/serializers/school-serializer.js
+++ b/api/src/school/infrastructure/serializers/school-serializer.js
@@ -6,4 +6,4 @@ const serialize = function (school) {
   }).serialize(school);
 };
 
-export { serialize };
+export const schoolSerializer = { serialize };

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -1,6 +1,6 @@
 import { AssessmentDtoFactory } from '../../domain/models/AssessmentDtoFactory.js';
 import { sharedUsecases } from '../../domain/usecases/index.js';
-import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
+import { assessmentSerializer } from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
 import { extractUserIdFromRequest, getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
 
 const getAssessmentWithNextChallenge = async function (

--- a/api/src/shared/application/country/country-controller.js
+++ b/api/src/shared/application/country/country-controller.js
@@ -1,5 +1,5 @@
 import { sharedUsecases } from '../../domain/usecases/index.js';
-import * as countrySerializer from '../../infrastructure/serializers/jsonapi/country-serializer.js';
+import { countrySerializer } from '../../infrastructure/serializers/jsonapi/country-serializer.js';
 
 const findCountries = async function (_request, _h, dependencies = { countrySerializer }) {
   const countries = await sharedUsecases.findCountries();

--- a/api/src/shared/application/errors/http-errors.js
+++ b/api/src/shared/application/errors/http-errors.js
@@ -1,4 +1,4 @@
-import * as errorSerializer from '../../infrastructure/serializers/jsonapi/error-serializer.js';
+import { errorSerializer } from '../../infrastructure/serializers/jsonapi/error-serializer.js';
 
 class BaseHttpError extends Error {
   constructor(message) {

--- a/api/src/shared/application/feature-toggles/feature-toggle-controller.js
+++ b/api/src/shared/application/feature-toggles/feature-toggle-controller.js
@@ -1,10 +1,10 @@
 import { featureToggles } from '../../infrastructure/feature-toggles/index.js';
-import * as serializer from '../../infrastructure/serializers/jsonapi/feature-toggle-serializer.js';
+import { featureToggleSerializer } from '../../infrastructure/serializers/jsonapi/feature-toggle-serializer.js';
 
 const getActiveFeatures = async function () {
   const featureTogglesList = await featureToggles.withTag('frontend');
 
-  return serializer.serialize(featureTogglesList);
+  return featureToggleSerializer.serialize(featureTogglesList);
 };
 
 const featureToggleController = { getActiveFeatures };

--- a/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -126,8 +126,6 @@ const deserialize = function (json) {
   });
 };
 
-export { deserialize, serialize };
-
 function _includeCourse(assessments) {
   if (Array.isArray(assessments)) {
     return assessments.length && assessments[0].course;
@@ -135,3 +133,5 @@ function _includeCourse(assessments) {
 
   return assessments.course ? true : false;
 }
+
+export const assessmentSerializer = { deserialize, serialize };

--- a/api/src/shared/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -39,4 +39,4 @@ const serialize = function (challenges) {
   return new Serializer('challenge', config).serialize(challenges);
 };
 
-export { config, serialize };
+export const challengeSerializer = { config, serialize };

--- a/api/src/shared/infrastructure/serializers/jsonapi/country-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/country-serializer.js
@@ -11,4 +11,4 @@ const serialize = function (country) {
   }).serialize(country);
 };
 
-export { serialize };
+export const countrySerializer = { serialize };

--- a/api/src/shared/infrastructure/serializers/jsonapi/course-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/course-serializer.js
@@ -8,4 +8,4 @@ const serialize = function (courses) {
   }).serialize(courses);
 };
 
-export { serialize };
+export const courseSerializer = { serialize };

--- a/api/src/shared/infrastructure/serializers/jsonapi/error-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/error-serializer.js
@@ -37,4 +37,4 @@ const serialize = function (infrastructureError) {
   );
 };
 
-export { serialize };
+export const errorSerializer = { serialize };

--- a/api/src/shared/infrastructure/serializers/jsonapi/feature-toggle-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/feature-toggle-serializer.js
@@ -11,4 +11,4 @@ const serialize = function (features) {
   }).serialize(features);
 };
 
-export { serialize };
+export const featureToggleSerializer = { serialize };

--- a/api/src/shared/infrastructure/serializers/jsonapi/membership.serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/membership.serializer.js
@@ -176,4 +176,4 @@ const deserialize = function (json) {
   });
 };
 
-export { deserialize, serialize, serializeForAdmin };
+export const membershipSerializer = { deserialize, serialize, serializeForAdmin };

--- a/api/src/shared/infrastructure/serializers/jsonapi/validation-error-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/validation-error-serializer.js
@@ -37,4 +37,4 @@ function serialize(validationErrors) {
   };
 }
 
-export { serialize };
+export const validationErrorSerializer = { serialize };

--- a/api/src/team/application/certification-center-membership/certification-center-membership.admin.controller.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.admin.controller.js
@@ -1,6 +1,6 @@
 import { BadRequestError } from '../../../shared/application/errors/http-errors.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
-import * as certificationCenterMembershipSerializer from '../../../team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
+import { certificationCenterMembershipSerializer } from '../../../team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const findCertificationCenterMembershipsByCertificationCenter = async function (

--- a/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
@@ -1,6 +1,6 @@
 import { ForbiddenError } from '../../../shared/application/errors/http-errors.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
-import * as certificationCenterMembershipSerializer from '../../../team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
+import { certificationCenterMembershipSerializer } from '../../../team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { certificationCenterMembershipRepository } from '../../infrastructure/repositories/certification-center-membership.repository.js';
 

--- a/api/src/team/application/membership/membership.admin.controller.js
+++ b/api/src/team/application/membership/membership.admin.controller.js
@@ -1,6 +1,6 @@
 import { membershipSerializer } from '../../../shared/infrastructure/serializers/jsonapi/membership.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
-import * as userOrganizationForAdminSerializer from '../../infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js';
+import { userOrganizationForAdminSerializer } from '../../infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js';
 
 const findPaginatedFilteredMembershipsForAdmin = async function (request) {
   const organizationId = request.params.id;

--- a/api/src/team/application/membership/membership.admin.controller.js
+++ b/api/src/team/application/membership/membership.admin.controller.js
@@ -1,4 +1,4 @@
-import * as membershipSerializer from '../../../shared/infrastructure/serializers/jsonapi/membership.serializer.js';
+import { membershipSerializer } from '../../../shared/infrastructure/serializers/jsonapi/membership.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as userOrganizationForAdminSerializer from '../../infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js';
 

--- a/api/src/team/application/membership/membership.controller.js
+++ b/api/src/team/application/membership/membership.controller.js
@@ -1,5 +1,5 @@
 import { BadRequestError } from '../../../shared/application/errors/http-errors.js';
-import * as membershipSerializer from '../../../shared/infrastructure/serializers/jsonapi/membership.serializer.js';
+import { membershipSerializer } from '../../../shared/infrastructure/serializers/jsonapi/membership.serializer.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 

--- a/api/src/team/application/membership/organization-member-identities.controller.js
+++ b/api/src/team/application/membership/organization-member-identities.controller.js
@@ -1,4 +1,4 @@
-import * as organizationMemberIdentitySerializer from '../../../team/infrastructure/serializers/jsonapi/organization-member-identity.serializer.js';
+import { organizationMemberIdentitySerializer } from '../../../team/infrastructure/serializers/jsonapi/organization-member-identity.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 export const getOrganizationMemberIdentities = async function (

--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -4,7 +4,7 @@ import { MissingQueryParamError } from '../../../shared/application/errors/http-
 import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { organizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/organization-invitation.serializer.js';
-import { serializer as scoOrganizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
+import { scoOrganizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
 
 const acceptOrganizationInvitation = async function (request) {
   const organizationInvitationId = request.params.id;

--- a/api/src/team/application/user-orga-settings.controller.js
+++ b/api/src/team/application/user-orga-settings.controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import * as userOrgaSettingsSerializer from '../infrastructure/serializers/jsonapi/user-orga-settings.serializer.js';
+import { userOrgaSettingsSerializer } from '../infrastructure/serializers/jsonapi/user-orga-settings.serializer.js';
 
 const createOrUpdate = async function (request, h, dependencies = { userOrgaSettingsSerializer }) {
   const userId = request.params.id;

--- a/api/src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
@@ -24,6 +24,4 @@ const deserializeForAdmin = function (payload) {
   });
 };
 
-const certificationCenterInvitationSerializer = { serialize, serializeForAdmin, deserializeForAdmin };
-
-export { certificationCenterInvitationSerializer, deserializeForAdmin, serialize, serializeForAdmin };
+export const certificationCenterInvitationSerializer = { deserializeForAdmin, serialize, serializeForAdmin };

--- a/api/src/team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js
@@ -74,4 +74,4 @@ const deserialize = function (payload) {
   });
 };
 
-export { deserialize, serialize, serializeForAdmin, serializeMembers };
+export const certificationCenterMembershipSerializer = { deserialize, serialize, serializeForAdmin, serializeMembers };

--- a/api/src/team/infrastructure/serializers/jsonapi/organization-member-identity.serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/organization-member-identity.serializer.js
@@ -9,4 +9,4 @@ const serialize = function (model) {
   }).serialize(model);
 };
 
-export { serialize };
+export const organizationMemberIdentitySerializer = { serialize };

--- a/api/src/team/infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js
@@ -8,5 +8,4 @@ const serialize = function (invitation) {
   }).serialize(invitation);
 };
 
-const serializer = { serialize };
-export { serialize, serializer };
+export const scoOrganizationInvitationSerializer = { serialize };

--- a/api/src/team/infrastructure/serializers/jsonapi/user-orga-settings.serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/user-orga-settings.serializer.js
@@ -76,4 +76,4 @@ const serialize = function (userOrgaSettings) {
   }).serialize(userOrgaSettings);
 };
 
-export { serialize };
+export const userOrgaSettingsSerializer = { serialize };

--- a/api/src/team/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js
@@ -15,4 +15,4 @@ const serialize = function (organization) {
   }).serialize(organization);
 };
 
-export { serialize };
+export const userOrganizationForAdminSerializer = { serialize };

--- a/api/tests/banner/unit/domain/serializers/information-banner-serializer_test.js
+++ b/api/tests/banner/unit/domain/serializers/information-banner-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../src/banner/infrastructure/serializers/jsonapi/information-banner-serializer.js';
+import { informationBannerSerializer } from '../../../../../src/banner/infrastructure/serializers/jsonapi/information-banner-serializer.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
@@ -17,7 +17,7 @@ describe('Unit | Serializer | JSONAPI | information-banner-serializer', function
         ],
       });
 
-      const serializedBannerInformation = await serializer.serialize(bannerInformation);
+      const serializedBannerInformation = await informationBannerSerializer.serialize(bannerInformation);
 
       expect(serializedBannerInformation).to.deep.equal({
         data: {

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/candidate-serializer.js';
+import { candidateSerializer } from '../../../../../../src/certification/enrolment/infrastructure/serializers/candidate-serializer.js';
 import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
@@ -18,7 +18,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
       };
 
       // when
-      const result = serializer.serializeId(candidateId);
+      const result = candidateSerializer.serializeId(candidateId);
 
       // then
       expect(result).to.deep.equal(expectedSerializedResult);
@@ -100,7 +100,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
       };
 
       // when
-      const deserializedCandidate = await serializer.deserialize(candidateJsonApiData);
+      const deserializedCandidate = await candidateSerializer.deserialize(candidateJsonApiData);
 
       // then
       expect(deserializedCandidate).to.deepEqualInstance(
@@ -166,7 +166,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
       };
 
       // when
-      const jsonApi = serializer.serializeForParticipation(candidate);
+      const jsonApi = candidateSerializer.serializeForParticipation(candidate);
 
       // then
       expect(jsonApi).to.deep.equal(expectedJsonApiData);
@@ -228,7 +228,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
       };
 
       // when
-      const jsonApi = serializer.serialize(candidate);
+      const jsonApi = candidateSerializer.serialize(candidate);
 
       // then
       expect(jsonApi).to.deep.equal(expectedJsonApiData);
@@ -275,7 +275,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
       };
 
       // when
-      const jsonApi = serializer.serializeForSession(sessionCandidate);
+      const jsonApi = candidateSerializer.serializeForSession(sessionCandidate);
 
       // then
       expect(jsonApi).to.deep.equal(expectedJsonApiData);

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/csv/sessions-csv-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/csv/sessions-csv-serializer_test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { deserializeForSessionsImport } from '../../../../../../../src/certification/enrolment/infrastructure/serializers/csv/sessions-csv-serializer.js';
+import { sessionsCsvSerializer } from '../../../../../../../src/certification/enrolment/infrastructure/serializers/csv/sessions-csv-serializer.js';
 import { ComplementaryCertificationKeys } from '../../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { emptySession } from '../../../../../../../src/certification/shared/infrastructure/utils/csv/sessions-import.js';
 import { FileValidationError } from '../../../../../../../src/shared/domain/errors.js';
@@ -15,7 +15,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
         const parsedCsvData = [{ '* Nom du site': `Site 1` }];
 
         // when
-        const error = await catchErr(deserializeForSessionsImport)({
+        const error = await catchErr(sessionsCsvSerializer.deserializeForSessionsImport)({
           parsedCsvData,
           hasBillingMode: true,
         });
@@ -53,7 +53,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
             ];
 
             // when
-            const error = await catchErr(deserializeForSessionsImport)({
+            const error = await catchErr(sessionsCsvSerializer.deserializeForSessionsImport)({
               parsedCsvData,
               hasBillingMode: true,
             });
@@ -91,7 +91,10 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
             ];
 
             // when
-            const result = await deserializeForSessionsImport({ parsedCsvData, hasBillingMode: false });
+            const result = await sessionsCsvSerializer.deserializeForSessionsImport({
+              parsedCsvData,
+              hasBillingMode: false,
+            });
 
             // then
             expect(result).to.deep.equal([emptySession]);
@@ -149,7 +152,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const error = await catchErr(deserializeForSessionsImport)({
+          const error = await catchErr(sessionsCsvSerializer.deserializeForSessionsImport)({
             parsedCsvData: parsedCsvDataWithCleASubscription,
             hasBillingMode: true,
             certificationCenterHabilitations: habilitationsWithoutCleA,
@@ -192,7 +195,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const error = await catchErr(deserializeForSessionsImport)({
+          const error = await catchErr(sessionsCsvSerializer.deserializeForSessionsImport)({
             parsedCsvData,
             hasBillingMode: false,
           });
@@ -234,7 +237,10 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = await deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+          const result = await sessionsCsvSerializer.deserializeForSessionsImport({
+            parsedCsvData,
+            hasBillingMode: true,
+          });
 
           // then
           expect(result).to.deep.equal([emptySession]);
@@ -273,7 +279,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+          const result = sessionsCsvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -310,7 +316,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+          const result = sessionsCsvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -340,7 +346,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+          const result = sessionsCsvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -369,7 +375,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
             ];
 
             // when
-            const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+            const result = sessionsCsvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
             // then
             expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -412,7 +418,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+          const result = sessionsCsvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -510,7 +516,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+          const result = sessionsCsvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -580,9 +586,9 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true }).map((session) =>
-            _.omit(session, 'uniqueKey'),
-          );
+          const result = sessionsCsvSerializer
+            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
+            .map((session) => _.omit(session, 'uniqueKey'));
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -633,9 +639,9 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true }).map((session) =>
-            _.omit(session, 'uniqueKey'),
-          );
+          const result = sessionsCsvSerializer
+            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
+            .map((session) => _.omit(session, 'uniqueKey'));
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -654,9 +660,9 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
             const csvLine = [_lineWithCandidateAndBillingInformation({ prepaymentCode })];
 
             // when
-            const result = deserializeForSessionsImport({ parsedCsvData: csvLine, hasBillingMode: true }).map(
-              (session) => _.omit(session, 'uniqueKey'),
-            );
+            const result = sessionsCsvSerializer
+              .deserializeForSessionsImport({ parsedCsvData: csvLine, hasBillingMode: true })
+              .map((session) => _.omit(session, 'uniqueKey'));
 
             // then
             const expectedResult = [
@@ -748,11 +754,13 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
         ];
 
         // when
-        const result = deserializeForSessionsImport({
-          parsedCsvData,
-          hasBillingMode: true,
-          certificationCenterHabilitations: habilitations,
-        }).map((session) => _.omit(session, 'uniqueKey'));
+        const result = sessionsCsvSerializer
+          .deserializeForSessionsImport({
+            parsedCsvData,
+            hasBillingMode: true,
+            certificationCenterHabilitations: habilitations,
+          })
+          .map((session) => _.omit(session, 'uniqueKey'));
 
         // then
         expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -928,7 +936,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const [result] = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+          const [result] = sessionsCsvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(result.candidates).to.have.lengthOf(6);
@@ -955,9 +963,9 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           ];
 
           // when
-          const result = deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true }).map((session) =>
-            _.omit(session, 'uniqueKey'),
-          );
+          const result = sessionsCsvSerializer
+            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
+            .map((session) => _.omit(session, 'uniqueKey'));
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -984,7 +992,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
       ];
 
       // when
-      const [firstSession, secondSession] = deserializeForSessionsImport({
+      const [firstSession, secondSession] = sessionsCsvSerializer.deserializeForSessionsImport({
         parsedCsvData,
         hasBillingMode: true,
       });
@@ -1053,7 +1061,7 @@ describe('Certification | Enrolment | Unit | Infrastructure | Serializers | CSV 
           },
         ];
 
-        const error = await catchErr(deserializeForSessionsImport)({
+        const error = await catchErr(sessionsCsvSerializer.deserializeForSessionsImport)({
           parsedCsvData,
           hasBillingMode: true,
         });

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/division-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/division-serializer_test.js
@@ -1,11 +1,11 @@
-import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/division-serializer.js';
+import { divisionSerializer } from '../../../../../../src/certification/enrolment/infrastructure/serializers/division-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | division-serializer', function () {
   describe('#serialize', function () {
     it('serializes all division', function () {
       // when
-      const json = serializer.serialize([{ name: '6eme' }, { name: '3eme' }]);
+      const json = divisionSerializer.serialize([{ name: '6eme' }, { name: '3eme' }]);
       // then
       expect(json).to.deep.equal({
         data: [

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/session-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/session-serializer_test.js
@@ -1,5 +1,5 @@
 import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
-import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/session-serializer.js';
+import { sessionSerializer } from '../../../../../../src/certification/enrolment/infrastructure/serializers/session-serializer.js';
 import { SESSION_STATUSES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { expect } from '../../../../../test-helper.js';
 
@@ -51,7 +51,7 @@ describe('Unit | Certification | enrolment | Serializer | session-serializer', f
     context('when session does not have a link to an existing certification center', function () {
       it('should convert a SessionEnrolment model object into JSON API data including invigilator password', function () {
         // when
-        const json = serializer.serialize(session);
+        const json = sessionSerializer.serialize(session);
 
         // then
         expect(json).to.deep.equal(expectedJsonApi);
@@ -91,7 +91,7 @@ describe('Unit | Certification | enrolment | Serializer | session-serializer', f
 
     it('should convert JSON API data to a Session', function () {
       // when
-      const session = serializer.deserialize(jsonApiSession);
+      const session = sessionSerializer.deserialize(jsonApiSession);
 
       // then
       expect(session).to.be.instanceOf(SessionEnrolment);

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/student-certification-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/student-certification-serializer_test.js
@@ -1,5 +1,5 @@
 import { StudentForEnrolment } from '../../../../../../src/certification/enrolment/domain/read-models/StudentForEnrolment.js';
-import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/student-certification-serializer.js';
+import { studentCertificationSerializer } from '../../../../../../src/certification/enrolment/infrastructure/serializers/student-certification-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -28,7 +28,7 @@ describe('Unit | Serializer | JSONAPI | student-certification-serializer', funct
       };
 
       // when
-      const json = serializer.serialize(studentEnrolmentReadmodel);
+      const json = studentCertificationSerializer.serialize(studentEnrolmentReadmodel);
 
       // then
       expect(json).to.deep.equal(expectedSerializedStudent);

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/timeline-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/timeline-serializer_test.js
@@ -1,6 +1,6 @@
 import { CandidateTimeline } from '../../../../../../src/certification/enrolment/domain/models/timeline/CandidateTimeline.js';
 import { TimelineEvent } from '../../../../../../src/certification/enrolment/domain/models/timeline/TimelineEvent.js';
-import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/timeline-serializer.js';
+import { timelineSerializer } from '../../../../../../src/certification/enrolment/infrastructure/serializers/timeline-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Certification | Enrolment | Unit | Serializer | timeline-serializer', function () {
@@ -15,7 +15,7 @@ describe('Certification | Enrolment | Unit | Serializer | timeline-serializer', 
       timeline.addEvent(new TimelineEvent({ code: 'test', when, metadata: { x: 'y' } }));
 
       // when
-      const json = serializer.serialize(timeline);
+      const json = timelineSerializer.serialize(timeline);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/user-certification-eligibility-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/user-certification-eligibility-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/user-certification-eligibility-serializer.js';
+import { userCertificationEligibilitySerializer } from '../../../../../../src/certification/enrolment/infrastructure/serializers/user-certification-eligibility-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -14,7 +14,7 @@ describe('Certification | Enrolment | Unit | Serializer | user-certification-eli
         });
 
         // when
-        const json = serializer.serialize(userCertificationEligibility);
+        const json = userCertificationEligibilitySerializer.serialize(userCertificationEligibility);
 
         // then
         expect(json).to.deep.equal({
@@ -44,7 +44,7 @@ describe('Certification | Enrolment | Unit | Serializer | user-certification-eli
         });
 
         // when
-        const json = serializer.serialize(userCertificationEligibility);
+        const json = userCertificationEligibilitySerializer.serialize(userCertificationEligibility);
 
         // then
         expect(json).to.deep.equal({

--- a/api/tests/certification/shared/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
+++ b/api/tests/certification/shared/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
@@ -2,7 +2,7 @@ import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
-import * as serializer from '../../../../../../../src/certification/shared/infrastructure/serializers/jsonapi/certification-report-serializer.js';
+import { certificationReportSerializer } from '../../../../../../../src/certification/shared/infrastructure/serializers/jsonapi/certification-report-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -40,7 +40,7 @@ describe('Unit | Serializer | JSONAPI | certification-report-serializer', functi
       };
 
       // when
-      const jsonApi = serializer.serialize(certificationReport);
+      const jsonApi = certificationReportSerializer.serialize(certificationReport);
 
       // then
       expect(jsonApi).to.deep.equal(jsonApiData);
@@ -82,7 +82,7 @@ describe('Unit | Serializer | JSONAPI | certification-report-serializer', functi
       ];
 
       // when
-      const jsonApi = serializer.serialize(certificationReport);
+      const jsonApi = certificationReportSerializer.serialize(certificationReport);
 
       // then
       expect(jsonApi.included).to.deep.equal(jsonApiDataIncluded);
@@ -117,7 +117,7 @@ describe('Unit | Serializer | JSONAPI | certification-report-serializer', functi
       };
 
       // when
-      const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
+      const deserializedCertificationReport = await certificationReportSerializer.deserialize(jsonApiData);
 
       // then
       expect(deserializedCertificationReport).to.deep.equal(certificationReport);

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-response-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-response-serializer_test.js
@@ -1,5 +1,5 @@
 import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
-import * as correctionResponseSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js';
+import { correctionResponseSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
 import { expect } from '../../../../../test-helper.js';
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
@@ -1,7 +1,7 @@
 import { TutorialEvaluation } from '../../../../../../src/devcomp/domain/models/TutorialEvaluation.js';
 import { UserSavedTutorial } from '../../../../../../src/devcomp/domain/models/UserSavedTutorial.js';
 import { TutorialForUser } from '../../../../../../src/devcomp/domain/read-models/TutorialForUser.js';
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js';
+import { correctionSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js';
 import { Correction } from '../../../../../../src/shared/domain/models/Correction.js';
 import { Hint } from '../../../../../../src/shared/domain/models/Hint.js';
 import { expect } from '../../../../../test-helper.js';
@@ -95,7 +95,7 @@ describe('Unit | Serializer | JSONAPI | correction-serializer', function () {
       });
 
       // when
-      const json = serializer.serialize(correction);
+      const json = correctionSerializer.serialize(correction);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
@@ -2,7 +2,7 @@ import { ElementAnswer } from '../../../../../../src/devcomp/domain/models/Eleme
 import { QcmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcmCorrectionResponse.js';
 import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
 import { QrocmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QrocmCorrectionResponse.js';
-import * as elementAnswerSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js';
+import { elementAnswerSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
 import { expect } from '../../../../../test-helper.js';
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-metadata-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-metadata-serializer_test.js
@@ -1,5 +1,5 @@
 import { ModuleMetadata } from '../../../../../../src/devcomp/domain/models/module/ModuleMetadata.js';
-import * as moduleMetadataSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js';
+import { moduleMetadataSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleMetadataSerializer', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -17,7 +17,7 @@ import { Separator } from '../../../../../../src/devcomp/domain/models/element/S
 import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
 import { Video } from '../../../../../../src/devcomp/domain/models/element/Video.js';
 import { Module } from '../../../../../../src/devcomp/domain/models/module/Module.js';
-import * as moduleSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js';
+import { moduleSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerializer', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-event-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-event-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js';
+import { passageEventSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageEventSerializer', function () {
@@ -29,7 +29,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageEvent
       };
 
       // when
-      const results = await serializer.deserialize(json);
+      const results = await passageEventSerializer.deserialize(json);
 
       // then
       expect(results).to.deep.equal([

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-serializer_test.js
@@ -1,5 +1,5 @@
 import { Passage } from '../../../../../../src/devcomp/domain/models/Passage.js';
-import * as passageSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/passage-serializer.js';
+import { passageSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/passage-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageSerializer', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -1,5 +1,5 @@
 import { Training } from '../../../../../../src/devcomp/domain/models/Training.js';
-import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js';
+import { trainingSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -324,7 +324,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
       };
 
       // when
-      const json = serializer.serializeForAdmin(training);
+      const json = trainingSerializer.serializeForAdmin(training);
 
       // then
       expect(json).to.deep.equal(expectedSerializedTraining);
@@ -335,7 +335,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
       const training = domainBuilder.buildTrainingForAdmin({ objectives: null });
 
       // when
-      const json = serializer.serializeForAdmin(training);
+      const json = trainingSerializer.serializeForAdmin(training);
 
       // then
       expect(json.data.attributes.objectives).to.be.null;
@@ -381,7 +381,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
       };
 
       // when
-      const json = serializer.serialize(training);
+      const json = trainingSerializer.serialize(training);
 
       // then
       expect(json).to.deep.equal(expectedSerializedTraining);
@@ -433,7 +433,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
       };
 
       // when
-      const json = serializer.serialize(training, meta);
+      const json = trainingSerializer.serialize(training, meta);
 
       // then
       expect(json).to.deep.equal(expectedSerializedTraining);
@@ -464,7 +464,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
       };
 
       // when
-      const training = await serializer.deserialize(jsonTraining);
+      const training = await trainingSerializer.deserialize(jsonTraining);
 
       // then
       expect(training).to.deep.equal({
@@ -495,7 +495,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
       };
 
       // when
-      const training = await serializer.deserialize(jsonTraining);
+      const training = await trainingSerializer.deserialize(jsonTraining);
 
       // then
       expect(training.objectives).to.deep.equal(['Objectif 1', 'Objectif 2']);
@@ -513,7 +513,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
       };
 
       // when
-      const training = await serializer.deserialize(jsonTraining);
+      const training = await trainingSerializer.deserialize(jsonTraining);
 
       // then
       expect(training.objectives).to.deep.equal(['Objectif 1', 'Objectif 2', 'Objectif 3']);
@@ -549,7 +549,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
         };
 
         // when
-        const deserializedTraining = await serializer.deserialize(jsonTraining);
+        const deserializedTraining = await trainingSerializer.deserialize(jsonTraining);
 
         // then
         expect(deserializedTraining.duration).to.deep.equal(expectedDuration);

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer.js';
+import { trainingSummarySerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -24,7 +24,7 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
       const meta = { pagination: { page: 1, pageSize: 3, pageCount: 1, rowCount: 2 } };
 
       // when
-      const serializedTrainingSummaries = serializer.serialize(trainingSummaries, meta);
+      const serializedTrainingSummaries = trainingSummarySerializer.serialize(trainingSummaries, meta);
 
       // then
       expect(serializedTrainingSummaries).to.deep.equal({

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-trigger-serializer.js';
+import { trainingTriggerSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-trigger-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -143,7 +143,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-tri
       };
 
       // when
-      const json = serializer.serialize(trainingTrigger);
+      const json = trainingTriggerSerializer.serialize(trainingTrigger);
 
       // then
       expect(json).to.deep.equal(expectedSerializedTrainingTrigger);
@@ -165,7 +165,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-tri
       };
 
       // when
-      const trainingTrigger = await serializer.deserialize(jsonTraining);
+      const trainingTrigger = await trainingTriggerSerializer.deserialize(jsonTraining);
 
       // then
       expect(trainingTrigger).to.deep.equal({

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer_test.js
@@ -1,5 +1,5 @@
 import { TutorialEvaluation } from '../../../../../../src/devcomp/domain/models/TutorialEvaluation.js';
-import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js';
+import { tutorialEvaluationSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -26,7 +26,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-evaluation-serializer', functio
           },
         };
         // when
-        const json = serializer.serialize(tutorialEvaluation);
+        const json = tutorialEvaluationSerializer.serialize(tutorialEvaluation);
 
         // then
         expect(json).to.be.deep.equal(expectedJsonTutorialEvaluation);
@@ -74,7 +74,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-evaluation-serializer', functio
           ],
         };
         // when
-        const json = serializer.serialize(tutorialEvaluation);
+        const json = tutorialEvaluationSerializer.serialize(tutorialEvaluation);
 
         // then
         expect(json).to.be.deep.equal(expectedJsonTutorialEvaluation);
@@ -99,7 +99,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-evaluation-serializer', functio
       };
 
       // when
-      const tutorialEvaluation = serializer.deserialize(jsonTutorialEvaluation);
+      const tutorialEvaluation = tutorialEvaluationSerializer.deserialize(jsonTutorialEvaluation);
 
       // then
       expect(tutorialEvaluation).to.be.instanceOf(TutorialEvaluation);

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/tutorial-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/tutorial-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/tutorial-serializer.js';
+import { tutorialSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/tutorial-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -40,7 +40,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
       };
 
       // when
-      const result = serializer.serialize(tutorial);
+      const result = tutorialSerializer.serialize(tutorial);
 
       // then
       expect(result).to.deep.equal(expectedSerializedResult);
@@ -77,7 +77,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
       };
 
       // when
-      const result = serializer.serialize(tutorial);
+      const result = tutorialSerializer.serialize(tutorial);
 
       // then
       expect(result).to.deep.equal(expectedSerializedResult);
@@ -148,7 +148,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
       };
 
       // when
-      const result = serializer.serialize(tutorial);
+      const result = tutorialSerializer.serialize(tutorial);
 
       // then
       expect(result).to.deep.equal(expectedSerializedResult);
@@ -193,7 +193,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
       };
 
       // when
-      const result = serializer.serialize(tutorials, pagination);
+      const result = tutorialSerializer.serialize(tutorials, pagination);
 
       // then
       expect(result).to.deep.equal(expectedSerializedResult);

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/user-saved-tutorial-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/user-saved-tutorial-serializer_test.js
@@ -1,5 +1,5 @@
 import { UserSavedTutorial } from '../../../../../../src/devcomp/domain/models/UserSavedTutorial.js';
-import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/user-saved-tutorial-serializer.js';
+import { userSavedTutorialSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/user-saved-tutorial-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -26,7 +26,7 @@ describe('Unit | Serializer | JSONAPI | user-saved-tutorial-serializer', functio
           },
         };
         // when
-        const json = serializer.serialize(userSavedTutorial);
+        const json = userSavedTutorialSerializer.serialize(userSavedTutorial);
 
         // then
         expect(json).to.be.deep.equal(expectedJsonUserSavedTutorial);
@@ -55,7 +55,7 @@ describe('Unit | Serializer | JSONAPI | user-saved-tutorial-serializer', functio
           },
         };
         // when
-        const json = serializer.serialize(userSavedTutorial);
+        const json = userSavedTutorialSerializer.serialize(userSavedTutorial);
 
         // then
         expect(json).to.be.deep.equal(expectedJsonUserSavedTutorial);
@@ -78,7 +78,7 @@ describe('Unit | Serializer | JSONAPI | user-saved-tutorial-serializer', functio
       };
 
       // when
-      const userSavedTutorial = serializer.deserialize(jsonUserSavedTutorial);
+      const userSavedTutorial = userSavedTutorialSerializer.deserialize(jsonUserSavedTutorial);
 
       // then
       expect(userSavedTutorial).to.be.instanceOf(UserSavedTutorial);

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -1,6 +1,6 @@
 import { Answer } from '../../../../../../src/evaluation/domain/models/Answer.js';
 import { AnswerStatusJsonApiAdapter as answerStatusJSONAPIAdapter } from '../../../../../../src/evaluation/infrastructure/adapters/answer-status-json-api-adapter.js';
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/answer-serializer.js';
+import { answerSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/answer-serializer.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -63,7 +63,7 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(answer);
+      const json = answerSerializer.serialize(answer);
 
       // then
       expect(json).to.deep.equal(expectedJSON);
@@ -106,7 +106,7 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function () {
 
     it('should convert JSON API data into an Answer model object', function () {
       // when
-      const answer = serializer.deserialize(jsonAnswer);
+      const answer = answerSerializer.deserialize(jsonAnswer);
 
       // then
       expect(answer).to.be.an.instanceOf(Answer);

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js';
+import { autonomousCoursePaginatedListSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | autonomous-course-paginated-list-serializer', function () {
@@ -45,7 +45,7 @@ describe('Unit | Serializer | JSONAPI | autonomous-course-paginated-list-seriali
         meta,
       };
 
-      const serializedResult = serializer.serialize(autonomousCoursesList, meta);
+      const serializedResult = autonomousCoursePaginatedListSerializer.serialize(autonomousCoursesList, meta);
 
       return expect(serializedResult).to.deep.equal(expectedResponse);
     });

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-serializer_test.js
@@ -1,11 +1,11 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js';
+import { autonomousCourseSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | autonomous-course-serializer', function () {
   describe('#serializeId', function () {
     it('should return a serialized autonomous course to JSONAPI with only ID filled', function () {
       // when
-      const serializedAutonomousCourse = serializer.serializeId(1);
+      const serializedAutonomousCourse = autonomousCourseSerializer.serializeId(1);
 
       // then
       const expectedSerializedAutonomousCourse = {
@@ -34,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | autonomous-course-serializer', function 
       };
 
       // when
-      const autonomousCourse = await serializer.deserialize(jsonTraining);
+      const autonomousCourse = await autonomousCourseSerializer.deserialize(jsonTraining);
 
       // then
       expect(autonomousCourse).to.deep.equal({

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-target-profiles-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-target-profiles-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-target-profiles-serializer.js';
+import { autonomousCourseTargetProfilesSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-target-profiles-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -16,7 +16,10 @@ describe('Unit | Serializer | JSONAPI | autonomous-course-target-profile-seriali
       });
 
       // when
-      const serializedAutonomousCourseTargetProfiles = serializer.serialize([targetProfile1, targetProfile2]);
+      const serializedAutonomousCourseTargetProfiles = autonomousCourseTargetProfilesSerializer.serialize([
+        targetProfile1,
+        targetProfile2,
+      ]);
 
       // then
       const expectedSerializedAutonomousCourse = {

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-criterion-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-criterion-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/badge-criterion-serializer.js';
+import { badgeCriterionSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/badge-criterion-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | badge-criterion-serializer', function () {
@@ -27,7 +27,7 @@ describe('Unit | Serializer | JSONAPI | badge-criterion-serializer', function ()
       };
 
       // when
-      const badgeCriterion = await serializer.deserialize(jsonTraining);
+      const badgeCriterion = await badgeCriterionSerializer.deserialize(jsonTraining);
 
       // then
       expect(badgeCriterion).to.deep.equal({

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/challenge-to-play-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/challenge-to-play-serializer_test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/challenge-to-play-serializer.js';
+import { challengeToPlaySerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/challenge-to-play-serializer.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Evaluation | Unit | Infrastructure | Serializer | JSONAPI | challenge-serializer', function () {
@@ -37,7 +37,7 @@ describe('Evaluation | Unit | Infrastructure | Serializer | JSONAPI | challenge-
         focused: null,
       });
 
-      const json = serializer.serialize(challenge);
+      const json = challengeToPlaySerializer.serialize(challenge);
 
       expect(json).to.deep.equal({
         data: {
@@ -99,7 +99,7 @@ describe('Evaluation | Unit | Infrastructure | Serializer | JSONAPI | challenge-
         focused: null,
       });
 
-      const json = serializer.serialize(challenge);
+      const json = challengeToPlaySerializer.serialize(challenge);
 
       expect(json).to.deep.equal({
         data: {

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/competence-evaluation-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/competence-evaluation-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
+import { competenceEvaluationSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -36,7 +36,7 @@ describe('Unit | Serializer | JSONAPI | competence-evaluation-serializer', funct
       };
 
       // when
-      const json = serializer.serialize(competenceEvaluation);
+      const json = competenceEvaluationSerializer.serialize(competenceEvaluation);
 
       // then
       expect(json).to.deep.equal(expectedSerializedCompetenceEvaluation);

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/feedback-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/feedback-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/feedback-serializer.js';
+import { feedbackSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/feedback-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
@@ -43,7 +43,7 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
       };
 
       // when
-      const response = serializer.serialize(feedback);
+      const response = feedbackSerializer.serialize(feedback);
 
       // then
       expect(response).to.deep.equal(serializedFeedback);
@@ -77,7 +77,7 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
       const persistedFeedbacks = [simpleFeedback, otherFeedback, matchingDatesFeedback];
 
       // when
-      const result = serializer.serialize(persistedFeedbacks);
+      const result = feedbackSerializer.serialize(persistedFeedbacks);
 
       // then
       const expectedResponse = {
@@ -155,7 +155,7 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
       };
 
       // when
-      const deserializedFeedback = await serializer.deserialize(serializedFeedback);
+      const deserializedFeedback = await feedbackSerializer.deserialize(serializedFeedback);
 
       // then
       expect(deserializedFeedback.id).to.equal(serializedFeedback.data.id);

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/progression-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/progression-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/progression-serializer.js';
+import { progressionSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/progression-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -8,7 +8,7 @@ describe('Unit | Serializer | JSONAPI | progression-serializer', function () {
       const progression = domainBuilder.buildProgression();
 
       // when
-      const json = serializer.serialize(progression);
+      const json = progressionSerializer.serialize(progression);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/scorecard-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/scorecard-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/scorecard-serializer.js';
+import { scorecardSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/scorecard-serializer.js';
 import { MAX_REACHABLE_LEVEL } from '../../../../../../src/shared/domain/constants.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -88,7 +88,7 @@ describe('Unit | Serializer | JSONAPI | scorecard-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(scorecardObject);
+      const json = scorecardSerializer.serialize(scorecardObject);
 
       // then
       expect(json).to.deep.equal(expectedSerializedScorecard);

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/smart-random-simulator-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/smart-random-simulator-serializer_test.js
@@ -1,6 +1,6 @@
 import { Answer } from '../../../../../../src/evaluation/domain/models/Answer.js';
 import { SimulationParameters } from '../../../../../../src/evaluation/domain/models/SimulationParameters.js';
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js';
+import { smartRandomSimulatorSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js';
 import { Challenge } from '../../../../../../src/shared/domain/models/Challenge.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { Skill } from '../../../../../../src/shared/domain/models/Skill.js';
@@ -54,7 +54,7 @@ describe('Unit | Serializer | JSONAPI | smart-random-simulator-serializer', func
 
     it('should convert JSON API data into an object', async function () {
       // when
-      const simulatorParameters = await serializer.deserialize(jsonAnswer);
+      const simulatorParameters = await smartRandomSimulatorSerializer.deserialize(jsonAnswer);
 
       // then
       expect(simulatorParameters).to.be.instanceOf(SimulationParameters);

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.test.js
@@ -1,4 +1,4 @@
-import * as certificationPointOfContactSerializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js';
+import { certificationPointOfContactSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
+import { oidcIdentityProvidersSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Infrastructure | Serializer | JSONAPI | oidc-identity-providers', function () {
@@ -17,7 +17,7 @@ describe('Unit | Identity Access Management | Infrastructure | Serializer | JSON
       };
 
       // when
-      const json = serializer.serialize(oidcIdentityProvider);
+      const json = oidcIdentityProvidersSerializer.serialize(oidcIdentityProvider);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.test.js
@@ -1,5 +1,5 @@
 import { StudentInformationForAccountRecovery } from '../../../../../../src/identity-access-management/domain/read-models/StudentInformationForAccountRecovery.js';
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
+import { studentInformationForAccountRecoverySerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | student-information-for-account-recovery', function () {
@@ -15,7 +15,7 @@ describe('Unit | Serializer | JSONAPI | student-information-for-account-recovery
       });
 
       // when
-      const json = serializer.serialize(modelStudentInformationForAccountRecovery);
+      const json = studentInformationForAccountRecoverySerializer.serialize(modelStudentInformationForAccountRecovery);
 
       // then
       const expectedJsonApi = {
@@ -46,7 +46,7 @@ describe('Unit | Serializer | JSONAPI | student-information-for-account-recovery
       };
 
       // when
-      const json = serializer.serializeAccountRecovery(accountRecoveryDetails);
+      const json = studentInformationForAccountRecoverySerializer.serializeAccountRecovery(accountRecoveryDetails);
 
       // then
       const expectedJsonApi = {
@@ -82,7 +82,7 @@ describe('Unit | Serializer | JSONAPI | student-information-for-account-recovery
       };
 
       // when
-      const json = await serializer.deserialize(payload);
+      const json = await studentInformationForAccountRecoverySerializer.deserialize(payload);
 
       // then
       const expectedJsonApi = {
@@ -110,7 +110,7 @@ describe('Unit | Serializer | JSONAPI | student-information-for-account-recovery
       };
 
       // when
-      const json = await serializer.deserialize(payload);
+      const json = await studentInformationForAccountRecoverySerializer.deserialize(payload);
 
       // then
       const expectedJsonApi = {

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/update-email.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/update-email.serializer.test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/update-email.serializer.js';
+import { updateEmailSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/update-email.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Infrastructure | Serializer | JSONAPI | update-email-serializer', function () {
@@ -10,7 +10,7 @@ describe('Unit | Identity Access Management | Infrastructure | Serializer | JSON
       };
 
       // when
-      const json = serializer.serialize(updatedUserAttributes);
+      const json = updateEmailSerializer.serialize(updatedUserAttributes);
 
       // then
       const expectedJsonApi = {

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer_test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin.serializer.js';
+import { userAnonymizedDetailsForAdminSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -14,7 +14,7 @@ describe('Unit | Identity Access Management | Serializer | JSONAPI | user-anonym
       });
 
       // when
-      const json = serializer.serialize(modelObject);
+      const json = userAnonymizedDetailsForAdminSerializer.serialize(modelObject);
 
       // then
       expect(json).to.be.deep.equal({

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
@@ -1,5 +1,5 @@
 import { LastUserApplicationConnection } from '../../../../../../src/identity-access-management/domain/models/LastUserApplicationConnection.js';
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js';
+import { userDetailsForAdminSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js';
 import { STATUS } from '../../../../../../src/legal-documents/domain/models/LegalDocumentStatus.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -50,7 +50,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
       userDetailsForAdmin.setTosStatus({ pixAppTosStatus, pixOrgaTosStatus });
 
       // when
-      const json = serializer.serialize(userDetailsForAdmin);
+      const json = userDetailsForAdminSerializer.serialize(userDetailsForAdmin);
 
       // then
       expect(json).to.be.deep.equal({
@@ -194,7 +194,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
       });
 
       // when
-      const json = serializer.serializeForUpdate(modelObject);
+      const json = userDetailsForAdminSerializer.serializeForUpdate(modelObject);
 
       // then
       expect(json).to.be.deep.equal({
@@ -278,7 +278,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
       };
 
       // when
-      const user = serializer.deserialize(jsonUser);
+      const user = userDetailsForAdminSerializer.deserialize(jsonUser);
 
       // then
       expect(user.firstName).to.equal('Luke');

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-for-admin.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-for-admin.serializer.test.js
@@ -1,5 +1,5 @@
 import { User } from '../../../../../../src/identity-access-management/domain/models/User.js';
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-for-admin.serializer.js';
+import { userForAdminSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-for-admin.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Serializer | JSONAPI | user-for-admin', function () {
@@ -64,7 +64,7 @@ describe('Unit | Identity Access Management | Serializer | JSONAPI | user-for-ad
         };
 
         // when
-        const json = serializer.serialize(userModelObject);
+        const json = userForAdminSerializer.serialize(userModelObject);
 
         // then
         expect(json).to.be.deep.equal(expectedSerializedUser);

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-login-serializer_test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-login-serializer_test.js
@@ -1,5 +1,5 @@
 import { UserLogin } from '../../../../../../src/identity-access-management/domain/models/UserLogin.js';
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-login-serializer.js';
+import { userLoginSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-login-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | user-login-serializer', function () {
@@ -20,7 +20,7 @@ describe('Unit | Serializer | JSONAPI | user-login-serializer', function () {
       });
 
       // when
-      const json = serializer.serialize(userLogin);
+      const json = userLoginSerializer.serialize(userLogin);
 
       // then
       expect(json).to.be.deep.equal({

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-oidc-authentication-request.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-oidc-authentication-request.serializer.test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-oidc-authentication-request.serializer.js';
+import { userOidcAuthenticationRequestSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-oidc-authentication-request.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | user-oidc-authentication-requests', function () {
@@ -19,7 +19,7 @@ describe('Unit | Serializer | JSONAPI | user-oidc-authentication-requests', func
       };
 
       // when
-      const json = serializer.serialize(authenticationContent);
+      const json = userOidcAuthenticationRequestSerializer.serialize(authenticationContent);
 
       // then
       const expectedJson = {

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -1,5 +1,5 @@
 import { User } from '../../../../../../src/identity-access-management/domain/models/User.js';
-import * as serializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-serializer.js';
+import { userSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Shared | Infrastructure | Serializer | JSONAPI | user-serializer', function () {
@@ -79,7 +79,7 @@ describe('Unit | Shared | Infrastructure | Serializer | JSONAPI | user-serialize
         };
 
         // when
-        const json = serializer.serialize(userModelObject);
+        const json = userSerializer.serialize(userModelObject);
 
         // then
         expect(json).to.be.deep.equal(expectedSerializedUser);
@@ -108,7 +108,7 @@ describe('Unit | Shared | Infrastructure | Serializer | JSONAPI | user-serialize
 
     it('should convert JSON API data into an User model object', function () {
       // when
-      const user = serializer.deserialize(jsonUser);
+      const user = userSerializer.deserialize(jsonUser);
 
       // then
       expect(user).to.be.an.instanceOf(User);
@@ -122,7 +122,7 @@ describe('Unit | Shared | Infrastructure | Serializer | JSONAPI | user-serialize
       jsonUser.data.id = '42';
 
       // when
-      const user = serializer.deserialize(jsonUser);
+      const user = userSerializer.deserialize(jsonUser);
 
       // then
       expect(user.id).to.equal('42');
@@ -130,7 +130,7 @@ describe('Unit | Shared | Infrastructure | Serializer | JSONAPI | user-serialize
 
     it('should not contain an ID attribute when not given', function () {
       // when
-      const user = serializer.deserialize(jsonUser);
+      const user = userSerializer.deserialize(jsonUser);
 
       // then
       expect(user.id).to.be.undefined;

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/administration-team-serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/administration-team-serializer.test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js';
+import { administrationTeamSerializer } from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -22,7 +22,7 @@ describe('Unit | Organizational Entities | Serializer | JSONAPI | administration
       };
 
       // when
-      const json = serializer.serialize(administrationTeam);
+      const json = administrationTeamSerializer.serialize(administrationTeam);
 
       // then
       expect(json).to.deep.equal(expectedSerializedTeam);

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js';
+import { certificationCenterForAdminSerializer } from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -49,7 +49,7 @@ describe('Unit | Organizational Entities | Infrastructure | Serializer | JSONAPI
       const createdBy = 123;
 
       // when
-      const deserializedCertificationCenterForAdmin = serializer.deserialize({
+      const deserializedCertificationCenterForAdmin = certificationCenterForAdminSerializer.deserialize({
         data: certificationCenterJsonApi.data,
         createdBy,
       });
@@ -87,7 +87,7 @@ describe('Unit | Organizational Entities | Infrastructure | Serializer | JSONAPI
         });
 
         // when
-        const serializedCertificationCenter = serializer.serialize(certificationCenter);
+        const serializedCertificationCenter = certificationCenterForAdminSerializer.serialize(certificationCenter);
 
         // then
         certificationCenterJsonApi.data.attributes['created-at'] = new Date('2018-01-01T05:43:10Z');

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
+import { certificationCenterSerializer } from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -54,7 +54,7 @@ describe('Unit | Organizational Entities | Infrastructure | Serializer | JSONAPI
       };
 
       // when
-      const serializedCertificationCenter = serializer.serialize(certificationCenter);
+      const serializedCertificationCenter = certificationCenterSerializer.serialize(certificationCenter);
 
       // then
       expect(serializedCertificationCenter).to.deep.equal(expectedSerializedCertificationCenter);

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/network/network.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/network/network.serializer.test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/network/network.serializer.js';
+import { networkSerializer } from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/network/network.serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -28,7 +28,7 @@ describe('Unit | Infrastructure | Serializers | JsonApi |  Network | network-ser
       };
 
       // when
-      const json = serializer.serialize(network);
+      const json = networkSerializer.serialize(network);
 
       // then
       expect(json).to.deep.equal(expectedSerializedNetwork);
@@ -40,7 +40,7 @@ describe('Unit | Infrastructure | Serializers | JsonApi |  Network | network-ser
       const meta = { page: 1, pageSize: 10, rowCount: 1, pageCount: 1 };
 
       // when
-      const json = serializer.serialize([network], meta);
+      const json = networkSerializer.serialize([network], meta);
 
       // then
       expect(json.meta).to.deep.equal(meta);
@@ -67,7 +67,7 @@ describe('Unit | Infrastructure | Serializers | JsonApi |  Network | network-ser
       };
 
       // when
-      const deserializedData = serializer.deserialize(jsonApiFormData);
+      const deserializedData = networkSerializer.deserialize(jsonApiFormData);
 
       // then
       expect(deserializedData).to.deep.equal({

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-learner-type-serializer_test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-learner-type-serializer_test.js
@@ -1,4 +1,4 @@
-import * as organizationLearnerTypeSerializer from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js';
+import { organizationLearnerTypeSerializer } from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -1,6 +1,6 @@
 import { Organization } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
 import { Tag } from '../../../../../../src/organizational-entities/domain/models/Tag.js';
-import * as serializer from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js';
+import { organizationSerializer } from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -26,7 +26,7 @@ describe('Unit | Serializer | organization-serializer', function () {
       const meta = { some: 'meta' };
 
       // when
-      const serializedOrganization = serializer.serialize(organization, meta);
+      const serializedOrganization = organizationSerializer.serialize(organization, meta);
 
       // then
       expect(serializedOrganization).to.deep.equal({
@@ -131,7 +131,7 @@ describe('Unit | Serializer | organization-serializer', function () {
       };
 
       // when
-      const organization = serializer.deserialize(jsonApiOrganization);
+      const organization = organizationSerializer.deserialize(jsonApiOrganization);
 
       // then
       const expectedOrganization = new Organization({
@@ -189,7 +189,7 @@ describe('Unit | Serializer | organization-serializer', function () {
       };
 
       // when
-      const organization = serializer.deserialize(jsonApiOrganization);
+      const organization = organizationSerializer.deserialize(jsonApiOrganization);
 
       // then
       const expectedTag1 = new Tag({ id: parseInt(tagAttributes1.id) });

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.test.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
 import { PlacesStatistics } from '../../../../../../../src/organizational-entities/domain/read-models/PlacesStatistics.js';
-import * as organizationPlaceStatisticsSerializer from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js';
+import { organizationPlacesStatisticsSerializer } from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js';
 import { PlacesLot } from '../../../../../../../src/prescription/organization-place/domain/read-models/PlacesLot.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -38,7 +38,7 @@ describe('Unit | Infrastructure | Serializers | JSONAPI | Organizations-Administ
       };
 
       // when
-      const json = organizationPlaceStatisticsSerializer.serialize(placesStatistics);
+      const json = organizationPlacesStatisticsSerializer.serialize(placesStatistics);
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.test.js
@@ -1,4 +1,4 @@
-import * as organizationStatisticsSerializer from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js';
+import { organizationStatisticsSerializer } from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-statistics.serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Infrastructure | Serializers | JSONAPI | Organizations-Administrations | organization-statistics', function () {

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/tag-serializer_test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/tag-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/tag-serializer.js';
+import { tagSerializer } from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/tag-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -19,7 +19,7 @@ describe('Unit | Organizational Entities | Serializer | JSONAPI | tag', function
       };
 
       // when
-      const json = serializer.serialize(tag);
+      const json = tagSerializer.serialize(tag);
 
       // then
       expect(json).to.deep.equal(expectedSerializedTag);

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js';
+import { anonymisedCampaignAssessmentSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js';
 import { Assessment } from '../../../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
@@ -15,7 +15,7 @@ describe('Unit | Serializer | JSONAPI | anonymised-campaign-assessment-serialize
       });
 
       // when
-      const json = serializer.serialize([assessment]);
+      const json = anonymisedCampaignAssessmentSerializer.serialize([assessment]);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/available-campaign-participation-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/available-campaign-participation-serializer_test.js
@@ -1,5 +1,5 @@
 import { AvailableCampaignParticipation } from '../../../../../../../src/prescription/campaign-participation/domain/read-models/AvailableCampaignParticipation.js';
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';
+import { availableCampaignParticipationSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';
 import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -30,7 +30,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
 
     it('should convert an AvailableCampaignParticipation model object into JSON API data', function () {
       // when
-      const json = serializer.serialize(campaignParticipation);
+      const json = availableCampaignParticipationSerializer.serialize(campaignParticipation);
 
       // then
       expect(json).to.deep.equal(expectedSerializedCampaignParticipation);

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer_test.js
@@ -1,5 +1,5 @@
 import { CampaignAssessmentParticipationResult } from '../../../../../../../src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipationResult.js';
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer.js';
+import { campaignAssessmentParticipationResultSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer.js';
 import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
@@ -69,7 +69,9 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-result
 
     it('should convert a CampaignAssessmentParticipationResult model object into JSON API data', function () {
       // when
-      const json = serializer.serialize(modelCampaignAssessmentParticipationResult);
+      const json = campaignAssessmentParticipationResultSerializer.serialize(
+        modelCampaignAssessmentParticipationResult,
+      );
 
       // then
       expect(json).to.deep.equal(expectedJsonApi);

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer_test.js
@@ -1,5 +1,5 @@
 import { CampaignAssessmentParticipation } from '../../../../../../../src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipation.js';
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js';
+import { campaignAssessmentParticipationSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js';
 import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { Assessment } from '../../../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../../../test-helper.js';
@@ -93,7 +93,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-serial
 
       it('should convert a CampaignAssessmentParticipation model object into JSON API data', function () {
         // when
-        const json = serializer.serialize(modelCampaignAssessmentParticipation);
+        const json = campaignAssessmentParticipationSerializer.serialize(modelCampaignAssessmentParticipation);
 
         // then
         expect(json).to.deep.equal(expectedJsonApi);
@@ -166,7 +166,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-serial
 
       it('should convert a CampaignAssessmentParticipation model object into JSON API data', function () {
         // when
-        const json = serializer.serialize(modelCampaignAssessmentParticipation);
+        const json = campaignAssessmentParticipationSerializer.serialize(modelCampaignAssessmentParticipation);
 
         // then
         expect(json).to.deep.equal(expectedJsonApi);

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer.js';
+import { campaignParticipationForUserManagementSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -21,7 +21,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-for-user-manageme
       participationForUserManagement.setIsFromCombinedCourse(true);
 
       // when
-      const json = serializer.serialize([participationForUserManagement]);
+      const json = campaignParticipationForUserManagementSerializer.serialize([participationForUserManagement]);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -1,5 +1,5 @@
 import { CampaignParticipationOverview } from '../../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
+import { campaignParticipationOverviewSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
 import {
   CampaignParticipationStatuses,
   CampaignTypes,
@@ -55,7 +55,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
 
     it('should convert a CampaignParticipation model object into JSON API data', function () {
       // when
-      const json = serializer.serialize(campaignParticipationOverview);
+      const json = campaignParticipationOverviewSerializer.serialize(campaignParticipationOverview);
 
       // then
       expect(json).to.deep.equal(expectedSerializedCampaignParticipationOverview);
@@ -76,7 +76,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
       });
 
       // when
-      const json = serializer.serialize(campaignParticipationOverview);
+      const json = campaignParticipationOverviewSerializer.serialize(campaignParticipationOverview);
 
       // then
       expect(json.data.attributes['can-retry']).to.be.true;
@@ -97,7 +97,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
       });
 
       // when
-      const json = serializer.serialize(campaignParticipationOverview);
+      const json = campaignParticipationOverviewSerializer.serialize(campaignParticipationOverview);
 
       // then
       expect(json.data.attributes['can-retry']).to.be.false;

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -1,5 +1,5 @@
 import { CampaignParticipation } from '../../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
+import { campaignParticipationSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
 import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -67,7 +67,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
 
     it('should convert a CampaignParticipation model object into JSON API data', function () {
       // when
-      const json = serializer.serialize(campaignParticipation);
+      const json = campaignParticipationSerializer.serialize(campaignParticipation);
 
       // then
       expect(json).to.deep.equal(expectedSerializedCampaignParticipation);
@@ -96,7 +96,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
       };
 
       // when
-      const campaignParticipation = await serializer.deserialize(jsonAnswer);
+      const campaignParticipation = await campaignParticipationSerializer.deserialize(jsonAnswer);
 
       // then
       expect(campaignParticipation).to.be.instanceOf(CampaignParticipation);

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-profile-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-profile-serializer_test.js
@@ -1,5 +1,5 @@
 import { CampaignProfile } from '../../../../../../../src/prescription/campaign-participation/domain/models/CampaignProfile.js';
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-profile-serializer.js';
+import { campaignProfileSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-profile-serializer.js';
 import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { PlacementProfile } from '../../../../../../../src/shared/domain/models/PlacementProfile.js';
 import { UserCompetence } from '../../../../../../../src/shared/domain/models/UserCompetence.js';
@@ -39,7 +39,7 @@ describe('Unit | Serializer | JSONAPI | campaign-profile-serializer', function (
       });
 
       // when
-      const json = serializer.serialize(campaignProfile);
+      const json = campaignProfileSerializer.serialize(campaignProfile);
 
       // then
       const expectedJsonApi = {

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participant-result-serializer.js';
+import { participantResultSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participant-result-serializer.js';
 import {
   CampaignParticipationStatuses,
   CampaignTypes,
@@ -207,7 +207,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
       };
 
       // when
-      const json = serializer.serialize(assessmentResult);
+      const json = participantResultSerializer.serialize(assessmentResult);
 
       // then
       expect(json).to.deep.equal(expectedSerializedCampaignParticipationResult);

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js';
+import { participationForCampaignManagementSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -17,7 +17,7 @@ describe('Unit | Serializer | JSONAPI | participation-for-campaign-management-se
       });
 
       // when
-      const json = serializer.serialize([participationForCampaignManagement]);
+      const json = participationForCampaignManagementSerializer.serialize([participationForCampaignManagement]);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
 import { SharedProfileForCampaign } from '../../../../../../../src/prescription/campaign-participation/domain/read-models/SharedProfileForCampaign.js';
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js';
+import { sharedProfileForCampaignSerializer } from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -154,7 +154,7 @@ describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer',
       };
 
       // when
-      const json = serializer.serialize(profileSharedForCampaign);
+      const json = sharedProfileForCampaignSerializer.serialize(profileSharedForCampaign);
 
       // then
       expect(json).to.deep.equal(expectedSharedProfileForCampaign);

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer_test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js';
+import { badgeAcquisitionsStatisticsSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js';
 
 describe('Unit | Serializer | JSONAPI | badge-acquisitions-statistics-serializer', function () {
   describe('#serialize', function () {
@@ -8,7 +8,7 @@ describe('Unit | Serializer | JSONAPI | badge-acquisitions-statistics-serializer
       const badge1 = Symbol('badge1');
       const badge2 = Symbol('badge2');
 
-      const json = serializer.serialize({
+      const json = badgeAcquisitionsStatisticsSerializer.serialize({
         campaignId: 1,
         data: [
           { badge: badge1, percentage: 12, count: 1 },

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js';
+import { campaignAssessmentResultMinimalSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -42,7 +42,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-result-minimal-seria
         },
       };
 
-      const resultsSerialized = serializer.serialize({ participations, pagination });
+      const resultsSerialized = campaignAssessmentResultMinimalSerializer.serialize({ participations, pagination });
 
       expect(resultsSerialized).to.deep.equal({
         data: [

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-collective-result-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-collective-result-serializer_test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-collective-result-serializer.js';
+import { campaignCollectiveResultSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-collective-result-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -107,7 +107,7 @@ describe('Unit | Serializer | JSONAPI | campaign-collective-results-serializer',
       };
 
       // when
-      const result = serializer.serialize(campaignCollectiveResult);
+      const result = campaignCollectiveResultSerializer.serialize(campaignCollectiveResult);
 
       // then
       expect(result).to.deep.equal(expectedSerializedResult);

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-management-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-management-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-management-serializer.js';
+import { campaignManagementSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-management-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -9,7 +9,7 @@ describe('Unit | Serializer | JSONAPI | campaign-management-serializer', functio
       const campaignManagement = domainBuilder.buildCampaignManagement();
 
       // when
-      const json = serializer.serialize(campaignManagement);
+      const json = campaignManagementSerializer.serialize(campaignManagement);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer_test.js
@@ -1,5 +1,5 @@
 import { CampaignParticipantActivity } from '../../../../../../../src/prescription/campaign/domain/read-models/CampaignParticipantActivity.js';
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js';
+import { campaignParticipantActivitySerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js';
 import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -36,7 +36,10 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
         },
       };
 
-      const resultsSerialized = serializer.serialize({ campaignParticipantsActivities, pagination });
+      const resultsSerialized = campaignParticipantActivitySerializer.serialize({
+        campaignParticipantsActivities,
+        pagination,
+      });
 
       expect(resultsSerialized).to.deep.equal({
         data: [

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer_test.js
@@ -1,10 +1,10 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js';
+import { campaignParticipationsCountByStageSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | campaign-participations-count-by-stage-serializer', function () {
   describe('#serialize', function () {
     it('should convert a participations count by stage model object into JSON API data', function () {
-      const json = serializer.serialize({
+      const json = campaignParticipationsCountByStageSerializer.serialize({
         campaignId: 1,
         data: [
           { id: 'stage1', value: 0, title: 'title1', description: 'description1' },

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer_test.js
@@ -1,10 +1,10 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer.js';
+import { campaignParticipationsCountsByDaySerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | campaign-participations-counts-by-day-serializer', function () {
   describe('#serialize', function () {
     it('should convert a participations count by day object into JSON API data', function () {
-      const json = serializer.serialize({
+      const json = campaignParticipationsCountsByDaySerializer.serialize({
         campaignId: 1,
         startedParticipations: [{ day: '2021-06-01', count: 1 }],
         sharedParticipations: [{ day: '2021-06-01', count: 1 }],

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer_test.js
@@ -1,10 +1,10 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js';
+import { campaignParticipationsCountsByStatusSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | campaign-participations-counts-by-status-serializer', function () {
   describe('#serialize', function () {
     it('should convert a participations count by stage model object into JSON API data', function () {
-      const json = serializer.serialize({
+      const json = campaignParticipationsCountsByStatusSerializer.serialize({
         campaignId: 1,
         started: 1,
         shared: 1,

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer_test.js
@@ -1,5 +1,5 @@
 import { CampaignProfilesCollectionParticipationSummary } from '../../../../../../../src/prescription/campaign/domain/read-models/CampaignProfilesCollectionParticipationSummary.js';
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer.js';
+import { campaignProfilesCollectionParticipationSummarySerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | campaign-profiles-collection-participation-summary-serializer', function () {
@@ -39,7 +39,10 @@ describe('Unit | Serializer | JSONAPI | campaign-profiles-collection-participati
       };
 
       // when
-      const result = serializer.serialize({ data: participationSummary, pagination: meta });
+      const result = campaignProfilesCollectionParticipationSummarySerializer.serialize({
+        data: participationSummary,
+        pagination: meta,
+      });
 
       // then
       expect(result).to.deep.equal(expectedSerializedResult);

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js';
+import { campaignReportSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -47,7 +47,7 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
       });
 
       // when
-      const json = serializer.serialize(report);
+      const json = campaignReportSerializer.serialize(report);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
+import { campaignResultLevelsPerTubesAndCompetencesSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-competences-serializer', function () {
@@ -8,7 +8,7 @@ describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-com
     it('should convert CampaignResultLevelPerTubesAndCompetences acquisitions statistics into JSON API data', function () {
       const campaignId = 1;
       const model = domainBuilder.prescription.campaign.buildCampaignResultLevelsPerTubesAndCompetences();
-      const json = serializer.serialize(model);
+      const json = campaignResultLevelsPerTubesAndCompetencesSerializer.serialize(model);
 
       expect(json).to.deep.equal({
         data: {
@@ -69,7 +69,7 @@ describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-com
 
     it('should serialize with correct type in case of campaign participation', function () {
       const model = domainBuilder.prescription.campaign.buildCampaignResultLevelsPerTubesAndCompetences();
-      const json = serializer.serialize(model, true);
+      const json = campaignResultLevelsPerTubesAndCompetencesSerializer.serialize(model, true);
       expect(json.data.type).to.equal('campaign-participation-levels-per-tubes-and-competences');
     });
   });

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
@@ -1,4 +1,4 @@
-import * as campaignToJoinSerializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js';
+import { campaignToJoinSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js';
 import { CampaignExternalIdTypes } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/division-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/division-serializer_test.js
@@ -1,11 +1,11 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/division-serializer.js';
+import { divisionSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/division-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | division-serializer', function () {
   describe('#serialize', function () {
     it('serializes all division', function () {
       // when
-      const json = serializer.serialize([{ name: '6eme' }, { name: '3eme' }]);
+      const json = divisionSerializer.serialize([{ name: '6eme' }, { name: '3eme' }]);
       // then
       expect(json).to.deep.equal({
         data: [

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/group-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/group-serializer_test.js
@@ -1,11 +1,11 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/group-serializer.js';
+import { groupSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/group-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | group-serializer', function () {
   describe('#serialize', function () {
     it('serializes all groups', function () {
       // when
-      const json = serializer.serialize([{ name: 'LB6' }, { name: 'AB3' }]);
+      const json = groupSerializer.serialize([{ name: 'LB6' }, { name: 'AB3' }]);
       // then
       expect(json).to.deep.equal({
         data: [

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate_test.js
@@ -1,10 +1,10 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate.js';
+import { participationsCountByMasteryRateSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | participations-count-by-mastery-rate', function () {
   describe('#serialize', function () {
     it('should convert a campaign result distribution object into JSON API data', function () {
-      const json = serializer.serialize({
+      const json = participationsCountByMasteryRateSerializer.serialize({
         campaignId: 1,
         resultDistribution: [
           { count: 1, masteryRate: '0.50' },

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/presentation-steps-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/presentation-steps-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/presentation-steps-serializer.js';
+import { presentationStepsSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/presentation-steps-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -29,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | Campaign Presentation Steps Serializer',
       const presentationSteps = { customLandingPageText, competences, badges };
 
       // when
-      const json = serializer.serialize(presentationSteps);
+      const json = presentationStepsSerializer.serialize(presentationSteps);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/target-profile-serializer.js';
+import { targetProfileSerializer } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/target-profile-serializer.js';
 import { TargetProfile } from '../../../../../../../src/shared/domain/models/TargetProfile.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -24,7 +24,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       };
 
       // when
-      const serializedTargetProfile = serializer.serialize(targetProfile);
+      const serializedTargetProfile = targetProfileSerializer.serialize(targetProfile);
 
       // then
       return expect(serializedTargetProfile).to.deep.equal(expectedTargetProfile);

--- a/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-import-detail-serializer_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-import-detail-serializer_test.js
@@ -1,6 +1,6 @@
 import { IMPORT_STATUSES } from '../../../../../../../src/prescription/learner-management/domain/constants.js';
 import { OrganizationImportDetail } from '../../../../../../../src/prescription/learner-management/domain/read-models/OrganizationImportDetail.js';
-import { serialize } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-detail-serializer.js';
+import { organizationImportDetailSerializer } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-detail-serializer.js';
 import { CsvImportError } from '../../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -20,7 +20,7 @@ describe('Unit | Serializer | JSONAPI | organization-import-detail-serializer', 
         updatedAt,
         createdAt,
       });
-      expect(serialize(organizationImport)).to.eql({
+      expect(organizationImportDetailSerializer.serialize(organizationImport)).to.eql({
         data: {
           id: '1',
           type: 'organization-import-details',

--- a/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer_test.js
@@ -1,5 +1,5 @@
 import { OrganizationLearnerImportFormat } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js';
-import { serialize } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js';
+import { organizationLearnerImportFormatSerializer } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-learner-import-format-serializer', function () {
@@ -40,7 +40,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-import-format-seria
         createdAt,
       });
 
-      expect(serialize(organizationImport)).deep.equal({
+      expect(organizationLearnerImportFormatSerializer.serialize(organizationImport)).deep.equal({
         data: {
           type: 'organization-learner-import-formats',
           id: '123',

--- a/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/sco-organization-learner-serializer_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/sco-organization-learner-serializer_test.js
@@ -1,5 +1,5 @@
 import { OrganizationLearner } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationLearner.js';
-import * as serializer from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
+import { scoOrganizationLearnerSerializer } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', function () {
@@ -26,7 +26,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
       };
 
       // when
-      const json = serializer.serializeIdentity(organizationLearner);
+      const json = scoOrganizationLearnerSerializer.serializeIdentity(organizationLearner);
 
       // then
       expect(json).to.deep.equal(expectedSerializedOrganizationLearner);
@@ -57,7 +57,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
       };
 
       // when
-      const json = serializer.serializeWithUsernameGeneration(organizationLearner);
+      const json = scoOrganizationLearnerSerializer.serializeWithUsernameGeneration(organizationLearner);
 
       // then
       expect(json).to.deep.equal(expectedSerializedOrganizationLearner);
@@ -82,7 +82,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
       };
 
       // when
-      const json = serializer.serializeExternal(organizationLearner);
+      const json = scoOrganizationLearnerSerializer.serializeExternal(organizationLearner);
 
       // then
       expect(json).to.deep.equal(expectedSerializedOrganizationLearner);
@@ -110,7 +110,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
       };
 
       // when
-      const json = serializer.serializeCredentialsForDependent(organizationLearner);
+      const json = scoOrganizationLearnerSerializer.serializeCredentialsForDependent(organizationLearner);
 
       // then
       expect(json).to.deep.equal(expectedSerializedOrganizationLearner);

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
+import { analysisByTubesSerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | analysis-by-tubes-serializer', function () {
@@ -34,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | analysis-by-tubes-serializer', function 
       ];
 
       // when
-      const json = serializer.serialize(analysisByTubes);
+      const json = analysisByTubesSerializer.serialize(analysisByTubes);
 
       // then
       expect(json.data.type).to.equal(expectedType);

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/attestation-participants-status-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/attestation-participants-status-serializer_test.js
@@ -1,5 +1,5 @@
 import { AttestationParticipantStatus } from '../../../../../../../src/prescription/organization-learner/domain/read-models/AttestationParticipantStatus.js';
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js';
+import { attestationParticipantsStatusSerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | attestation-participants-status-serializer', function () {
@@ -41,7 +41,7 @@ describe('Unit | Serializer | JSONAPI | attestation-participants-status-serializ
       };
 
       // when
-      const json = serializer.serialize({ attestationParticipantsStatus, pagination });
+      const json = attestationParticipantsStatusSerializer.serialize({ attestationParticipantsStatus, pagination });
 
       // then
       expect(json).to.deep.equal(expectedData);

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
@@ -1,6 +1,6 @@
 import { OrganizationLearnerActivity } from '../../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerActivity.js';
 import { OrganizationLearnerParticipation } from '../../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerParticipation.js';
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js';
+import { organizationLearnerActivitySerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js';
 import { CampaignTypes } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -49,7 +49,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
         ],
       });
       // when
-      const json = serializer.serialize(organizationLearnerActivity);
+      const json = organizationLearnerActivitySerializer.serialize(organizationLearnerActivity);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-identity-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-identity-serializer_test.js
@@ -1,5 +1,5 @@
 import { OrganizationLearner } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationLearner.js';
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-identity-serializer.js';
+import { organizationLearnerIdentitySerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-identity-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-learner-identity-serializer', function () {
@@ -24,7 +24,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-identity-serializer
       };
 
       // when
-      const json = serializer.serialize(organizationLearner);
+      const json = organizationLearnerIdentitySerializer.serialize(organizationLearner);
 
       // then
       expect(json).to.deep.equal(expectedSerializedOrganizationLearner);

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-serializer_test.js
@@ -1,5 +1,5 @@
 import { OrganizationLearner } from '../../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearner.js';
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-serializer.js';
+import { organizationLearnerSerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-learner-serializer', function () {
@@ -38,7 +38,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-serializer', functi
       };
 
       // when
-      const json = serializer.serialize(organizationLearner);
+      const json = organizationLearnerSerializer.serialize(organizationLearner);
 
       // then
       expect(json).to.deep.equal(expectedSerializedOrganizationLearner);

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-participants-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-participants-serializer_test.js
@@ -1,5 +1,5 @@
 import { OrganizationParticipant } from '../../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationParticipant.js';
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-participants-serializer.js';
+import { organizationParticipantsSerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-participants-serializer.js';
 import { CampaignParticipationStatuses as campaignParticipationsStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -79,7 +79,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
       };
 
       // when
-      const json = serializer.serialize({ organizationParticipants, meta });
+      const json = organizationParticipantsSerializer.serialize({ organizationParticipants, meta });
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-to-join-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-to-join-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organizations-to-join-serializer.js';
+import { organizationsToJoinSerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organizations-to-join-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -9,7 +9,7 @@ describe('Unit | Serializer | JSONAPI | organization-to-join-serializer', functi
         identityProvider: 'GAR',
       });
 
-      const json = serializer.serialize(organizationToJoin);
+      const json = organizationsToJoinSerializer.serialize(organizationToJoin);
 
       expect(json).to.deep.equal({
         data: {

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/sco-organization-participants-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/sco-organization-participants-serializer_test.js
@@ -1,5 +1,5 @@
 import { ScoOrganizationParticipant } from '../../../../../../../src/prescription/organization-learner/domain/read-models/ScoOrganizationParticipant.js';
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/sco-organization-participants-serializer.js';
+import { scoOrganizationParticipantsSerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/sco-organization-participants-serializer.js';
 import { CampaignParticipationStatuses as campaignParticipationsStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -106,7 +106,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
       };
 
       // when
-      const json = serializer.serialize({ scoOrganizationParticipants, meta });
+      const json = scoOrganizationParticipantsSerializer.serialize({ scoOrganizationParticipants, meta });
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/sup-organization-participants-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/sup-organization-participants-serializer_test.js
@@ -1,5 +1,5 @@
 import { SupOrganizationParticipant } from '../../../../../../../src/prescription/organization-learner/domain/read-models/SupOrganizationParticipant.js';
-import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/sup-organization-participants-serializer.js';
+import { supOrganizationParticipantsSerializer } from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/sup-organization-participants-serializer.js';
 import { CampaignParticipationStatuses as campaignParticipationsStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -86,7 +86,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
       };
 
       // when
-      const json = serializer.serialize({ supOrganizationParticipants, meta });
+      const json = supOrganizationParticipantsSerializer.serialize({ supOrganizationParticipants, meta });
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-lot-managment-serializer_test.js
+++ b/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-lot-managment-serializer_test.js
@@ -1,7 +1,7 @@
 import { FREE_RATE } from '../../../../../../../src/prescription/organization-place/domain/constants/organization-places-categories.js';
 import * as organizationPlacesLotCategories from '../../../../../../../src/prescription/organization-place/domain/constants/organization-places-categories.js';
 import { OrganizationPlacesLotManagement } from '../../../../../../../src/prescription/organization-place/domain/read-models/OrganizationPlacesLotManagement.js';
-import * as organizationPlacesLotManagementSerializer from '../../../../../../../src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-lot-management-serializer.js';
+import { organizationPlacesLotManagementSerializer } from '../../../../../../../src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-lot-management-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 

--- a/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-lots-serializer_test.js
+++ b/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-lots-serializer_test.js
@@ -1,4 +1,4 @@
-import * as organizationPlacesLotsSerializer from '../../../../../../../src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-lots-serializer.js';
+import { organizationPlacesLotsSerializer } from '../../../../../../../src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-lots-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-places-lot-management-serializer', function () {

--- a/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-statistics-serializer_test.js
+++ b/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-statistics-serializer_test.js
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 
 import { PlacesLot } from '../../../../../../../src/prescription/organization-place/domain/read-models/PlacesLot.js';
 import { PlaceStatistics } from '../../../../../../../src/prescription/organization-place/domain/read-models/PlaceStatistics.js';
-import * as organizationPlaceStatisticsSerializer from '../../../../../../../src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js';
+import { organizationPlacesStatisticsSerializer } from '../../../../../../../src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-places-statistics-serializer', function () {
@@ -38,7 +38,7 @@ describe('Unit | Serializer | JSONAPI | organization-places-statistics-serialize
       };
 
       // when
-      const json = organizationPlaceStatisticsSerializer.serialize(placeStatistics);
+      const json = organizationPlacesStatisticsSerializer.serialize(placeStatistics);
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/framework-wth-skills-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/framework-wth-skills-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/framework-with-skills-serializer.js';
+import { frameworkWithSkillsSerializer } from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/framework-with-skills-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | framework', function () {
@@ -324,7 +324,7 @@ describe('Unit | Serializer | JSONAPI | framework', function () {
       };
 
       // when
-      const serializedFramework = serializer.serialize(frameworks);
+      const serializedFramework = frameworkWithSkillsSerializer.serialize(frameworks);
 
       // then
       return expect(serializedFramework).to.deep.equal(expectedResult);

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer_test.js
@@ -1,10 +1,10 @@
-import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js';
+import { targetProfileAttachOrganizationSerializer } from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | target-profile-attach-organization-serializer', function () {
   describe('#serialize', function () {
     it('should convert a target profile attach organization object to JSON API data', function () {
-      const json = serializer.serialize({
+      const json = targetProfileAttachOrganizationSerializer.serialize({
         targetProfileId: 1,
         attachedIds: [1, 5],
         duplicatedIds: [8, 9],

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-detach-organizations-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-detach-organizations-serializer_test.js
@@ -1,10 +1,10 @@
-import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-detach-organizations-serializer.js';
+import { targetProfileDetachOrganizationsSerializer } from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-detach-organizations-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | target-profile-detach-organizations-serializer', function () {
   describe('#serialize', function () {
     it('should convert a target profile detach organizations object to JSON API data', function () {
-      const json = serializer.serialize({
+      const json = targetProfileDetachOrganizationsSerializer.serialize({
         targetProfileId: 1,
         detachedOrganizationIds: [1, 5],
       });

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -1,5 +1,5 @@
 import { TargetProfileForAdmin } from '../../../../../../../src/prescription/target-profile/domain/models/TargetProfileForAdmin.js';
-import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js';
+import { targetProfileForAdminSerializer } from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -573,7 +573,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
       };
 
       // when
-      const serializedTargetProfile = serializer.serialize({ targetProfile, filter: null });
+      const serializedTargetProfile = targetProfileForAdminSerializer.serialize({ targetProfile, filter: null });
 
       // then
       expect(serializedTargetProfile).to.deep.equal(expectedSerializedTargetProfile);
@@ -629,7 +629,10 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
         };
 
         // when
-        const serializedTargetProfile = serializer.serialize({ targetProfile, filter: { badges: 'certifiable' } });
+        const serializedTargetProfile = targetProfileForAdminSerializer.serialize({
+          targetProfile,
+          filter: { badges: 'certifiable' },
+        });
 
         // then
         expect(serializedTargetProfile).to.deep.equal(expectedSerializedTargetProfile);

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer_test.js
@@ -1,5 +1,5 @@
 import { TargetProfileForSpecifier } from '../../../../../../../src/prescription/target-profile/domain/read-models/TargetProfileForSpecifier.js';
-import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js';
+import { targetProfileForSpecifierSerializer } from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer', function () {
@@ -37,7 +37,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer'
         meta,
       };
 
-      const serializedTargetProfile = serializer.serialize(targetProfile, meta);
+      const serializedTargetProfile = targetProfileForSpecifierSerializer.serialize(targetProfile, meta);
 
       return expect(serializedTargetProfile).to.deep.equal(expectedTargetProfile);
     });

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-overview-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-overview-serializer_test.js
@@ -1,5 +1,5 @@
 import { TargetProfileOverview } from '../../../../../../../src/prescription/target-profile/domain/models/TargetProfileOverview.js';
-import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-overview-serializer.js';
+import { targetProfileOverviewSerializer } from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-overview-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 import { buildThematic } from '../../../../../../tooling/domain-builder/factory/build-thematic.js';
@@ -69,7 +69,7 @@ describe('Unit | Serializer | JSONAPI | targetProfileOverview', function () {
       });
 
       // when
-      const serializedTargetProfile = serializer.serialize(
+      const serializedTargetProfile = targetProfileOverviewSerializer.serialize(
         new TargetProfileOverview({ ...targetProfile, frameworks: [framework] }),
       );
 

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-serializer.js';
+import { targetProfileSerializer } from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-serializer.js';
 import { TargetProfile } from '../../../../../../../src/shared/domain/models/TargetProfile.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -29,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       };
 
       // when
-      const serializedTargetProfile = serializer.serialize(targetProfile, meta);
+      const serializedTargetProfile = targetProfileSerializer.serialize(targetProfile, meta);
 
       // then
       return expect(serializedTargetProfile).to.deep.equal(expectedTargetProfile);
@@ -39,7 +39,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
   describe('#serializeId', function () {
     it('should return a serialized target profile to JSONAPI with only ID filled', function () {
       // when
-      const serializedTargetProfile = serializer.serializeId(123);
+      const serializedTargetProfile = targetProfileSerializer.serializeId(123);
 
       // then
       const expectedTargetProfileSerialized = {
@@ -73,7 +73,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       };
 
       // when
-      const deserializedTargetProfileCreationCommand = serializer.deserialize(json);
+      const deserializedTargetProfileCreationCommand = targetProfileSerializer.deserialize(json);
 
       // then
       const expectedTargetProfileCreationCommand = {

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js';
+import { targetProfileSummaryForAdminSerializer } from '../../../../../../../src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -26,7 +26,10 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       const meta = { page: 1, pageSize: 3, pageCount: 1, rowCount: 2 };
 
       // when
-      const serializedTargetProfileSummaries = serializer.serialize(targetProfileSummaries, meta);
+      const serializedTargetProfileSummaries = targetProfileSummaryForAdminSerializer.serialize(
+        targetProfileSummaries,
+        meta,
+      );
 
       // then
       expect(serializedTargetProfileSummaries).to.deep.equal({

--- a/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-detail-serializer_test.js
+++ b/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-detail-serializer_test.js
@@ -1,12 +1,12 @@
 import { AttestationDetail } from '../../../../../../src/profile/domain/models/AttestationDetail.js';
-import * as serializer from '../../../../../../src/profile/infrastructure/serializers/jsonapi/attestation-detail-serializer.js';
+import { attestationDetailSerializer } from '../../../../../../src/profile/infrastructure/serializers/jsonapi/attestation-detail-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | attestation-detail', function () {
   describe('#serialize()', function () {
     it('should convert a scorecard object into JSON API data', function () {
       // when
-      const json = serializer.serialize([
+      const json = attestationDetailSerializer.serialize([
         new AttestationDetail({ id: 45, type: 'POUET', obtainedAt: new Date('2020-01-05') }),
         new AttestationDetail({ id: 46, type: 'CACAHUETE', obtainedAt: new Date('2022-01-05') }),
       ]);

--- a/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-serializer_test.js
+++ b/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-serializer_test.js
@@ -1,12 +1,12 @@
 import { Attestation } from '../../../../../../src/profile/domain/models/Attestation.js';
-import * as serializer from '../../../../../../src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js';
+import { attestationSerializer } from '../../../../../../src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Profile | Unit | Serializer | JSONAPI | attestation', function () {
   describe('#serialize()', function () {
     it('should convert attestation objects into JSON API data', function () {
       // when
-      const json = serializer.serialize([
+      const json = attestationSerializer.serialize([
         new Attestation({ id: 1, key: 'PARENTHOOD', templateName: 'template-parenthood', label: 'Parentalité' }),
         new Attestation({ id: 2, key: 'SIXTH_GRADE', templateName: 'template-sixth-grade', label: '6ème' }),
       ]);

--- a/api/tests/profile/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
+++ b/api/tests/profile/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/profile/infrastructure/serializers/jsonapi/profile-serializer.js';
+import { profileSerializer } from '../../../../../../src/profile/infrastructure/serializers/jsonapi/profile-serializer.js';
 import { MAX_REACHABLE_LEVEL } from '../../../../../../src/shared/domain/constants.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -152,7 +152,7 @@ describe('Unit | Serializer | JSONAPI | profile', function () {
       };
 
       // when
-      const json = serializer.serialize(profile);
+      const json = profileSerializer.serialize(profile);
 
       // then
       expect(json).to.deep.equal(expectedSerializedProfile);

--- a/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-details-serializer_test.js
@@ -1,7 +1,7 @@
 import { COMBINED_COURSE_ITEM_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { AdminCombinedCourseBlueprintDetails } from '../../../../../src/quest/domain/models/combined-course-blueprints/value-objects/AdminCombinedCourseBlueprintDetails.js';
 import { Quest } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
-import * as adminCombinedCourseBlueprintDetailsSerializer from '../../../../../src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js';
+import { adminCombinedCourseBlueprintDetailsSerializer } from '../../../../../src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-blueprint-details', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-for-creation-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-for-creation-serializer_test.js
@@ -8,7 +8,7 @@ import {
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
-import * as combinedCourseBlueprintForCreationSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js';
+import { combinedCourseBlueprintForCreationSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-for-creation-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-blueprint', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-for-update-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-for-update-serializer_test.js
@@ -1,5 +1,5 @@
 import { CombinedCourseBlueprintForUpdate } from '../../../../../src/quest/domain/models/combined-course-blueprints/value-objects/CombinedCourseBlueprintForUpdate.js';
-import * as combinedCourseforUpdateSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-for-update-serializer.js';
+import { combinedCourseBlueprintForUpdateSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-for-update-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | combined-course-for-update', function () {
@@ -30,7 +30,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-for-upda
     };
 
     // when
-    const deserialized = await combinedCourseforUpdateSerializer.deserialize(payload);
+    const deserialized = await combinedCourseBlueprintForUpdateSerializer.deserialize(payload);
 
     // then
     expect(deserialized).to.be.instanceOf(CombinedCourseBlueprintForUpdate);

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-overview-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-overview-serializer_test.js
@@ -1,6 +1,6 @@
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
 import { Quest } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
-import * as combinedCourseBlueprintOverviewSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js';
+import { combinedCourseBlueprintOverviewSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-overview-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprint-overview', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
@@ -1,6 +1,6 @@
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
 import { Quest } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
-import * as combinedCourseBlueprintSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js';
+import { combinedCourseBlueprintSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprint', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
@@ -1,4 +1,4 @@
-import * as combinedCourseDetailsSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-details-serializer.js';
+import { combinedCourseDetailsSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-details-serializer.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-for-creation-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-for-creation-serializer_test.js
@@ -1,4 +1,4 @@
-import * as combinedCourseforCreationSerialzer from '../../../../../src/quest/infrastructure/serializers/combined-course-for-creation-serializer.js';
+import { combinedCourseForCreationSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-for-creation-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | combined-course-for-creation', function () {
@@ -25,7 +25,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-for-crea
     };
 
     // when
-    const deserialized = await combinedCourseforCreationSerialzer.deserialize(payload);
+    const deserialized = await combinedCourseForCreationSerializer.deserialize(payload);
 
     // then
     expect(deserialized).deep.equal({

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-list-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-list-serializer_test.js
@@ -1,7 +1,7 @@
 import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseParticipation } from '../../../../../src/quest/domain/models/combined-course-participations/entities/CombinedCourseParticipation.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/combined-courses/entities/CombinedCourse.js';
-import * as combinedCourseListSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-list-serializer.js';
+import { combinedCourseListSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-list-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | combined-course-list', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-detail-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-detail-serializer_test.js
@@ -1,7 +1,7 @@
 import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { OrganizationLearnerParticipationStatuses } from '../../../../../src/quest/domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
 import { COMBINED_COURSE_ITEM_TYPES } from '../../../../../src/quest/domain/models/combined-course-participations/value-objects/CombinedCourseItem.js';
-import { serialize } from '../../../../../src/quest/infrastructure/serializers/combined-course-participation-detail-serializer.js';
+import { combinedCourseParticipationDetailSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-participation-detail-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('CombinedCourseParticipationSerializer', function () {
@@ -44,7 +44,7 @@ describe('CombinedCourseParticipationSerializer', function () {
       ],
     };
 
-    const serialized = serialize(combinedCourseDetails);
+    const serialized = combinedCourseParticipationDetailSerializer.serialize(combinedCourseDetails);
 
     expect(serialized).deep.equal({
       data: {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-serializer_test.js
@@ -1,6 +1,6 @@
 import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseParticipationDetails } from '../../../../../src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseParticipationDetails.js';
-import { serialize } from '../../../../../src/quest/infrastructure/serializers/combined-course-participation-serializer.js';
+import { combinedCourseParticipationSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-participation-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('CombinedCourseParticipationSerializer', function () {
@@ -21,7 +21,7 @@ describe('CombinedCourseParticipationSerializer', function () {
       nbCampaignsCompleted: 1,
     });
 
-    const serialized = serialize(combinedCourseParticipation);
+    const serialized = combinedCourseParticipationSerializer.serialize(combinedCourseParticipation);
 
     expect(serialized).to.deep.equal({
       data: {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -4,7 +4,7 @@ import { CombinedCourseStatuses } from '../../../../../src/prescription/shared/d
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourseRewardStatuses } from '../../../../../src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseReward.js';
 import { COMBINED_COURSE_ITEM_TYPES } from '../../../../../src/quest/domain/models/combined-course-participations/value-objects/CombinedCourseItem.js';
-import * as combinedCourseSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-serializer.js';
+import { combinedCourseSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-serializer.js';
 import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-statistics-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-statistics-serializer_test.js
@@ -1,5 +1,5 @@
 import { CombinedCourseStatistics } from '../../../../../src/quest/domain/models/combined-courses/value-objects/CombinedCourseStatistics.js';
-import { serialize } from '../../../../../src/quest/infrastructure/serializers/combined-course-statistics-serializer.js';
+import { combinedCourseStatisticsSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-statistics-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('CombinedCourseStatisticsSerializer', function () {
@@ -10,7 +10,7 @@ describe('CombinedCourseStatisticsSerializer', function () {
       completedParticipationsCount: 1,
     });
 
-    const serialized = serialize(combinedCourseStatistics);
+    const serialized = combinedCourseStatisticsSerializer.serialize(combinedCourseStatistics);
 
     expect(serialized).to.deep.equal({
       data: {

--- a/api/tests/quest/unit/infrastructure/serializers/course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/course-serializer_test.js
@@ -2,7 +2,7 @@ import {
   COURSE_ITEM_TYPES,
   CourseItem,
 } from '../../../../../src/quest/domain/models/combined-courses/value-objects/CourseItem.js';
-import * as courseSerializer from '../../../../../src/quest/infrastructure/serializers/course-serializer.js';
+import { courseSerializer } from '../../../../../src/quest/infrastructure/serializers/course-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | course', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/quest-result-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/quest-result-serializer_test.js
@@ -1,6 +1,6 @@
 import { Attestation } from '../../../../../src/profile/domain/models/Attestation.js';
 import { QuestResult } from '../../../../../src/quest/domain/models/quests/value-objects/QuestResult.js';
-import * as questResultSerializer from '../../../../../src/quest/infrastructure/serializers/quest-result-serializer.js';
+import { questResultSerializer } from '../../../../../src/quest/infrastructure/serializers/quest-result-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | quest-result', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/verified-code-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/verified-code-serializer_test.js
@@ -1,5 +1,5 @@
 import { VerifiedCode } from '../../../../../src/quest/domain/models/prescription/value-objects/VerifiedCode.js';
-import * as verifiedCodeSerializer from '../../../../../src/quest/infrastructure/serializers/verified-code-serializer.js';
+import { verifiedCodeSerializer } from '../../../../../src/quest/infrastructure/serializers/verified-code-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | verified-code', function () {

--- a/api/tests/school/unit/infrastructure/serializers/activity-answer-serializer_test.js
+++ b/api/tests/school/unit/infrastructure/serializers/activity-answer-serializer_test.js
@@ -1,5 +1,5 @@
 import { ActivityAnswer } from '../../../../../src/school/domain/models/ActivityAnswer.js';
-import * as serializer from '../../../../../src/school/infrastructure/serializers/activity-answer-serializer.js';
+import { activityAnswerSerializer } from '../../../../../src/school/infrastructure/serializers/activity-answer-serializer.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
@@ -44,7 +44,7 @@ describe('Unit | Serializer | JSONAPI | activity-answer-serializer', function ()
       };
 
       // when
-      const json = serializer.serialize(answer);
+      const json = activityAnswerSerializer.serialize(answer);
 
       // then
       expect(json).to.deep.equal(expectedJSON);
@@ -57,7 +57,7 @@ describe('Unit | Serializer | JSONAPI | activity-answer-serializer', function ()
       const challengeId = 'recChallengeId';
 
       // when
-      const { activityAnswer, assessmentId, isPreview } = serializer.deserialize({
+      const { activityAnswer, assessmentId, isPreview } = activityAnswerSerializer.deserialize({
         data: {
           type: 'activity-answers',
           attributes: {

--- a/api/tests/school/unit/infrastructure/serializers/activity-serializer_test.js
+++ b/api/tests/school/unit/infrastructure/serializers/activity-serializer_test.js
@@ -1,5 +1,5 @@
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
-import * as serializer from '../../../../../src/school/infrastructure/serializers/activity-serializer.js';
+import { activitySerializer } from '../../../../../src/school/infrastructure/serializers/activity-serializer.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
@@ -26,7 +26,7 @@ describe('Unit | Serializer | JSONAPI | activity-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(activity);
+      const json = activitySerializer.serialize(activity);
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/school/unit/infrastructure/serializers/challenge-serializer_test.js
+++ b/api/tests/school/unit/infrastructure/serializers/challenge-serializer_test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import * as serializer from '../../../../../src/school/infrastructure/serializers/challenge-serializer.js';
+import { challengeSerializer } from '../../../../../src/school/infrastructure/serializers/challenge-serializer.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | Serializer | challenge-serializer', function () {
@@ -35,7 +35,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
       });
 
       // when
-      const json = serializer.serialize(challenge);
+      const json = challengeSerializer.serialize(challenge);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/school/unit/infrastructure/serializers/organization-learner_test.js
+++ b/api/tests/school/unit/infrastructure/serializers/organization-learner_test.js
@@ -1,5 +1,5 @@
 import { OrganizationLearner } from '../../../../../src/school/domain/models/OrganizationLearner.js';
-import * as serializer from '../../../../../src/school/infrastructure/serializers/organization-learner.js';
+import { organizationLearnerSerializer } from '../../../../../src/school/infrastructure/serializers/organization-learner.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-learner', function () {
@@ -31,7 +31,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner', function () {
       };
 
       // when
-      const json = serializer.serialize(organizationLearner);
+      const json = organizationLearnerSerializer.serialize(organizationLearner);
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -4,7 +4,7 @@ import { Assessment } from '../../../../../../src/shared/domain/models/Assessmen
 import { CampaignAssessment } from '../../../../../../src/shared/domain/read-models/CampaignAssessment.js';
 import { CertificationAssessment } from '../../../../../../src/shared/domain/read-models/CertificationAssessment.js';
 import { CompetenceEvaluationAssessment } from '../../../../../../src/shared/domain/read-models/CompetenceEvaluationAssessment.js';
-import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js';
+import { assessmentSerializer } from '../../../../../../src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
@@ -131,7 +131,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(certificationAssessment);
+      const json = assessmentSerializer.serialize(certificationAssessment);
 
       // then
       expect(json).to.deep.equal(expectedJson);
@@ -156,7 +156,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(competenceEvaluationAssessment);
+      const json = assessmentSerializer.serialize(competenceEvaluationAssessment);
 
       // then
       expect(json.data.relationships['progression']).to.deep.equal(expectedProgressionJson);
@@ -224,7 +224,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(campaignAssessment);
+      const json = assessmentSerializer.serialize(campaignAssessment);
 
       // then
       expect(json.data).to.deep.equal(expectedJson);
@@ -288,7 +288,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(campaignAssessment);
+      const json = assessmentSerializer.serialize(campaignAssessment);
 
       // then
       expect(json.data).to.deep.equal(expectedJson);
@@ -322,7 +322,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
         jsonAssessment.data.attributes.type = Assessment.types.PREVIEW;
 
         // when
-        const assessment = serializer.deserialize(jsonAssessment);
+        const assessment = assessmentSerializer.deserialize(jsonAssessment);
 
         // then
         expect(assessment).to.be.instanceOf(Assessment);
@@ -339,7 +339,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
         jsonAssessment.data.attributes.type = Assessment.types.DEMO;
 
         // when
-        const assessment = serializer.deserialize(jsonAssessment);
+        const assessment = assessmentSerializer.deserialize(jsonAssessment);
 
         // then
         expect(assessment).to.be.instanceOf(Assessment);
@@ -368,7 +368,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
         jsonAssessment.data.attributes.type = campaignType;
 
         // when
-        const error = catchErrSync(serializer.deserialize)(jsonAssessment);
+        const error = catchErrSync(assessmentSerializer.deserialize)(jsonAssessment);
 
         // then
         expect(error).to.be.instanceOf(DomainError);

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -1,5 +1,5 @@
 import { Challenge } from '../../../../../../src/shared/domain/models/Challenge.js';
-import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/challenge-serializer.js';
+import { challengeSerializer } from '../../../../../../src/shared/infrastructure/serializers/jsonapi/challenge-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
@@ -34,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
       });
 
       // when
-      const json = serializer.serialize(challenge);
+      const json = challengeSerializer.serialize(challenge);
 
       // then
       expect(json).to.deep.equal({
@@ -73,7 +73,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
         challenge.competenceId = 'competence_id';
 
         // when
-        const json = serializer.serialize(challenge);
+        const json = challengeSerializer.serialize(challenge);
 
         // then
         expect(json).to.deep.equal({
@@ -93,7 +93,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
         challenge.id = 1;
 
         // when
-        const json = serializer.serialize(challenge);
+        const json = challengeSerializer.serialize(challenge);
 
         // then
         expect(json).to.deep.equal({

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/country-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/country-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/country-serializer.js';
+import { countrySerializer } from '../../../../../../src/shared/infrastructure/serializers/jsonapi/country-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -18,7 +18,7 @@ describe('Unit | Shared | Serializers | country-serializer', function () {
       ];
 
       // when
-      const json = serializer.serialize(countries);
+      const json = countrySerializer.serialize(countries);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
@@ -1,5 +1,5 @@
 import { Course } from '../../../../../../src/evaluation/domain/models/Course.js';
-import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/course-serializer.js';
+import { courseSerializer } from '../../../../../../src/shared/infrastructure/serializers/jsonapi/course-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | course-serializer', function () {
@@ -13,7 +13,7 @@ describe('Unit | Serializer | JSONAPI | course-serializer', function () {
       });
 
       // when
-      const json = serializer.serialize(course);
+      const json = courseSerializer.serialize(course);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
@@ -1,7 +1,7 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
 import { ConflictError, MissingQueryParamError } from '../../../../../../src/shared/application/errors/http-errors.js';
-import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/error-serializer.js';
+import { errorSerializer } from '../../../../../../src/shared/infrastructure/serializers/jsonapi/error-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 const { Error: JSONAPIError } = jsonapiSerializer;
@@ -18,7 +18,7 @@ describe('Shared |Unit | Serializer | JSONAPI | error-serializer', function () {
       });
 
       // when
-      const serializedError = serializer.serialize(error);
+      const serializedError = errorSerializer.serialize(error);
 
       // then
       expect(serializedError).to.deep.equal(expectedJSONAPIError);
@@ -36,7 +36,7 @@ describe('Shared |Unit | Serializer | JSONAPI | error-serializer', function () {
       });
 
       // when
-      const serializedError = serializer.serialize(error);
+      const serializedError = errorSerializer.serialize(error);
 
       // then
       expect(serializedError).to.deep.equal(expectedJSONAPIError);

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/feature-toggle-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/feature-toggle-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/feature-toggle-serializer.js';
+import { featureToggleSerializer } from '../../../../../../src/shared/infrastructure/serializers/jsonapi/feature-toggle-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | feature-toggle-serializer', function () {
@@ -19,7 +19,7 @@ describe('Unit | Serializer | JSONAPI | feature-toggle-serializer', function () 
       };
 
       // when
-      const json = serializer.serialize(featureToggles);
+      const json = featureToggleSerializer.serialize(featureToggles);
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -1,5 +1,5 @@
 import { Membership } from '../../../../../../src/shared/domain/models/Membership.js';
-import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/membership.serializer.js';
+import { membershipSerializer } from '../../../../../../src/shared/infrastructure/serializers/jsonapi/membership.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -93,7 +93,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(membership);
+      const json = membershipSerializer.serialize(membership);
 
       // then
       expect(json).to.deep.equal(expectedSerializedMembership);
@@ -104,7 +104,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', function () {
       const membership = domainBuilder.buildMembership();
 
       // when
-      const json = serializer.serialize(membership);
+      const json = membershipSerializer.serialize(membership);
 
       // then
       expect(json.data.relationships.organization.data.type).to.equal('organizations');
@@ -123,7 +123,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', function () {
       const membership = domainBuilder.buildMembership();
 
       // when
-      const json = serializer.serialize(membership);
+      const json = membershipSerializer.serialize(membership);
 
       // then
       expect(json.data.relationships.user.data.type).to.equal('users');
@@ -142,7 +142,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', function () {
       membership.organization = null;
 
       // when
-      const json = serializer.serialize(membership);
+      const json = membershipSerializer.serialize(membership);
 
       // then
       expect(json.data.relationships.organization).to.be.undefined;
@@ -156,7 +156,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', function () {
       membership.user = undefined;
 
       // when
-      const json = serializer.serialize(membership);
+      const json = membershipSerializer.serialize(membership);
 
       // then
       expect(json.data.relationships.user).to.be.undefined;
@@ -182,7 +182,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', function () {
 
     it('should convert JSON API data into a map object that contain attribute to patch', function () {
       // when
-      const membership = serializer.deserialize(jsonMembership);
+      const membership = membershipSerializer.deserialize(jsonMembership);
 
       // then
       expect(membership.organizationRole).to.equal('ADMIN');

--- a/api/tests/team/integration/application/organization-invitation/organization-invitation.controller.test.js
+++ b/api/tests/team/integration/application/organization-invitation/organization-invitation.controller.test.js
@@ -9,7 +9,7 @@ import {
 import { teamRoutes } from '../../../../../src/team/application/routes.js';
 import { OrganizationArchivedError } from '../../../../../src/team/domain/errors.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
-import { serializer as scoOrganizationInvitationSerializer } from '../../../../../src/team/infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
+import { scoOrganizationInvitationSerializer } from '../../../../../src/team/infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
 import { expect } from '../../../../test-helper.js';
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/certification-center-invitation-serializer_test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/certification-center-invitation-serializer_test.js
@@ -1,5 +1,5 @@
 import { CertificationCenterInvitation } from '../../../../../../src/team/domain/models/CertificationCenterInvitation.js';
-import * as serializer from '../../../../../../src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
+import { certificationCenterInvitationSerializer } from '../../../../../../src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Team | Serializer | JSONAPI | certification-center-invitation-serializer', function () {
@@ -14,7 +14,7 @@ describe('Unit | Team | Serializer | JSONAPI | certification-center-invitation-s
       });
 
       // when
-      const json = serializer.serialize(invitation);
+      const json = certificationCenterInvitationSerializer.serialize(invitation);
 
       // then
       expect(json).to.deep.equal({
@@ -45,7 +45,7 @@ describe('Unit | Team | Serializer | JSONAPI | certification-center-invitation-s
       });
 
       // when
-      const json = serializer.serializeForAdmin(certificationCenterInvitation);
+      const json = certificationCenterInvitationSerializer.serializeForAdmin(certificationCenterInvitation);
 
       // then
       expect(json).to.deep.equal({
@@ -78,7 +78,7 @@ describe('Unit | Team | Serializer | JSONAPI | certification-center-invitation-s
       };
 
       // when
-      const json = await serializer.deserializeForAdmin(payload);
+      const json = await certificationCenterInvitationSerializer.deserializeForAdmin(payload);
 
       // then
       expect(json).to.deep.equal({

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/certification-center-membership.serializer.test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/certification-center-membership.serializer.test.js
@@ -1,5 +1,5 @@
 import { CertificationCenterMembership } from '../../../../../../src/team/domain/models/CertificationCenterMembership.js';
-import * as certificationCenterMembershipSerializer from '../../../../../../src/team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
+import { certificationCenterMembershipSerializer } from '../../../../../../src/team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/organization-member-identity.serializer.test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/organization-member-identity.serializer.test.js
@@ -1,5 +1,5 @@
 import { OrganizationMemberIdentity } from '../../../../../../src/team/domain/models/OrganizationMemberIdentity.js';
-import * as serializer from '../../../../../../src/team/infrastructure/serializers/jsonapi/organization-member-identity.serializer.js';
+import { organizationMemberIdentitySerializer } from '../../../../../../src/team/infrastructure/serializers/jsonapi/organization-member-identity.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-members-serializer', function () {
@@ -19,7 +19,7 @@ describe('Unit | Serializer | JSONAPI | organization-members-serializer', functi
       const members = [organizationMember1, organizationMember2];
 
       // when
-      const serializedOrganizationMemberIdentity = serializer.serialize(members);
+      const serializedOrganizationMemberIdentity = organizationMemberIdentitySerializer.serialize(members);
 
       // then
       expect(serializedOrganizationMemberIdentity).to.deep.equal({

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer_test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/team/infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
+import { scoOrganizationInvitationSerializer } from '../../../../../../src/team/infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -16,7 +16,7 @@ describe('Unit | Team | Infrastructure | Serializer | JSONAPI | sco-organization
 
     it('should convert an organization-invitation object into JSON API data', function () {
       // when
-      const json = serializer.serialize(invitationObject);
+      const json = scoOrganizationInvitationSerializer.serialize(invitationObject);
 
       // then
       expect(json).to.deep.equal(expectedInvitationJson);

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/user-orga-settings.serializer.test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/user-orga-settings.serializer.test.js
@@ -1,5 +1,5 @@
 import { UserOrgaSettings } from '../../../../../../src/team/domain/models/UserOrgaSettings.js';
-import * as serializer from '../../../../../../src/team/infrastructure/serializers/jsonapi/user-orga-settings.serializer.js';
+import { userOrgaSettingsSerializer } from '../../../../../../src/team/infrastructure/serializers/jsonapi/user-orga-settings.serializer.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -90,7 +90,7 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', function
       };
 
       // when
-      const json = serializer.serialize(userOrgaSettings);
+      const json = userOrgaSettingsSerializer.serialize(userOrgaSettings);
 
       // then
       expect(json).to.deep.equal(expectedSerializedUserOrgaSettings);
@@ -101,7 +101,7 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', function
       const userOrgaSettings = domainBuilder.buildUserOrgaSettings();
 
       // when
-      const json = serializer.serialize(userOrgaSettings);
+      const json = userOrgaSettingsSerializer.serialize(userOrgaSettings);
 
       // then
       expect(json.data.relationships.organization.data.type).to.equal('organizations');
@@ -120,7 +120,7 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', function
       const userOrgaSettings = domainBuilder.buildUserOrgaSettings();
 
       // when
-      const json = serializer.serialize(userOrgaSettings);
+      const json = userOrgaSettingsSerializer.serialize(userOrgaSettings);
 
       // then
       expect(json.data.relationships.user.data.type).to.equal('users');
@@ -139,7 +139,7 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', function
       userOrgaSettings.currentOrganization = null;
 
       // when
-      const json = serializer.serialize(userOrgaSettings);
+      const json = userOrgaSettingsSerializer.serialize(userOrgaSettings);
 
       // then
       expect(json.data.relationships.organization.data).to.be.null;
@@ -151,7 +151,7 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', function
       userOrgaSettings.user = undefined;
 
       // when
-      const json = serializer.serialize(userOrgaSettings);
+      const json = userOrgaSettingsSerializer.serialize(userOrgaSettings);
 
       // then
       expect(json.data.relationships.user).to.be.undefined;

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.test.js
@@ -1,5 +1,5 @@
 import { UserOrganizationForAdmin } from '../../../../../../src/team/domain/read-models/UserOrganizationForAdmin.js';
-import * as serializer from '../../../../../../src/team/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js';
+import { userOrganizationForAdminSerializer } from '../../../../../../src/team/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Team | Serializer | JSONAPI | user-organization-for-admin-serializer', function () {
@@ -26,7 +26,7 @@ describe('Unit | Team | Serializer | JSONAPI | user-organization-for-admin-seria
       const modelObjects = [userOrganizationForAdmin1, userOrganizationForAdmin2];
 
       // when
-      const json = serializer.serialize(modelObjects);
+      const json = userOrganizationForAdminSerializer.serialize(modelObjects);
 
       // then
       expect(json).to.be.deep.equal({

--- a/api/tests/unit/infrastructure/serializers/jsonapi/framework-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/framework-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../src/learning-content/infrastructure/serializers/framework-serializer.js';
+import { frameworkSerializer } from '../../../../../src/learning-content/infrastructure/serializers/framework-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | framework-serializer', function () {
@@ -40,7 +40,7 @@ describe('Unit | Serializer | JSONAPI | framework-serializer', function () {
       };
 
       // when
-      const result = serializer.serialize(frameworks);
+      const result = frameworkSerializer.serialize(frameworks);
 
       // then
       expect(result).to.deep.equal(expectedSerializedResult);


### PR DESCRIPTION
## 🪧 Problème

`knip` est un outil permettant d'identifier les dépendances, le code ou les exports non utilisés. Il fait partie de nos outils de lint, nous l'avons activé localement pour identifier ces erreurs.

Les imports par namespaces (`import * as NS from './file.js') ne permettent pas de correctement identifier les exports non utilisés et **retourne des faux-positifs principalement sur les serializers**.

## 🌈 Proposition

**Préférer l'utilisation d'exports nommés sur les serializers**, ce qui permet à knip d'identifier que les propriété exportés sont bien utilisées et en plus facilite l'autocomplétion dans les IDEs quand on souhaite importer ces serializers.

**Avant :**
```js
const serialize = ...;
const deserialize = ...;

export { serialize, deserialize };
```

**Après :** 
```js
const serialize = ...;
const deserialize = ...;

export const fooSerializer = { serialize, deserialize };
```

## ✊ Remarques

- La migration a été effectuée à l'aide d'une IA.
- Un commit par contexte.
- 🔥 `knip` est maintenant activé pour vérifier les exports non utilisés.

## 🎉 Pour tester

Les tests d'acceptances des routes doivent tous passer.
