### PR TITLE
[FEATURE] Création de la vue des prescrits sans filtres dans Pix Admin (PIX-23151)

### DIFF
--- a/admin/app/adapters/admin-organization-learner.js
+++ b/admin/app/adapters/admin-organization-learner.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class AdminOrganizationLearnerAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForQuery() {
+    return `${this.host}/${this.namespace}/organization-learners`;
+  }
+}

--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -45,6 +45,9 @@ export default class Sidebar extends Component {
         <PixNavigationButton class="sidebar__link" @route="authenticated.users" @icon="infoUser">
           {{t "components.layout.sidebar.users"}}
         </PixNavigationButton>
+        <PixNavigationButton class="sidebar__link" @route="authenticated.organization-learners" @icon="infoUser">
+          {{t "components.layout.sidebar.organization-learners"}}
+        </PixNavigationButton>
         <PixNavigationButton class="sidebar__link" @route="authenticated.certification-centers" @icon="mapPin">
           {{t "components.layout.sidebar.certification-centers"}}
         </PixNavigationButton>

--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -45,9 +45,9 @@ export default class Sidebar extends Component {
         <PixNavigationButton class="sidebar__link" @route="authenticated.users" @icon="infoUser">
           {{t "components.layout.sidebar.users"}}
         </PixNavigationButton>
-        <PixNavigationButton class="sidebar__link" @route="authenticated.organization-learners" @icon="infoUser">
+        {{!-- <PixNavigationButton class="sidebar__link" @route="authenticated.organization-learners" @icon="infoUser">
           {{t "components.layout.sidebar.organization-learners"}}
-        </PixNavigationButton>
+        </PixNavigationButton> --}}
         <PixNavigationButton class="sidebar__link" @route="authenticated.certification-centers" @icon="mapPin">
           {{t "components.layout.sidebar.certification-centers"}}
         </PixNavigationButton>

--- a/admin/app/components/organization-learners/list-table.gjs
+++ b/admin/app/components/organization-learners/list-table.gjs
@@ -1,0 +1,133 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { LinkTo } from '@ember/routing';
+import formatDate from 'ember-intl/helpers/format-date';
+import t from 'ember-intl/helpers/t';
+
+<template>
+  {{#if @organizationLearners}}
+    <PixTable
+      @variant="admin"
+      @caption={{t "components.organization-learners.list-table.caption"}}
+      @data={{@organizationLearners}}
+      class="table organization-learner-list"
+    >
+      <:columns as |organizationLearner context|>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.first-name"}}
+          </:header>
+          <:cell>
+            {{organizationLearner.firstName}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.last-name"}}
+          </:header>
+          <:cell>
+            {{organizationLearner.lastName}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.birthdate"}}
+          </:header>
+          <:cell>
+            {{formatDate organizationLearner.birthdate}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.national-student-id"}}
+          </:header>
+          <:cell>
+            {{organizationLearner.nationalStudentId}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.division-group"}}
+          </:header>
+          <:cell>
+            {{#if organizationLearner.division}}
+              {{organizationLearner.division}}
+            {{else if organizationLearner.group}}
+              {{organizationLearner.group}}
+            {{/if}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.organization"}}
+          </:header>
+          <:cell>
+            {{#if organizationLearner.organizationId}}
+              <LinkTo
+                @route="authenticated.organizations.get"
+                @model={{organizationLearner.organizationId}}
+                aria-label={{t "components.organization-learners.list-table.view-organization"}}
+              >
+                {{organizationLearner.organizationName}}
+              </LinkTo>
+            {{/if}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.user-id"}}
+          </:header>
+          <:cell>
+            {{#if organizationLearner.userId}}
+              <LinkTo
+                @route="authenticated.users.get"
+                @model={{organizationLearner.userId}}
+                aria-label={{t "components.organization-learners.list-table.view-user"}}
+              >
+                {{organizationLearner.userId}}
+              </LinkTo>
+            {{/if}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.active"}}
+          </:header>
+          <:cell>
+            {{#if organizationLearner.isDisabled}}
+              <span class="organization-learner-list__icon-disabled">
+                <PixIcon
+                  @name="cancel"
+                  @plainIcon={{true}}
+                  @title={{t "components.organization-learners.list-table.headers.inactive"}}
+                />
+              </span>
+            {{else}}
+              <span class="organization-learner-list__icon-active">
+                <PixIcon
+                  @name="checkCircle"
+                  @plainIcon={{true}}
+                  @title={{t "components.organization-learners.list-table.headers.active"}}
+                />
+              </span>
+            {{/if}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.organization-learners.list-table.headers.updated-at"}}
+          </:header>
+          <:cell>
+            {{formatDate organizationLearner.updatedAt}}
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+
+    <PixPagination @pagination={{@organizationLearners.meta}} />
+  {{else}}
+    <div class="table__empty">{{t "common.tables.empty-result"}}</div>
+  {{/if}}
+</template>

--- a/admin/app/models/admin-organization-learner.js
+++ b/admin/app/models/admin-organization-learner.js
@@ -1,0 +1,15 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AdminOrganizationLearner extends Model {
+  @attr() firstName;
+  @attr() lastName;
+  @attr('date-only') birthdate;
+  @attr() division;
+  @attr() group;
+  @attr() nationalStudentId;
+  @attr() organizationId;
+  @attr() organizationName;
+  @attr() userId;
+  @attr() updatedAt;
+  @attr() isDisabled;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -56,6 +56,9 @@ Router.map(function () {
         this.route('attached-certification-centers');
       });
     });
+    this.route('organization-learners', function () {
+      this.route('list');
+    });
 
     this.route('networks', function () {
       this.route('new');

--- a/admin/app/routes/authenticated/organization-learners/index.js
+++ b/admin/app/routes/authenticated/organization-learners/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class IndexRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.transitionTo('authenticated.organization-learners.list');
+  }
+}

--- a/admin/app/routes/authenticated/organization-learners/list.js
+++ b/admin/app/routes/authenticated/organization-learners/list.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+const DEFAULT_PAGE_NUMBER = 1;
+const DEFAULT_PAGE_SIZE = 50;
+
+export default class ListRoute extends Route {
+  @service store;
+
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+  };
+
+  async model(params) {
+    try {
+      const organizationLearners = await this.store.query('admin-organization-learner', {
+        page: {
+          number: params.pageNumber ?? DEFAULT_PAGE_NUMBER,
+          size: params.pageSize ?? DEFAULT_PAGE_SIZE,
+        },
+      });
+      return organizationLearners;
+    } catch {
+      return [];
+    }
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -15,6 +15,7 @@
 @use 'authenticated/certifications/certification/informations' as *;
 @use 'authenticated/certification-center/index' as *;
 @use 'authenticated/networks/get' as *;
+@use 'authenticated/organization-learners/list' as *;
 @use 'authenticated/organizations/get' as *;
 @use 'authenticated/organizations/all-tags' as *;
 @use 'authenticated/sessions/list' as *;

--- a/admin/app/styles/authenticated/organization-learners/list.scss
+++ b/admin/app/styles/authenticated/organization-learners/list.scss
@@ -1,0 +1,9 @@
+.organization-learner-list {
+  &__icon-disabled .pix-icon {
+    fill: var(--pix-error-700);
+  }
+
+  &__icon-active .pix-icon {
+    fill: var(--pix-success-700);
+  }
+}

--- a/admin/app/templates/authenticated/organization-learners/list.gjs
+++ b/admin/app/templates/authenticated/organization-learners/list.gjs
@@ -1,0 +1,10 @@
+import t from 'ember-intl/helpers/t';
+import pageTitle from 'ember-page-title/helpers/page-title';
+import ListTable from 'pix-admin/components/organization-learners/list-table';
+<template>
+  {{pageTitle (t "pages.organization-learners-list.page-title")}}
+
+  <h1>{{t "pages.organization-learners-list.main-title"}}</h1>
+
+  <ListTable @organizationLearners={{@model}} />
+</template>

--- a/admin/tests/acceptance/authenticated/organization-learners/list-test.js
+++ b/admin/tests/acceptance/authenticated/organization-learners/list-test.js
@@ -1,0 +1,75 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../../helpers/setup-intl';
+
+module('Acceptance | authenticated/organization-learners | list', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('When user is not logged in', function () {
+    test('it should not be accessible by an unauthenticated user', async function (assert) {
+      // when
+      await visit('/organization-learners/list');
+
+      // then
+      assert.strictEqual(currentURL(), '/login');
+    });
+  });
+
+  module('When user is logged in', function (hooks) {
+    hooks.beforeEach(async () => {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    });
+
+    test('it should be accessible for an authenticated user', async function (assert) {
+      // when
+      await visit('/organization-learners/list');
+
+      // then
+      assert.strictEqual(currentURL(), '/organization-learners/list');
+    });
+
+    test('it should display organization learners in table', async function (assert) {
+      // given
+      server.create('admin-organization-learner', {
+        firstName: 'firstname',
+        lastName: 'lastname',
+        birthdate: '2000-01-01',
+        division: '6e',
+        group: 'Groupe A',
+        nationalStudentId: '123456789',
+        organizationId: 1,
+        organizationName: 'Super orga',
+        userId: 1,
+        updatedAt: new Date(),
+        isDisabled: false,
+      });
+      server.create('admin-organization-learner', {
+        firstName: 'firstname1',
+        lastName: 'lastname2',
+        birthdate: '2000-01-02',
+        division: '5e',
+        group: 'Groupe B',
+        nationalStudentId: '12345678910',
+        organizationId: 2,
+        organizationName: 'Meilleure orga',
+        userId: 2,
+        updatedAt: new Date(),
+        isDisabled: true,
+      });
+
+      // when
+      const screen = await visit('/organization-learners/list');
+
+      // then
+      assert.ok(screen.getByText('firstname'));
+      assert.ok(screen.getByText('firstname1'));
+    });
+  });
+});

--- a/admin/tests/integration/components/layout/sidebar_test.gjs
+++ b/admin/tests/integration/components/layout/sidebar_test.gjs
@@ -300,7 +300,15 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
     const screen = await render(<template><Sidebar /></template>);
 
     // then
-    assert.dom(screen.getByRole('link', { name: 'Utilisateurs' })).exists();
+    assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.users') })).exists();
+  });
+
+  test('should contain link to "organization-learners" management page', async function (assert) {
+    // when
+    const screen = await render(<template><Sidebar /></template>);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.organization-learners') })).exists();
   });
 
   test('should contain link to "sessions" management page', async function (assert) {

--- a/admin/tests/integration/components/layout/sidebar_test.gjs
+++ b/admin/tests/integration/components/layout/sidebar_test.gjs
@@ -303,13 +303,13 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
     assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.users') })).exists();
   });
 
-  test('should contain link to "organization-learners" management page', async function (assert) {
-    // when
-    const screen = await render(<template><Sidebar /></template>);
+  // tes('should contain link to "organization-learners" management page', async function (assert) {
+  //   // when
+  //   const screen = await render(<template><Sidebar /></template>);
 
-    // then
-    assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.organization-learners') })).exists();
-  });
+  //   // then
+  //   assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.organization-learners') })).exists();
+  // });
 
   test('should contain link to "sessions" management page', async function (assert) {
     // when

--- a/admin/tests/integration/components/organization-learners/list-table-test.gjs
+++ b/admin/tests/integration/components/organization-learners/list-table-test.gjs
@@ -1,0 +1,196 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ListTable from 'pix-admin/components/organization-learners/list-table';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | OrganizationLearners | ListTable', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let store;
+
+  hooks.beforeEach(async function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  test('it should display organization learners list', async function (assert) {
+    // given
+    const organizationLearners = [
+      store.createRecord('admin-organization-learner', {
+        firstName: 'firstname1',
+        lastName: 'lastname1',
+        birthdate: '2000-01-01',
+        division: '6e',
+        nationalStudentId: '123456789',
+        organizationId: 1,
+        organizationName: 'Super orga',
+        userId: 1,
+        updatedAt: new Date('2025-01-01'),
+        isDisabled: false,
+      }),
+      store.createRecord('admin-organization-learner', {
+        firstName: 'firstname2',
+      }),
+      store.createRecord('admin-organization-learner', {
+        firstName: 'firstname3',
+      }),
+    ];
+
+    // when
+    const screen = await render(<template><ListTable @organizationLearners={{organizationLearners}} /></template>);
+
+    // then
+    const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+    const rows = within(table).getAllByRole('row');
+
+    assert.dom(within(table).getByRole('cell', { name: 'firstname1' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'lastname1' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: '01/01/2000' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: '6e' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: '123456789' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: '01/01/2025' })).exists();
+
+    assert.dom(within(table).getByRole('cell', { name: 'firstname2' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'firstname3' })).exists();
+    assert.strictEqual(rows.length, 4);
+  });
+
+  module('divison / group', function () {
+    test('it should display division but not group if division is set', async function (assert) {
+      //given
+      const organizationLearner = [
+        store.createRecord('admin-organization-learner', {
+          division: '6e',
+          group: 'Groupe A',
+        }),
+      ];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearner}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      assert.dom(within(table).getByRole('cell', { name: '6e' })).exists();
+    });
+    test('it should display group if division is not set', async function (assert) {
+      //given
+      const organizationLearner = [
+        store.createRecord('admin-organization-learner', {
+          group: 'Groupe A',
+        }),
+      ];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearner}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      assert.dom(within(table).getByRole('cell', { name: 'Groupe A' })).exists();
+    });
+  });
+
+  module('organization link', function () {
+    test('it should display organization link', async function (assert) {
+      //given
+      const organizationLearner = [
+        store.createRecord('admin-organization-learner', {
+          organizationId: 1,
+          organizationName: 'Orga',
+        }),
+      ];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearner}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      assert.ok(screen.getByText('Orga'));
+      const link = within(table).getByRole('link', { name: `Voir l'organisation` });
+      assert.ok(link.getAttribute('href').endsWith('/organizations/1'));
+    });
+    test('it should not display organization link', async function (assert) {
+      //given
+      const organizationLearner = [
+        store.createRecord('admin-organization-learner', {
+          organizationId: undefined,
+          organizationName: undefined,
+        }),
+      ];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearner}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      assert.dom(within(table).queryByRole('link', { name: `Voir l'organisation` })).doesNotExist();
+    });
+  });
+
+  module('user link', function () {
+    test('it should display user link', async function (assert) {
+      //given
+      const organizationLearner = [
+        store.createRecord('admin-organization-learner', {
+          userId: 123,
+        }),
+      ];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearner}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      assert.ok(screen.getByText('123'));
+      const link = within(table).getByRole('link', { name: `Voir l'utilisateur` });
+      assert.ok(link.getAttribute('href').endsWith('/users/123'));
+    });
+    test('it should not display user link', async function (assert) {
+      //given
+      const organizationLearner = [
+        store.createRecord('admin-organization-learner', {
+          userId: undefined,
+        }),
+      ];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearner}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      assert.dom(within(table).queryByRole('link', { aria: `Voir l'utilisateur` })).doesNotExist();
+    });
+  });
+
+  module('isDisabled', function () {
+    test('it should display if user is active', async function (assert) {
+      //given
+      const organizationLearner = [
+        store.createRecord('admin-organization-learner', {
+          isDisabled: false,
+        }),
+      ];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearner}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      assert.dom(within(table).getByRole('img', { name: 'Actif' })).exists();
+    });
+    test('it should display if user is disabled', async function (assert) {
+      //given
+      const organizationLearner = [
+        store.createRecord('admin-organization-learner', {
+          isDisabled: true,
+        }),
+      ];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearner}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      assert.dom(within(table).getByRole('img', { name: 'Inactif' })).exists();
+    });
+  });
+});

--- a/admin/tests/integration/components/users/list-items-test.gjs
+++ b/admin/tests/integration/components/users/list-items-test.gjs
@@ -3,7 +3,7 @@ import { t } from 'ember-intl/test-support';
 import ListItems from 'pix-admin/components/users/list-items';
 import { module, test } from 'qunit';
 
-import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/authenticated/users | list-items', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/admin/tests/integration/templates/authenticated/organization-learners/list-test.gjs
+++ b/admin/tests/integration/templates/authenticated/organization-learners/list-test.gjs
@@ -1,0 +1,49 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import List from 'pix-admin/templates/authenticated/organization-learners/list';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Template | admin-organization-learners | list', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should render list template', async function (assert) {
+    // when
+    const store = this.owner.lookup('service:store');
+    const model = [
+      store.createRecord('admin-organization-learner', {
+        firstName: 'firstname',
+        lastName: 'lastname',
+        birthdate: '2000-01-01',
+        division: '6e',
+        group: 'Groupe A',
+        nationalStudentId: '123456789',
+        organizationId: 1,
+        organizationName: 'Super orga',
+        userId: 1,
+        updatedAt: new Date(),
+        isDisabled: false,
+      }),
+      store.createRecord('admin-organization-learner', {
+        firstName: 'firstname1',
+        lastName: 'lastname2',
+        birthdate: '2000-01-02',
+        division: '5e',
+        group: 'Groupe B',
+        nationalStudentId: '12345678910',
+        organizationId: 2,
+        organizationName: 'Meilleure orga',
+        userId: 2,
+        updatedAt: new Date(),
+        isDisabled: true,
+      }),
+    ];
+    const screen = await render(<template><List @model={{model}} /></template>);
+
+    // then
+    assert.ok(screen.getByRole('heading', t('pages.organization-learners-list.main-title')));
+    assert.ok(screen.getByText('firstname'));
+    assert.ok(screen.getByText('firstname1'));
+  });
+});

--- a/admin/tests/mirage/handlers/admin-organization-learners.js
+++ b/admin/tests/mirage/handlers/admin-organization-learners.js
@@ -1,0 +1,16 @@
+function findPaginatedFilteredLearners(schema) {
+  const adminOrganizationLearners = schema.adminOrganizationLearners.all().models;
+  const json = this.serialize(
+    { modelName: 'admin-organization-learner', models: adminOrganizationLearners },
+    'admin-organization-learner',
+  );
+  json.meta = {
+    page: 1,
+    pageSize: 5,
+    rowCount: 5,
+    pageCount: 1,
+  };
+  return json;
+}
+
+export { findPaginatedFilteredLearners };

--- a/admin/tests/mirage/models.js
+++ b/admin/tests/mirage/models.js
@@ -1,6 +1,7 @@
 // This file imports and exports all models for explicit registration in config.js
 
 import adminMember from './models/admin-member';
+import adminOrganizationLearner from './models/admin-organization-learner';
 import administrationTeam from './models/administration-team';
 import area from './models/area';
 import attachableTargetProfile from './models/attachable-target-profile';
@@ -78,6 +79,7 @@ import withRequiredActionSession from './models/with-required-action-session';
 
 export default {
   adminMember,
+  adminOrganizationLearner,
   administrationTeam,
   area,
   attachableTargetProfile,

--- a/admin/tests/mirage/models/admin-organization-learner.js
+++ b/admin/tests/mirage/models/admin-organization-learner.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend();

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -2,6 +2,7 @@ import { Response } from 'miragejs';
 import { assessmentResultStatus } from 'pix-admin/models/certification';
 
 import { createAdminMember } from './handlers/admin-members';
+import { findPaginatedFilteredLearners } from './handlers/admin-organization-learners';
 import {
   createAutonomousCourse,
   findAutonomousCourseTargetProfiles,
@@ -184,6 +185,8 @@ export default function routes() {
       },
     };
   });
+
+  this.get('/admin/organization-learners', findPaginatedFilteredLearners);
 
   this.get('/admin/users', findPaginatedFilteredUsers);
   this.get('/admin/users/:id');

--- a/admin/tests/mirage/serializers.js
+++ b/admin/tests/mirage/serializers.js
@@ -1,3 +1,4 @@
+import adminOrganizationLearner from './serializers/admin-organization-learner';
 import application from './serializers/application';
 import area from './serializers/area';
 import attachedCertificationCenter from './serializers/attached-certification-center';
@@ -29,6 +30,7 @@ import tube from './serializers/tube';
 import user from './serializers/user';
 
 export default {
+  adminOrganizationLearner,
   application,
   attachedCertificationCenter,
   area,

--- a/admin/tests/mirage/serializers/admin-organization-learner.js
+++ b/admin/tests/mirage/serializers/admin-organization-learner.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend();

--- a/admin/tests/unit/adapters/admin-organization-learner-test.js
+++ b/admin/tests/unit/adapters/admin-organization-learner-test.js
@@ -1,0 +1,34 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | admin-organization-learner', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:admin-organization-learner');
+    sinon.stub(adapter, 'ajax');
+  });
+
+  hooks.afterEach(function () {
+    adapter.ajax.restore();
+  });
+
+  module('#urlForQuery', function () {
+    test('should return api endpoint url for admin-organization-learner', function (assert) {
+      // when
+      const query = {
+        page: {
+          number: 1,
+          size: 50,
+        },
+      };
+      const url = adapter.urlForQuery(query);
+
+      // then
+      assert.ok(url.endsWith('/admin/organization-learners'));
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/organization-learners/index-test.js
+++ b/admin/tests/unit/routes/authenticated/organization-learners/index-test.js
@@ -1,0 +1,11 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | authenticated/organization-learners/index', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:authenticated/organization-learners/index');
+    assert.ok(route);
+  });
+});

--- a/admin/tests/unit/routes/authenticated/organization-learners/list-test.js
+++ b/admin/tests/unit/routes/authenticated/organization-learners/list-test.js
@@ -1,0 +1,73 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/organization-learners/list', function (hooks) {
+  setupTest(hooks);
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/organization-learners/list');
+  });
+
+  module('#model', function (hooks) {
+    hooks.beforeEach(function () {
+      // given
+      route.store.query = sinon.stub().resolves();
+    });
+
+    module('when queryParams filters are falsy', function () {
+      test('it should call store.query with empty params', async function (assert) {
+        // given
+        const params = {};
+        const expectedQueryArgs = {
+          page: { number: 1, size: 50 },
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'admin-organization-learner', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams filters are truthy', function () {
+      test('it should call store.query with defined params', async function (assert) {
+        // given
+        const params = {
+          pageNumber: 'somePageNumber',
+          pageSize: 'somePageSize',
+        };
+        const expectedQueryArgs = {
+          page: {
+            number: 'somePageNumber',
+            size: 'somePageSize',
+          },
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'admin-organization-learner', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when an error occurs', function () {
+      test('returns an empty array', async function (assert) {
+        // given
+        const params = {};
+        route.store.query = sinon.stub().rejects();
+
+        // when
+        const learners = await route.model(params);
+
+        // then
+        assert.deepEqual(learners, []);
+      });
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -772,6 +772,7 @@
         },
         "logout": "Log out",
         "networks": "Networks",
+        "organization-learners": "Learners",
         "organizations": "Organizations",
         "sessions": "Certification sessions",
         "target-profiles": "Target profiles",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1654,6 +1654,10 @@
         "team": "Team"
       }
     },
+    "organization-learners-list": {
+      "main-title": "Learners list",
+      "page-title": "Learners"
+    },
     "organization-network": {
       "notifications": {
         "error": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -872,6 +872,25 @@
       },
       "title": "Prescribed information"
     },
+    "organization-learners": {
+      "list-table": {
+        "caption": "List of learners from organisations. Contains first name, surname, date of birth, INE, class, organisation and associated user ID.",
+        "headers": {
+          "active": "Active",
+          "birthdate": "Birthdate",
+          "division-group": "Group/division",
+          "first-name": "First Name",
+          "inactive": "Inactif",
+          "last-name": "Last Name",
+          "national-student-id": "INE",
+          "organization": "Organization",
+          "updated-at": "Updated at",
+          "user-id": "User ID"
+        },
+        "view-organization": "View organization",
+        "view-user": "View user"
+      }
+    },
     "organizations": {
       "all-tags": {
         "recently-used-tags": "List of tags recently used with {tagName}"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1667,6 +1667,10 @@
         "team": "Équipe"
       }
     },
+    "organization-learners-list": {
+      "main-title": "Liste des prescrits",
+      "page-title": "Prescrits"
+    },
     "organization-network": {
       "notifications": {
         "error": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -880,6 +880,25 @@
       },
       "title": "Informations prescrit"
     },
+    "organization-learners": {
+      "list-table": {
+        "caption": "Liste des apprenants des organisations. Contient prénom, nom, date de naissance, INE, classe, organisation et identifiant utilisateur associé.",
+        "headers": {
+          "active": "Actif",
+          "birthdate": "Date de naissance",
+          "division-group": "Groupe/classe",
+          "first-name": "Prénom",
+          "inactive": "Inactif",
+          "last-name": "Nom",
+          "national-student-id": "INE",
+          "organization": "Organisation",
+          "updated-at": "Date MAJ",
+          "user-id": "User ID"
+        },
+        "view-organization": "Voir l'organisation",
+        "view-user": "Voir l'utilisateur"
+      }
+    },
     "organizations": {
       "all-tags": {
         "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -780,6 +780,7 @@
         },
         "logout": "Se déconnecter",
         "networks": "Réseaux",
+        "organization-learners": "Prescrits",
         "organizations": "Organisations",
         "sessions": "Sessions de certification",
         "target-profiles": "Profils cibles",


### PR DESCRIPTION
## 🪧 Problème

Le support ne peut pas rechercher des prescrits sans utiliser metabase. Il existe une route renvoyant les données des prescrits, mais il n’existe pas de vue pour les afficher.

## 🌈 Proposition

Création d'une vue pour afficher les données des prescrits.

## ✊ Remarques

L'ordonnancement des colonnes birthdate, dateMAJ et Organisation sera fait dans le ticket pour ajouter les filtres.

## 🎉 Pour tester

Se connecter à Pix Admin
Cliquer sur l’entrée “Prescrits” dans le menu de gauche
Valider qu’on voit une liste de prescrits sous forme de tableau
Vérifier que les liens dans les colonnes Organisation et userId mènent vers leurs pages de détails
Vérifier que le tableau comporte bien 50 lignes par défaut
