### PR TITLE
[TECH] Ajout de deux index, les deux sur "LOWER(externalId)" des tables "certification-centers" et "organizations"

### DIFF
--- a/api/db/migrations/20260629154903_add_index_on_lower_external_id_in_table_organizations.js
+++ b/api/db/migrations/20260629154903_add_index_on_lower_external_id_in_table_organizations.js
@@ -1,0 +1,26 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'externalId';
+const INDEX_NAME = 'organizations_lower_externalid_index';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS "${INDEX_NAME}"
+    ON "${TABLE_NAME}" (LOWER("${COLUMN_NAME}"))
+  `);
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(`
+    DROP INDEX IF EXISTS "${INDEX_NAME}";
+  `);
+}

--- a/api/db/migrations/20260629154913_add_index_on_lower_external_id_in_table_certification_centers.js
+++ b/api/db/migrations/20260629154913_add_index_on_lower_external_id_in_table_certification_centers.js
@@ -1,0 +1,26 @@
+const TABLE_NAME = 'certification-centers';
+const COLUMN_NAME = 'externalId';
+const INDEX_NAME = 'certificationcenters_lower_externalid_index';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS "${INDEX_NAME}"
+    ON "${TABLE_NAME}" (LOWER("${COLUMN_NAME}"))
+  `);
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(`
+    DROP INDEX IF EXISTS "${INDEX_NAME}";
+  `);
+}


### PR DESCRIPTION
## 🪧 Problème

Des requêtes sont plus lentes que ce qu'elle ne devrait l'être car on trouve souvent dans le code des recherches insensibles à la casse par `externalId` dans les tables `certification-centers` et `organizations`. Mais aucun index n'existe dans ce sens-là.
On pense notamment à la requête de récupération des résultats pour le LSU

## 🌈 Proposition

Ajout des migrations pour les index

## ✊ Remarques

L'adaptation des requêtes dans la codebase pour faire usage de ces index sera fait dans une PR ultérieure

## 🎉 Pour tester
Run les migrations
constater l'existence des index
rollback
constater la disparition
✅ 
