### PR TITLE
[FEATURE] Affiche l'objectif de la campagne en premier et cache les autres champs (PIX-22753)

### DIFF
--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -44,6 +44,7 @@ export default class CreateForm extends Component {
 
   get isMultipleSendingEnabled() {
     const isMulipleSendingsAllowed =
+      Boolean(this.args.campaign.course) &&
       this.isMultipleSendingAssessmentEnabled &&
       (this.isCampaignGoalAssessment || this.isCampaignGoalExam) &&
       !this.isCombinedCourseGoal;
@@ -94,7 +95,7 @@ export default class CreateForm extends Component {
   }
 
   get isTitleInputEnable() {
-    return (this.isCampaignGoalAssessment || this.isCampaignGoalExam) && !this.isCombinedCourseGoal;
+    return Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal;
   }
 
   get displayTitleField() {
@@ -106,7 +107,10 @@ export default class CreateForm extends Component {
   }
 
   get displayOwnerField() {
-    return this.isCampaignGoalAssessment || this.isCampaignGoalExam || this.isCampaignGoalProfileCollection;
+    return (
+      Boolean(this.args.campaign.course) &&
+      (this.isCampaignGoalAssessment || this.isCampaignGoalExam || this.isCampaignGoalProfileCollection)
+    );
   }
 
   get displayCourseSelection() {

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -44,10 +44,7 @@ export default class CreateForm extends Component {
 
   get isMultipleSendingEnabled() {
     const isMulipleSendingsAllowed =
-      Boolean(this.args.campaign.course) &&
-      this.isMultipleSendingAssessmentEnabled &&
-      (this.isCampaignGoalAssessment || this.isCampaignGoalExam) &&
-      !this.isCombinedCourseGoal;
+      Boolean(this.args.campaign.course) && this.isMultipleSendingAssessmentEnabled && !this.isCombinedCourseGoal;
 
     return this.isCampaignGoalProfileCollection || isMulipleSendingsAllowed;
   }

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -101,6 +101,10 @@ export default class CreateForm extends Component {
     return Boolean(this.args.campaign.course);
   }
 
+  get displayExternalUserIdField() {
+    return Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal;
+  }
+
   get displayOwnerField() {
     return this.isCampaignGoalAssessment || this.isCampaignGoalExam || this.isCampaignGoalProfileCollection;
   }
@@ -408,7 +412,7 @@ export default class CreateForm extends Component {
         </FormField>
       {{/if}}
 
-      {{#unless this.isCombinedCourseGoal}}
+      {{#if this.displayExternalUserIdField}}
         <FormField>
           <PixFieldset aria-labelledby="external-ids-label" role="radiogroup">
             <:title>{{t "pages.campaign-creation.external-id-label.question-label"}}</:title>
@@ -432,7 +436,7 @@ export default class CreateForm extends Component {
             </:content>
           </PixFieldset>
         </FormField>
-      {{/unless}}
+      {{/if}}
 
       {{#if this.wantIdPix}}
         <FormField>

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -113,6 +113,10 @@ export default class CreateForm extends Component {
     return !this.isCampaignGoalProfileCollection;
   }
 
+  get displayLandingPageInfo() {
+    return Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal;
+  }
+
   get catalogueCourseSelectionTab() {
     if (this.isCombinedCourseGoal) {
       return 'blueprint';
@@ -503,7 +507,7 @@ export default class CreateForm extends Component {
         </FormField>
       {{/if}}
 
-      {{#unless this.isCombinedCourseGoal}}
+      {{#if this.displayLandingPageInfo}}
         <FormField>
           <PixTextarea
             @id="custom-landing-page-text"
@@ -516,7 +520,7 @@ export default class CreateForm extends Component {
             <:label>{{t "pages.campaign-creation.landing-page-text.label"}}</:label>
           </PixTextarea>
         </FormField>
-      {{/unless}}
+      {{/if}}
 
       <div class="form__validation">
         <PixButton @triggerAction={{@onCancel}} @variant="secondary">

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -66,6 +66,9 @@ export default class CreateForm extends Component {
     }
   }
 
+  get isSubmitDisabled() {
+    return !(this.isCampaignGoalProfileCollection || this.args.campaign.course);
+  }
   get isCreateCampaignOfTypeExamEnabled() {
     return this.currentUser.prescriber.enableCampaignWithoutUserProfile;
   }
@@ -526,7 +529,7 @@ export default class CreateForm extends Component {
           {{t "common.actions.cancel"}}
         </PixButton>
 
-        <PixButton @type="submit">
+        <PixButton @type="submit" @isDisabled={{this.isSubmitDisabled}}>
           {{t "pages.campaign-creation.actions.create"}}
         </PixButton>
       </div>

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -97,6 +97,10 @@ export default class CreateForm extends Component {
     return (this.isCampaignGoalAssessment || this.isCampaignGoalExam) && !this.isCombinedCourseGoal;
   }
 
+  get displayTitleField() {
+    return Boolean(this.args.campaign.course);
+  }
+
   get displayOwnerField() {
     return this.isCampaignGoalAssessment || this.isCampaignGoalExam || this.isCampaignGoalProfileCollection;
   }
@@ -182,29 +186,6 @@ export default class CreateForm extends Component {
         <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark">*</abbr>
         {{t "common.form.mandatory-fields"}}
       </p>
-
-      <FormField>
-        <PixInput
-          @id="campaign-name"
-          @name="campaign-name"
-          @requiredLabel={{t "common.form.mandatory-fields-title"}}
-          type="text"
-          class="input"
-          maxlength="255"
-          {{on "change" (fn this.onChangeCampaignValue "name")}}
-          @value={{@campaign.name}}
-          required={{true}}
-          aria-required={{true}}
-        >
-          <:label>{{t "pages.campaign-creation.name.label"}}</:label>
-        </PixInput>
-
-        {{#if @errors.name}}
-          <div class="form__error error-message">
-            {{displayCampaignErrors @errors.name}}
-          </div>
-        {{/if}}
-      </FormField>
 
       <FormField>
         <:default>
@@ -323,6 +304,31 @@ export default class CreateForm extends Component {
               </div>
             {{/if}}
           </:default>
+        </FormField>
+      {{/if}}
+
+      {{#if this.displayTitleField}}
+        <FormField>
+          <PixInput
+            @id="campaign-name"
+            @name="campaign-name"
+            @requiredLabel={{t "common.form.mandatory-fields-title"}}
+            type="text"
+            class="input"
+            maxlength="255"
+            {{on "change" (fn this.onChangeCampaignValue "name")}}
+            @value={{@campaign.name}}
+            required={{true}}
+            aria-required={{true}}
+          >
+            <:label>{{t "pages.campaign-creation.name.label"}}</:label>
+          </PixInput>
+
+          {{#if @errors.name}}
+            <div class="form__error error-message">
+              {{displayCampaignErrors @errors.name}}
+            </div>
+          {{/if}}
         </FormField>
       {{/if}}
 

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -94,11 +94,11 @@ export default class CreateForm extends Component {
     return this.args.campaign.externalIdType === '';
   }
 
-  get isTitleInputEnable() {
+  get displayTitleField() {
     return Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal;
   }
 
-  get displayTitleField() {
+  get displayCampaignNameField() {
     return Boolean(this.args.campaign.course);
   }
 
@@ -319,7 +319,7 @@ export default class CreateForm extends Component {
         </FormField>
       {{/if}}
 
-      {{#if this.displayTitleField}}
+      {{#if this.displayCampaignNameField}}
         <FormField>
           <PixInput
             @id="campaign-name"
@@ -372,9 +372,7 @@ export default class CreateForm extends Component {
             </ExplanationCard>
 
           </:information>
-
         </FormField>
-
       {{/if}}
 
       {{#if this.isMultipleSendingEnabled}}
@@ -497,7 +495,7 @@ export default class CreateForm extends Component {
         </FormField>
       {{/if}}
 
-      {{#if this.isTitleInputEnable}}
+      {{#if this.displayTitleField}}
         <FormField>
           <PixInput
             @id="campaign-title"

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -94,31 +94,28 @@ export default class CreateForm extends Component {
     return this.args.campaign.externalIdType === '';
   }
 
-  get displayTitleField() {
-    return Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal;
-  }
-
   get displayCampaignNameField() {
-    return Boolean(this.args.campaign.course);
-  }
-
-  get displayExternalUserIdField() {
-    return Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal;
+    return Boolean(this.args.campaign.course) || this.isCampaignGoalProfileCollection;
   }
 
   get displayOwnerField() {
-    return (
-      Boolean(this.args.campaign.course) &&
-      (this.isCampaignGoalAssessment || this.isCampaignGoalExam || this.isCampaignGoalProfileCollection)
-    );
+    return (Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal) || this.isCampaignGoalProfileCollection;
+  }
+
+  get displayExternalUserIdField() {
+    return (Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal) || this.isCampaignGoalProfileCollection;
   }
 
   get displayCourseSelection() {
     return !this.isCampaignGoalProfileCollection;
   }
 
-  get displayLandingPageInfo() {
+  get displayTitleField() {
     return Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal;
+  }
+
+  get displayLandingPageInfo() {
+    return (Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal) || this.isCampaignGoalProfileCollection;
   }
 
   get catalogueCourseSelectionTab() {

--- a/orga/tests/acceptance/campaign-creation-catalogue-test.js
+++ b/orga/tests/acceptance/campaign-creation-catalogue-test.js
@@ -143,8 +143,8 @@ module('Acceptance | Campaign Creation (catalogue)', function (hooks) {
     test('it should allow to create a campaign of type PROFILES_COLLECTION and redirect to the newly created campaign', async function (assert) {
       // given
       const screen = await visit('/campagnes/creation-catalogue');
-      await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       await clickByName('Collecter les profils Pix des participants');
+      await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       const externalIdentifier = screen
         .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
         .closest('fieldset');

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -61,7 +61,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
     assert.strictEqual(within(fieldset).getAllByRole('radio').length, 3);
     assert.dom('button[type="submit"]').exists();
-    assert.dom('textarea').hasAttribute('maxLength', '5000');
   });
 
   test("it should display campaign's name", async function (assert) {
@@ -236,7 +235,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       test('it should explain which informations will be visible to organization-learners', async function () {
         // given
         data.campaign.type = campaignType.status;
-
+        data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
         // when
         const screen = await render(
           <template>
@@ -862,10 +861,54 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       .hasValue('Mon titre de parcours');
   });
 
+  module('landing page customization', function () {
+    test('should not display hide landing page info for combinedCourse', async function () {
+      // given
+      data.campaign.course = store.createRecord('course', { type: 'blueprint' });
+      data.campaign.type = 'COMBINED_COURSE';
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      // then
+      assert
+        .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
+        .doesNotExist();
+    });
+    test('should not display hide landing page until user select a course', async function () {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      // then
+      assert
+        .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
+        .doesNotExist();
+    });
+  });
+
   test('it should fill campaign landing page text', async function (assert) {
     // given
+    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
+    data.campaign.type = 'ASSESSMENT';
     data.campaign.customLandingPageText = 'Mon texte de landing page';
-
     // when
     const screen = await render(
       <template>

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -128,9 +128,96 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
       });
 
+      test('hides owner field if no course are selected', async function () {
+        // given
+        data.campaign.type = campaignType.status;
+
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+
+        assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
+      });
+
+      test('hides multiple sendings field if no course are selected', async function () {
+        // given
+        data.campaign.type = campaignType.status;
+        data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+        assert
+          .dom(
+            screen.queryByRole('radiogroup', {
+              name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+            }),
+          )
+          .doesNotExist();
+      });
+
+      test('it should hides campaign title', async function (assert) {
+        // given
+        data.campaign.type = 'ASSESSMENT';
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+
+        assert
+          .dom(screen.queryByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false }))
+          .doesNotExist();
+      });
+
+      test('should hides hide landing page until user select a course', async function () {
+        // when
+        const screen = await render(
+          <template>
+            <CreateForm
+              @campaign={{data.campaign}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{data.errors}}
+              @membersSortedByFullName={{data.defaultMembers}}
+            />
+          </template>,
+        );
+        // then
+        assert
+          .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
+          .doesNotExist();
+      });
+
       test(`it should have checked ${campaignType.status}`, async function (assert) {
         // given
         data.campaign.type = campaignType.status;
+        data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
+
         // when
         const screen = await render(
           <template>
@@ -149,8 +236,11 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       });
 
       test("it should display owner fields and auto complete owner field with owner's full name", async function (assert) {
-        // when
+        // given
         data.campaign.type = campaignType.status;
+        data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
+
+        // when
         const screen = await render(
           <template>
             <CreateForm
@@ -175,13 +265,8 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
       test('it should fill course fields', async function (assert) {
         // given
-        const course = store.createRecord('course', {
-          id: '1',
-          name: 'Target profile 1',
-          type: 'targetProfile',
-        });
         data.campaign.type = campaignType.status;
-        data.campaign.course = course;
+        data.campaign.course = store.createRecord('course', { type: 'targetProfile', name: 'yolo' });
 
         // when
         const screen = await render(
@@ -200,7 +285,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         assert
           .dom(
             screen.getByRole('heading', {
-              name: course.name,
+              name: data.campaign.course.name,
             }),
           )
           .exists();
@@ -208,10 +293,10 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
       test('it should fill multiple sendings fields', async function (assert) {
         // given
-        data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
         data.campaign.type = campaignType.status;
+        data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
+        data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
         data.campaign.multipleSendings = true;
-
         // when
         const screen = await render(
           <template>
@@ -260,14 +345,12 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         assert.ok(testTitleSublabel);
         assert.ok(landingPageSublabel);
       });
-    });
-
-    module(`when user choose to create a campaign of type ${campaignType.status}`, function (hooks) {
-      hooks.beforeEach(function () {
-        data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
-      });
 
       test('it should display fields for campaign title', async function (assert) {
+        // given
+        data.campaign.type = campaignType.status;
+        data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
+
         // when
         const screen = await render(
           <template>
@@ -842,7 +925,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     // given
     data.campaign.type = 'ASSESSMENT';
     data.campaign.title = 'Mon titre de parcours';
-
+    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
     // when
     const screen = await render(
       <template>
@@ -862,29 +945,11 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('landing page customization', function () {
-    test('should not display hide landing page info for combinedCourse', async function () {
+    test('should hides landing page info for combinedCourse', async function () {
       // given
       data.campaign.course = store.createRecord('course', { type: 'blueprint' });
       data.campaign.type = 'COMBINED_COURSE';
 
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      // then
-      assert
-        .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
-        .doesNotExist();
-    });
-    test('should not display hide landing page until user select a course', async function () {
       // when
       const screen = await render(
         <template>

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -42,7 +42,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     data.errors = {};
   });
 
-  test('it display campaign goals', async function (assert) {
+  test('it displays campaign goals', async function (assert) {
     // when
     const screen = await render(
       <template>
@@ -61,7 +61,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     assert.strictEqual(within(fieldset).getAllByRole('radio').length, 3);
   });
 
-  test('it disables the the submit button if no course (other than profile collection) is selected', async function () {
+  test('it disables the submit button if no course (other than profile collection) is selected', async function () {
     // when
     const screen = await render(
       <template>
@@ -80,7 +80,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     assert.dom(button).hasAria('disabled', 'true');
   });
 
-  test('it enables the the submit button profile collection is selected', async function () {
+  test('it enables the submit button profile collection is selected', async function () {
     data.campaign.type = 'PROFILES_COLLECTION';
     // when
     const screen = await render(
@@ -100,7 +100,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     assert.dom(button).doesNotHaveAria('disabled');
   });
 
-  test("it should display campaign's name", async function (assert) {
+  test("it displays campaign's name", async function (assert) {
     // given
     data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
     data.campaign.name = 'Campagne de test';
@@ -124,7 +124,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       .hasValue('Campagne de test');
   });
 
-  test('[a11y] it should display a message that some inputs are required', async function (assert) {
+  test('[a11y] it displays a message that some inputs are required', async function (assert) {
     // when
     const screen = await render(
       <template>
@@ -165,7 +165,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
       });
 
-      test('hides owner field if no course are selected', async function () {
+      test('it hides owner field if no course selected', async function () {
         // given
         data.campaign.type = campaignType.status;
 
@@ -185,7 +185,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
       });
 
-      test('hides multiple sendings field if no course are selected', async function () {
+      test('it hides multiple sendings field if no course selected', async function () {
         // given
         data.campaign.type = campaignType.status;
         data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
@@ -210,7 +210,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
           .doesNotExist();
       });
 
-      test('it should hides campaign title', async function (assert) {
+      test('it hides campaign title until user select a course', async function (assert) {
         // given
         data.campaign.type = 'ASSESSMENT';
         // when
@@ -231,7 +231,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
           .doesNotExist();
       });
 
-      test('should hides hide landing page until user select a course', async function () {
+      test('it hides landing page until user select a course', async function () {
         // when
         const screen = await render(
           <template>
@@ -250,7 +250,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
           .doesNotExist();
       });
 
-      test(`it should have checked ${campaignType.status}`, async function (assert) {
+      test(`it has ${campaignType.status} checked`, async function (assert) {
         // given
         data.campaign.type = campaignType.status;
         data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
@@ -272,7 +272,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         assert.dom(screen.getByLabelText(t(campaignType.purpose))).isChecked();
       });
 
-      test("it should display owner fields and auto complete owner field with owner's full name", async function (assert) {
+      test("it displays owner fields and auto complete owner field with owner's full name", async function (assert) {
         // given
         data.campaign.type = campaignType.status;
         data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
@@ -300,7 +300,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         assert.dom(screen.getByRole('option', { name: 'Adam Troisjour', selected: true })).exists();
       });
 
-      test('it should fill course fields', async function (assert) {
+      test('it fills course fields', async function (assert) {
         // given
         data.campaign.type = campaignType.status;
         data.campaign.course = store.createRecord('course', { type: 'targetProfile', name: 'yolo' });
@@ -328,7 +328,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
           .exists();
       });
 
-      test('it should fill multiple sendings fields', async function (assert) {
+      test('it fills multiple sendings fields', async function (assert) {
         // given
         data.campaign.type = campaignType.status;
         data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
@@ -354,7 +354,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
       });
 
-      test('it should explain which informations will be visible to organization-learners', async function () {
+      test('it explains which informations will be visible to organization-learners', async function () {
         // given
         data.campaign.type = campaignType.status;
         data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
@@ -383,7 +383,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         assert.ok(landingPageSublabel);
       });
 
-      test('it should display fields for campaign title', async function (assert) {
+      test('it displays fields for campaign title', async function (assert) {
         // given
         data.campaign.type = campaignType.status;
         data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
@@ -407,7 +407,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         assert.dom(screen.getByText(t('pages.campaign-creation.purpose.label'))).exists();
       });
 
-      test(`it should display the purpose explanation of an ${campaignType.status} campaign`, async function (assert) {
+      test(`it displays the purpose explanation of an ${campaignType.status} campaign`, async function (assert) {
         // when
         const screen = await render(
           <template>
@@ -427,7 +427,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       });
 
       module('when the user has selected a course', function () {
-        test('it should display informations about the course', async function (assert) {
+        test('it displays informations about the course', async function (assert) {
           // given
 
           const course = store.createRecord('course', {
@@ -461,7 +461,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         });
 
         module('when the user wants to select another course', function () {
-          test('it should redirect to /catalogue/targetProfile', async function (assert) {
+          test('it redirects to /catalogue/targetProfile', async function (assert) {
             // given
 
             data.campaign.course = store.createRecord('course', {
@@ -497,7 +497,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module(`when campaign is of type combined course`, function () {
-    test(`it should not display external id fields`, async function (assert) {
+    test(`it not displays external id fields`, async function (assert) {
       // given
       data.campaign.type = 'COMBINED_COURSE';
       data.campaign.course = store.createRecord('course', {
@@ -527,7 +527,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         .doesNotExist();
     });
 
-    test(`it should have checked combined course goal and not display owner fields`, async function (assert) {
+    test(`it has combined course goal checked and not display owner fields`, async function (assert) {
       const campaignType = {
         status: 'COMBINED_COURSE',
         purpose: 'pages.campaign-creation.purpose.combined-course',
@@ -561,7 +561,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       assert.dom(screen.queryByText(t('pages.campaign-creation.owner.title'))).doesNotExist();
     });
 
-    test('it should redirect to /catalogue/blueprint', async function (assert) {
+    test('it redirects to /catalogue/blueprint', async function (assert) {
       // given
 
       data.campaign.course = store.createRecord('course', {
@@ -593,7 +593,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     });
   });
 
-  test('should not display EXAM type when feature is not enable', async function () {
+  test('it not displays EXAM type when feature is not enable', async function () {
     // given
     data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: false, params: null };
 
@@ -614,7 +614,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when campaign is of type PROFILES_COLLECTION', function () {
-    test('it should have checked PROFILES_COLLECTION', async function (assert) {
+    test('it has PROFILES_COLLECTION checked', async function (assert) {
       // given
       data.campaign.type = 'PROFILES_COLLECTION';
 
@@ -634,7 +634,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.profiles-collection'))).isChecked();
     });
 
-    test('it should fill multiple sendings fields', async function (assert) {
+    test('it fills multiple sendings fields', async function (assert) {
       // given
       data.campaign.type = 'PROFILES_COLLECTION';
       data.campaign.multipleSendings = true;
@@ -661,7 +661,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when user choose to create a campaign of type PROFILES_COLLECTION', () => {
-    test('it should not display fields for campaign title and target profile', async function (assert) {
+    test('it not displays fields for campaign title and target profile', async function (assert) {
       // when
       const screen = await render(
         <template>
@@ -681,7 +681,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
     });
 
-    test('it should display fields for enabling multiple sendings', async function (assert) {
+    test('it displays fields for enabling multiple sendings', async function (assert) {
       // when
       const screen = await render(
         <template>
@@ -701,7 +701,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.info'))).exists();
     });
 
-    test('it should display the purpose explanation of a profiles collection campaign', async function (assert) {
+    test('it displays the purpose explanation of a profiles collection campaign', async function (assert) {
       // when
       const screen = await render(
         <template>
@@ -723,7 +723,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when user choose to create a campaign of type COMBINED_COURSE', () => {
-    test('it should not display fields for campaign title and target profile', async function (assert) {
+    test('it not displays fields for campaign title and target profile', async function (assert) {
       // when
 
       data.campaign.course = store.createRecord('course', {
@@ -750,7 +750,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     });
   });
 
-  test('it should fill external user ID selection (yes)', async function (assert) {
+  test('it fills external user ID selection (yes)', async function (assert) {
     // given
     data.campaign.externalIdLabel = 'Numéro étudiant';
     data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
@@ -779,7 +779,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       .hasValue('Numéro étudiant');
   });
 
-  test('it should fill external user ID selection (no)', async function (assert) {
+  test('it fills external user ID selection (no)', async function (assert) {
     // given
     data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
     data.campaign.externalIdLabel = null;
@@ -806,7 +806,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when user has not chosen yet to ask or not an external user ID', function () {
-    test('it should fill the default external user ID selection', async function (assert) {
+    test('it fills the default external user ID selection', async function (assert) {
       data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       // when
       const screen = await render(
@@ -830,7 +830,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.yes'))).isNotChecked();
     });
 
-    test('it should not display gdpr footnote', async function (assert) {
+    test('it not displays gdpr footnote', async function (assert) {
       // when
       data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
@@ -851,7 +851,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when user choose not to ask an external user ID', function () {
-    test('it should not display gdpr footnote either', async function (assert) {
+    test('it not displays gdpr footnote either', async function (assert) {
       // when
       data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
@@ -873,7 +873,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when user choose to ask an external user ID', function () {
-    test('it should display gdpr footnote', async function (assert) {
+    test('it displays gdpr footnote', async function (assert) {
       // when
       data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
@@ -893,7 +893,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       assert.dom(screen.getByText(t('pages.campaign-creation.legal-warning'))).exists();
     });
 
-    test('it set the external id as required', async function (assert) {
+    test('it sets the external id as required', async function (assert) {
       // when
       data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
@@ -958,7 +958,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     });
   });
 
-  test('it should fill campaign title', async function (assert) {
+  test('it fills campaign title', async function (assert) {
     // given
     data.campaign.type = 'ASSESSMENT';
     data.campaign.title = 'Mon titre de parcours';
@@ -982,7 +982,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('landing page customization', function () {
-    test('should hides landing page info for combinedCourse', async function () {
+    test('it hides landing page info for combinedCourse', async function () {
       // given
       data.campaign.course = store.createRecord('course', { type: 'blueprint' });
       data.campaign.type = 'COMBINED_COURSE';
@@ -1006,7 +1006,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     });
   });
 
-  test('it should fill campaign landing page text', async function (assert) {
+  test('it fills campaign landing page text', async function (assert) {
     // given
     data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
     data.campaign.type = 'ASSESSMENT';
@@ -1029,7 +1029,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       .hasValue('Mon texte de landing page');
   });
 
-  test('it should send campaign creation action when submitted', async function (assert) {
+  test('it sends campaign creation action when submitted', async function (assert) {
     // given
 
     data.campaign.course = store.createRecord('course', { name: 'targetProfile1', id: '123', type: 'targetProfile' });
@@ -1057,7 +1057,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     assert.ok(true);
   });
 
-  test('it should not display the explanation of automatic compute certificability if the feature is not activated', async function (assert) {
+  test('it not displays the explanation of automatic compute certificability if the feature is not activated', async function (assert) {
     // when
     const screen = await render(
       <template>
@@ -1076,7 +1076,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     assert.dom(screen.queryByRole('link', { name: 'Élèves' })).doesNotExist();
   });
 
-  test('it should display the explanation of automatic compute certificability if the feature is activated', async function (assert) {
+  test('it displays the explanation of automatic compute certificability if the feature is activated', async function (assert) {
     // when
     data.prescriber.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY = { active: true, params: null };
 
@@ -1098,7 +1098,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when there are errors', function () {
-    test('it should display errors messages when the campaign purpose fields is empty', async function (assert) {
+    test('it displays errors messages when the campaign purpose fields is empty', async function (assert) {
       // given
       const campaignWithErrors = EmberObject.create({
         errors: {
@@ -1131,7 +1131,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       assert.dom(screen.getByText(t('api-error-messages.campaign-creation.purpose-required'))).exists();
     });
 
-    test('it should display errors messages when the name, and external user id fields are empty', async function (assert) {
+    test('it displays errors messages when the name, and external user id fields are empty', async function (assert) {
       // given
       const campaignWithErrors = EmberObject.create({
         errors: {
@@ -1172,7 +1172,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     });
 
     ['targetProfile', 'blueprint'].forEach((error) => {
-      test(`it should display error message when the ${error} course field is empty`, async function (assert) {
+      test(`it displays error message when the ${error} course field is empty`, async function (assert) {
         // given
         const campaignWithErrors = EmberObject.create({
           errors: {

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -56,15 +56,19 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     );
 
     // then
-    assert.dom(screen.getByLabelText(t('pages.campaign-creation.name.label'), { exact: false })).exists();
+    const fieldset = screen.getByRole('radiogroup', { name: t('pages.campaign-creation.purpose.label') });
+
+    assert.strictEqual(within(fieldset).getAllByRole('radio').length, 3);
     assert.dom('button[type="submit"]').exists();
-    assert.dom('input[type=text]').hasAttribute('maxLength', '255');
     assert.dom('textarea').hasAttribute('maxLength', '5000');
   });
 
   test("it should display campaign's name", async function (assert) {
     // given
+    const store = this.owner.lookup('service:store');
+    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
     data.campaign.name = 'Campagne de test';
+    data.campaign.type = 'ASSESSMENT';
 
     // when
     const screen = await render(
@@ -915,8 +919,43 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when there are errors', function () {
-    test('it should display errors messages when the name, the campaign purpose and the external user id fields are empty', async function (assert) {
+    test('it should display errors messages when the campaign purpose fields is empty', async function (assert) {
       // given
+      const store = this.owner.lookup('service:store');
+      const campaignWithErrors = EmberObject.create({
+        errors: {
+          type: [
+            {
+              message: 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+            },
+          ],
+        },
+      });
+
+      data.errors = campaignWithErrors.errors;
+
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
+      data.campaign.type = 'ASSESSMENT';
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+      // then
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.purpose-required'))).exists();
+    });
+
+    test('it should display errors messages when the name, and external user id fields are empty', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
       const campaignWithErrors = EmberObject.create({
         errors: {
           name: [
@@ -929,16 +968,13 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
               message: 'EXTERNAL_USER_ID_IS_REQUIRED',
             },
           ],
-          type: [
-            {
-              message: 'CAMPAIGN_PURPOSE_IS_REQUIRED',
-            },
-          ],
         },
       });
 
       data.errors = campaignWithErrors.errors;
 
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
+      data.campaign.type = 'ASSESSMENT';
       // when
       const screen = await render(
         <template>
@@ -955,7 +991,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
       // then
       assert.dom(screen.getByText(t('api-error-messages.campaign-creation.name-required'))).exists();
-      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.purpose-required'))).exists();
       assert.dom(screen.getByText(t('api-error-messages.campaign-creation.external-user-id-required'))).exists();
     });
 

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -13,13 +13,14 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   setupIntlRenderingTest(hooks);
 
   const data = {};
+  let store;
   const createCampaignSpy = (event) => {
     event.preventDefault();
   };
   const cancelSpy = () => {};
 
   hooks.beforeEach(function () {
-    const store = this.owner.lookup('service:store');
+    store = this.owner.lookup('service:store');
     const prescriber = store.createRecord('prescriber', {
       firstName: 'Adam',
       lastName: 'Troisjour',
@@ -65,7 +66,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
   test("it should display campaign's name", async function (assert) {
     // given
-    const store = this.owner.lookup('service:store');
     data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
     data.campaign.name = 'Campagne de test';
     data.campaign.type = 'ASSESSMENT';
@@ -176,7 +176,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
       test('it should fill course fields', async function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const course = store.createRecord('course', {
           id: '1',
           name: 'Target profile 1',
@@ -311,7 +310,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       module('when the user has selected a course', function () {
         test('it should display informations about the course', async function (assert) {
           // given
-          const store = this.owner.lookup('service:store');
+
           const course = store.createRecord('course', {
             id: '1',
             name: 'targetProfile1',
@@ -345,7 +344,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         module('when the user wants to select another course', function () {
           test('it should redirect to /catalogue/targetProfile', async function (assert) {
             // given
-            const store = this.owner.lookup('service:store');
+
             data.campaign.course = store.createRecord('course', {
               id: '1',
               name: 'targetProfile1',
@@ -379,8 +378,37 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module(`when campaign is of type combined course`, function () {
+    test(`it should not display external id fields`, async function (assert) {
+      // given
+      data.campaign.type = 'COMBINED_COURSE';
+      data.campaign.course = store.createRecord('course', {
+        id: '1',
+        name: 'Mon schéma de parcours combiné',
+        type: 'blueprint',
+        nbModules: 3,
+        isSimplifiedAccess: true,
+      });
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.queryByRole('radiogroup', { name: t('pages.campaign-creation.external-id-label.question-label') }))
+        .doesNotExist();
+    });
+
     test(`it should have checked combined course goal and not display owner fields`, async function (assert) {
-      const store = this.owner.lookup('service:store');
       const campaignType = {
         status: 'COMBINED_COURSE',
         purpose: 'pages.campaign-creation.purpose.combined-course',
@@ -416,7 +444,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
     test('it should redirect to /catalogue/blueprint', async function (assert) {
       // given
-      const store = this.owner.lookup('service:store');
+
       data.campaign.course = store.createRecord('course', {
         id: '1',
         name: 'blueprint1',
@@ -578,7 +606,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   module('when user choose to create a campaign of type COMBINED_COURSE', () => {
     test('it should not display fields for campaign title and target profile', async function (assert) {
       // when
-      const store = this.owner.lookup('service:store');
+
       data.campaign.course = store.createRecord('course', {
         id: '1',
         name: 'Blueprint 1',
@@ -606,7 +634,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   test('it should fill external user ID selection (yes)', async function (assert) {
     // given
     data.campaign.externalIdLabel = 'Numéro étudiant';
-
+    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
     // when
     const screen = await render(
       <template>
@@ -634,8 +662,8 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
   test('it should fill external user ID selection (no)', async function (assert) {
     // given
+    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
     data.campaign.externalIdLabel = null;
-
     // when
     const screen = await render(
       <template>
@@ -660,6 +688,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
   module('when user has not chosen yet to ask or not an external user ID', function () {
     test('it should fill the default external user ID selection', async function (assert) {
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       // when
       const screen = await render(
         <template>
@@ -684,6 +713,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
     test('it should not display gdpr footnote', async function (assert) {
       // when
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
         <template>
           <CreateForm
@@ -704,6 +734,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   module('when user choose not to ask an external user ID', function () {
     test('it should not display gdpr footnote either', async function (assert) {
       // when
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
         <template>
           <CreateForm
@@ -725,6 +756,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   module('when user choose to ask an external user ID', function () {
     test('it should display gdpr footnote', async function (assert) {
       // when
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
         <template>
           <CreateForm
@@ -744,6 +776,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
     test('it set the external id as required', async function (assert) {
       // when
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
         <template>
           <CreateForm
@@ -763,6 +796,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     });
     test('it asks for external id type', async function (assert) {
       // when
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
         <template>
           <CreateForm
@@ -785,6 +819,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
     test('it updates campaign model when select a type', async function (assert) {
       // when
+      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
       const screen = await render(
         <template>
           <CreateForm
@@ -851,7 +886,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
   test('it should send campaign creation action when submitted', async function (assert) {
     // given
-    const store = this.owner.lookup('service:store');
 
     data.campaign.course = store.createRecord('course', { name: 'targetProfile1', id: '123', type: 'targetProfile' });
     const createCampaignSpy = sinon.stub();
@@ -921,7 +955,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   module('when there are errors', function () {
     test('it should display errors messages when the campaign purpose fields is empty', async function (assert) {
       // given
-      const store = this.owner.lookup('service:store');
       const campaignWithErrors = EmberObject.create({
         errors: {
           type: [
@@ -955,7 +988,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
     test('it should display errors messages when the name, and external user id fields are empty', async function (assert) {
       // given
-      const store = this.owner.lookup('service:store');
       const campaignWithErrors = EmberObject.create({
         errors: {
           name: [

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -42,7 +42,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     data.errors = {};
   });
 
-  test('it should contain inputs, attributes and validation button', async function (assert) {
+  test('it display campaign goals', async function (assert) {
     // when
     const screen = await render(
       <template>
@@ -58,9 +58,46 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
     // then
     const fieldset = screen.getByRole('radiogroup', { name: t('pages.campaign-creation.purpose.label') });
-
     assert.strictEqual(within(fieldset).getAllByRole('radio').length, 3);
-    assert.dom('button[type="submit"]').exists();
+  });
+
+  test('it disables the the submit button if no course (other than profile collection) is selected', async function () {
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    // then
+    const button = screen.getByRole('button', { name: t('pages.campaign-creation.actions.create') });
+    assert.dom(button).hasAria('disabled', 'true');
+  });
+
+  test('it enables the the submit button profile collection is selected', async function () {
+    data.campaign.type = 'PROFILES_COLLECTION';
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    // then
+    const button = screen.getByRole('button', { name: t('pages.campaign-creation.actions.create') });
+    assert.dom(button).doesNotHaveAria('disabled');
   });
 
   test("it should display campaign's name", async function (assert) {


### PR DESCRIPTION
## 🪧 Problème

Actuellement le formulaire de creation de campagne est complexe, on souhaite le simplifier et le rendre plus clair


## 🌈 Proposition

On affiche l'objectif de la campagne avec la selection du parcours en premier et on cache les champs tant que la sélection d'un parcours n'est pas faite.
- [x] Basculer le titre en dessous du bloc objectif  
- [x] Désactiver le bouton si un parcours n'est pas sélectionné

## ✊ Remarques

Les infos-bulles s’affichaient déjà à la sélection de l’objectif.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
- Aller sur la catalogue
- choisir un parcours
- voir le bloc Objectif en premier
- changer des type de parcours
- constater que les champs de personnalisation ont disparu
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
