### PR TITLE
[TECH] Pouvoir exécuter les tests dans un ordre aléatoire

### DIFF
--- a/api/tests/test-random.js
+++ b/api/tests/test-random.js
@@ -1,0 +1,45 @@
+import Mocha from 'mocha';
+
+/**
+ * Permet d'exécuter les tests dans un ordre aléatoire permettant d'identifier les
+ * problèmes d'isolation des tests.
+ *
+ * Exemple d'exécution avec une seed aléatoire :
+ * npm run test:api:unit -- --require ./tests/test-random.js --bail
+ *
+ * Exemple d'exécution avec une seed fixe, nombre flottant: 0 < seed < 1 :
+ * SEED=0.12243342423 npm run test:api:unit -- --require ./tests/test-random.js --bail
+ */
+
+const run = Mocha.prototype.run;
+const each = Mocha.Suite.prototype.eachTest;
+
+const SEED = Number.parseFloat(process.env.SEED) || Math.random();
+
+// eslint-disable-next-line no-console
+console.log(`Seed: ${SEED}`);
+
+Mocha.prototype.run = function () {
+  shuffle(this.files);
+  return run.apply(this, arguments);
+};
+
+Mocha.Suite.prototype.eachTest = function () {
+  shuffle(this.tests);
+  shuffle(this.suites);
+  return each.apply(this, arguments);
+};
+
+function shuffle(array) {
+  if (array == null || !array.length) return;
+
+  let index = -1;
+  const length = array.length;
+  const lastIndex = length - 1;
+  while (++index < length) {
+    const rand = index + Math.floor(SEED * (lastIndex - index + 1));
+    const value = array[rand];
+    array[rand] = array[index];
+    array[index] = value;
+  }
+}


### PR DESCRIPTION
## 🪧 Problème

Mocha ne permet pas d'éxecuter les tests de manière aléatoire pour identifier les problèmes d'isolation des tests.

## 🌈 Proposition

Ajouter un script permettant d'exécuter les tests mocha dans un ordre aléatoire permettant d'identifier les problèmes d'isolation des tests.

Exemple d'exécution avec une seed aléatoire :
```sh
npm run test:api:unit -- --require ./tests/test-random.js --bail
```

Exemple d'exécution avec une seed fixe, nombre flottant: 0 < seed < 1 :
```sh
SEED=0.12243342423 npm run test:api:unit -- --require ./tests/test-random.js --bail
(lastIndex - index + 1));
```

## ✊ Remarques

N/A

## 🎉 Pour tester

**Lancer et noter la seed :**
```sh
MOCHA_REPORTER=spec npm run test:api:unit -- --require ./tests/test-random.js --bail
```

**Relancer avec la seed :**
```sh
SEED=XXXXXX MOCHA_REPORTER=spec npm run test:api:unit -- --require ./tests/test-random.js --bail
```

Vérifier que l'ordre est le même.