### PR TITLE
[FEATURE] Mise à jour des wordings d'attestation des parcours combinés (PIX-23359)

### DIFF
--- a/mon-pix/app/components/combined-course/attestation.gjs
+++ b/mon-pix/app/components/combined-course/attestation.gjs
@@ -31,9 +31,10 @@ export default class Attestation extends Component {
     const status = this.args.attestation.computedStatus;
     return {
       information: this.intl.t(`pages.combined-courses.rewards.${status}.details.title`),
-      text: status === REWARD_STATUSES.OBTAINED
-        ? this.intl.t(`pages.combined-courses.rewards.${status}.details.text`)
-        : null,
+      text:
+        status === REWARD_STATUSES.OBTAINED
+          ? this.intl.t(`pages.combined-courses.rewards.${status}.details.text`)
+          : null,
     };
   }
 

--- a/mon-pix/app/components/combined-course/attestation.gjs
+++ b/mon-pix/app/components/combined-course/attestation.gjs
@@ -28,9 +28,12 @@ export default class Attestation extends Component {
   }
 
   get mainContentDetails() {
+    const status = this.args.attestation.computedStatus;
     return {
-      information: this.intl.t(`pages.combined-courses.rewards.${this.args.attestation.computedStatus}.details.title`),
-      text: this.intl.t(`pages.combined-courses.rewards.${this.args.attestation.computedStatus}.details.text`),
+      information: this.intl.t(`pages.combined-courses.rewards.${status}.details.title`),
+      text: status === REWARD_STATUSES.OBTAINED
+        ? this.intl.t(`pages.combined-courses.rewards.${status}.details.text`)
+        : null,
     };
   }
 
@@ -87,8 +90,10 @@ const AttestationDetails = <template>
 
     <p>
       <em class="attestation-details__information">{{@information}}</em>
-      <br />
-      {{@text}}
+      {{#if @text}}
+        <br />
+        {{@text}}
+      {{/if}}
     </p>
   </section>
 </template>;

--- a/mon-pix/tests/integration/components/combined-course/attestation-test.gjs
+++ b/mon-pix/tests/integration/components/combined-course/attestation-test.gjs
@@ -114,7 +114,7 @@ module('Integration | Component | Combined Courses | Attestation', function (hoo
       assert.ok(tag.getAttribute('class').includes('pix-tag pix-tag--error'));
 
       assert.ok(screen.getByText(t('pages.combined-courses.rewards.not-obtained.details.title')));
-      assert.ok(screen.getByText(t('pages.combined-courses.rewards.not-obtained.details.text')));
+      assert.notOk(screen.queryByText(t('pages.combined-courses.rewards.not-obtained.details.text')));
       assert
         .dom(screen.getByRole('img', { name: 'attestation-image-not-obtained' }))
         .hasAttribute('src', 'https://assets.pix.org/combined-courses/attestation-image.svg')
@@ -152,7 +152,7 @@ module('Integration | Component | Combined Courses | Attestation', function (hoo
         assert.ok(tag.getAttribute('class').includes('pix-tag pix-tag--grey'));
 
         assert.ok(screen.getByText(t('pages.combined-courses.rewards.in-progress.details.title')));
-        assert.ok(screen.getByText(t('pages.combined-courses.rewards.in-progress.details.text')));
+        assert.notOk(screen.queryByText(t('pages.combined-courses.rewards.in-progress.details.text')));
         assert
           .dom(screen.getByRole('img', { name: 'attestation-image-in-progress' }))
           .hasAttribute('src', 'https://assets.pix.org/combined-courses/attestation-image.svg')

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1314,21 +1314,21 @@
         "in-progress": {
           "details": {
             "text": "Je nach Ihrem Leistungsstand am Ende des Kurses kann eine Teilnahmebescheinigung ausgestellt werden.",
-            "title": "Schließe alle Kurse ab, um dein Zertifikat zu erhalten"
+            "title": "Schließen Sie Ihren Kurs ab, um Ihre Bescheinigung zu erhalten"
           },
           "status": "Steht noch aus"
         },
         "not-obtained": {
           "details": {
-            "text": "Leider lassen die auf den absolvierten Strecken erzielten Ergebnisse keine Bestätigung des Erwerbs Ihrer Bescheinigung zu",
-            "title": "Den Grund verstehen"
+            "text": "Leider lassen die auf den absolvierten Strecken erzielten Ergebnisse keine Bestätigung des Erwerbs Ihrer Bescheinigung zu.",
+            "title": "Leider haben Sie die Voraussetzungen für den Erhalt der Bescheinigung nicht erfüllt"
           },
           "status": "Nicht erhalten"
         },
         "obtained": {
           "details": {
-            "text": "Laden Sie Ihre Teilnahmebescheinigung herunter! Dieses Dokument finden Sie auch in Ihrem Pix-Konto.",
-            "title": "Wo findet man das?"
+            "text": "Sie können Ihre Bescheinigung jetzt herunterladen oder in Ihrem Pix-Konto finden.",
+            "title": "Sie haben Ihre Bescheinigung erhalten!"
           },
           "link": "Ich lade meine Bescheinigung herunter",
           "status": "Erhalten"

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1313,14 +1313,12 @@
       "rewards": {
         "in-progress": {
           "details": {
-            "text": "Je nach Ihrem Leistungsstand am Ende des Kurses kann eine Teilnahmebescheinigung ausgestellt werden.",
             "title": "Schließen Sie Ihren Kurs ab, um Ihre Bescheinigung zu erhalten"
           },
           "status": "Steht noch aus"
         },
         "not-obtained": {
           "details": {
-            "text": "Leider lassen die auf den absolvierten Strecken erzielten Ergebnisse keine Bestätigung des Erwerbs Ihrer Bescheinigung zu.",
             "title": "Leider haben Sie die Voraussetzungen für den Erhalt der Bescheinigung nicht erfüllt"
           },
           "status": "Nicht erhalten"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1314,21 +1314,21 @@
         "in-progress": {
           "details": {
             "text": "Depending on your level at the end of the course, a certificate of completion may be issued.",
-            "title": "Complete all the courses to earn your attestation"
+            "title": "Complete your course to earn your attestation"
           },
           "status": "Pending"
         },
         "not-obtained": {
           "details": {
-            "text": "Unfortunately, the results obtained on the courses you completed do not meet the requirements for issuing your attestation",
-            "title": "Understand why"
+            "text": "Unfortunately, the results obtained on the courses you completed do not meet the requirements for issuing your attestation.",
+            "title": "Unfortunately, you did not meet the conditions to obtain the attestation"
           },
           "status": "Not obtained"
         },
         "obtained": {
           "details": {
-            "text": "Download your certificate of completion! This document is also available in your Pix account.",
-            "title": "Where can I find it?"
+            "text": "You can download your attestation now or find it in your Pix account.",
+            "title": "You have obtained your attestation!"
           },
           "link": "Download my attestation",
           "status": "Obtained"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1313,14 +1313,12 @@
       "rewards": {
         "in-progress": {
           "details": {
-            "text": "Depending on your level at the end of the course, a certificate of completion may be issued.",
             "title": "Complete your course to earn your attestation"
           },
           "status": "Pending"
         },
         "not-obtained": {
           "details": {
-            "text": "Unfortunately, the results obtained on the courses you completed do not meet the requirements for issuing your attestation.",
             "title": "Unfortunately, you did not meet the conditions to obtain the attestation"
           },
           "status": "Not obtained"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1314,21 +1314,21 @@
         "in-progress": {
           "details": {
             "text": "En función de tu nivel al finalizar el curso, se te podrá expedir un certificado de superación.",
-            "title": "Completa todos los cursos para obtener tu certificado"
+            "title": "Completa tu curso para obtener tu certificado"
           },
           "status": "Pendiente"
         },
         "not-obtained": {
           "details": {
-            "text": "Por desgracia, los resultados obtenidos en las pruebas realizadas no permiten validar la obtención de su certificado",
-            "title": "Entender el motivo"
+            "text": "Lamentablemente, los resultados obtenidos en las pruebas realizadas no permiten validar la obtención de tu certificado.",
+            "title": "Lamentablemente, no has cumplido las condiciones para obtener el certificado"
           },
           "status": "No obtenido"
         },
         "obtained": {
           "details": {
-            "text": "¡Descarga tu certificado de aprobación! Este documento también está disponible en tu cuenta Pix.",
-            "title": "¿Dónde se puede encontrar eso?"
+            "text": "Puedes descargar tu certificado ahora mismo o encontrarlo en tu cuenta Pix.",
+            "title": "¡Has obtenido tu certificado!"
           },
           "link": "Descargaré mi certificado",
           "status": "Obtenido"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1313,14 +1313,12 @@
       "rewards": {
         "in-progress": {
           "details": {
-            "text": "En función de tu nivel al finalizar el curso, se te podrá expedir un certificado de superación.",
             "title": "Completa tu curso para obtener tu certificado"
           },
           "status": "Pendiente"
         },
         "not-obtained": {
           "details": {
-            "text": "Lamentablemente, los resultados obtenidos en las pruebas realizadas no permiten validar la obtención de tu certificado.",
             "title": "Lamentablemente, no has cumplido las condiciones para obtener el certificado"
           },
           "status": "No obtenido"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1314,21 +1314,21 @@
         "in-progress": {
           "details": {
             "text": "En fonction de votre niveau en fin de parcours, une attestation de réussite pourra être délivrée.",
-            "title": "Terminez tous les parcours pour obtenir votre attestation"
+            "title": "Finalisez votre parcours pour obtenir votre attestation"
           },
           "status": "En cours"
         },
         "not-obtained": {
           "details": {
-            "text": "Malheureusement les résultats obtenus sur les parcours réalisés ne permettent pas de valider l’obtention de votre attestation",
-            "title": "Comprendre pourquoi"
+            "text": "Malheureusement, les résultats obtenus sur les parcours réalisés ne permettent pas de valider l’obtention de votre attestation.",
+            "title": "Malheureusement, vous n’avez pas rempli les conditions pour obtenir l’attestation"
           },
           "status": "Non obtenue"
         },
         "obtained": {
           "details": {
-            "text": "Téléchargez votre attestation de réussite ! Ce document est également disponible dans votre compte Pix.",
-            "title": "Où la retrouver ?"
+            "text": "Vous pouvez télécharger votre attestation dès maintenant ou la retrouver dans votre compte Pix.",
+            "title": "Vous avez obtenu votre attestation !"
           },
           "link": "Je télécharge mon attestation",
           "status": "Obtenue"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1313,14 +1313,12 @@
       "rewards": {
         "in-progress": {
           "details": {
-            "text": "En fonction de votre niveau en fin de parcours, une attestation de réussite pourra être délivrée.",
             "title": "Finalisez votre parcours pour obtenir votre attestation"
           },
           "status": "En cours"
         },
         "not-obtained": {
           "details": {
-            "text": "Malheureusement, les résultats obtenus sur les parcours réalisés ne permettent pas de valider l’obtention de votre attestation.",
             "title": "Malheureusement, vous n’avez pas rempli les conditions pour obtenir l’attestation"
           },
           "status": "Non obtenue"

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1314,21 +1314,21 @@
         "in-progress": {
           "details": {
             "text": "A seconda del livello raggiunto al termine del corso, potrà essere rilasciato un attestato di completamento.",
-            "title": "Completa tutti i percorsi per ottenere il tuo attestato"
+            "title": "Completa il tuo percorso per ottenere il tuo attestato"
           },
           "status": "In attesa"
         },
         "not-obtained": {
           "details": {
-            "text": "Purtroppo, i risultati ottenuti nei percorsi svolti non consentono di confermare il rilascio del certificato",
-            "title": "Capire il motivo"
+            "text": "Purtroppo, i risultati ottenuti nei percorsi svolti non consentono di confermare il rilascio del certificato.",
+            "title": "Purtroppo, non hai soddisfatto le condizioni per ottenere l'attestato"
           },
           "status": "Non ottenuto"
         },
         "obtained": {
           "details": {
-            "text": "Scarica il tuo attestato di superamento dell'esame! Questo documento è disponibile anche nel tuo account Pix.",
-            "title": "Dove si trova?"
+            "text": "Puoi scaricare il tuo attestato adesso o trovarlo nel tuo account Pix.",
+            "title": "Hai ottenuto il tuo attestato!"
           },
           "link": "Scarico il mio certificato",
           "status": "Ottenuto"

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1313,14 +1313,12 @@
       "rewards": {
         "in-progress": {
           "details": {
-            "text": "A seconda del livello raggiunto al termine del corso, potrà essere rilasciato un attestato di completamento.",
             "title": "Completa il tuo percorso per ottenere il tuo attestato"
           },
           "status": "In attesa"
         },
         "not-obtained": {
           "details": {
-            "text": "Purtroppo, i risultati ottenuti nei percorsi svolti non consentono di confermare il rilascio del certificato.",
             "title": "Purtroppo, non hai soddisfatto le condizioni per ottenere l'attestato"
           },
           "status": "Non ottenuto"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1314,21 +1314,21 @@
         "in-progress": {
           "details": {
             "text": "Afhankelijk van uw niveau aan het einde van de opleiding kan een certificaat van succes worden uitgereikt.",
-            "title": "Voltooi alle parcours om je certificaat te behalen"
+            "title": "Voltooi je parcours om je certificaat te behalen"
           },
           "status": "Behandeling"
         },
         "not-obtained": {
           "details": {
-            "text": "Helaas kunnen we op basis van de behaalde resultaten op de afgelegde parcoursen niet bevestigen dat u uw certificaat hebt behaald",
-            "title": "De reden begrijpen"
+            "text": "Helaas kunnen we op basis van de behaalde resultaten op de afgelegde parcoursen niet bevestigen dat u uw certificaat hebt behaald.",
+            "title": "Helaas heb je niet aan de voorwaarden voldaan om het certificaat te behalen"
           },
           "status": "Niet behaald"
         },
         "obtained": {
           "details": {
-            "text": "Download je certificaat van succes! Dit document is ook beschikbaar in je Pix-account.",
-            "title": "Waar is ze te vinden?"
+            "text": "Je kunt je certificaat nu downloaden of terugvinden in je Pix-account.",
+            "title": "Je hebt je certificaat behaald!"
           },
           "link": "Ik download mijn verklaring",
           "status": "Behaald"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1313,14 +1313,12 @@
       "rewards": {
         "in-progress": {
           "details": {
-            "text": "Afhankelijk van uw niveau aan het einde van de opleiding kan een certificaat van succes worden uitgereikt.",
             "title": "Voltooi je parcours om je certificaat te behalen"
           },
           "status": "Behandeling"
         },
         "not-obtained": {
           "details": {
-            "text": "Helaas kunnen we op basis van de behaalde resultaten op de afgelegde parcoursen niet bevestigen dat u uw certificaat hebt behaald.",
             "title": "Helaas heb je niet aan de voorwaarden voldaan om het certificaat te behalen"
           },
           "status": "Niet behaald"


### PR DESCRIPTION


## 🪧 Problème
On a un parcours avec attestation a lancé mardi prochain, hors les wordings ne sont pas tout à fait exacts. 
Pour la version finale on va ajouter un champ à compléter au niveau du blueprint pour expliciter les critères mais en attendant il faut que ce soit utilisable mardi. 


## 🌈 Proposition

- Mise à jour des wordings des attestations de parcours combinés (titres et textes) dans les 6 langues (fr, en, de, es, it, nl)
- Masquage du texte de détai pour les statuts `in-progress` et `not-obtained` (sera remplacé par un champ libre ultérieurement)

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
code parcours SCOMBINIX (il faut se connecter avec un utilisateur de type learner_email)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>