### PR TITLE
[TECH] Afficher le chemin relative au fichier de test dans la CI

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -585,11 +585,10 @@ jobs:
           at: ~/pix
       - run:
           name: Test
-          command: npm run test:api:unit
+          command: npm run test:api:unit -- --reporter-option=showRelativePaths --reporter-option output=/home/circleci/test-results/test-results.xml
           environment:
             NODE_ENV: test
-            MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
-            MOCHA_REPORTER: mocha-junit-reporter
+            MOCHA_REPORTER: xunit
           when: always
       - store_test_results:
           path: /home/circleci/test-results
@@ -635,7 +634,7 @@ jobs:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_integration
       - run:
           name: Test
-          command: npm run test:api:integration
+          command: npm run test:api:integration -- --reporter-option=showRelativePaths --reporter-option output=/home/circleci/test-results/test-results.xml
           environment:
             NODE_ENV: test
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_integration
@@ -645,8 +644,7 @@ jobs:
             TEST_REDIS_URL: redis://localhost:6379
             TEST_IMPORT_STORAGE_ENDPOINT: http://localhost:9090
             TEST_IMPORT_STORAGE_BUCKET_NAME: pix-import-test
-            MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
-            MOCHA_REPORTER: mocha-junit-reporter
+            MOCHA_REPORTER: xunit
             MOCHA_RETRIES: 2
           when: always
       - store_test_results:
@@ -692,7 +690,7 @@ jobs:
           command: |
             circleci tests glob 'tests/**/acceptance/**/*test.js' |
             circleci tests split --split-by=filesize |
-            xargs npm run test:api:path --
+            xargs npm run test:api:path -- --reporter-option=showRelativePaths --reporter-option output=/home/circleci/test-results/test-results.xml
           environment:
             NODE_ENV: test
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_acceptance
@@ -702,8 +700,7 @@ jobs:
             TEST_REDIS_URL: redis://localhost:6379
             TEST_IMPORT_STORAGE_ENDPOINT: http://localhost:9090
             TEST_IMPORT_STORAGE_BUCKET_NAME: pix-import-test
-            MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
-            MOCHA_REPORTER: mocha-junit-reporter
+            MOCHA_REPORTER: xunit
             MOCHA_RETRIES: 2
           when: always
       - store_test_results:

--- a/api/knip.jsonc
+++ b/api/knip.jsonc
@@ -2,7 +2,6 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "entry": ["**/scripts/**/*.js", "**/*job-controller.js", "datamart/**/*.js", "db/**/*.js", "tests/**/*.{cjs,js}"],
   "ignoreDependencies": [
-    "mocha-junit-reporter", // used by .circleci/config.yml
     "pg-query-stream", // https://knexjs.org/guide/interfaces.html#streams
     "json-autotranslate", // used by api/scripts/translate-language-files.js
   ],

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -99,7 +99,6 @@
         "jsdoc-to-markdown": "^9.0.0",
         "knip": "^6.17.1",
         "mocha": "^11.7.5",
-        "mocha-junit-reporter": "^2.2.1",
         "nock": "^14.0.0",
         "nodemon": "^3.0.0",
         "npm-run-all2": "^9.0.0",
@@ -5714,16 +5713,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "license": "MIT"
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -6078,16 +6067,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-js": {
@@ -8370,13 +8349,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-builtin-module": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
@@ -9563,18 +9535,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -9750,39 +9710,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/mocha-junit-reporter": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.2.1.tgz",
-      "integrity": "sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "md5": "^2.3.0",
-        "mkdirp": "^3.0.0",
-        "strip-ansi": "^6.0.1",
-        "xml": "^1.0.1"
-      },
-      "peerDependencies": {
-        "mocha": ">=2.2.5"
-      }
-    },
-    "node_modules/mocha-junit-reporter/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/@isaacs/cliui": {

--- a/api/package.json
+++ b/api/package.json
@@ -181,7 +181,6 @@
     "jsdoc-to-markdown": "^9.0.0",
     "knip": "^6.17.1",
     "mocha": "^11.7.5",
-    "mocha-junit-reporter": "^2.2.1",
     "nock": "^14.0.0",
     "nodemon": "^3.0.0",
     "npm-run-all2": "^9.0.0",


### PR DESCRIPTION
## 🪧 Problème

Dans CircleCI, quand un test échoue, le chemin du test affiché est en absolu et quand on veut le copier on a le répertoire de la machine de la CI : 
<img width="699" height="46" alt="image" src="https://github.com/user-attachments/assets/2d9d00e5-6b3c-4d56-a421-4bbba3af0809" />


## 🌈 Proposition

Utiliser le reporter mocha de base [XUnit](https://mochajs.org/reporters/xunit/#_top) au lieu de [mocha-junit-reporter](https://github.com/michaelleeallen/mocha-junit-reporter) qui n'est **plus maintenue depuis 3 ans**.

Le reporter **XUnit de mocha** propose l'option `--reporter-option showRelativePaths` et on obtient :
<img width="560" height="44" alt="image" src="https://github.com/user-attachments/assets/4fb7a5b4-8d30-4990-95b5-206f51671231" />


✅ **Avantages :**
- On a le lien relatif du test (sans le chemin absolu CircleCI) et on peut directement **copier** le lien direct du test en échec depuis CircleCI pour le tester en local.
- On utilise un reporter supporté officiellement par mocha
- On supprime la dépendance `mocha-junit-reporter` qui n'est **plus maintenue depuis 3 ans**

ℹ️ **Changement entre les 2 reporters :**
- L'affichage des libellés de test dans Circle CI n'est pas le même (inversé), mais exactement les mêmes informations sont présentes.

**AVANT - avec mocha-junit-reporter:**
<img width="1127" height="323" alt="image" src="https://github.com/user-attachments/assets/90caa442-3cff-4045-b592-802452f8d0fe" />

**APRÈS - avec XUnit de mocha:**
<img width="1145" height="367" alt="image" src="https://github.com/user-attachments/assets/234acdb1-fc05-4fe2-9f5c-60540c3ae511" />


## 🎉 Pour tester

**Faire échouer des tests dans la CI** et vérifier dans CircleCI (voir les captures).
- CI échoue avec `mocha-junit-reporter` : [Build Circle CI](https://app.circleci.com/pipelines/gh/1024pix/pix/178357/workflows/9882b9c4-4221-47bd-94cf-edc7f6ef0f57)
- CI échoue avec `xunit` : [Build Circle CI](https://app.circleci.com/pipelines/gh/1024pix/pix/178353/workflows/55bb4475-6be5-4948-87d9-013155293f36)

**Tester manuellement le local** la génération du fichier : 
```
MOCHA_REPORTER=xunit npm run test:api:path -- tests/shared/unit/domain/models/AnswerStatus_test.js --reporter-option=showRelativePaths --reporter-option output=./test-results.xml
```
> Vérifier les chemins relatifs dans `test-results.xml`