### PR TITLE
[TECH] Update scalingo stack to scalingo-26 for RAs

### DIFF
--- a/admin/scalingo.json
+++ b/admin/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-24",
+  "stack": "scalingo-26",
   "addons": [
     {
       "plan": "postgresql:postgresql-starter-512"

--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -49,5 +49,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-24"
+  "stack": "scalingo-26"
 }

--- a/audit-logger/scalingo.json
+++ b/audit-logger/scalingo.json
@@ -43,5 +43,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-24"
+  "stack": "scalingo-26"
 }

--- a/certif/scalingo.json
+++ b/certif/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-24",
+  "stack": "scalingo-26",
   "addons": [
     {
       "plan": "postgresql:postgresql-starter-512"

--- a/junior/scalingo.json
+++ b/junior/scalingo.json
@@ -12,7 +12,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-24",
+  "stack": "scalingo-26",
   "addons": [
     {
       "plan": "postgresql:postgresql-starter-512"

--- a/mon-pix/scalingo.json
+++ b/mon-pix/scalingo.json
@@ -12,7 +12,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-24",
+  "stack": "scalingo-26",
   "addons": [
     {
       "plan": "postgresql:postgresql-starter-512"

--- a/orga/scalingo.json
+++ b/orga/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-24",
+  "stack": "scalingo-26",
   "addons": [
     {
       "plan": "postgresql:postgresql-starter-512"

--- a/scalingo.json
+++ b/scalingo.json
@@ -35,5 +35,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-24"
+  "stack": "scalingo-26"
 }


### PR DESCRIPTION
## 🪧 Problème

La nouvelle stack scalingo avec ubuntu-26 est sortie. on peut la tester sur les RA.

## 🌈 Proposition

modification des scalingo.json

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
