### PR TITLE
[BUGFIX] Répare un bug sur les labels d'attestations dans PixApp (PIX-23353)

### DIFF
--- a/api/src/profile/domain/models/AttestationDetail.js
+++ b/api/src/profile/domain/models/AttestationDetail.js
@@ -1,7 +1,8 @@
 export class AttestationDetail {
-  constructor({ id, type, obtainedAt } = {}) {
+  constructor({ id, obtainedAt, label, key } = {}) {
     this.id = id;
-    this.type = type;
     this.obtainedAt = obtainedAt;
+    this.label = label;
+    this.key = key;
   }
 }

--- a/api/src/profile/domain/usecases/get-attestation-details.js
+++ b/api/src/profile/domain/usecases/get-attestation-details.js
@@ -7,6 +7,11 @@ export async function getAttestationDetails({ profileRewards = [], rewardReposit
       rewardType: profileReward.rewardType,
     });
 
-    return new AttestationDetail({ id: profileReward.id, obtainedAt: profileReward.createdAt, type: reward.key });
+    return new AttestationDetail({
+      id: profileReward.id,
+      obtainedAt: profileReward.createdAt,
+      label: reward.label,
+      key: reward.key,
+    });
   });
 }

--- a/api/src/profile/infrastructure/serializers/jsonapi/attestation-detail-serializer.js
+++ b/api/src/profile/infrastructure/serializers/jsonapi/attestation-detail-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (attestationDetail) {
   return new Serializer('attestation-detail', {
-    attributes: ['obtainedAt', 'type'],
+    attributes: ['obtainedAt', 'label', 'key'],
   }).serialize(attestationDetail);
 };
 

--- a/api/tests/profile/integration/domain/usecases/get-attestation-details_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-attestation-details_test.js
@@ -30,7 +30,7 @@ describe('Profile | Integration | Domain | get-attestation-details', function ()
 
       expect(results).lengthOf(1);
       expect(results[0].obtainedAt).to.deep.equal(new Date('2024-07-07'));
-      expect(results[0].type).to.equal(attestation.key);
+      expect(results[0].key).to.equal(attestation.key);
     });
 
     it('should return empty user does not have profileReward', async function () {

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -119,7 +119,20 @@ describe('Profile | Integration | Repository | profile-reward', function () {
 
       // then
       expect(results).to.have.lengthOf(2);
-      expect(results).to.have.deep.members([firstProfileReward, secondProfileReward]);
+      expect(results[0]).to.deep.include({
+        id: firstProfileReward.id,
+        createdAt: firstProfileReward.createdAt,
+        rewardType: firstProfileReward.rewardType,
+        rewardId: firstProfileReward.rewardId,
+        userId: firstProfileReward.userId,
+      });
+      expect(results[1]).to.deep.include({
+        id: secondProfileReward.id,
+        createdAt: secondProfileReward.createdAt,
+        rewardType: secondProfileReward.rewardType,
+        rewardId: secondProfileReward.rewardId,
+        userId: secondProfileReward.userId,
+      });
     });
   });
 
@@ -129,7 +142,12 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: secondUserId } = databaseBuilder.factory.buildUser();
 
+      const firstAttestation = databaseBuilder.factory.buildAttestation({
+        templateName: 'firstTemplateName',
+        key: 'firstKey',
+      });
       const { rewardId: firstRewardId } = databaseBuilder.factory.buildQuest({
+        rewardId: firstAttestation.id,
         rewardType: REWARD_TYPES.ATTESTATION,
         eligibilityRequirements: [],
         successRequirements: [],
@@ -138,6 +156,7 @@ describe('Profile | Integration | Repository | profile-reward', function () {
         templateName: 'otherTemplateName',
         key: 'otherKey',
       });
+
       const { rewardId: secondRewardId } = databaseBuilder.factory.buildQuest({
         rewardType: REWARD_TYPES.ATTESTATION,
         rewardId: otherAttestation.id,

--- a/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-detail-serializer_test.js
+++ b/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-detail-serializer_test.js
@@ -7,8 +7,13 @@ describe('Unit | Serializer | JSONAPI | attestation-detail', function () {
     it('should convert a scorecard object into JSON API data', function () {
       // when
       const json = attestationDetailSerializer.serialize([
-        new AttestationDetail({ id: 45, type: 'POUET', obtainedAt: new Date('2020-01-05') }),
-        new AttestationDetail({ id: 46, type: 'CACAHUETE', obtainedAt: new Date('2022-01-05') }),
+        new AttestationDetail({ id: 45, key: 'POUET', obtainedAt: new Date('2020-01-05'), label: 'Pouet label' }),
+        new AttestationDetail({
+          id: 46,
+          key: 'CACAHUETE',
+          obtainedAt: new Date('2022-01-05'),
+          label: 'Cacahuète label',
+        }),
       ]);
 
       // then
@@ -18,16 +23,18 @@ describe('Unit | Serializer | JSONAPI | attestation-detail', function () {
             type: 'attestation-details',
             id: '45',
             attributes: {
-              type: 'POUET',
+              key: 'POUET',
               'obtained-at': new Date('2020-01-05'),
+              label: 'Pouet label',
             },
           },
           {
             type: 'attestation-details',
             id: '46',
             attributes: {
-              type: 'CACAHUETE',
+              key: 'CACAHUETE',
               'obtained-at': new Date('2022-01-05'),
+              label: 'Cacahuète label',
             },
           },
         ],

--- a/api/tests/quest/unit/infrastructure/repositories/reward-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/reward-repository_test.js
@@ -24,7 +24,7 @@ describe('Quest | Unit | Infrastructure | Repositories | Reward', function () {
         rewardId: Symbol('rewardId'),
         rewardType: Symbol('rewardType'),
       };
-      reward = Symbol('reward');
+      reward = { id: 1, label: 'Label' };
       rewardApiStub = {
         getByIdAndType: sinon.stub(),
       };

--- a/mon-pix/app/components/attestations/card.gjs
+++ b/mon-pix/app/components/attestations/card.gjs
@@ -4,10 +4,6 @@ import { fn } from '@ember/helper';
 import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 
-function attestationTitle(type) {
-  return `components.campaigns.attestation-result.title.${type}`;
-}
-
 function attestationDelivery(obtainedAt) {
   return dayjs(obtainedAt).format('D MMM YYYY');
 }
@@ -16,17 +12,21 @@ function attestationDelivery(obtainedAt) {
   <PixBlock class="attestation-card">
     <header class="attestation-card__header">
       <div class="attestation-card__content">
-        <h2 class="attestation-card__title">{{t (attestationTitle @type)}}</h2>
+        <h2 class="attestation-card__title">{{@attestationDetail.label}}</h2>
         <p class="attestation-card__subtitle">{{t
             "components.attestations.obtainedAt"
-            date=(attestationDelivery @obtainedAt)
+            date=(attestationDelivery @attestationDetail.obtainedAt)
           }}</p>
       </div>
-      <img src="/images/illustrations/attestations/{{@type}}.svg" alt="" class="attestation-card__illustration" />
+      <img
+        src="/images/illustrations/attestations/{{@attestationDetail.key}}.svg"
+        alt=""
+        class="attestation-card__illustration"
+      />
     </header>
 
     <PixButton
-      @triggerAction={{fn @downloadAttestation @type}}
+      @triggerAction={{fn @downloadAttestation @attestationDetail}}
       @variant="secondary"
       @iconBefore="download"
       class="attestation-card__button"

--- a/mon-pix/app/components/attestations/content.gjs
+++ b/mon-pix/app/components/attestations/content.gjs
@@ -1,3 +1,4 @@
+import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -14,16 +15,12 @@ export default class AttestationContent extends Component {
   @service pixMetrics;
   @service intl;
 
-  getFilename(type) {
-    return `components.campaigns.attestation-result.title.${type}`;
-  }
-
   @action
-  async onClick(type) {
+  async onClick(attestationDetail) {
     const { access_token: token, user_id: userId } = this.session.data.authenticated;
     this.sendMetrics();
-    const url = `/api/users/${userId}/attestations/${type}`;
-    const fileName = 'attestation-' + kebabCase(deburr(this.intl.t(this.getFilename(type))));
+    const url = `/api/users/${userId}/attestations/${attestationDetail.key}`;
+    const fileName = 'attestation-' + kebabCase(deburr(attestationDetail.label));
 
     await this.fileSaver.save({ url, token, fileName });
   }
@@ -47,9 +44,8 @@ export default class AttestationContent extends Component {
         {{#each @attestationsDetails as |attestationDetail|}}
           <li>
             <AttestationCard
-              @type={{attestationDetail.type}}
-              @obtainedAt={{attestationDetail.obtainedAt}}
-              @downloadAttestation={{this.onClick}}
+              @attestationDetail={{attestationDetail}}
+              @downloadAttestation={{fn this.onClick attestationDetail}}
             />
           </li>
         {{/each}}

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
@@ -18,15 +18,11 @@ export default class AttestationResult extends Component {
     return this.args.results[0];
   }
 
-  get resultTitle() {
-    return `components.campaigns.attestation-result.title.${this.result.reward.key}`;
-  }
-
   @action async onClick() {
     const { access_token: token, user_id: userId } = this.session.data.authenticated;
     this.sendMetrics();
     const url = `/api/users/${userId}/attestations/${this.result.reward.key}`;
-    const fileName = kebabCase(deburr(this.intl.t(this.resultTitle)));
+    const fileName = 'attestation-' + kebabCase(deburr(this.result.reward.label));
 
     try {
       await this.fileSaver.save({ url, token, fileName });
@@ -53,7 +49,7 @@ export default class AttestationResult extends Component {
           </span>
         </p>
         <span class="attestation-result__title">
-          {{t this.resultTitle}}
+          {{this.result.reward.label}}
         </span>
         <img
           class="attestation-result__illustration"
@@ -77,7 +73,7 @@ export default class AttestationResult extends Component {
           </span>
         </p>
         <span class="attestation-result__title">
-          {{t this.resultTitle}}
+          {{this.result.reward.label}}
         </span>
       {{else if (eq this.result.obtained null)}}
         <img

--- a/mon-pix/app/models/attestation-detail.js
+++ b/mon-pix/app/models/attestation-detail.js
@@ -3,4 +3,6 @@ import Model, { attr } from '@ember-data/model';
 export default class AttestationDetail extends Model {
   @attr('string') type;
   @attr('date') obtainedAt;
+  @attr('string') label;
+  @attr('string') key;
 }

--- a/mon-pix/tests/integration/components/attestations/card-test.gjs
+++ b/mon-pix/tests/integration/components/attestations/card-test.gjs
@@ -1,5 +1,4 @@
 import { render } from '@1024pix/ember-testing-library';
-import { t } from 'ember-intl/test-support';
 import AttestationCard from 'mon-pix/components/attestations/card';
 import { module, test } from 'qunit';
 
@@ -8,46 +7,35 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Attestations | card', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  const attestationTypes = [
-    'EDUCOLLAB',
-    'EDUCULTURENUM',
-    'EDUDOC',
-    'EDUIA',
-    'EDUINCONTOURNABLES',
-    'EDURESSOURCES',
-    'EDUSECU',
-    'EDUSUPPORT',
-    'EDUVEILLE',
-    'MINARM',
-    'PARENTHOOD',
-    'SIXTH_GRADE',
-  ];
+  test(`it renders attestation card with label`, async function (assert) {
+    const attestationDetail = {
+      obtainedAt: '2025-01-15',
+      label: 'Label',
+      key: 'key',
+    };
 
-  attestationTypes.forEach((type) => {
-    test(`it renders attestation card with ${type} type`, async function (assert) {
-      const obtainedAt = '2025-01-15';
+    const downloadAttestation = () => {};
 
-      const downloadAttestation = () => {};
+    const screen = await render(
+      <template>
+        <AttestationCard @attestationDetail={{attestationDetail}} @downloadAttestation={{downloadAttestation}} />
+      </template>,
+    );
 
-      const screen = await render(
-        <template>
-          <AttestationCard @type={{type}} @obtainedAt={{obtainedAt}} @downloadAttestation={{downloadAttestation}} />
-        </template>,
-      );
-
-      const expectedTitle = t(`components.campaigns.attestation-result.title.${type}`);
-      assert.dom(screen.getByRole('heading', { level: 2 })).hasText(expectedTitle);
-    });
+    assert.dom(screen.getByRole('heading', { level: 2 })).hasText(attestationDetail.label);
   });
-
   test('it displays correct SVG for PARENTHOOD type', async function (assert) {
-    const type = 'PARENTHOOD';
-    const obtainedAt = '2025-01-15';
+    const attestationDetail = {
+      obtainedAt: '2025-01-15',
+      label: 'Parentalité',
+      key: 'PARENTHOOD',
+    };
+
     const downloadAttestation = () => {};
 
     await render(
       <template>
-        <AttestationCard @type={{type}} @obtainedAt={{obtainedAt}} @downloadAttestation={{downloadAttestation}} />
+        <AttestationCard @attestationDetail={{attestationDetail}} @downloadAttestation={{downloadAttestation}} />
       </template>,
     );
 
@@ -55,13 +43,17 @@ module('Integration | Component | Attestations | card', function (hooks) {
   });
 
   test('it displays correct SVG for SIXTH_GRADE type', async function (assert) {
-    const type = 'SIXTH_GRADE';
-    const obtainedAt = '2025-01-15';
+    const attestationDetail = {
+      obtainedAt: '2025-01-15',
+      label: 'Parentalité',
+      key: 'SIXTH_GRADE',
+    };
+
     const downloadAttestation = () => {};
 
     await render(
       <template>
-        <AttestationCard @type={{type}} @obtainedAt={{obtainedAt}} @downloadAttestation={{downloadAttestation}} />
+        <AttestationCard @attestationDetail={{attestationDetail}} @downloadAttestation={{downloadAttestation}} />
       </template>,
     );
 

--- a/mon-pix/tests/integration/components/attestations/content-test.gjs
+++ b/mon-pix/tests/integration/components/attestations/content-test.gjs
@@ -32,8 +32,8 @@ module('Integration | Component | Attestations | content', function (hooks) {
   test('it renders attestation cards for each attestation detail', async function (assert) {
     // given
     const attestationsDetails = [
-      { type: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') },
-      { type: 'PARENTHOOD', obtainedAt: new Date('2025-03-20') },
+      { key: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') },
+      { key: 'PARENTHOOD', obtainedAt: new Date('2025-03-20') },
     ];
 
     // when
@@ -69,7 +69,7 @@ module('Integration | Component | Attestations | content', function (hooks) {
     }
     this.owner.register('service:fileSaver', FileSaverStub);
 
-    const attestationsDetails = [{ type: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') }];
+    const attestationsDetails = [{ key: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') }];
 
     const screen = await render(
       <template><AttestationContent @attestationsDetails={{attestationsDetails}} /></template>,
@@ -93,7 +93,7 @@ module('Integration | Component | Attestations | content', function (hooks) {
     }
     this.owner.register('service:pixMetrics', PixMetricsStub);
 
-    const attestationsDetails = [{ type: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') }];
+    const attestationsDetails = [{ key: 'SIXTH_GRADE', obtainedAt: new Date('2025-01-15') }];
 
     const screen = await render(
       <template><AttestationContent @attestationsDetails={{attestationsDetails}} /></template>,

--- a/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
+++ b/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
@@ -13,10 +13,10 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
   setupIntlRenderingTest(hooks);
 
   module('when the attestation is obtained', function () {
-    test('it should display the expected message', async function (assert) {
+    test('it should display the expected message and title', async function (assert) {
       const result = [
         {
-          reward: { key: 'SIXTH_GRADE' },
+          reward: { key: 'SIXTH_GRADE', label: '6ème' },
           obtained: true,
         },
       ];
@@ -24,44 +24,14 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       const screen = await render(<template><AttestationResult @results={{result}} /></template>);
       const obtainedTitle = t('components.campaigns.attestation-result.obtained');
       assert.dom(screen.getByText(obtainedTitle)).exists();
-    });
 
-    module('attestation title', function () {
-      const attestationKeys = [
-        'EDUCOLLAB',
-        'EDUCULTURENUM',
-        'EDUDOC',
-        'EDUIA',
-        'EDUINCONTOURNABLES',
-        'EDURESSOURCES',
-        'EDUSECU',
-        'EDUSUPPORT',
-        'EDUVEILLE',
-        'MINARM',
-        'PARENTHOOD',
-        'SIXTH_GRADE',
-      ];
-
-      attestationKeys.forEach((key) => {
-        test(`it should display ${key} attestation title`, async function (assert) {
-          const result = [
-            {
-              reward: { key },
-              obtained: true,
-            },
-          ];
-
-          const screen = await render(<template><AttestationResult @results={{result}} /></template>);
-          const rewardTitle = t(`components.campaigns.attestation-result.title.${key}`);
-          assert.dom(screen.getByText(rewardTitle)).exists();
-        });
-      });
+      assert.dom(screen.getByText(result[0].reward.label)).exists();
     });
 
     test('it should display the download button', async function (assert) {
       const result = [
         {
-          reward: { key: 'SIXTH_GRADE' },
+          reward: { key: 'SIXTH_GRADE', label: '6ème' },
           obtained: true,
         },
       ];
@@ -75,7 +45,7 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       // given
       const result = [
         {
-          reward: { key: 'SIXTH_GRADE' },
+          reward: { key: 'SIXTH_GRADE', label: 'Sensibilisation au numérique' },
           obtained: true,
         },
       ];
@@ -98,12 +68,11 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       // when
       const screen = await render(<template><AttestationResult @results={{result}} /></template>);
       await click(screen.getByRole('button', { name: t('common.actions.download') }));
-
       // then
       assert.ok(
         fileSaverSaveStub.calledWithExactly({
           url: '/api/users/123/attestations/SIXTH_GRADE',
-          fileName: 'sensibilisation-au-numerique',
+          fileName: 'attestation-sensibilisation-au-numerique',
           token: 'access_token!',
         }),
       );
@@ -121,7 +90,7 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       // given
       const result = [
         {
-          reward: { key: 'SIXTH_GRADE' },
+          reward: { key: 'SIXTH_GRADE', label: 'Sensibilisation au numérique' },
           obtained: true,
         },
       ];
@@ -145,7 +114,7 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       assert.ok(
         fileSaverSaveStub.calledWithExactly({
           url: '/api/users/123/attestations/SIXTH_GRADE',
-          fileName: 'sensibilisation-au-numerique',
+          fileName: 'attestation-sensibilisation-au-numerique',
           token: 'access_token!',
         }),
       );
@@ -157,7 +126,7 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
     test('it should display the expected message', async function (assert) {
       const result = [
         {
-          reward: { key: 'SIXTH_GRADE' },
+          reward: { key: 'SIXTH_GRADE', label: '6ème' },
           obtained: false,
         },
       ];
@@ -170,20 +139,19 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
     test('it should display the attestation title', async function (assert) {
       const result = [
         {
-          reward: { key: 'SIXTH_GRADE' },
+          reward: { key: 'SIXTH_GRADE', label: '6ème' },
           obtained: false,
         },
       ];
 
       const screen = await render(<template><AttestationResult @results={{result}} /></template>);
-      const rewardTitle = t(`components.campaigns.attestation-result.title.SIXTH_GRADE`);
-      assert.dom(screen.getByText(rewardTitle)).exists();
+      assert.dom(screen.getByText(result[0].reward.label)).exists();
     });
 
     test('it should not display the download button', async function (assert) {
       const result = [
         {
-          reward: { key: 'SIXTH_GRADE' },
+          reward: { key: 'SIXTH_GRADE', label: '6ème' },
           obtained: false,
         },
       ];
@@ -196,7 +164,7 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
 
   module('when the attestation is still computing', function () {
     test('it should display the expected message', async function (assert) {
-      const result = [{ obtained: null }];
+      const result = [{ obtained: null, label: '6ème' }];
 
       const screen = await render(<template><AttestationResult @results={{result}} /></template>);
       const computingTitle = t('components.campaigns.attestation-result.computing');


### PR DESCRIPTION
## 🪧 Problème
Dans PixApp, on a des traductions manquantes sur les titres des attestations. On les a en effet enlevées parce qu'on souhaite les remplacer par l'attribut `label` sur la table `attestations`.

## 🌈 Proposition
Sur les routes de PixApp qui viennent récupérer des détails d'attestations, on affiche ou on fait remonter + on affiche le label lié aux attestations de l'utilisateur.


## ✊ Remarques
C'est un bugfix pour mardi donc on essaie de faire vite. ProfileReward ne devrait pas remonter directement le label car ce n'est pas sa responsabilité. Il faudrait le remplacer par un aggrégat sur cette route-là pour aller chercher le label d'attestation.
On a refactoré le code en remplaçant l'attribut `type` à plusieurs endroits par `key`.

## 🎉 Pour tester
Se connecter avec attestation-success sur la campagne ATTEST001
L’affichage en fin de campagne doit remonter le label (voir Network)

Cliquer sur le lien “Mes attestations” dans la barre de navigation à gauche
Le label doit remonter pour chaque attestation.
