### PR TITLE
[TECH] Aligner les fichiers de traductions (PIX-23348)

### DIFF
--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -52,6 +52,7 @@
       "ine-required": "Das INE-Feld ist für jeden Schüler/jede Schülerin obligatorisch.",
       "ine-unique": "Die INE {nationalStudentId} ist in der Datei mehrfach für mehrere Schüler vorhanden.",
       "invalid-birthdate-format": "Der Schüler mit der INE {nationalStudentId} hat das falsche Format für sein Geburtsdatum. Es muss im Format 'DD/MM/YYYY' sein.",
+      "invalid-char-detected": "Der Name/Vorname des Schülers mit INE {nationalStudentId} enthält nicht unterstützte Zeichen.",
       "invalid-file": "Die Datei ist nicht konform.",
       "invalid-file-extension": "Erweiterung {fileExtension} nicht unterstützt.",
       "last-name-required": "Bei einem Schüler mit der INE {nationalStudentId} ist das Feld Nachname nicht ausgefüllt. Dieses ist für jeden Schüler obligatorisch.",
@@ -67,13 +68,7 @@
     "certification": {
       "message": "'<strong>'Zertifizierungen:'</strong>' vergessen Sie nicht, '< a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'die Sitzungen in Pix Certif'</a>' abzuschließen und dann die Zertifikate über den Reiter \"Zertifizierungen\" vor Schulbeginn {year} hochzuladen."
     },
-    "ia": {
-      "message": "Die neuen Pix-Lernpfade zum Thema KI sind in Ihrem Pix Orga-Bereich verfügbar! Sie sind für die Schüler der 4e, der 2de (allgemein und technologisch) und des 1. Jahres der CAP verpflichtend und werden schrittweise in den Schuljahren 2025-2026 und 2026-2027 eingeführt.",
-      "step1": "Sehen Sie sich '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' title='KI-Einsatzkit' class='link link--banner link--bold link--underlined' '>'das Einsatzkit'</a>' an.",
-      "step2": "Melden Sie sich für das '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'Webinar'</a>' an."
-    },
     "import": {
-      "ia-message": "📢 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Neu: Entdecken Sie das Kit zur Einführung von KI-Lernpfaden'</a>'.",
       "message": "Die wichtigsten Etappen des Jahres in der Schulbildung :",
       "step1a": "Einführung : '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Anleitung zum Herunterladen der Ergebnisse' class='link link--banner link--bold link--underlined' '>'Ergebnisse herunterladen'</a>' Zertifizierung und",
       "step1b": "importieren",
@@ -241,6 +236,9 @@
         "placeholder": "Gruppen"
       },
       "loading": "Laden...",
+      "participantExternalId": {
+        "label": "Externe ID-Suche"
+      },
       "placeholder": "-- -- Auswählen --",
       "title": "Filter"
     },
@@ -1516,6 +1514,11 @@
         },
         "column": {
           "checkbox": "Auswählen/Aufheben der Auswahl {firstname} {lastname}",
+          "division": {
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Klasse sortiert. Klicken Sie, um in alphabetischer Reihenfolge zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Klasse sortiert, alphabetisch in umgekehrter Reihenfolge. Klicken Sie, um in alphabetischer Reihenfolge zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle wird nach Klassen in alphabetischer Reihenfolge sortiert. Klicken Sie, um in umgekehrter alphabetischer Reihenfolge zu sortieren."
+          },
           "first-name": "Vorname",
           "is-certifiable": {
             "label": "Zertifizierbarkeit"
@@ -2000,6 +2003,7 @@
     },
     "team-invitations": {
       "cancel-invitation": "Einladung löschen",
+      "empty-table": "Sie haben keine ausstehenden Einladungen.",
       "invitation-cancelled-succeed-message": "Die Einladung wurde tatsächlich gelöscht.",
       "invitation-resent-succeed-message": "Die Einladung wurde ordnungsgemäß zurückgeschickt.",
       "resend-invitation": "Einladung erneut senden",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -741,18 +741,6 @@
       },
       "title": "Analysis"
     },
-    "campaign-combined-courses": {
-      "empty": "No learning courses found for this campaign",
-      "table": {
-        "column": {
-          "code": "Course code",
-          "name": "Course name",
-          "participants": "Number of participants"
-        },
-        "description": "List of learning courses associated with this campaign"
-      },
-      "title": "Learning courses"
-    },
     "campaign-creation": {
       "actions": {
         "create": "Create a campaign",
@@ -1148,7 +1136,6 @@
         }
       }
     },
-    "combined-course-blueprints-list-label": "Sélectionnez un schéma de parcours",
     "combined-courses": {
       "empty-state": "No learning course available at the moment.",
       "table": {

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -68,13 +68,7 @@
     "certification": {
       "message": "'<strong>'Certificaciones:'</strong>' no olvide '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finalizar las sesiones en Pix Certif'</a>' y, a continuación, descargar los certificados a través de la pestaña \"Certificaciones\" antes del inicio del nuevo curso escolar {year}."
     },
-    "ia": {
-      "message": "¡Los nuevos itinerarios de aprendizaje Pix sobre IA están disponibles en tu espacio Pix Orga! Son obligatorios para los alumnos de 4e, 2de (general y tecnológico) y 1º de CAP, y se introducirán progresivamente a lo largo de los cursos 2025-2026 y 2026-2027.",
-      "step1": "Echa un vistazo a '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' title='Kit de despliegue de IA' class='link link--banner link--bold link--underlined' '>'el kit de despliegue'</a>'",
-      "step2": "Inscríbase en el '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinar'</a>'"
-    },
     "import": {
-      "ia-message": "📢 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Nuevo: descubre el kit de despliegue de la vía de aprendizaje de IA'</a>'",
       "message": "Etapas clave del curso escolar :",
       "step1a": "Implement : '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Guía descarga resultados' class='link link--banner link--bold link--underlined' '>'descarga resultados'</a>' certificación y",
       "step1b": "importar",
@@ -1520,6 +1514,11 @@
         },
         "column": {
           "checkbox": "Seleccionar/Deseleccionar {firstname} {lastname}",
+          "division": {
+            "ariaLabelDefaultSort": "La mesa no está clasificada por clase. Haga clic para ordenar alfabéticamente.",
+            "ariaLabelSortDown": "La tabla está ordenada por clase en el orden alfabético inverso. Haga clic para ordenar alfabéticamente.",
+            "ariaLabelSortUp": "La tabla está ordenada por clase en orden alfabético. Haga clic para ordenar en orden alfabético inverso."
+          },
           "first-name": "Nombre",
           "is-certifiable": {
             "label": "Certificación"

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -68,13 +68,7 @@
     "certification": {
       "message": "'<strong>'Certificazioni:'</strong>' non dimenticate di '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finalizzare le sessioni in Pix Certif'</a>' e poi scaricare i certificati tramite la scheda \"Certificazioni\" prima dell'inizio del nuovo anno scolastico {year}."
     },
-    "ia": {
-      "message": "I nuovi percorsi di apprendimento Pix sull'IA sono disponibili nel vostro spazio Pix Orga! Sono obbligatori per gli alunni delle 4e, 2de (generale e tecnologica) e del 1° anno del PAC, con un'implementazione graduale negli anni scolastici 2025-2026 e 2026-2027.",
-      "step1": "Consultate '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' title='kit di implementazione IA' class='link link--banner link--bold link--underlined' '>'il kit di implementazione'</a>'",
-      "step2": "Registratevi per il '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinar'</a>'."
-    },
     "import": {
-      "ia-message": "🚀 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Nuovo: scopri il kit di implementazione dei percorsi di apprendimento IA'</a>'",
       "message": "Fasi chiave dell'anno scolastico :",
       "step1a": "Implementare : '<'a href='https://cloud.pix.fr/s/TBF97QzSni7SWpc' title='Guida scarica risultati' class='link link--banner link--bold link--underlined' '>'scarica risultati'</a>' certificazione e",
       "step1b": "Importazione",
@@ -242,6 +236,9 @@
         "placeholder": "Gruppi"
       },
       "loading": "Caricamento...",
+      "participantExternalId": {
+        "label": "Ricerca di identificatore esterno"
+      },
       "placeholder": "-- Seleziona...",
       "title": "Filtri"
     },
@@ -1517,6 +1514,11 @@
         },
         "column": {
           "checkbox": "Selezionare/Deselezionare {firstname} {lastname}",
+          "division": {
+            "ariaLabelDefaultSort": "La tabella non è al momento ordinata per classe. Cliccare per ordinare in ordine alfabetico.",
+            "ariaLabelSortDown": "La tabella è suddivisa per classe in ordine alfabetico inverso. Cliccare per ordinare l'alfabeto.",
+            "ariaLabelSortUp": "La tabella è suddivisa per classe in ordine alfabetico. Cliccare per ordinare in ordine alfabetico inverso."
+          },
           "first-name": "Nome",
           "is-certifiable": {
             "label": "Certificazione"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -134,11 +134,6 @@
       "title": "Participaties voltooid"
     }
   },
-  "cgu": {
-    "error": "Je moet de gebruiksvoorwaarden en het privacybeleid van Pix accepteren om een account aan te maken.",
-    "label": "De gebruiksvoorwaarden van Pix accepteren",
-    "read-message": "Lees de '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'gebruiksvoorwaarden'</a>' en de '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'privacybeleid'</a>'."
-  },
   "charts": {
     "participants-by-day": {
       "captions": {
@@ -206,7 +201,6 @@
       "bad-request-error": "De gegevens die u heeft opgegeven, hebben niet het juiste formaat.",
       "default": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice.",
       "expired-authentication-key": "Uw verificatieverzoek is verlopen.",
-      "gateway-timeout-error": "De service ondervindt vertragingen. Probeer het later nog eens.",
       "internal-server-error": "Er is een interne fout opgetreden. Onze teams zijn bezig het probleem op te lossen. Probeer het later nog eens.",
       "login-unauthorized-error": "Het e-mailadres of de ingevoerde gebruikersnaam en/of wachtwoord zijn onjuist.",
       "login-unauthorized-remaining-attempts-error": "Waarschuwing: je hebt {remainingAttempts, plural, =0 {0 poging} =1 {1 poging} other {# pogingen}} over voordat je Pix account permanent geblokkeerd wordt.",
@@ -218,6 +212,11 @@
       "login-user-temporary-blocked-with-username-error": "Je hebt te veel inlogpogingen gedaan, je Pix-account is tijdelijk geblokkeerd voor {blockingDurationMinutes} minuten.'<br>'Als je je wachtwoord bent vergeten, '<strong>'neem contact op met je docent'</strong>' om je wachtwoord opnieuw in te stellen en/of je aanmelding te herstellen."
     },
     "breadcrumb": "Leidraad",
+    "cgu": {
+      "error": "Je moet de gebruiksvoorwaarden en het privacybeleid van Pix accepteren om een account aan te maken.",
+      "label": "De gebruiksvoorwaarden van Pix accepteren",
+      "read-message": "Lees de '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'gebruiksvoorwaarden'</a>' en de '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'privacybeleid'</a>'."
+    },
     "filters": {
       "actions": {
         "clear": "Alle filters verwijderen"
@@ -297,6 +296,7 @@
     "activity-type": {
       "explanation": {
         "ASSESSMENT": "Beoordelingscampagne",
+        "CAMPAIGN": "Evaluatiecampagne",
         "COMBINED_COURSE": "Leetraject",
         "EXAM": "Vraagmodus",
         "FORMATION": "Training",
@@ -305,6 +305,7 @@
       },
       "information": {
         "ASSESSMENT": "Beoordeling",
+        "CAMPAIGN": "Beoordeling",
         "COMBINED_COURSE": "Leetraject",
         "EXAM": "Vraagmodus",
         "FORMATION": "Training",
@@ -1052,6 +1053,16 @@
       },
       "modal": {
         "associated-badges": "Gerelateerde badges",
+        "combined-course-content": {
+          "aria-label-duration": "Geschatte duur: {duration} minuten",
+          "description": "Leertrajecten vormen individuele evaluaties en leermodules, waardoor pedagogische aanpassing mogelijk is op basis van het niveau van elke deelnemer.",
+          "duration": "≈ {duration} min",
+          "module-info": "Modules worden aanbevolen aan deelnemers op basis van hun resultaten.",
+          "prescribed": "Voorgeschreven",
+          "recommended": "Aanbevolen",
+          "step": "Stap nr. {number}",
+          "title": "Leertrajecten"
+        },
         "max-level": "Max. niveau",
         "open-modal": "Bekijk de details van het traject",
         "select-course": "Deze cursus selecteren",
@@ -1161,7 +1172,12 @@
             "label": "Achternaam",
             "placeholder": "b.v. Jansen"
           },
-          "legend": "Vereiste informatie voor registratie."
+          "legend": "Vereiste informatie voor registratie.",
+          "password": {
+            "completed-message": "{ rulesCompleted } op { rulesCount } voltooid.",
+            "instructions-label": "Uw wachtwoord moet voldoen aan de volgende regels:",
+            "label": "Wachtwoord"
+          }
         },
         "submit": "Ik meld me aan",
         "subtitle": "om toegang te krijgen tot uw Pix Orga-account",
@@ -1498,6 +1514,11 @@
         },
         "column": {
           "checkbox": "Selecteren/Deselecteren {firstname} {lastname}",
+          "division": {
+            "ariaLabelDefaultSort": "De tabel is momenteel niet gesorteerd op klasse. Klik om alfabetisch te sorteren.",
+            "ariaLabelSortDown": "De tabel is gesorteerd op klasse in omgekeerde alfabetische volgorde. Klik om alfabetisch te sorteren.",
+            "ariaLabelSortUp": "De tabel is gerangschikt naar klasse in alfabetische volgorde. Klik om te sorteren in omgekeerde alfabetische volgorde."
+          },
           "first-name": "Voornaam",
           "is-certifiable": {
             "label": "Certificeerbaarheid"


### PR DESCRIPTION
## 🪧 Problème

Les fichiers de traductions de Pix Orga ne sont pas alignés : chacun d'entre eux ont un nombre différent de clés.

## 🌈 Proposition

Se baser sur le fichier de traduction `fr` pour aligner tous les autres.

## ✊ Remarques
Les modifications concernent uniquement les clés des fichiers et non pas les valeurs.

## 🎉 Pour tester
Constater qu'il n'y a pas de différences entre les clés du fichier `fr` et les clés des fichiers `en`, `es`, `it`, `de`, `nl`.

On peut utiliser l'outil [JSON Diff](https://jsondiff.com/) :
1. Copier / coller le contenu du fichier `fr` dans la partie gauche
2. Copier / coller le contenu d'un autre fichier de traduction dans la partie droite
3. Cliquer sur "Compare"
4. Constater qu'il n'y a pas d'erreur "missing property"
5. Recommencer avec un autre fichier de traduction en cliquant sur "Perform a new diff"
