### PR TITLE
[FEATURE] Vérifier l'habilitation du centre avant l'entrée en certif (PIX-23234).

### DIFF
--- a/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
+++ b/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
@@ -43,7 +43,6 @@ export const registerCandidateParticipation = withTransaction(
 
     await usecases.verifyCandidateReconciliationRequirements({
       candidate: reconciliedCandidate,
-      sessionId,
     });
 
     return reconciliedCandidate;

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
@@ -15,6 +15,7 @@ import {
   UserAlreadyLinkedToCandidateInSessionError,
 } from '../../../../shared/domain/errors.js';
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
+import { CenterHabilitationError } from '../../../shared/domain/errors.js';
 import { CertificationCourse } from '../../../shared/domain/models/CertificationCourse.js';
 
 /**
@@ -74,6 +75,12 @@ export const verifyCandidateIdentity = async ({
   }
 
   const center = await centerRepository.getById({ id: session.certificationCenterId });
+
+  if (!candidate.hasCoreFrameworkSubscription() && !center.isHabilitated(candidate.subscription)) {
+    throw new CenterHabilitationError({
+      meta: { framework: candidate.subscription },
+    });
+  }
 
   if (center.isMatchingOrganizationScoAndManagingStudents) {
     if (!user.has({ organizationLearnerId: candidate.organizationLearnerId })) {

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
@@ -1,28 +1,19 @@
 /**
  * @typedef {import ('../models/Candidate.js').Candidate} Candidate
  * @typedef {import ('./index.js').PlacementProfileService} PlacementProfileService
- * @typedef {import ('./index.js').CertificationCenterRepository} CertificationCenterRepository
  */
 
 import { UserNotAuthorizedToCertifyError } from '../../../../shared/domain/errors.js';
-import { CenterHabilitationError } from '../../../shared/domain/errors.js';
 
 /**
  * @param {object} params
  * @param {Candidate} params.candidate
- * @param {number} params.sessionId
  * @param {PlacementProfileService} params.placementProfileService
- * @param {CertificationCenterRepository} params.certificationCenterRepository
  *
  * @returns {Promise<void>} if candidate is deemed eligible
  * @throws {UserNotAuthorizedToCertifyError} candidate is not certifiable for CORE
  */
-export const verifyCandidateReconciliationRequirements = async ({
-  candidate,
-  sessionId,
-  placementProfileService,
-  certificationCenterRepository,
-}) => {
+export const verifyCandidateReconciliationRequirements = async ({ candidate, placementProfileService }) => {
   const placementProfile = await placementProfileService.getPlacementProfile({
     userId: candidate.userId,
     limitDate: candidate.reconciledAt,
@@ -30,13 +21,5 @@ export const verifyCandidateReconciliationRequirements = async ({
 
   if (!placementProfile.isCertifiable()) {
     throw new UserNotAuthorizedToCertifyError();
-  }
-
-  if (!candidate.hasCoreFrameworkSubscription()) {
-    const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
-
-    if (!certificationCenter.isHabilitated(candidate.subscription)) {
-      throw new CenterHabilitationError();
-    }
   }
 };

--- a/api/src/certification/shared/application/http-error-mapper-configuration.js
+++ b/api/src/certification/shared/application/http-error-mapper-configuration.js
@@ -31,7 +31,7 @@ const certificationDomainErrorMappingConfiguration = [
   },
   {
     name: CenterHabilitationError.name,
-    httpErrorFn: (error) => new ForbiddenError(error.message, error.code),
+    httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
     name: CertificationCandidateNotFoundError.name,

--- a/api/src/certification/shared/domain/errors.js
+++ b/api/src/certification/shared/domain/errors.js
@@ -19,9 +19,13 @@ class InvalidCertificationReportForFinalization extends DomainError {
 }
 
 class CenterHabilitationError extends DomainError {
-  constructor() {
-    super('This certification center has no habilitation for the given complementary certification.');
+  constructor({
+    message = 'This certification center has no habilitation for the given complementary certification.',
+    meta,
+  } = {}) {
+    super(message);
     this.code = 'CENTER_HABILITATION_ERROR';
+    this.meta = meta;
   }
 }
 

--- a/api/tests/certification/enrolment/integration/domain/services/register-candidate-participation-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/register-candidate-participation-service_test.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { services } from '../../../../../../src/certification/enrolment/application/services/index.js';
 import { normalize } from '../../../../../../src/shared/infrastructure/utils/string-utils.js';
 import { expect } from '../../../../../test-helper.js';
@@ -29,19 +27,12 @@ describe('Integration | Application | Service | register-candidate-participation
         certificationCandidateId: certificationCandidate.id,
         complementaryCertificationId: 1234,
       });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId,
+        complementaryCertificationId: 1234,
+      });
 
       await databaseBuilder.commit();
-
-      const placementProfileService = {
-        getPlacementProfile: sinon.stub(),
-      };
-
-      placementProfileService.getPlacementProfile
-        .withArgs({
-          userId: certificationCandidate.userId,
-          limitDate: certificationCandidate.reconciledAt,
-        })
-        .resolves({ isCertifiable: sinon.stub().returns(false) });
 
       // when
       await catchErr(services.registerCandidateParticipation)({
@@ -55,11 +46,11 @@ describe('Integration | Application | Service | register-candidate-participation
       });
 
       // then
-      const candidate = await knex('certification-candidates')
+      const [candidate] = await knex('certification-candidates')
         .select('userId', 'reconciledAt')
         .where({ id: certificationCandidate.id });
-      expect(candidate.userId).to.be.undefined;
-      expect(candidate.reconciledAt).to.be.undefined;
+      expect(candidate.userId).to.be.null;
+      expect(candidate.reconciledAt).to.be.null;
     });
   });
 });

--- a/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
@@ -121,7 +121,6 @@ describe('Unit | Application | Service | register-candidate-participation', func
       // then
       expect(usecases.verifyCandidateReconciliationRequirements).to.have.been.calledWithExactly({
         candidate: unlinkedCandidate,
-        sessionId,
       });
     });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-identity_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-identity_test.js
@@ -1,6 +1,8 @@
 import sinon from 'sinon';
 
 import { verifyCandidateIdentity } from '../../../../../../src/certification/enrolment/domain/usecases/verify-candidate-identity.js';
+import { CenterHabilitationError } from '../../../../../../src/certification/shared/domain/errors.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { types } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
 import {
   CertificationCandidateByPersonalInfoNotFoundError,
@@ -388,6 +390,98 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
     });
 
     context('when reconciliation is non-existent on all sides', function () {
+      context('when matching candidate has a complementary subscription', function () {
+        context('when the certification center is not habilitated for the subscription', function () {
+          it('should throw a CenterHabilitationError holding the subscription framework', async function () {
+            // given
+            userRepository.get.withArgs({ id: userId }).resolves(
+              domainBuilder.certification.enrolment.buildUser({
+                id: userId,
+                lang: 'fr',
+              }),
+            );
+            sessionRepository.get.withArgs({ id: sessionId }).resolves(
+              domainBuilder.certification.enrolment.buildSession({
+                id: sessionId,
+                certificationCenterId,
+              }),
+            );
+            centerRepository.getById.withArgs({ id: certificationCenterId }).resolves(
+              domainBuilder.certification.enrolment.buildCenter({
+                id: certificationCenterId,
+                habilitations: [],
+                matchingOrganization: null,
+              }),
+            );
+            candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
+              domainBuilder.certification.enrolment.buildCandidate({
+                firstName,
+                lastName,
+                userId: null,
+                birthdate,
+                subscription: Frameworks.DROIT,
+                subscriptions: [domainBuilder.certification.enrolment.buildComplementarySubscription()],
+              }),
+            ]);
+
+            // when
+            const error = await catchErr(verifyCandidateIdentity)({
+              ...dependencies,
+            });
+
+            // then
+            expect(error).to.be.instanceof(CenterHabilitationError);
+            expect(error.meta).to.deep.equal({ framework: Frameworks.DROIT });
+          });
+        });
+
+        context('when the certification center is habilitated for the subscription', function () {
+          it('should return the candidate', async function () {
+            // given
+            const matchingCandidate = domainBuilder.certification.enrolment.buildCandidate({
+              firstName,
+              lastName,
+              userId: null,
+              birthdate,
+              subscription: Frameworks.DROIT,
+              subscriptions: [domainBuilder.certification.enrolment.buildComplementarySubscription()],
+            });
+            userRepository.get.withArgs({ id: userId }).resolves(
+              domainBuilder.certification.enrolment.buildUser({
+                id: userId,
+                lang: 'fr',
+              }),
+            );
+            sessionRepository.get.withArgs({ id: sessionId }).resolves(
+              domainBuilder.certification.enrolment.buildSession({
+                id: sessionId,
+                certificationCenterId,
+              }),
+            );
+            centerRepository.getById.withArgs({ id: certificationCenterId }).resolves(
+              domainBuilder.certification.enrolment.buildCenter({
+                id: certificationCenterId,
+                habilitations: [
+                  domainBuilder.certification.enrolment.buildHabilitation({
+                    key: Frameworks.DROIT,
+                  }),
+                ],
+                matchingOrganization: null,
+              }),
+            );
+            candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([matchingCandidate]);
+
+            // when
+            const result = await verifyCandidateIdentity({
+              ...dependencies,
+            });
+
+            // then
+            expect(result).to.deep.equal(matchingCandidate);
+          });
+        });
+      });
+
       context('when it is a session sco / is managing students', function () {
         context('when matching candidate is not related to a reconcilied learner', function () {
           it('should throw a MatchingReconciledStudentNotFoundError', async function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-reconciliation-requirements_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-reconciliation-requirements_test.js
@@ -1,24 +1,17 @@
 import sinon from 'sinon';
 
 import { verifyCandidateReconciliationRequirements } from '../../../../../../src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js';
-import { CenterHabilitationError } from '../../../../../../src/certification/shared/domain/errors.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
-import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { UserNotAuthorizedToCertifyError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Enrolment | Unit | Domain | UseCases | verify-candidate-reconciliation-requirements', function () {
-  let placementProfileService, certificationCenterRepository;
+  let placementProfileService;
 
   beforeEach(function () {
     placementProfileService = {
       getPlacementProfile: sinon.stub(),
-    };
-
-    certificationCenterRepository = {
-      getBySessionId: sinon.stub(),
     };
   });
 
@@ -26,7 +19,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCases | verify-candidat
     it('throws an error', async function () {
       // given
       const userId = 123;
-      const sessionId = 123;
       const reconciledAt = new Date();
       const candidate = domainBuilder.certification.enrolment.buildCandidate({
         userId,
@@ -41,7 +33,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCases | verify-candidat
       // when
       const error = await catchErr(verifyCandidateReconciliationRequirements)({
         candidate,
-        sessionId,
         placementProfileService,
       });
 
@@ -73,88 +64,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCases | verify-candidat
           placementProfileService,
         }),
       ).to.be.fulfilled;
-    });
-  });
-
-  context('when the candidate is enrolled to a double certification or complementary only', function () {
-    context('when the centre has lost his habilitation', function () {
-      it('throws an error', async function () {
-        // given
-        const userId = 123;
-        const sessionId = 123;
-        const reconciledAt = new Date();
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
-          userId,
-          reconciledAt,
-          subscription: Frameworks.DROIT,
-        });
-
-        placementProfileService.getPlacementProfile
-          .withArgs({ userId: candidate.userId, limitDate: candidate.reconciledAt })
-          .resolves({ isCertifiable: sinon.stub().returns(true) });
-
-        certificationCenterRepository.getBySessionId.withArgs({ sessionId }).resolves(
-          domainBuilder.buildCertificationCenter({
-            habilitations: [],
-          }),
-        );
-
-        // when
-        const error = await catchErr(verifyCandidateReconciliationRequirements)({
-          candidate,
-          sessionId,
-          placementProfileService,
-          certificationCenterRepository,
-        });
-
-        //then
-        expect(error).to.be.instanceOf(CenterHabilitationError);
-      });
-    });
-
-    context('when the centre is habilitated', function () {
-      it('resolves', async function () {
-        // given
-        const userId = 123;
-        const sessionId = 123;
-        const reconciledAt = new Date();
-        const complementaryCertification = domainBuilder.certification.shared.buildComplementaryCertification({
-          label: 'Pix+Droit',
-          key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-        });
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
-          userId,
-          reconciledAt,
-          subscription: complementaryCertification.key,
-        });
-
-        placementProfileService.getPlacementProfile
-          .withArgs({ userId: candidate.userId, limitDate: candidate.reconciledAt })
-          .resolves({ isCertifiable: sinon.stub().returns(true) });
-
-        certificationCenterRepository.getBySessionId.withArgs({ sessionId }).resolves(
-          domainBuilder.buildCertificationCenter({
-            habilitations: [
-              domainBuilder.certification.enrolment.buildHabilitation({
-                complementaryCertificationId: complementaryCertification.id,
-                key: complementaryCertification.key,
-                label: complementaryCertification.label,
-              }),
-            ],
-          }),
-        );
-
-        // when
-        // then
-        return expect(
-          verifyCandidateReconciliationRequirements({
-            candidate,
-            sessionId,
-            placementProfileService,
-            certificationCenterRepository,
-          }),
-        ).to.be.fulfilled;
-      });
     });
   });
 });

--- a/mon-pix/app/components/certification-joiner.gjs
+++ b/mon-pix/app/components/certification-joiner.gjs
@@ -277,7 +277,6 @@ export default class CertificationJoiner extends Component {
                   {{this.errorMessageLink.label}}
                   <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
                 </a>
-
               {{/if}}
             </PixNotificationAlert>
           </div>
@@ -336,9 +335,11 @@ const ERROR_HANDLERS = [
   },
   {
     match: (error) => error.status === '403' && error.code === 'CENTER_HABILITATION_ERROR',
-    handle(component) {
+    handle(component, error) {
+      const subscription = component.intl.t(`pages.certification-frameworks.${error.meta?.framework}`);
       component.errorMessage = component.intl.t(
         'pages.certification-joiner.error-messages.missing-center-habilitation',
+        { subscription, htmlSafe: true },
       );
     },
   },

--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -178,7 +178,9 @@ export default class CertificationStarter extends Component {
     if (ERROR_MESSAGE_KEYS[statusCode]) {
       this.apiErrorMessage = this.intl.t(ERROR_MESSAGE_KEYS[statusCode]);
     } else if (statusCode === '403' && FORBIDDEN_ERROR_MESSAGE_KEYS[errorCode]) {
-      this.apiErrorMessage = this.intl.t(FORBIDDEN_ERROR_MESSAGE_KEYS[errorCode]);
+      const interpolationValues =
+        errorCode === 'CENTER_HABILITATION_ERROR' ? { subscription: this.subscriptionLabel, htmlSafe: true } : {};
+      this.apiErrorMessage = this.intl.t(FORBIDDEN_ERROR_MESSAGE_KEYS[errorCode], interpolationValues);
     } else {
       this.technicalErrorInformation = `${error.message} ${error.stack}`;
       this.apiErrorMessage = this.intl.t('pages.certification-start.error-messages.generic');

--- a/mon-pix/tests/integration/components/certification-joiner-test.js
+++ b/mon-pix/tests/integration/components/certification-joiner-test.js
@@ -265,7 +265,7 @@ module('Integration | Component | certification-joiner', function (hooks) {
         const saveStub = sinon.stub();
         saveStub
           .withArgs({ adapterOptions: { joinSession: true, sessionId: '123456' } })
-          .throws({ errors: [{ status: '403', code: 'CENTER_HABILITATION_ERROR' }] });
+          .throws({ errors: [{ status: '403', code: 'CENTER_HABILITATION_ERROR', meta: { framework: 'DROIT' } }] });
         const createRecordMock = sinon.mock();
         createRecordMock.returns({ save: saveStub, deleteRecord: function () {} });
         store.createRecord = createRecordMock;
@@ -274,7 +274,7 @@ module('Integration | Component | certification-joiner', function (hooks) {
         await click(screen.getByRole('button', { name: t('pages.certification-joiner.form.actions.submit') }));
 
         // then
-        assert.ok(screen.getByText(t('pages.certification-joiner.error-messages.missing-center-habilitation')));
+        assert.ok(screen.getByText('Vous êtes inscrit à la certification Pix+ Droit.', { exact: false }));
       });
     });
 

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -824,7 +824,7 @@ module('Integration | Component | certification-starter', function (hooks) {
               sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
 
               this.set('model', {
-                certificationCandidate: { hasStartedTest: false, sessionId: 123 },
+                certificationCandidate: { hasStartedTest: false, sessionId: 123, subscription: 'DROIT' },
               });
               const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
               await fillIn(
@@ -846,7 +846,7 @@ module('Integration | Component | certification-starter', function (hooks) {
               await clickByLabel(t('pages.certification-start.actions.submit'));
 
               // then
-              assert.ok(screen.getByText(t('pages.certification-joiner.error-messages.missing-center-habilitation')));
+              assert.ok(screen.getByText('Vous êtes inscrit à la certification Pix+ Droit.', { exact: false }));
             });
           });
         });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -887,7 +887,7 @@
         },
         "language-not-supported": "Die Pix-Zertifizierung ist derzeit nicht in {userLanguage} verfügbar. '<br>' Die derzeit verfügbaren Sprachen, um die Zertifizierung zu absolvieren, sind : {availableLanguages}. '<br>' Du kannst eine andere Sprache von der Seite",
         "language-not-supported-link": "Mein Konto",
-        "missing-center-habilitation": "Du kannst nicht an der Testung teilnehmen. Die Zertifizierungsstelle ist nicht berechtigt, dich zu dieser Zertifizierung zuzulassen.",
+        "missing-center-habilitation": "Du bist für die Zertifizierung {subscription} angemeldet. '<br><br><strong>'Deine Zertifizierungsstelle ist nicht mehr berechtigt, diese Zertifizierung abzunehmen'</strong>'. '<br><br>' Bitte wende dich an deine Aufsichtsperson.",
         "session-not-accessible": "Die Testung, an der du versuchst teilzunehmen, ist nicht mehr zugänglich.",
         "wrong-account": "Die eingegebenen Informationen beziehen sich auf einen Kandidaten/eine Kandidatin, der/die sich für die Testung angemeldet hat und bereits mit einem anderen Konto angemeldet ist. Vergewissere dich, dass du mit dem Konto verbunden bist, das die Zertifizierung gestartet hat.",
         "wrong-account-sco": "Du verwendest derzeit ein Konto, das nicht mit deiner Organisation verknüpft ist.\nMelde dich bei dem Konto an, mit dem du deine Laufwege absolviert hast, oder bitte die Aufsichtsperson um Hilfe.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -887,7 +887,7 @@
         },
         "language-not-supported": "The Pix certification is not yet available in {userLanguage}. '<br>' The languages currently available for taking the certification exam are: {availableLanguages}. '<br>' You may choose another language from ",
         "language-not-supported-link": "My account page",
-        "missing-center-habilitation": "You cannot join the session. The certification centre is not authorized to administer this certification to you.",
+        "missing-center-habilitation": "You are registered for the {subscription} certification. '<br><br><strong>'Your certification centre is no longer authorized to administer this certification'</strong>'. '<br><br>' Please contact your invigilator.",
         "session-not-accessible": "The session you are trying to join is no longer available.",
         "wrong-account": "The information entered matches a candidate enrolled in the session and already logged in with another account. Please check that you are logged into the account that started the exam.",
         "wrong-account-sco": "You are currently using an account that is not linked to your school/organisation.\nLog in to the account you used to complete your customised tests or ask the invigilator for help.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -887,7 +887,7 @@
         },
         "language-not-supported": "La certificación Pix aún no está disponible en {userLanguage}. '<br>' Los idiomas disponibles actualmente para la certificación son: {availableLanguages}. '<br>' Puedes elegir otro idioma en la página",
         "language-not-supported-link": "Mi cuenta",
-        "missing-center-habilitation": "No puedes unirte a la sesión. El centro de certificación no está autorizado para realizar esta certificación.",
+        "missing-center-habilitation": "Estás inscrito en la certificación {subscription}. '<br><br><strong>'Tu centro de certificación ya no está autorizado para realizar esta certificación'</strong>'. '<br><br>' Por favor, ponte en contacto con tu supervisor.",
         "session-not-accessible": "La sesión a la que intentas unirte ya no está disponible.",
         "wrong-account": "La información introducida corresponde a un candidato registrado en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
         "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus test o pide ayuda al supervisor.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -887,7 +887,7 @@
         },
         "language-not-supported": "La certification Pix n'est pas encore disponible en {userLanguage}. '<br>' Les langues disponibles actuellement pour passer la certification sont : {availableLanguages}. '<br>' Vous pouvez choisir une autre langue depuis la page ",
         "language-not-supported-link": "Mon compte",
-        "missing-center-habilitation": "Vous ne pouvez pas rejoindre la session. Le centre de certification n'est pas habilité à vous faire passer cette certification.",
+        "missing-center-habilitation": "Vous êtes inscrit à la certification {subscription}. '<br><br><strong>'Votre centre de certification n'est plus habilité à faire passer cette certification'</strong>'. '<br><br>' Merci de vous rapprocher de votre surveillant.",
         "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
         "wrong-account": "Les informations saisies correspondent à un(e) candidat(e) inscrit(e) à la session et déjà connecté(e) avec un autre compte. Vérifiez que vous êtes connecté(e) au compte qui a démarré la certification.",
         "wrong-account-sco": "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement.\nConnectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant.",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -887,7 +887,7 @@
         },
         "language-not-supported": "La certificazione Pix non è ancora disponibile in {userLanguage}. '<br>' Le lingue attualmente disponibili per ottenere la certificazione sono: {availableLanguages}. '<br>' È possibile scegli un'altra lingua dalla pagina",
         "language-not-supported-link": "Il mio account",
-        "missing-center-habilitation": "Non è possibile partecipare alla sessione. Il centro di certificazione non è autorizzato a rilasciare questa certificazione.",
+        "missing-center-habilitation": "Sei iscritto alla certificazione {subscription}. '<br><br><strong>'Il tuo centro di certificazione non è più autorizzato a rilasciare questa certificazione'</strong>'. '<br><br>' Ti preghiamo di rivolgerti al tuo sorvegliante.",
         "session-not-accessible": "La sessione a cui si sta cercando di accedere non è più accessibile.",
         "wrong-account": "Le informazioni inserisci corrispondono a un candidato registrato per la sessione e già loggato con un altro account. Verificare di aver effettuato l'accesso con l'account che ha avviato la certificazione.",
         "wrong-account-sco": "Si sta utilizzando un account non collegato alla propria scuola.\nAccedi all'account con cui hai completato i corsi o chiedete aiuto al tuo sorvegliante.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -887,7 +887,7 @@
         },
         "language-not-supported": "Pix-certificering is nog niet beschikbaar in het {userLanguage}. '<br>' De talen die momenteel beschikbaar zijn voor certificering zijn: {availableLanguages}. '<br>' Je kunt een andere taal kiezen op de pagina",
         "language-not-supported-link": "Mijn account",
-        "missing-center-habilitation": "U kunt niet deelnemen aan de sessie. Het certificeringscentrum is niet bevoegd om u deze certificering te laten afleggen.",
+        "missing-center-habilitation": "Je bent ingeschreven voor de certificering {subscription}. '<br><br><strong>'Je certificeringscentrum is niet langer bevoegd om deze certificering af te nemen'</strong>'. '<br><br>' Neem contact op met je toezichthouder.",
         "session-not-accessible": "De sessie die u probeert te bezoeken is niet langer toegankelijk.",
         "wrong-account": "De ingevoerde informatie komt overeen met een kandidaat die is geregistreerd voor de sessie en al is ingelogd met een ander account. Controleer of u bent aangemeld bij het account waarmee de certificering is gestart.",
         "wrong-account-sco": "Je gebruikt momenteel een account dat niet aan je school is gekoppeld.\nLog in op het account waarmee je je cursussen hebt afgerond of vraag de toezichthouder om hulp.",


### PR DESCRIPTION
## 🪧 Problème

On ne vérifie ainsi plus l’habilitation pix+ d’un centre avant l’entrée en certif.

## 🌈 Proposition

Vérifier l'habilitation dans les 2 formulaires d'entrée en certif : 
- celui de réconciliation
- celui du mot de passe de session

## 🎉 Pour tester

En RA : 
- Ajouter un candidat à une session Pix+ non finalisée
- Modifier l'habilitation du centre pour qu'il n'ait plus les droits du Pix+ choisi
- Essayer d'entrer en certif avec ce candidat (faire le test sur les 2 formulaires)
