### PR TITLE
[FEATURE] Ajouter un endpoint pour rattacher un centre de certification à une organisation (PIX-22632)

### DIFF
--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -15,6 +15,7 @@ import {
   ParentOrganizationNotInNetworkError,
   StructureNotFoundError,
   TagNotFoundError,
+  UnableToAttachCertificationCenterToOrganization,
   UnableToAttachChildOrganizationToParentOrganizationError,
   UnableToDetachParentOrganizationFromChildOrganization,
 } from '../domain/errors.js';
@@ -86,6 +87,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   },
   {
     name: ArchiveOrganizationError.name,
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: UnableToAttachCertificationCenterToOrganization.name,
     httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -206,6 +206,15 @@ const findAttachedCertificationCenterForAdmin = async function (request) {
   return certificationCenterSerializer.serialize(certificationCenter);
 };
 
+const attachCertificationCenter = async function (request, h) {
+  const { certificationCenterId } = request.payload;
+  const { organizationId } = request.params;
+
+  await usecases.attachCertificationCenterToOrganization({ organizationId, certificationCenterId });
+
+  return h.response().code(204);
+};
+
 const organizationAdminController = {
   getTemplateForAddTagsToOrganizations,
   addTagsToOrganizations,
@@ -228,6 +237,7 @@ const organizationAdminController = {
   findChildrenOrganizations,
   getOrganizationStatistics,
   findAttachedCertificationCenterForAdmin,
+  attachCertificationCenter,
 };
 
 export { organizationAdminController };

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -585,6 +585,38 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/organizations/{organizationId}/attach-certification-centers',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+          payload: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+        },
+        handler: (request, h) => organizationAdminController.attachCertificationCenter(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations', 'certification-centers'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, METIER, SUPPORT ou CERTIF permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet de rattacher un centre de certification à un organisation donnée.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -150,6 +150,18 @@ class StructureNotFoundError extends DomainError {
   }
 }
 
+class UnableToAttachCertificationCenterToOrganization extends DomainError {
+  constructor({
+    code = 'UNABLE_TO_ATTACH_CERTIFICATION_CENTER_TO_ORGANIZATION',
+    message = 'Unable to attach certification center to organization',
+    meta,
+  } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 export {
   AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
@@ -166,6 +178,7 @@ export {
   ParentOrganizationNotInNetworkError,
   StructureNotFoundError,
   TagNotFoundError,
+  UnableToAttachCertificationCenterToOrganization,
   UnableToAttachChildOrganizationToParentOrganizationError,
   UnableToDetachParentOrganizationFromChildOrganization,
 };

--- a/api/src/organizational-entities/domain/usecases/attach-certification-center-to-organization.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/attach-certification-center-to-organization.usecase.js
@@ -1,0 +1,69 @@
+/**
+ * @typedef {import ('./index.js').OrganizationForAdminRepository} OrganizationForAdminRepository
+ * @typedef {import ('./index.js').CertificationCenterForAdminRepository} CertificationCenterForAdminRepository
+ */
+
+import { UnableToAttachCertificationCenterToOrganization } from '../errors.js';
+
+/**
+ * @param {object} params
+ * @param {number} params.organizationId
+ * @param {number} params.certificationCenterId
+ * @param {OrganizationForAdminRepository} params.organizationForAdminRepository
+ * @param {CertificationCenterForAdminRepository} params.certificationCenterForAdminRepository
+ * @returns {Promise<void>}
+ */
+export const attachCertificationCenterToOrganization = async function ({
+  organizationId,
+  certificationCenterId,
+  organizationForAdminRepository,
+  certificationCenterForAdminRepository,
+}) {
+  const existingOrganization = await organizationForAdminRepository.exist({ organizationId });
+  if (!existingOrganization) {
+    throw new UnableToAttachCertificationCenterToOrganization({
+      code: 'ORGANIZATION_NOT_FOUND',
+      message: 'Organization not found',
+      meta: { organizationId },
+    });
+  }
+
+  const existingCertificationCenter = await certificationCenterForAdminRepository.exists({ certificationCenterId });
+
+  if (!existingCertificationCenter) {
+    throw new UnableToAttachCertificationCenterToOrganization({
+      code: 'NON_EXISTING_CERTIFICATION_CENTER',
+      message: 'Unable to attach a non existing certification center.',
+      meta: { organizationId, certificationCenterId },
+    });
+  }
+
+  const alreadyAttachedCertificationCenter =
+    await certificationCenterForAdminRepository.findAttachedByOrganizationId(organizationId);
+
+  if (alreadyAttachedCertificationCenter.length) {
+    throw new UnableToAttachCertificationCenterToOrganization({
+      code: 'ALREADY_ATTACHED_ORGANIZATION',
+      message: 'Organization already has an attached certification center',
+      meta: {
+        organizationId,
+        certificationCenterId,
+        alreadyAttachedCertificationCenterId: alreadyAttachedCertificationCenter[0].id,
+      },
+    });
+  }
+
+  const alreadyAttachedOrganization = await organizationForAdminRepository.findAttachedByCertificationCenterId({
+    certificationCenterId,
+  });
+
+  if (alreadyAttachedOrganization.length) {
+    throw new UnableToAttachCertificationCenterToOrganization({
+      code: 'ALREADY_ATTACHED_CERTIFICATION_CENTER',
+      message: 'Unable to attach a certification center already attached to another organization.',
+      meta: { organizationId, certificationCenterId, alreadyAttachedOrganizationId: alreadyAttachedOrganization[0].id },
+    });
+  }
+
+  await organizationForAdminRepository.attachCertificationCenter({ organizationId, certificationCenterId });
+};

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -87,6 +87,7 @@ import { archiveCertificationCenter } from './archive-certification-center.useca
 import { archiveCertificationCentersInBatch } from './archive-certification-centers-in-batch.usecase.js';
 import { archiveOrganization } from './archive-organization.usecase.js';
 import { archiveOrganizationsInBatch } from './archive-organizations-in-batch.usecase.js';
+import { attachCertificationCenterToOrganization } from './attach-certification-center-to-organization.usecase.js';
 import { attachChildOrganizationToOrganizationUsecase } from './attach-child-organization-to-organization.usecase.js';
 import { createCertificationCenter } from './create-certification-center.usecase.js';
 import { createNetwork } from './create-network.usecase.js';
@@ -124,6 +125,7 @@ const usecasesWithoutInjectedDependencies = {
   archiveCertificationCentersInBatch,
   archiveOrganization,
   archiveOrganizationsInBatch,
+  attachCertificationCenterToOrganization,
   attachChildOrganizationToOrganization: attachChildOrganizationToOrganizationUsecase,
   createCertificationCenter,
   createNetwork,
@@ -156,8 +158,9 @@ const usecasesWithoutInjectedDependencies = {
 };
 /**
  * @typedef OrganizationalEntitiesUsecases
- * @property {addOrganizationFeatureInBatch} addOrganizationFeatureInBatch
  * @property {attachChildOrganizationToOrganizationUsecase} attachChildOrganizationToOrganization
+ * @property {attachCertificationCenterToOrganization} attachCertificationCenterToOrganization
+ * @property {addOrganizationFeatureInBatch} addOrganizationFeatureInBatch
  * @property {createCertificationCenter} createCertificationCenter
  * @property {createTag} createTag
  * @property {detachParentOrganizationFromOrganization} detachParentOrganizationFromOrganization

--- a/api/src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js
@@ -72,7 +72,23 @@ const findAttachedByOrganizationId = async (organizationId) => {
   );
 };
 
-export { archive, findAttachedByOrganizationId, save, update };
+/**
+ * @type {function}
+ * @param {object} params
+ * @param {number} params.certificationCenterId
+ * @return {Promise<boolean>}
+ */
+const exists = async function ({ certificationCenterId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  const certificationCenter = await knexConnection('certification-centers')
+    .select('id')
+    .where({ id: certificationCenterId })
+    .first();
+
+  return Boolean(certificationCenter);
+};
+
+export { archive, exists, findAttachedByOrganizationId, save, update };
 
 function _toDomainCenterForAdmin(certificationCenterDTO) {
   return new CenterForAdmin({

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -413,6 +413,21 @@ const findAttachedByCertificationCenterId = async ({ certificationCenterId }) =>
   );
 };
 
+/**
+ * @type {function}
+ * @param {object} params
+ * @param {number} params.organizationId
+ * @param {number} params.certificationCenterId
+ * @returns {Promise<void>}
+ */
+const attachCertificationCenter = async ({ organizationId, certificationCenterId }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  await knexConn('fct_structures').where({ organization_id: organizationId }).update({
+    certification_center_id: certificationCenterId,
+  });
+};
+
 async function _addOrUpdateDataProtectionOfficer(knexConn, dataProtectionOfficer) {
   await knexConn(DATA_PROTECTION_OFFICERS_TABLE_NAME)
     .insert(dataProtectionOfficer)
@@ -590,6 +605,7 @@ function _createOrganizationLearnerType(organizationLearnerTypeId, organizationL
 
 export const organizationForAdminRepository = {
   archive,
+  attachCertificationCenter,
   createProOrganizationInvitation,
   exist,
   findAttachedByCertificationCenterId,

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1671,6 +1671,31 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       expect(response.result.data[0].type).to.equal('certification-centers');
     });
   });
+  describe('POST /api/admin/organizations/{id}/attach-certification-centers', function () {
+    it('should attach a given certification center to a given organization and return http code 204', async function () {
+      // given
+      const server = await createServer();
+
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure();
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'POST',
+        url: `/api/admin/organizations/${organization.id}/attach-certification-centers`,
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+        payload: { certificationCenterId: certificationCenterId },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
 });
 
 function _createMultipartPayload({ boundary, filename, fieldName, contentType, content }) {

--- a/api/tests/organizational-entities/integration/domain/usecases/attach-certification-center-to-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/attach-certification-center-to-organization.usecase.test.js
@@ -1,0 +1,128 @@
+import { UnableToAttachCertificationCenterToOrganization } from '../../../../../src/organizational-entities/domain/errors.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+describe('Integration | Organizational Entities | Domain | UseCase | attach-certification-center-to-organization', function () {
+  describe('success case', function () {
+    it('attaches certification center to organization', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure();
+
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.attachCertificationCenterToOrganization({
+        organizationId: organization.id,
+        certificationCenterId,
+      });
+
+      // then
+      const organizationFactStructure = await knex('fct_structures')
+        .where({ organization_id: organization.id })
+        .first();
+
+      expect(organizationFactStructure.certification_center_id).to.equal(certificationCenterId);
+    });
+  });
+
+  describe('error cases', function () {
+    context('when organization does not exist', function () {
+      it('throws an UnableToAttachCertificationCenterToOrganization error', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const unknownOrganizationId = 999;
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(usecases.attachCertificationCenterToOrganization)({
+          organizationId: unknownOrganizationId,
+          certificationCenterId: certificationCenterId,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(UnableToAttachCertificationCenterToOrganization);
+        expect(error.code).to.equal('ORGANIZATION_NOT_FOUND');
+        expect(error.meta.organizationId).to.equal(unknownOrganizationId);
+      });
+    });
+
+    context('when certification-center does not exist', function () {
+      it('throws an UnableToAttachCertificationCenterToOrganization error', async function () {
+        // given
+        const { organization } = databaseBuilder.factory.buildOrganizationWithStructure();
+        const unknownCertificationCenterId = 999;
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(usecases.attachCertificationCenterToOrganization)({
+          organizationId: organization.id,
+          certificationCenterId: unknownCertificationCenterId,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(UnableToAttachCertificationCenterToOrganization);
+        expect(error.code).to.equal('NON_EXISTING_CERTIFICATION_CENTER');
+        expect(error.meta.certificationCenterId).to.equal(unknownCertificationCenterId);
+        expect(error.meta.organizationId).to.equal(organization.id);
+      });
+    });
+
+    context('when organization is already attached to another certification center', function () {
+      it('throws an UnableToAttachCertificationCenterToOrganization error', async function () {
+        // given
+        const alreadyAttachedCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const { organization: alreadyAttachedOrganization } = databaseBuilder.factory.buildOrganizationWithStructure({
+          certificationCenterId: alreadyAttachedCertificationCenterId,
+        });
+
+        const certificationCenterToAttach = databaseBuilder.factory.buildCertificationCenter();
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(usecases.attachCertificationCenterToOrganization)({
+          organizationId: alreadyAttachedOrganization.id,
+          certificationCenterId: certificationCenterToAttach.id,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(UnableToAttachCertificationCenterToOrganization);
+        expect(error.code).to.equal('ALREADY_ATTACHED_ORGANIZATION');
+        expect(error.meta.organizationId).to.equal(alreadyAttachedOrganization.id);
+        expect(error.meta.alreadyAttachedCertificationCenterId).to.equal(alreadyAttachedCertificationCenterId);
+      });
+    });
+
+    context('when certification-center is already attached to another organization', function () {
+      it('throws an UnableToAttachCertificationCenterToOrganization error', async function () {
+        // given
+        const alreadyAttachedCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const { organization: alreadyAttachedOrganization } = databaseBuilder.factory.buildOrganizationWithStructure({
+          certificationCenterId: alreadyAttachedCertificationCenterId,
+        });
+
+        const { organization } = databaseBuilder.factory.buildOrganizationWithStructure();
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(usecases.attachCertificationCenterToOrganization)({
+          organizationId: organization.id,
+          certificationCenterId: alreadyAttachedCertificationCenterId,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(UnableToAttachCertificationCenterToOrganization);
+        expect(error.code).to.equal('ALREADY_ATTACHED_CERTIFICATION_CENTER');
+        expect(error.meta.certificationCenterId).to.equal(alreadyAttachedCertificationCenterId);
+        expect(error.meta.organizationId).to.equal(organization.id);
+        expect(error.meta.alreadyAttachedOrganizationId).to.equal(alreadyAttachedOrganization.id);
+      });
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin.repository.test.js
@@ -188,4 +188,34 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       });
     });
   });
+
+  describe('#exists', function () {
+    describe('when a given certification center exists', function () {
+      it('returns true', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        await databaseBuilder.commit();
+
+        // when
+        const result = await certificationCenterForAdminRepository.exists({ certificationCenterId });
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    describe('when a given certification center does not exist', function () {
+      it('returns false', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCenter();
+        await databaseBuilder.commit();
+
+        // when
+        const result = await certificationCenterForAdminRepository.exists({ certificationCenterId: 99 });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -2023,4 +2023,49 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       });
     });
   });
+
+  describe('#attachCertificationCenterId', function () {
+    it('attaches the certification center to the organization through its fact_structure', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure();
+
+      await databaseBuilder.commit();
+
+      // when
+      await repositories.organizationForAdminRepository.attachCertificationCenter({
+        organizationId: organization.id,
+        certificationCenterId,
+      });
+
+      // then
+      const organizationFactStructure = await knex('fct_structures')
+        .where({ organization_id: organization.id })
+        .first();
+
+      expect(organizationFactStructure.certification_center_id).to.equal(certificationCenterId);
+    });
+
+    it('does not attach certification center to another organization', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure();
+      const { organization: otherOrganization } = databaseBuilder.factory.buildOrganizationWithStructure();
+
+      await databaseBuilder.commit();
+
+      // when
+      await repositories.organizationForAdminRepository.attachCertificationCenter({
+        organizationId: organization.id,
+        certificationCenterId,
+      });
+
+      // then
+      const otherOrganizationFactStructure = await knex('fct_structures')
+        .where({ organization_id: otherOrganization.id })
+        .first();
+
+      expect(otherOrganizationFactStructure.certification_center_id).to.be.null;
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -6,6 +6,7 @@ import {
   ParentOrganizationNotInNetworkError,
   StructureNotFoundError,
   TagNotFoundError,
+  UnableToAttachCertificationCenterToOrganization,
   UnableToDetachParentOrganizationFromChildOrganization,
 } from '../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationLearnerTypeNotFound } from '../../../../src/organizational-entities/domain/errors.js';
@@ -164,6 +165,26 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       // then
       expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('Error during organization archiving');
+      expect(error.meta).to.equal(meta);
+    });
+  });
+
+  context('when mapping "UnableToAttachCertificationCenterToOrganization"', function () {
+    it('should return an UnprocessableEntityError Http Error', function () {
+      // given
+      const httpErrorMapper = organizationalEntitiesDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === UnableToAttachCertificationCenterToOrganization.name,
+      );
+
+      const meta = { organizationId: 1234, certificationCenterId: 456 };
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new UnableToAttachCertificationCenterToOrganization({ meta }));
+
+      // then
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
+      expect(error.code).to.equal('UNABLE_TO_ATTACH_CERTIFICATION_CENTER_TO_ORGANIZATION');
+      expect(error.message).to.equal('Unable to attach certification center to organization');
       expect(error.meta).to.equal(meta);
     });
   });

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
@@ -192,4 +192,56 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
       });
     });
   });
+
+  describe('POST /api/admin/organizations/{id}/attach-certification-centers', function () {
+    describe('when the user authenticated has no role', function () {
+      it('returns a 403 HTTP status code', async function () {
+        // given
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
+
+        sinon.stub(organizationAdminController, 'attachCertificationCenter');
+
+        const payload = { certificationCenterId: 42 };
+
+        // when
+        const response = await httpTestServer.request(
+          'POST',
+          '/api/admin/organizations/1/attach-certification-centers',
+          payload,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(organizationAdminController.attachCertificationCenter);
+      });
+    });
+
+    const authorizedRoles = [
+      { role: 'SuperAdmin', stub: 'checkAdminMemberHasRoleSuperAdmin' },
+      { role: 'Support', stub: 'checkAdminMemberHasRoleSupport' },
+      { role: 'Certif', stub: 'checkAdminMemberHasRoleCertif' },
+      { role: 'Metier', stub: 'checkAdminMemberHasRoleMetier' },
+    ];
+
+    authorizedRoles.forEach(({ role, stub }) => {
+      describe(`when the user has ${role} role`, function () {
+        it('should call controller method', async function () {
+          // given
+          sinon.stub(securityPreHandlers, stub).callsFake((request, h) => h.response(true));
+          securityPreHandlers.hasAtLeastOneAccessOf.callsFake((_handlers) => {
+            return () => true;
+          });
+          sinon.stub(organizationAdminController, 'attachCertificationCenter').returns('ok');
+
+          const payload = { certificationCenterId: 42 };
+
+          // when
+          await httpTestServer.request('POST', '/api/admin/organizations/1/attach-certification-centers', payload);
+
+          // then
+          sinon.assert.called(organizationAdminController.attachCertificationCenter);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🪧 Problème

On peut désormais récupérer le centre de certification rattaché à une organisation, mais il n'y a pour le moment aucun moyen d'effectuer cette action de rattachement.

## 🌈 Proposition

Créer un endpoint de type RPC (Remote Procedure Call) `/api/admin/organizations/{organizationId}/attach-certification-centers` afin d'effectuer cette action côté API.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
- Avec un curl ou client HTTP, requêter le endpoint `/api/admin/organizations/{organizationId}/attach-certification-centers` en POST avec le payload {"certificationCenterId": <id>}
- constater un code réponse 204
- naviguer sur Pix Admin sur la page de l'orga sur laquelle on a effectué l'action
- dans l'onglet Lien Certif, constater le centre rattaché

On peut tester les cas d'erreurs suivants:
- tenter de rattacher un centre de certif déjà rattaché à une autre orga
- tenter de rattacher un centre de certif qui n'existe pas

Exemple de curl
``` bash
TOKEN=$(curl -s -X POST https://admin-pr16665.review.pix.fr/api/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=password&username=superadmin@example.net&password=pix123" \
  | jq -r '.access_token') && \
curl -s -X POST https://admin-pr16665.review.pix.fr/api/admin/organizations/<ID>/attach-certification-centers \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"certificationCenterId": <ID>}' | jq
```
