### PR TITLE
[TECH] Récupération des compétences par ID pour le scoring des certifications (PIX-23280).

### DIFF
--- a/api/db/database-builder/factory/build-certification-version.js
+++ b/api/db/database-builder/factory/build-certification-version.js
@@ -74,6 +74,7 @@ const defaultGlobalScoringConfiguration = [
 const defaultCompetencesScoringConfiguration = [
   {
     competence: '1.1',
+    competenceId: 'competence1_1',
     values: [
       {
         bounds: {

--- a/api/db/seeds/data/team-certification/shared/common-certification-versions.js
+++ b/api/db/seeds/data/team-certification/shared/common-certification-versions.js
@@ -181,6 +181,21 @@ export class CommonCertificationVersions {
     }
   }
 
+  static async #buildCompetencesScoringConfiguration({ databaseBuilder }) {
+    await databaseBuilder.commit();
+    const competences = await databaseBuilder
+      .knex('learningcontent.competences')
+      .select('id', 'index')
+      .where('origin', 'Pix');
+
+    const competenceIdByIndex = new Map(competences.map(({ id, index }) => [index, id]));
+
+    return COMPETENCES_SCORING_CONFIGURATION.map(({ competence, values }) => ({
+      competenceId: competenceIdByIndex.get(competence),
+      values,
+    }));
+  }
+
   /**
    * @param {Object} params
    * @param {string} params.frameworkName
@@ -293,6 +308,8 @@ export class CommonCertificationVersions {
         break;
     }
 
+    const competencesScoringConfiguration = await this.#buildCompetencesScoringConfiguration({ databaseBuilder });
+
     const currentVersion = await createVersion({
       databaseBuilder,
       status: 'ACTIVE',
@@ -300,7 +317,7 @@ export class CommonCertificationVersions {
       assessmentDuration,
       challengesConfiguration: CHALLENGES_CONFIGURATION,
       globalScoringConfiguration: GLOBAL_SCORING_CONFIGURATION,
-      competencesScoringConfiguration: COMPETENCES_SCORING_CONFIGURATION,
+      competencesScoringConfiguration,
     });
     await linkChallengesAndVersionFromTubeIds({ databaseBuilder, challengeIds, versionId: currentVersion.id });
 

--- a/api/src/certification/evaluation/domain/models/V3CertificationScoring.js
+++ b/api/src/certification/evaluation/domain/models/V3CertificationScoring.js
@@ -38,13 +38,13 @@ export class V3CertificationScoring {
     versionId,
   }) {
     const competencesForScoring =
-      competenceForScoringConfiguration?.map(({ competence: competenceCode, values }) => {
-        const competence = competenceList.find(({ index: code }) => code === competenceCode);
+      competenceForScoringConfiguration?.map(({ competenceId, values }) => {
+        const competence = competenceList.find(({ id }) => id === competenceId);
         const area = allAreas.find((area) => area.id === competence.areaId);
         return new CompetenceForScoring({
           competenceId: competence.id,
           areaCode: area.code,
-          competenceCode,
+          competenceCode: competence.index,
           intervals: values,
         });
       }) || [];

--- a/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
@@ -33,7 +33,7 @@ export const getLatestByDateAndLocale = async ({ locale, date }) => {
 
 export const getLatestByVersion = async ({ version }) => {
   const allAreas = await areaRepository.list();
-  const competenceList = await competenceRepository.listPixCompetencesOnly();
+  const competenceList = await competenceRepository.list();
 
   return V3CertificationScoring.fromConfigurations({
     competenceForScoringConfiguration: version.competencesScoringConfiguration,

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -68,6 +68,13 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
             { bounds: { max: -4, min: -8 }, meshLevel: 0 },
             { bounds: { max: 8, min: -4 }, meshLevel: 1 },
           ],
+          competencesScoringConfiguration: [
+            {
+              competence: '1.1',
+              competenceId: 'recCompetence0',
+              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+            },
+          ],
           minimumAnswersRequiredToValidateACertification: 1,
         });
 
@@ -207,6 +214,13 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           globalScoringConfiguration: [
             { bounds: { max: -4, min: -8 }, meshLevel: 0 },
             { bounds: { max: 8, min: -4 }, meshLevel: 1 },
+          ],
+          competencesScoringConfiguration: [
+            {
+              competence: '1.1',
+              competenceId: 'recCompetence0',
+              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+            },
           ],
           minimumAnswersRequiredToValidateACertification: 1,
         });

--- a/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
@@ -458,6 +458,7 @@ describe('Certification | Evaluation | Acceptance | scoring-and-capacity-simulat
             competencesScoringConfiguration: [
               {
                 competence: '1.1',
+                competenceId: 'recCompetence0',
                 values: [
                   { bounds: { max: -2, min: -8 }, competenceLevel: 0 },
                   { bounds: { max: -0.5, min: -2 }, competenceLevel: 1 },

--- a/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
@@ -140,6 +140,22 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
     certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
       challengesConfiguration: { maximumAssessmentLength: 10 },
       minimumAnswersRequiredToValidateACertification: 10,
+      competencesScoringConfiguration: [
+        {
+          competence: '1.1',
+          competenceId: 'recCompetence0',
+          values: [
+            { bounds: { max: -2, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
+            { bounds: { max: -1, min: -2 }, competenceLevel: 1 },
+            { bounds: { max: 0.5, min: -1 }, competenceLevel: 2 },
+            { bounds: { max: 1, min: 0.5 }, competenceLevel: 3 },
+            { bounds: { max: 2, min: 1 }, competenceLevel: 4 },
+            { bounds: { max: 3, min: 2 }, competenceLevel: 5 },
+            { bounds: { max: 4, min: 3 }, competenceLevel: 6 },
+            { bounds: { max: Number.MAX_SAFE_INTEGER, min: 4 }, competenceLevel: 7 },
+          ],
+        },
+      ],
     }).id;
 
     await databaseBuilder.commit();
@@ -336,6 +352,13 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
         challengesConfiguration: { maximumAssessmentLength: 10 },
         minimumAnswersRequiredToValidateACertification: 10,
         globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: 10, max: 20 } }],
+        competencesScoringConfiguration: [
+          {
+            competence: '1.1',
+            competenceId: 'recCompetence0',
+            values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+          },
+        ],
       });
 
       const session = databaseBuilder.factory.buildSession({
@@ -408,6 +431,13 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
           challengesConfiguration: { maximumAssessmentLength: 10 },
           minimumAnswersRequiredToValidateACertification: 10,
           globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: 10, max: 20 } }],
+          competencesScoringConfiguration: [
+            {
+              competence: '1.1',
+              competenceId: 'recCompetence0',
+              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+            },
+          ],
         });
 
         const session = databaseBuilder.factory.buildSession({

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
@@ -17,6 +17,7 @@ describe('Certification | Evaluation | Integration | Repositories | scoring-conf
       const secondCompetenceScoringConfiguration = [
         {
           competence: '1.1',
+          competenceId: `${PIX_ORIGIN}Competence`,
           values: [
             {
               bounds: {
@@ -117,6 +118,7 @@ describe('Certification | Evaluation | Integration | Repositories | scoring-conf
           {
             values: [{ bounds: { max: -1, min: -4 }, competenceLevel: 0 }],
             competence: competenceIndex,
+            competenceId: `${PIX_ORIGIN}Competence`,
           },
         ],
         scope: Frameworks.CORE,

--- a/api/tests/certification/evaluation/unit/domain/models/V3CertificationScoring_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/V3CertificationScoring_test.js
@@ -1,7 +1,7 @@
+import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { V3CertificationScoring } from '../../../../../../src/certification/evaluation/domain/models/V3CertificationScoring.js';
-import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Certification | Evaluation | Unit | Domain | Models | V3CertificationScoring', function () {
@@ -66,10 +66,11 @@ describe('Certification | Evaluation | Unit | Domain | Models | V3CertificationS
   describe('#fromConfigurations', function () {
     it('should return a valid V3CertificationScoring', function () {
       const area = domainBuilder.buildArea();
-      const competence = domainBuilder.buildCompetence({ areaId: area.id });
+      const competence = domainBuilder.buildCompetence({ id: 'myCompetenceId', areaId: area.id });
+
       const competenceForScoringConfiguration = [
         {
-          competence: competence.index,
+          competenceId: competence.id,
           values: [
             {
               competenceLevel: 0,

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -160,6 +160,7 @@ describe('Certification | Session-management | Acceptance | Application | Routes
           competencesScoringConfiguration: [
             {
               competence: 'index Compétence A',
+              competenceId: 'index Compétence A',
               values: [
                 {
                   bounds: {
@@ -288,6 +289,7 @@ describe('Certification | Session-management | Acceptance | Application | Routes
         competencesScoringConfiguration: [
           {
             competence: 'index Compétence A',
+            competenceId: 'index Compétence A',
             values: [
               {
                 bounds: {

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -212,6 +212,13 @@ describe('Certification | Session Management | Acceptance | Application | Routes
 
         const versionId = databaseBuilder.factory.buildCertificationVersion({
           startDate: new Date('2018-12-01T01:02:03Z'),
+          competencesScoringConfiguration: [
+            {
+              competence: '1.1',
+              competenceId: 'competenceId',
+              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+            },
+          ],
         }).id;
 
         const candidateId = databaseBuilder.factory.buildCertificationCandidate({
@@ -272,6 +279,13 @@ describe('Certification | Session Management | Acceptance | Application | Routes
       const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
       const versionId = databaseBuilder.factory.buildCertificationVersion({
         minimumAnswersRequiredToValidateACertification: 1,
+        competencesScoringConfiguration: [
+          {
+            competence: '1.1',
+            competenceId: 'competenceId',
+            values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+          },
+        ],
       }).id;
       const session = databaseBuilder.factory.buildSession({
         finalizedAt: new Date('2018-12-01T01:02:03Z'),

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -396,6 +396,15 @@ describe('Certification | Session Management | Acceptance | Application | Route 
           ({ options, session } = await _createSession({ version: 3 }));
           certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
             minimumAnswersRequiredToValidateACertification: 1,
+            competencesScoringConfiguration: [
+              {
+                competence: '1.1',
+                competenceId: 'recCompetence0',
+                values: [
+                  { bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
+                ],
+              },
+            ],
           }).id;
           await databaseBuilder.commit();
         });
@@ -944,6 +953,13 @@ const _createSessionWithoutChallenge = async () => {
   const session = databaseBuilder.factory.buildSession({ version: 3 });
   const version = databaseBuilder.factory.buildCertificationVersion({
     startDate: new Date('2024-01-01'),
+    competencesScoringConfiguration: [
+      {
+        competence: '1.1',
+        competenceId: 'recCompetence0',
+        values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+      },
+    ],
   });
   databaseBuilder.factory.buildCertificationCenterMembership({
     userId,

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-core-version.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-core-version.ts
@@ -1,6 +1,45 @@
 import { Knex } from 'knex';
 
+const competencesScoringValues = [
+  { bounds: { max: -2, min: -9007199254740991 }, competenceLevel: 0 },
+  { bounds: { max: -1, min: -2 }, competenceLevel: 1 },
+  { bounds: { max: 0.5, min: -1 }, competenceLevel: 2 },
+  { bounds: { max: 1, min: 0.5 }, competenceLevel: 3 },
+  { bounds: { max: 2, min: 1 }, competenceLevel: 4 },
+  { bounds: { max: 3, min: 2 }, competenceLevel: 5 },
+  { bounds: { max: 4, min: 3 }, competenceLevel: 6 },
+  { bounds: { max: 9007199254740991, min: 4 }, competenceLevel: 7 },
+];
+
+const competenceIndexes = [
+  '1.1',
+  '1.2',
+  '1.3',
+  '2.1',
+  '2.2',
+  '2.3',
+  '2.4',
+  '3.1',
+  '3.2',
+  '3.3',
+  '3.4',
+  '4.1',
+  '4.2',
+  '4.3',
+  '5.1',
+  '5.2',
+];
+
 export async function buildCoreVersion(knex: Knex) {
+  const competences = await knex('learningcontent.competences').select('id', 'index').where('origin', 'Pix');
+
+  const competenceIdByIndex = new Map(competences.map(({ id, index }: { id: string; index: string }) => [index, id]));
+
+  const competencesScoringConfiguration = competenceIndexes.map((competenceIndex) => ({
+    competenceId: competenceIdByIndex.get(competenceIndex),
+    values: competencesScoringValues,
+  }));
+
   const [{ id: versionId }] = await knex('certification_versions')
     .insert({
       scope: 'CORE',
@@ -10,8 +49,7 @@ export async function buildCoreVersion(knex: Knex) {
       minimumAnswersRequiredToValidateACertification: 20,
       globalScoringConfiguration:
         '[{"bounds": {"max": -1.4, "min": -8}, "meshLevel": 0}, {"bounds": {"max": -0.519, "min": -1.4}, "meshLevel": 1}, {"bounds": {"max": 0.6, "min": -0.519}, "meshLevel": 2}, {"bounds": {"max": 1.5, "min": 0.6}, "meshLevel": 3}, {"bounds": {"max": 2.25, "min": 1.5}, "meshLevel": 4}, {"bounds": {"max": 3.1, "min": 2.25}, "meshLevel": 5}, {"bounds": {"max": 4, "min": 3.1}, "meshLevel": 6}, {"bounds": {"max": 8, "min": 4}, "meshLevel": 7}]',
-      competencesScoringConfiguration:
-        '[{"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "1.1"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "1.2"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "1.3"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "2.1"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "2.2"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "2.3"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "2.4"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "3.1"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "3.2"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "3.3"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "3.4"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "4.1"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "4.2"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "4.3"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "5.1"}, {"values": [{"bounds": {"max": -2, "min": -9007199254740991}, "competenceLevel": 0}, {"bounds": {"max": -1, "min": -2}, "competenceLevel": 1}, {"bounds": {"max": 0.5, "min": -1}, "competenceLevel": 2}, {"bounds": {"max": 1, "min": 0.5}, "competenceLevel": 3}, {"bounds": {"max": 2, "min": 1}, "competenceLevel": 4}, {"bounds": {"max": 3, "min": 2}, "competenceLevel": 5}, {"bounds": {"max": 4, "min": 3}, "competenceLevel": 6}, {"bounds": {"max": 9007199254740991, "min": 4}, "competenceLevel": 7}], "competence": "5.2"}]',
+      competencesScoringConfiguration: JSON.stringify(competencesScoringConfiguration),
       challengesConfiguration: JSON.stringify({
         maximumAssessmentLength: 32,
         challengesBetweenSameCompetence: 2,


### PR DESCRIPTION
## 🪧 Problème

Dans le scoring (et dans d'autres endroits de la codebase qui ne nous intéressent pas ici), les compétences sont retrouvées à l'aide de la valeur `competenceCode` correspondant à `competence.index` dans `LCMS`.
Cela ne posait pas de problème jusqu'à maintenant mais l'arrivée future du calcul de niveau par compétence pour les Pix+ change la donne.
En effet, il arrive que des compétences se situant dans différents référentiels (ex: `Pix`, `Droit` etc.) aient des compétences ayant le même `index` (ex: `1.1`)

## 🌈 Proposition

Dans le cas du scoring, nous récupérons désormais les compétences nécessaires au calcul du score via leur `id` et non plus par le `competenceCode`

## ✊ Remarques

Cette PR ne doit pas être envoyée en production tant que le script de la PR #16601 n'est pas exécuté en production.

## 🎉 Pour tester

- Exécuter le script de la PR #16601 avec 

```
scalingo -a pix-api-review-pr16647 run "node scripts/certification/add-competence-ids-to-scoring-configurations.js --dryRun=false"
```

- Passer des certifications COEUR (et/ou Cléa) et Pix+ et vérifier qu'il n'y ait pas de régression sur le calcul du score et compétence s'il existe
- Tests verts
