### PR TITLE
[FEATURE] Permettre la création d'une campagne à partir d'un parcours du catalogue (PIX-22919)

### DIFF
--- a/orga/app/adapters/campaign.js
+++ b/orga/app/adapters/campaign.js
@@ -31,12 +31,16 @@ export default class CampaignAdapter extends ApplicationAdapter {
 
     if (payload.data.attributes.type === 'COMBINED_COURSE') {
       payload.data.relationships['combined-course-blueprint'] = {
-        data: { id: snapshot.record.combinedCourseBlueprint.id },
+        data: { id: snapshot.record.combinedCourseBlueprint?.id || snapshot.record.course?.id },
       };
       const url = `${this.host}/${this.namespace}/combined-courses`;
 
       return this.ajax(url, 'POST', { data: payload });
     } else {
+      payload.data.relationships['target-profile'] = {
+        data: { id: snapshot.record.targetProfile?.id || snapshot.record.course?.id },
+      };
+
       const url = `${this.host}/${this.namespace}/campaigns`;
 
       return this.ajax(url, 'POST', { data: payload });

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -1,0 +1,605 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixFilterableAndSearchableSelect from '@1024pix/pix-ui/components/pix-filterable-and-searchable-select';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { eq, gt, not } from 'ember-truth-helpers';
+import { ID_PIX_TYPES } from 'pix-orga/helpers/id-pix-types.js';
+import { orderBy } from 'pix-orga/utils/collection';
+
+import displayCampaignErrors from '../../helpers/display-campaign-errors';
+import TargetProfileDetails from '../campaign/target-profile-details';
+import ExplanationCard from '../ui/explanation-card';
+import FormField from '../ui/form-field';
+import PixFieldset from '../ui/pix-fieldset';
+export default class CreateForm extends Component {
+  @service currentUser;
+  @service intl;
+  @service locale;
+  @service store;
+
+  @tracked wantIdPix = Boolean(this.args.campaign.externalIdLabel);
+
+  get isMultipleSendingAssessmentEnabled() {
+    return this.currentUser.prescriber.enableMultipleSendingAssessment;
+  }
+
+  get isComputeLearnerCertificabilityEnabled() {
+    return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
+  }
+
+  get targetOwnerOptions() {
+    const options = this.args.targetProfiles.map((targetProfile) => {
+      return {
+        value: targetProfile.id,
+        label: targetProfile.name,
+        category: this.intl.t(`pages.campaign-creation.tags.${targetProfile.category}`),
+        icon: targetProfile.isSimplifiedAccess ? 'accountOff' : 'users',
+        iconTitle: targetProfile.isSimplifiedAccess
+          ? this.intl.t('common.target-profile-details.simplified-access.without-account')
+          : this.intl.t('common.target-profile-details.simplified-access.with-account'),
+        order: 'OTHER' === targetProfile.category ? 1 : 0,
+      };
+    });
+    return orderBy(options, ['order', 'category', 'label']);
+  }
+
+  get blueprintOwnerOptions() {
+    const options = this.args.combinedCourseBlueprints.map((blueprint) => {
+      return {
+        value: blueprint.id,
+        label: blueprint.name,
+      };
+    });
+    return orderBy(options, ['label']);
+  }
+
+  get campaignOwnerOptions() {
+    if (!this.args.membersSortedByFullName) return [];
+
+    return this.args.membersSortedByFullName.map((member) => ({ value: member.id, label: member.fullName }));
+  }
+
+  get isMultipleSendingEnabled() {
+    const isMulipleSendingsAllowed =
+      this.isMultipleSendingAssessmentEnabled &&
+      (this.isCampaignGoalAssessment || this.isCampaignGoalExam) &&
+      !this.isCombinedCourseGoal;
+
+    return this.isCampaignGoalProfileCollection || isMulipleSendingsAllowed;
+  }
+
+  get multipleSendingWording() {
+    if (this.isCampaignGoalProfileCollection) {
+      return {
+        label: 'pages.campaign-creation.multiple-sendings.profiles.question-label',
+        info: 'pages.campaign-creation.multiple-sendings.profiles.info',
+      };
+    } else {
+      return {
+        label: 'pages.campaign-creation.multiple-sendings.assessments.question-label',
+        info: 'pages.campaign-creation.multiple-sendings.assessments.info',
+      };
+    }
+  }
+
+  get isCreateCampaignOftypeExamEnabled() {
+    return this.currentUser.prescriber.enableCampaignWithoutUserProfile;
+  }
+
+  get isCampaignGoalExam() {
+    return this.args.campaign.type === 'EXAM';
+  }
+
+  get isCampaignGoalAssessment() {
+    return this.args.campaign.type === 'ASSESSMENT';
+  }
+
+  get isCampaignGoalProfileCollection() {
+    return this.args.campaign.type === 'PROFILES_COLLECTION';
+  }
+
+  get isCombinedCourseGoal() {
+    return this.args.campaign.type === 'COMBINED_COURSE';
+  }
+
+  get isExternalIdSelectedChecked() {
+    return this.wantIdPix === true;
+  }
+
+  get isExternalIdTypeNotSelectedChecked() {
+    return this.args.campaign.externalIdType === '';
+  }
+
+  get isTargetProfileSelectable() {
+    return this.isCampaignGoalAssessment || this.isCampaignGoalExam;
+  }
+
+  get isCombinedCourseBlueprintSelectable() {
+    return this.isCombinedCourseGoal;
+  }
+
+  get isTitleInputEnable() {
+    return (this.isCampaignGoalAssessment || this.isCampaignGoalExam) && !this.isCombinedCourseGoal;
+  }
+
+  get hasCombinedCourseBlueprintShares() {
+    return this.args.combinedCourseBlueprints ? this.args.combinedCourseBlueprints.length > 0 : false;
+  }
+
+  get displayOwnerField() {
+    return this.isCampaignGoalAssessment || this.isCampaignGoalExam || this.isCampaignGoalProfileCollection;
+  }
+
+  @action
+  askLabelIdPix() {
+    this.wantIdPix = true;
+    this.args.campaign.externalIdLabel = '';
+    this.args.campaign.externalIdType = '';
+  }
+
+  @action
+  doNotAskLabelIdPix() {
+    this.wantIdPix = false;
+    this.args.campaign.externalIdLabel = null;
+    this.args.campaign.externalIdType = '';
+  }
+
+  @action
+  selectTargetProfile(targetProfileId) {
+    this.args.campaign.targetProfile = this.args.targetProfiles.find(
+      (targetProfile) => targetProfile.id === targetProfileId,
+    );
+  }
+
+  @action
+  selectCombinedCourseBlueprint(blueprintId) {
+    const record = this.store.peekRecord('combined-course-blueprint', blueprintId);
+    this.args.campaign.combinedCourseBlueprint = record;
+  }
+
+  @action
+  selectMultipleSendingsStatus(value) {
+    this.args.campaign.multipleSendings = value;
+  }
+
+  @action
+  setCampaignGoal(event) {
+    if (event.target.value === 'collect-participants-profile') {
+      this.args.campaign.setType('PROFILES_COLLECTION');
+    } else if (event.target.value === 'exam-participants') {
+      this.args.campaign.setType('EXAM');
+    } else if (event.target.value === 'assess-participants') {
+      this.args.campaign.setType('ASSESSMENT');
+    } else if (event.target.value === 'combined-course') {
+      this.args.campaign.setType('COMBINED_COURSE');
+    }
+  }
+
+  @action
+  onChangeCampaignValue(key, event) {
+    this.args.campaign[key] = event.target.value;
+  }
+
+  @action
+  onChangeCampaignOwner(newOwnerId) {
+    const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerId === member.id);
+    if (selectedMember) {
+      this.args.campaign.ownerId = selectedMember.id;
+    }
+  }
+
+  @action
+  onChangeCampaignCustomLandingPageText(event) {
+    this.args.campaign.customLandingPageText = event.target.value;
+  }
+  @action
+  onChangeIdPixType(event) {
+    this.args.campaign.externalIdType = event.target.value;
+  }
+
+  @action
+  onSubmit(event) {
+    event.preventDefault();
+    this.args.onSubmit(this.args.campaign);
+  }
+
+  <template>
+    <form {{on "submit" this.onSubmit}} class="form">
+      <p class="form__mandatory-fields-information" aria-hidden="true">
+        <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark">*</abbr>
+        {{t "common.form.mandatory-fields"}}
+      </p>
+
+      <FormField>
+        <PixInput
+          @id="campaign-name"
+          @name="campaign-name"
+          @requiredLabel={{t "common.form.mandatory-fields-title"}}
+          type="text"
+          class="input"
+          maxlength="255"
+          {{on "change" (fn this.onChangeCampaignValue "name")}}
+          @value={{@campaign.name}}
+          required={{true}}
+          aria-required={{true}}
+        >
+          <:label>{{t "pages.campaign-creation.name.label"}}</:label>
+        </PixInput>
+
+        {{#if @errors.name}}
+          <div class="form__error error-message">
+            {{displayCampaignErrors @errors.name}}
+          </div>
+        {{/if}}
+      </FormField>
+
+      <FormField>
+        <:default>
+          <PixFieldset @required={{true}} aria-labelledby="campaign-goal" role="radiogroup">
+            <:title>{{t "pages.campaign-creation.purpose.label"}}</:title>
+            <:content>
+              <PixRadioButton
+                name="campaign-goal"
+                @value="assess-participants"
+                {{on "change" this.setCampaignGoal}}
+                aria-describedby="campaign-goal-assessment-info"
+                checked={{this.isCampaignGoalAssessment}}
+              >
+                <:label>{{t "pages.campaign-creation.purpose.assessment"}}</:label>
+              </PixRadioButton>
+
+              {{#if this.hasCombinedCourseBlueprintShares}}
+                <PixRadioButton
+                  name="campaign-goal"
+                  @value="combined-course"
+                  {{on "change" this.setCampaignGoal}}
+                  aria-describedby="combined-course-info"
+                  checked={{this.isCombinedCourseGoal}}
+                >
+                  <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
+                </PixRadioButton>
+              {{/if}}
+
+              {{#if this.isCreateCampaignOftypeExamEnabled}}
+                <PixRadioButton
+                  name="campaign-goal"
+                  @value="exam-participants"
+                  {{on "change" this.setCampaignGoal}}
+                  aria-describedby="exam-participants-info"
+                  checked={{this.isCampaignGoalExam}}
+                >
+                  <:label>{{t "pages.campaign-creation.purpose.exam"}}</:label>
+                </PixRadioButton>
+              {{/if}}
+
+              <PixRadioButton
+                name="campaign-goal"
+                @value="collect-participants-profile"
+                {{on "change" this.setCampaignGoal}}
+                aria-describedby="campaign-goal-profiles-collection-info"
+                checked={{this.isCampaignGoalProfileCollection}}
+              >
+                <:label>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:label>
+              </PixRadioButton>
+
+              {{#if @errors.type}}
+                <div class="form__error error-message">
+                  {{displayCampaignErrors @errors.type}}
+                </div>
+              {{/if}}
+            </:content>
+          </PixFieldset>
+        </:default>
+        <:information>
+          {{#if this.isCampaignGoalExam}}
+            <ExplanationCard id="campaign-goal-exam-info">
+              <:title>{{t "pages.campaign-creation.purpose.exam"}}</:title>
+
+              <:message>{{t "pages.campaign-creation.purpose.exam-info"}}</:message>
+            </ExplanationCard>
+          {{else if this.isCampaignGoalAssessment}}
+            <ExplanationCard id="campaign-goal-assessment-info">
+              <:title>{{t "pages.campaign-creation.purpose.assessment"}}</:title>
+
+              <:message>{{t "pages.campaign-creation.purpose.assessment-info"}}</:message>
+            </ExplanationCard>
+          {{else if this.isCombinedCourseGoal}}
+            <ExplanationCard id="combined-course-info">
+              <:title>{{t "pages.campaign-creation.purpose.combined-course"}}</:title>
+
+              <:message>{{t "pages.campaign-creation.purpose.combined-course-info"}}</:message>
+            </ExplanationCard>
+          {{else if this.isCampaignGoalProfileCollection}}
+            <ExplanationCard id="campaign-goal-profiles-collection-info">
+              <:title>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:title>
+
+              <:message>
+                {{t "pages.campaign-creation.purpose.profiles-collection-info"}}
+                {{#if this.isComputeLearnerCertificabilityEnabled}}
+                  {{t
+                    "pages.campaign-creation.purpose.profiles-collection-info-certificability-calculation"
+                    linkClasses="link link--banner link--bold link--underlined"
+                    htmlSafe=true
+                  }}
+                {{/if}}
+              </:message>
+            </ExplanationCard>
+          {{/if}}
+        </:information>
+      </FormField>
+
+      {{#if this.displayOwnerField}}
+
+        <FormField>
+          <:default>
+            <PixSelect
+              class="pix-select-owner"
+              @options={{this.campaignOwnerOptions}}
+              @onChange={{this.onChangeCampaignOwner}}
+              @value="{{@campaign.ownerId}}"
+              @isSearchable={{true}}
+              @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
+              @locale={{this.locale.currentLocale}}
+              @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
+              @requiredLabel={{t "common.form.mandatory-fields-title"}}
+              @hideDefaultOption={{true}}
+            >
+              <:label>{{t "pages.campaign-creation.owner.label"}}</:label>
+            </PixSelect>
+
+          </:default>
+
+          <:information>
+            <ExplanationCard>
+              <:title>{{t "pages.campaign-creation.owner.title"}}</:title>
+
+              <:message>{{t "pages.campaign-creation.owner.info"}}</:message>
+            </ExplanationCard>
+
+          </:information>
+
+        </FormField>
+
+      {{/if}}
+
+      {{#if this.isTargetProfileSelectable}}
+        <FormField>
+          <:default>
+            <PixFilterableAndSearchableSelect
+              @placeholder={{t "pages.campaign-creation.target-profiles-label"}}
+              @categoriesPlaceholder={{t "pages.campaign-creation.target-profiles-category-placeholder"}}
+              @options={{this.targetOwnerOptions}}
+              @hideDefaultOption={{true}}
+              @onChange={{this.selectTargetProfile}}
+              @value={{@campaign.targetProfile.id}}
+              @requiredLabel={{t "common.form.mandatory-fields-title"}}
+              @errorMessage={{if
+                @errors.targetProfile
+                (t "api-error-messages.campaign-creation.target-profile-required")
+              }}
+              @isSearchable={{true}}
+              @locale={{this.locale.currentLocale}}
+              @searchLabel={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
+            >
+              <:label>{{t "pages.campaign-creation.target-profiles-list-label"}}</:label>
+              <:categoriesLabel>{{t "pages.campaign-creation.target-profiles-category-label"}}</:categoriesLabel>
+            </PixFilterableAndSearchableSelect>
+          </:default>
+          <:information>
+            {{#if @campaign.targetProfile}}
+              <ExplanationCard id="target-profile-info">
+                <:title>{{@campaign.targetProfile.name}}</:title>
+
+                <:message>
+                  <TargetProfileDetails
+                    class="form__field-info-message"
+                    @targetProfileDescription={{@campaign.targetProfile.description}}
+                    @hasStages={{@campaign.targetProfile.hasStage}}
+                    @hasBadges={{gt @campaign.targetProfile.thematicResultCount 0}}
+                    @targetProfileTubesCount={{@campaign.targetProfile.tubeCount}}
+                    @targetProfileThematicResultCount={{@campaign.targetProfile.thematicResultCount}}
+                    @simplifiedAccess={{@campaign.targetProfile.isSimplifiedAccess}}
+                  />
+                </:message>
+              </ExplanationCard>
+            {{/if}}
+          </:information>
+        </FormField>
+      {{/if}}
+
+      {{#if this.isCombinedCourseBlueprintSelectable}}
+        <FormField>
+          <:default>
+            <PixSelect
+              @placeholder={{t "pages.campaign-creation.combined-course-blueprints-label"}}
+              @options={{this.blueprintOwnerOptions}}
+              @hideDefaultOption={{true}}
+              @onChange={{this.selectCombinedCourseBlueprint}}
+              @value={{@campaign.combinedCourseBlueprint.id}}
+              @requiredLabel={{t "common.form.mandatory-fields-title"}}
+              @errorMessage={{if @errors.blueprint (t "api-error-messages.campaign-creation.target-profile-required")}}
+              @locale={{this.locale.currentLocale}}
+              @searchLabel={{t "pages.campaign-creation.combined-course-blueprints-search-placeholder"}}
+            >
+              <:label>{{t "pages.campaign-creation.combined-course-blueprints-list-label"}}</:label>
+            </PixSelect>
+          </:default>
+        </FormField>
+      {{/if}}
+
+      {{#if this.isMultipleSendingEnabled}}
+        <FormField>
+          <:default>
+            <PixFieldset @required={{true}} aria-labelledby="multiple-sendings-label" role="radiogroup">
+              <:title>{{t this.multipleSendingWording.label}}</:title>
+              <:content>
+                <PixRadioButton
+                  name="multiple-sendings-label"
+                  @value="false"
+                  {{on "change" (fn this.selectMultipleSendingsStatus false)}}
+                  aria-describedby="multiple-sendings-info"
+                  checked={{not @campaign.multipleSendings}}
+                >
+                  <:label>{{t "pages.campaign-creation.no"}}</:label>
+                </PixRadioButton>
+
+                <PixRadioButton
+                  name="multiple-sendings-label"
+                  @value="true"
+                  {{on "change" (fn this.selectMultipleSendingsStatus true)}}
+                  aria-describedby="multiple-sendings-info"
+                  checked={{@campaign.multipleSendings}}
+                >
+                  <:label>{{t "pages.campaign-creation.yes"}}</:label>
+                </PixRadioButton>
+              </:content>
+            </PixFieldset>
+          </:default>
+          <:information>
+            <ExplanationCard id="multiple-sendings-info">
+              <:title>{{t "pages.campaign-creation.multiple-sendings.info-title"}}</:title>
+
+              <:message>
+                {{t this.multipleSendingWording.info}}
+                {{#if @campaign.targetProfile.areKnowledgeElementsResettable}}
+                  {{t "pages.campaign-creation.multiple-sendings.knowledge-elements-resettable"}}
+                {{/if}}
+              </:message>
+            </ExplanationCard>
+          </:information>
+        </FormField>
+      {{/if}}
+
+      {{#unless this.isCombinedCourseGoal}}
+        <FormField>
+          <PixFieldset aria-labelledby="external-ids-label" role="radiogroup">
+            <:title>{{t "pages.campaign-creation.external-id-label.question-label"}}</:title>
+            <:content>
+              <PixRadioButton
+                name="external-id-label"
+                @value="false"
+                {{on "change" this.doNotAskLabelIdPix}}
+                checked={{not this.isExternalIdSelectedChecked}}
+              >
+                <:label>{{t "pages.campaign-creation.no"}}</:label>
+              </PixRadioButton>
+              <PixRadioButton
+                name="external-id-label"
+                @value="true"
+                {{on "change" this.askLabelIdPix}}
+                checked={{this.isExternalIdSelectedChecked}}
+              >
+                <:label>{{t "pages.campaign-creation.yes"}}</:label>
+              </PixRadioButton>
+            </:content>
+          </PixFieldset>
+        </FormField>
+      {{/unless}}
+
+      {{#if this.wantIdPix}}
+        <FormField>
+          <PixFieldset @required={{true}} aria-labelledby="external-ids-types" role="radiogroup">
+            <:title>{{t "pages.campaign-creation.external-id-type.question-label"}}</:title>
+            <:content>
+              <PixRadioButton
+                name="external-id-types"
+                @value="EMAIL"
+                {{on "change" (fn this.onChangeCampaignValue "externalIdType")}}
+                checked={{eq @campaign.externalIdType "EMAIL"}}
+              >
+                <:label>{{t ID_PIX_TYPES.EMAIL}}</:label>
+
+              </PixRadioButton>
+              <PixRadioButton
+                name="external-id-types"
+                @value="STRING"
+                {{on "change" (fn this.onChangeCampaignValue "externalIdType")}}
+                checked={{eq @campaign.externalIdType "STRING"}}
+              >
+                <:label>{{t ID_PIX_TYPES.STRING}}</:label>
+              </PixRadioButton>
+              {{#if @errors.externalIdType}}
+                <div class="form__error error-message">
+                  {{displayCampaignErrors @errors.externalIdType}}
+                </div>
+              {{/if}}
+            </:content>
+          </PixFieldset>
+        </FormField>
+        <FormField>
+          <PixInput
+            @id="external-id-label"
+            @name="external-id-label"
+            @subLabel={{t "pages.campaign-creation.external-id-label.suggestion"}}
+            maxlength="255"
+            @requiredLabel={{t "pages.campaign-creation.external-id-label.required"}}
+            {{on "change" (fn this.onChangeCampaignValue "externalIdLabel")}}
+            @value={{@campaign.externalIdLabel}}
+          >
+            <:label>{{t "pages.campaign-creation.external-id-label.label"}}</:label>
+          </PixInput>
+
+          {{#if @errors.externalIdLabel}}
+            <div class="form__error error-message">
+              {{displayCampaignErrors @errors.externalIdLabel}}
+            </div>
+          {{/if}}
+        </FormField>
+      {{/if}}
+
+      {{#if this.isTitleInputEnable}}
+        <FormField>
+          <PixInput
+            @id="campaign-title"
+            @name="campaign-title"
+            @subLabel={{t "pages.campaign-creation.test-title.sublabel"}}
+            maxlength="50"
+            {{on "change" (fn this.onChangeCampaignValue "title")}}
+            @value={{@campaign.title}}
+          >
+            <:label>{{t "pages.campaign-creation.test-title.label"}}</:label></PixInput>
+        </FormField>
+      {{/if}}
+
+      {{#unless this.isCombinedCourseGoal}}
+        <FormField>
+          <PixTextarea
+            @id="custom-landing-page-text"
+            @maxlength="5000"
+            @value={{@campaign.customLandingPageText}}
+            @subLabel={{t "pages.campaign-creation.landing-page-text.sublabel"}}
+            {{on "change" this.onChangeCampaignCustomLandingPageText}}
+            rows="8"
+          >
+            <:label>{{t "pages.campaign-creation.landing-page-text.label"}}</:label>
+          </PixTextarea>
+        </FormField>
+      {{/unless}}
+
+      <div class="form__validation">
+        <PixButton @triggerAction={{@onCancel}} @variant="secondary">
+          {{t "common.actions.cancel"}}
+        </PixButton>
+
+        <PixButton @type="submit">
+          {{t "pages.campaign-creation.actions.create"}}
+        </PixButton>
+      </div>
+
+      {{#if this.wantIdPix}}
+        <div class="gdpr-information-external-id">
+          {{t "pages.campaign-creation.legal-warning"}}
+        </div>
+      {{/if}}
+    </form>
+  </template>
+}

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -1,5 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixFilterableAndSearchableSelect from '@1024pix/pix-ui/components/pix-filterable-and-searchable-select';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
@@ -11,15 +11,15 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import { eq, gt, not } from 'ember-truth-helpers';
+import { eq, not, or } from 'ember-truth-helpers';
 import { ID_PIX_TYPES } from 'pix-orga/helpers/id-pix-types.js';
-import { orderBy } from 'pix-orga/utils/collection';
 
 import displayCampaignErrors from '../../helpers/display-campaign-errors';
-import TargetProfileDetails from '../campaign/target-profile-details';
+import CourseCard from '../catalogue/course-card';
 import ExplanationCard from '../ui/explanation-card';
 import FormField from '../ui/form-field';
 import PixFieldset from '../ui/pix-fieldset';
+
 export default class CreateForm extends Component {
   @service currentUser;
   @service intl;
@@ -34,32 +34,6 @@ export default class CreateForm extends Component {
 
   get isComputeLearnerCertificabilityEnabled() {
     return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
-  }
-
-  get targetOwnerOptions() {
-    const options = this.args.targetProfiles.map((targetProfile) => {
-      return {
-        value: targetProfile.id,
-        label: targetProfile.name,
-        category: this.intl.t(`pages.campaign-creation.tags.${targetProfile.category}`),
-        icon: targetProfile.isSimplifiedAccess ? 'accountOff' : 'users',
-        iconTitle: targetProfile.isSimplifiedAccess
-          ? this.intl.t('common.target-profile-details.simplified-access.without-account')
-          : this.intl.t('common.target-profile-details.simplified-access.with-account'),
-        order: 'OTHER' === targetProfile.category ? 1 : 0,
-      };
-    });
-    return orderBy(options, ['order', 'category', 'label']);
-  }
-
-  get blueprintOwnerOptions() {
-    const options = this.args.combinedCourseBlueprints.map((blueprint) => {
-      return {
-        value: blueprint.id,
-        label: blueprint.name,
-      };
-    });
-    return orderBy(options, ['label']);
   }
 
   get campaignOwnerOptions() {
@@ -91,7 +65,7 @@ export default class CreateForm extends Component {
     }
   }
 
-  get isCreateCampaignOftypeExamEnabled() {
+  get isCreateCampaignOfTypeExamEnabled() {
     return this.currentUser.prescriber.enableCampaignWithoutUserProfile;
   }
 
@@ -119,24 +93,26 @@ export default class CreateForm extends Component {
     return this.args.campaign.externalIdType === '';
   }
 
-  get isTargetProfileSelectable() {
-    return this.isCampaignGoalAssessment || this.isCampaignGoalExam;
-  }
-
-  get isCombinedCourseBlueprintSelectable() {
-    return this.isCombinedCourseGoal;
-  }
-
   get isTitleInputEnable() {
     return (this.isCampaignGoalAssessment || this.isCampaignGoalExam) && !this.isCombinedCourseGoal;
   }
 
-  get hasCombinedCourseBlueprintShares() {
-    return this.args.combinedCourseBlueprints ? this.args.combinedCourseBlueprints.length > 0 : false;
-  }
-
   get displayOwnerField() {
     return this.isCampaignGoalAssessment || this.isCampaignGoalExam || this.isCampaignGoalProfileCollection;
+  }
+
+  get displayCourseSelection() {
+    return !this.isCampaignGoalProfileCollection;
+  }
+
+  get catalogueCourseSelectionTab() {
+    if (this.isCombinedCourseGoal) {
+      return 'blueprint';
+    }
+    if (this.isCampaignGoalAssessment || this.isCampaignGoalExam) {
+      return 'targetProfile';
+    }
+    return 'all';
   }
 
   @action
@@ -151,19 +127,6 @@ export default class CreateForm extends Component {
     this.wantIdPix = false;
     this.args.campaign.externalIdLabel = null;
     this.args.campaign.externalIdType = '';
-  }
-
-  @action
-  selectTargetProfile(targetProfileId) {
-    this.args.campaign.targetProfile = this.args.targetProfiles.find(
-      (targetProfile) => targetProfile.id === targetProfileId,
-    );
-  }
-
-  @action
-  selectCombinedCourseBlueprint(blueprintId) {
-    const record = this.store.peekRecord('combined-course-blueprint', blueprintId);
-    this.args.campaign.combinedCourseBlueprint = record;
   }
 
   @action
@@ -201,6 +164,7 @@ export default class CreateForm extends Component {
   onChangeCampaignCustomLandingPageText(event) {
     this.args.campaign.customLandingPageText = event.target.value;
   }
+
   @action
   onChangeIdPixType(event) {
     this.args.campaign.externalIdType = event.target.value;
@@ -213,7 +177,7 @@ export default class CreateForm extends Component {
   }
 
   <template>
-    <form {{on "submit" this.onSubmit}} class="form">
+    <form {{on "submit" this.onSubmit}} class="form campaign-creation-form">
       <p class="form__mandatory-fields-information" aria-hidden="true">
         <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark">*</abbr>
         {{t "common.form.mandatory-fields"}}
@@ -257,19 +221,17 @@ export default class CreateForm extends Component {
                 <:label>{{t "pages.campaign-creation.purpose.assessment"}}</:label>
               </PixRadioButton>
 
-              {{#if this.hasCombinedCourseBlueprintShares}}
-                <PixRadioButton
-                  name="campaign-goal"
-                  @value="combined-course"
-                  {{on "change" this.setCampaignGoal}}
-                  aria-describedby="combined-course-info"
-                  checked={{this.isCombinedCourseGoal}}
-                >
-                  <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
-                </PixRadioButton>
-              {{/if}}
+              <PixRadioButton
+                name="campaign-goal"
+                @value="combined-course"
+                {{on "change" this.setCampaignGoal}}
+                aria-describedby="combined-course-info"
+                checked={{this.isCombinedCourseGoal}}
+              >
+                <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
+              </PixRadioButton>
 
-              {{#if this.isCreateCampaignOftypeExamEnabled}}
+              {{#if this.isCreateCampaignOfTypeExamEnabled}}
                 <PixRadioButton
                   name="campaign-goal"
                   @value="exam-participants"
@@ -337,8 +299,34 @@ export default class CreateForm extends Component {
         </:information>
       </FormField>
 
-      {{#if this.displayOwnerField}}
+      {{#if this.displayCourseSelection}}
+        <FormField>
+          <:default>
+            <div class="campaign-creation-form__course-selection">
+              <PixFieldset @required={{true}}>
+                <:title>{{t "pages.campaign-creation.course-label"}}</:title>
+                <:content>
+                  {{#if @campaign.course}}
+                    <CourseCard @course={{@campaign.course}} @type={{@campaign.course.type}} />
+                  {{/if}}
+                  <PixButtonLink
+                    @route="authenticated.catalogue.list"
+                    @model={{this.catalogueCourseSelectionTab}}
+                    @variant="primary-bis"
+                  >{{t "pages.campaign-creation.course-selection-label"}}</PixButtonLink>
+                </:content>
+              </PixFieldset>
+            </div>
+            {{#if (or @errors.targetProfile @errors.blueprint)}}
+              <div class="form__error error-message">
+                <span>{{t "api-error-messages.campaign-creation.target-profile-required"}}</span>
+              </div>
+            {{/if}}
+          </:default>
+        </FormField>
+      {{/if}}
 
+      {{#if this.displayOwnerField}}
         <FormField>
           <:default>
             <PixSelect
@@ -369,71 +357,6 @@ export default class CreateForm extends Component {
 
         </FormField>
 
-      {{/if}}
-
-      {{#if this.isTargetProfileSelectable}}
-        <FormField>
-          <:default>
-            <PixFilterableAndSearchableSelect
-              @placeholder={{t "pages.campaign-creation.target-profiles-label"}}
-              @categoriesPlaceholder={{t "pages.campaign-creation.target-profiles-category-placeholder"}}
-              @options={{this.targetOwnerOptions}}
-              @hideDefaultOption={{true}}
-              @onChange={{this.selectTargetProfile}}
-              @value={{@campaign.targetProfile.id}}
-              @requiredLabel={{t "common.form.mandatory-fields-title"}}
-              @errorMessage={{if
-                @errors.targetProfile
-                (t "api-error-messages.campaign-creation.target-profile-required")
-              }}
-              @isSearchable={{true}}
-              @locale={{this.locale.currentLocale}}
-              @searchLabel={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
-            >
-              <:label>{{t "pages.campaign-creation.target-profiles-list-label"}}</:label>
-              <:categoriesLabel>{{t "pages.campaign-creation.target-profiles-category-label"}}</:categoriesLabel>
-            </PixFilterableAndSearchableSelect>
-          </:default>
-          <:information>
-            {{#if @campaign.targetProfile}}
-              <ExplanationCard id="target-profile-info">
-                <:title>{{@campaign.targetProfile.name}}</:title>
-
-                <:message>
-                  <TargetProfileDetails
-                    class="form__field-info-message"
-                    @targetProfileDescription={{@campaign.targetProfile.description}}
-                    @hasStages={{@campaign.targetProfile.hasStage}}
-                    @hasBadges={{gt @campaign.targetProfile.thematicResultCount 0}}
-                    @targetProfileTubesCount={{@campaign.targetProfile.tubeCount}}
-                    @targetProfileThematicResultCount={{@campaign.targetProfile.thematicResultCount}}
-                    @simplifiedAccess={{@campaign.targetProfile.isSimplifiedAccess}}
-                  />
-                </:message>
-              </ExplanationCard>
-            {{/if}}
-          </:information>
-        </FormField>
-      {{/if}}
-
-      {{#if this.isCombinedCourseBlueprintSelectable}}
-        <FormField>
-          <:default>
-            <PixSelect
-              @placeholder={{t "pages.campaign-creation.combined-course-blueprints-label"}}
-              @options={{this.blueprintOwnerOptions}}
-              @hideDefaultOption={{true}}
-              @onChange={{this.selectCombinedCourseBlueprint}}
-              @value={{@campaign.combinedCourseBlueprint.id}}
-              @requiredLabel={{t "common.form.mandatory-fields-title"}}
-              @errorMessage={{if @errors.blueprint (t "api-error-messages.campaign-creation.target-profile-required")}}
-              @locale={{this.locale.currentLocale}}
-              @searchLabel={{t "pages.campaign-creation.combined-course-blueprints-search-placeholder"}}
-            >
-              <:label>{{t "pages.campaign-creation.combined-course-blueprints-list-label"}}</:label>
-            </PixSelect>
-          </:default>
-        </FormField>
       {{/if}}
 
       {{#if this.isMultipleSendingEnabled}}

--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -62,22 +62,24 @@ export default class CourseCard extends Component {
         </:footer>
       </PixCard>
 
-      {{#if (eq @course.type "targetProfile")}}
-        <LinkTo
-          @route="authenticated.catalogue.list"
-          @model={{@type}}
-          @query={{hash targetProfileId=@course.id}}
-          {{on "click" @selectCourse}}
-          aria-label={{t "pages.catalogue.modal.open-modal" name=@course.name}}
-        />
-      {{else if (eq @course.type "blueprint")}}
-        <LinkTo
-          @route="authenticated.catalogue.list"
-          @model={{@type}}
-          @query={{hash blueprintId=@course.id}}
-          {{on "click" @selectCourse}}
-          aria-label={{t "pages.catalogue.modal.open-modal" name=@course.name}}
-        />
+      {{#if @selectCourse}}
+        {{#if (eq @course.type "targetProfile")}}
+          <LinkTo
+            @route="authenticated.catalogue.list"
+            @model={{@type}}
+            @query={{hash targetProfileId=@course.id}}
+            {{on "click" @selectCourse}}
+            aria-label={{t "pages.catalogue.modal.open-modal" name=@course.name}}
+          />
+        {{else if (eq @course.type "blueprint")}}
+          <LinkTo
+            @route="authenticated.catalogue.list"
+            @model={{@type}}
+            @query={{hash blueprintId=@course.id}}
+            {{on "click" @selectCourse}}
+            aria-label={{t "pages.catalogue.modal.open-modal" name=@course.name}}
+          />
+        {{/if}}
       {{/if}}
     </div>
   </template>

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixOverlay from '@1024pix/pix-ui/components/pix-overlay';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { hash } from '@ember/helper';
 import { service } from '@ember/service';
 import { recordIdentifierFor } from '@ember-data/store';
 import Component from '@glimmer/component';
@@ -43,7 +44,7 @@ export default class CourseModal extends Component {
     if (this.hasReachedPlacesLimit) {
       return null;
     }
-    return 'authenticated.campaigns.new';
+    return 'authenticated.campaigns.new-catalogue';
   }
 
   get courseLevelLabel() {
@@ -116,6 +117,7 @@ export default class CourseModal extends Component {
 
             <PixButtonLink
               @route={{this.campaignCreationRoute}}
+              @query={{hash courseId=@currentCourse.id}}
               @isDisabled={{this.hasReachedPlacesLimit}}
               @size="small"
               class="course-modal__body__form-link"

--- a/orga/app/controllers/authenticated/campaigns/new-catalogue.js
+++ b/orga/app/controllers/authenticated/campaigns/new-catalogue.js
@@ -1,0 +1,48 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class NewController extends Controller {
+  @service router;
+  @service store;
+  @service notifications;
+  @service intl;
+
+  @tracked errors;
+
+  queryParams = ['source'];
+
+  @action
+  async createCampaign() {
+    this.notifications.clearAll();
+    this.errors = null;
+    try {
+      await this.model.campaign.save();
+    } catch (errorResponse) {
+      errorResponse.errors.forEach((error) => {
+        if (error.status === '500') {
+          this.notifications.sendError(this.intl.t('api-error-messages.global'));
+        }
+      });
+      this.errors = this.model.campaign.errors;
+    }
+
+    if (!this.errors) {
+      if (this.model.campaign.type === 'COMBINED_COURSE') {
+        this.router.transitionTo('authenticated.combined-course', this.model.campaign.id);
+      } else {
+        this.router.transitionTo('authenticated.campaigns.campaign.settings', this.model.campaign.id);
+      }
+    }
+  }
+
+  @action
+  cancel() {
+    if (this.source) {
+      this.router.transitionTo('authenticated.campaigns.campaign.settings', this.source);
+    } else {
+      this.router.transitionTo('authenticated.campaigns');
+    }
+  }
+}

--- a/orga/app/controllers/authenticated/campaigns/new-catalogue.js
+++ b/orga/app/controllers/authenticated/campaigns/new-catalogue.js
@@ -10,8 +10,9 @@ export default class NewController extends Controller {
   @service intl;
 
   @tracked errors;
+  @tracked courseId = null;
 
-  queryParams = ['source'];
+  queryParams = ['source', 'courseId'];
 
   @action
   async createCampaign() {

--- a/orga/app/controllers/authenticated/catalogue/list.js
+++ b/orga/app/controllers/authenticated/catalogue/list.js
@@ -3,12 +3,14 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class CatalogueListController extends Controller {
-  queryParams = ['search', 'category', 'areas', 'competences'];
+  queryParams = ['search', 'category', 'areas', 'competences', 'targetProfileId', 'blueprintId'];
 
   @tracked search = '';
   @tracked category = '';
   @tracked areas = [];
   @tracked competences = [];
+  @tracked targetProfileId = null;
+  @tracked blueprintId = null;
 
   @action
   updateFilter(fieldName, value) {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -37,6 +37,8 @@ export default class Campaign extends Model {
   @belongsTo('target-profile', { async: true, inverse: null }) targetProfile;
   @belongsTo('combined-course-blueprint', { async: true, inverse: null }) combinedCourseBlueprint;
 
+  @belongsTo('course', { async: false, inverse: null }) course;
+
   @belongsTo('campaign-collective-result', { async: true, inverse: null }) campaignCollectiveResult;
   @belongsTo('campaign-result-levels-per-tubes-and-competence', { async: true, inverse: null })
   campaignResultLevelsPerTubesAndCompetence;
@@ -102,11 +104,16 @@ export default class Campaign extends Model {
   setType(type) {
     if (['ASSESSMENT', 'EXAM'].includes(type)) {
       this.multipleSendings = false;
+      this.course = this.course?.type === 'blueprint' ? null : this.course;
     }
     if (type === 'PROFILES_COLLECTION') {
       this.multipleSendings = true;
       this.title = null;
       this.targetProfileId = null;
+      this.course = null;
+    }
+    if (type === 'COMBINED_COURSE') {
+      this.course = this.course?.type === 'targetProfile' ? null : this.course;
     }
     this.type = type;
   }

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -69,6 +69,7 @@ Router.map(function () {
         this.route('all-campaigns', { path: '/toutes' });
       });
       this.route('new', { path: '/creation' });
+      this.route('new-catalogue', { path: '/creation-catalogue' });
       this.route('update', { path: '/:campaign_id/modification' });
       this.route(
         'participant-assessment',

--- a/orga/app/routes/authenticated/campaigns/new-catalogue.js
+++ b/orga/app/routes/authenticated/campaigns/new-catalogue.js
@@ -22,8 +22,7 @@ export default class NewRoute extends Route {
 
   async model(params) {
     const organization = this.currentUser.organization;
-    await organization.targetProfiles;
-    await organization.combinedCourseBlueprints;
+
     const membersSortedByFullName = await this.store.findAll('member-identity', {
       adapterOptions: { organizationId: organization.id },
     });
@@ -63,15 +62,35 @@ export default class NewRoute extends Route {
       ...(campaignAttributes ?? campaignAttributes),
     });
 
-    const targetProfiles = (await organization.targetProfiles) ?? undefined;
-    const combinedCourseBlueprints = (await organization.combinedCourseBlueprints) ?? undefined;
+    if (params?.courseId) {
+      let course = await this.store.peekRecord('course', params.courseId, {
+        adapterOptions: { organizationId: organization.id },
+      });
 
-    return { campaign, membersSortedByFullName, targetProfiles, combinedCourseBlueprints };
+      if (!course) {
+        const courses = await this.store.findAll('course', {
+          adapterOptions: { organizationId: organization.id },
+        });
+        course = courses.find(({ id }) => id === params.courseId);
+      }
+
+      campaign.course = course;
+
+      if (campaign.course.type === 'targetProfile') {
+        campaign.type = 'ASSESSMENT';
+      }
+      if (campaign.course.type === 'blueprint') {
+        campaign.type = 'COMBINED_COURSE';
+      }
+    }
+
+    return { campaign, membersSortedByFullName };
   }
 
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.set('source', null);
+      controller.set('courseId', null);
     }
   }
 }

--- a/orga/app/routes/authenticated/campaigns/new-catalogue.js
+++ b/orga/app/routes/authenticated/campaigns/new-catalogue.js
@@ -1,0 +1,77 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import { pick } from 'pix-orga/utils/collection';
+
+export default class NewRoute extends Route {
+  @service currentUser;
+  @service intl;
+  @service router;
+  @service store;
+
+  queryParams = {
+    source: { refreshModel: true },
+  };
+
+  beforeModel() {
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachedMaximumPlacesLimit) {
+      this.router.replaceWith('authenticated.campaigns');
+    }
+  }
+
+  async model(params) {
+    const organization = this.currentUser.organization;
+    await organization.targetProfiles;
+    await organization.combinedCourseBlueprints;
+    const membersSortedByFullName = await this.store.findAll('member-identity', {
+      adapterOptions: { organizationId: organization.id },
+    });
+
+    let campaignAttributes;
+    if (params?.source) {
+      try {
+        const from = await this.store.findRecord('campaign', params.source);
+
+        campaignAttributes = pick(from, [
+          'type',
+          'title',
+          'description',
+          'targetProfileId',
+          'ownerId',
+          'multipleSendings',
+          'externalIdLabel',
+          'externalIdType',
+          'customLandingPageText',
+        ]);
+
+        campaignAttributes.name = `${this.intl.t('pages.campaign-creation.copy-of')} ${from.name}`;
+        if (campaignAttributes.targetProfileId) {
+          campaignAttributes.targetProfile = this.store.peekRecord(
+            'target-profile',
+            campaignAttributes.targetProfileId,
+          );
+        }
+      } catch {
+        this.router.replaceWith('authenticated.campaigns.new', { queryParams: { source: null } });
+      }
+    }
+
+    const campaign = await this.store.createRecord('campaign', {
+      organization,
+      ownerId: this.currentUser.prescriber.id,
+      ...(campaignAttributes ?? campaignAttributes),
+    });
+
+    const targetProfiles = (await organization.targetProfiles) ?? undefined;
+    const combinedCourseBlueprints = (await organization.combinedCourseBlueprints) ?? undefined;
+
+    return { campaign, membersSortedByFullName, targetProfiles, combinedCourseBlueprints };
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('source', null);
+    }
+  }
+}

--- a/orga/app/routes/authenticated/catalogue/list.js
+++ b/orga/app/routes/authenticated/catalogue/list.js
@@ -53,4 +53,11 @@ export default class AuthenticatedCatalogueFilter extends Route {
     }
     this.#currentOrgaId = orgId;
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('targetProfileId', null);
+      controller.set('blueprintId', null);
+    }
+  }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -39,3 +39,17 @@
     }
   }
 }
+
+.campaign-creation-form {
+  &__course-selection {
+    .pix-fieldset {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+
+      &__label, .course-card {
+        margin-bottom: var(--pix-spacing-4x);
+      }
+    }
+  }
+}

--- a/orga/app/templates/authenticated/campaigns/new-catalogue.gjs
+++ b/orga/app/templates/authenticated/campaigns/new-catalogue.gjs
@@ -1,0 +1,21 @@
+import t from 'ember-intl/helpers/t';
+import pageTitle from 'ember-page-title/helpers/page-title';
+import CreateForm from 'pix-orga/components/campaign/create-form-catalogue';
+import PageTitle from 'pix-orga/components/ui/page-title';
+<template>
+  {{pageTitle (t "pages.campaign-creation.title")}}
+
+  <PageTitle>
+    <:title>{{t "pages.campaign-creation.title"}}</:title>
+  </PageTitle>
+
+  <CreateForm
+    @campaign={{@model.campaign}}
+    @targetProfiles={{@model.targetProfiles}}
+    @errors={{@controller.errors}}
+    @onSubmit={{@controller.createCampaign}}
+    @onCancel={{@controller.cancel}}
+    @membersSortedByFullName={{@model.membersSortedByFullName}}
+    @combinedCourseBlueprints={{@model.combinedCourseBlueprints}}
+  />
+</template>

--- a/orga/tests/acceptance/campaign-creation-catalogue-test.js
+++ b/orga/tests/acceptance/campaign-creation-catalogue-test.js
@@ -9,7 +9,7 @@ import authenticateSession from '../helpers/authenticate-session';
 import setupIntl from '../helpers/setup-intl';
 import { createPrescriberByUser, createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
-module('Acceptance | Campaign Creation', function (hooks) {
+module('Acceptance | Campaign Creation (catalogue)', function (hooks) {
   let availableTargetProfiles;
   let availableCombinedCourseBlueprints;
 
@@ -17,9 +17,25 @@ module('Acceptance | Campaign Creation', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
+  hooks.beforeEach(function () {
+    server.create('feature-toggle', { id: '0', displayCatalogue: true });
+
+    availableCombinedCourseBlueprints = server.createList('course', 2, { type: 'blueprint' });
+    availableCombinedCourseBlueprints.forEach((course) => {
+      server.create('combined-course-blueprint-overview', { id: course.id, name: course.name });
+      server.create('combined-course-blueprint', { id: course.id, name: course.name });
+    });
+
+    availableTargetProfiles = server.createList('course', 2, { type: 'targetProfile' });
+    availableTargetProfiles.forEach((course) => {
+      server.create('target-profile-overview', { id: course.id, name: course.name });
+      server.create('target-profile', { id: course.id, name: course.name });
+    });
+  });
+
   test('it should not be accessible by an unauthenticated user', async function (assert) {
     // when
-    await visit('/campagnes/creation');
+    await visit('/campagnes/creation-catalogue');
 
     // then
     assert.strictEqual(currentURL(), '/connexion');
@@ -32,18 +48,31 @@ module('Acceptance | Campaign Creation', function (hooks) {
     createPrescriberByUser({ user });
 
     await authenticateSession(user.id);
-    availableCombinedCourseBlueprints = server.createList('combined-course-blueprint', 2);
+
     const expectedCombinedCourseBlueprintName = availableCombinedCourseBlueprints[1].name;
 
-    const screen = await visit('/campagnes/creation');
-    await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
-    await clickByName(t('pages.campaign-creation.purpose.combined-course'));
+    const screen = await visit('/campagnes/creation-catalogue');
 
-    await click(screen.getByLabelText(`${t('pages.campaign-creation.combined-course-blueprints-list-label')} *`));
-    await click(await screen.findByRole('option', { description: expectedCombinedCourseBlueprintName }));
+    await click(
+      screen.getByRole('link', {
+        name: t('pages.campaign-creation.course-selection-label'),
+      }),
+    );
+
+    await click(
+      screen.getByRole('link', {
+        name: t('pages.catalogue.modal.open-modal', { name: expectedCombinedCourseBlueprintName }),
+      }),
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+
+    await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
 
     // when
     await clickByName('Créer la campagne');
+
     // then
     assert.strictEqual(server.db.campaigns[0].name, 'Mon parcours combiné');
     assert.strictEqual(currentURL(), `/parcours/${server.db.campaigns[0].id}`);
@@ -51,8 +80,6 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
   module('when the prescriber is authenticated', (hooks) => {
     hooks.beforeEach(async () => {
-      availableTargetProfiles = server.createList('target-profile', 2);
-
       const user = createUserWithMembershipAndTermsOfServiceAccepted();
       server.create('member-identity', { id: user.id, firstName: user.firstName, lastName: user.lastName });
       createPrescriberByUser({ user });
@@ -67,10 +94,10 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     test('it should be accessible for an authenticated prescriber', async function (assert) {
       // when
-      const screen = await visit('/campagnes/creation');
+      const screen = await visit('/campagnes/creation-catalogue');
 
       // then
-      assert.strictEqual(currentURL(), '/campagnes/creation');
+      assert.strictEqual(currentURL(), '/campagnes/creation-catalogue');
       assert.ok(screen.getByText("Création d'une campagne"));
     });
 
@@ -79,11 +106,23 @@ module('Acceptance | Campaign Creation', function (hooks) {
       const expectedTargetProfileId = availableTargetProfiles[1].id;
       const expectedTargetProfileName = availableTargetProfiles[1].name;
 
-      const screen = await visit('/campagnes/creation');
+      const screen = await visit('/campagnes/creation-catalogue');
+
+      await click(
+        screen.getByRole('link', {
+          name: t('pages.campaign-creation.course-selection-label'),
+        }),
+      );
+
+      await click(
+        screen.getByRole('link', {
+          name: t('pages.catalogue.modal.open-modal', { name: expectedTargetProfileName }),
+        }),
+      );
+      const dialog = await screen.findByRole('dialog');
+      await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
-      await clickByName('Évaluer les participants');
-      await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
-      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
 
       const externalIdentifier = screen
         .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
@@ -103,7 +142,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     test('it should allow to create a campaign of type PROFILES_COLLECTION and redirect to the newly created campaign', async function (assert) {
       // given
-      const screen = await visit('/campagnes/creation');
+      const screen = await visit('/campagnes/creation-catalogue');
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       await clickByName('Collecter les profils Pix des participants');
       const externalIdentifier = screen
@@ -124,11 +163,23 @@ module('Acceptance | Campaign Creation', function (hooks) {
       // given
       const expectedTargetProfileName = availableTargetProfiles[1].name;
 
-      const screen = await visit('/campagnes/creation');
+      const screen = await visit('/campagnes/creation-catalogue');
+
+      await click(
+        screen.getByRole('link', {
+          name: t('pages.campaign-creation.course-selection-label'),
+        }),
+      );
+
+      await click(
+        screen.getByRole('link', {
+          name: t('pages.catalogue.modal.open-modal', { name: expectedTargetProfileName }),
+        }),
+      );
+      const dialog = await screen.findByRole('dialog');
+      await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
-      await clickByName('Évaluer les participants');
-      await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
-      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
 
       const title = `${t('pages.campaign-creation.test-title.label')} ${t('pages.campaign-creation.test-title.sublabel')}`;
 
@@ -146,11 +197,23 @@ module('Acceptance | Campaign Creation', function (hooks) {
     test('it should set the current user as owner by default when creating a campaign', async function (assert) {
       // given
       const targetProfileName = availableTargetProfiles[1].name;
-      const screen = await visit('/campagnes/creation');
+      const screen = await visit('/campagnes/creation-catalogue');
+
+      await click(
+        screen.getByRole('link', {
+          name: t('pages.campaign-creation.course-selection-label'),
+        }),
+      );
+
+      await click(
+        screen.getByRole('link', {
+          name: t('pages.catalogue.modal.open-modal', { name: targetProfileName }),
+        }),
+      );
+      const dialog = await screen.findByRole('dialog');
+      await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
-      await clickByName('Évaluer les participants');
-      await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
-      await click(await screen.findByRole('option', { description: targetProfileName }));
 
       // when
       await clickByName('Créer la campagne');
@@ -161,16 +224,27 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     test('it should display error on global form when error 500 is returned from backend', async function (assert) {
       // given
-      const screen = await visit('/campagnes/creation');
+      const screen = await visit('/campagnes/creation-catalogue');
 
       const expectedTargetProfileName = availableTargetProfiles[1].name;
       server.post('/campaigns', {}, 500);
 
       // when
+      await click(
+        screen.getByRole('link', {
+          name: t('pages.campaign-creation.course-selection-label'),
+        }),
+      );
+
+      await click(
+        screen.getByRole('link', {
+          name: t('pages.catalogue.modal.open-modal', { name: expectedTargetProfileName }),
+        }),
+      );
+      const dialog = await screen.findByRole('dialog');
+      await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
-      await clickByName('Évaluer les participants');
-      await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
-      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
       const externalIdentifier = screen
         .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
         .closest('fieldset');
@@ -179,7 +253,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await clickByName('Créer la campagne');
 
       // then
-      assert.strictEqual(currentURL(), '/campagnes/creation');
+      assert.strictEqual(currentURL(), '/campagnes/creation-catalogue?courseId=4');
       assert.ok(screen.getByText('Une erreur est survenue. Veuillez réessayer ultérieurement.'));
     });
   });

--- a/orga/tests/acceptance/campaign-creation-catalogue-test.js
+++ b/orga/tests/acceptance/campaign-creation-catalogue-test.js
@@ -1,0 +1,186 @@
+import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'pix-orga/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import authenticateSession from '../helpers/authenticate-session';
+import setupIntl from '../helpers/setup-intl';
+import { createPrescriberByUser, createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
+
+module('Acceptance | Campaign Creation', function (hooks) {
+  let availableTargetProfiles;
+  let availableCombinedCourseBlueprints;
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  test('it should not be accessible by an unauthenticated user', async function (assert) {
+    // when
+    await visit('/campagnes/creation');
+
+    // then
+    assert.strictEqual(currentURL(), '/connexion');
+  });
+
+  test('it should allow to create a combined course and redirect to the newly created combined course', async function (assert) {
+    // given
+    const user = createUserWithMembershipAndTermsOfServiceAccepted();
+    server.create('member-identity', { id: user.id, firstName: user.firstName, lastName: user.lastName });
+    createPrescriberByUser({ user });
+
+    await authenticateSession(user.id);
+    availableCombinedCourseBlueprints = server.createList('combined-course-blueprint', 2);
+    const expectedCombinedCourseBlueprintName = availableCombinedCourseBlueprints[1].name;
+
+    const screen = await visit('/campagnes/creation');
+    await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
+    await clickByName(t('pages.campaign-creation.purpose.combined-course'));
+
+    await click(screen.getByLabelText(`${t('pages.campaign-creation.combined-course-blueprints-list-label')} *`));
+    await click(await screen.findByRole('option', { description: expectedCombinedCourseBlueprintName }));
+
+    // when
+    await clickByName('Créer la campagne');
+    // then
+    assert.strictEqual(server.db.campaigns[0].name, 'Mon parcours combiné');
+    assert.strictEqual(currentURL(), `/parcours/${server.db.campaigns[0].id}`);
+  });
+
+  module('when the prescriber is authenticated', (hooks) => {
+    hooks.beforeEach(async () => {
+      availableTargetProfiles = server.createList('target-profile', 2);
+
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      server.create('member-identity', { id: user.id, firstName: user.firstName, lastName: user.lastName });
+      createPrescriberByUser({ user });
+
+      await authenticateSession(user.id);
+    });
+
+    hooks.afterEach(function () {
+      const notificationMessagesService = this.owner.lookup('service:notifications');
+      notificationMessagesService.clearAll();
+    });
+
+    test('it should be accessible for an authenticated prescriber', async function (assert) {
+      // when
+      const screen = await visit('/campagnes/creation');
+
+      // then
+      assert.strictEqual(currentURL(), '/campagnes/creation');
+      assert.ok(screen.getByText("Création d'une campagne"));
+    });
+
+    test('it should allow to create a campaign of type ASSESSMENT and redirect to the newly created campaign', async function (assert) {
+      // given
+      const expectedTargetProfileId = availableTargetProfiles[1].id;
+      const expectedTargetProfileName = availableTargetProfiles[1].name;
+
+      const screen = await visit('/campagnes/creation');
+      await fillByLabel('Nom de la campagne *', 'Ma Campagne');
+      await clickByName('Évaluer les participants');
+      await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
+      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
+
+      const externalIdentifier = screen
+        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .closest('fieldset');
+      const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
+      await click(element);
+
+      // when
+      await clickByName('Créer la campagne');
+
+      // then
+      const firstCampaign = server.db.campaigns[0];
+      assert.strictEqual(firstCampaign.name, 'Ma Campagne');
+      assert.strictEqual(firstCampaign.targetProfileId, expectedTargetProfileId);
+      assert.strictEqual(currentURL(), '/campagnes/1/parametres');
+    });
+
+    test('it should allow to create a campaign of type PROFILES_COLLECTION and redirect to the newly created campaign', async function (assert) {
+      // given
+      const screen = await visit('/campagnes/creation');
+      await fillByLabel('Nom de la campagne *', 'Ma Campagne');
+      await clickByName('Collecter les profils Pix des participants');
+      const externalIdentifier = screen
+        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .closest('fieldset');
+      const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
+      await click(element);
+
+      // when
+      await clickByName('Créer la campagne');
+
+      // then
+      assert.strictEqual(server.db.campaigns[0].name, 'Ma Campagne');
+      assert.strictEqual(currentURL(), '/campagnes/1/parametres');
+    });
+
+    test('it should create campaign if user changes type after filling the form', async function (assert) {
+      // given
+      const expectedTargetProfileName = availableTargetProfiles[1].name;
+
+      const screen = await visit('/campagnes/creation');
+      await fillByLabel('Nom de la campagne *', 'Ma Campagne');
+      await clickByName('Évaluer les participants');
+      await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
+      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
+
+      const title = `${t('pages.campaign-creation.test-title.label')} ${t('pages.campaign-creation.test-title.sublabel')}`;
+
+      await fillByLabel(title, 'Savoir rechercher');
+      await clickByName('Non');
+
+      // when
+      await clickByName(t('pages.campaign-creation.actions.create'));
+
+      // then
+      assert.strictEqual(server.db.campaigns[0].name, 'Ma Campagne');
+      assert.strictEqual(currentURL(), '/campagnes/1/parametres');
+    });
+
+    test('it should set the current user as owner by default when creating a campaign', async function (assert) {
+      // given
+      const targetProfileName = availableTargetProfiles[1].name;
+      const screen = await visit('/campagnes/creation');
+      await fillByLabel('Nom de la campagne *', 'Ma Campagne');
+      await clickByName('Évaluer les participants');
+      await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
+      await click(await screen.findByRole('option', { description: targetProfileName }));
+
+      // when
+      await clickByName('Créer la campagne');
+
+      // then
+      assert.ok(screen.getByText('Harry Cover', { selector: 'dd' }));
+    });
+
+    test('it should display error on global form when error 500 is returned from backend', async function (assert) {
+      // given
+      const screen = await visit('/campagnes/creation');
+
+      const expectedTargetProfileName = availableTargetProfiles[1].name;
+      server.post('/campaigns', {}, 500);
+
+      // when
+      await fillByLabel('Nom de la campagne *', 'Ma Campagne');
+      await clickByName('Évaluer les participants');
+      await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
+      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
+      const externalIdentifier = screen
+        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .closest('fieldset');
+      const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
+      await click(element);
+      await clickByName('Créer la campagne');
+
+      // then
+      assert.strictEqual(currentURL(), '/campagnes/creation');
+      assert.ok(screen.getByText('Une erreur est survenue. Veuillez réessayer ultérieurement.'));
+    });
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -1,0 +1,1454 @@
+import { clickByName, fillByLabel, render, within } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import CreateForm from 'pix-orga/components/campaign/create-form';
+import { assert, module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+  const createCampaignSpy = (event) => {
+    event.preventDefault();
+  };
+  const cancelSpy = () => {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    const prescriber = store.createRecord('prescriber', {
+      firstName: 'Adam',
+      lastName: 'Troisjour',
+      id: '1',
+      features: {
+        MULTIPLE_SENDING_ASSESSMENT: { active: false, params: null },
+        COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: { active: false, params: null },
+      },
+    });
+
+    class CurrentUserStub extends Service {
+      prescriber = prescriber;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    data.prescriber = prescriber;
+    data.defaultMembers = [prescriber];
+    data.campaign = store.createRecord('campaign', { ownerId: prescriber.id });
+    data.errors = {};
+    data.targetProfiles = [];
+    data.combinedCourseBlueprints = [];
+  });
+
+  test('it should contain inputs, attributes and validation button', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByLabelText(t('pages.campaign-creation.name.label'), { exact: false })).exists();
+    assert.dom('button[type="submit"]').exists();
+    assert.dom('input[type=text]').hasAttribute('maxLength', '255');
+    assert.dom('textarea').hasAttribute('maxLength', '5000');
+  });
+
+  test("it should display campaign's name", async function (assert) {
+    // given
+    data.campaign.name = 'Campagne de test';
+
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.name.label'), { exact: false }))
+      .hasValue('Campagne de test');
+  });
+
+  test('[a11y] it should display a message that some inputs are required', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    // then
+    assert
+      .dom(
+        screen.getByText(t('common.form.mandatory-fields'), {
+          exact: false,
+        }),
+      )
+      .exists();
+  });
+
+  [
+    {
+      status: 'ASSESSMENT',
+      purpose: 'pages.campaign-creation.purpose.assessment',
+      explanation: 'pages.campaign-creation.purpose.assessment-info',
+    },
+    {
+      status: 'EXAM',
+      purpose: 'pages.campaign-creation.purpose.exam',
+      explanation: 'pages.campaign-creation.purpose.exam-info',
+    },
+  ].forEach(async function (campaignType) {
+    module(`when campaign is of type ${campaignType.status}`, function (hooks) {
+      hooks.beforeEach(function () {
+        data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
+      });
+
+      test(`it should have checked ${campaignType.status}`, async function (assert) {
+        // given
+        data.campaign.type = campaignType.status;
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @targetProfiles={{data.targetProfiles}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByLabelText(t(campaignType.purpose))).isChecked();
+      });
+
+      test("it should display owner fields and auto complete owner field with owner's full name", async function (assert) {
+        // when
+        data.campaign.type = campaignType.status;
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @targetProfiles={{data.targetProfiles}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+
+        assert.dom(screen.getByText(t('pages.campaign-creation.owner.info'))).exists();
+        assert.dom(screen.getAllByText(t('pages.campaign-creation.owner.title'))[0]).exists();
+        await click(screen.getByLabelText(t('pages.campaign-creation.owner.label'), { exact: false }));
+        await screen.findByRole('listbox');
+
+        // then
+        assert.dom(screen.getByRole('option', { name: 'Adam Troisjour', selected: true })).exists();
+      });
+
+      test('it should fill target-profile fields', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const targetProfile = store.createRecord('target-profile', {
+          id: '1',
+          name: 'Target profile 1',
+          description: 'Description 1',
+          category: 'Category 1',
+        });
+        data.targetProfiles = [targetProfile];
+        data.campaign.type = campaignType.status;
+        data.campaign.targetProfile = targetProfile;
+
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @targetProfiles={{data.targetProfiles}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+
+        // then
+        const targetProfileField = screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), {
+          exact: false,
+        });
+        assert.strictEqual(targetProfileField.innerText, targetProfile.name);
+      });
+
+      test('it should fill multiple sendings fields', async function (assert) {
+        // given
+        data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
+        data.campaign.type = campaignType.status;
+        data.campaign.multipleSendings = true;
+
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @targetProfiles={{data.targetProfiles}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+
+        // then
+        const radiogroup = screen.getByRole('radiogroup', {
+          name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+        });
+        assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
+      });
+
+      test('it should explain which informations will be visible to organization-learners', async function () {
+        // given
+        data.campaign.type = campaignType.status;
+
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @targetProfiles={{data.targetProfiles}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+
+        // then
+        const testTitleSublabel = screen.getAllByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), {
+          exact: false,
+        })[0];
+        const landingPageSublabel = screen.getAllByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), {
+          exact: false,
+        })[1];
+
+        assert.ok(testTitleSublabel);
+        assert.ok(landingPageSublabel);
+      });
+    });
+
+    module(`when user choose to create a campaign of type ${campaignType.status}`, function (hooks) {
+      hooks.beforeEach(function () {
+        data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
+      });
+
+      test('it should display fields for campaign title and target profile', async function (assert) {
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @targetProfiles={{data.targetProfiles}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+        await clickByName(t(campaignType.purpose));
+
+        // then
+        assert.dom(screen.getByText(t('pages.campaign-creation.test-title.label'))).exists();
+        assert.dom(screen.getByText(t('pages.campaign-creation.purpose.label'))).exists();
+      });
+
+      test(`it should display the purpose explanation of an ${campaignType.status} campaign`, async function (assert) {
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @targetProfiles={{data.targetProfiles}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+        await clickByName(t(campaignType.purpose));
+
+        // then
+        assert.dom(screen.getByText(t(campaignType.explanation))).exists();
+      });
+
+      module('when the user chose a target profile', function () {
+        test('it should display informations about target profile', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          data.targetProfiles = [
+            store.createRecord('target-profile', {
+              id: '1',
+              name: 'targetProfile1',
+              description: 'description1',
+              tubeCount: 11,
+              thematicResultCount: 12,
+              hasStage: true,
+            }),
+            store.createRecord('target-profile', {
+              id: '2',
+              name: 'targetProfile2',
+              description: 'description2',
+              tubeCount: 21,
+              thematicResultCount: 22,
+              hasStage: false,
+            }),
+          ];
+
+          // when
+          const screen = await render(
+            <template>
+              <CreateForm
+                @campaign={{data.campaign}}
+                @targetProfiles={{data.targetProfiles}}
+                @onSubmit={{createCampaignSpy}}
+                @onCancel={{cancelSpy}}
+                @errors={{data.errors}}
+                @membersSortedByFullName={{data.defaultMembers}}
+              />
+            </template>,
+          );
+          await clickByName(t(campaignType.purpose));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
+          // then
+          assert.dom(screen.getByText('description1')).exists();
+          assert.dom(screen.getByText(t('common.target-profile-details.subjects', { value: 11 }))).exists();
+          assert.dom(screen.getByText(t('common.target-profile-details.thematic-results', { value: 12 }))).exists();
+        });
+
+        test('it should display a message about result', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          data.targetProfiles = [
+            store.createRecord('target-profile', {
+              id: '1',
+              name: 'targetProfile1',
+              description: 'description1',
+              tubeCount: 11,
+              thematicResultCount: 12,
+              hasStage: true,
+            }),
+            store.createRecord('target-profile', {
+              id: '2',
+              name: 'targetProfile2',
+              description: 'description2',
+              tubeCount: 21,
+              thematicResultCount: 22,
+              hasStage: false,
+            }),
+          ];
+
+          // when
+          const screen = await render(
+            <template>
+              <CreateForm
+                @campaign={{data.campaign}}
+                @targetProfiles={{data.targetProfiles}}
+                @onSubmit={{createCampaignSpy}}
+                @onCancel={{cancelSpy}}
+                @errors={{data.errors}}
+                @membersSortedByFullName={{data.defaultMembers}}
+              />
+            </template>,
+          );
+          await clickByName(t(campaignType.purpose));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
+
+          // then
+          assert.dom(screen.getByText(t('common.target-profile-details.results.common'))).exists();
+        });
+
+        module('simplified access', function () {
+          test('it should display with simplified access label in options list', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            data.targetProfiles = [
+              store.createRecord('target-profile', {
+                id: '1',
+                name: 'targetProfile1',
+                isSimplifiedAccess: true,
+              }),
+            ];
+
+            // when
+            const screen = await render(
+              <template>
+                <CreateForm
+                  @campaign={{data.campaign}}
+                  @targetProfiles={{data.targetProfiles}}
+                  @onSubmit={{createCampaignSpy}}
+                  @onCancel={{cancelSpy}}
+                  @errors={{data.errors}}
+                  @membersSortedByFullName={{data.defaultMembers}}
+                />
+              </template>,
+            );
+
+            await clickByName(t(campaignType.purpose));
+
+            await click(
+              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+            );
+
+            // then
+            assert.ok(screen.getByText(t('common.target-profile-details.simplified-access.without-account')));
+          });
+
+          test('it should display without simplified access label in options list', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            data.targetProfiles = [
+              store.createRecord('target-profile', {
+                id: '1',
+                name: 'targetProfile1',
+                isSimplifiedAccess: false,
+              }),
+            ];
+
+            // when
+            const screen = await render(
+              <template>
+                <CreateForm
+                  @campaign={{data.campaign}}
+                  @targetProfiles={{data.targetProfiles}}
+                  @onSubmit={{createCampaignSpy}}
+                  @onCancel={{cancelSpy}}
+                  @errors={{data.errors}}
+                  @membersSortedByFullName={{data.defaultMembers}}
+                />
+              </template>,
+            );
+            await clickByName(t(campaignType.purpose));
+
+            await click(
+              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+            );
+
+            // then
+            assert.ok(screen.getByText(t('common.target-profile-details.simplified-access.with-account')));
+          });
+        });
+
+        module('Displaying options and categories', function () {
+          test('it should display options in alphapetical order', async function (assert) {
+            // given
+
+            const store = this.owner.lookup('service:store');
+            data.targetProfiles = [
+              store.createRecord('target-profile', {
+                id: '1',
+                name: 'targetProfile4',
+                description: 'description4',
+                tubeCount: 11,
+                thematicResultCount: 12,
+                hasStage: true,
+                category: 'B',
+              }),
+              store.createRecord('target-profile', {
+                id: '2',
+                name: 'targetProfile3',
+                description: 'description3',
+                tubeCount: 21,
+                thematicResultCount: 22,
+                hasStage: false,
+                category: 'B',
+              }),
+              store.createRecord('target-profile', {
+                id: '3',
+                name: 'targetProfile2',
+                description: 'description2',
+                tubeCount: 33,
+                thematicResultCount: 12,
+                hasStage: true,
+                category: 'A',
+              }),
+              store.createRecord('target-profile', {
+                id: '4',
+                name: 'targetProfile1',
+                description: 'description1',
+                tubeCount: 44,
+                thematicResultCount: 12,
+                hasStage: true,
+                category: 'A',
+              }),
+            ];
+
+            // when
+            const screen = await render(
+              <template>
+                <CreateForm
+                  @campaign={{data.campaign}}
+                  @targetProfiles={{data.targetProfiles}}
+                  @onSubmit={{createCampaignSpy}}
+                  @onCancel={{cancelSpy}}
+                  @errors={{data.errors}}
+                  @membersSortedByFullName={{data.defaultMembers}}
+                />
+              </template>,
+            );
+            await clickByName(t(campaignType.purpose));
+
+            await click(
+              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+            );
+            let options = await screen.findAllByRole('option');
+
+            // then
+            options = options.map((option) => {
+              return option.innerText;
+            });
+            assert.deepEqual(options, ['targetProfile1', 'targetProfile2', 'targetProfile3', 'targetProfile4']);
+          });
+
+          test('it should display options with OTHER category at last position', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            data.targetProfiles = [
+              store.createRecord('target-profile', {
+                id: '2',
+                name: 'targetProfile3',
+                description: 'description3',
+                tubeCount: 21,
+                thematicResultCount: 22,
+                hasStage: false,
+                category: 'OTHER',
+              }),
+              store.createRecord('target-profile', {
+                id: '1',
+                name: 'targetProfile4',
+                description: 'description4',
+                tubeCount: 11,
+                thematicResultCount: 12,
+                hasStage: true,
+                category: 'A',
+              }),
+            ];
+
+            // when
+            const screen = await render(
+              <template>
+                <CreateForm
+                  @campaign={{data.campaign}}
+                  @targetProfiles={{data.targetProfiles}}
+                  @onSubmit={{createCampaignSpy}}
+                  @onCancel={{cancelSpy}}
+                  @errors={{data.errors}}
+                  @membersSortedByFullName={{data.defaultMembers}}
+                />
+              </template>,
+            );
+            await clickByName(t(campaignType.purpose));
+
+            await click(
+              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+            );
+            let options = await screen.findAllByRole('option');
+
+            // then
+            options = options.map((option) => {
+              return option.innerText;
+            });
+            assert.deepEqual(options, ['targetProfile4', 'targetProfile3']);
+          });
+        });
+      });
+
+      module('when the user wants to clear the content of the target profile input', function (hooks) {
+        hooks.beforeEach(function () {
+          const store = this.owner.lookup('service:store');
+          data.targetProfiles = [
+            store.createRecord('target-profile', {
+              id: '1',
+              name: 'targetProfile1',
+              description: 'description1',
+            }),
+          ];
+        });
+      });
+
+      module('multiple sending', function () {
+        test('it should not display multiple sendings field', async function (assert) {
+          // when
+          const screen = await render(
+            <template>
+              <CreateForm
+                @campaign={{data.campaign}}
+                @onSubmit={{createCampaignSpy}}
+                @onCancel={{cancelSpy}}
+                @errors={{data.errors}}
+                @targetProfiles={{data.targetProfiles}}
+                @membersSortedByFullName={{data.defaultMembers}}
+              />
+            </template>,
+          );
+          await clickByName(t(campaignType.purpose));
+
+          // then
+          assert
+            .dom(screen.queryByLabelText(t('pages.campaign-creation.multiple-sendings.assessments.question-label')))
+            .doesNotExist();
+          assert
+            .dom(screen.queryByLabelText(t('pages.campaign-creation.multiple-sendings.assessments.info')))
+            .doesNotExist();
+        });
+
+        test('it should display multiple sendings field', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          data.targetProfiles = [
+            store.createRecord('target-profile', {
+              id: '1',
+              name: 'targetProfile1',
+              description: 'description1',
+              tubeCount: 11,
+              thematicResultCount: 12,
+              hasStage: true,
+            }),
+            store.createRecord('target-profile', {
+              id: '2',
+              name: 'targetProfile2',
+              description: 'description2',
+              tubeCount: 21,
+              thematicResultCount: 22,
+              hasStage: false,
+            }),
+          ];
+          data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = true;
+
+          // when
+          const screen = await render(
+            <template>
+              <CreateForm
+                @campaign={{data.campaign}}
+                @targetProfiles={{data.targetProfiles}}
+                @onSubmit={{createCampaignSpy}}
+                @onCancel={{cancelSpy}}
+                @errors={{data.errors}}
+                @membersSortedByFullName={{data.defaultMembers}}
+              />
+            </template>,
+          );
+          await clickByName(t(campaignType.purpose));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
+
+          // then
+          assert.dom(screen.getByText(t('common.target-profile-details.results.common'))).exists();
+        });
+
+        module('when target profile are knowledge elements resettable', function () {
+          test('it should display specific message', async function (assert) {
+            // given
+            data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
+            const store = this.owner.lookup('service:store');
+
+            data.targetProfiles = [
+              store.createRecord('target-profile', {
+                id: '1',
+                name: 'targetProfile1',
+                description: 'description1',
+                tubeCount: 11,
+                thematicResultCount: 12,
+                hasStage: true,
+                areKnowledgeElementsResettable: true,
+              }),
+              store.createRecord('target-profile', {
+                id: '2',
+                name: 'targetProfile2',
+                description: 'description2',
+                tubeCount: 21,
+                thematicResultCount: 22,
+                hasStage: false,
+              }),
+            ];
+
+            // when
+            const screen = await render(
+              <template>
+                <CreateForm
+                  @campaign={{data.campaign}}
+                  @targetProfiles={{data.targetProfiles}}
+                  @onSubmit={{createCampaignSpy}}
+                  @onCancel={{cancelSpy}}
+                  @errors={{data.errors}}
+                  @membersSortedByFullName={{data.defaultMembers}}
+                />
+              </template>,
+            );
+            await clickByName(t(campaignType.purpose));
+
+            await click(
+              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+            );
+            await click(await screen.findByRole('option', { description: 'targetProfile1' }));
+
+            // then
+            assert
+              .dom(
+                screen.getByText(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'), {
+                  exact: false,
+                }),
+              )
+              .exists();
+          });
+        });
+
+        module('when target profile are not knowledge elements resettable', function () {
+          test('it should not display specific message', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            data.targetProfiles = [
+              store.createRecord('target-profile', {
+                id: '1',
+                name: 'targetProfile1',
+                description: 'description1',
+                tubeCount: 11,
+                thematicResultCount: 12,
+                hasStage: true,
+                areKnowledgeElementsResettable: false,
+              }),
+              store.createRecord('target-profile', {
+                id: '2',
+                name: 'targetProfile2',
+                description: 'description2',
+                tubeCount: 21,
+                thematicResultCount: 22,
+                hasStage: false,
+              }),
+            ];
+            data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = true;
+
+            // when
+            const screen = await render(
+              <template>
+                <CreateForm
+                  @campaign={{data.campaign}}
+                  @targetProfiles={{data.targetProfiles}}
+                  @onSubmit={{createCampaignSpy}}
+                  @onCancel={{cancelSpy}}
+                  @errors={{data.errors}}
+                  @membersSortedByFullName={{data.defaultMembers}}
+                />
+              </template>,
+            );
+            await clickByName(t(campaignType.purpose));
+
+            await click(
+              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+            );
+            await click(await screen.findByRole('option', { description: 'targetProfile1' }));
+
+            // then
+            assert
+              .dom(
+                screen.queryByText(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'), {
+                  exact: false,
+                }),
+              )
+              .doesNotExist();
+          });
+        });
+      });
+    });
+  });
+
+  module(`when campaign is of type combined course`, function () {
+    test(`it should have checked combined course goal and not display owner fields`, async function (assert) {
+      const campaignType = {
+        status: 'COMBINED_COURSE',
+        purpose: 'pages.campaign-creation.purpose.combined-course',
+      };
+      // given
+      data.campaign.type = campaignType.status;
+      data.combinedCourseBlueprints = [{ id: 1, name: 'Mon schéma de parcours combiné' }];
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+            @combinedCourseBlueprints={{data.combinedCourseBlueprints}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText(t(campaignType.purpose))).isChecked();
+      assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
+      assert.dom(screen.queryByText(t('pages.campaign-creation.owner.title'))).doesNotExist();
+    });
+  });
+  test('should not display EXAM type when feature is not enable', async function () {
+    // given
+    data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: false, params: null };
+
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    assert.notOk(screen.queryByLabelText(t('pages.campaign-creation.purpose.exam')));
+  });
+
+  module('when campaign is of type PROFILES_COLLECTION', function () {
+    test('it should have checked PROFILES_COLLECTION', async function (assert) {
+      // given
+      data.campaign.type = 'PROFILES_COLLECTION';
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.profiles-collection'))).isChecked();
+    });
+
+    test('it should fill multiple sendings fields', async function (assert) {
+      // given
+      data.campaign.type = 'PROFILES_COLLECTION';
+      data.campaign.multipleSendings = true;
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      const radiogroup = screen.getByRole('radiogroup', {
+        name: t('pages.campaign-creation.multiple-sendings.profiles.question-label'),
+      });
+      assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
+    });
+  });
+
+  module('when user choose to create a campaign of type PROFILES_COLLECTION', () => {
+    test('it should not display fields for campaign title and target profile', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
+      assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
+    });
+
+    test('it should display fields for enabling multiple sendings', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.question-label'))).exists();
+      assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.info'))).exists();
+    });
+
+    test('it should display the purpose explanation of a profiles collection campaign', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert.dom(screen.getByText(t('pages.campaign-creation.purpose.profiles-collection-info'))).exists();
+      assert.dom(screen.queryByText(t('pages.campaign-creation.purpose.assessment-info'))).doesNotExist();
+    });
+  });
+
+  module('when user choose to create a campaign of type COMBINED_COURSE', () => {
+    test('it should not display fields for campaign title and target profile', async function (assert) {
+      // when
+      const store = this.owner.lookup('service:store');
+      const combinedCourseBlueprint = store.createRecord('combined-course-blueprint', {
+        id: '1',
+        name: 'Blueprint 1',
+      });
+
+      data.combinedCourseBlueprints = [combinedCourseBlueprint];
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+            @combinedCourseBlueprints={{data.combinedCourseBlueprints}}
+          />
+        </template>,
+      );
+
+      await clickByName(t('pages.campaign-creation.purpose.combined-course'));
+
+      // then
+      assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
+      assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
+      await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
+      await clickByName(t('pages.campaign-creation.purpose.combined-course'));
+
+      await click(screen.getByLabelText(`${t('pages.campaign-creation.combined-course-blueprints-list-label')} *`));
+      assert.ok(await screen.findByRole('option', { description: combinedCourseBlueprint.name }));
+    });
+  });
+
+  test('it should fill external user ID selection (yes)', async function (assert) {
+    // given
+    data.campaign.externalIdLabel = 'Numéro étudiant';
+
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    // then
+    const externalIdentifier = screen
+      .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
+      .closest('fieldset');
+    const element = within(externalIdentifier).getByRole('radio', { name: t('pages.campaign-creation.yes') });
+
+    assert.dom(element).isChecked();
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.external-id-label.label'), { exact: false }))
+      .hasValue('Numéro étudiant');
+  });
+
+  test('it should fill external user ID selection (no)', async function (assert) {
+    // given
+    data.campaign.externalIdLabel = null;
+
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    // then
+    const externalIdentifier = screen
+      .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
+      .closest('fieldset');
+    const element = within(externalIdentifier).getByRole('radio', { name: t('pages.campaign-creation.no') });
+
+    assert.dom(element).isChecked();
+  });
+
+  module('when user has not chosen yet to ask or not an external user ID', function () {
+    test('it should fill the default external user ID selection', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      const externalIdentifier = screen
+        .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
+        .closest('fieldset');
+
+      assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.no'))).isChecked();
+      assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.yes'))).isNotChecked();
+    });
+
+    test('it should not display gdpr footnote', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.queryByText(t('pages.campaign-creation.legal-warning'))).doesNotExist();
+    });
+  });
+
+  module('when user choose not to ask an external user ID', function () {
+    test('it should not display gdpr footnote either', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.no'));
+
+      // then
+      assert.dom(screen.queryByText(t('pages.campaign-creation.legal-warning'))).doesNotExist();
+    });
+  });
+
+  module('when user choose to ask an external user ID', function () {
+    test('it should display gdpr footnote', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      // then
+      assert.dom(screen.getByText(t('pages.campaign-creation.legal-warning'))).exists();
+    });
+
+    test('it set the external id as required', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      // then
+      const label = screen.getByLabelText(new RegExp(t('pages.campaign-creation.external-id-label.label')));
+      assert.true(label.hasAttribute('aria-required', false));
+    });
+    test('it asks for external id type', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      // then
+      const radioGroup = screen.getByRole('radiogroup', {
+        name: t('pages.campaign-creation.external-id-type.question-label'),
+      });
+      assert.ok(radioGroup);
+    });
+
+    test('it updates campaign model when select a type', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      const checkedRadio = screen.getByLabelText(t('pages.campaign-settings.external-user-id-types.email'));
+      await checkedRadio.click();
+      assert.strictEqual(data.campaign.externalIdType, 'EMAIL');
+    });
+  });
+
+  test('it should fill campaign title', async function (assert) {
+    // given
+    data.campaign.type = 'ASSESSMENT';
+    data.campaign.title = 'Mon titre de parcours';
+
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false }))
+      .hasValue('Mon titre de parcours');
+  });
+
+  test('it should fill campaign landing page text', async function (assert) {
+    // given
+    data.campaign.customLandingPageText = 'Mon texte de landing page';
+
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
+      .hasValue('Mon texte de landing page');
+  });
+
+  test('it should send campaign creation action when submitted', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const targetProfile = store.createRecord('target-profile', { name: 'targetProfile1', id: '123' });
+    data.targetProfiles = [targetProfile];
+    const createCampaignSpy = sinon.stub();
+
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+    await fillByLabel(`${t('pages.campaign-creation.name.label')} *`, 'Ma campagne');
+    await clickByName(t('pages.campaign-creation.purpose.assessment'));
+    await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+    await click(await screen.findByRole('option', { description: targetProfile.name }));
+
+    // when
+    await clickByName(t('pages.campaign-creation.actions.create'));
+
+    sinon.assert.calledWithExactly(createCampaignSpy, data.campaign);
+    // then
+    assert.ok(true);
+  });
+
+  test('it should not display the explanation of automatic compute certificability if the feature is not activated', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+    await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+
+    // then
+    assert.dom(screen.queryByRole('link', { name: 'Élèves' })).doesNotExist();
+  });
+
+  test('it should display the explanation of automatic compute certificability if the feature is activated', async function (assert) {
+    // when
+    data.prescriber.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY = { active: true, params: null };
+
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @targetProfiles={{data.targetProfiles}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+    await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Élèves' })).exists();
+  });
+
+  module('when there are errors', function () {
+    test('it should display errors messages when the name, the campaign purpose and the external user id fields are empty', async function (assert) {
+      // given
+      const campaignWithErrors = EmberObject.create({
+        errors: {
+          name: [
+            {
+              message: 'CAMPAIGN_NAME_IS_REQUIRED',
+            },
+          ],
+          externalIdLabel: [
+            {
+              message: 'EXTERNAL_USER_ID_IS_REQUIRED',
+            },
+          ],
+          type: [
+            {
+              message: 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+            },
+          ],
+        },
+      });
+
+      data.errors = campaignWithErrors.errors;
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      // then
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.name-required'))).exists();
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.purpose-required'))).exists();
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.external-user-id-required'))).exists();
+    });
+
+    test('it should display errors messages when the target profile field is empty', async function (assert) {
+      // given
+      const campaignWithErrors = EmberObject.create({
+        errors: {
+          targetProfile: [
+            {
+              message: 'TARGET_PROFILE_IS_REQUIRED',
+            },
+          ],
+        },
+      });
+      data.errors = campaignWithErrors.errors;
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+      // then
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
+    });
+
+    test('it should display errors messages when the blueprint id field is empty', async function (assert) {
+      // given
+      const campaignWithErrors = EmberObject.create({
+        errors: {
+          blueprint: [
+            {
+              message: 'TARGET_PROFILE_IS_REQUIRED',
+            },
+          ],
+        },
+      });
+      data.errors = campaignWithErrors.errors;
+
+      const store = this.owner.lookup('service:store');
+      const combinedCourseBlueprint = store.createRecord('combined-course-blueprint', {
+        id: '1',
+        name: 'Blueprint 1',
+      });
+
+      data.combinedCourseBlueprints = [combinedCourseBlueprint];
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @targetProfiles={{data.targetProfiles}}
+            @membersSortedByFullName={{data.defaultMembers}}
+            @combinedCourseBlueprints={{data.combinedCourseBlueprints}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.purpose.combined-course'));
+
+      // then
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
+    });
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -3,13 +3,13 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
-import CreateForm from 'pix-orga/components/campaign/create-form';
+import CreateForm from 'pix-orga/components/campaign/create-form-catalogue';
 import { assert, module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | Campaign::CreateForm', function (hooks) {
+module('Integration | Component | Campaign::CreateForm (catalogue)', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   const data = {};
@@ -39,8 +39,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     data.defaultMembers = [prescriber];
     data.campaign = store.createRecord('campaign', { ownerId: prescriber.id });
     data.errors = {};
-    data.targetProfiles = [];
-    data.combinedCourseBlueprints = [];
   });
 
   test('it should contain inputs, attributes and validation button', async function (assert) {
@@ -52,7 +50,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -77,7 +74,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -97,7 +93,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -141,7 +136,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               @onSubmit={{createCampaignSpy}}
               @onCancel={{cancelSpy}}
               @errors={{data.errors}}
-              @targetProfiles={{data.targetProfiles}}
               @membersSortedByFullName={{data.defaultMembers}}
             />
           </template>,
@@ -161,7 +155,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               @onSubmit={{createCampaignSpy}}
               @onCancel={{cancelSpy}}
               @errors={{data.errors}}
-              @targetProfiles={{data.targetProfiles}}
               @membersSortedByFullName={{data.defaultMembers}}
             />
           </template>,
@@ -170,24 +163,23 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         assert.dom(screen.getByText(t('pages.campaign-creation.owner.info'))).exists();
         assert.dom(screen.getAllByText(t('pages.campaign-creation.owner.title'))[0]).exists();
         await click(screen.getByLabelText(t('pages.campaign-creation.owner.label'), { exact: false }));
+
         await screen.findByRole('listbox');
 
         // then
         assert.dom(screen.getByRole('option', { name: 'Adam Troisjour', selected: true })).exists();
       });
 
-      test('it should fill target-profile fields', async function (assert) {
+      test('it should fill course fields', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const targetProfile = store.createRecord('target-profile', {
+        const course = store.createRecord('course', {
           id: '1',
           name: 'Target profile 1',
-          description: 'Description 1',
-          category: 'Category 1',
+          type: 'targetProfile',
         });
-        data.targetProfiles = [targetProfile];
         data.campaign.type = campaignType.status;
-        data.campaign.targetProfile = targetProfile;
+        data.campaign.course = course;
 
         // when
         const screen = await render(
@@ -197,17 +189,19 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               @onSubmit={{createCampaignSpy}}
               @onCancel={{cancelSpy}}
               @errors={{data.errors}}
-              @targetProfiles={{data.targetProfiles}}
               @membersSortedByFullName={{data.defaultMembers}}
             />
           </template>,
         );
 
         // then
-        const targetProfileField = screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), {
-          exact: false,
-        });
-        assert.strictEqual(targetProfileField.innerText, targetProfile.name);
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: course.name,
+            }),
+          )
+          .exists();
       });
 
       test('it should fill multiple sendings fields', async function (assert) {
@@ -224,7 +218,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               @onSubmit={{createCampaignSpy}}
               @onCancel={{cancelSpy}}
               @errors={{data.errors}}
-              @targetProfiles={{data.targetProfiles}}
               @membersSortedByFullName={{data.defaultMembers}}
             />
           </template>,
@@ -249,7 +242,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               @onSubmit={{createCampaignSpy}}
               @onCancel={{cancelSpy}}
               @errors={{data.errors}}
-              @targetProfiles={{data.targetProfiles}}
               @membersSortedByFullName={{data.defaultMembers}}
             />
           </template>,
@@ -273,7 +265,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
       });
 
-      test('it should display fields for campaign title and target profile', async function (assert) {
+      test('it should display fields for campaign title', async function (assert) {
         // when
         const screen = await render(
           <template>
@@ -282,7 +274,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               @onSubmit={{createCampaignSpy}}
               @onCancel={{cancelSpy}}
               @errors={{data.errors}}
-              @targetProfiles={{data.targetProfiles}}
               @membersSortedByFullName={{data.defaultMembers}}
             />
           </template>,
@@ -303,7 +294,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               @onSubmit={{createCampaignSpy}}
               @onCancel={{cancelSpy}}
               @errors={{data.errors}}
-              @targetProfiles={{data.targetProfiles}}
               @membersSortedByFullName={{data.defaultMembers}}
             />
           </template>,
@@ -314,35 +304,25 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         assert.dom(screen.getByText(t(campaignType.explanation))).exists();
       });
 
-      module('when the user chose a target profile', function () {
-        test('it should display informations about target profile', async function (assert) {
+      module('when the user has selected a course', function () {
+        test('it should display informations about the course', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
-          data.targetProfiles = [
-            store.createRecord('target-profile', {
-              id: '1',
-              name: 'targetProfile1',
-              description: 'description1',
-              tubeCount: 11,
-              thematicResultCount: 12,
-              hasStage: true,
-            }),
-            store.createRecord('target-profile', {
-              id: '2',
-              name: 'targetProfile2',
-              description: 'description2',
-              tubeCount: 21,
-              thematicResultCount: 22,
-              hasStage: false,
-            }),
-          ];
+          const course = store.createRecord('course', {
+            id: '1',
+            name: 'targetProfile1',
+            type: 'targetProfile',
+            nbTubes: 3,
+            isSimplifiedAccess: true,
+          });
+          data.campaign.course = course;
+          data.campaign.type = campaignType.status;
 
           // when
           const screen = await render(
             <template>
               <CreateForm
                 @campaign={{data.campaign}}
-                @targetProfiles={{data.targetProfiles}}
                 @onSubmit={{createCampaignSpy}}
                 @onCancel={{cancelSpy}}
                 @errors={{data.errors}}
@@ -350,232 +330,32 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               />
             </template>,
           );
-          await clickByName(t(campaignType.purpose));
 
-          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
           // then
-          assert.dom(screen.getByText('description1')).exists();
-          assert.dom(screen.getByText(t('common.target-profile-details.subjects', { value: 11 }))).exists();
-          assert.dom(screen.getByText(t('common.target-profile-details.thematic-results', { value: 12 }))).exists();
+          assert.dom(screen.getByText(t('pages.catalogue.card.tag.target-profile'))).exists();
+          assert.dom(screen.getByRole('heading', { name: course.name })).exists();
+          assert.dom(screen.getByText(t('pages.catalogue.card.tubes-count', { count: course.nbTubes }))).exists();
+          assert.dom(screen.getByText(t('pages.catalogue.card.simplified-access'))).exists();
         });
 
-        test('it should display a message about result', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          data.targetProfiles = [
-            store.createRecord('target-profile', {
+        module('when the user wants to select another course', function () {
+          test('it should redirect to /catalogue/targetProfile', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            data.campaign.course = store.createRecord('course', {
               id: '1',
               name: 'targetProfile1',
-              description: 'description1',
-              tubeCount: 11,
-              thematicResultCount: 12,
-              hasStage: true,
-            }),
-            store.createRecord('target-profile', {
-              id: '2',
-              name: 'targetProfile2',
-              description: 'description2',
-              tubeCount: 21,
-              thematicResultCount: 22,
-              hasStage: false,
-            }),
-          ];
-
-          // when
-          const screen = await render(
-            <template>
-              <CreateForm
-                @campaign={{data.campaign}}
-                @targetProfiles={{data.targetProfiles}}
-                @onSubmit={{createCampaignSpy}}
-                @onCancel={{cancelSpy}}
-                @errors={{data.errors}}
-                @membersSortedByFullName={{data.defaultMembers}}
-              />
-            </template>,
-          );
-          await clickByName(t(campaignType.purpose));
-
-          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
-
-          // then
-          assert.dom(screen.getByText(t('common.target-profile-details.results.common'))).exists();
-        });
-
-        module('simplified access', function () {
-          test('it should display with simplified access label in options list', async function (assert) {
-            // given
-            const store = this.owner.lookup('service:store');
-            data.targetProfiles = [
-              store.createRecord('target-profile', {
-                id: '1',
-                name: 'targetProfile1',
-                isSimplifiedAccess: true,
-              }),
-            ];
-
-            // when
-            const screen = await render(
-              <template>
-                <CreateForm
-                  @campaign={{data.campaign}}
-                  @targetProfiles={{data.targetProfiles}}
-                  @onSubmit={{createCampaignSpy}}
-                  @onCancel={{cancelSpy}}
-                  @errors={{data.errors}}
-                  @membersSortedByFullName={{data.defaultMembers}}
-                />
-              </template>,
-            );
-
-            await clickByName(t(campaignType.purpose));
-
-            await click(
-              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
-            );
-
-            // then
-            assert.ok(screen.getByText(t('common.target-profile-details.simplified-access.without-account')));
-          });
-
-          test('it should display without simplified access label in options list', async function (assert) {
-            // given
-            const store = this.owner.lookup('service:store');
-            data.targetProfiles = [
-              store.createRecord('target-profile', {
-                id: '1',
-                name: 'targetProfile1',
-                isSimplifiedAccess: false,
-              }),
-            ];
-
-            // when
-            const screen = await render(
-              <template>
-                <CreateForm
-                  @campaign={{data.campaign}}
-                  @targetProfiles={{data.targetProfiles}}
-                  @onSubmit={{createCampaignSpy}}
-                  @onCancel={{cancelSpy}}
-                  @errors={{data.errors}}
-                  @membersSortedByFullName={{data.defaultMembers}}
-                />
-              </template>,
-            );
-            await clickByName(t(campaignType.purpose));
-
-            await click(
-              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
-            );
-
-            // then
-            assert.ok(screen.getByText(t('common.target-profile-details.simplified-access.with-account')));
-          });
-        });
-
-        module('Displaying options and categories', function () {
-          test('it should display options in alphapetical order', async function (assert) {
-            // given
-
-            const store = this.owner.lookup('service:store');
-            data.targetProfiles = [
-              store.createRecord('target-profile', {
-                id: '1',
-                name: 'targetProfile4',
-                description: 'description4',
-                tubeCount: 11,
-                thematicResultCount: 12,
-                hasStage: true,
-                category: 'B',
-              }),
-              store.createRecord('target-profile', {
-                id: '2',
-                name: 'targetProfile3',
-                description: 'description3',
-                tubeCount: 21,
-                thematicResultCount: 22,
-                hasStage: false,
-                category: 'B',
-              }),
-              store.createRecord('target-profile', {
-                id: '3',
-                name: 'targetProfile2',
-                description: 'description2',
-                tubeCount: 33,
-                thematicResultCount: 12,
-                hasStage: true,
-                category: 'A',
-              }),
-              store.createRecord('target-profile', {
-                id: '4',
-                name: 'targetProfile1',
-                description: 'description1',
-                tubeCount: 44,
-                thematicResultCount: 12,
-                hasStage: true,
-                category: 'A',
-              }),
-            ];
-
-            // when
-            const screen = await render(
-              <template>
-                <CreateForm
-                  @campaign={{data.campaign}}
-                  @targetProfiles={{data.targetProfiles}}
-                  @onSubmit={{createCampaignSpy}}
-                  @onCancel={{cancelSpy}}
-                  @errors={{data.errors}}
-                  @membersSortedByFullName={{data.defaultMembers}}
-                />
-              </template>,
-            );
-            await clickByName(t(campaignType.purpose));
-
-            await click(
-              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
-            );
-            let options = await screen.findAllByRole('option');
-
-            // then
-            options = options.map((option) => {
-              return option.innerText;
+              type: 'targetProfile',
+              nbTubes: 3,
+              isSimplifiedAccess: true,
             });
-            assert.deepEqual(options, ['targetProfile1', 'targetProfile2', 'targetProfile3', 'targetProfile4']);
-          });
-
-          test('it should display options with OTHER category at last position', async function (assert) {
-            // given
-            const store = this.owner.lookup('service:store');
-            data.targetProfiles = [
-              store.createRecord('target-profile', {
-                id: '2',
-                name: 'targetProfile3',
-                description: 'description3',
-                tubeCount: 21,
-                thematicResultCount: 22,
-                hasStage: false,
-                category: 'OTHER',
-              }),
-              store.createRecord('target-profile', {
-                id: '1',
-                name: 'targetProfile4',
-                description: 'description4',
-                tubeCount: 11,
-                thematicResultCount: 12,
-                hasStage: true,
-                category: 'A',
-              }),
-            ];
+            data.campaign.type = campaignType.status;
 
             // when
             const screen = await render(
               <template>
                 <CreateForm
                   @campaign={{data.campaign}}
-                  @targetProfiles={{data.targetProfiles}}
                   @onSubmit={{createCampaignSpy}}
                   @onCancel={{cancelSpy}}
                   @errors={{data.errors}}
@@ -583,216 +363,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
                 />
               </template>,
             );
-            await clickByName(t(campaignType.purpose));
-
-            await click(
-              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
-            );
-            let options = await screen.findAllByRole('option');
-
-            // then
-            options = options.map((option) => {
-              return option.innerText;
-            });
-            assert.deepEqual(options, ['targetProfile4', 'targetProfile3']);
-          });
-        });
-      });
-
-      module('when the user wants to clear the content of the target profile input', function (hooks) {
-        hooks.beforeEach(function () {
-          const store = this.owner.lookup('service:store');
-          data.targetProfiles = [
-            store.createRecord('target-profile', {
-              id: '1',
-              name: 'targetProfile1',
-              description: 'description1',
-            }),
-          ];
-        });
-      });
-
-      module('multiple sending', function () {
-        test('it should not display multiple sendings field', async function (assert) {
-          // when
-          const screen = await render(
-            <template>
-              <CreateForm
-                @campaign={{data.campaign}}
-                @onSubmit={{createCampaignSpy}}
-                @onCancel={{cancelSpy}}
-                @errors={{data.errors}}
-                @targetProfiles={{data.targetProfiles}}
-                @membersSortedByFullName={{data.defaultMembers}}
-              />
-            </template>,
-          );
-          await clickByName(t(campaignType.purpose));
-
-          // then
-          assert
-            .dom(screen.queryByLabelText(t('pages.campaign-creation.multiple-sendings.assessments.question-label')))
-            .doesNotExist();
-          assert
-            .dom(screen.queryByLabelText(t('pages.campaign-creation.multiple-sendings.assessments.info')))
-            .doesNotExist();
-        });
-
-        test('it should display multiple sendings field', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          data.targetProfiles = [
-            store.createRecord('target-profile', {
-              id: '1',
-              name: 'targetProfile1',
-              description: 'description1',
-              tubeCount: 11,
-              thematicResultCount: 12,
-              hasStage: true,
-            }),
-            store.createRecord('target-profile', {
-              id: '2',
-              name: 'targetProfile2',
-              description: 'description2',
-              tubeCount: 21,
-              thematicResultCount: 22,
-              hasStage: false,
-            }),
-          ];
-          data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = true;
-
-          // when
-          const screen = await render(
-            <template>
-              <CreateForm
-                @campaign={{data.campaign}}
-                @targetProfiles={{data.targetProfiles}}
-                @onSubmit={{createCampaignSpy}}
-                @onCancel={{cancelSpy}}
-                @errors={{data.errors}}
-                @membersSortedByFullName={{data.defaultMembers}}
-              />
-            </template>,
-          );
-          await clickByName(t(campaignType.purpose));
-
-          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
-
-          // then
-          assert.dom(screen.getByText(t('common.target-profile-details.results.common'))).exists();
-        });
-
-        module('when target profile are knowledge elements resettable', function () {
-          test('it should display specific message', async function (assert) {
-            // given
-            data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
-            const store = this.owner.lookup('service:store');
-
-            data.targetProfiles = [
-              store.createRecord('target-profile', {
-                id: '1',
-                name: 'targetProfile1',
-                description: 'description1',
-                tubeCount: 11,
-                thematicResultCount: 12,
-                hasStage: true,
-                areKnowledgeElementsResettable: true,
-              }),
-              store.createRecord('target-profile', {
-                id: '2',
-                name: 'targetProfile2',
-                description: 'description2',
-                tubeCount: 21,
-                thematicResultCount: 22,
-                hasStage: false,
-              }),
-            ];
-
-            // when
-            const screen = await render(
-              <template>
-                <CreateForm
-                  @campaign={{data.campaign}}
-                  @targetProfiles={{data.targetProfiles}}
-                  @onSubmit={{createCampaignSpy}}
-                  @onCancel={{cancelSpy}}
-                  @errors={{data.errors}}
-                  @membersSortedByFullName={{data.defaultMembers}}
-                />
-              </template>,
-            );
-            await clickByName(t(campaignType.purpose));
-
-            await click(
-              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
-            );
-            await click(await screen.findByRole('option', { description: 'targetProfile1' }));
 
             // then
             assert
-              .dom(
-                screen.getByText(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'), {
-                  exact: false,
-                }),
-              )
-              .exists();
-          });
-        });
-
-        module('when target profile are not knowledge elements resettable', function () {
-          test('it should not display specific message', async function (assert) {
-            // given
-            const store = this.owner.lookup('service:store');
-            data.targetProfiles = [
-              store.createRecord('target-profile', {
-                id: '1',
-                name: 'targetProfile1',
-                description: 'description1',
-                tubeCount: 11,
-                thematicResultCount: 12,
-                hasStage: true,
-                areKnowledgeElementsResettable: false,
-              }),
-              store.createRecord('target-profile', {
-                id: '2',
-                name: 'targetProfile2',
-                description: 'description2',
-                tubeCount: 21,
-                thematicResultCount: 22,
-                hasStage: false,
-              }),
-            ];
-            data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = true;
-
-            // when
-            const screen = await render(
-              <template>
-                <CreateForm
-                  @campaign={{data.campaign}}
-                  @targetProfiles={{data.targetProfiles}}
-                  @onSubmit={{createCampaignSpy}}
-                  @onCancel={{cancelSpy}}
-                  @errors={{data.errors}}
-                  @membersSortedByFullName={{data.defaultMembers}}
-                />
-              </template>,
-            );
-            await clickByName(t(campaignType.purpose));
-
-            await click(
-              screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
-            );
-            await click(await screen.findByRole('option', { description: 'targetProfile1' }));
-
-            // then
-            assert
-              .dom(
-                screen.queryByText(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'), {
-                  exact: false,
-                }),
-              )
-              .doesNotExist();
+              .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+              .hasAttribute('href', '/catalogue/targetProfile');
           });
         });
       });
@@ -801,13 +376,21 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
   module(`when campaign is of type combined course`, function () {
     test(`it should have checked combined course goal and not display owner fields`, async function (assert) {
+      const store = this.owner.lookup('service:store');
       const campaignType = {
         status: 'COMBINED_COURSE',
         purpose: 'pages.campaign-creation.purpose.combined-course',
       };
       // given
       data.campaign.type = campaignType.status;
-      data.combinedCourseBlueprints = [{ id: 1, name: 'Mon schéma de parcours combiné' }];
+      data.campaign.course = store.createRecord('course', {
+        id: '1',
+        name: 'Mon schéma de parcours combiné',
+        type: 'blueprint',
+        nbModules: 3,
+        isSimplifiedAccess: true,
+      });
+
       // when
       const screen = await render(
         <template>
@@ -816,9 +399,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
-            @combinedCourseBlueprints={{data.combinedCourseBlueprints}}
           />
         </template>,
       );
@@ -828,7 +409,39 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
       assert.dom(screen.queryByText(t('pages.campaign-creation.owner.title'))).doesNotExist();
     });
+
+    test('it should redirect to /catalogue/blueprint', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      data.campaign.course = store.createRecord('course', {
+        id: '1',
+        name: 'blueprint1',
+        type: 'blueprint',
+        nbModules: 3,
+        isSimplifiedAccess: true,
+      });
+      data.campaign.type = 'COMBINED_COURSE';
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+        .hasAttribute('href', '/catalogue/blueprint');
+    });
   });
+
   test('should not display EXAM type when feature is not enable', async function () {
     // given
     data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: false, params: null };
@@ -841,7 +454,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -863,7 +475,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -885,7 +496,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -909,7 +519,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -930,7 +539,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -951,7 +559,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -968,12 +575,13 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     test('it should not display fields for campaign title and target profile', async function (assert) {
       // when
       const store = this.owner.lookup('service:store');
-      const combinedCourseBlueprint = store.createRecord('combined-course-blueprint', {
+      data.campaign.course = store.createRecord('course', {
         id: '1',
         name: 'Blueprint 1',
+        type: 'blueprint',
       });
+      data.campaign.type = 'COMBINED_COURSE';
 
-      data.combinedCourseBlueprints = [combinedCourseBlueprint];
       const screen = await render(
         <template>
           <CreateForm
@@ -982,21 +590,12 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
-            @combinedCourseBlueprints={{data.combinedCourseBlueprints}}
           />
         </template>,
       );
 
-      await clickByName(t('pages.campaign-creation.purpose.combined-course'));
-
       // then
       assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
-      assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
-      await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
-      await clickByName(t('pages.campaign-creation.purpose.combined-course'));
-
-      await click(screen.getByLabelText(`${t('pages.campaign-creation.combined-course-blueprints-list-label')} *`));
-      assert.ok(await screen.findByRole('option', { description: combinedCourseBlueprint.name }));
     });
   });
 
@@ -1012,7 +611,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -1042,7 +640,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -1067,7 +664,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -1091,7 +687,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -1112,7 +707,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -1134,7 +728,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -1154,7 +747,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -1174,7 +766,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -1197,7 +788,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -1223,7 +813,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -1246,7 +835,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -1261,26 +849,22 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
 
-    const targetProfile = store.createRecord('target-profile', { name: 'targetProfile1', id: '123' });
-    data.targetProfiles = [targetProfile];
+    data.campaign.course = store.createRecord('course', { name: 'targetProfile1', id: '123', type: 'targetProfile' });
     const createCampaignSpy = sinon.stub();
 
-    const screen = await render(
+    await render(
       <template>
         <CreateForm
           @campaign={{data.campaign}}
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
     );
     await fillByLabel(`${t('pages.campaign-creation.name.label')} *`, 'Ma campagne');
     await clickByName(t('pages.campaign-creation.purpose.assessment'));
-    await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-    await click(await screen.findByRole('option', { description: targetProfile.name }));
 
     // when
     await clickByName(t('pages.campaign-creation.actions.create'));
@@ -1299,7 +883,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -1321,7 +904,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{createCampaignSpy}}
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
-          @targetProfiles={{data.targetProfiles}}
           @membersSortedByFullName={{data.defaultMembers}}
         />
       </template>,
@@ -1365,7 +947,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             @onSubmit={{createCampaignSpy}}
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
             @membersSortedByFullName={{data.defaultMembers}}
           />
         </template>,
@@ -1378,77 +959,37 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       assert.dom(screen.getByText(t('api-error-messages.campaign-creation.external-user-id-required'))).exists();
     });
 
-    test('it should display errors messages when the target profile field is empty', async function (assert) {
-      // given
-      const campaignWithErrors = EmberObject.create({
-        errors: {
-          targetProfile: [
-            {
-              message: 'TARGET_PROFILE_IS_REQUIRED',
-            },
-          ],
-        },
+    ['targetProfile', 'blueprint'].forEach((error) => {
+      test(`it should display error message when the ${error} course field is empty`, async function (assert) {
+        // given
+        const campaignWithErrors = EmberObject.create({
+          errors: {
+            [error]: [
+              {
+                message: 'TARGET_PROFILE_IS_REQUIRED',
+              },
+            ],
+          },
+        });
+        data.errors = campaignWithErrors.errors;
+
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+        // then
+        assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
       });
-      data.errors = campaignWithErrors.errors;
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.purpose.assessment'));
-
-      // then
-      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
-    });
-
-    test('it should display errors messages when the blueprint id field is empty', async function (assert) {
-      // given
-      const campaignWithErrors = EmberObject.create({
-        errors: {
-          blueprint: [
-            {
-              message: 'TARGET_PROFILE_IS_REQUIRED',
-            },
-          ],
-        },
-      });
-      data.errors = campaignWithErrors.errors;
-
-      const store = this.owner.lookup('service:store');
-      const combinedCourseBlueprint = store.createRecord('combined-course-blueprint', {
-        id: '1',
-        name: 'Blueprint 1',
-      });
-
-      data.combinedCourseBlueprints = [combinedCourseBlueprint];
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @targetProfiles={{data.targetProfiles}}
-            @membersSortedByFullName={{data.defaultMembers}}
-            @combinedCourseBlueprints={{data.combinedCourseBlueprints}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.purpose.combined-course'));
-
-      // then
-      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
     });
   });
 });

--- a/orga/tests/integration/components/catalogue/course-card-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-card-test.gjs
@@ -23,6 +23,18 @@ module('Integration | Component | Catalogue::CourseCard', function (hooks) {
     assert.dom(within(card).getByRole('heading', { name: 'Ma super formation' })).exists();
   });
 
+  test('it does not show anchor link if selectCourse is not defined', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const course = store.createRecord('course', { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5 });
+
+    const screen = await render(<template><CourseCard @course={{course}} @type="all" /></template>);
+    const card = await screen.getByRole('article');
+
+    assert.notOk(
+      within(card).queryByRole('link', { name: t('pages.catalogue.modal.open-modal', { name: course.name }) }),
+    );
+  });
+
   module('for a "targetProfile" type course', function () {
     test('it shows the "Parcours" type tag', async function (assert) {
       const store = this.owner.lookup('service:store');

--- a/orga/tests/integration/components/catalogue/course-modal-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-modal-test.gjs
@@ -275,7 +275,7 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
   module('campaign creation page link', function () {
     test('it shows enabled campaign creation route button if enough "places"', async function (assert) {
       //given
-      const currentCourse = store.createRecord('target-profile-overview', { name: 'Ma super formation' });
+      const currentCourse = store.createRecord('target-profile-overview', { id: 123, name: 'Ma super formation' });
       sinon.stub(currentUser, 'placeStatistics').value({ hasReachedMaximumPlacesLimit: false });
 
       //when
@@ -284,8 +284,9 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
       );
       const submitButton = await screen.getByText(t('pages.catalogue.modal.select-course'));
 
-      // // then
+      //then
       assert.dom(submitButton).hasAttribute('aria-disabled', 'false');
+      assert.ok(submitButton.href.includes('/creation-catalogue?courseId=123'));
     });
     test('it disables campaign creation route button if not enough "places"', async function (assert) {
       //given

--- a/orga/tests/mirage/factories/course.js
+++ b/orga/tests/mirage/factories/course.js
@@ -3,9 +3,13 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   name() {
-    return 'Parcours';
+    return faker.lorem.word(10);
   },
   description() {
     return faker.lorem.sentence();
+  },
+
+  type() {
+    return 'targetProfile';
   },
 });

--- a/orga/tests/mirage/models.js
+++ b/orga/tests/mirage/models.js
@@ -20,6 +20,7 @@ export default {
     organization: belongsTo('organization'),
     stages: hasMany('stage'),
     targetProfile: belongsTo('targetProfile'),
+    course: belongsTo('course'),
   }),
   campaignAnalysis: Model.extend({
     campaignTubeRecommendations: hasMany('campaignTubeRecommendation'),

--- a/orga/tests/mirage/routes.js
+++ b/orga/tests/mirage/routes.js
@@ -378,7 +378,8 @@ export default function routes() {
     if (campaign.type === 'PROFILES_COLLECTION') {
       return schema.campaigns.create(campaign);
     } else if (campaign.type === 'ASSESSMENT') {
-      const targetProfileId = body.data.relationships['target-profile'].data.id;
+      const targetProfileId =
+        body.data.relationships['target-profile']?.data.id || body.data.relationships['course']?.data.id;
       return schema.campaigns.create({ ...campaign, targetProfileId });
     }
     return new Response(422);
@@ -500,7 +501,8 @@ export default function routes() {
       customLandingPageText: body.data.attributes['custom-landing-page-text'],
       externalIdLabel: body.data.attributes['id-pix-label'],
     };
-    const combinedCourseBlueprintId = body.data.relationships['combined-course-blueprint'].data.id;
+    const combinedCourseBlueprintId =
+      body.data.relationships['combined-course-blueprint']?.data.id || body.data.relationships['course']?.data.id;
     return schema.campaigns.create({ ...campaign, combinedCourseBlueprintId });
   });
   this.get('feature-toggles', (schema) => {
@@ -702,6 +704,10 @@ export default function routes() {
   this.get('/organizations/:id/combined-course-blueprints/:blueprintId', (schema, request) => {
     const combinedCourseBlueprintId = request.params.blueprintId;
     return schema.combinedCourseBlueprintOverviews.find(combinedCourseBlueprintId);
+  });
+
+  this.get('/organizations/:organizationId/courses', function (schema) {
+    return schema.courses.all();
   });
 
   this.get('/oidc/identity-providers/:cache_buster', () => {

--- a/orga/tests/unit/controllers/authenticated/campaigns/new-catalogue-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/new-catalogue-test.js
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/campaigns/new-catalogue', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/campaigns/new-catalogue');
+  });
+
+  module('#action cancel', function () {
+    module('when source is empty', function () {
+      test('it should call transitionTo with appropriate arguments', function (assert) {
+        // given
+        controller.router = { transitionTo: sinon.stub() };
+
+        // when
+        controller.cancel();
+
+        // then
+        assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns'));
+      });
+    });
+
+    module('when source is filled with a campaign id', function () {
+      test('it should call transitionTo with appropriate arguments', function (assert) {
+        // given
+        const source = Symbol('Source campaign id');
+        controller.source = source;
+        controller.router = { transitionTo: sinon.stub() };
+
+        // when
+        controller.cancel();
+
+        // then
+        assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns.campaign.settings', source));
+      });
+    });
+  });
+
+  module('#action createCampaign', function () {
+    test('it should call transitionTo with appropriate arguments', async function (assert) {
+      // given
+      controller.router = { transitionTo: sinon.stub() };
+      controller.notifications = {
+        clearAll: sinon.stub(),
+      };
+      controller.model = {
+        campaign: {
+          id: 1,
+          save: sinon.stub().resolves(),
+          setProperties: sinon.stub(),
+        },
+      };
+
+      // when
+      await controller.createCampaign({ name: 'ma campagne' });
+
+      // then
+      assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns.campaign.settings', 1));
+    });
+  });
+  module('#action createCampaign when creating a combined course', function () {
+    test('it should call transitionTo with appropriate arguments', async function (assert) {
+      // given
+      controller.router = { transitionTo: sinon.stub() };
+      controller.notifications = {
+        clearAll: sinon.stub(),
+      };
+      controller.model = {
+        campaign: {
+          id: 1,
+          save: sinon.stub().resolves(),
+          setProperties: sinon.stub(),
+          type: 'COMBINED_COURSE',
+        },
+      };
+
+      // when
+      await controller.createCampaign({ name: 'ma campagne' });
+
+      // then
+      assert.true(controller.router.transitionTo.calledWith('authenticated.combined-course', 1));
+    });
+  });
+});

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -122,79 +122,147 @@ module('Unit | Model | campaign', function (hooks) {
   });
 
   module('#setType', function () {
-    test('set default to false multiple sending to false on ASSESSMENT type', function (assert) {
-      //given
-      const store = this.owner.lookup('service:store');
+    module('when switching type is ASSESSMENT', function () {
+      test('set multiple sending to false', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
 
-      const model = store.createRecord('campaign', {
-        multipleSendings: true,
+        const model = store.createRecord('campaign', {
+          multipleSendings: true,
+        });
+
+        //when
+        model.setType('ASSESSMENT');
+
+        assert.false(model.multipleSendings);
+        assert.strictEqual(model.type, 'ASSESSMENT');
       });
 
-      //when
-      model.setType('ASSESSMENT');
+      test('it should reset course if it is a blueprint', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
 
-      assert.false(model.multipleSendings);
-      assert.strictEqual(model.type, 'ASSESSMENT');
+        const model = store.createRecord('campaign', {
+          course: store.createRecord('course', { type: 'blueprint' }),
+        });
+
+        //when
+        model.setType('ASSESSMENT');
+
+        //then
+        assert.strictEqual(model.course, null);
+      });
     });
 
-    test('set default to false multiple sending on EXAM type', function (assert) {
-      //given
-      const store = this.owner.lookup('service:store');
+    module('when switching type is EXAM', function () {
+      test('set multiple sending to false', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
 
-      const model = store.createRecord('campaign', {
-        multipleSendings: true,
+        const model = store.createRecord('campaign', {
+          multipleSendings: true,
+        });
+
+        //when
+        model.setType('EXAM');
+
+        assert.false(model.multipleSendings);
+        assert.strictEqual(model.type, 'EXAM');
       });
 
-      //when
-      model.setType('EXAM');
+      test('it should reset course if it is a blueprint', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
 
-      assert.false(model.multipleSendings);
-      assert.strictEqual(model.type, 'EXAM');
+        const model = store.createRecord('campaign', {
+          course: store.createRecord('course', { type: 'blueprint' }),
+        });
+
+        //when
+        model.setType('EXAM');
+
+        //then
+        assert.strictEqual(model.course, null);
+      });
     });
 
-    test('set default to true multiple sending on PROFILES_COLLECTION type', function (assert) {
-      //given
-      const store = this.owner.lookup('service:store');
+    module('when switching type is PROFILES_COLLECTION', function () {
+      test('set multiple sending to true', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
 
-      const model = store.createRecord('campaign', {
-        multipleSendings: false,
+        const model = store.createRecord('campaign', {
+          multipleSendings: false,
+        });
+
+        //when
+        model.setType('PROFILES_COLLECTION');
+
+        assert.true(model.multipleSendings);
+        assert.strictEqual(model.type, 'PROFILES_COLLECTION');
       });
 
-      //when
-      model.setType('PROFILES_COLLECTION');
+      test('set default to null target profile', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
 
-      assert.true(model.multipleSendings);
-      assert.strictEqual(model.type, 'PROFILES_COLLECTION');
+        const model = store.createRecord('campaign', {
+          targetProfileId: 18,
+        });
+
+        //when
+        model.setType('PROFILES_COLLECTION');
+
+        assert.strictEqual(model.targetProfileId, null);
+        assert.strictEqual(model.type, 'PROFILES_COLLECTION');
+      });
+
+      test('set default to null title', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+
+        const model = store.createRecord('campaign', {
+          title: 'wahout',
+        });
+
+        //when
+        model.setType('PROFILES_COLLECTION');
+
+        assert.strictEqual(model.title, null);
+        assert.strictEqual(model.type, 'PROFILES_COLLECTION');
+      });
+
+      test('it should reset course', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+
+        const model = store.createRecord('campaign', {
+          course: store.createRecord('course', { type: 'blueprint' }),
+        });
+
+        //when
+        model.setType('PROFILES_COLLECTION');
+
+        //then
+        assert.strictEqual(model.course, null);
+      });
     });
 
-    test('set default to null target profile on PROFILES_COLLECTION type', function (assert) {
-      //given
-      const store = this.owner.lookup('service:store');
+    module('when switching type is COMBINED_COURSE', function () {
+      test('it should reset course if it is a target profile', function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
 
-      const model = store.createRecord('campaign', {
-        targetProfileId: 18,
+        const model = store.createRecord('campaign', {
+          course: store.createRecord('course', { type: 'targetProfile' }),
+        });
+
+        //when
+        model.setType('COMBINED_COURSE');
+
+        //then
+        assert.strictEqual(model.course, null);
       });
-
-      //when
-      model.setType('PROFILES_COLLECTION');
-
-      assert.strictEqual(model.targetProfileId, null);
-      assert.strictEqual(model.type, 'PROFILES_COLLECTION');
-    });
-
-    test('set default to null title on PROFILES_COLLECTION type', function (assert) {
-      //given
-      const store = this.owner.lookup('service:store');
-
-      const model = store.createRecord('campaign', {
-        title: 'wahout',
-      });
-
-      //when
-      model.setType('PROFILES_COLLECTION');
-
-      assert.strictEqual(model.title, null);
-      assert.strictEqual(model.type, 'PROFILES_COLLECTION');
     });
   });
 

--- a/orga/tests/unit/routes/authenticated/campaigns/new-catalogue-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new-catalogue-test.js
@@ -83,6 +83,89 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
     sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
   });
 
+  module('when courseId param is defined', function (hooks) {
+    const organizationId = 12345;
+    const createdCampaignRecord = {};
+    let courseRecord;
+    let peekRecordStub;
+
+    hooks.beforeEach(async function () {
+      const organization = EmberObject.create({
+        id: organizationId,
+      });
+
+      const prescriber = { id: Symbol('prescriber id') };
+
+      class CurrentUserStub extends Service {
+        organization = organization;
+        prescriber = prescriber;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const members = Symbol('list of members sorted by firstnames and lastnames');
+
+      const findAllStub = sinon.stub();
+      const createRecordStub = sinon.stub();
+      peekRecordStub = sinon.stub();
+
+      courseRecord = {
+        id: Symbol('target profile overview id'),
+      };
+
+      class StoreStub extends Service {
+        findAll = findAllStub.resolves(members);
+        createRecord = createRecordStub.resolves(createdCampaignRecord);
+        peekRecord = peekRecordStub.resolves(courseRecord);
+      }
+
+      this.owner.register('service:store', StoreStub);
+    });
+
+    test('should return a campaign with course set', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+      courseRecord.type = 'targetProfile';
+
+      // when
+      const model = await route.model({ courseId: courseRecord.id });
+
+      assert.strictEqual(model.campaign.course, courseRecord);
+      sinon.assert.calledWithExactly(peekRecordStub, 'course', courseRecord.id, {
+        adapterOptions: { organizationId },
+      });
+    });
+
+    module('when course is a target profile', function () {
+      test('it should set the campaign type to ASSESSMENT', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+        courseRecord.type = 'targetProfile';
+
+        // when
+        const model = await route.model({ courseId: courseRecord.id });
+
+        assert.strictEqual(model.campaign.type, 'ASSESSMENT');
+      });
+    });
+
+    module('when course is a blueprint', function () {
+      test('it should set the campaign type to COMBINED_COURSE', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+        courseRecord.type = 'blueprint';
+
+        // when
+        const model = await route.model({ courseId: courseRecord.id });
+
+        assert.strictEqual(model.campaign.type, 'COMBINED_COURSE');
+      });
+    });
+  });
+
   module('when duplicating a campaign', function () {
     module('when campaign type is ASSESSMENT', function () {
       test('should prefill campaign attributes from given source campaign', async function (assert) {
@@ -264,12 +347,17 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
   });
 
   module('resetController', function () {
-    test('should reset source to null when isExiting true', function (assert) {
+    test('should reset source and courseId when isExiting true', function (assert) {
+      // given
       const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
-
       const controller = { set: sinon.stub() };
+
+      // when
       route.resetController(controller, true);
-      assert.true(controller.set.calledWithExactly('source', null));
+
+      // then
+      assert.true(controller.set.firstCall.calledWithExactly('source', null));
+      assert.true(controller.set.secondCall.calledWithExactly('courseId', null));
     });
   });
 

--- a/orga/tests/unit/routes/authenticated/campaigns/new-catalogue-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new-catalogue-test.js
@@ -1,0 +1,319 @@
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntl from '../../../../helpers/setup-intl';
+
+module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  test('should return members', async function (assert) {
+    // given
+    const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+    class CurrentUserStub extends Service {
+      organization = EmberObject.create({
+        id: 12345,
+      });
+      prescriber = { id: Symbol('prescriber id') };
+    }
+
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    const members = Symbol('list of members sorted by firstnames and lastnames');
+    const findAllStub = sinon.stub();
+
+    class StoreStub extends Service {
+      findAll = findAllStub.resolves(members);
+      createRecord = sinon.stub();
+    }
+
+    this.owner.register('service:store', StoreStub);
+
+    // when
+    const result = await route.model();
+
+    //then
+    assert.strictEqual(result.membersSortedByFullName, members);
+  });
+
+  test('should return an empty campaign when there is no given source', async function (assert) {
+    // given
+    const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+    const organization = EmberObject.create({
+      id: 12345,
+    });
+
+    const prescriber = { id: Symbol('prescriber id') };
+
+    class CurrentUserStub extends Service {
+      organization = organization;
+      prescriber = prescriber;
+    }
+
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    const members = Symbol('list of members sorted by firstnames and lastnames');
+
+    const expectedCampaignAttributes = {
+      organization,
+      ownerId: prescriber.id,
+    };
+
+    const createdCampaignRecord = Symbol('created campaign record');
+
+    const findAllStub = sinon.stub();
+    const createRecordStub = sinon.stub();
+
+    class StoreStub extends Service {
+      findAll = findAllStub.resolves(members);
+      createRecord = createRecordStub.resolves(createdCampaignRecord);
+    }
+
+    this.owner.register('service:store', StoreStub);
+
+    // when
+    const model = await route.model();
+
+    assert.strictEqual(await model.campaign, createdCampaignRecord);
+    sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
+  });
+
+  module('when duplicating a campaign', function () {
+    module('when campaign type is ASSESSMENT', function () {
+      test('should prefill campaign attributes from given source campaign', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+        const organization = EmberObject.create({
+          id: 12345,
+          targetProfiles: new Promise((resolve) => resolve([])),
+        });
+
+        class CurrentUserStub extends Service {
+          organization = organization;
+          prescriber = { id: Symbol('prescriber id') };
+        }
+
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        const members = Symbol('list of members sorted by firstnames and lastnames');
+        const sourceCampaign = {
+          name: 'A real campaign name',
+          type: Symbol('campaign type'),
+          title: Symbol('campaign title'),
+          description: Symbol('campaign description'),
+          targetProfileId: Symbol('campaign target profile id'),
+          ownerId: Symbol('campaign owner id'),
+          multipleSendings: Symbol('campaign multiple sendings activation'),
+          externalIdLabel: Symbol('campaign external id'),
+          customLandingPageText: Symbol('campaign custom landing page text'),
+        };
+        const targetProfile = Symbol('campaign target profile');
+
+        const expectedCampaignAttributes = {
+          ...sourceCampaign,
+          name: 'Copie de A real campaign name',
+          targetProfile,
+          organization,
+        };
+
+        const duplicatedCampaignRecord = Symbol('duplicated campaign record');
+
+        const findAllStub = sinon.stub();
+        const findRecordStub = sinon.stub();
+        const peekRecordStub = sinon.stub();
+        const createRecordStub = sinon.stub();
+
+        class StoreStub extends Service {
+          findAll = findAllStub.resolves(members);
+          createRecord = createRecordStub.resolves(duplicatedCampaignRecord);
+          findRecord = findRecordStub.resolves(sourceCampaign);
+          peekRecord = peekRecordStub.returns(targetProfile);
+        }
+
+        this.owner.register('service:store', StoreStub);
+
+        // when
+        const model = await route.model({ source: Symbol('source campaign id') });
+
+        assert.strictEqual(await model.campaign, duplicatedCampaignRecord);
+        sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
+        assert.false(model.targetProfiles instanceof Promise);
+      });
+    });
+
+    module('when campaign type is PROFILES_COLLECTION', function () {
+      test('should prefill campaign attributes from given source campaign', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+        const organization = EmberObject.create({
+          id: 12345,
+        });
+
+        class CurrentUserStub extends Service {
+          organization = organization;
+          prescriber = { id: Symbol('prescriber id') };
+        }
+
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        const members = Symbol('list of members sorted by firstnames and lastnames');
+        const sourceCampaign = {
+          name: 'A real campaign name',
+          type: Symbol('campaign type'),
+          title: Symbol('campaign title'),
+          description: Symbol('campaign description'),
+          ownerId: Symbol('campaign owner id'),
+          multipleSendings: Symbol('campaign multiple sendings activation'),
+          externalIdLabel: Symbol('campaign external id'),
+          customLandingPageText: Symbol('campaign custom landing page text'),
+        };
+
+        const expectedCampaignAttributes = {
+          ...sourceCampaign,
+          name: 'Copie de A real campaign name',
+          organization,
+        };
+
+        const duplicatedCampaignRecord = Symbol('duplicated campaign record');
+
+        const findAllStub = sinon.stub();
+        const findRecordStub = sinon.stub();
+        const peekRecordStub = sinon.stub();
+        const createRecordStub = sinon.stub();
+
+        class StoreStub extends Service {
+          findAll = findAllStub.resolves(members);
+          createRecord = createRecordStub.resolves(duplicatedCampaignRecord);
+          findRecord = findRecordStub.resolves(sourceCampaign);
+          peekRecord = peekRecordStub;
+        }
+
+        this.owner.register('service:store', StoreStub);
+
+        // when
+        const model = await route.model({ source: Symbol('source campaign id') });
+
+        assert.strictEqual(await model.campaign, duplicatedCampaignRecord);
+        sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
+        sinon.assert.notCalled(peekRecordStub);
+      });
+    });
+
+    test('should return empty campaign when searching for given source campaign raises an error', async function (assert) {
+      // given
+      const organization = EmberObject.create({
+        id: 12345,
+      });
+
+      const prescriber = { id: Symbol('prescriber id') };
+
+      class CurrentUserStub extends Service {
+        organization = organization;
+        prescriber = prescriber;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const members = Symbol('list of members sorted by firstnames and lastnames');
+
+      const expectedCampaignAttributes = {
+        organization,
+        ownerId: prescriber.id,
+      };
+
+      const createdCampaignRecord = Symbol('created campaign record');
+
+      const findAllStub = sinon.stub();
+      const findRecordStub = sinon.stub();
+      const createRecordStub = sinon.stub();
+
+      class StoreStub extends Service {
+        findAll = findAllStub.resolves(members);
+        findRecord = findRecordStub.rejects(new Error());
+        createRecord = createRecordStub.resolves(createdCampaignRecord);
+      }
+
+      this.owner.register('service:store', StoreStub);
+
+      const replaceWithStub = sinon.stub();
+
+      class RouterStub extends Service {
+        replaceWith = replaceWithStub.returns();
+      }
+
+      this.owner.register('service:router', RouterStub);
+
+      const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+      // when
+      const model = await route.model({ source: Symbol('source campaign id') });
+
+      assert.strictEqual(await model.campaign, createdCampaignRecord);
+      sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
+      sinon.assert.calledWithMatch(replaceWithStub, 'authenticated.campaigns.new', {
+        queryParams: { source: null },
+      });
+    });
+  });
+
+  module('resetController', function () {
+    test('should reset source to null when isExiting true', function (assert) {
+      const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+      const controller = { set: sinon.stub() };
+      route.resetController(controller, true);
+      assert.true(controller.set.calledWithExactly('source', null));
+    });
+  });
+
+  module('beforeModel', function (hooks) {
+    let route;
+
+    hooks.beforeEach(function () {
+      route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+    });
+
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    module('When places limit is reached', function () {
+      test('should redirect to main campaign page', function (assert) {
+        //given
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
+
+        //when
+        route.beforeModel();
+
+        //then
+        assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns'));
+      });
+    });
+
+    module('When places limit is not reached', function () {
+      test('should not redirect to main campaign page', function (assert) {
+        //given
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
+
+        //when
+        route.beforeModel();
+
+        //then
+        assert.notOk(replaceWithStub.called);
+      });
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/catalogue/list-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue/list-test.js
@@ -166,4 +166,19 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
       assert.ok(store.unloadAll.notCalled);
     });
   });
+
+  module('resetController', function () {
+    test('should reset targetProfileId and blueprintId when isExiting is true', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/catalogue/list');
+      const controller = { set: sinon.stub() };
+
+      // when
+      route.resetController(controller, true);
+
+      // then
+      assert.true(controller.set.firstCall.calledWithExactly('targetProfileId', null));
+      assert.true(controller.set.secondCall.calledWithExactly('blueprintId', null));
+    });
+  });
 });

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -751,6 +751,8 @@
       "combined-course-blueprints-label": "Einen Lernpfad auswählen",
       "combined-course-blueprints-list-label": "Einen Lernpfad auswählen",
       "copy-of": "Kopieren von",
+      "course-label": "Einen Kurs auswählen",
+      "course-selection-label": "Einen Kurs auswählen",
       "external-id-label": {
         "label": "Bezeichnung der Kennung",
         "question-label": "Möchten Sie eine externe Kennung beantragen?",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -761,6 +761,8 @@
       "combined-course-blueprints-label": "Select a learning course",
       "combined-course-blueprints-list-label": "Select a learning course",
       "copy-of": "Copy of",
+      "course-label": "Select a course",
+      "course-selection-label": "Select a course",
       "external-id-label": {
         "label": "external user ID label",
         "question-label": "Do you need an external user ID?",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -755,6 +755,8 @@
       "combined-course-blueprints-label": "Seleccionar una vía de aprendizaje",
       "combined-course-blueprints-list-label": "Seleccionar una vía de aprendizaje",
       "copy-of": "Copia de",
+      "course-label": "Seleccionar un curso",
+      "course-selection-label": "Seleccionar un curso",
       "external-id-label": {
         "label": "Texto del identificador",
         "question-label": "¿Desea solicitar un identificador externo?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -749,6 +749,8 @@
       "combined-course-blueprints-label": "Sélectionnez un parcours",
       "combined-course-blueprints-list-label": "Sélectionnez un parcours apprenant",
       "copy-of": "Copie de",
+      "course-label": "Sélectionnez un parcours",
+      "course-selection-label": "Sélectionner un parcours",
       "external-id-label": {
         "label": "Libellé de l’identifiant",
         "question-label": "Souhaitez-vous demander un identifiant externe ?",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -752,6 +752,8 @@
       "combined-course-blueprints-label": "Seleziona un percorso di apprendimento",
       "combined-course-blueprints-list-label": "Seleziona un percorso di apprendimento",
       "copy-of": "Copia di",
+      "course-label": "Seleziona un corso",
+      "course-selection-label": "Selezionare un corso",
       "external-id-label": {
         "label": "Formulazione dell'identificatore",
         "question-label": "Desiderate richiedere un identificatore esterno?",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -748,6 +748,8 @@
       "combined-course-blueprints-label": "Selecteer een leetraject",
       "combined-course-blueprints-list-label": "Selecteer een leetraject",
       "copy-of": "Kopie van",
+      "course-label": "Selecteer een traject",
+      "course-selection-label": "Selecteer een traject",
       "external-id-label": {
         "label": "Type externe user-ID",
         "question-label": "Wil je een externe gebruikers-ID aanvragen?",


### PR DESCRIPTION
## 🪧 Problème
Actuellement, il n’est pas possible depuis le catalogue de sélectionner un profil cible ou parcours pour pré remplir le formulaire de création de campagne / parcours.

## 🌈 Proposition
Permettre la création d'une campagne à partir d'un parcours du catalogue

## ✊ Remarques
Il y a un impact côté API pour récupérer l'id du profil cible/blueprint

## 🎉 Pour tester
- Se connecter à Pix Orga
- Aller sur le catalogue et sélectionner un parcours combiné/profil cible
- Vérifier que les règles métier sont implémentées et que l'on peut créer la campagne