### PR TITLE
[FEATURE] Renommer les onglets du catalogue (PIX-23386)

### DIFF
--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1073,9 +1073,9 @@
       },
       "tab-filters": {
         "all": "Alle",
-        "blueprints": "Lernpfade",
+        "blueprints": "Lernen",
         "label": "Kurstyp",
-        "target-profiles": "Kurse"
+        "target-profiles": "Assessment"
       },
       "title": "Kurskatalog"
     },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1073,9 +1073,9 @@
       },
       "tab-filters": {
         "all": "All",
-        "blueprints": "Learning courses",
+        "blueprints": "Learning",
         "label": "Course type",
-        "target-profiles": "Courses"
+        "target-profiles": "Assessment"
       },
       "title": "Courses catalogue"
     },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1073,9 +1073,9 @@
       },
       "tab-filters": {
         "all": "Todos",
-        "blueprints": "Rutas de aprendizaje",
+        "blueprints": "Aprendizaje",
         "label": "Tipo de curso",
-        "target-profiles": "Cursos"
+        "target-profiles": "Evaluación"
       },
       "title": "Catálogo de cursos"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1073,9 +1073,9 @@
       },
       "tab-filters": {
         "all": "Tous",
-        "blueprints": "Parcours apprenants",
+        "blueprints": "Apprentissage",
         "label": "Type de parcours",
-        "target-profiles": "Parcours"
+        "target-profiles": "Évaluation"
       },
       "title": "Catalogue de parcours"
     },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1073,9 +1073,9 @@
       },
       "tab-filters": {
         "all": "Tutti",
-        "blueprints": "Percorsi di apprendimento",
+        "blueprints": "Apprendimento",
         "label": "Tipo di percorso",
-        "target-profiles": "Percorsi"
+        "target-profiles": "Valutazione"
       },
       "title": "Catalogo dei percorsi"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1073,9 +1073,9 @@
       },
       "tab-filters": {
         "all": "Alle",
-        "blueprints": "Leertrajecten",
+        "blueprints": "Leren",
         "label": "Type traject",
-        "target-profiles": "Trajecten"
+        "target-profiles": "Evaluatie"
       },
       "title": "Overzicht van leertrajecten"
     },


### PR DESCRIPTION
## 🪧 Problème
L’utilisation du terme “parcours” dans les deux onglets peut poser des problèmes de compréhension.

## 🌈 Proposition

<img width="945" height="581" alt="image" src="https://github.com/user-attachments/assets/92011b8f-f982-42d3-85e9-32e09d4c0581" />

## 🎉 Pour tester
Se connecter à Pix Orga (.org) et vérifier les libellés des onglets du catalogue
