### PR TITLE
[BUGFIX] Rejeter les certifs v3 coeur avec 0 points actuellement valides (PIX-19378).

### DIFF
--- a/api/scripts/certification/fix-validated-v3-assessment-results-with-zero-score.js
+++ b/api/scripts/certification/fix-validated-v3-assessment-results-with-zero-score.js
@@ -1,0 +1,63 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { AutoJuryCommentKeys } from '../../src/certification/shared/domain/models/JuryComment.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class FixValidatedV3AssessmentResultsWithZeroScoreScript extends Script {
+  constructor() {
+    super({
+      description:
+        'Fix assessment-results for v3 certifications that were incorrectly set to "validated" status ' +
+        'despite having a pixScore of 0. Those records should be "rejected".',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info(`Script execution started with options ${JSON.stringify(options)}`);
+
+    const trx = await knex.transaction();
+
+    try {
+      const updatedIds = await fixValidatedResultsWithZeroScore(trx);
+
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(`[DRY RUN] ${updatedIds.length} assessment-results would have been updated to "rejected".`);
+        return;
+      }
+
+      await trx.commit();
+      logger.info(`Script finished. ${updatedIds.length} assessment-results updated from "validated" to "rejected".`);
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+async function fixValidatedResultsWithZeroScore(trx) {
+  return trx('assessment-results')
+    .update({ status: 'rejected', commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE })
+    .whereIn(
+      'id',
+      trx('assessment-results as ar')
+        .select('ar.id')
+        .join('assessments as ass', 'ass.id', 'ar.assessmentId')
+        .join('certification-courses as cs', 'cs.id', 'ass.certificationCourseId')
+        .where('ar.pixScore', 0)
+        .where('ar.status', 'validated')
+        .where('cs.version', 3),
+    )
+    .returning('id');
+}
+
+await ScriptRunner.execute(import.meta.url, FixValidatedV3AssessmentResultsWithZeroScoreScript);

--- a/api/tests/certification/scripts/fix-validated-v3-assessment-results-with-zero-score_test.js
+++ b/api/tests/certification/scripts/fix-validated-v3-assessment-results-with-zero-score_test.js
@@ -1,0 +1,139 @@
+import sinon from 'sinon';
+
+import { FixValidatedV3AssessmentResultsWithZeroScoreScript } from '../../../scripts/certification/fix-validated-v3-assessment-results-with-zero-score.js';
+import { AlgorithmEngineVersion } from '../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { Frameworks } from '../../../src/certification/shared/domain/models/Frameworks.js';
+import { AutoJuryCommentKeys } from '../../../src/certification/shared/domain/models/JuryComment.js';
+import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
+import { expect } from '../../test-helper.js';
+import { databaseBuilder, knex } from '../../tooling/databases.js';
+import { catchErr } from '../../tooling/test-utils/error.js';
+
+describe('Integration | Scripts | Certification | fix-validated-v3-assessment-results-with-zero-score', function () {
+  let script;
+  let logger;
+
+  beforeEach(function () {
+    script = new FixValidatedV3AssessmentResultsWithZeroScoreScript();
+    logger = { info: sinon.stub(), error: sinon.stub() };
+  });
+
+  function buildCertificationAssessmentResult({ version, pixScore, status, framework = Frameworks.CORE }) {
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ version, framework }).id;
+    const assessmentId = databaseBuilder.factory.buildAssessment({
+      certificationCourseId,
+      type: Assessment.types.CERTIFICATION,
+    }).id;
+    return databaseBuilder.factory.buildAssessmentResult({ assessmentId, pixScore, status }).id;
+  }
+
+  async function getAssessmentResult(id) {
+    return knex('assessment-results').where({ id }).first();
+  }
+
+  describe('#handle', function () {
+    context('when dryRun is false', function () {
+      it('updates only the v3 validated assessment-results with a pixScore of 0 to "rejected"', async function () {
+        // given
+        const targetId = buildCertificationAssessmentResult({
+          version: AlgorithmEngineVersion.V3,
+          pixScore: 0,
+          status: AssessmentResult.status.VALIDATED,
+        });
+        const v3WithPositiveScoreId = buildCertificationAssessmentResult({
+          version: AlgorithmEngineVersion.V3,
+          pixScore: 10,
+          status: AssessmentResult.status.VALIDATED,
+        });
+        const v2WithZeroScoreId = buildCertificationAssessmentResult({
+          version: AlgorithmEngineVersion.V2,
+          pixScore: 0,
+          status: AssessmentResult.status.VALIDATED,
+        });
+        const alreadyRejectedId = buildCertificationAssessmentResult({
+          version: AlgorithmEngineVersion.V3,
+          pixScore: 0,
+          status: AssessmentResult.status.REJECTED,
+        });
+        const v3NonCoreWithoutScoreId = buildCertificationAssessmentResult({
+          version: AlgorithmEngineVersion.V3,
+          framework: Frameworks.DROIT,
+          pixScore: null,
+          status: AssessmentResult.status.VALIDATED,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: false } });
+
+        // then
+        const targetToReject = await getAssessmentResult(targetId);
+        expect(targetToReject.status).to.equal(AssessmentResult.status.REJECTED);
+        expect(targetToReject.commentByAutoJury).to.equal(AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE);
+
+        const v3WithPositiveScore = await getAssessmentResult(v3WithPositiveScoreId);
+        expect(v3WithPositiveScore.status).to.equal(AssessmentResult.status.VALIDATED);
+        expect(v3WithPositiveScore.commentByAutoJury).to.be.null;
+
+        expect((await getAssessmentResult(v2WithZeroScoreId)).status).to.equal(AssessmentResult.status.VALIDATED);
+        expect((await getAssessmentResult(alreadyRejectedId)).status).to.equal(AssessmentResult.status.REJECTED);
+        expect((await getAssessmentResult(v3NonCoreWithoutScoreId)).status).to.equal(AssessmentResult.status.VALIDATED);
+        expect(logger.info).to.have.been.calledWith(
+          'Script finished. 1 assessment-results updated from "validated" to "rejected".',
+        );
+      });
+    });
+
+    context('when dryRun is true', function () {
+      it('does not persist any change', async function () {
+        // given
+        const targetId = buildCertificationAssessmentResult({
+          version: AlgorithmEngineVersion.V3,
+          pixScore: 0,
+          status: AssessmentResult.status.VALIDATED,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: true } });
+
+        // then
+        const assessmentResult = await getAssessmentResult(targetId);
+        expect(assessmentResult.status).to.equal(AssessmentResult.status.VALIDATED);
+
+        expect(logger.info).to.have.been.calledWith(
+          '[DRY RUN] 1 assessment-results would have been updated to "rejected".',
+        );
+      });
+    });
+
+    context('when an error occurs while fixing the results', function () {
+      it('rolls back the changes and rethrows the error', async function () {
+        // given
+        const targetId = buildCertificationAssessmentResult({
+          version: AlgorithmEngineVersion.V3,
+          pixScore: 0,
+          status: AssessmentResult.status.VALIDATED,
+        });
+        await databaseBuilder.commit();
+
+        const beginTransaction = knex.transaction.bind(knex);
+        sinon.stub(knex, 'transaction').callsFake(async () => {
+          const trx = await beginTransaction();
+          trx.commit = () => Promise.reject(new Error('BOOM'));
+          return trx;
+        });
+
+        // when
+        const error = await catchErr(script.handle, script)({ logger, options: { dryRun: false } });
+
+        // then
+        expect(error.message).to.equal('BOOM');
+
+        const assessmentResult = await getAssessmentResult(targetId);
+        expect(assessmentResult.status).to.equal(AssessmentResult.status.VALIDATED);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

Certaines certifications ont déjà été validées depuis le lancement de la v3 avec un score Pix de 0.

Or, depuis https://github.com/1024pix/pix/pull/13406, nous rejetons les certifs coeur v3 avec un score Pix de 0.

## 🌈 Proposition

Créer un script pour rattraper les données et rejeter ces certifs coeur v3 avec 0 pix.

## 🎉 Pour tester

- En local, modifier un assessment-result d'une certif coeur v3 pour avoir un `pixScore` de 0 et un statut `validated`
- Lancer le script en dryRun puis sans
- Vérifier que cet assessment-result a maintenant un statut `rejected`
