### PR TITLE
[TECH] Utiliser uniquement des exports nommés pour les erreurs Http.

### DIFF
--- a/api/src/certification/configuration/application/http-error-mapper-configuration.js
+++ b/api/src/certification/configuration/application/http-error-mapper-configuration.js
@@ -1,13 +1,13 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import { BadRequestError, UnprocessableEntityError } from '../../../shared/application/errors/http-errors.js';
 import { CertificationVersionDraftAlreadyExistError, InvalidScoWhitelistError } from '../domain/errors.js';
 
 export const configurationDomainErrorMappingConfiguration = [
   {
     name: InvalidScoWhitelistError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: CertificationVersionDraftAlreadyExistError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code, error.meta),
   },
 ];

--- a/api/src/certification/enrolment/application/http-error-mapper-configuration.js
+++ b/api/src/certification/enrolment/application/http-error-mapper-configuration.js
@@ -1,4 +1,8 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import {
+  ConflictError,
+  ForbiddenError,
+  UnprocessableEntityError,
+} from '../../../shared/application/errors/http-errors.js';
 import {
   CertificationCandidateForbiddenDeletionError,
   InvalidCertificationCandidate,
@@ -10,20 +14,20 @@ import {
 const enrolmentDomainErrorMappingConfiguration = [
   {
     name: CertificationCandidateForbiddenDeletionError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code),
   },
-  { name: SessionStartedDeletionError.name, httpErrorFn: (error) => new HttpErrors.ConflictError(error.message) },
+  { name: SessionStartedDeletionError.name, httpErrorFn: (error) => new ConflictError(error.message) },
   {
     name: UnknownCountryForStudentEnrolmentError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: InvalidCertificationCandidate.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message),
   },
   {
     name: WrongDomainExtensionForPixPlusError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code),
   },
 ];
 export { enrolmentDomainErrorMappingConfiguration };

--- a/api/src/certification/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/certification/evaluation/application/http-error-mapper-configuration.js
@@ -1,10 +1,10 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import { LockedError } from '../../../shared/application/errors/http-errors.js';
 import { NextChallengeAlreadyComputingError } from '../domain/errors.js';
 
 const evaluationDomainErrorMappingConfiguration = [
   {
     name: NextChallengeAlreadyComputingError.name,
-    httpErrorFn: (error) => new HttpErrors.LockedError(error.message),
+    httpErrorFn: (error) => new LockedError(error.message),
   },
 ];
 export { evaluationDomainErrorMappingConfiguration };

--- a/api/src/certification/results/application/http-error-mapper-configuration.js
+++ b/api/src/certification/results/application/http-error-mapper-configuration.js
@@ -1,4 +1,8 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import {
+  ConflictError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from '../../../shared/application/errors/http-errors.js';
 import {
   CertificateGenerationError,
   MoreThanOneMatchingCertificationError,
@@ -8,18 +12,18 @@ import {
 const parcoursupDomainErrorMappingConfiguration = [
   {
     name: MoreThanOneMatchingCertificationError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message),
+    httpErrorFn: (error) => new ConflictError(error.message),
   },
 ];
 
 const resultsDomainErrorMappingConfiguration = [
   {
     name: NoCertificationResultForDivision.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new NotFoundError(error.message, error.code, error.meta),
   },
   {
     name: CertificateGenerationError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/certification/session-management/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session-management/application/http-error-mapper-configuration.js
@@ -1,4 +1,11 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  ConflictError,
+  PreconditionFailedError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+} from '../../../shared/application/errors/http-errors.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import {
   CertificationCenterIsArchivedError,
   ChallengeToBeDeneutralizedNotFoundError,
@@ -17,51 +24,51 @@ import {
 const sessionDomainErrorMappingConfiguration = [
   {
     name: SessionWithoutStartedCertificationError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code, error.meta),
   },
   {
     name: SessionWithMissingAbortReasonError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code),
+    httpErrorFn: (error) => new ConflictError(error.message, error.code),
   },
   {
     name: SessionAlreadyFinalizedError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code),
+    httpErrorFn: (error) => new ConflictError(error.message, error.code),
   },
   {
     name: SessionAlreadyPublishedError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code),
   },
   {
     name: ChallengeToBeDeneutralizedNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code),
+    httpErrorFn: (error) => new NotFoundError(error.message, error.code),
   },
   {
     name: ChallengeToBeNeutralizedNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code),
+    httpErrorFn: (error) => new NotFoundError(error.message, error.code),
   },
   {
     name: SessionNotAccessible.name,
-    httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new PreconditionFailedError(error.message, error.code, error.meta),
   },
   {
     name: SessionFinalized.name,
-    httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code),
+    httpErrorFn: (error) => new PreconditionFailedError(error.message, error.code),
   },
   {
     name: InvalidSessionSupervisingLoginError.name,
-    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+    httpErrorFn: (error) => new UnauthorizedError(error.message, error.code),
   },
   {
     name: CertificationCenterIsArchivedError.name,
-    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+    httpErrorFn: (error) => new UnauthorizedError(error.message, error.code),
   },
   {
     name: SendingEmailToRefererError.name,
-    httpErrorFn: (error) => new HttpErrors.ServiceUnavailableError(error.message),
+    httpErrorFn: (error) => new ServiceUnavailableError(error.message),
   },
   {
     name: SendingEmailToResultRecipientError.name,
-    httpErrorFn: (error) => new HttpErrors.ServiceUnavailableError(error.message),
+    httpErrorFn: (error) => new ServiceUnavailableError(error.message),
   },
 ];
 

--- a/api/src/certification/shared/application/http-error-mapper-configuration.js
+++ b/api/src/certification/shared/application/http-error-mapper-configuration.js
@@ -1,4 +1,9 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from '../../../shared/application/errors/http-errors.js';
 import { configurationDomainErrorMappingConfiguration } from '../../configuration/application/http-error-mapper-configuration.js';
 import { enrolmentDomainErrorMappingConfiguration } from '../../enrolment/application/http-error-mapper-configuration.js';
 import { evaluationDomainErrorMappingConfiguration } from '../../evaluation/application/http-error-mapper-configuration.js';
@@ -18,23 +23,23 @@ import {
 const certificationDomainErrorMappingConfiguration = [
   {
     name: InvalidCertificationReportForFinalization.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code, error.meta),
   },
   {
     name: CertificationCourseUpdateError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code, error.meta),
   },
   {
     name: CenterHabilitationError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code),
   },
   {
     name: CertificationCandidateNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code),
+    httpErrorFn: (error) => new NotFoundError(error.message, error.code),
   },
   {
     name: CsvWithNoSessionDataError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/devcomp/application/http-error-mapper-configuration.js
+++ b/api/src/devcomp/application/http-error-mapper-configuration.js
@@ -1,4 +1,8 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import {
+  BadGatewayError,
+  PreconditionFailedError,
+  UnprocessableEntityError,
+} from '../../shared/application/errors/http-errors.js';
 import {
   ElementInstantiationError,
   ModuleDoesNotExistError,
@@ -11,31 +15,31 @@ const devcompDomainErrorMappingConfiguration = [
   {
     name: ModuleDoesNotExistError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+      return new UnprocessableEntityError(error.message, error.code, error.meta);
     },
   },
   {
     name: ModuleInstantiationError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.BadGatewayError(error.message, error.code, error.meta);
+      return new BadGatewayError(error.message, error.code, error.meta);
     },
   },
   {
     name: ElementInstantiationError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.BadGatewayError(error.message, error.code, error.meta);
+      return new BadGatewayError(error.message, error.code, error.meta);
     },
   },
   {
     name: PassageDoesNotExistError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+      return new UnprocessableEntityError(error.message, error.code, error.meta);
     },
   },
   {
     name: PassageTerminatedError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+      return new PreconditionFailedError(error.message, error.code, error.meta);
     },
   },
 ];

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -1,4 +1,8 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import {
+  ForbiddenError,
+  InternalServerError,
+  PreconditionFailedError,
+} from '../../shared/application/errors/http-errors.js';
 import {
   AcquiredBadgeForbiddenUpdateError,
   AlreadyRatedAssessmentError,
@@ -11,31 +15,31 @@ const evaluationDomainErrorMappingConfiguration = [
   {
     name: ImproveCompetenceEvaluationForbiddenError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.ForbiddenError(error.message, error.code);
+      return new ForbiddenError(error.message, error.code);
     },
   },
   {
     name: CompetenceResetError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.PreconditionFailedError(error.message);
+      return new PreconditionFailedError(error.message);
     },
   },
   {
     name: AcquiredBadgeForbiddenUpdateError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.ForbiddenError(error.message);
+      return new ForbiddenError(error.message);
     },
   },
   {
     name: AnswerEvaluationError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.InternalServerError(error.message);
+      return new InternalServerError(error.message);
     },
   },
   {
     name: AlreadyRatedAssessmentError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.PreconditionFailedError(error.message);
+      return new PreconditionFailedError(error.message);
     },
   },
 ];

--- a/api/src/identity-access-management/application/http-error-mapper-configuration.js
+++ b/api/src/identity-access-management/application/http-error-mapper-configuration.js
@@ -1,4 +1,11 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  PasswordShouldChangeError,
+  UnauthorizedError,
+  UnprocessableEntityError,
+} from '../../shared/application/errors/http-errors.js';
 import {
   AuthenticationKeyExpired,
   DifferentExternalIdentifierError,
@@ -15,43 +22,43 @@ import {
 const authenticationDomainErrorMappingConfiguration = [
   {
     name: AuthenticationKeyExpired.name,
-    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+    httpErrorFn: (error) => new UnauthorizedError(error.message, error.code),
   },
   {
     name: PasswordResetTokenInvalidOrExpired.name,
-    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+    httpErrorFn: (error) => new UnauthorizedError(error.message, error.code),
   },
   {
     name: DifferentExternalIdentifierError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message),
+    httpErrorFn: (error) => new ConflictError(error.message),
   },
   {
     name: InvalidOrAlreadyUsedEmailError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code),
   },
   {
     name: MissingOrInvalidCredentialsError.name,
-    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnauthorizedError(error.message, error.code, error.meta),
   },
   {
     name: MissingUserAccountError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message),
+    httpErrorFn: (error) => new BadRequestError(error.message),
   },
   {
     name: PasswordResetDemandNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message),
+    httpErrorFn: (error) => new NotFoundError(error.message),
   },
   {
     name: PixAdminLoginFromPasswordDisabledError.name,
-    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+    httpErrorFn: (error) => new UnauthorizedError(error.message, error.code),
   },
   {
     name: UserCantBeCreatedError.name,
-    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message),
+    httpErrorFn: (error) => new UnauthorizedError(error.message),
   },
   {
     name: UserShouldChangePasswordError.name,
-    httpErrorFn: (error) => new HttpErrors.PasswordShouldChangeError(error.message, error.meta),
+    httpErrorFn: (error) => new PasswordShouldChangeError(error.message, error.meta),
   },
 ];
 

--- a/api/src/legal-documents/application/http-error-mapper-configuration.js
+++ b/api/src/legal-documents/application/http-error-mapper-configuration.js
@@ -1,10 +1,10 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import { UnprocessableEntityError } from '../../shared/application/errors/http-errors.js';
 import { LegalDocumentInvalidDateError } from '../domain/errors.js';
 
 const legalDocumentsDomainErrorMappingConfiguration = [
   {
     name: LegalDocumentInvalidDateError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/llm/application/http-error-mapper-configuration.js
+++ b/api/src/llm/application/http-error-mapper-configuration.js
@@ -1,4 +1,12 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+  PayloadTooLargeError,
+  ServiceUnavailableError,
+} from '../../shared/application/errors/http-errors.js';
 import {
   ChatForbiddenError,
   ChatNotFoundError,
@@ -16,46 +24,46 @@ import {
 export const llmDomainErrorMappingConfiguration = [
   {
     name: ChatNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new NotFoundError(error.message, error.code, error.meta),
   },
   {
     name: MaxPromptsReachedError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
     name: ChatForbiddenError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
     name: PromptAlreadyOngoingError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
   },
   {
     name: ConfigurationNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code, error.meta),
   },
   {
     name: NoUserIdProvidedError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code, error.meta),
   },
   {
     name: NoAttachmentNeededError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code, error.meta),
   },
   {
     name: NoAttachmentNorMessageProvidedError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code, error.meta),
   },
   {
     name: LLMApiError.name,
-    httpErrorFn: (error) => new HttpErrors.ServiceUnavailableError(error.message),
+    httpErrorFn: (error) => new ServiceUnavailableError(error.message),
   },
   {
     name: IncorrectMessagesOrderingError.name,
-    httpErrorFn: (error) => new HttpErrors.InternalServerError(error.message),
+    httpErrorFn: (error) => new InternalServerError(error.message),
   },
   {
     name: TooLargeMessageInputError.name,
-    httpErrorFn: (error) => new HttpErrors.PayloadTooLargeError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new PayloadTooLargeError(error.message, error.code, error.meta),
   },
 ];

--- a/api/src/llm/application/pre-handlers/index.js
+++ b/api/src/llm/application/pre-handlers/index.js
@@ -1,4 +1,4 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import { ServiceUnavailableError } from '../../../shared/application/errors/http-errors.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { errorSerializer } from '../../../shared/infrastructure/serializers/jsonapi/error-serializer.js';
 
@@ -15,6 +15,6 @@ export async function checkLLMChatIsEnabled(request, h) {
 }
 
 function replyServiceNotAvailableError(h) {
-  const error = new HttpErrors.ServiceUnavailableError();
+  const error = new ServiceUnavailableError();
   return h.response(errorSerializer.serialize(error)).code(error.status).takeover();
 }

--- a/api/src/maddo/application/http-error-mapper-configuration.js
+++ b/api/src/maddo/application/http-error-mapper-configuration.js
@@ -1,9 +1,9 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import { BadRequestError } from '../../shared/application/errors/http-errors.js';
 import { InvalidAuthenticationDataError } from '../domain/errors.js';
 
 export const maddoDomainErrorMappingConfiguration = [
   {
     name: InvalidAuthenticationDataError.name,
-    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code),
+    httpErrorFn: (error) => new BadRequestError(error.message, error.code),
   },
 ];

--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -1,4 +1,4 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import { ConflictError, NotFoundError, UnprocessableEntityError } from '../../shared/application/errors/http-errors.js';
 import {
   AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
@@ -22,71 +22,71 @@ import {
 const organizationalEntitiesDomainErrorMappingConfiguration = [
   {
     name: UnableToAttachChildOrganizationToParentOrganizationError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
   },
   {
     name: UnableToDetachParentOrganizationFromChildOrganization.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: OrganizationNotFound.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: OrganizationLearnerTypeNotFound.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: TagNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new NotFoundError(error.message, error.code, error.meta),
   },
   {
     name: FeatureNotFound.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: FeatureParamsNotProcessable.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: DpoEmailInvalid.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: OrganizationBatchUpdateError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: ArchiveCertificationCentersInBatchError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: ArchiveOrganizationsInBatchError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: AdministrationTeamNotFound.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: NetworkAlreadyExistError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
   },
   {
     name: ParentOrganizationNotInNetworkError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: CountryNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new NotFoundError(error.message, error.code, error.meta),
   },
   {
     name: StructureNotFoundError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: ArchiveOrganizationError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/prescription/campaign/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/campaign/application/http-error-mapper-configuration.js
@@ -1,4 +1,9 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import {
+  ConflictError,
+  ForbiddenError,
+  PreconditionFailedError,
+  UnprocessableEntityError,
+} from '../../../shared/application/errors/http-errors.js';
 import {
   CampaignBelongsToCombinedCourseError,
   CampaignCodeFormatError,
@@ -18,52 +23,52 @@ const campaignDomainErrorMappingConfiguration = [
   {
     name: UnknownCampaignId.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+      return new UnprocessableEntityError(error.message, error.code, error.meta);
     },
   },
   {
     name: SwapCampaignMismatchOrganizationError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
     name: IsForAbsoluteNoviceUpdateError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
     name: MultipleSendingsUpdateError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
     name: CampaignUniqueCodeError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
   },
   {
     name: CampaignCodeFormatError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: CampaignParticipationDoesNotBelongToUser.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
     name: UserNotAuthorizedToCreateCampaignError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message),
+    httpErrorFn: (error) => new ForbiddenError(error.message),
   },
   {
     name: OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message),
+    httpErrorFn: (error) => new ForbiddenError(error.message),
   },
   {
     name: OrganizationNotAuthorizedToCreateCampaignError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message),
+    httpErrorFn: (error) => new ForbiddenError(error.message),
   },
   {
     name: CampaignBelongsToCombinedCourseError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code),
   },
   {
     name: DeletedCampaignError.name,
-    httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new PreconditionFailedError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/prescription/learner-management/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/learner-management/application/http-error-mapper-configuration.js
@@ -1,4 +1,4 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import { PreconditionFailedError } from '../../../shared/application/errors/http-errors.js';
 import { AggregateImportError, CouldNotDeleteLearnersError, SiecleXmlImportError } from '../domain/errors.js';
 
 const learnerManagementDomainErrorMappingConfiguration = [
@@ -6,18 +6,16 @@ const learnerManagementDomainErrorMappingConfiguration = [
     name: AggregateImportError.name,
     httpErrorFn: (aggregateError) => {
       // For AggregateImportError, all errors are aggregated in error.meta
-      return aggregateError.meta.map(
-        (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
-      );
+      return aggregateError.meta.map((error) => new PreconditionFailedError(error.message, error.code, error.meta));
     },
   },
   {
     name: CouldNotDeleteLearnersError.name,
-    httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new PreconditionFailedError(error.message, error.code, error.meta),
   },
   {
     name: SiecleXmlImportError.name,
-    httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new PreconditionFailedError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/prescription/shared/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/shared/application/http-error-mapper-configuration.js
@@ -1,4 +1,4 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import { PreconditionFailedError } from '../../../shared/application/errors/http-errors.js';
 import { campaignDomainErrorMappingConfiguration } from '../../campaign/application/http-error-mapper-configuration.js';
 import { learnerManagementDomainErrorMappingConfiguration } from '../../learner-management/application/http-error-mapper-configuration.js';
 import { ArchivedCampaignError } from '../domain/errors.js';
@@ -7,7 +7,7 @@ const sharedDomainErrorMappingConfiguration = [
   {
     name: ArchivedCampaignError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+      return new PreconditionFailedError(error.message, error.code, error.meta);
     },
   },
 ];

--- a/api/src/prescription/stages/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/stages/application/http-error-mapper-configuration.js
@@ -1,11 +1,11 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import { PreconditionFailedError } from '../../../shared/application/errors/http-errors.js';
 import { StageModificationForbiddenForLinkedTargetProfileError } from '../domain/errors.js';
 
 const stagesDomainErrorMappingConfiguration = [
   {
     name: StageModificationForbiddenForLinkedTargetProfileError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.PreconditionFailedError(error.message);
+      return new PreconditionFailedError(error.message);
     },
   },
 ];

--- a/api/src/profile/application/http-error-mapper-configuration.js
+++ b/api/src/profile/application/http-error-mapper-configuration.js
@@ -1,4 +1,8 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  NotFoundError,
+  PreconditionFailedError,
+} from '../../shared/application/errors/http-errors.js';
 import {
   AttestationNotFoundError,
   NoProfileRewardsFoundError,
@@ -10,25 +14,25 @@ const profileDomainErrorMappingConfiguration = [
   {
     name: AttestationNotFoundError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.NotFoundError(error.message, error.code, error.meta);
+      return new NotFoundError(error.message, error.code, error.meta);
     },
   },
   {
     name: NoProfileRewardsFoundError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.NotFoundError(error.message, error.code, error.meta);
+      return new NotFoundError(error.message, error.code, error.meta);
     },
   },
   {
     name: ProfileRewardCantBeSharedError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+      return new PreconditionFailedError(error.message, error.code, error.meta);
     },
   },
   {
     name: RewardTypeDoesNotExistError.name,
     httpErrorFn: (error) => {
-      return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
+      return new BadRequestError(error.message, error.code, error.meta);
     },
   },
 ];

--- a/api/src/quest/application/pre-handlers/display-catalogue.js
+++ b/api/src/quest/application/pre-handlers/display-catalogue.js
@@ -1,4 +1,4 @@
-import { HttpErrors } from '../../../shared/application/errors/http-errors.js';
+import { NotFoundError } from '../../../shared/application/errors/http-errors.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { errorSerializer } from '../../../shared/infrastructure/serializers/jsonapi/error-serializer.js';
 
@@ -7,6 +7,6 @@ export async function checkDisplayCatalogueIsEnabled(request, h) {
   if (isEnabled) {
     return h.response(true);
   }
-  const error = new HttpErrors.NotFoundError();
+  const error = new NotFoundError();
   return h.response(errorSerializer.serialize(error)).code(error.status).takeover();
 }

--- a/api/src/school/application/http-error-mapper-configuration.js
+++ b/api/src/school/application/http-error-mapper-configuration.js
@@ -1,10 +1,10 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import { PreconditionFailedError } from '../../shared/application/errors/http-errors.js';
 import { NotInProgressAssessmentError } from '../domain/school-errors.js';
 
 const schoolDomainErrorMappingConfiguration = [
   {
     name: NotInProgressAssessmentError.name,
-    httpErrorFn: (error) => new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new PreconditionFailedError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/shared/application/errors/error-manager.js
+++ b/api/src/shared/application/errors/error-manager.js
@@ -1,5 +1,15 @@
 import * as SharedDomainErrors from '../../domain/errors.js';
-import { HttpErrors } from './http-errors.js';
+import {
+  BadRequestError,
+  BaseHttpError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  PreconditionFailedError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+  UnprocessableEntityError,
+} from './http-errors.js';
 
 const NOT_FOUND_ERRORS = [
   SharedDomainErrors.NotFoundError,
@@ -126,22 +136,19 @@ const SERVICE_UNAVAILABLE_ERRORS = [
 ];
 
 export function mapToHttpError(error) {
-  if (NOT_FOUND_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.NotFoundError(error.message, error.code, error.meta);
+  if (NOT_FOUND_ERRORS.some((E) => error instanceof E)) return new NotFoundError(error.message, error.code, error.meta);
   if (FORBIDDEN_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.ForbiddenError(error.message, error.code, error.meta);
-  if (CONFLICT_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.ConflictError(error.message, error.code, error.meta);
+    return new ForbiddenError(error.message, error.code, error.meta);
+  if (CONFLICT_ERRORS.some((E) => error instanceof E)) return new ConflictError(error.message, error.code, error.meta);
   if (PRECONDITION_FAILED_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+    return new PreconditionFailedError(error.message, error.code, error.meta);
   if (BAD_REQUEST_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
+    return new BadRequestError(error.message, error.code, error.meta);
   if (UNPROCESSABLE_ENTITY_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+    return new UnprocessableEntityError(error.message, error.code, error.meta);
   if (UNAUTHORIZED_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.UnauthorizedError(error.message, error.code, error.meta);
-  if (SERVICE_UNAVAILABLE_ERRORS.some((E) => error instanceof E))
-    return new HttpErrors.ServiceUnavailableError(error.message);
+    return new UnauthorizedError(error.message, error.code, error.meta);
+  if (SERVICE_UNAVAILABLE_ERRORS.some((E) => error instanceof E)) return new ServiceUnavailableError(error.message);
 
-  return new HttpErrors.BaseHttpError(error.message);
+  return new BaseHttpError(error.message);
 }

--- a/api/src/shared/application/errors/hapi-error-mapper.js
+++ b/api/src/shared/application/errors/hapi-error-mapper.js
@@ -5,7 +5,7 @@ import { getBaseLocale } from '../../domain/services/locale-service.js';
 import { getI18n } from '../../infrastructure/i18n/i18n.js';
 import { getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
 import { mapToHttpError } from './error-manager.js';
-import { HttpErrors } from './http-errors.js';
+import { BaseHttpError, InvalidEntityError, sendJsonApiError } from './http-errors.js';
 
 const NOT_VALID_RELATIONSHIPS = ['externalId', 'participantExternalId'];
 
@@ -19,8 +19,8 @@ export class HapiErrorMapper {
   handle(request, h) {
     const { response } = request;
 
-    if (response instanceof HttpErrors.BaseHttpError) {
-      return HttpErrors.sendJsonApiError(response, h);
+    if (response instanceof BaseHttpError) {
+      return sendJsonApiError(response, h);
     }
 
     if (response instanceof EntityValidationError) {
@@ -29,12 +29,12 @@ export class HapiErrorMapper {
       const jsonApiError = response.invalidAttributes?.map((invalidAttribute) =>
         this.#formatInvalidAttribute(language, response.meta, invalidAttribute),
       );
-      return HttpErrors.sendJsonApiError(jsonApiError ?? new HttpErrors.InvalidEntityError(), h);
+      return sendJsonApiError(jsonApiError ?? new InvalidEntityError(), h);
     }
 
     if (response instanceof DomainError) {
       const httpError = this.#registry.mapToError(response) ?? mapToHttpError(response);
-      return HttpErrors.sendJsonApiError(httpError, h);
+      return sendJsonApiError(httpError, h);
     }
     return h.continue;
   }
@@ -50,7 +50,7 @@ export class HapiErrorMapper {
   }
 
   #formatUndefinedAttribute({ message, locale, meta }) {
-    return new HttpErrors.InvalidEntityError({
+    return new InvalidEntityError({
       message: this.#translateMessage(locale, message),
       code: undefined,
       meta,
@@ -61,7 +61,7 @@ export class HapiErrorMapper {
 
   #formatRelationship({ attribute, message, locale, meta }) {
     const relationship = attribute.replace('Id', '');
-    return new HttpErrors.InvalidEntityError({
+    return new InvalidEntityError({
       message: this.#translateMessage(locale, message),
       code: undefined,
       meta,
@@ -73,7 +73,7 @@ export class HapiErrorMapper {
   }
 
   #formatAttribute({ attribute, message, locale, meta }) {
-    return new HttpErrors.InvalidEntityError({
+    return new InvalidEntityError({
       message: this.#translateMessage(locale, message),
       code: undefined,
       meta,

--- a/api/src/shared/application/errors/http-errors.js
+++ b/api/src/shared/application/errors/http-errors.js
@@ -161,14 +161,6 @@ export class SessionPublicationBatchError extends BaseHttpError {
   }
 }
 
-export class TooManyRequestsError extends BaseHttpError {
-  constructor(message) {
-    super(message);
-    this.title = 'Too many requests';
-    this.status = 429;
-  }
-}
-
 /**
  * @typedef {import('../../infrastructure/serializers/jsonapi/error-serializer.js').HttpError} HttpError
  * @param {Array<HttpError>|HttpError} httpError

--- a/api/src/shared/application/errors/http-errors.js
+++ b/api/src/shared/application/errors/http-errors.js
@@ -1,6 +1,6 @@
 import { errorSerializer } from '../../infrastructure/serializers/jsonapi/error-serializer.js';
 
-class BaseHttpError extends Error {
+export class BaseHttpError extends Error {
   constructor(message) {
     super(message);
     this.title = 'Default Bad Request';
@@ -8,7 +8,7 @@ class BaseHttpError extends Error {
   }
 }
 
-class UnprocessableEntityError extends BaseHttpError {
+export class UnprocessableEntityError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
     this.title = 'Unprocessable entity';
@@ -18,7 +18,7 @@ class UnprocessableEntityError extends BaseHttpError {
   }
 }
 
-class InvalidEntityError extends BaseHttpError {
+export class InvalidEntityError extends BaseHttpError {
   constructor({ message, code, meta, source, title } = {}) {
     super(message);
     this.title = title;
@@ -29,7 +29,7 @@ class InvalidEntityError extends BaseHttpError {
   }
 }
 
-class PreconditionFailedError extends BaseHttpError {
+export class PreconditionFailedError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
     this.title = 'Precondition Failed';
@@ -39,7 +39,7 @@ class PreconditionFailedError extends BaseHttpError {
   }
 }
 
-class ConflictError extends BaseHttpError {
+export class ConflictError extends BaseHttpError {
   constructor(message = 'Conflict between request and server state.', code, meta) {
     super(message);
     this.code = code;
@@ -49,7 +49,7 @@ class ConflictError extends BaseHttpError {
   }
 }
 
-class LockedError extends BaseHttpError {
+export class LockedError extends BaseHttpError {
   constructor(message = 'The resource being accessed is currently locked', code, meta) {
     super(message);
     this.code = code;
@@ -59,7 +59,7 @@ class LockedError extends BaseHttpError {
   }
 }
 
-class MissingQueryParamError extends BaseHttpError {
+export class MissingQueryParamError extends BaseHttpError {
   constructor(missingParamName) {
     const message = `Missing ${missingParamName} query parameter.`;
     super(message);
@@ -68,7 +68,7 @@ class MissingQueryParamError extends BaseHttpError {
   }
 }
 
-class NotFoundError extends BaseHttpError {
+export class NotFoundError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
     this.title = 'Not Found';
@@ -78,7 +78,7 @@ class NotFoundError extends BaseHttpError {
   }
 }
 
-class UnauthorizedError extends BaseHttpError {
+export class UnauthorizedError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
     this.title = 'Unauthorized';
@@ -88,7 +88,7 @@ class UnauthorizedError extends BaseHttpError {
   }
 }
 
-class PasswordShouldChangeError extends BaseHttpError {
+export class PasswordShouldChangeError extends BaseHttpError {
   constructor(message, meta) {
     super(message);
     this.title = 'PasswordShouldChange';
@@ -98,7 +98,7 @@ class PasswordShouldChangeError extends BaseHttpError {
   }
 }
 
-class ForbiddenError extends BaseHttpError {
+export class ForbiddenError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
     this.title = 'Forbidden';
@@ -108,7 +108,7 @@ class ForbiddenError extends BaseHttpError {
   }
 }
 
-class InternalServerError extends BaseHttpError {
+export class InternalServerError extends BaseHttpError {
   constructor(message) {
     super(message);
     this.title = 'Internal server error';
@@ -116,7 +116,7 @@ class InternalServerError extends BaseHttpError {
   }
 }
 
-class ServiceUnavailableError extends BaseHttpError {
+export class ServiceUnavailableError extends BaseHttpError {
   constructor(message) {
     super(message);
     this.title = 'ServiceUnavailable';
@@ -124,7 +124,7 @@ class ServiceUnavailableError extends BaseHttpError {
   }
 }
 
-class BadGatewayError extends BaseHttpError {
+export class BadGatewayError extends BaseHttpError {
   constructor(message) {
     super(message);
     this.title = 'BadGateway';
@@ -132,7 +132,7 @@ class BadGatewayError extends BaseHttpError {
   }
 }
 
-class BadRequestError extends BaseHttpError {
+export class BadRequestError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
     this.title = 'Bad Request';
@@ -142,7 +142,7 @@ class BadRequestError extends BaseHttpError {
   }
 }
 
-class PayloadTooLargeError extends BaseHttpError {
+export class PayloadTooLargeError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
     this.title = 'Payload too large';
@@ -152,7 +152,7 @@ class PayloadTooLargeError extends BaseHttpError {
   }
 }
 
-class SessionPublicationBatchError extends BaseHttpError {
+export class SessionPublicationBatchError extends BaseHttpError {
   constructor(batchId) {
     super(`${batchId}`);
     this.title = 'One or more error occurred while publishing session in batch';
@@ -161,7 +161,7 @@ class SessionPublicationBatchError extends BaseHttpError {
   }
 }
 
-class TooManyRequestsError extends BaseHttpError {
+export class TooManyRequestsError extends BaseHttpError {
   constructor(message) {
     super(message);
     this.title = 'Too many requests';
@@ -175,45 +175,7 @@ class TooManyRequestsError extends BaseHttpError {
  * @param {Object} h
  * @returns {Promise}
  */
-function sendJsonApiError(httpError, h) {
+export function sendJsonApiError(httpError, h) {
   const errors = errorSerializer.serialize(httpError);
   return h.response(errors).code(Number(errors.errors[0].status)).takeover();
 }
-
-const HttpErrors = {
-  BadGatewayError,
-  BadRequestError,
-  BaseHttpError,
-  ConflictError,
-  LockedError,
-  ForbiddenError,
-  MissingQueryParamError,
-  NotFoundError,
-  PasswordShouldChangeError,
-  PayloadTooLargeError,
-  PreconditionFailedError,
-  sendJsonApiError,
-  ServiceUnavailableError,
-  SessionPublicationBatchError,
-  UnauthorizedError,
-  UnprocessableEntityError,
-  TooManyRequestsError,
-  InternalServerError,
-  InvalidEntityError,
-};
-
-export {
-  BadRequestError,
-  BaseHttpError,
-  ConflictError,
-  ForbiddenError,
-  HttpErrors,
-  MissingQueryParamError,
-  NotFoundError,
-  PayloadTooLargeError,
-  PreconditionFailedError,
-  sendJsonApiError,
-  SessionPublicationBatchError,
-  UnauthorizedError,
-  UnprocessableEntityError,
-};

--- a/api/src/shared/infrastructure/utils/network.js
+++ b/api/src/shared/infrastructure/utils/network.js
@@ -1,4 +1,4 @@
-import { HttpErrors } from '../../application/errors/http-errors.js';
+import { BadRequestError } from '../../application/errors/http-errors.js';
 
 const PIX_APP_APPLICATION_NAME = 'app';
 const PIX_ADMIN_APPLICATION_NAME = 'admin';
@@ -110,7 +110,7 @@ export class RequestedApplication {
   }
 }
 
-export class ForwardedOriginError extends HttpErrors.BadRequestError {
+export class ForwardedOriginError extends BadRequestError {
   constructor(message) {
     super(message);
   }

--- a/api/src/team/application/http-error-mapper-configuration.js
+++ b/api/src/team/application/http-error-mapper-configuration.js
@@ -1,4 +1,8 @@
-import { HttpErrors } from '../../shared/application/errors/http-errors.js';
+import {
+  ConflictError,
+  ForbiddenError,
+  UnprocessableEntityError,
+} from '../../shared/application/errors/http-errors.js';
 import {
   AdminMemberError,
   AlreadyAcceptedOrCancelledInvitationError,
@@ -12,31 +16,31 @@ import {
 const teamDomainErrorMappingConfiguration = [
   {
     name: AdminMemberError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: UncancellableOrganizationInvitationError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: AlreadyExistingAdminMemberError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: OrganizationArchivedError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: AlreadyAcceptedOrCancelledInvitationError.name,
-    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
   },
   {
     name: UserHasNoOrganizationMembershipError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
     name: UserNotMemberOfOrganizationError.name,
-    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/tests/certification/configuration/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/configuration/unit/application/http-error-mapper-configuration_test.js
@@ -3,7 +3,7 @@ import {
   CertificationVersionDraftAlreadyExistError,
   InvalidScoWhitelistError,
 } from '../../../../../src/certification/configuration/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { BadRequestError, UnprocessableEntityError } from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Certification | Configuration | Application | HttpErrorMapperConfiguration', function () {
@@ -18,7 +18,7 @@ describe('Unit | Certification | Configuration | Application | HttpErrorMapperCo
       const error = httpErrorMapper.httpErrorFn(new InvalidScoWhitelistError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('La liste blanche contient des données invalides.');
     });
   });
@@ -34,7 +34,7 @@ describe('Unit | Certification | Configuration | Application | HttpErrorMapperCo
       const error = httpErrorMapper.httpErrorFn(new CertificationVersionDraftAlreadyExistError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
       expect(error.message).to.equal(
         "Il est interdit de créer une nouvelle version lorsqu'il y en a déjà une en cours d'édition",
       );

--- a/api/tests/certification/enrolment/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/enrolment/unit/application/http-error-mapper-configuration_test.js
@@ -4,7 +4,11 @@ import {
   SessionStartedDeletionError,
   UnknownCountryForStudentEnrolmentError,
 } from '../../../../../src/certification/enrolment/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import {
+  ConflictError,
+  ForbiddenError,
+  UnprocessableEntityError,
+} from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Certification | Enrolment | Application | HttpErrorMapperConfiguration', function () {
@@ -19,7 +23,7 @@ describe('Unit | Certification | Enrolment | Application | HttpErrorMapperConfig
       const error = httpErrorMapper.httpErrorFn(new CertificationCandidateForbiddenDeletionError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+      expect(error).to.be.instanceOf(ForbiddenError);
       expect(error.message).to.equal(
         'Il est interdit de supprimer un candidat de certification déjà lié à un utilisateur.',
       );
@@ -37,7 +41,7 @@ describe('Unit | Certification | Enrolment | Application | HttpErrorMapperConfig
       const error = httpErrorMapper.httpErrorFn(new SessionStartedDeletionError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+      expect(error).to.be.instanceOf(ConflictError);
       expect(error.message).to.equal('La session a déjà commencé.');
     });
   });
@@ -55,7 +59,7 @@ describe('Unit | Certification | Enrolment | Application | HttpErrorMapperConfig
       );
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal(
         "L'élève Paul Preboist a été inscrit avec un code pays de naissance invalide. Veuillez corriger ses informations sur l'espace PixOrga de l'établissement ou contacter le support Pix",
       );

--- a/api/tests/certification/evaluation/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/evaluation/unit/application/http-error-mapper-configuration_test.js
@@ -1,6 +1,6 @@
 import { evaluationDomainErrorMappingConfiguration } from '../../../../../src/certification/evaluation/application/http-error-mapper-configuration.js';
 import { NextChallengeAlreadyComputingError } from '../../../../../src/certification/evaluation/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { LockedError } from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Certification | Evaluation | Application | HttpErrorMapperConfiguration', function () {
@@ -15,7 +15,7 @@ describe('Unit | Certification | Evaluation | Application | HttpErrorMapperConfi
       const error = httpErrorMapper.httpErrorFn(new NextChallengeAlreadyComputingError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.LockedError);
+      expect(error).to.be.instanceOf(LockedError);
       expect(error.message).to.equal('Une nouvelle épreuve est en cours de calcul');
     });
   });

--- a/api/tests/certification/results/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/results/unit/application/http-error-mapper-configuration_test.js
@@ -7,7 +7,11 @@ import {
   MoreThanOneMatchingCertificationError,
   NoCertificationResultForDivision,
 } from '../../../../../src/certification/results/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import {
+  ConflictError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Certification | Results | Application | HttpErrorMapperConfiguration', function () {
@@ -22,7 +26,7 @@ describe('Unit | Certification | Results | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new MoreThanOneMatchingCertificationError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+      expect(error).to.be.instanceOf(ConflictError);
       expect(error.message).to.equal('More than one candidate found for current search parameters');
     });
   });
@@ -38,7 +42,7 @@ describe('Unit | Certification | Results | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new NoCertificationResultForDivision());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error).to.be.instanceOf(NotFoundError);
       expect(error.message).to.equal('Aucun résultat de certification pour cette classe.');
     });
   });
@@ -54,7 +58,7 @@ describe('Unit | Certification | Results | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new CertificateGenerationError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('An error has occurred during PDF generation');
     });
   });

--- a/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
@@ -9,7 +9,12 @@ import {
   SessionAlreadyPublishedError,
   SessionWithoutStartedCertificationError,
 } from '../../../../../src/certification/session-management/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  ConflictError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+} from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Certification | Session | Application | HttpErrorMapperConfiguration', function () {
@@ -26,7 +31,7 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new SessionWithoutStartedCertificationError(message, code));
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
       expect(error.message).to.equal(message);
       expect(error.code).to.equal(code);
     });
@@ -45,7 +50,7 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new SessionAlreadyFinalizedError(message, code));
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+      expect(error).to.be.instanceOf(ConflictError);
       expect(error.message).to.equal(message);
       expect(error.code).to.equal(code);
     });
@@ -63,7 +68,7 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new SessionAlreadyPublishedError(message));
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
       expect(error.message).to.equal(message);
     });
   });
@@ -81,7 +86,7 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new CertificationCenterIsArchivedError(message, code));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+      expect(error).to.be.instanceOf(UnauthorizedError);
       expect(error.message).to.equal(message);
       expect(error.code).to.equal(code);
     });
@@ -98,7 +103,7 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new InvalidSessionSupervisingLoginError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+      expect(error).to.be.instanceOf(UnauthorizedError);
       expect(error.message).to.equal(SESSION_SUPERVISING.INCORRECT_DATA.getMessage());
       expect(error.code).to.equal(SESSION_SUPERVISING.INCORRECT_DATA.code);
     });
@@ -115,7 +120,7 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new SendingEmailToRefererError(['test1@email.com', 'test2@email.com']));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.ServiceUnavailableError);
+      expect(error).to.be.instanceOf(ServiceUnavailableError);
       expect(error.message).to.equal(
         "Échec lors de l'envoi du mail au(x) référent(s) du centre de certification : test1@email.com, test2@email.com",
       );
@@ -135,7 +140,7 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       );
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.ServiceUnavailableError);
+      expect(error).to.be.instanceOf(ServiceUnavailableError);
       expect(error.message).to.equal(
         "Échec lors de l'envoi des résultats au(x) destinataire(s) : test1@email.com, test2@email.com",
       );

--- a/api/tests/certification/shared/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/shared/unit/application/http-error-mapper-configuration_test.js
@@ -6,7 +6,12 @@ import {
   CsvWithNoSessionDataError,
   InvalidCertificationReportForFinalization,
 } from '../../../../../src/certification/shared/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Certification | Shared | Application | HttpErrorMapperConfiguration', function () {
@@ -22,7 +27,7 @@ describe('Unit | Certification | Shared | Application | HttpErrorMapperConfigura
       const error = httpErrorMapper.httpErrorFn(new CertificationCourseUpdateError(message));
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
       expect(error.message).to.equal(message);
     });
   });
@@ -39,7 +44,7 @@ describe('Unit | Certification | Shared | Application | HttpErrorMapperConfigura
       const error = httpErrorMapper.httpErrorFn(new InvalidCertificationReportForFinalization(message));
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
       expect(error.message).to.equal(message);
     });
   });
@@ -55,7 +60,7 @@ describe('Unit | Certification | Shared | Application | HttpErrorMapperConfigura
       const error = httpErrorMapper.httpErrorFn(new CenterHabilitationError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+      expect(error).to.be.instanceOf(ForbiddenError);
       expect(error.message).to.equal(
         'This certification center has no habilitation for the given complementary certification.',
       );
@@ -74,7 +79,7 @@ describe('Unit | Certification | Shared | Application | HttpErrorMapperConfigura
       const error = httpErrorMapper.httpErrorFn(new CertificationCandidateNotFoundError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error).to.be.instanceOf(NotFoundError);
       expect(error.message).to.equal('No candidate found');
       expect(error.code).to.equal('CANDIDATE_NOT_FOUND');
     });
@@ -91,7 +96,7 @@ describe('Unit | Certification | Shared | Application | HttpErrorMapperConfigura
       const error = httpErrorMapper.httpErrorFn(new CsvWithNoSessionDataError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('No session data in csv');
       expect(error.code).to.equal('CSV_DATA_REQUIRED');
     });

--- a/api/tests/evaluation/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/evaluation/unit/application/http-error-mapper-configuration_test.js
@@ -1,6 +1,6 @@
 import { evaluationDomainErrorMappingConfiguration } from '../../../../src/evaluation/application/http-error-mapper-configuration.js';
 import { AlreadyRatedAssessmentError } from '../../../../src/evaluation/domain/errors.js';
-import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
+import { PreconditionFailedError } from '../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../test-helper.js';
 
 describe('Unit | Evaluation | Application | HttpErrorMapperConfiguration', function () {
@@ -15,7 +15,7 @@ describe('Unit | Evaluation | Application | HttpErrorMapperConfiguration', funct
       const error = httpErrorMapper.httpErrorFn(new AlreadyRatedAssessmentError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+      expect(error).to.be.instanceOf(PreconditionFailedError);
     });
   });
 });

--- a/api/tests/identity-access-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/identity-access-management/unit/application/http-error-mapper-configuration_test.js
@@ -8,7 +8,13 @@ import {
   UserCantBeCreatedError,
   UserShouldChangePasswordError,
 } from '../../../../src/identity-access-management/domain/errors.js';
-import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  PasswordShouldChangeError,
+  UnauthorizedError,
+} from '../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Application | HttpErrorMapperConfiguration', function () {
@@ -23,7 +29,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
       const error = httpErrorMapper.httpErrorFn(new AuthenticationKeyExpired());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+      expect(error).to.be.instanceOf(UnauthorizedError);
       expect(error.code).to.equal('EXPIRED_AUTHENTICATION_KEY');
     });
   });
@@ -39,7 +45,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
       const error = httpErrorMapper.httpErrorFn(new DifferentExternalIdentifierError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+      expect(error).to.be.instanceOf(ConflictError);
     });
   });
 
@@ -57,7 +63,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
         );
 
         // then
-        expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+        expect(error).to.be.instanceOf(UnauthorizedError);
         expect(error.meta.isLoginFailureWithUsername).to.be.true;
       });
     });
@@ -75,7 +81,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
         );
 
         // then
-        expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+        expect(error).to.be.instanceOf(UnauthorizedError);
         expect(error.meta.isLoginFailureWithUsername).to.be.false;
       });
     });
@@ -92,7 +98,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
         const error = httpErrorMapper.httpErrorFn(new MissingOrInvalidCredentialsError({ remainingAttempts }));
 
         // then
-        expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+        expect(error).to.be.instanceOf(UnauthorizedError);
         expect(error.meta.remainingAttempts).to.equal(remainingAttempts);
       });
     });
@@ -109,7 +115,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
       const error = httpErrorMapper.httpErrorFn(new MissingUserAccountError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
     });
   });
 
@@ -125,7 +131,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
       const error = httpErrorMapper.httpErrorFn(new PasswordResetDemandNotFoundError(message));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error).to.be.instanceOf(NotFoundError);
       expect(error.message).to.equal(message);
     });
   });
@@ -142,7 +148,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
       const error = httpErrorMapper.httpErrorFn(new UserCantBeCreatedError(message));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+      expect(error).to.be.instanceOf(UnauthorizedError);
       expect(error.message).to.equal(message);
     });
   });
@@ -160,7 +166,7 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
       const error = httpErrorMapper.httpErrorFn(new UserShouldChangePasswordError(message, meta));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.PasswordShouldChangeError);
+      expect(error).to.be.instanceOf(PasswordShouldChangeError);
       expect(error.message).to.equal(message);
       expect(error.meta).to.equal(meta);
     });

--- a/api/tests/legal-documents/unit/domain/application/http-error-mapper-configuration_test.js
+++ b/api/tests/legal-documents/unit/domain/application/http-error-mapper-configuration_test.js
@@ -1,6 +1,6 @@
 import { legalDocumentsDomainErrorMappingConfiguration } from '../../../../../src/legal-documents/application/http-error-mapper-configuration.js';
 import { LegalDocumentInvalidDateError } from '../../../../../src/legal-documents/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { UnprocessableEntityError } from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Legal Documents | Application | HttpErrorMapperConfiguration', function () {
@@ -15,7 +15,7 @@ describe('Unit | Legal Documents | Application | HttpErrorMapperConfiguration', 
       const error = httpErrorMapper.httpErrorFn(new LegalDocumentInvalidDateError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
     });
   });
 });

--- a/api/tests/llm/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/llm/unit/application/http-error-mapper-configuration_test.js
@@ -12,7 +12,15 @@ import {
   PromptAlreadyOngoingError,
   TooLargeMessageInputError,
 } from '../../../../src/llm/domain/errors.js';
-import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+  PayloadTooLargeError,
+  ServiceUnavailableError,
+} from '../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../test-helper.js';
 
 describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () {
@@ -27,7 +35,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new ChatNotFoundError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error).to.be.instanceOf(NotFoundError);
     });
   });
 
@@ -42,7 +50,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new MaxPromptsReachedError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+      expect(error).to.be.instanceOf(ForbiddenError);
     });
   });
 
@@ -57,7 +65,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new ChatForbiddenError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+      expect(error).to.be.instanceOf(ForbiddenError);
     });
   });
 
@@ -72,7 +80,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new PromptAlreadyOngoingError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+      expect(error).to.be.instanceOf(ConflictError);
     });
   });
 
@@ -87,7 +95,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new ConfigurationNotFoundError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
     });
   });
 
@@ -102,7 +110,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new NoUserIdProvidedError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
     });
   });
 
@@ -117,7 +125,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new NoAttachmentNeededError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
     });
   });
 
@@ -132,7 +140,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new NoAttachmentNorMessageProvidedError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error).to.be.instanceOf(BadRequestError);
     });
   });
 
@@ -147,7 +155,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new LLMApiError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.ServiceUnavailableError);
+      expect(error).to.be.instanceOf(ServiceUnavailableError);
     });
   });
 
@@ -162,7 +170,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new IncorrectMessagesOrderingError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.InternalServerError);
+      expect(error).to.be.instanceOf(InternalServerError);
     });
   });
 
@@ -177,7 +185,7 @@ describe('Unit | LLM | Application | HttpErrorMapperConfiguration', function () 
       const error = httpErrorMapper.httpErrorFn(new TooLargeMessageInputError());
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.PayloadTooLargeError);
+      expect(error).to.be.instanceOf(PayloadTooLargeError);
     });
   });
 });

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -9,7 +9,11 @@ import {
   UnableToDetachParentOrganizationFromChildOrganization,
 } from '../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationLearnerTypeNotFound } from '../../../../src/organizational-entities/domain/errors.js';
-import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
+import {
+  ConflictError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from '../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../test-helper.js';
 
 describe('Unit | Organizational Entities | Application | HttpErrorMapperConfiguration', function () {
@@ -25,7 +29,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new TagNotFoundError(meta));
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error).to.be.instanceOf(NotFoundError);
       expect(error.message).to.equal('Tag does not exist');
       expect(error.meta).to.equal(meta);
     });
@@ -44,7 +48,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new UnableToDetachParentOrganizationFromChildOrganization({ meta }));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('Unable to detach parent organization from child organization');
       expect(error.meta).to.equal(meta);
     });
@@ -63,7 +67,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new CountryNotFoundError({ meta }));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error).to.be.instanceOf(NotFoundError);
       expect(error.message).to.equal('Country not found');
       expect(error.meta).to.equal(meta);
     });
@@ -82,7 +86,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new OrganizationLearnerTypeNotFound({ meta }));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('Organization learner type does not exist');
       expect(error.meta).to.equal(meta);
     });
@@ -101,7 +105,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new NetworkAlreadyExistError({ meta }));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+      expect(error).to.be.instanceOf(ConflictError);
       expect(error.message).to.equal('Network already exists');
       expect(error.meta).to.equal(meta);
     });
@@ -120,7 +124,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new ParentOrganizationNotInNetworkError({ meta }));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('Parent organization not in network');
       expect(error.meta).to.equal(meta);
     });
@@ -139,7 +143,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new StructureNotFoundError({ meta }));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('Structure not found');
       expect(error.meta).to.equal(meta);
     });
@@ -158,7 +162,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       const error = httpErrorMapper.httpErrorFn(new ArchiveOrganizationError({ meta }));
 
       // then
-      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('Error during organization archiving');
       expect(error.meta).to.equal(meta);
     });

--- a/api/tests/prescription/campaign/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/prescription/campaign/unit/application/http-error-mapper-configuration_test.js
@@ -6,7 +6,7 @@ import {
   OrganizationNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateCampaignError,
 } from '../../../../../src/prescription/campaign/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { ForbiddenError, PreconditionFailedError } from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfiguration', function () {
@@ -20,7 +20,7 @@ describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfigur
     const error = httpErrorMapper.httpErrorFn(new CampaignParticipationDoesNotBelongToUser());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    expect(error).to.be.instanceOf(ForbiddenError);
   });
 
   it('instantiates ForbiddenError when UserNotAuthorizedToCreateCampaignError', async function () {
@@ -33,7 +33,7 @@ describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfigur
     const error = httpErrorMapper.httpErrorFn(new UserNotAuthorizedToCreateCampaignError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    expect(error).to.be.instanceOf(ForbiddenError);
   });
 
   it('instantiates ForbiddenError when OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError', async function () {
@@ -49,7 +49,7 @@ describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfigur
     );
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    expect(error).to.be.instanceOf(ForbiddenError);
   });
 
   it('instantiates ForbiddenError when OrganizationNotAuthorizedToCreateCampaignError', async function () {
@@ -62,7 +62,7 @@ describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfigur
     const error = httpErrorMapper.httpErrorFn(new OrganizationNotAuthorizedToCreateCampaignError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    expect(error).to.be.instanceOf(ForbiddenError);
   });
 
   it('instantiates PreconditionFailedError when DeletedCampaignError', async function () {
@@ -75,6 +75,6 @@ describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfigur
     const error = httpErrorMapper.httpErrorFn(new DeletedCampaignError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+    expect(error).to.be.instanceOf(PreconditionFailedError);
   });
 });

--- a/api/tests/prescription/learner-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/prescription/learner-management/unit/application/http-error-mapper-configuration_test.js
@@ -4,7 +4,7 @@ import {
   CouldNotDeleteLearnersError,
   SiecleXmlImportError,
 } from '../../../../../src/prescription/learner-management/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { PreconditionFailedError } from '../../../../../src/shared/application/errors/http-errors.js';
 import { CsvImportError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 
@@ -22,8 +22,8 @@ describe('Prescription | Learner Management | Unit | Application | HttpErrorMapp
 
     //then
     expect(error).to.be.deep.equal([
-      new HttpErrors.PreconditionFailedError(error1.message, error1.code),
-      new HttpErrors.PreconditionFailedError(error2.message, error2.code),
+      new PreconditionFailedError(error1.message, error1.code),
+      new PreconditionFailedError(error2.message, error2.code),
     ]);
   });
 
@@ -37,7 +37,7 @@ describe('Prescription | Learner Management | Unit | Application | HttpErrorMapp
     const error = httpErrorMapper.httpErrorFn(new CouldNotDeleteLearnersError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+    expect(error).to.be.instanceOf(PreconditionFailedError);
   });
 
   it('instantiates PreconditionFailedError when SiecleXmlImportError', async function () {
@@ -50,6 +50,6 @@ describe('Prescription | Learner Management | Unit | Application | HttpErrorMapp
     const error = httpErrorMapper.httpErrorFn(new SiecleXmlImportError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+    expect(error).to.be.instanceOf(PreconditionFailedError);
   });
 });

--- a/api/tests/prescription/shared/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/prescription/shared/unit/application/http-error-mapper-configuration_test.js
@@ -1,6 +1,6 @@
 import { prescriptionDomainErrorMappingConfiguration } from '../../../../../src/prescription/shared/application/http-error-mapper-configuration.js';
 import { ArchivedCampaignError } from '../../../../../src/prescription/shared/domain/errors.js';
-import { HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { PreconditionFailedError } from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Prescription | Shared | Application | HttpErrorMapperConfiguration', function () {
@@ -15,7 +15,7 @@ describe('Unit | Prescription | Shared | Application | HttpErrorMapperConfigurat
       const error = httpErrorMapper.httpErrorFn(new ArchivedCampaignError());
 
       //then
-      expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+      expect(error).to.be.instanceOf(PreconditionFailedError);
       expect(error.message).to.equal('Cette campagne est déjà archivée.');
     });
   });

--- a/api/tests/profile/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/profile/unit/application/http-error-mapper-configuration_test.js
@@ -4,7 +4,11 @@ import {
   ProfileRewardCantBeSharedError,
   RewardTypeDoesNotExistError,
 } from '../../../../src/profile/domain/errors.js';
-import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
+import {
+  BadRequestError,
+  NotFoundError,
+  PreconditionFailedError,
+} from '../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../test-helper.js';
 
 describe('Profile | Unit | Application | HttpErrorMapperConfiguration', function () {
@@ -18,7 +22,7 @@ describe('Profile | Unit | Application | HttpErrorMapperConfiguration', function
     const error = httpErrorMapper.httpErrorFn(new AttestationNotFoundError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+    expect(error).to.be.instanceOf(NotFoundError);
   });
 
   it('instantiates PreconditionFailedError when ProfileRewardCantBeShared', async function () {
@@ -31,7 +35,7 @@ describe('Profile | Unit | Application | HttpErrorMapperConfiguration', function
     const error = httpErrorMapper.httpErrorFn(new ProfileRewardCantBeSharedError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+    expect(error).to.be.instanceOf(PreconditionFailedError);
   });
 
   it('instantiates BadRequestError when RewardTypeDoesNotExistError', async function () {
@@ -44,6 +48,6 @@ describe('Profile | Unit | Application | HttpErrorMapperConfiguration', function
     const error = httpErrorMapper.httpErrorFn(new RewardTypeDoesNotExistError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+    expect(error).to.be.instanceOf(BadRequestError);
   });
 });

--- a/api/tests/shared/unit/application/errors/http-errors_test.js
+++ b/api/tests/shared/unit/application/errors/http-errors_test.js
@@ -1,13 +1,13 @@
-import { BaseHttpError, HttpErrors } from '../../../../../src/shared/application/errors/http-errors.js';
+import { BaseHttpError } from '../../../../../src/shared/application/errors/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
-describe('Unit | Shared | Application | HttpErrors', function () {
+describe('Unit | Shared | Application | ', function () {
   it('instantiates BaseHttpError', async function () {
     // when
     const error = new BaseHttpError('');
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.BaseHttpError);
+    expect(error).to.be.instanceOf(BaseHttpError);
     expect({ ...error }).to.deep.equal({ status: 400, title: 'Default Bad Request' });
   });
 });

--- a/api/tests/team/unit/application/http-error-mapper-configuration.test.js
+++ b/api/tests/team/unit/application/http-error-mapper-configuration.test.js
@@ -1,4 +1,8 @@
-import { HttpErrors } from '../../../../src/shared/application/errors/http-errors.js';
+import {
+  ConflictError,
+  ForbiddenError,
+  UnprocessableEntityError,
+} from '../../../../src/shared/application/errors/http-errors.js';
 import { teamDomainErrorMappingConfiguration } from '../../../../src/team/application/http-error-mapper-configuration.js';
 import {
   AdminMemberError,
@@ -22,7 +26,7 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     const error = httpErrorMapper.httpErrorFn(new AdminMemberError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+    expect(error).to.be.instanceOf(UnprocessableEntityError);
   });
 
   it('instantiates UnprocessableEntityError when UncancellableOrganizationInvitationError', async function () {
@@ -35,7 +39,7 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     const error = httpErrorMapper.httpErrorFn(new UncancellableOrganizationInvitationError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+    expect(error).to.be.instanceOf(UnprocessableEntityError);
   });
 
   it('instantiates UnprocessableEntityError when AlreadyExistingAdminMemberError', async function () {
@@ -48,7 +52,7 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     const error = httpErrorMapper.httpErrorFn(new AlreadyExistingAdminMemberError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+    expect(error).to.be.instanceOf(UnprocessableEntityError);
   });
 
   it('instantiates UnprocessableEntityError when OrganizationArchivedError', async function () {
@@ -61,7 +65,7 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     const error = httpErrorMapper.httpErrorFn(new OrganizationArchivedError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+    expect(error).to.be.instanceOf(UnprocessableEntityError);
     expect(error.message).to.equal("L'organisation est archivée.");
   });
 
@@ -75,7 +79,7 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     const error = httpErrorMapper.httpErrorFn(new AlreadyAcceptedOrCancelledInvitationError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.ConflictError);
+    expect(error).to.be.instanceOf(ConflictError);
     expect(error.message).to.equal('The invitation has already been accepted or cancelled');
   });
 
@@ -89,7 +93,7 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     const error = httpErrorMapper.httpErrorFn(new UserHasNoOrganizationMembershipError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    expect(error).to.be.instanceOf(ForbiddenError);
     expect(error.message).to.equal('User is not member of any organization');
   });
 
@@ -103,7 +107,7 @@ describe('Unit | Team | Application | HttpErrorMapperConfiguration', function ()
     const error = httpErrorMapper.httpErrorFn(new UserNotMemberOfOrganizationError());
 
     //then
-    expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+    expect(error).to.be.instanceOf(UnprocessableEntityError);
     expect(error.message).to.equal("L'utilisateur n'est pas membre de l'organisation.");
   });
 });


### PR DESCRIPTION
## 🪧 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Le fichier `http-errors.js` exporte à la fois les erreurs de manière nommée et dans un namespace `HttpErrors`.

Cela entraine une double maintenance et de la confusion pour les devs.

## 🌈 Proposition

On utilise uniquement des exports nommés.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ✊ Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

CI verte
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
