### PR TITLE
[TECH] Utiliser api/admin comme namespace par défaut dans les adapters de admin

### DIFF
--- a/admin/app/adapters/admin-member.js
+++ b/admin/app/adapters/admin-member.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class AdminMemberAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQueryRecord(query) {
     if (query.me) {
       delete query.me;

--- a/admin/app/adapters/administration-team.js
+++ b/admin/app/adapters/administration-team.js
@@ -1,5 +1,0 @@
-import ApplicationAdapter from './application';
-
-export default class AdministrationTeam extends ApplicationAdapter {
-  namespace = 'api/admin';
-}

--- a/admin/app/adapters/announcement.js
+++ b/admin/app/adapters/announcement.js
@@ -2,6 +2,6 @@ import ApplicationAdapter from './application';
 
 export default class AnnouncementAdapter extends ApplicationAdapter {
   urlForUpdateRecord(id) {
-    return `${this.host}/${this.namespace}/admin/announcements/${id}`;
+    return `${this.host}/${this.namespace}/announcements/${id}`;
   }
 }

--- a/admin/app/adapters/application.js
+++ b/admin/app/adapters/application.js
@@ -7,7 +7,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
   @service session;
 
   host = ENV.APP.API_HOST;
-  namespace = 'api';
+  namespace = 'api/admin';
 
   get headers() {
     const headers = {};

--- a/admin/app/adapters/attached-certification-center.js
+++ b/admin/app/adapters/attached-certification-center.js
@@ -4,6 +4,6 @@ export default class AttachedCertificationCenterAdapter extends ApplicationAdapt
   urlForQuery(query) {
     const { organizationId } = query;
     delete query.organizationId;
-    return `${this.host}/${this.namespace}/admin/organizations/${organizationId}/certification-centers`;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/certification-centers`;
   }
 }

--- a/admin/app/adapters/attached-organization.js
+++ b/admin/app/adapters/attached-organization.js
@@ -4,6 +4,6 @@ export default class AttachedOrganizationAdapter extends ApplicationAdapter {
   urlForQuery(query) {
     const { certificationCenterId } = query;
     delete query.certificationCenterId;
-    return `${this.host}/${this.namespace}/admin/certification-centers/${certificationCenterId}/organizations`;
+    return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/organizations`;
   }
 }

--- a/admin/app/adapters/attestation.js
+++ b/admin/app/adapters/attestation.js
@@ -1,5 +1,0 @@
-import ApplicationAdapter from './application';
-
-export default class AttestationAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-}

--- a/admin/app/adapters/authentication-method.js
+++ b/admin/app/adapters/authentication-method.js
@@ -13,7 +13,7 @@ export default class AuthenticationMethodAdapter extends ApplicationAdapter {
         },
       };
 
-      const url = `${this.host}/${this.namespace}/admin/users/${snapshot.adapterOptions.originUserId}/authentication-methods/${snapshot.id}`;
+      const url = `${this.host}/${this.namespace}/users/${snapshot.adapterOptions.originUserId}/authentication-methods/${snapshot.id}`;
 
       return this.ajax(url, 'POST', payload);
     }

--- a/admin/app/adapters/autonomous-course-target-profile.js
+++ b/admin/app/adapters/autonomous-course-target-profile.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class AutonomousCourseTargetProfileAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForFindAll() {
     return `${this.host}/${this.namespace}/autonomous-courses/target-profiles`;
   }

--- a/admin/app/adapters/autonomous-course.js
+++ b/admin/app/adapters/autonomous-course.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class AutonomousCourseAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   updateRecord(store, type, snapshot) {
     const data = {};
     const serializer = store.serializerFor(type.modelName);

--- a/admin/app/adapters/badge-criterion.js
+++ b/admin/app/adapters/badge-criterion.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class BadgeCriterionAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForCreateRecord(_modelName, badgeCriterion) {
     return `${this.host}/${this.namespace}/badges/${badgeCriterion.belongsTo('badge').id}/badge-criteria`;
   }

--- a/admin/app/adapters/badge.js
+++ b/admin/app/adapters/badge.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class BadgeAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForCreateRecord(modelName, { adapterOptions: { targetProfileId } }) {
     return `${this.host}/${this.namespace}/target-profiles/${targetProfileId}/badges`;
   }

--- a/admin/app/adapters/campaign-participation.js
+++ b/admin/app/adapters/campaign-participation.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CampaignParticipations extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery(query) {
     const baseUrl = this.buildURL();
     const url = `${baseUrl}/campaigns/${query.campaignId}/participations`;

--- a/admin/app/adapters/campaign.js
+++ b/admin/app/adapters/campaign.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class Campaigns extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery(query) {
     const baseUrl = this.buildURL();
     const url = `${baseUrl}/organizations/${query.organizationId}/campaigns`;

--- a/admin/app/adapters/certification-candidate-timeline.js
+++ b/admin/app/adapters/certification-candidate-timeline.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationCandidateTimelineAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQueryRecord(query) {
     const { candidateId } = query;
     if (candidateId) {

--- a/admin/app/adapters/certification-candidate.js
+++ b/admin/app/adapters/certification-candidate.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationCandidateAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery(query) {
     const sessionId = query.sessionId;
     if (sessionId) {

--- a/admin/app/adapters/certification-center-invitation.js
+++ b/admin/app/adapters/certification-center-invitation.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationCenterInvitationAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   queryRecord(store, type, query) {
     if (query.certificationCenterId) {
       const url = `${this.host}/${this.namespace}/certification-centers/${query.certificationCenterId}/invitations`;

--- a/admin/app/adapters/certification-center-membership.js
+++ b/admin/app/adapters/certification-center-membership.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationCenterMembershipAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery(query) {
     if (query.filter.certificationCenterId) {
       const { certificationCenterId } = query.filter;

--- a/admin/app/adapters/certification-center.js
+++ b/admin/app/adapters/certification-center.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationCenterAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   archiveCertificationCenter(certificationCenterId) {
     return this.ajax(`${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/archive`, 'POST');
   }

--- a/admin/app/adapters/certification-centers-batch-archive.js
+++ b/admin/app/adapters/certification-centers-batch-archive.js
@@ -4,7 +4,7 @@ export default class CertificationCentersBatchArchiveAdapter extends Application
   archiveCertificationCenters(files) {
     if (!files || files.length === 0) return;
 
-    const url = `${this.host}/${this.namespace}/admin/certification-centers/batch-archive`;
+    const url = `${this.host}/${this.namespace}/certification-centers/batch-archive`;
     return this.ajax(url, 'POST', { data: files[0] });
   }
 }

--- a/admin/app/adapters/certification-details.js
+++ b/admin/app/adapters/certification-details.js
@@ -2,15 +2,15 @@ import ApplicationAdapter from './application';
 
 export default class CertificationDetails extends ApplicationAdapter {
   urlForFindRecord(id) {
-    return `${this.host}/${this.namespace}/admin/certifications/${id}/details`;
+    return `${this.host}/${this.namespace}/certifications/${id}/details`;
   }
 
   urlForNeutralizeChallenge() {
-    return `${this.host}/${this.namespace}/admin/certification/neutralize-challenge`;
+    return `${this.host}/${this.namespace}/certification/neutralize-challenge`;
   }
 
   urlForDeneutralizeChallenge() {
-    return `${this.host}/${this.namespace}/admin/certification/deneutralize-challenge`;
+    return `${this.host}/${this.namespace}/certification/deneutralize-challenge`;
   }
 
   updateRecord(store, type, snapshot) {

--- a/admin/app/adapters/certification-framework.js
+++ b/admin/app/adapters/certification-framework.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationFrameworkAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForFindRecord(id) {
     return `${this.host}/${this.namespace}/certification-frameworks/${id}/target-profiles`;
   }

--- a/admin/app/adapters/certification-issue-report.js
+++ b/admin/app/adapters/certification-issue-report.js
@@ -1,10 +1,10 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationIssueReportAdapter extends ApplicationAdapter {
-  namespace = 'api/';
+  namespace = 'api';
 
   urlForUpdateRecord(certificationIssueReportId) {
-    return `${this.host}/api/certification-issue-reports/${certificationIssueReportId}`;
+    return `${this.host}/${this.namespace}/certification-issue-reports/${certificationIssueReportId}`;
   }
 
   updateRecord(store, type, snapshot) {

--- a/admin/app/adapters/certification-version.js
+++ b/admin/app/adapters/certification-version.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationVersionAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   updateRecord(store, type, snapshot) {
     const certificationVersionId = snapshot.id;
     const url = `${this.host}/${this.namespace}/certification-versions/${certificationVersionId}`;

--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -2,43 +2,43 @@ import ApplicationAdapter from './application';
 
 export default class Certification extends ApplicationAdapter {
   urlForFindRecord(id) {
-    return `${this.host}/${this.namespace}/admin/certifications/${id}`;
+    return `${this.host}/${this.namespace}/certifications/${id}`;
   }
 
   urlForUpdateJuryComment(id) {
-    return `${this.host}/${this.namespace}/admin/certification-courses/${id}/assessment-results`;
+    return `${this.host}/${this.namespace}/certification-courses/${id}/assessment-results`;
   }
 
   urlForUpdateRecord(certificationCourseId) {
-    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}`;
+    return `${this.host}/${this.namespace}/certification-courses/${certificationCourseId}`;
   }
 
   urlForCancelCertification(certificationCourseId) {
-    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/cancel`;
+    return `${this.host}/${this.namespace}/certification-courses/${certificationCourseId}/cancel`;
   }
 
   urlForUncancelCertification(certificationCourseId) {
-    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/uncancel`;
+    return `${this.host}/${this.namespace}/certification-courses/${certificationCourseId}/uncancel`;
   }
 
   urlForRejectCertification(certificationCourseId) {
-    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/reject`;
+    return `${this.host}/${this.namespace}/certification-courses/${certificationCourseId}/reject`;
   }
 
   urlForUnrejectCertification(certificationCourseId) {
-    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/unreject`;
+    return `${this.host}/${this.namespace}/certification-courses/${certificationCourseId}/unreject`;
   }
 
   urlForEduExternalJuryResult(certificationCourseId) {
-    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/edu-v3-external-jury-result`;
+    return `${this.host}/${this.namespace}/certification-courses/${certificationCourseId}/edu-v3-external-jury-result`;
   }
 
   urlForEditJuryLevel() {
-    return `${this.host}/${this.namespace}/admin/complementary-certification-course-results`;
+    return `${this.host}/${this.namespace}/complementary-certification-course-results`;
   }
 
   rescoreCertification({ certificationCourseId }) {
-    const path = `${this.host}/${this.namespace}/admin/certifications/${certificationCourseId}/rescore`;
+    const path = `${this.host}/${this.namespace}/certifications/${certificationCourseId}/rescore`;
     return this.ajax(path, 'POST');
   }
 

--- a/admin/app/adapters/certified-profile.js
+++ b/admin/app/adapters/certified-profile.js
@@ -2,6 +2,6 @@ import ApplicationAdapter from './application';
 
 export default class CertificationDetails extends ApplicationAdapter {
   urlForFindRecord(id) {
-    return `${this.host}/${this.namespace}/admin/certifications/${id}/certified-profile`;
+    return `${this.host}/${this.namespace}/certifications/${id}/certified-profile`;
   }
 }

--- a/admin/app/adapters/combined-course-blueprint.js
+++ b/admin/app/adapters/combined-course-blueprint.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class CombinedCourseBlueprintAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   async detachOrganizations(combinedCourseBlueprintId, organizationId) {
     const url = `${this.host}/${this.namespace}/combined-course-blueprints/${combinedCourseBlueprintId}/organizations/${organizationId}`;
     await this.ajax(url, 'DELETE');

--- a/admin/app/adapters/complementary-certification.js
+++ b/admin/app/adapters/complementary-certification.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class ComplementaryCertificationAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForFindRecord(id, modelName, snapshot) {
     const key = snapshot.attr('key');
     return `${this.host}/${this.namespace}/complementary-certifications/${key}/target-profiles`;

--- a/admin/app/adapters/country.js
+++ b/admin/app/adapters/country.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class CountryAdapter extends ApplicationAdapter {
+  namespace = 'api';
+}

--- a/admin/app/adapters/feature-toggle.js
+++ b/admin/app/adapters/feature-toggle.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class FeatureToggleAdapter extends ApplicationAdapter {
+  namespace = 'api';
+}

--- a/admin/app/adapters/framework-history.js
+++ b/admin/app/adapters/framework-history.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class FrameworkHistoryAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   queryRecord(store, type, scope) {
     const url = `${this.host}/${this.namespace}/certification-frameworks/${scope}/framework-history`;
     return this.ajax(url, 'GET');

--- a/admin/app/adapters/framework.js
+++ b/admin/app/adapters/framework.js
@@ -1,5 +1,0 @@
-import ApplicationAdapter from './application';
-
-export default class FrameworkAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-}

--- a/admin/app/adapters/import-files.js
+++ b/admin/app/adapters/import-files.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class ImportFilesAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   importCampaignsToArchive(files) {
     if (!files || files.length === 0) return;
 

--- a/admin/app/adapters/learning-content-cache.js
+++ b/admin/app/adapters/learning-content-cache.js
@@ -1,6 +1,7 @@
 import ApplicationAdapter from './application';
 
 export default class LearningContentCache extends ApplicationAdapter {
+  namespace = 'api';
   refreshCacheEntries() {
     const url = `${this.host}/${this.namespace}/cache`;
     return this.ajax(url, 'PATCH');

--- a/admin/app/adapters/module-metadata.js
+++ b/admin/app/adapters/module-metadata.js
@@ -2,6 +2,6 @@ import ApplicationAdapter from './application';
 
 export default class ModuleMetadata extends ApplicationAdapter {
   urlForFindAll() {
-    return `${this.host}/${this.namespace}/admin/modules-metadata`;
+    return `${this.host}/${this.namespace}/modules-metadata`;
   }
 }

--- a/admin/app/adapters/module.js
+++ b/admin/app/adapters/module.js
@@ -1,6 +1,7 @@
 import ApplicationAdapter from './application';
 
 export default class Module extends ApplicationAdapter {
+  namespace = 'api';
   urlForFindRecord(id) {
     return `${this.host}/${this.namespace}/modules/v2/${id}`;
   }

--- a/admin/app/adapters/network.js
+++ b/admin/app/adapters/network.js
@@ -1,5 +1,0 @@
-import ApplicationAdapter from './application';
-
-export default class NetworkAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-}

--- a/admin/app/adapters/oidc-identity-provider.js
+++ b/admin/app/adapters/oidc-identity-provider.js
@@ -1,6 +1,8 @@
 import ApplicationAdapter from './application';
 
 export default class OidcIdentityProviderAdapter extends ApplicationAdapter {
+  namespace = 'api';
+
   urlForFindAll(_, snapshot) {
     if (snapshot.adapterOptions?.readyIdentityProviders) {
       return `${this.host}/${this.namespace}/oidc/identity-providers`;

--- a/admin/app/adapters/organization-invitation.js
+++ b/admin/app/adapters/organization-invitation.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class OrganizationInvitation extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForCreateRecord(modelName, { adapterOptions }) {
     const { organizationId } = adapterOptions;
 

--- a/admin/app/adapters/organization-learner-import-format.js
+++ b/admin/app/adapters/organization-learner-import-format.js
@@ -1,5 +1,0 @@
-import ApplicationAdapter from './application';
-
-export default class OrganizationLearnerImportFormat extends ApplicationAdapter {
-  namespace = 'api/admin';
-}

--- a/admin/app/adapters/organization-learner-type.js
+++ b/admin/app/adapters/organization-learner-type.js
@@ -1,5 +1,0 @@
-import ApplicationAdapter from './application';
-
-export default class OrganizationLearnerTypeAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-}

--- a/admin/app/adapters/organization-learner.js
+++ b/admin/app/adapters/organization-learner.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class OrganizationLearnerAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForDeleteRecord(id, _, snapshot) {
     return `${this.host}/${this.namespace}/organizations/${snapshot.attr('organizationId')}/organization-learners/${id}`;
   }

--- a/admin/app/adapters/organization-membership.js
+++ b/admin/app/adapters/organization-membership.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class OrganizationMembershipAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery(query) {
     if (query.filter?.organizationId) {
       const { organizationId } = query.filter;

--- a/admin/app/adapters/organization-place.js
+++ b/admin/app/adapters/organization-place.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class OrganizationPlaceAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery(query) {
     const organizationId = query.organizationId;
     delete query.organizationId;

--- a/admin/app/adapters/organization-places-statistic.js
+++ b/admin/app/adapters/organization-places-statistic.js
@@ -5,6 +5,6 @@ export default class PlacesStatisticsAdapter extends ApplicationAdapter {
     const { organizationId } = query;
     delete query.organizationId;
 
-    return `${this.host}/${this.namespace}/admin/organizations/${organizationId}/places-statistics`;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/places-statistics`;
   }
 }

--- a/admin/app/adapters/organization-statistic.js
+++ b/admin/app/adapters/organization-statistic.js
@@ -5,6 +5,6 @@ export default class OrganizationStatisticsAdapter extends ApplicationAdapter {
     const { organizationId } = query;
     delete query.organizationId;
 
-    return `${this.host}/${this.namespace}/admin/organizations/${organizationId}/statistics`;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/statistics`;
   }
 }

--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class OrganizationAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   updateRecord(store, type, snapshot) {
     if (snapshot?.adapterOptions?.archiveOrganization) {
       const url = `${this.host}/${this.namespace}/organizations/${snapshot.id}/archive`;

--- a/admin/app/adapters/organizations-import.js
+++ b/admin/app/adapters/organizations-import.js
@@ -4,7 +4,7 @@ export default class OrganizationsImportAdapter extends ApplicationAdapter {
   addOrganizationsCsv(files) {
     if (!files || files.length === 0) return;
 
-    const url = `${this.host}/${this.namespace}/admin/organizations/import-csv`;
+    const url = `${this.host}/${this.namespace}/organizations/import-csv`;
     return this.ajax(url, 'POST', { data: files[0] });
   }
 }

--- a/admin/app/adapters/sco-blocked-access-date.js
+++ b/admin/app/adapters/sco-blocked-access-date.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class ScoBlockedAccessDatesAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForFindAll() {
     return `${this.host}/${this.namespace}/sco-blocked-access-dates`;
   }

--- a/admin/app/adapters/scoring-and-capacity-simulator-report.js
+++ b/admin/app/adapters/scoring-and-capacity-simulator-report.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class ScoringAndCapacitySimulatorReportAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   getSimulatorResult({ score, capacity, date }) {
     let data;
     if (score) {

--- a/admin/app/adapters/session.js
+++ b/admin/app/adapters/session.js
@@ -2,7 +2,7 @@ import ApplicationAdapter from './application';
 
 export default class SessionAdapter extends ApplicationAdapter {
   urlForQuery() {
-    return `${this.host}/${this.namespace}/admin/sessions`;
+    return `${this.host}/${this.namespace}/sessions`;
   }
 
   findHasMany(store, snapshot, url, relationship) {
@@ -19,15 +19,15 @@ export default class SessionAdapter extends ApplicationAdapter {
   }
 
   urlForFindRecord(id) {
-    return `${this.host}/${this.namespace}/admin/sessions/${id}`;
+    return `${this.host}/${this.namespace}/sessions/${id}`;
   }
 
   urlForUpdateRecord(id) {
-    return `${this.host}/${this.namespace}/admin/sessions/${id}`;
+    return `${this.host}/${this.namespace}/sessions/${id}`;
   }
 
   getDownloadLink({ id, lang }) {
-    const link = `${this.host}/${this.namespace}/admin/sessions/${id}/generate-results-download-link?lang=${lang}`;
+    const link = `${this.host}/${this.namespace}/sessions/${id}/generate-results-download-link?lang=${lang}`;
     return this.ajax(link, 'GET');
   }
 

--- a/admin/app/adapters/stage-collection.js
+++ b/admin/app/adapters/stage-collection.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class StageCollectionAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   updateRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
     const payload = this.serialize(snapshot);

--- a/admin/app/adapters/stage.js
+++ b/admin/app/adapters/stage.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class StageAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   deleteRecord(store, type, snapshot) {
     const data = {};
     const serializer = store.serializerFor(type.modelName);

--- a/admin/app/adapters/swap-campaign-code.js
+++ b/admin/app/adapters/swap-campaign-code.js
@@ -2,7 +2,7 @@ import ApplicationAdapter from './application';
 
 export default class SwapCampaignCode extends ApplicationAdapter {
   swap({ firstCampaignId, secondCampaignId }) {
-    const url = `${this.host}/${this.namespace}/admin/campaigns/swap-codes`;
+    const url = `${this.host}/${this.namespace}/campaigns/swap-codes`;
 
     return this.ajax(url, 'POST', { data: { firstCampaignId, secondCampaignId } });
   }

--- a/admin/app/adapters/tag.js
+++ b/admin/app/adapters/tag.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class TagAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery(query) {
     const { tagId, recentlyUsedTags } = query;
     delete query.tagId;

--- a/admin/app/adapters/target-profile-summary.js
+++ b/admin/app/adapters/target-profile-summary.js
@@ -1,5 +1,0 @@
-import ApplicationAdapter from './application';
-
-export default class TargetProfileSummaryAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-}

--- a/admin/app/adapters/target-profile.js
+++ b/admin/app/adapters/target-profile.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class TargetProfileAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   updateRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
 

--- a/admin/app/adapters/to-be-published-session.js
+++ b/admin/app/adapters/to-be-published-session.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class ToBePublishedSessionAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery() {
     return `${this.host}/${this.namespace}/sessions/to-publish`;
   }

--- a/admin/app/adapters/training-summary.js
+++ b/admin/app/adapters/training-summary.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class TrainingSummaryAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery(query) {
     if (query.targetProfileId) {
       const targetProfileId = query.targetProfileId;

--- a/admin/app/adapters/training-trigger.js
+++ b/admin/app/adapters/training-trigger.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class TrainingTriggerAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForCreateRecord(modelName, { adapterOptions }) {
     const { trainingId } = adapterOptions;
 

--- a/admin/app/adapters/training.js
+++ b/admin/app/adapters/training.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class TrainingAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   async attachTargetProfile(options) {
     const { trainingId } = options;
     const payload = {

--- a/admin/app/adapters/update-campaign-code.js
+++ b/admin/app/adapters/update-campaign-code.js
@@ -2,7 +2,7 @@ import ApplicationAdapter from './application';
 
 export default class UpdateCampaignCode extends ApplicationAdapter {
   updateCampaignCode({ campaignId, campaignCode }) {
-    const url = `${this.host}/${this.namespace}/admin/campaigns/${campaignId}/update-code`;
+    const url = `${this.host}/${this.namespace}/campaigns/${campaignId}/update-code`;
 
     return this.ajax(url, 'PATCH', { data: { campaignCode } });
   }

--- a/admin/app/adapters/user-certification-course.js
+++ b/admin/app/adapters/user-certification-course.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class UserCertificationCourseAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery({ userId }) {
     return `${this.host}/${this.namespace}/users/${Number(userId)}/certification-courses`;
   }

--- a/admin/app/adapters/user-login.js
+++ b/admin/app/adapters/user-login.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class UserLoginAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForUpdateRecord(id) {
     return `${this.host}/${this.namespace}/users/${id}`;
   }

--- a/admin/app/adapters/user-participation.js
+++ b/admin/app/adapters/user-participation.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class UserParticipations extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForDeleteRecord(id, modelName, snapshot) {
     const baseUrl = this.buildURL();
     return `${baseUrl}/campaigns/${snapshot.attr('campaignId')}/campaign-participations/${snapshot.attr('campaignParticipationId')}`;

--- a/admin/app/adapters/user.js
+++ b/admin/app/adapters/user.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class UserAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForFindRecord(id) {
     return `${this.host}/${this.namespace}/users/${id}`;
   }

--- a/admin/app/adapters/v3-certification-course-details-for-administration.js
+++ b/admin/app/adapters/v3-certification-course-details-for-administration.js
@@ -2,6 +2,6 @@ import ApplicationAdapter from './application';
 
 export default class V3CertificationCourseDetailsForAdministration extends ApplicationAdapter {
   urlForFindRecord(certificationCourseId) {
-    return `${this.host}/${this.namespace}/admin/certification-courses-v3/${certificationCourseId}/details`;
+    return `${this.host}/${this.namespace}/certification-courses-v3/${certificationCourseId}/details`;
   }
 }

--- a/admin/app/adapters/with-required-action-session.js
+++ b/admin/app/adapters/with-required-action-session.js
@@ -1,8 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class WithRequiredSessionAdapter extends ApplicationAdapter {
-  namespace = 'api/admin';
-
   urlForQuery() {
     return `${this.host}/${this.namespace}/sessions/with-required-action`;
   }

--- a/admin/tests/unit/adapters/application-test.js
+++ b/admin/tests/unit/adapters/application-test.js
@@ -5,12 +5,12 @@ import sinon from 'sinon';
 module('Unit | Adapters | ApplicationAdapter', function (hooks) {
   setupTest(hooks);
 
-  test('should specify /api as the root url', function (assert) {
+  test('should specify /api/admin as the root url', function (assert) {
     // given
     const applicationAdapter = this.owner.lookup('adapter:application');
 
     // then
-    assert.strictEqual(applicationAdapter.namespace, 'api');
+    assert.strictEqual(applicationAdapter.namespace, 'api/admin');
   });
 
   module('get headers()', function () {


### PR DESCRIPTION
## 🪧 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Le namespace par défaut défini dans `admin/app/adapters/application.js` est `api`. Or quasi toutes les routes de admin doivent être préfixées pas `api/admin`, ce qui oblige à le re-spécifier dans les adapters de chaque route concernée.

## 🌈 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Utiliser `api/admin` comme namespace par défaut, et gérer les quelques exceptions dans les adapters des routes spécifiques.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
CI au vert.
