### PR TITLE
[TECH] Corrige le OS Health Check derrière un feature toggle.

### DIFF
--- a/api/src/shared/application/healthcheck/healthcheck-controller.js
+++ b/api/src/shared/application/healthcheck/healthcheck-controller.js
@@ -6,10 +6,11 @@ import { databaseConnections } from '../../../../db/database-connections.js';
 import packageJSON from '../../../../package.json' with { type: 'json' };
 import { config } from '../../config.js';
 import { getBaseLocale } from '../../domain/services/locale-service.js';
+import { featureToggles } from '../../infrastructure/feature-toggles/index.js';
 import * as network from '../../infrastructure/utils/network.js';
 import { redisMonitor } from '../../infrastructure/utils/redis-monitor.js';
 import { getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
-import { featureToggles } from "../../infrastructure/feature-toggles/index.js";
+import { NotFoundError } from '../errors/http-errors.js';
 
 const get = function (request) {
   const locale = getChallengeLocale(request);
@@ -58,13 +59,11 @@ const checkForwardedOriginStatus = async function (request, h) {
   return h.response(forwardedOrigin).code(200);
 };
 
-const checkOsStatus = async function (_request, h) {
-  const isOsHealthcheckEnabled = await featureToggles.get(
-    "isOsHealthcheckEnabled",
-  );
+const checkOsStatus = async function () {
+  const isOsHealthcheckEnabled = await featureToggles.get('isOsHealthcheckEnabled');
 
   if (!isOsHealthcheckEnabled) {
-    return h.response({}).code(404);
+    throw new NotFoundError();
   }
 
   return {

--- a/api/src/shared/application/healthcheck/healthcheck-controller.js
+++ b/api/src/shared/application/healthcheck/healthcheck-controller.js
@@ -9,6 +9,7 @@ import { getBaseLocale } from '../../domain/services/locale-service.js';
 import * as network from '../../infrastructure/utils/network.js';
 import { redisMonitor } from '../../infrastructure/utils/redis-monitor.js';
 import { getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
+import { featureToggles } from "../../infrastructure/feature-toggles/index.js";
 
 const get = function (request) {
   const locale = getChallengeLocale(request);
@@ -57,7 +58,15 @@ const checkForwardedOriginStatus = async function (request, h) {
   return h.response(forwardedOrigin).code(200);
 };
 
-const checkOsStatus = function () {
+const checkOsStatus = async function (_request, h) {
+  const isOsHealthcheckEnabled = await featureToggles.get(
+    "isOsHealthcheckEnabled",
+  );
+
+  if (!isOsHealthcheckEnabled) {
+    return h.response({}).code(404);
+  }
+
   return {
     type: os.type(),
     version: os.version(),

--- a/api/src/shared/application/healthcheck/index.js
+++ b/api/src/shared/application/healthcheck/index.js
@@ -1,8 +1,7 @@
-import { featureToggles } from '../../infrastructure/feature-toggles/index.js';
 import { healthcheckController } from './healthcheck-controller.js';
 
 const register = async function (server) {
-  const routes = [
+  server.route([
     {
       method: 'GET',
       path: '/api',
@@ -40,21 +39,17 @@ const register = async function (server) {
         tags: ['api', 'healthcheck'],
       },
     },
-  ];
-
-  if (await featureToggles.get('isOsHealthcheckEnabled')) {
-    routes.push({
+    {
       method: 'GET',
       path: '/api/healthcheck/os',
       config: {
         auth: false,
         handler: healthcheckController.checkOsStatus,
         tags: ['api', 'healthcheck'],
-      },
-    });
-  }
+      }
+    },
+  ]);
 
-  server.route(routes);
 };
 
 export const healthcheckRoute = { name: 'shared/healthcheck-api', register };

--- a/api/src/shared/application/healthcheck/index.js
+++ b/api/src/shared/application/healthcheck/index.js
@@ -46,10 +46,9 @@ const register = async function (server) {
         auth: false,
         handler: healthcheckController.checkOsStatus,
         tags: ['api', 'healthcheck'],
-      }
+      },
     },
   ]);
-
 };
 
 export const healthcheckRoute = { name: 'shared/healthcheck-api', register };

--- a/api/tests/shared/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/shared/unit/application/healthcheck/healthcheck-controller_test.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 
 import { healthcheckController } from '../../../../../src/shared/application/healthcheck/healthcheck-controller.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { redisMonitor } from '../../../../../src/shared/infrastructure/utils/redis-monitor.js';
 import { expect } from '../../../../test-helper.js';
 import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
@@ -54,12 +55,23 @@ describe('Unit | Controller | healthcheckController', function () {
   });
 
   describe('#checkOsStatus', function () {
-    it('should reply with OS information', function () {
+    it('should reply with OS information if feature toggle is true', async function () {
+      // given
+      sinon.stub(featureToggles, 'get').resolves(true);
+
       // when
-      const response = healthcheckController.checkOsStatus();
+      const response = await healthcheckController.checkOsStatus();
 
       // then
       expect(response).to.include.keys('type', 'version', 'platform', 'release', 'arch');
+    });
+
+    it('should throw a NotFound error if feature toggle is false', async function () {
+      // given
+      sinon.stub(featureToggles, 'get').resolves(false);
+
+      // when
+      await expect(healthcheckController.checkOsStatus()).to.be.eventually.rejected;
     });
   });
 });

--- a/api/tests/shared/unit/application/healthcheck/index_test.js
+++ b/api/tests/shared/unit/application/healthcheck/index_test.js
@@ -2,7 +2,6 @@ import sinon from 'sinon';
 
 import { healthcheckController } from '../../../../../src/shared/application/healthcheck/healthcheck-controller.js';
 import { healthcheckRoute as moduleUnderTest } from '../../../../../src/shared/application/healthcheck/index.js';
-import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect } from '../../../../test-helper.js';
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 
@@ -11,41 +10,11 @@ describe('Unit | Router | HealthcheckRouter', function () {
     it('should exist', async function () {
       // given
       sinon.stub(healthcheckController, 'get').returns('ok');
-      sinon.stub(featureToggles, 'get').resolves(false);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request('GET', '/api');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
-  describe('GET /api/healthcheck/os', function () {
-    it('should not exist when feature toggle is disabled', async function () {
-      // given
-      sinon.stub(featureToggles, 'get').resolves(false);
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/healthcheck/os');
-
-      // then
-      expect(response.statusCode).to.equal(404);
-    });
-
-    it('should exist when feature toggle is enabled', async function () {
-      // given
-      sinon.stub(featureToggles, 'get').resolves(true);
-      sinon.stub(healthcheckController, 'checkOsStatus').returns({ type: 'Linux' });
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/healthcheck/os');
 
       // then
       expect(response.statusCode).to.equal(200);


### PR DESCRIPTION
## 🪧 Problème

Dans la PR #16653, nous avons rajouté un service derrière un feature toggle.
Le problème, c'est que feature toggle conditionne l'ajout de la route au démarrage de l'application et non l'activation ou non du comportement.

## 🌈 Proposition

On déplace le check du feature toggle dans le healthcheck-controller.
