### PR TITLE
[TECH] Remplacer XRegex par des regex native node dans l'API

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -78,7 +78,6 @@
         "xml-buffer-tostring": "^0.2.0",
         "xml2js": "^0.6.0",
         "xmlbuilder2": "^4.0.0",
-        "xregexp": "^5.1.1",
         "yargs": "^18.0.0"
       },
       "devDependencies": {
@@ -1247,18 +1246,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.48.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -6012,17 +5999,6 @@
       "dependencies": {
         "browserslist": "^4.28.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
-      "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -13147,15 +13123,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/xregexp": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.2.tgz",
-      "integrity": "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.26.9"
       }
     },
     "node_modules/xtend": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -72,7 +72,6 @@
         "samlify": "^2.8.5",
         "sax": "^1.2.4",
         "saxpath": "^0.6.5",
-        "schemalint": "^2.0.0",
         "undici": "8.4.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "xml-buffer-tostring": "^0.2.0",
@@ -103,6 +102,7 @@
         "npm-run-all2": "^9.0.0",
         "oxfmt": "^0.54.0",
         "pdfjs-dist": "^6.0.0",
+        "schemalint": "^2.3.2",
         "sinon": "^22.0.0",
         "sinon-chai": "^4.0.0"
       },
@@ -1298,9 +1298,10 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz",
-      "integrity": "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.3.tgz",
+      "integrity": "sha512-iTTYbA5Uesrl+N7zss0J5LopT7KE4j9aymYo+EZZh+rZbARQCUQOs+n2pay64JRUpc3fCkpfrniTNJnvYzOE+g==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true
     },
@@ -2413,6 +2414,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@kristiandupont/recase/-/recase-1.4.1.tgz",
       "integrity": "sha512-e5t4YqhnRGbS9sU4N52cQgTn37qKwTsxDDcIuIkgPvX0UmnL+7eoOR6oFXeCib5zYuw03vYKpR55NBq+W43j1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.30.0"
@@ -2422,6 +2424,7 @@
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6136,6 +6139,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-object-diff": {
@@ -7072,9 +7076,10 @@
       }
     },
     "node_modules/extract-pg-schema": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/extract-pg-schema/-/extract-pg-schema-5.8.1.tgz",
-      "integrity": "sha512-rNotRBXxWQnvjcErsX3k9cZwY4KQbVniEp+KAd6RghfDvt29kOtnDdfO7S+Y6b/5tge6caovbJq8s9cgsUtBUA==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/extract-pg-schema/-/extract-pg-schema-5.8.2.tgz",
+      "integrity": "sha512-UN07KsJh11BlC8K0ad7cEJ8nXwCFV1AoI0VHh+oLT8N5sQmoY43vpTwBSL46rnJBGc9pVkWYEopry/tk1Nvriw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "knex": "3.1.0",
@@ -7094,6 +7099,7 @@
       "version": "8.17.2",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
       "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.10.1",
@@ -7118,9 +7124,10 @@
       }
     },
     "node_modules/extract-pg-schema/node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-copy": {
@@ -9057,6 +9064,7 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/knex-pglite/-/knex-pglite-0.12.1.tgz",
       "integrity": "sha512-7aMZfDVt2f6MQEdT1ASP/rS8T2bQCIieFGxMry9AO1zEHduI1fwqsOa0D63z3qFzHHLcEGNfSCqOfoUFbXoxtg==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@electric-sql/pglite": "0.x",
@@ -9160,6 +9168,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -10528,6 +10537,7 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -10545,6 +10555,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/os-tmpdir": {
@@ -10969,6 +10980,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/pg-query-emscripten/-/pg-query-emscripten-5.1.0.tgz",
       "integrity": "sha512-H1ZWOzLRddmHuE4GZqFjjo55hA9zMiePz/WDDGANA/EnvILCJps9pcRucyGd+MFvapeYOy6TWSYz6DbtBOaxRQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-query-stream": {
@@ -11194,6 +11206,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -11420,6 +11433,7 @@
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.31.3.tgz",
       "integrity": "sha512-xKADKRNnqmDdX59PPKLm3gGmk1ZgNnj3k7DryqWwkamp4TJ6B36DdpyKEQ0EoEYmH2R62bV4Q+S0ym2z8N2f3Q==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -11827,6 +11841,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/schemalint/-/schemalint-2.3.2.tgz",
       "integrity": "sha512-jaIl/ulSRWEhKPmMiuRHCoodAGxkIGSz3ZmqMt67UTJ4lwqx3r8ywkKjkzm6JMwIquKjIIhL9ro1r3H+WMNgXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kristiandupont/recase": "^1.2.1",
@@ -11848,6 +11863,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
       "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12582,6 +12598,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -12864,6 +12881,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/api/package.json
+++ b/api/package.json
@@ -160,7 +160,6 @@
     "xml-buffer-tostring": "^0.2.0",
     "xml2js": "^0.6.0",
     "xmlbuilder2": "^4.0.0",
-    "xregexp": "^5.1.1",
     "yargs": "^18.0.0"
   },
   "devDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -154,7 +154,6 @@
     "samlify": "^2.8.5",
     "sax": "^1.2.4",
     "saxpath": "^0.6.5",
-    "schemalint": "^2.0.0",
     "undici": "8.4.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "xml-buffer-tostring": "^0.2.0",
@@ -185,6 +184,7 @@
     "npm-run-all2": "^9.0.0",
     "oxfmt": "^0.54.0",
     "pdfjs-dist": "^6.0.0",
+    "schemalint": "^2.3.2",
     "sinon": "^22.0.0",
     "sinon-chai": "^4.0.0"
   },

--- a/api/src/identity-access-management/application/account-recovery/account-recovery.route.js
+++ b/api/src/identity-access-management/application/account-recovery/account-recovery.route.js
@@ -1,13 +1,11 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
-import XRegExp from 'xregexp';
 
-import { config } from '../../../shared/config.js';
 import { studentIdentifierType } from '../../../shared/domain/types/identifiers-type.js';
+import { PasswordSchema } from '../../../shared/domain/validators/password-validator.js';
 import { accountRecoveryController } from './account-recovery.controller.js';
 
 const Joi = BaseJoi.extend(JoiDate);
-const { passwordValidationPattern } = config.account;
 
 export const accountRecoveryRoutes = [
   {
@@ -21,7 +19,7 @@ export const accountRecoveryRoutes = [
           data: {
             attributes: {
               'temporary-key': Joi.string().min(32).required(),
-              password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
+              password: PasswordSchema.required(),
             },
           },
         }),

--- a/api/src/identity-access-management/application/password/password.route.js
+++ b/api/src/identity-access-management/application/password/password.route.js
@@ -1,10 +1,7 @@
 import Joi from 'joi';
-import XRegExp from 'xregexp';
 
-import { config } from '../../../shared/config.js';
+import { PasswordSchema } from '../../../shared/domain/validators/password-validator.js';
 import { passwordController } from './password.controller.js';
-
-const { passwordValidationPattern } = config.account;
 
 export const passwordRoutes = [
   {
@@ -55,7 +52,7 @@ export const passwordRoutes = [
           data: {
             attributes: {
               'password-reset-token': Joi.string().required(),
-              'new-password': Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
+              'new-password': PasswordSchema.required(),
             },
             type: Joi.string(),
           },

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -1,15 +1,12 @@
 import Joi from 'joi';
-import XRegExp from 'xregexp';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
-import { config } from '../../../shared/config.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { getSupportedLanguages, getSupportedLocales } from '../../../shared/domain/services/locale-service.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { PasswordSchema } from '../../../shared/domain/validators/password-validator.js';
 import { userController } from './user.controller.js';
 import { userVerification } from './user-existence-verification-pre-handler.js';
-
-const { passwordValidationPattern } = config.account;
 
 export const userRoutes = [
   {
@@ -231,11 +228,7 @@ export const userRoutes = [
           id: identifiersType.userId,
         }),
         payload: Joi.object({
-          data: {
-            attributes: {
-              password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
-            },
-          },
+          data: { attributes: { password: PasswordSchema.required() } },
         }),
       },
       notes: [

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
@@ -8,13 +8,11 @@ import {
   UnprocessableEntityError,
 } from '../../../shared/application/errors/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
-import { config } from '../../../shared/config.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { PasswordSchema } from '../../../shared/domain/validators/password-validator.js';
 import { scoOrganizationLearnerController } from './sco-organization-learner-controller.js';
 
 const Joi = BaseJoi.extend(JoiDate);
-
-const { passwordValidationPattern } = config.account;
 
 const register = async function (server) {
   server.route([
@@ -66,7 +64,7 @@ const register = async function (server) {
                 birthdate: Joi.date().format('YYYY-MM-DD').raw().required(),
                 'organization-id': Joi.number().empty(null).required(),
                 'redirection-url': Joi.string().uri().empty(null).required(),
-                password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
+                password: PasswordSchema.required(),
                 'with-username': Joi.boolean().required(),
                 username: Joi.string().pattern(XRegExp('^([a-z]+[.]+[a-z]+[0-9]{4})$')).allow(null),
               },

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
@@ -1,6 +1,5 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
-import XRegExp from 'xregexp';
 
 import {
   BadRequestError,
@@ -10,6 +9,7 @@ import {
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { PasswordSchema } from '../../../shared/domain/validators/password-validator.js';
+import { UsernameSchema } from '../../../shared/domain/validators/username-validator.js';
 import { scoOrganizationLearnerController } from './sco-organization-learner-controller.js';
 
 const Joi = BaseJoi.extend(JoiDate);
@@ -66,7 +66,7 @@ const register = async function (server) {
                 'redirection-url': Joi.string().uri().empty(null).required(),
                 password: PasswordSchema.required(),
                 'with-username': Joi.boolean().required(),
-                username: Joi.string().pattern(XRegExp('^([a-z]+[.]+[a-z]+[0-9]{4})$')).allow(null),
+                username: UsernameSchema.allow(null),
               },
             },
           }),

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -201,9 +201,6 @@ const configuration = (function () {
         },
       },
     },
-    account: {
-      passwordValidationPattern: '^(?=.*\\p{Lu})(?=.*\\p{Ll})(?=.*\\d).{8,}$',
-    },
     anonymous: {
       accessTokenLifespanMs: ms(process.env.ANONYMOUS_ACCESS_TOKEN_LIFESPAN || '4h'),
     },

--- a/api/src/shared/domain/validators/password-validator.js
+++ b/api/src/shared/domain/validators/password-validator.js
@@ -1,16 +1,14 @@
 import Joi from 'joi';
-import XRegExp from 'xregexp';
-
-import { config } from '../../config.js';
-
-const { passwordValidationPattern } = config.account;
 
 import { EntityValidationError } from '../errors.js';
 
-const pattern = XRegExp(passwordValidationPattern);
+const pattern = /^(?=.*\p{Lu})(?=.*\p{Ll})(?=.*\d).{8,}$/v;
 
-const passwordValidationJoiSchema = Joi.object({
-  password: Joi.string().pattern(pattern).required().max(255).messages({
+/** @type {Joi.StringSchema<string>} */
+export const PasswordSchema = Joi.string().pattern(pattern);
+
+const PasswordWithMessagesSchema = Joi.object({
+  password: PasswordSchema.required().max(255).messages({
     'string.empty': 'Votre mot de passe n’est pas renseigné.',
     'string.pattern.base':
       'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.',
@@ -20,20 +18,16 @@ const passwordValidationJoiSchema = Joi.object({
 });
 
 /**
- * @param password
- * @return {boolean}
+ * Validates a password against the password policy.
+ *
+ * @param {string} password - The password to validate.
+ * @returns {true} Returns `true` when the password is valid.
+ * @throws {EntityValidationError} When the password fails validation.
  */
-const validate = function (password) {
-  const { error } = passwordValidationJoiSchema.validate({ password });
+export function validate(password) {
+  const { error } = PasswordWithMessagesSchema.validate({ password });
   if (error) {
     throw EntityValidationError.fromJoiErrors(error.details);
   }
   return true;
-};
-
-/**
- * @typedef {Object} PasswordValidator
- * @property {function} validate
- */
-
-export { validate };
+}

--- a/api/src/shared/domain/validators/username-validator.js
+++ b/api/src/shared/domain/validators/username-validator.js
@@ -1,0 +1,6 @@
+import Joi from 'joi';
+
+const pattern = /^([a-z]+[.]+[a-z]+[0-9]{4})$/;
+
+/** @type {Joi.StringSchema<string>} */
+export const UsernameSchema = Joi.string().pattern(pattern);

--- a/api/tests/shared/unit/domain/validators/password-validator_test.js
+++ b/api/tests/shared/unit/domain/validators/password-validator_test.js
@@ -1,76 +1,97 @@
+import Joi from 'joi';
+
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
-import * as passwordValidator from '../../../../../src/shared/domain/validators/password-validator.js';
+import { PasswordSchema, validate } from '../../../../../src/shared/domain/validators/password-validator.js';
 import { expect } from '../../../../test-helper.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
-function _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError) {
-  expect(entityValidationErrors).to.be.instanceOf(EntityValidationError);
-  expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(1);
-  expect(entityValidationErrors.invalidAttributes[0]).to.deep.equal(expectedError);
-}
-
 describe('Unit | Shared | Domain | Validator | password-validator', function () {
-  let password;
-
-  describe('#validate', function () {
-    context('when validation is successful', function () {
-      it('should not throw any error', function () {
+  describe('#PasswordSchema', function () {
+    context('valid values', function () {
+      it('accepts a valid password', function () {
         // when
-        password = 'Pix12345';
+        const validation = PasswordSchema.validate('Pix12345');
 
         // then
-        expect(() => passwordValidator.validate(password)).to.not.throw();
+        expect(validation.error).to.be.undefined;
+      });
+
+      ['Pixé1234', 'Éxample1', 'Straße12', 'Pix1 !@#$%^&*'].forEach((password) => {
+        it(`accepts unicode and special characters password "${password}"`, function () {
+          // when
+          const validation = PasswordSchema.validate(password);
+
+          // then
+          expect(validation.error).to.be.undefined;
+        });
+      });
+    });
+
+    context('invalid values', function () {
+      [
+        ['Pix123', 'must be at least 8 characters long'],
+        ['pix12345', 'must contain at least one uppercase letter'],
+        ['PIX12345', 'must contain at least one lowercase letter'],
+        ['Pixxxxxx', 'must contain at least one digit'],
+      ].forEach(([password, message]) => {
+        it(`rejects password "${password}" (${message})`, async function () {
+          // when
+          const validation = PasswordSchema.validate(password);
+
+          // then
+          expect(validation.error).to.be.instanceOf(Joi.ValidationError);
+        });
+      });
+    });
+  });
+
+  describe('validate', function () {
+    context('when validation is successful', function () {
+      it('should not throw any error', function () {
+        // when / then
+        expect(() => validate('Pix12345')).to.not.throw();
       });
     });
 
     context('when validation fails', function () {
       it('should reject with error on field "password" when password is missing', async function () {
-        // given
-        password = '';
-
-        const expectedError = {
-          attribute: 'password',
-          message: 'Votre mot de passe n’est pas renseigné.',
-        };
-
         // when
-        const errors = await catchErr(passwordValidator.validate)(password);
+        const errors = await catchErr(validate)('');
 
         // then
-        _assertErrorMatchesWithExpectedOne(errors, expectedError);
+        expect(errors).to.be.instanceOf(EntityValidationError);
+        expect(errors.invalidAttributes).to.have.lengthOf(1);
+        expect(errors.invalidAttributes[0]).to.deep.equal({
+          attribute: 'password',
+          message: 'Votre mot de passe n’est pas renseigné.',
+        });
       });
 
       it('should reject with error on field "password" when password is invalid', async function () {
-        // given
-        password = 'invalid';
+        // when
+        const errors = await catchErr(validate)('invalid');
 
-        const expectedError = {
+        // then
+        expect(errors).to.be.instanceOf(EntityValidationError);
+        expect(errors.invalidAttributes).to.have.lengthOf(1);
+        expect(errors.invalidAttributes[0]).to.deep.equal({
           attribute: 'password',
           message:
             'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.',
-        };
-
-        // when
-        const errors = await catchErr(passwordValidator.validate)(password);
-
-        // then
-        _assertErrorMatchesWithExpectedOne(errors, expectedError);
+        });
       });
 
       it('should reject with errors on password when password have a maximum length of 255', async function () {
-        // given
-        password = 'Password1234'.repeat(22);
-
-        const expectedError = {
-          attribute: 'password',
-          message: 'Votre mot de passe ne doit pas dépasser les 255 caractères.',
-        };
-
         // when
-        const errors = await catchErr(passwordValidator.validate)(password);
+        const errors = await catchErr(validate)('Password1234'.repeat(22));
 
         // then
-        _assertErrorMatchesWithExpectedOne(errors, expectedError);
+        expect(errors).to.be.instanceOf(EntityValidationError);
+        expect(errors.invalidAttributes).to.have.lengthOf(1);
+        expect(errors.invalidAttributes[0]).to.deep.equal({
+          attribute: 'password',
+          message: 'Votre mot de passe ne doit pas dépasser les 255 caractères.',
+        });
       });
     });
   });

--- a/api/tests/shared/unit/domain/validators/username-validator_test.js
+++ b/api/tests/shared/unit/domain/validators/username-validator_test.js
@@ -1,0 +1,43 @@
+import Joi from 'joi';
+
+import { UsernameSchema } from '../../../../../src/shared/domain/validators/username-validator.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Shared | Domain | Validator | username-validator', function () {
+  context('valid values', function () {
+    ['john.doe2025', 'a.b9999', 'alice.smith0000'].forEach((value) => {
+      it(`accepts "${value}"`, function () {
+        // when
+        const validation = UsernameSchema.validate(value);
+
+        // then
+        expect(validation.error).to.be.undefined;
+      });
+    });
+  });
+
+  context('invalid values', function () {
+    [
+      ['John.doe2025', 'contains an uppercase letter'],
+      ['johndoe2025', 'has no dot separator'],
+      ['john.doe123', 'has only 3 digits'],
+      ['john.doe12345', 'has 5 digits'],
+      ['john.2025', 'has no letters after the dot'],
+      ['.doe2025', 'has no letters before the dot'],
+      ['john.doe', 'has no digits'],
+      ['1234.doe2025', 'starts with digits'],
+      ['john.doe2025 ', 'has a trailing space'],
+      [' john.doe2025', 'has a leading space'],
+      ['john_doe2025', 'uses an underscore instead of a dot'],
+      ['', 'is empty'],
+    ].forEach(([value, reason]) => {
+      it(`rejects "${value}" (${reason})`, function () {
+        // when
+        const validation = UsernameSchema.validate(value);
+
+        // then
+        expect(validation.error).to.be.instanceOf(Joi.ValidationError);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

Dans l'API on utilise pour 2 cas de validation (password et username) la librarie [XRegex](https://github.com/slevithan/xregexp). Mais comme ils l'indiquent dans leur doc, la plupart des features sont gérées maintenant nativement :
> XRegExp was indispensable for heavy regex users in its time, but many of its best features have been adopted into modern JavaScript
> _[Source](https://github.com/slevithan/xregexp)_ 

## 🌈 Proposition

2 cas d'utilisation de XRegex : 
- **La validation du format du mot de passe côté API** : dans ce cas on utilisait XRegexp principalement pour sa gestion des caractères spéciaux et unicode. Ce qui est maintenant géré via le flag `v` des regexp depuis node 20 **([source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets))**
- **La validation du format du username côté API :** rien de particulier dans cette regex qui impose d''utiliser XRegexp

Chaque expression régulière XRegex a été traduite en Regex native nodejs moderne.

Les pattern de regex sont utilisés dans 2 schémas Joi `PasswordSchema` et `UsernameSchema` et on a ajouté leurs tests respectifs pour exprimer explicitement la description de chaque expression régulière.

## ✊ Remarques

- Suppression du pattern de password du fichier `config.js`, il réside dans le password validator.
- Suppression de la librarie `XRegex`

**Scout:** le dernier commit déplace la lib `schemalint` en `devDependencies`

## 🎉 Pour tester

- Les tests doivent passer.
- Création de compte avec des mots de passe différents qui doivent respecter ou non les règles de validation.
