### PR TITLE
[TECH] Ne pas importer depuis les fichiers de migration

### DIFF
--- a/api/.dependency-cruiser.mjs
+++ b/api/.dependency-cruiser.mjs
@@ -10,7 +10,15 @@ for await (const file of glob('src/**/dependencies.json')) {
 }
 
 export default {
-  forbidden: buildForbiddenRules(contexts),
+  forbidden: [
+    ...buildForbiddenRules(contexts),
+    {
+      name: 'do-not-import-migrations',
+      severity: 'error',
+      from: { path: '^(.*)' },
+      to: { path: '^db/migrations/(.*)' },
+    },
+  ],
   options: {
     doNotFollow: { path: 'node_modules' },
   },

--- a/api/db/database-builder/factory/build-attestation.js
+++ b/api/db/database-builder/factory/build-attestation.js
@@ -1,5 +1,4 @@
 import { ATTESTATIONS } from '../../../src/profile/domain/constants.js';
-import { ATTESTATIONS_TABLE_NAME } from '../../migrations/20240820101115_add-attestations-table.js';
 import { databaseBuffer } from '../database-buffer.js';
 
 const buildAttestation = function ({
@@ -18,7 +17,7 @@ const buildAttestation = function ({
   };
 
   return databaseBuffer.pushInsertable({
-    tableName: ATTESTATIONS_TABLE_NAME,
+    tableName: 'attestations',
     values,
   });
 };

--- a/api/db/database-builder/factory/build-organization-profile-reward.js
+++ b/api/db/database-builder/factory/build-organization-profile-reward.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../migrations/20241118134739_create-organizations-profile-rewards-table.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildOrganization } from './build-organization.js';
 import { buildProfileReward } from './build-profile-reward.js';
@@ -20,7 +19,7 @@ export const buildOrganizationProfileReward = ({
   };
 
   return databaseBuffer.pushInsertable({
-    tableName: ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME,
+    tableName: 'organizations-profile-rewards',
     values,
   });
 };

--- a/api/db/database-builder/factory/build-organizations-profile-rewards.js
+++ b/api/db/database-builder/factory/build-organizations-profile-rewards.js
@@ -1,4 +1,3 @@
-import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../migrations/20241118134739_create-organizations-profile-rewards-table.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildOrganization } from './build-organization.js';
 import { buildProfileReward } from './build-profile-reward.js';
@@ -18,7 +17,7 @@ const buildOrganizationsProfileRewards = function ({
   };
 
   return databaseBuffer.pushInsertable({
-    tableName: ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME,
+    tableName: 'organizations-profile-rewards',
     values,
   });
 };

--- a/api/db/database-builder/factory/build-profile-reward.js
+++ b/api/db/database-builder/factory/build-profile-reward.js
@@ -1,7 +1,6 @@
 import isUndefined from 'lodash/isUndefined.js';
 
 import { REWARD_TYPES } from '../../../src/quest/domain/constants.js';
-import { PROFILE_REWARDS_TABLE_NAME } from '../../migrations/20240820101213_add-profile-rewards-table.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildAttestation } from './build-attestation.js';
 import { buildUser } from './build-user.js';
@@ -25,7 +24,7 @@ const buildProfileReward = function ({
   };
 
   return databaseBuffer.pushInsertable({
-    tableName: PROFILE_REWARDS_TABLE_NAME,
+    tableName: 'profile-rewards',
     values,
   });
 };

--- a/api/db/database-builder/factory/build-stage-acquisition.js
+++ b/api/db/database-builder/factory/build-stage-acquisition.js
@@ -1,4 +1,3 @@
-import { STAGE_ACQUISITIONS_TABLE_NAME } from '../../migrations/20230721114848_create-stage_acquisitions-table.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildCampaignParticipation } from './build-campaign-participation.js';
 import { buildStage } from './build-stage.js';
@@ -10,7 +9,7 @@ const buildStageAcquisition = function ({
   createdAt = new Date('2000-01-01'),
 } = {}) {
   return databaseBuffer.pushInsertable({
-    tableName: STAGE_ACQUISITIONS_TABLE_NAME,
+    tableName: 'stage-acquisitions',
     values: {
       id,
       stageId,

--- a/api/db/database-builder/factory/build-user-recommended-training.js
+++ b/api/db/database-builder/factory/build-user-recommended-training.js
@@ -1,4 +1,3 @@
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../migrations/20221017085933_create-user-recommended-trainings.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildTraining } from './build-training.js';
 
@@ -15,7 +14,7 @@ const buildUserRecommendedTraining = function ({
     trainingId = buildTraining().id;
   }
   return databaseBuffer.pushInsertable({
-    tableName: USER_RECOMMENDED_TRAININGS_TABLE_NAME,
+    tableName: 'user-recommended-trainings',
     values: { id, userId, trainingId, campaignParticipationId, isRelevant, createdAt, updatedAt },
   });
 };

--- a/api/db/migrations/20221017085933_create-user-recommended-trainings.js
+++ b/api/db/migrations/20221017085933_create-user-recommended-trainings.js
@@ -1,4 +1,4 @@
-export const USER_RECOMMENDED_TRAININGS_TABLE_NAME = 'user-recommended-trainings';
+const USER_RECOMMENDED_TRAININGS_TABLE_NAME = 'user-recommended-trainings';
 
 const up = function (knex) {
   return knex.schema.createTable(USER_RECOMMENDED_TRAININGS_TABLE_NAME, (t) => {

--- a/api/db/migrations/20230721114848_create-stage_acquisitions-table.js
+++ b/api/db/migrations/20230721114848_create-stage_acquisitions-table.js
@@ -1,7 +1,7 @@
-export const STAGE_ACQUISITIONS_TABLE_NAME = 'stage-acquisitions';
-export const USER_ID_COLUMN = 'userId';
-export const STAGE_ID_COLUMN = 'stageId';
-export const CAMPAIGN_PARTICIPATION_ID_COLUMN = 'campaignParticipationId';
+const STAGE_ACQUISITIONS_TABLE_NAME = 'stage-acquisitions';
+const USER_ID_COLUMN = 'userId';
+const STAGE_ID_COLUMN = 'stageId';
+const CAMPAIGN_PARTICIPATION_ID_COLUMN = 'campaignParticipationId';
 
 const up = async function (knex) {
   await knex.schema.createTable(STAGE_ACQUISITIONS_TABLE_NAME, function (table) {

--- a/api/db/migrations/20231201142713_remove-autonomous-courses-table.js
+++ b/api/db/migrations/20231201142713_remove-autonomous-courses-table.js
@@ -1,11 +1,20 @@
-import { up as autonomousCoursesTableCreation } from './20231030144246_create_autonomous_courses.js';
-
 const TABLE_NAME = 'autonomous-courses';
 
 const up = async function (knex) {
   await knex.schema.dropTable(TABLE_NAME);
 };
 
-const down = autonomousCoursesTableCreation;
+const down = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('organizationId').notNullable().unsigned().references('organizations.id');
+    t.integer('targetProfileId').notNullable().unsigned().references('target-profiles.id');
+    t.integer('campaignId').notNullable().unsigned().references('campaigns.id');
+    t.string('publicTitle').notNullable();
+    t.string('internalTitle').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
 
 export { down, up };

--- a/api/db/migrations/20240820101115_add-attestations-table.js
+++ b/api/db/migrations/20240820101115_add-attestations-table.js
@@ -7,7 +7,7 @@
 // If your migrations target `answers` or `knowledge-elements`
 // contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
 // this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
-export const ATTESTATIONS_TABLE_NAME = 'attestations';
+const ATTESTATIONS_TABLE_NAME = 'attestations';
 
 const up = async function (knex) {
   await knex.schema.createTable(ATTESTATIONS_TABLE_NAME, function (table) {

--- a/api/db/migrations/20240820101213_add-profile-rewards-table.js
+++ b/api/db/migrations/20240820101213_add-profile-rewards-table.js
@@ -1,4 +1,4 @@
-export const PROFILE_REWARDS_TABLE_NAME = 'profile-rewards';
+const PROFILE_REWARDS_TABLE_NAME = 'profile-rewards';
 
 const up = async function (knex) {
   await knex.schema.createTable(PROFILE_REWARDS_TABLE_NAME, function (table) {

--- a/api/db/migrations/20241118134739_create-organizations-profile-rewards-table.js
+++ b/api/db/migrations/20241118134739_create-organizations-profile-rewards-table.js
@@ -1,6 +1,4 @@
-import { PROFILE_REWARDS_TABLE_NAME } from './20240820101213_add-profile-rewards-table.js';
-
-export const ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME = 'organizations-profile-rewards';
+const ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME = 'organizations-profile-rewards';
 const ORGANIZATION_ID_COLUMN = 'organizationId';
 const PROFILE_REWARD_ID_COLUMN = 'profileRewardId';
 const CONSTRAINT_NAME = 'organizationId_profileRewardId_unique';
@@ -9,12 +7,7 @@ const up = async function (knex) {
   await knex.schema.createTable(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME, function (table) {
     table.increments().primary().notNullable();
     table.integer(ORGANIZATION_ID_COLUMN).notNullable().unsigned().references('organizations.id').index();
-    table
-      .integer(PROFILE_REWARD_ID_COLUMN)
-      .notNullable()
-      .unsigned()
-      .references(`${PROFILE_REWARDS_TABLE_NAME}.id`)
-      .index();
+    table.integer(PROFILE_REWARD_ID_COLUMN).notNullable().unsigned().references('profile-rewards.id').index();
     table.unique([ORGANIZATION_ID_COLUMN, PROFILE_REWARD_ID_COLUMN], { indexName: CONSTRAINT_NAME });
   });
 };

--- a/api/db/migrations/20241119103307_devcomp-user-recommended-trainings-remove-nullable-constraint-on-campaign-participation-id.js
+++ b/api/db/migrations/20241119103307_devcomp-user-recommended-trainings-remove-nullable-constraint-on-campaign-participation-id.js
@@ -1,14 +1,13 @@
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from './20221017085933_create-user-recommended-trainings.js';
 const COLUMN_NAME = 'campaignParticipationId';
 
 const up = async (knex) => {
-  await knex.schema.alterTable(USER_RECOMMENDED_TRAININGS_TABLE_NAME, (table) => {
+  await knex.schema.alterTable('user-recommended-trainings', (table) => {
     table.integer(COLUMN_NAME).nullable().alter();
   });
 };
 
 const down = async (knex) => {
-  await knex.schema.table(USER_RECOMMENDED_TRAININGS_TABLE_NAME, (table) => {
+  await knex.schema.table('user-recommended-trainings', (table) => {
     table.integer(COLUMN_NAME).notNullable().alter();
   });
 };

--- a/api/db/migrations/20241227103334_add-comments-on-quests-tables.js
+++ b/api/db/migrations/20241227103334_add-comments-on-quests-tables.js
@@ -1,9 +1,5 @@
-import { ATTESTATIONS_TABLE_NAME } from './20240820101115_add-attestations-table.js';
-import { PROFILE_REWARDS_TABLE_NAME } from './20240820101213_add-profile-rewards-table.js';
-import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from './20241118134739_create-organizations-profile-rewards-table.js';
-
 const up = async function (knex) {
-  await knex.schema.alterTable(ATTESTATIONS_TABLE_NAME, function (table) {
+  await knex.schema.alterTable('attestations', function (table) {
     table.comment(
       `Table containing the attestation that can be delivered to users after completing a quest.
       This table is linked to the profile-rewards table.
@@ -45,7 +41,7 @@ const up = async function (knex) {
       .alter();
   });
 
-  await knex.schema.alterTable(PROFILE_REWARDS_TABLE_NAME, function (table) {
+  await knex.schema.alterTable('profile-rewards', function (table) {
     table.comment(
       `This table links a user and a reward. It is a polymorphic relationship.
             The “reward” table referred to is defined by the “rewardType” column.`,
@@ -64,7 +60,7 @@ const up = async function (knex) {
       .alter();
   });
 
-  await knex.schema.alterTable(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME, function (table) {
+  await knex.schema.alterTable('organizations-profile-rewards', function (table) {
     table.comment(
       `This is the linking table between an attestation and an organization.
             In essence, attestations are not necessarily linked to an organization.
@@ -79,7 +75,7 @@ const up = async function (knex) {
 };
 
 const down = async function (knex) {
-  await knex.schema.alterTable(ATTESTATIONS_TABLE_NAME, function (table) {
+  await knex.schema.alterTable('attestations', function (table) {
     table.comment(null);
     table.string('templateName').comment(null).alter();
     table.string('key').comment(null).alter();
@@ -94,7 +90,7 @@ const down = async function (knex) {
     table.jsonb('successRequirements').comment(null).alter();
   });
 
-  await knex.schema.alterTable(PROFILE_REWARDS_TABLE_NAME, function (table) {
+  await knex.schema.alterTable('profile-rewards', function (table) {
     table.comment(null);
 
     table.bigInteger('userId').comment(null).alter();
@@ -102,7 +98,7 @@ const down = async function (knex) {
     table.bigInteger('rewardId').comment(null).alter();
   });
 
-  await knex.schema.alterTable(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME, function (table) {
+  await knex.schema.alterTable('organizations-profile-rewards', function (table) {
     table.comment(null);
 
     table.bigInteger('organizationId').comment(null).alter();

--- a/api/package.json
+++ b/api/package.json
@@ -50,7 +50,7 @@
     "lint": "run-s -clns 'lint:(dependencies|context-deps|filenames|js|format)'",
     "lint:fix": "run-s -clns 'lint:(js|format):fix'",
     "lint:dependencies": "knip -n",
-    "lint:context-deps": "depcruise --config .dependency-cruiser.mjs src",
+    "lint:context-deps": "depcruise --config .dependency-cruiser.mjs .",
     "lint:filenames": "ls-lint",
     "lint:js": "eslint . --cache --cache-strategy content",
     "lint:js:fix": "npm run lint:js -- --fix",

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -1,6 +1,5 @@
 import lodash from 'lodash';
 
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
@@ -195,7 +194,7 @@ async function findPaginatedByUserId({ userId, locale, page }) {
   const baseQuery = knexConn(TABLE_NAME)
     .select('trainings.*', 'isRelevant')
     .distinct('trainings.id')
-    .join(USER_RECOMMENDED_TRAININGS_TABLE_NAME, 'trainings.id', 'trainingId')
+    .join('user-recommended-trainings', 'trainings.id', 'trainingId')
     .where({ userId, isDisabled: false })
     .whereRaw('? = ANY(locales)', locale)
     .orderBy('id', 'asc');

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -1,10 +1,9 @@
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserRecommendedTraining } from '../../domain/read-models/UserRecommendedTraining.js';
 
 const save = function ({ userId, trainingId, campaignParticipationId, isRelevant }) {
   const knexConn = DomainTransaction.getConnection();
-  return knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+  return knexConn('user-recommended-trainings')
     .insert({ userId, trainingId, campaignParticipationId, isRelevant, updatedAt: knexConn.fn.now() })
     .onConflict(['userId', 'trainingId', 'campaignParticipationId'])
     .merge(['isRelevant', 'updatedAt']);
@@ -12,9 +11,9 @@ const save = function ({ userId, trainingId, campaignParticipationId, isRelevant
 
 const findByCampaignParticipationId = async function ({ campaignParticipationId, locale }) {
   const knexConn = DomainTransaction.getConnection();
-  const trainings = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+  const trainings = await knexConn('user-recommended-trainings')
     .select('trainings.*', 'isRelevant')
-    .innerJoin('trainings', 'trainings.id', `${USER_RECOMMENDED_TRAININGS_TABLE_NAME}.trainingId`)
+    .innerJoin('trainings', 'trainings.id', 'user-recommended-trainings.trainingId')
     .where({ campaignParticipationId, isDisabled: false })
     .whereRaw('? = ANY(locales)', locale)
     .orderBy('id', 'asc');
@@ -27,9 +26,9 @@ const findByCampaignParticipationIdAndTrainingIdAndUserId = async function ({
   userId,
 }) {
   const knexConn = DomainTransaction.getConnection();
-  const result = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+  const result = await knexConn('user-recommended-trainings')
     .select('trainings.*', 'isRelevant')
-    .innerJoin('trainings', 'trainings.id', `${USER_RECOMMENDED_TRAININGS_TABLE_NAME}.trainingId`)
+    .innerJoin('trainings', 'trainings.id', 'user-recommended-trainings.trainingId')
     .where({ campaignParticipationId, trainingId, userId, isDisabled: false })
     .first();
 
@@ -38,9 +37,9 @@ const findByCampaignParticipationIdAndTrainingIdAndUserId = async function ({
 
 const findModulesByCampaignParticipationIds = async function ({ campaignParticipationIds }) {
   const knexConn = DomainTransaction.getConnection();
-  const moduleLinks = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+  const moduleLinks = await knexConn('user-recommended-trainings')
     .select('trainings.*')
-    .innerJoin('trainings', 'trainings.id', `${USER_RECOMMENDED_TRAININGS_TABLE_NAME}.trainingId`)
+    .innerJoin('trainings', 'trainings.id', 'user-recommended-trainings.trainingId')
     .where({ isDisabled: false, type: 'modulix' })
     .whereIn('campaignParticipationId', campaignParticipationIds)
     .orderBy('trainings.id', 'asc');
@@ -58,13 +57,13 @@ const findModulesByCampaignParticipationIds = async function ({ campaignParticip
 
 const hasRecommendedTrainings = async function ({ userId }) {
   const knexConn = DomainTransaction.getConnection();
-  const result = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME).select(1).where({ userId }).first();
+  const result = await knexConn('user-recommended-trainings').select(1).where({ userId }).first();
   return Boolean(result);
 };
 
 const deleteCampaignParticipationIds = async ({ campaignParticipationIds }) => {
   const knexConn = DomainTransaction.getConnection();
-  return knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+  return knexConn('user-recommended-trainings')
     .update({ campaignParticipationId: null, updatedAt: new Date() })
     .whereIn('campaignParticipationId', campaignParticipationIds);
 };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -1,4 +1,3 @@
-import { STAGE_ACQUISITIONS_TABLE_NAME } from '../../../../../db/migrations/20230721114848_create-stage_acquisitions-table.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
@@ -236,7 +235,7 @@ const buildCampaignAssessmentParticipationResultList = async (results, stageColl
 const getAcquiredStages = (campaignParticipationId) => {
   const knexConn = DomainTransaction.getConnection();
 
-  return knexConn(STAGE_ACQUISITIONS_TABLE_NAME).select('*').where({ campaignParticipationId });
+  return knexConn('stage-acquisitions').select('*').where({ campaignParticipationId });
 };
 
 const getAcquiredBadges = (campaignParticipationId) => {

--- a/api/src/prescription/scripts/delete-organization-learners-from-organization.js
+++ b/api/src/prescription/scripts/delete-organization-learners-from-organization.js
@@ -1,4 +1,3 @@
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
@@ -151,7 +150,7 @@ export class DeleteOrganizationLearnersFromOrganizationScript extends Script {
 
   async #detachRecommendedTrainings({ campaignParticipationsIds, updatedAt }) {
     const knexConnection = DomainTransaction.getConnection();
-    await knexConnection(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+    await knexConnection('user-recommended-trainings')
       .update({ campaignParticipationId: null, updatedAt })
       .whereIn('campaignParticipationId', campaignParticipationsIds);
   }

--- a/api/src/prescription/stages/infrastructure/repositories/stage-acquisition-repository.js
+++ b/api/src/prescription/stages/infrastructure/repositories/stage-acquisition-repository.js
@@ -1,8 +1,3 @@
-import {
-  CAMPAIGN_PARTICIPATION_ID_COLUMN,
-  STAGE_ACQUISITIONS_TABLE_NAME,
-  STAGE_ID_COLUMN,
-} from '../../../../../db/migrations/20230721114848_create-stage_acquisitions-table.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { StageAcquisition } from '../../domain/models/StageAcquisition.js';
 
@@ -31,9 +26,7 @@ const toDomain = (stageAcquisitionData) =>
  */
 const buildSelectAllQuery = () => {
   const knexConnection = DomainTransaction.getConnection();
-  return knexConnection(STAGE_ACQUISITIONS_TABLE_NAME)
-    .select(`${STAGE_ACQUISITIONS_TABLE_NAME}.*`)
-    .from(STAGE_ACQUISITIONS_TABLE_NAME);
+  return knexConnection('stage-acquisitions').select('stage-acquisitions.*').from('stage-acquisitions');
 };
 
 /**
@@ -42,7 +35,7 @@ const buildSelectAllQuery = () => {
  * @returns Promise<StageAcquisition[]>
  */
 const getByCampaignParticipations = async (campaignParticipationsIds) =>
-  toDomain(await buildSelectAllQuery().whereIn(CAMPAIGN_PARTICIPATION_ID_COLUMN, campaignParticipationsIds));
+  toDomain(await buildSelectAllQuery().whereIn('campaignParticipationId', campaignParticipationsIds));
 
 /**
  * @param {number} campaignParticipationsId
@@ -50,7 +43,7 @@ const getByCampaignParticipations = async (campaignParticipationsIds) =>
  * @returns {Promise<StageAcquisition[]>}
  */
 const getByCampaignParticipation = async (campaignParticipationsId) =>
-  toDomain(await buildSelectAllQuery().where(CAMPAIGN_PARTICIPATION_ID_COLUMN, campaignParticipationsId));
+  toDomain(await buildSelectAllQuery().where('campaignParticipationId', campaignParticipationsId));
 
 /**
  * @param {number} campaignParticipationsId
@@ -59,9 +52,9 @@ const getByCampaignParticipation = async (campaignParticipationsId) =>
  */
 const getStageIdsByCampaignParticipation = async (campaignParticipationsId) => {
   const knexConnection = DomainTransaction.getConnection();
-  return knexConnection(STAGE_ACQUISITIONS_TABLE_NAME)
-    .where(CAMPAIGN_PARTICIPATION_ID_COLUMN, campaignParticipationsId)
-    .pluck(STAGE_ID_COLUMN);
+  return knexConnection('stage-acquisitions')
+    .where('campaignParticipationId', campaignParticipationsId)
+    .pluck('stageId');
 };
 
 /**
@@ -76,7 +69,7 @@ const saveStages = async (stages, campaignParticipationId) => {
     stageId: stage.id,
     campaignParticipationId,
   }));
-  return knexConnection(STAGE_ACQUISITIONS_TABLE_NAME).insert(acquiredStages);
+  return knexConnection('stage-acquisitions').insert(acquiredStages);
 };
 
 /**

--- a/api/src/profile/infrastructure/repositories/organizations-profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/organizations-profile-reward-repository.js
@@ -1,11 +1,10 @@
-import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { batchUpdate } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { OrganizationProfileReward } from '../../domain/models/OrganizationProfileReward.js';
 
 export const save = async ({ organizationId, profileRewardId }) => {
   const knexConn = DomainTransaction.getConnection();
-  await knexConn(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME)
+  await knexConn('organizations-profile-rewards')
     .insert({
       organizationId,
       profileRewardId,
@@ -21,7 +20,7 @@ export const save = async ({ organizationId, profileRewardId }) => {
  */
 export const removeInBatch = async (organizationProfileRewards) => {
   await batchUpdate({
-    tableName: ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME,
+    tableName: 'organizations-profile-rewards',
     primaryKeyName: 'id',
     rows: organizationProfileRewards.map((organizationProfileReward) => ({
       id: organizationProfileReward.id,

--- a/api/src/profile/infrastructure/repositories/profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/profile-reward-repository.js
@@ -1,9 +1,6 @@
-import { PROFILE_REWARDS_TABLE_NAME } from '../../../../db/migrations/20240820101213_add-profile-rewards-table.js';
 import { REWARD_TYPES } from '../../../quest/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ProfileReward } from '../../domain/models/ProfileReward.js';
-
-const ATTESTATIONS_TABLE_NAME = 'attestations';
 
 /**
  * @param {Object} args
@@ -14,7 +11,7 @@ const ATTESTATIONS_TABLE_NAME = 'attestations';
  */
 export const save = async ({ userId, rewardId, rewardType = REWARD_TYPES.ATTESTATION }) => {
   const knexConnection = await DomainTransaction.getConnection();
-  await knexConnection(PROFILE_REWARDS_TABLE_NAME)
+  await knexConnection('profile-rewards')
     .insert({
       userId,
       rewardId,
@@ -31,7 +28,7 @@ export const save = async ({ userId, rewardId, rewardType = REWARD_TYPES.ATTESTA
  */
 export const getByUserId = async ({ userId }) => {
   const knexConnection = await DomainTransaction.getConnection();
-  const profileRewards = await knexConnection(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+  const profileRewards = await knexConnection('profile-rewards').where({ userId });
   return profileRewards.map(toDomain);
 };
 
@@ -42,7 +39,7 @@ export const getByUserId = async ({ userId }) => {
  */
 export const getById = async ({ profileRewardId }) => {
   const knexConnection = await DomainTransaction.getConnection();
-  const profileReward = await knexConnection(PROFILE_REWARDS_TABLE_NAME).where({ id: profileRewardId }).first();
+  const profileReward = await knexConnection('profile-rewards').where({ id: profileRewardId }).first();
 
   return profileReward ? toDomain(profileReward) : null;
 };
@@ -54,7 +51,7 @@ export const getById = async ({ profileRewardId }) => {
  */
 export const getByIds = async ({ profileRewardIds }) => {
   const knexConnection = await DomainTransaction.getConnection();
-  const profileRewards = await knexConnection(PROFILE_REWARDS_TABLE_NAME).whereIn('id', profileRewardIds);
+  const profileRewards = await knexConnection('profile-rewards').whereIn('id', profileRewardIds);
 
   return profileRewards.map(toDomain);
 };
@@ -67,11 +64,11 @@ export const getByIds = async ({ profileRewardIds }) => {
  */
 export const getByAttestationKeyAndUserIds = async ({ attestationKey, userIds }) => {
   const knexConnection = await DomainTransaction.getConnection();
-  const profileRewards = await knexConnection(PROFILE_REWARDS_TABLE_NAME)
-    .select(PROFILE_REWARDS_TABLE_NAME + '.*')
-    .join(ATTESTATIONS_TABLE_NAME, ATTESTATIONS_TABLE_NAME + '.id', PROFILE_REWARDS_TABLE_NAME + '.rewardId')
+  const profileRewards = await knexConnection('profile-rewards')
+    .select('profile-rewards.*')
+    .join('attestations', 'attestations.id', 'profile-rewards.rewardId')
     .whereIn('userId', userIds)
-    .where(ATTESTATIONS_TABLE_NAME + '.key', attestationKey)
+    .where('attestations.key', attestationKey)
     .orderBy('id');
   return profileRewards.map(toDomain);
 };

--- a/api/src/quest/domain/constants.js
+++ b/api/src/quest/domain/constants.js
@@ -1,7 +1,6 @@
-import { ATTESTATIONS_TABLE_NAME } from '../../../db/migrations/20240820101115_add-attestations-table.js';
 import { CsvColumn } from '../../shared/infrastructure/serializers/csv/csv-column.js';
 
-export const REWARD_TYPES = { ATTESTATION: ATTESTATIONS_TABLE_NAME };
+export const REWARD_TYPES = { ATTESTATION: 'attestations' };
 
 export const COMBINED_COURSE_ITEM_TYPES = {
   MODULE: 'module',

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import sinon from 'sinon';
 
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { UserRecommendedTraining } from '../../../../../src/devcomp/domain/read-models/UserRecommendedTraining.js';
 import * as userRecommendedTrainingRepository from '../../../../../src/devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import { deleteCampaignParticipationIds } from '../../../../../src/devcomp/infrastructure/repositories/user-recommended-training-repository.js';
@@ -24,7 +23,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       await userRecommendedTrainingRepository.save(userRecommendedTraining);
 
       // then
-      const persistedUserRecommendedTraining = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+      const persistedUserRecommendedTraining = await knex('user-recommended-trainings')
         .where({
           userId: userRecommendedTraining.userId,
           trainingId: userRecommendedTraining.trainingId,
@@ -55,7 +54,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       expect(async () => {
         await saveSameUserRecommendedTraining();
 
-        const updatedUserRecommendedTraining = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+        const updatedUserRecommendedTraining = await knex('user-recommended-trainings')
           .where({
             id: userRecommendedTraining.id,
           })
@@ -459,7 +458,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       });
 
       // then
-      const updatedUserRecommendedTrainings = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+      const updatedUserRecommendedTrainings = await knex('user-recommended-trainings')
         .select('userId', 'campaignParticipationId')
         .where('updatedAt', now);
 
@@ -475,7 +474,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
         },
       ]);
 
-      const otherRecommendedTrainings = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+      const otherRecommendedTrainings = await knex('user-recommended-trainings')
         .select('userId', 'campaignParticipationId', 'updatedAt')
         .where('updatedAt', '!=', now);
 

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -6,7 +6,6 @@ import nock from 'nock';
 import sinon from 'sinon';
 import { MockAgent, setGlobalDispatcher } from 'undici';
 
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { createServer } from '../../../../../server.js';
 import { CertificationCompletedJob } from '../../../../../src/certification/evaluation/domain/events/CertificationCompleted.js';
 import { TrainingTrigger } from '../../../../../src/devcomp/domain/models/TrainingTrigger.js';
@@ -612,7 +611,7 @@ describe('Acceptance | Controller | assessment-controller', function () {
         });
 
         // then
-        const recommendedTraining = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+        const recommendedTraining = await knex('user-recommended-trainings')
           .where({
             userId: user.id,
             trainingId: training.id,

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
 import { CampaignParticipationLoggerContext } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
@@ -295,7 +294,7 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
       });
 
       //then
-      const userRecommendedTrainingAnonymized = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+      const userRecommendedTrainingAnonymized = await knex('user-recommended-trainings')
         .where('id', userRecommendedTrainingId)
         .first();
 

--- a/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { CampaignBelongsToCombinedCourseError } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import * as campaignAdministrationRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
@@ -178,7 +177,7 @@ describe('Integration | UseCases | delete-campaign', function () {
         });
 
         //then
-        const userRecommendedTrainingAnonymized = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+        const userRecommendedTrainingAnonymized = await knex('user-recommended-trainings')
           .where('id', userRecommendedTrainingId)
           .first();
 

--- a/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { ANONYMIZATION_RULE } from '../../../../../../src/prescription/learner-management/domain/constants.js';
 import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
 import {
@@ -496,7 +495,7 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
       });
 
       //then
-      const userRecommendedTrainingAnonymized = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+      const userRecommendedTrainingAnonymized = await knex('user-recommended-trainings')
         .where('id', userRecommendedTrainingId)
         .first();
 

--- a/api/tests/prescription/scripts/integration/delete-and-anonymise-organization-learners_test.js
+++ b/api/tests/prescription/scripts/integration/delete-and-anonymise-organization-learners_test.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DeleteAndAnonymiseOrganizationLearnerScript } from '../../../../src/prescription/scripts/delete-and-anonymise-organization-learners.js';
 import { databaseBuilder, knex } from '../../../tooling/databases.js';
 
@@ -219,11 +218,10 @@ describe('DeleteAndAnonymiseOrganizationLearnerScript', function () {
         });
 
         // then
-        const anonymizedRecommendedTrainingResults = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).whereNull(
-          'campaignParticipationId',
-        );
+        const anonymizedRecommendedTrainingResults =
+          await knex('user-recommended-trainings').whereNull('campaignParticipationId');
 
-        const otherRecommendedTrainingResults = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).where({
+        const otherRecommendedTrainingResults = await knex('user-recommended-trainings').where({
           campaignParticipationId: otherParticipation.id,
         });
 

--- a/api/tests/prescription/scripts/integration/delete-organization-learners-from-organization_test.js
+++ b/api/tests/prescription/scripts/integration/delete-organization-learners-from-organization_test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DeleteOrganizationLearnersFromOrganizationScript } from '../../../../src/prescription/scripts/delete-organization-learners-from-organization.js';
 import { expect } from '../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../tooling/databases.js';
@@ -270,9 +269,8 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
         .first();
       const participationResult = await knex('campaign-participations').where({ id: campaignParticipation.id }).first();
       const assessmentResult = await knex('assessments').where({ id: assessmentId }).first();
-      const anonymizedRecommendedTrainingResults = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).whereNull(
-        'campaignParticipationId',
-      );
+      const anonymizedRecommendedTrainingResults =
+        await knex('user-recommended-trainings').whereNull('campaignParticipationId');
 
       expect(organizationLearnerResult.userId).to.equal(null);
       expect(participationResult.userId).to.equal(null);
@@ -313,9 +311,8 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
       const organizationLearnerResult = await knex('organization-learners').where({ organizationId }).first();
       const participationResult = await knex('campaign-participations').where({ organizationLearnerId }).first();
       const assessmentResult = await knex('assessments').where({ id: assessmentId }).first();
-      const anonymizedRecommendedTrainingResults = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).whereNull(
-        'campaignParticipationId',
-      );
+      const anonymizedRecommendedTrainingResults =
+        await knex('user-recommended-trainings').whereNull('campaignParticipationId');
       expect(organizationLearnerResult.firstName).to.not.equal('');
       expect(organizationLearnerResult.lastName).to.not.equal('');
       expect(participationResult.participantExternalId).to.be.not.null;

--- a/api/tests/prescription/stages/integration/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/prescription/stages/integration/domain/usecases/handle-stage-acquisition_test.js
@@ -1,4 +1,3 @@
-import { STAGE_ACQUISITIONS_TABLE_NAME } from '../../../../../../db/migrations/20230721114848_create-stage_acquisitions-table.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { stageUsecases } from '../../../../../../src/prescription/stages/domain/usecases/index.js';
@@ -146,7 +145,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
               );
 
             await databaseBuilder.commit();
-            const stageAcquisitionsBefore = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({
+            const stageAcquisitionsBefore = await knex('stage-acquisitions').where({
               campaignParticipationId,
             });
 
@@ -157,7 +156,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
 
             // then
             expect(stageAcquisitionsBefore).to.have.lengthOf(3);
-            const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+            const stageAcquisitionsAfter = await knex('stage-acquisitions').where({ campaignParticipationId });
             expect(stageAcquisitionsAfter).to.have.lengthOf(4);
           });
         });
@@ -182,7 +181,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
 
               // then
               const transactionStageAcquisitions = await domainTransaction
-                .knexTransaction(STAGE_ACQUISITIONS_TABLE_NAME)
+                .knexTransaction('stage-acquisitions')
                 .select('campaignParticipationId', 'stageId')
                 .where({ campaignParticipationId });
 
@@ -205,7 +204,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
                 },
               ]);
 
-              const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+              const stageAcquisitions = await knex('stage-acquisitions').where({ campaignParticipationId });
               expect(stageAcquisitions).to.have.lengthOf(0);
             });
           });
@@ -227,7 +226,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             });
 
             // then
-            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+            const stageAcquisitions = await knex('stage-acquisitions').where({ campaignParticipationId });
             expect(stageAcquisitions).to.have.lengthOf(0);
           });
         });
@@ -251,7 +250,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             });
 
             // then
-            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+            const stageAcquisitions = await knex('stage-acquisitions').where({ campaignParticipationId });
             expect(stageAcquisitions).to.have.lengthOf(4);
           });
         });
@@ -282,7 +281,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
           });
 
           // then
-          const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+          const stageAcquisitionsAfter = await knex('stage-acquisitions').where({ campaignParticipationId });
           expect(stageAcquisitionsAfter).to.have.lengthOf(1);
         });
       });
@@ -346,7 +345,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
               );
 
             await databaseBuilder.commit();
-            const stageAcquisitionsBefore = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({
+            const stageAcquisitionsBefore = await knex('stage-acquisitions').where({
               campaignParticipationId,
             });
 
@@ -357,7 +356,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
 
             // then
             expect(stageAcquisitionsBefore).to.have.lengthOf(3);
-            const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+            const stageAcquisitionsAfter = await knex('stage-acquisitions').where({ campaignParticipationId });
             expect(stageAcquisitionsAfter).to.have.lengthOf(4);
           });
         });
@@ -382,7 +381,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
 
               // then
               const transactionStageAcquisitions = await domainTransaction
-                .knexTransaction(STAGE_ACQUISITIONS_TABLE_NAME)
+                .knexTransaction('stage-acquisitions')
                 .select('campaignParticipationId', 'stageId')
                 .where({ campaignParticipationId });
 
@@ -405,7 +404,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
                 },
               ]);
 
-              const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+              const stageAcquisitions = await knex('stage-acquisitions').where({ campaignParticipationId });
               expect(stageAcquisitions).to.have.lengthOf(0);
             });
           });
@@ -427,7 +426,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             });
 
             // then
-            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+            const stageAcquisitions = await knex('stage-acquisitions').where({ campaignParticipationId });
             expect(stageAcquisitions).to.have.lengthOf(0);
           });
         });
@@ -451,7 +450,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             });
 
             // then
-            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+            const stageAcquisitions = await knex('stage-acquisitions').where({ campaignParticipationId });
             expect(stageAcquisitions).to.have.lengthOf(4);
           });
         });
@@ -488,7 +487,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
           });
 
           // then
-          const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
+          const stageAcquisitionsAfter = await knex('stage-acquisitions').where({ campaignParticipationId });
           expect(stageAcquisitionsAfter).to.have.lengthOf(1);
         });
       });

--- a/api/tests/profile/integration/domain/usecases/share-profile-reward_test.js
+++ b/api/tests/profile/integration/domain/usecases/share-profile-reward_test.js
@@ -1,4 +1,3 @@
-import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
 import { ProfileRewardCantBeSharedError } from '../../../../../src/profile/domain/errors.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
@@ -76,7 +75,7 @@ describe('Profile | Integration | Domain | Usecases | share-profile-reward', fun
           campaignParticipationId,
         });
 
-        const organizationsProfileRewards = await knex(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME);
+        const organizationsProfileRewards = await knex('organizations-profile-rewards');
 
         expect(organizationsProfileRewards).to.have.lengthOf(1);
         expect(organizationsProfileRewards[0].profileRewardId).to.equal(profileRewardId);

--- a/api/tests/profile/integration/infrastructure/repositories/organizations-profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/organizations-profile-reward-repository_test.js
@@ -1,4 +1,3 @@
-import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
 import { OrganizationProfileReward } from '../../../../../src/profile/domain/models/OrganizationProfileReward.js';
 import {
   getByOrganizationId,
@@ -20,7 +19,7 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
       await save({ organizationId: organization.id, profileRewardId: profileReward.id });
 
       // then
-      const organizationProfileReward = await knex(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME).where({
+      const organizationProfileReward = await knex('organizations-profile-rewards').where({
         organizationId: organization.id,
         profileRewardId: profileReward.id,
       });
@@ -43,11 +42,9 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
       await save({ organizationId: organization.id, profileRewardId: otherProfileReward.id });
 
       // then
-      const organizationProfileReward = await knex(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME)
-        .select('profileRewardId')
-        .where({
-          organizationId: organization.id,
-        });
+      const organizationProfileReward = await knex('organizations-profile-rewards').select('profileRewardId').where({
+        organizationId: organization.id,
+      });
       expect(organizationProfileReward).to.have.lengthOf(2);
       expect(organizationProfileReward).to.have.deep.members([
         { profileRewardId: profileReward.id },
@@ -69,7 +66,7 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
       await save({ organizationId: organization.id, profileRewardId: profileReward.id });
 
       // then
-      const organizationProfileReward = await knex(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME).where({
+      const organizationProfileReward = await knex('organizations-profile-rewards').where({
         organizationId: organization.id,
         profileRewardId: profileReward.id,
       });

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -1,4 +1,3 @@
-import { PROFILE_REWARDS_TABLE_NAME } from '../../../../../db/migrations/20240820101213_add-profile-rewards-table.js';
 import { ATTESTATIONS } from '../../../../../src/profile/domain/constants.js';
 import { ProfileReward } from '../../../../../src/profile/domain/models/ProfileReward.js';
 import {
@@ -29,7 +28,7 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       await save({ userId: userId, rewardId });
 
       // then
-      const result = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId: userId });
+      const result = await knex('profile-rewards').where({ userId: userId });
 
       expect(result).to.have.lengthOf(1);
       expect(result[0].userId).to.equal(userId);
@@ -52,7 +51,7 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       await save({ userId: userId, rewardId });
 
       // then
-      const result = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId: userId });
+      const result = await knex('profile-rewards').where({ userId: userId });
 
       expect(result).to.have.lengthOf(1);
       expect(result[0].userId).to.equal(userId);

--- a/api/tests/quest/integration/domain/usecases/reward-user_test.js
+++ b/api/tests/quest/integration/domain/usecases/reward-user_test.js
@@ -1,4 +1,3 @@
-import { PROFILE_REWARDS_TABLE_NAME } from '../../../../../db/migrations/20240820101213_add-profile-rewards-table.js';
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import {
   CRITERION_COMPARISONS,
@@ -155,7 +154,7 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
         await usecases.rewardUser({ userId });
 
         // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        const profileRewards = await knex('profile-rewards').where({ userId });
         expect(profileRewards).to.have.lengthOf(1);
         expect(profileRewards[0].userId).to.equal(userId);
       });
@@ -165,7 +164,7 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
         await usecases.rewardUser({ userId, buildCampaignParticipation: false });
 
         // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        const profileRewards = await knex('profile-rewards').where({ userId });
         expect(profileRewards).to.have.lengthOf(1);
         expect(profileRewards[0].userId).to.equal(userId);
       });
@@ -250,7 +249,7 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
         await usecases.rewardUser({ userId });
 
         // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        const profileRewards = await knex('profile-rewards').where({ userId });
         expect(profileRewards).to.have.lengthOf(1);
       });
     });
@@ -265,7 +264,7 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
         await usecases.rewardUser({ userId });
 
         // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        const profileRewards = await knex('profile-rewards').where({ userId });
         expect(profileRewards).to.have.lengthOf(0);
       });
     });
@@ -280,7 +279,7 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
         await usecases.rewardUser({ userId });
 
         // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        const profileRewards = await knex('profile-rewards').where({ userId });
         expect(profileRewards).to.have.lengthOf(0);
       });
     });
@@ -295,7 +294,7 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
         await usecases.rewardUser({ userId });
 
         // then
-        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        const profileRewards = await knex('profile-rewards').where({ userId });
         expect(profileRewards).to.have.lengthOf(1);
         expect(profileRewards[0].userId).to.equal(userId);
       });


### PR DESCRIPTION
## 🪧 Problème

Des fichier des dossiers `src`, `tests`, `db/database-builder` importe directement des fichiers de migration. Or ces fichiers peuvent être amenés à disparaître à un moment donné pour repartir d'une baseline pour les migrations.

## 🌈 Proposition

**Ne plus importer les fichiers de migration de base de données.**

De plus, **il faudrait éviter les noms de variable** pour les noms de tables facilite l'écriture et la lecture des requêtes avec knex. Les tests s'assure que le nom de la table est le bon.

**Exemple avant:**
```js
const profileRewards = await knexConnection(PROFILE_REWARDS_TABLE_NAME)
    .select(PROFILE_REWARDS_TABLE_NAME + '.*')
    .join(ATTESTATIONS_TABLE_NAME, ATTESTATIONS_TABLE_NAME + '.id', PROFILE_REWARDS_TABLE_NAME + '.rewardId')
    .where(ATTESTATIONS_TABLE_NAME + '.key', attestationKey)
    .orderBy('id');
```

**Exemple après:**
```js
 const profileRewards = await knexConnection('profile-rewards')
    .select('profile-rewards.*')
    .join('attestations', 'attestations.id', 'profile-rewards.rewardId')
    .whereIn('userId', userIds)
    .where('attestations.key', attestationKey)
    .orderBy('id');
```

## ✊ Remarques

🤖 **Pour éviter ce type d'import dans le futur,** une règle `dependency-cruiser` a été ajoutée : elle déclenche une erreur si un fichier de migration est importé.

## 🎉 Pour tester

La CI doit passer.
