### PR TITLE
[TECH] Ne faire qu'une requête pour récupérer les badges et paliers des participants dans GET /api/campaigns/{campaignId}/assessment-results

### DIFF
--- a/api/src/prescription/campaign/domain/read-models/CampaignAssessmentParticipationResultMinimal.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignAssessmentParticipationResultMinimal.js
@@ -27,7 +27,12 @@ export class CampaignAssessmentParticipationResultMinimal {
     this.prescriberTitle = prescriberTitle;
     this.prescriberDescription = prescriberDescription;
     //TODO REMOVE WHEN https://1024pix.atlassian.net/browse/PIX-6849 IS DONE
-    this.badges = _.uniqBy(badges, 'id');
+    this.badges = _.uniqBy(badges, 'id').map(({ id, title, altMessage, imageUrl }) => ({
+      id,
+      title,
+      altMessage,
+      imageUrl,
+    }));
     this.sharedResultCount = sharedResultCount;
     this.evolution = this.#computeEvolution();
   }

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -208,9 +208,13 @@ const filterByUnacquiredBadges = (queryBuilder, filters) => {
  *
  * @returns {Promise<Array>}
  */
-const buildCampaignAssessmentParticipationResultList = async (results, stageCollection) =>
-  PromiseUtils.mapSeries(results, async (result) => {
-    const badges = await getAcquiredBadges(result.campaignParticipationId);
+const buildCampaignAssessmentParticipationResultList = async (results, stageCollection) => {
+  const campaignParticipationIds = results.map(({ campaignParticipationId }) => campaignParticipationId);
+  const badgesByParticipationId = await getAcquiredBadgesByParticipationIds(campaignParticipationIds);
+  const stagesByParticipationId = await getAcquiredStagesByParticipationIds(campaignParticipationIds);
+
+  return PromiseUtils.mapSeries(results, async (result) => {
+    const badges = badgesByParticipationId.get(result.campaignParticipationId) ?? [];
 
     if (!stageCollection.hasStage) {
       return new CampaignAssessmentParticipationResultMinimal({
@@ -219,7 +223,7 @@ const buildCampaignAssessmentParticipationResultList = async (results, stageColl
       });
     }
 
-    const acquiredStages = await getAcquiredStages(result.campaignParticipationId);
+    const acquiredStages = stagesByParticipationId.get(result.campaignParticipationId) ?? [];
     const acquiredStagesCollection = new StageAcquisitionCollection(stageCollection.stages, acquiredStages);
 
     return new CampaignAssessmentParticipationResultMinimal({
@@ -231,18 +235,25 @@ const buildCampaignAssessmentParticipationResultList = async (results, stageColl
       badges,
     });
   });
-
-const getAcquiredStages = (campaignParticipationId) => {
-  const knexConn = DomainTransaction.getConnection();
-
-  return knexConn('stage-acquisitions').select('*').where({ campaignParticipationId });
 };
 
-const getAcquiredBadges = (campaignParticipationId) => {
+const getAcquiredStagesByParticipationIds = async (campaignParticipationIds) => {
   const knexConn = DomainTransaction.getConnection();
 
-  return knexConn('badge-acquisitions')
-    .select(['badges.id AS id', 'title', 'altMessage', 'imageUrl'])
+  const stageAcquisitions = await knexConn('stage-acquisitions')
+    .select('*')
+    .whereIn('campaignParticipationId', campaignParticipationIds);
+
+  return Map.groupBy(stageAcquisitions, (stageAcquisition) => stageAcquisition.campaignParticipationId);
+};
+
+const getAcquiredBadgesByParticipationIds = async (campaignParticipationIds) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const badgesAcquisitions = await knexConn('badge-acquisitions')
+    .select(['badges.id AS id', 'title', 'altMessage', 'imageUrl', 'campaignParticipationId'])
     .join('badges', 'badges.id', 'badge-acquisitions.badgeId')
-    .where({ campaignParticipationId: campaignParticipationId });
+    .whereIn('campaignParticipationId', campaignParticipationIds);
+
+  return Map.groupBy(badgesAcquisitions, (badgesAcquisition) => badgesAcquisition.campaignParticipationId);
 };

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -244,7 +244,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
     });
 
     context('when there are badges acquired', function () {
-      let badge1Id, badge2Id;
+      let badge1Id, badge3Id;
 
       beforeEach(async function () {
         campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [{ id: 'Skill1' }]);
@@ -259,14 +259,22 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         badge1Id = databaseBuilder.factory.buildBadge({
           key: 'Badge1',
           targetProfileId: campaign.targetProfileId,
-          title: 'BadgeTitle',
-          altMessage: 'BadgeMessage',
-          imageUrl: 'BadgeImageUrl',
+          title: 'BadgeTitle1',
+          altMessage: 'BadgeMessage1',
+          imageUrl: 'BadgeImageUrl1',
         }).id;
-        badge2Id = databaseBuilder.factory.buildBadge({ key: 'Badge2' }).id;
+        const badge2Id = databaseBuilder.factory.buildBadge({ key: 'Badge2' }).id;
+        badge3Id = databaseBuilder.factory.buildBadge({
+          key: 'Badge3',
+          targetProfileId: campaign.targetProfileId,
+          title: 'BadgeTitle3',
+          altMessage: 'BadgeMessage3',
+          imageUrl: 'BadgeImageUrl3',
+        }).id;
 
         databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge1Id, campaignParticipationId });
         databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge2Id });
+        databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge3Id, campaignParticipationId });
 
         const learningContent = [
           {
@@ -297,9 +305,15 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         expect(participations[0].badges).to.deep.equal([
           {
             id: badge1Id,
-            title: 'BadgeTitle',
-            altMessage: 'BadgeMessage',
-            imageUrl: 'BadgeImageUrl',
+            title: 'BadgeTitle1',
+            altMessage: 'BadgeMessage1',
+            imageUrl: 'BadgeImageUrl1',
+          },
+          {
+            id: badge3Id,
+            title: 'BadgeTitle3',
+            altMessage: 'BadgeMessage3',
+            imageUrl: 'BadgeImageUrl3',
           },
         ]);
       });

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignAssessmentParticipationResultMinimal_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignAssessmentParticipationResultMinimal_test.js
@@ -155,11 +155,73 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignAssessmentPart
     it('keeps only once each badge', function () {
       // when
       const campaignAssessmentParticipationResultMinimal = new CampaignAssessmentParticipationResultMinimal({
-        badges: [{ id: 1 }, { id: 1 }, { id: 2 }, { id: 2 }, { id: 3 }, { id: 3 }, { id: 3 }],
+        badges: [
+          {
+            id: 1,
+            title: 'title 1',
+            altMessage: 'altMessage 1',
+            imageUrl: 'imageUrl 1',
+          },
+          {
+            id: 1,
+            title: 'title 1',
+            altMessage: 'altMessage 1',
+            imageUrl: 'imageUrl 1',
+          },
+          {
+            id: 2,
+            title: 'title 2',
+            altMessage: 'altMessage 2',
+            imageUrl: 'imageUrl 2',
+          },
+          {
+            id: 2,
+            title: 'title 2',
+            altMessage: 'altMessage 2',
+            imageUrl: 'imageUrl 2',
+          },
+          {
+            id: 3,
+            title: 'title 3',
+            altMessage: 'altMessage 3',
+            imageUrl: 'imageUrl 3',
+          },
+          {
+            id: 3,
+            title: 'title 3',
+            altMessage: 'altMessage 3',
+            imageUrl: 'imageUrl 3',
+          },
+          {
+            id: 3,
+            title: 'title 3',
+            altMessage: 'altMessage 3',
+            imageUrl: 'imageUrl 3',
+          },
+        ],
       });
 
       // then
-      expect(campaignAssessmentParticipationResultMinimal.badges).to.exactlyContain([{ id: 1 }, { id: 2 }, { id: 3 }]);
+      expect(campaignAssessmentParticipationResultMinimal.badges).to.exactlyContain([
+        {
+          id: 1,
+          title: 'title 1',
+          altMessage: 'altMessage 1',
+          imageUrl: 'imageUrl 1',
+        },
+        {
+          id: 2,
+          title: 'title 2',
+          altMessage: 'altMessage 2',
+          imageUrl: 'imageUrl 2',
+        },
+        {
+          id: 3,
+          title: 'title 3',
+          altMessage: 'altMessage 3',
+          imageUrl: 'imageUrl 3',
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## 🪧 Problème
Lors de la récupération des résultats de campagne dans Pix Orga, nous bouclons sur les participants afin de récupérer leurs badges et paliers. Cela fonctionne mais il est plus performant de ne faire qu'une seule requête.

## 🌈 Proposition
Ne faire qu'une requête pour récupérer les badges et stages des participants

## 🎉 Pour tester
Aller sur la page de résultat d'une campagne et vérifier que les badges et paliers sont bien récupérés
