### PR TITLE
[FEATURE] Envoyer un event Plausible pour chaque contenu formatif affiché sur la page de résultats (PIX-23159)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -13,6 +13,12 @@ export default class EvaluationResultsRecommendationEngine extends Component {
   @service media;
   @service pixMetrics;
 
+  constructor(...args) {
+    super(...args);
+
+    this.trackTrainingsDisplayed(this.trainings);
+  }
+
   @action onCardClick({ trainingId }) {
     this.pixMetrics.trackEvent('Moteur de reco - Clic sur la carte du contenu formatif', {
       trainingId,
@@ -29,6 +35,15 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     this.pixMetrics.trackEvent("Moteur de reco - Clic sur l'accordéon de la modale du contenu formatif", {
       trainingId,
       accordionName,
+    });
+  }
+
+  trackTrainingsDisplayed(trainings) {
+    trainings.forEach((training, index) => {
+      this.pixMetrics.trackEvent('Moteur de reco - Affichage du contenu formatif sur la page de résultats', {
+        trainingId: training.id,
+        position: index + 1,
+      });
     });
   }
 

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -140,6 +140,15 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         sinon.assert.calledOnceWith(trackPageStub);
         assert.strictEqual(metricsService.context.code, campaign.code);
 
+        sinon.assert.calledWithExactly(
+          trackEventStub,
+          'Moteur de reco - Affichage du contenu formatif sur la page de résultats',
+          {
+            trainingId: training.id,
+            position: 1,
+          },
+        );
+
         // when
         await click(
           screen.getByRole('button', {
@@ -171,7 +180,7 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.objectives') }));
 
         // then
-        sinon.assert.callCount(trackEventStub, 3);
+        sinon.assert.callCount(trackEventStub, 4);
 
         // when
         await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.program') }));
@@ -191,7 +200,7 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.program') }));
 
         // then
-        sinon.assert.callCount(trackEventStub, 4);
+        sinon.assert.callCount(trackEventStub, 5);
 
         // when
         await click(


### PR DESCRIPTION
## 🪧 Problème

Actuellement, nous ne savons pas combien de fois un contenu formatif a été recommandé sur Plausible sur une campagne de type moteur de recommandation.

## 🌈 Proposition

Envoyer un event contenant l'id du CF recommandé ainsi que la position sur la page.

## ✊ Remarques

RAS

## 🎉 Pour tester
- Se connecter avec le compte `dave-comp@example.net`
- Passer la campagne `EDUMULTIP`. Ouvrir l'onglet network avant d'arriver sur la page de résultats
- Constater que plusieurs events avec le nom `Moteur de reco - Affichage du contenu formatif sur la page de résultats` sont bien envoyés à l'arrivée sur la page.
---

**(Enlever Ublock si les appels Plausible passent pas)**

---
- Vérifier, sur chaque event, que les champs `trainingId` et `position` sont bien définis dans la requête.
- Vérifier sur Plausible que l'event est bien arrivé 🚅 
