### PR TITLE
[BUGFIX] Ne pas essayer de créer des campagnes ou de recommander des modules si le parcours combiné n'a que des modules (PIX-23324)

### DIFF
--- a/api/src/quest/domain/usecases/create-combined-course.js
+++ b/api/src/quest/domain/usecases/create-combined-course.js
@@ -37,9 +37,11 @@ export const createCombinedCourse = async ({
   const targetProfileIds = combinedCourseBlueprint.targetProfileIds ?? [];
   const targetProfiles = await targetProfileRepository.findByIds({ ids: targetProfileIds });
   const campaignsToCreate = [];
-  const recommendableModules = await recommendedModuleRepository.findIdsByTargetProfileIds({
-    targetProfileIds,
-  });
+  const recommendableModules = targetProfileIds.length
+    ? await recommendedModuleRepository.findIdsByTargetProfileIds({
+        targetProfileIds,
+      })
+    : [];
 
   for (const targetProfile of targetProfiles) {
     const campaignForCombinedCourse = Campaign.buildCampaignForCombinedCourse({
@@ -55,9 +57,9 @@ export const createCombinedCourse = async ({
     campaignsToCreate.push(campaignForCombinedCourse);
   }
 
-  const createdCampaigns = await campaignRepository.save({
-    campaigns: campaignsToCreate,
-  });
+  const createdCampaigns = campaignsToCreate.length
+    ? await campaignRepository.save({ campaigns: campaignsToCreate })
+    : [];
 
   const combinedCourse = combinedCourseBlueprint.toCombinedCourse({
     name: combinedCourseForCreation.name,

--- a/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
@@ -92,6 +92,121 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     expect(campaigns[1].title).to.equal(otherTargetProfile.name);
     expect(campaigns[1].customResultPageButtonUrl.includes('/chargement')).false;
     expect(campaigns[1].customResultPageButtonText).to.equal('Continuer');
+
+    // Modules
+    const successRequirements = createdQuest.successRequirements;
+    const moduleRequirements = successRequirements.filter((req) => req.data.moduleId);
+    expect(moduleRequirements).to.have.lengthOf(2);
+    expect(moduleRequirements[0].data.moduleId.data).to.equal(moduleId1);
+    expect(moduleRequirements[1].data.moduleId.data).to.equal(moduleId2);
+  });
+
+  it('should create combined course even with no campaign', async function () {
+    // given
+    const moduleId1 = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+    const moduleId2 = 'f32a2238-4f65-4698-b486-15d51935d335';
+    const userId = databaseBuilder.factory.buildUser().id;
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const attestation = databaseBuilder.factory.buildAttestation();
+
+    const quest = databaseBuilder.factory.buildQuest({
+      rewardId: attestation.id,
+      rewardType: REWARD_TYPES.ATTESTATION,
+      successRequirements: [
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: moduleId1 }).toDTO(),
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: moduleId2 }).toDTO(),
+      ],
+    });
+
+    const combinedCourseBlueprintId = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: quest.id }).id;
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId });
+
+    await databaseBuilder.commit();
+
+    const nameInput = 'Un parcours combiné';
+
+    const combinedCourseForCreation = new CombinedCourseForCreation({
+      blueprintId: combinedCourseBlueprintId,
+      organizationId,
+      name: nameInput,
+    });
+
+    // when
+    await usecases.createCombinedCourse({
+      combinedCourseForCreation,
+      creatorId: userId,
+    });
+
+    // then
+    const [createdQuest] = await knex('quests')
+      .join('combined_courses', 'combined_courses.questId', 'quests.id')
+      .where('combined_courses.organizationId', organizationId)
+      .orderBy('quests.id');
+
+    // Quest
+    expect(createdQuest.combinedCourseBlueprintId).to.equal(combinedCourseBlueprintId);
+
+    // No campaign
+    const campaigns = await knex('campaigns').where({ organizationId });
+    expect(campaigns).to.have.lengthOf(0);
+
+    // Modules
+    const successRequirements = createdQuest.successRequirements;
+    expect(successRequirements).to.have.lengthOf(2);
+    expect(successRequirements[0].data.moduleId.data).to.equal(moduleId1);
+    expect(successRequirements[1].data.moduleId.data).to.equal(moduleId2);
+  });
+
+  it('should create combined course with only campaigns', async function () {
+    // given
+    const userId = databaseBuilder.factory.buildUser().id;
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
+    const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
+
+    const attestation = databaseBuilder.factory.buildAttestation();
+
+    const quest = databaseBuilder.factory.buildQuest({
+      rewardId: attestation.id,
+      rewardType: REWARD_TYPES.ATTESTATION,
+      successRequirements: [
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: targetProfile1.id }).toDTO(),
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: targetProfile2.id }).toDTO(),
+      ],
+    });
+
+    const combinedCourseBlueprintId = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: quest.id }).id;
+    databaseBuilder.factory.buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId });
+
+    await databaseBuilder.commit();
+
+    const nameInput = 'Un parcours combiné';
+
+    const combinedCourseForCreation = new CombinedCourseForCreation({
+      blueprintId: combinedCourseBlueprintId,
+      organizationId,
+      name: nameInput,
+    });
+
+    // when
+    await usecases.createCombinedCourse({
+      combinedCourseForCreation,
+      creatorId: userId,
+    });
+
+    // then
+    const [createdQuest] = await knex('quests')
+      .join('combined_courses', 'combined_courses.questId', 'quests.id')
+      .where('combined_courses.organizationId', organizationId)
+      .orderBy('quests.id');
+
+    // Quest
+    expect(createdQuest.combinedCourseBlueprintId).to.equal(combinedCourseBlueprintId);
+
+    // Campaigns
+    const campaigns = await knex('campaigns').where({ organizationId });
+    expect(campaigns).to.have.lengthOf(2);
   });
 
   it('should throw NotFoundError when blueprint is not found with the id in payload', async function () {


### PR DESCRIPTION
## 🪧 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Si on essaie de créer un parcours combiné qui contient seulement des modules, on a une erreur 400 "targetProfileIds can not be empty".

L'erreur se trouve au niveau de `recommended-modules-api` dans `findByCampaignParticipationIds`.

## 🌈 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Dans le usecase de création d'un parcours combiné, si on n'a pas de targetProfile associé :
- ne pas chercher de modules recommendables à partir d'un targetProfile
- ne pas essayer de créer de campagne

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

Sur PixAdmin, rattacher l'organisation 1000 (SCO SIECLE) au schema "Combinix sans campagne".

Sur PixOrga, en tant que SCO SIECLE, créer une campagne de type "Développer les compétences des participants" et sélectionner "Combinix sans campagne".
Le parcours doit se créer correctement.
