### PR TITLE
[FEATURE] Ajouter une route pour vérifier si un utilisateur a répondu au questionnaire NPS d'une campagne (PIX-23304)

### DIFF
--- a/api/src/devcomp/application/user-campaign-surveys/user-campaign-survey-controller.js
+++ b/api/src/devcomp/application/user-campaign-surveys/user-campaign-survey-controller.js
@@ -9,4 +9,11 @@ async function saveUserCampaignSurvey(request, h) {
   return h.response({ data: { id: String(id), type: 'user-campaign-surveys' } }).created();
 }
 
-export const userCampaignSurveyController = { saveUserCampaignSurvey };
+async function verifyExistingUserCampaignSurvey(request, h) {
+  const { userId } = request.auth.credentials;
+  const { campaignId } = request.params;
+  const isAlreadyAnsweredSurvey = await usecases.verifyExistingUserCampaignSurvey({ userId, campaignId });
+  return h.response({ hasAnswered: isAlreadyAnsweredSurvey });
+}
+
+export const userCampaignSurveyController = { saveUserCampaignSurvey, verifyExistingUserCampaignSurvey };

--- a/api/src/devcomp/application/user-campaign-surveys/user-campaign-survey-route.js
+++ b/api/src/devcomp/application/user-campaign-surveys/user-campaign-survey-route.js
@@ -27,6 +27,22 @@ const register = async function (server) {
         tags: ['api', 'user-campaign-surveys'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/campaigns/{campaignId}/has-answered-survey',
+      config: {
+        handler: userCampaignSurveyController.verifyExistingUserCampaignSurvey,
+        validate: {
+          params: Joi.object({
+            campaignId: identifiersType.campaignId,
+          }),
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n- Vérifie si un utilisateur a déjà répondu à la question NPS pour une campagne',
+        ],
+        tags: ['api', 'user-campaign-surveys'],
+      },
+    },
   ]);
 };
 

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -48,6 +48,7 @@ import { startEmbedLlmChat } from './start-embed-llm-chat.js';
 import { terminatePassage } from './terminate-passage.js';
 import { updateTraining } from './update-training.js';
 import { verifyAndSaveAnswer } from './verify-and-save-answer.js';
+import { verifyExistingUserCampaignSurvey } from './verify-existing-user-campaign-survey.js';
 
 const dependencies = {
   ...repositories,
@@ -102,6 +103,7 @@ const usecasesWithoutInjectedDependencies = {
   terminatePassage,
   updateTraining,
   verifyAndSaveAnswer,
+  verifyExistingUserCampaignSurvey,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/devcomp/domain/usecases/verify-existing-user-campaign-survey.js
+++ b/api/src/devcomp/domain/usecases/verify-existing-user-campaign-survey.js
@@ -1,0 +1,5 @@
+export const verifyExistingUserCampaignSurvey = async function ({ campaignId, userId, userCampaignSurveyRepository }) {
+  const userCampaignSurvey = await userCampaignSurveyRepository.findByCampaignIdAndUserId({ campaignId, userId });
+
+  return Boolean(userCampaignSurvey);
+};

--- a/api/src/devcomp/infrastructure/repositories/user-campaign-survey-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-campaign-survey-repository.js
@@ -1,11 +1,14 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
 import { isUniqConstraintViolated } from '../../../shared/infrastructure/utils/knex-utils.js';
+import { UserCampaignSurvey } from '../../domain/models/UserCampaignSurvey.js';
+
+const TABLE_NAME = 'user-campaign-surveys';
 
 export async function save(userCampaignSurvey) {
   const knexConn = DomainTransaction.getConnection();
   try {
-    const [result] = await knexConn('user-campaign-surveys').insert(userCampaignSurvey).returning('id');
+    const [result] = await knexConn(TABLE_NAME).insert(userCampaignSurvey).returning('id');
     return result.id;
   } catch (error) {
     if (isUniqConstraintViolated(error)) {
@@ -13,4 +16,19 @@ export async function save(userCampaignSurvey) {
     }
     throw error;
   }
+}
+
+export async function findByCampaignIdAndUserId({ campaignId, userId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const userCampaignSurvey = await knexConn(TABLE_NAME).where({ campaignId, userId }).first();
+
+  if (!userCampaignSurvey) {
+    return null;
+  }
+
+  return _toDomain(userCampaignSurvey);
+}
+
+function _toDomain({ campaignId, userId, satisfactionScore } = {}) {
+  return new UserCampaignSurvey({ campaignId, userId, satisfactionScore });
 }

--- a/api/tests/devcomp/acceptance/application/user-campaign-surveys/user-campaign-survey-route_test.js
+++ b/api/tests/devcomp/acceptance/application/user-campaign-surveys/user-campaign-survey-route_test.js
@@ -39,4 +39,25 @@ describe('Acceptance | API | user-campaign-surveys', function () {
       expect(response.result.data.id).to.be.a('string');
     });
   });
+
+  describe('GET /api/campaigns/{campaignId}/has-answered-survey', function () {
+    it('should return true if user has already answered the survey', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildUserCampaignSurvey({ userId, campaignId, satisfactionScore: 5 });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/campaigns/${campaignId}/has-answered-survey`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.hasAnswered).to.be.true;
+    });
+  });
 });

--- a/api/tests/devcomp/integration/domain/usecases/verify-existing-user-campaign-survey-test.js
+++ b/api/tests/devcomp/integration/domain/usecases/verify-existing-user-campaign-survey-test.js
@@ -1,0 +1,41 @@
+import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Integration | Devcomp | Domain | UseCases | verifyExistingUserCampaignSurvey', function () {
+  context('when a userCampaignSurvey exists for given campaignId and userId', function () {
+    it('returns true', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+
+      databaseBuilder.factory.buildUserCampaignSurvey({ userId, campaignId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.verifyExistingUserCampaignSurvey({ userId, campaignId });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  context('when a userCampaignSurvey does not exist for given campaignId and userId', function () {
+    it('returns false', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+
+      databaseBuilder.factory.buildUserCampaignSurvey({ userId: otherUserId, campaignId, satisfactionScore: 3 });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.verifyExistingUserCampaignSurvey({ userId, campaignId });
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+});

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-campaign-survey-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-campaign-survey-repository_test.js
@@ -63,4 +63,32 @@ describe('Integration | Infrastructure | Repository | userCampaignSurveyReposito
       });
     });
   });
+
+  describe('#findByCampaignIdAndUserId', function () {
+    context('when a userCampaignSurvey exists for given campaignId and userId', function () {
+      it('should return the survey', async function () {
+        // given
+        const userCampaignSurvey = { userId, campaignId, satisfactionScore: 3 };
+        databaseBuilder.factory.buildUserCampaignSurvey(userCampaignSurvey);
+        await databaseBuilder.commit();
+
+        // when
+        const survey = await userCampaignSurveyRepository.findByCampaignIdAndUserId({ campaignId, userId });
+
+        // then
+        expect(survey).to.be.instanceOf(UserCampaignSurvey);
+        expect(survey).to.deep.equal(userCampaignSurvey);
+      });
+    });
+
+    context('when a userCampaignSurvey does not exist for given campaignId and userId', function () {
+      it('should return null', async function () {
+        // when
+        const survey = await userCampaignSurveyRepository.findByCampaignIdAndUserId({ campaignId, userId });
+
+        // then
+        expect(survey).to.be.null;
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🪧 Problème

Nous avons besoin d'une API pour vérifier si l'utilisateur a déjà répondu à un questionnaire NPS.

## 🌈 Proposition

Ajouter une API `api/campaigns/{campaignId}/has-answered-survey` pour ça.
- s'il y a déjà eu une réponse : retourne true
- sinon, retourne false

## ✊ Remarques

RAS

## 🎉 Pour tester
- Lancer, en local, une instance API
- Lancer les commandes suivantes dans le terminal pour créer un user-campaign-survey
```
TOKEN=$(curl -s -X POST http://localhost:3000/api/token -H "Content-Type: application/x-www-form-urlencoded" -H "x-forwarded-proto: https" -H "x-forwarded-host: app.pix.fr" -d "grant_type=password&username=superadmin@example.net&password=pix123" | jq -r '.access_token')
curl -s -X POST http://localhost:3000/api/user-campaign-surveys -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/vnd.api+json" -H "x-forwarded-proto: https" -H "x-forwarded-host: app.pix.fr" -d '{"data":{"type":"user-campaign-surveys","attributes":{"campaign-id":6001,"satisfaction-score":4}}}'
```

- Lancer la commande suivante pour vérifier qu'il existe bien 🚀 
```
curl -s -X GET http://localhost:3000/api/campaigns/6001/has-answered-survey -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/vnd.api+json" -H "x-forwarded-proto: https"  -H "x-forwarded-host: app.pix.fr"
```