### PR TITLE
[FEATURE] Restreindre l'accès aux schémas de parcours par rôle (PIX-23125)

### DIFF
--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -16,6 +16,10 @@ export default class Details extends Component {
   @service intl;
   @service currentUser;
 
+  get isSuperAdmin() {
+    return this.currentUser.adminMember.isSuperAdmin;
+  }
+
   <template>
     {{pageTitle "Profil " @model.id " | Pix Admin" replace=true}}
     <div class="page">
@@ -82,15 +86,17 @@ export default class Details extends Component {
               {{/if}}
 
             </DescriptionList>
-            <PixButtonLink
-              @route="authenticated.combined-course-blueprints.edit"
-              @model={{@model.id}}
-              @size="small"
-              @variant="primary"
-              class="combined-course-blueprint__button"
-            >
-              {{t "common.actions.edit"}}
-            </PixButtonLink>
+            {{#if this.isSuperAdmin}}
+              <PixButtonLink
+                @route="authenticated.combined-course-blueprints.edit"
+                @model={{@model.id}}
+                @size="small"
+                @variant="primary"
+                class="combined-course-blueprint__button"
+              >
+                {{t "common.actions.edit"}}
+              </PixButtonLink>
+            {{/if}}
             <h2 class="page-section__title">{{t "components.combined-course-blueprints.items.title"}}</h2>
             <div class="combined-course-blueprint__content">
               {{#each @model.content as |requirement|}}

--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -76,7 +76,7 @@ export default class Sidebar extends Component {
           </PixNavigationButton>
         {{/if}}
 
-        {{#if this.currentUser.adminMember.isSuperAdmin}}
+        {{#if (or this.currentUser.adminMember.isSuperAdmin this.currentUser.adminMember.isMetier)}}
           <PixNavigationButton
             class="sidebar__link"
             @route="authenticated.combined-course-blueprints"

--- a/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint.js
@@ -3,6 +3,11 @@ import { inject as service } from '@ember/service';
 
 export default class BlueprintRoute extends Route {
   @service store;
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier'], 'authenticated');
+  }
 
   async model(params) {
     return this.store.findRecord('combined-course-blueprint', params.combined_course_blueprint_id);

--- a/admin/app/routes/authenticated/combined-course-blueprints/edit.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/edit.js
@@ -6,7 +6,7 @@ export default class EditRoute extends Route {
   @service accessControl;
 
   beforeModel() {
-    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
+    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
   }
 
   async model(params) {

--- a/admin/app/routes/authenticated/combined-course-blueprints/list.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/list.js
@@ -3,6 +3,11 @@ import { inject as service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service store;
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier'], 'authenticated');
+  }
 
   model() {
     return this.store.findAll('combined-course-blueprint');

--- a/admin/app/routes/authenticated/combined-course-blueprints/new.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/new.js
@@ -3,6 +3,11 @@ import { inject as service } from '@ember/service';
 
 export default class NewRoute extends Route {
   @service store;
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
+  }
 
   async model() {
     const attestations = await this.store.findAll('attestation');

--- a/admin/app/templates/authenticated/combined-course-blueprints/list.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/list.gjs
@@ -1,22 +1,34 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import CombinedCourseBlueprintListSummaryItems from 'pix-admin/components/combined-course-blueprints/list-summary-items';
 
-<template>
-  <div class="page">
-    <header>
-      <h1>{{t "components.combined-course-blueprints.list.title"}}</h1>
-      <div class="page-actions">
-        <PixButtonLink @route="authenticated.combined-course-blueprints.new" @variant="secondary" @iconBefore="add">
-          {{t "components.combined-course-blueprints.create.title"}}
-        </PixButtonLink>
-      </div>
-    </header>
+export default class CombinedCourseBlueprintsList extends Component {
+  @service currentUser;
 
-    <main class="page-body">
-      <section>
-        <CombinedCourseBlueprintListSummaryItems @summaries={{@model}} />
-      </section>
-    </main>
-  </div>
-</template>
+  get isSuperAdmin() {
+    return this.currentUser.adminMember.isSuperAdmin;
+  }
+
+  <template>
+    <div class="page">
+      <header>
+        <h1>{{t "components.combined-course-blueprints.list.title"}}</h1>
+        {{#if this.isSuperAdmin}}
+          <div class="page-actions">
+            <PixButtonLink @route="authenticated.combined-course-blueprints.new" @variant="secondary" @iconBefore="add">
+              {{t "components.combined-course-blueprints.create.title"}}
+            </PixButtonLink>
+          </div>
+        {{/if}}
+      </header>
+
+      <main class="page-body">
+        <section>
+          <CombinedCourseBlueprintListSummaryItems @summaries={{@model}} />
+        </section>
+      </main>
+    </div>
+  </template>
+}

--- a/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
@@ -9,7 +9,7 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
 
   hooks.beforeEach(function () {
     const currentUser = this.owner.lookup('service:current-user');
-    currentUser.adminMember = { userId: 456 };
+    currentUser.adminMember = { userId: 456, isSuperAdmin: true };
   });
 
   test('it should display details for a combined course blueprint', async function (assert) {
@@ -44,6 +44,7 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
     assert.ok(screen.getByText('Module - abc-123', { exact: false }));
     assert.ok(screen.getByText('Profil cible - 123', { exact: false }));
     assert.ok(screen.getByRole('link', { name: t('components.combined-course-blueprints.list.downloadButton') }));
+    assert.dom(screen.queryByRole('link', { name: t('common.actions.edit') }));
     assert.ok(screen.getByText('Il faut obtenir tel niveau sur tel sujet'));
   });
 
@@ -59,6 +60,23 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
 
     // then
     assert.ok(screen.getByText(t('components.combined-course-blueprints.survey-link.not-provided')));
+  });
+
+  test('it should not display edit button when user is not super admin', async function (assert) {
+    // given
+    const currentUser = this.owner.lookup('service:current-user');
+    currentUser.adminMember = { userId: 456, isSuperAdmin: false };
+
+    const combinedCourseBlueprint = {
+      id: 123,
+      internalName: 'Modèle de parcours apprenant',
+    };
+
+    // when
+    const screen = await render(<template><Details @model={{combinedCourseBlueprint}} /></template>);
+
+    // then
+    assert.dom(screen.queryByRole('link', { name: t('common.actions.edit') })).doesNotExist();
   });
 
   test('should hide description, illustration, reward requirements if not provided', async function (assert) {

--- a/admin/tests/integration/components/layout/sidebar_test.gjs
+++ b/admin/tests/integration/components/layout/sidebar_test.gjs
@@ -195,6 +195,68 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
     });
   });
 
+  module('Combined course blueprints tab', function () {
+    module('when admin member has "SUPER_ADMIN" as role', function () {
+      test('should contain link to "Combined course blueprints" page', async function (assert) {
+        // given
+        currentUser.adminMember = superAdminMember;
+
+        // when
+        const screen = await render(<template><Sidebar /></template>);
+
+        // then
+        assert
+          .dom(screen.getByRole('link', { name: t('components.layout.sidebar.combined-course-blueprints') }))
+          .exists();
+      });
+    });
+
+    module('when admin member has "METIER" as role', function () {
+      test('should contain link to "Combined course blueprints" page', async function (assert) {
+        // given
+        currentUser.adminMember = metierMember;
+
+        // when
+        const screen = await render(<template><Sidebar /></template>);
+
+        // then
+        assert
+          .dom(screen.getByRole('link', { name: t('components.layout.sidebar.combined-course-blueprints') }))
+          .exists();
+      });
+    });
+
+    module('when admin member has "SUPPORT" as role', function () {
+      test('should not contain link to "Combined course blueprints" page', async function (assert) {
+        // given
+        currentUser.adminMember = supportMember;
+
+        // when
+        const screen = await render(<template><Sidebar /></template>);
+
+        // then
+        assert
+          .dom(screen.queryByRole('link', { name: t('components.layout.sidebar.combined-course-blueprints') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when admin member has "CERTIF" as role', function () {
+      test('should not contain link to "Combined course blueprints" page', async function (assert) {
+        // given
+        currentUser.adminMember = certifMember;
+
+        // when
+        const screen = await render(<template><Sidebar /></template>);
+
+        // then
+        assert
+          .dom(screen.queryByRole('link', { name: t('components.layout.sidebar.combined-course-blueprints') }))
+          .doesNotExist();
+      });
+    });
+  });
+
   module('Trainings tab', function () {
     module('when admin member has "SUPER_ADMIN" role', function () {
       test('should contain link to "Trainings" page', async function (assert) {

--- a/admin/tests/integration/templates/authenticated/combined-course-blueprints/list-test.gjs
+++ b/admin/tests/integration/templates/authenticated/combined-course-blueprints/list-test.gjs
@@ -9,11 +9,30 @@ module('Integration | Template | combined-course-blueprints | list', function (h
   setupIntlRenderingTest(hooks);
 
   test('it should render combined course list component', async function (assert) {
+    // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
+
     // when
     const screen = await render(<template><CombinedCourseBlueprintList /></template>);
 
     // then
     assert.ok(screen.getByRole('heading', { level: 1, name: t('components.combined-course-blueprints.list.title') }));
     assert.ok(screen.getByRole('link', { name: t('components.combined-course-blueprints.create.title') }));
+  });
+
+  test('it should not display create button when user is not super admin', async function (assert) {
+    // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: false };
+
+    // when
+    const screen = await render(<template><CombinedCourseBlueprintList /></template>);
+
+    // then
+    assert.ok(screen.getByRole('heading', { level: 1, name: t('components.combined-course-blueprints.list.title') }));
+    assert
+      .dom(screen.queryByRole('link', { name: t('components.combined-course-blueprints.create.title') }))
+      .doesNotExist();
   });
 });

--- a/admin/tests/unit/routes/authenticated/combined-course-blueprints-test.js
+++ b/admin/tests/unit/routes/authenticated/combined-course-blueprints-test.js
@@ -1,0 +1,84 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/combined-course-blueprints', function (hooks) {
+  setupTest(hooks);
+
+  module('list', function () {
+    test('it should check if current user has super admin or metier role', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course-blueprints/list');
+      const restrictAccessToStub = sinon.stub().returns();
+
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isMetier'], 'authenticated'));
+    });
+  });
+
+  module('new', function () {
+    test('it should check if current user has super admin role', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course-blueprints/new');
+      const restrictAccessToStub = sinon.stub().returns();
+
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin'], 'authenticated'));
+    });
+  });
+
+  module('edit', function () {
+    test('it should check if current user has super admin role', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course-blueprints/edit');
+      const restrictAccessToStub = sinon.stub().returns();
+
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin'], 'authenticated'));
+    });
+  });
+  module('details', function () {
+    test('it should allow metier and superadmin roles to access details page', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course-blueprints/combined-course-blueprint');
+
+      const restrictAccessToStub = sinon.stub().returns();
+
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isMetier'], 'authenticated'));
+    });
+  });
+});

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -17,8 +17,6 @@ const register = async function (server) {
               securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },
@@ -34,13 +32,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-              ])(request, h),
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
@@ -86,8 +78,6 @@ const register = async function (server) {
               securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },
@@ -180,13 +170,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-              ])(request, h),
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],

--- a/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
@@ -33,8 +33,6 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
       expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
         securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
         securityPreHandlers.checkAdminMemberHasRoleMetier,
-        securityPreHandlers.checkAdminMemberHasRoleSupport,
-        securityPreHandlers.checkAdminMemberHasRoleCertif,
       ]);
     });
   });
@@ -42,7 +40,7 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
   describe('POST /api/admin/combined-course-blueprints', function () {
     it('should call prehandler', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
       sinon.stub(combinedCourseBlueprintController, 'save').callsFake((_, h) => h.response());
 
       const payload = {
@@ -76,12 +74,7 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
       );
 
       // then
-      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
-        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-        securityPreHandlers.checkAdminMemberHasRoleMetier,
-        securityPreHandlers.checkAdminMemberHasRoleSupport,
-        securityPreHandlers.checkAdminMemberHasRoleCertif,
-      ]);
+      expect(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin).to.have.been.called;
     });
   });
 
@@ -108,8 +101,6 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
       expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
         securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
         securityPreHandlers.checkAdminMemberHasRoleMetier,
-        securityPreHandlers.checkAdminMemberHasRoleSupport,
-        securityPreHandlers.checkAdminMemberHasRoleCertif,
       ]);
     });
   });
@@ -197,7 +188,7 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
   describe('PATCH /api/admin/combined-course-blueprints/{combinedCourseBlueprintId}', function () {
     it('should call prehandler', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
       sinon.stub(combinedCourseBlueprintController, 'update').callsFake((_, h) => h.response());
 
       const combinedCourseBlueprintId = '456';
@@ -229,12 +220,7 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
       );
 
       // then
-      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
-        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-        securityPreHandlers.checkAdminMemberHasRoleMetier,
-        securityPreHandlers.checkAdminMemberHasRoleSupport,
-        securityPreHandlers.checkAdminMemberHasRoleCertif,
-      ]);
+      expect(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin).to.have.been.called;
     });
   });
 


### PR DESCRIPTION
## 🪧 Problème

On aimerait laisser le métier rattacher et détacher des orgas aux bluepritns. 
On a aussi vu que la restriction était gérée uniquement côté front parfois. 

## 🌈 Proposition
Revoir les accès en suivant cette matrice : 

Action | Super Admin | Métier | Support | Certif
-- | -- | -- | -- | --
Consulter | oui | oui | non | non
Créer | oui | non | non | non
Modifier | oui | non | non | non
Rattacher/Détacher orgas | oui | oui | non | non

On veut que la restriction soit gérée côté front et back. 

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

- [ ] Avec le rôle Super Admin : je peux voir le menu, consulter, créer, modifier, rattacher/détacher
- [ ] Avec le rôle Métier : je peux voir le menu et consulter, mais pas créer ni modifier
- [ ] Avec le rôle Support : je ne vois pas le menu "Schémas de parcours"
- [ ] Avec le rôle Certif : je ne vois pas le menu "Schémas de parcours"

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>