### PR TITLE
[BUGFIX] Éviter les clignotements d'erreur dans la page d'entrée en session de certif (PIX-23410).

### DIFF
--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -114,6 +114,10 @@ export default class CertificationStarter extends Component {
   @action
   handleAccessCodeInput(event) {
     this.inputAccessCode = event.target.value;
+
+    if (this.apiErrorMessage || this.validationErrorMessage) {
+      this.clearErrorMessage();
+    }
   }
 
   @action
@@ -260,7 +264,6 @@ export default class CertificationStarter extends Component {
             @value={{this.inputAccessCode}}
             @validationStatus={{this.validationStatus}}
             @errorMessage={{this.validationErrorMessage}}
-            {{on "keyup" this.clearErrorMessage}}
             {{on "input" this.handleAccessCodeInput}}
           />
         </div>

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -11,25 +11,51 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 const tWithoutTags = (key, options) => t(key, options).replace(/<[^>]+>/g, '');
 
+const renderComponent = () => render(hbs`<CertificationStarter @model={{this.model}} />`);
+
+const getSubmitButton = (screen) => screen.getByRole('button', { name: t('pages.certification-start.actions.submit') });
+
+const fillAccessCode = (screen, accessCode) =>
+  fillIn(screen.getByRole('textbox', { name: `${t('pages.certification-start.access-code')} *` }), accessCode);
+
+const confirmLanguageSelection = (screen) =>
+  click(
+    screen.getByRole('checkbox', {
+      name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
+    }),
+  );
+
+const submitForm = () => clickByLabel(t('pages.certification-start.actions.submit'));
+
+const stubFranceDomain = (owner, isFranceDomain) =>
+  sinon.stub(owner.lookup('service:currentDomain'), 'isFranceDomain').get(() => isFranceDomain);
+
+const stubCertificationInEnglish = (owner, isEnabled) =>
+  sinon
+    .stub(owner.lookup('service:feature-toggles'), 'featureToggles')
+    .get(() => ({ isCertificationInEnglishEnabled: isEnabled }));
+
+const setCertificationCandidate = (context, attributes) => {
+  const store = context.owner.lookup('service:store');
+  context.set('model', {
+    certificationCandidate: store.createRecord('certification-candidate', attributes),
+  });
+};
+
 module('Integration | Component | certification-starter', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('certification language selection', function () {
-    module('when on France domain (pix.fr)', function () {
+    module('when on France domain (pix.fr)', function (hooks) {
+      hooks.beforeEach(function () {
+        stubFranceDomain(this.owner, true);
+        setCertificationCandidate(this, { hasStartedTest: false });
+      });
+
       module('when code input is not fully filled', function () {
         test('should not display the language inputs and disable submit button', async function (assert) {
-          // given
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => true);
-          const store = this.owner.lookup('service:store');
-          this.set('model', {
-            certificationCandidate: store.createRecord('certification-candidate', {
-              hasStartedTest: false,
-            }),
-          });
-
           // when
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+          const screen = await renderComponent();
 
           // then
           assert.notOk(screen.queryByRole('button', { name: 'Langue de certification' }));
@@ -38,37 +64,15 @@ module('Integration | Component | certification-starter', function (hooks) {
               name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
             }),
           );
-          assert
-            .dom(
-              screen.getByRole('button', {
-                name: t('pages.certification-start.actions.submit'),
-              }),
-            )
-            .hasAttribute('aria-disabled', 'true');
+          assert.dom(getSubmitButton(screen)).hasAttribute('aria-disabled', 'true');
         });
       });
 
       module('when code input is fully filled', function () {
         test('should not display the language inputs and enable submit button', async function (assert) {
-          // given
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => true);
-          const store = this.owner.lookup('service:store');
-          this.set('model', {
-            certificationCandidate: store.createRecord('certification-candidate', {
-              hasStartedTest: false,
-            }),
-          });
-
           // when
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-
-          await fillIn(
-            screen.getByRole('textbox', {
-              name: `${t('pages.certification-start.access-code')} *`,
-            }),
-            '111111',
-          );
+          const screen = await renderComponent();
+          await fillAccessCode(screen, '111111');
 
           // then
           assert.notOk(screen.queryByRole('button', { name: 'Langue de certification' }));
@@ -77,36 +81,24 @@ module('Integration | Component | certification-starter', function (hooks) {
               name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
             }),
           );
-          assert
-            .dom(
-              screen.getByRole('button', {
-                name: t('pages.certification-start.actions.submit'),
-              }),
-            )
-            .doesNotHaveAttribute('aria-disabled', 'true');
+          assert.dom(getSubmitButton(screen)).doesNotHaveAttribute('aria-disabled', 'true');
         });
       });
     });
 
     module('when on org domain (pix.org)', function () {
-      module('when the candidate has not started the test', function () {
-        test('should display the language selector and confirmation checkbox', async function (assert) {
-          // given
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-          const store = this.owner.lookup('service:store');
-          this.set('model', {
-            certificationCandidate: store.createRecord('certification-candidate', {
-              hasStarted: false,
-            }),
-          });
+      module('when the candidate has not started the test', function (hooks) {
+        hooks.beforeEach(function () {
+          stubFranceDomain(this.owner, false);
+          setCertificationCandidate(this, { hasStartedTest: false });
+        });
 
+        test('should display the language selector and confirmation checkbox', async function (assert) {
           // when
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+          const screen = await renderComponent();
 
           // then
           assert.ok(screen.getByRole('button', { name: 'Langue de certification' }));
-
           assert.ok(
             screen.getByRole('checkbox', {
               name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
@@ -117,18 +109,8 @@ module('Integration | Component | certification-starter', function (hooks) {
         module('when certification in english is enabled', function () {
           test('should be possible to update the selected language', async function (assert) {
             // given
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-            const featureTogglesService = this.owner.lookup('service:feature-toggles');
-            sinon.stub(featureTogglesService, 'featureToggles').get(() => ({ isCertificationInEnglishEnabled: true }));
-            const store = this.owner.lookup('service:store');
-            this.set('model', {
-              certificationCandidate: store.createRecord('certification-candidate', {
-                hasStartedTest: false,
-              }),
-            });
-
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+            stubCertificationInEnglish(this.owner, true);
+            const screen = await renderComponent();
 
             // when
             await click(screen.getByRole('button', { name: 'Langue de certification' }));
@@ -145,19 +127,10 @@ module('Integration | Component | certification-starter', function (hooks) {
         module('when certification in english is disabled', function () {
           test('should display the language selector as disabled and a a warning message', async function (assert) {
             // given
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-            const featureTogglesService = this.owner.lookup('service:feature-toggles');
-            sinon.stub(featureTogglesService, 'featureToggles').get(() => ({ isCertificationInEnglishEnabled: false }));
-            const store = this.owner.lookup('service:store');
-            this.set('model', {
-              certificationCandidate: store.createRecord('certification-candidate', {
-                hasStartedTest: false,
-              }),
-            });
+            stubCertificationInEnglish(this.owner, false);
 
             // when
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+            const screen = await renderComponent();
 
             // then
             assert.dom(screen.getByRole('button', { name: 'Langue de certification' })).hasAttribute('aria-disabled');
@@ -168,133 +141,56 @@ module('Integration | Component | certification-starter', function (hooks) {
 
         module('when the language confirmation checkbox is not checked and code filled', function () {
           test('should have a disabled submit button ', async function (assert) {
-            // given
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-            const store = this.owner.lookup('service:store');
-            this.set('model', {
-              certificationCandidate: store.createRecord('certification-candidate', {
-                hasStartedTest: false,
-              }),
-            });
-
             // when
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-
-            await fillIn(
-              screen.getByRole('textbox', {
-                name: `${t('pages.certification-start.access-code')} *`,
-              }),
-              '111111',
-            );
+            const screen = await renderComponent();
+            await fillAccessCode(screen, '111111');
 
             // then
-            assert
-              .dom(
-                screen.getByRole('button', {
-                  name: t('pages.certification-start.actions.submit'),
-                }),
-              )
-              .hasAttribute('aria-disabled', 'true');
+            assert.dom(getSubmitButton(screen)).hasAttribute('aria-disabled', 'true');
           });
         });
 
         module('when the language confirmation checkbox is checked and code not filled', function () {
           test('should have a disabled submit button ', async function (assert) {
-            // given
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-            const store = this.owner.lookup('service:store');
-            this.set('model', {
-              certificationCandidate: store.createRecord('certification-candidate', {
-                hasStartedTest: false,
-              }),
-            });
-
             // when
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-
-            await clickByLabel(tWithoutTags('pages.certification-start.language-selector.confirmation-label'));
+            const screen = await renderComponent();
+            await confirmLanguageSelection(screen);
 
             // then
-            assert
-              .dom(
-                screen.getByRole('button', {
-                  name: t('pages.certification-start.actions.submit'),
-                }),
-              )
-              .hasAttribute('aria-disabled', 'true');
+            assert.dom(getSubmitButton(screen)).hasAttribute('aria-disabled', 'true');
           });
         });
 
         module('when the language confirmation checkbox is checked and code is filled', function () {
           test('should not have a disabled submit button ', async function (assert) {
-            // given
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-            const store = this.owner.lookup('service:store');
-            this.set('model', {
-              certificationCandidate: store.createRecord('certification-candidate', {
-                hasStartedTest: false,
-              }),
-            });
-
             // when
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-
-            await fillIn(
-              screen.getByRole('textbox', {
-                name: `${t('pages.certification-start.access-code')} *`,
-              }),
-              '111111',
-            );
-
-            await clickByLabel(tWithoutTags('pages.certification-start.language-selector.confirmation-label'));
+            const screen = await renderComponent();
+            await fillAccessCode(screen, '111111');
+            await confirmLanguageSelection(screen);
 
             // then
-            assert
-              .dom(
-                screen.getByRole('button', {
-                  name: t('pages.certification-start.actions.submit'),
-                }),
-              )
-              .doesNotHaveAttribute('aria-disabled', 'true');
+            assert.dom(getSubmitButton(screen)).doesNotHaveAttribute('aria-disabled', 'true');
           });
         });
       });
 
-      module('when the candidate has started the test', function () {
-        test('should not display the language selector', async function (assert) {
-          // given
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => true);
-          const store = this.owner.lookup('service:store');
-          this.set('model', {
-            certificationCandidate: store.createRecord('certification-candidate', {
-              hasStartedTest: true,
-            }),
-          });
+      module('when the candidate has started the test', function (hooks) {
+        hooks.beforeEach(function () {
+          stubFranceDomain(this.owner, false);
+          setCertificationCandidate(this, { hasStartedTest: true });
+        });
 
+        test('should not display the language selector', async function (assert) {
           // when
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+          const screen = await renderComponent();
 
           // then
           assert.notOk(screen.queryByRole('button', { name: 'Langue de certification' }));
         });
 
         test('should not display the language selection confirmation checkbox', async function (assert) {
-          // given
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => true);
-          const store = this.owner.lookup('service:store');
-          this.set('model', {
-            certificationCandidate: store.createRecord('certification-candidate', {
-              hasStartedTest: true,
-            }),
-          });
-
           // when
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+          const screen = await renderComponent();
 
           // then
           assert.notOk(
@@ -306,67 +202,23 @@ module('Integration | Component | certification-starter', function (hooks) {
 
         module('when code is filled', function () {
           test('should not have a disabled submit button ', async function (assert) {
-            // given
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-            const store = this.owner.lookup('service:store');
-            this.set('model', {
-              certificationCandidate: store.createRecord('certification-candidate', {
-                hasStartedTest: true,
-              }),
-            });
-
             // when
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-
-            await fillIn(
-              screen.getByRole('textbox', {
-                name: `${t('pages.certification-start.access-code')} *`,
-              }),
-              '111111',
-            );
+            const screen = await renderComponent();
+            await fillAccessCode(screen, '111111');
 
             // then
-            assert
-              .dom(
-                screen.getByRole('button', {
-                  name: t('pages.certification-start.actions.submit'),
-                }),
-              )
-              .doesNotHaveAttribute('aria-disabled', 'true');
+            assert.dom(getSubmitButton(screen)).doesNotHaveAttribute('aria-disabled', 'true');
           });
         });
 
         module('when code is not fully filled', function () {
           test('should have a disabled submit button ', async function (assert) {
-            // given
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-            const store = this.owner.lookup('service:store');
-            this.set('model', {
-              certificationCandidate: store.createRecord('certification-candidate', {
-                hasStartedTest: true,
-              }),
-            });
-
             // when
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-
-            await fillIn(
-              screen.getByRole('textbox', {
-                name: `${t('pages.certification-start.access-code')} *`,
-              }),
-              '111',
-            );
+            const screen = await renderComponent();
+            await fillAccessCode(screen, '111');
 
             // then
-            assert
-              .dom(
-                screen.getByRole('button', {
-                  name: t('pages.certification-start.actions.submit'),
-                }),
-              )
-              .hasAttribute('aria-disabled', 'true');
+            assert.dom(getSubmitButton(screen)).hasAttribute('aria-disabled', 'true');
           });
         });
       });
@@ -377,22 +229,11 @@ module('Integration | Component | certification-starter', function (hooks) {
     module('when access code is not provided', function () {
       test('should display an error message', async function (assert) {
         // given
-        const currentDomainService = this.owner.lookup('service:currentDomain');
-        sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-        const store = this.owner.lookup('service:store');
-        this.set('model', {
-          certificationCandidate: store.createRecord('certification-candidate', {
-            hasStarted: false,
-          }),
-        });
+        stubFranceDomain(this.owner, false);
+        setCertificationCandidate(this, { hasStarted: false });
 
-        const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-        await fillIn(
-          screen.getByRole('textbox', {
-            name: `${t('pages.certification-start.access-code')} *`,
-          }),
-          '',
-        );
+        const screen = await renderComponent();
+        await fillAccessCode(screen, '');
 
         // when
         await triggerEvent('.certification-start__form', 'submit');
@@ -442,33 +283,21 @@ module('Integration | Component | certification-starter', function (hooks) {
           const routerObserver = this.owner.lookup('service:router');
           routerObserver.replaceWith = sinon.stub();
 
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
-          const featureTogglesService = this.owner.lookup('service:feature-toggles');
-          sinon.stub(featureTogglesService, 'featureToggles').get(() => ({ isCertificationInEnglishEnabled: true }));
+          stubFranceDomain(this.owner, false);
+          stubCertificationInEnglish(this.owner, true);
 
           this.set('model', {
             certificationCandidate: { hasStartedTest: false, sessionId: 123 },
           });
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-          await fillIn(
-            screen.getByRole('textbox', {
-              name: `${t('pages.certification-start.access-code')} *`,
-            }),
-            'ABC123',
-          );
+          const screen = await renderComponent();
+          await fillAccessCode(screen, 'ABC123');
           await click(screen.getByRole('button', { name: 'Langue de certification' }));
           await click(screen.getByText('anglais - EN'));
-          await click(
-            screen.getByRole('checkbox', {
-              name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-            }),
-          );
+          await confirmLanguageSelection(screen);
           routerObserver.replaceWith.returns('ok');
 
           // when
-          await clickByLabel(t('pages.certification-start.actions.submit'));
+          await submitForm();
 
           // then
           sinon.assert.calledWithExactly(createRecordStub, 'certification-course', {
@@ -500,26 +329,18 @@ module('Integration | Component | certification-starter', function (hooks) {
 
         this.owner.register('service:store', StoreServiceStub);
 
-        const currentDomainService = this.owner.lookup('service:currentDomain');
-        sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
+        stubFranceDomain(this.owner, false);
 
         this.set('model', {
           certificationCandidate: { hasStartedTest: false, sessionId: 123 },
         });
 
         // when
-        const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-        await fillIn(
-          screen.getByRole('textbox', { name: `${t('pages.certification-start.access-code')} *` }),
-          'ABC123',
-        );
-        await click(
-          screen.getByRole('checkbox', {
-            name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-          }),
-        );
+        const screen = await renderComponent();
+        await fillAccessCode(screen, 'ABC123');
+        await confirmLanguageSelection(screen);
 
-        const submitButton = screen.getByRole('button', { name: t('pages.certification-start.actions.submit') });
+        const submitButton = getSubmitButton(screen);
         await click(submitButton);
         await click(submitButton);
 
@@ -527,10 +348,36 @@ module('Integration | Component | certification-starter', function (hooks) {
         assert.ok(certificationCourse.save.calledOnce);
       });
 
-      module('when the creation of certification course is in error', function () {
+      module('when the creation of certification course is in error', function (hooks) {
+        hooks.beforeEach(function () {
+          class RouterServiceStub extends Service {
+            replaceWith = sinon.stub();
+          }
+
+          this.owner.register('service:router', RouterServiceStub);
+
+          const certificationCourse = {
+            id: '123',
+            save: sinon.stub(),
+            deleteRecord: sinon.stub(),
+          };
+          this.certificationCourse = certificationCourse;
+
+          class StoreServiceStub extends Service {
+            createRecord = sinon.stub().returns(certificationCourse);
+          }
+
+          this.owner.register('service:store', StoreServiceStub);
+
+          stubFranceDomain(this.owner, false);
+
+          this.set('model', {
+            certificationCandidate: { hasStartedTest: false, sessionId: 123 },
+          });
+        });
+
         test('should not notify pix companion', async function (assert) {
           // given
-          const replaceWithStub = sinon.stub();
           const startCertificationStub = sinon.stub();
 
           class PixCompanionServiceStub extends Service {
@@ -538,256 +385,85 @@ module('Integration | Component | certification-starter', function (hooks) {
           }
 
           this.owner.register('service:pix-companion', PixCompanionServiceStub);
+          this.certificationCourse.save.rejects({ errors: [{ status: '404' }] });
 
-          class RouterServiceStub extends Service {
-            replaceWith = replaceWithStub;
-          }
-
-          this.owner.register('service:router', RouterServiceStub);
-          const createRecordStub = sinon.stub();
-
-          class StoreStubService extends Service {
-            createRecord = createRecordStub;
-          }
-
-          this.owner.register('service:store', StoreStubService);
-
-          const certificationCourse = {
-            id: '123',
-            save: sinon.stub(),
-            deleteRecord: sinon.stub(),
-          };
-          createRecordStub.returns(certificationCourse);
-
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
-          this.set('model', {
-            certificationCandidate: { hasStartedTest: false, sessionId: 123 },
-          });
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-          await fillIn(
-            screen.getByRole('textbox', {
-              name: `${t('pages.certification-start.access-code')} *`,
-            }),
-            'ABC123',
-          );
-          await click(
-            screen.getByRole('checkbox', {
-              name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-            }),
-          );
-          certificationCourse.save.rejects({ errors: [{ status: '404' }] });
+          const screen = await renderComponent();
+          await fillAccessCode(screen, 'ABC123');
+          await confirmLanguageSelection(screen);
 
           // when
-          await clickByLabel(t('pages.certification-start.actions.submit'));
+          await submitForm();
 
           // then
-          assert.ok(screen.getByText('Ce code n’existe pas ou n’est plus valide.'));
+          assert.ok(screen.getByText(t('pages.certification-start.error-messages.access-code-error')));
           sinon.assert.notCalled(startCertificationStub);
         });
 
         test('should display the appropriate error message when error status is 404', async function (assert) {
           // given
-          const replaceWithStub = sinon.stub();
-
-          class RouterServiceStub extends Service {
-            replaceWith = replaceWithStub;
-          }
-
-          this.owner.register('service:router', RouterServiceStub);
-          const createRecordStub = sinon.stub();
-
-          class StoreStubService extends Service {
-            createRecord = createRecordStub;
-          }
-
-          this.owner.register('service:store', StoreStubService);
-          const certificationCourse = {
-            id: '123',
-            save: sinon.stub(),
-            deleteRecord: sinon.stub(),
-          };
-          createRecordStub.returns(certificationCourse);
-
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
-          this.set('model', {
-            certificationCandidate: { hasStartedTest: false, sessionId: 123 },
-          });
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-          await fillIn(
-            screen.getByRole('textbox', {
-              name: `${t('pages.certification-start.access-code')} *`,
-            }),
-            'ABC123',
-          );
-          await click(
-            screen.getByRole('checkbox', {
-              name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-            }),
-          );
-          certificationCourse.save.rejects({ errors: [{ status: '404' }] });
+          this.certificationCourse.save.rejects({ errors: [{ status: '404' }] });
+          const screen = await renderComponent();
+          await fillAccessCode(screen, 'ABC123');
+          await confirmLanguageSelection(screen);
 
           // when
-          await clickByLabel(t('pages.certification-start.actions.submit'));
+          await submitForm();
 
           // then
-          assert.ok(screen.getByText('Ce code n’existe pas ou n’est plus valide.'));
+          assert.ok(screen.getByText(t('pages.certification-start.error-messages.access-code-error')));
         });
 
         test('should clear the error only when the access code is edited', async function (assert) {
           // given
-          const replaceWithStub = sinon.stub();
-
-          class RouterServiceStub extends Service {
-            replaceWith = replaceWithStub;
-          }
-
-          this.owner.register('service:router', RouterServiceStub);
-          const createRecordStub = sinon.stub();
-
-          class StoreStubService extends Service {
-            createRecord = createRecordStub;
-          }
-
-          this.owner.register('service:store', StoreStubService);
-          const certificationCourse = {
-            id: '123',
-            save: sinon.stub(),
-            deleteRecord: sinon.stub(),
-          };
-          createRecordStub.returns(certificationCourse);
-
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
-          this.set('model', {
-            certificationCandidate: { hasStartedTest: false, sessionId: 123 },
-          });
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+          this.certificationCourse.save.rejects({ errors: [{ status: '404' }] });
+          const screen = await renderComponent();
           const accessCodeInput = screen.getByRole('textbox', {
             name: `${t('pages.certification-start.access-code')} *`,
           });
           await fillIn(accessCodeInput, 'ABC123');
-          await click(
-            screen.getByRole('checkbox', {
-              name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-            }),
-          );
-          certificationCourse.save.rejects({ errors: [{ status: '404' }] });
+          await confirmLanguageSelection(screen);
+          await submitForm();
+          assert.ok(screen.getByText(t('pages.certification-start.error-messages.access-code-error')));
 
-          await clickByLabel(t('pages.certification-start.actions.submit'));
-          assert.ok(screen.getByText('Ce code n’existe pas ou n’est plus valide.'));
-
+          // when a key is released without editing the code
           await triggerEvent(accessCodeInput, 'keyup');
 
-          assert.ok(screen.getByText('Ce code n’existe pas ou n’est plus valide.'));
+          // then the error message is still displayed
+          assert.ok(screen.getByText(t('pages.certification-start.error-messages.access-code-error')));
 
+          // when the access code is edited
           await fillIn(accessCodeInput, 'XYZ789');
 
-          assert.notOk(screen.queryByText('Ce code n’existe pas ou n’est plus valide.'));
+          // then the error message is cleared
+          assert.notOk(screen.queryByText(t('pages.certification-start.error-messages.access-code-error')));
         });
 
         test('should display the appropriate error message when error status is 412', async function (assert) {
           // given
-          const replaceWithStub = sinon.stub();
-
-          class RouterServiceStub extends Service {
-            replaceWith = replaceWithStub;
-          }
-
-          this.owner.register('service:router', RouterServiceStub);
-          const createRecordStub = sinon.stub();
-
-          class StoreStubService extends Service {
-            createRecord = createRecordStub;
-          }
-
-          this.owner.register('service:store', StoreStubService);
-          const certificationCourse = {
-            id: '123',
-            save: sinon.stub(),
-            deleteRecord: sinon.stub(),
-          };
-          createRecordStub.returns(certificationCourse);
-
-          const currentDomainService = this.owner.lookup('service:currentDomain');
-          sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
-          this.set('model', {
-            certificationCandidate: { hasStartedTest: false, sessionId: 123 },
-          });
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-          await fillIn(
-            screen.getByRole('textbox', {
-              name: `${t('pages.certification-start.access-code')} *`,
-            }),
-            'ABC123',
-          );
-          await click(
-            screen.getByRole('checkbox', {
-              name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-            }),
-          );
-          certificationCourse.save.rejects({ errors: [{ status: '412' }] });
+          this.certificationCourse.save.rejects({ errors: [{ status: '412' }] });
+          const screen = await renderComponent();
+          await fillAccessCode(screen, 'ABC123');
+          await confirmLanguageSelection(screen);
 
           // when
-          await clickByLabel(t('pages.certification-start.actions.submit'));
+          await submitForm();
 
           // then
-          assert.ok(screen.getByText("La session de certification n'est plus accessible."));
+          assert.ok(screen.getByText(t('pages.certification-start.error-messages.session-not-accessible')));
         });
 
         module('when error status is 403', function () {
           test('should display the appropriate error message when error candidate not authorized to join session', async function (assert) {
             // given
-            const replaceWithStub = sinon.stub();
-
-            class RouterServiceStub extends Service {
-              replaceWith = replaceWithStub;
-            }
-
-            this.owner.register('service:router', RouterServiceStub);
-            const createRecordStub = sinon.stub();
-
-            class StoreStubService extends Service {
-              createRecord = createRecordStub;
-            }
-
-            this.owner.register('service:store', StoreStubService);
-            const certificationCourse = {
-              id: '123',
-              save: sinon.stub(),
-              deleteRecord: sinon.stub(),
-            };
-            createRecordStub.returns(certificationCourse);
-
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
-            this.set('model', {
-              certificationCandidate: { hasStartedTest: false, sessionId: 123 },
-            });
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-            await fillIn(
-              screen.getByRole('textbox', {
-                name: `${t('pages.certification-start.access-code')} *`,
-              }),
-              'ABC123',
-            );
-            await click(
-              screen.getByRole('checkbox', {
-                name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-              }),
-            );
-            certificationCourse.save.rejects({
+            this.certificationCourse.save.rejects({
               errors: [{ status: '403', code: 'CANDIDATE_NOT_AUTHORIZED_TO_JOIN_SESSION' }],
             });
+            const screen = await renderComponent();
+            await fillAccessCode(screen, 'ABC123');
+            await confirmLanguageSelection(screen);
 
             // when
-            await clickByLabel(t('pages.certification-start.actions.submit'));
+            await submitForm();
 
             // then
             assert.ok(
@@ -797,51 +473,15 @@ module('Integration | Component | certification-starter', function (hooks) {
 
           test('should display the appropriate error message when error candidate not authorized to resume session', async function (assert) {
             // given
-            const replaceWithStub = sinon.stub();
-
-            class RouterServiceStub extends Service {
-              replaceWith = replaceWithStub;
-            }
-
-            this.owner.register('service:router', RouterServiceStub);
-            const createRecordStub = sinon.stub();
-
-            class StoreStubService extends Service {
-              createRecord = createRecordStub;
-            }
-
-            this.owner.register('service:store', StoreStubService);
-            const certificationCourse = {
-              id: '123',
-              save: sinon.stub(),
-              deleteRecord: sinon.stub(),
-            };
-            createRecordStub.returns(certificationCourse);
-
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
-            this.set('model', {
-              certificationCandidate: { hasStartedTest: false, sessionId: 123 },
-            });
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-            await fillIn(
-              screen.getByRole('textbox', {
-                name: `${t('pages.certification-start.access-code')} *`,
-              }),
-              'ABC123',
-            );
-            await click(
-              screen.getByRole('checkbox', {
-                name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-              }),
-            );
-            certificationCourse.save.rejects({
+            this.certificationCourse.save.rejects({
               errors: [{ status: '403', code: 'CANDIDATE_NOT_AUTHORIZED_TO_RESUME_SESSION' }],
             });
+            const screen = await renderComponent();
+            await fillAccessCode(screen, 'ABC123');
+            await confirmLanguageSelection(screen);
 
             // when
-            await clickByLabel(t('pages.certification-start.actions.submit'));
+            await submitForm();
 
             // then
             assert.ok(
@@ -852,51 +492,18 @@ module('Integration | Component | certification-starter', function (hooks) {
           module('when the certification centre has no habilitation to hold the session', function () {
             test('should display the appropriate error message', async function (assert) {
               // given
-              const replaceWithStub = sinon.stub();
-
-              class RouterServiceStub extends Service {
-                replaceWith = replaceWithStub;
-              }
-
-              this.owner.register('service:router', RouterServiceStub);
-              const createRecordStub = sinon.stub();
-
-              class StoreStubService extends Service {
-                createRecord = createRecordStub;
-              }
-
-              this.owner.register('service:store', StoreStubService);
-              const certificationCourse = {
-                id: '123',
-                save: sinon.stub(),
-                deleteRecord: sinon.stub(),
-              };
-              createRecordStub.returns(certificationCourse);
-
-              const currentDomainService = this.owner.lookup('service:currentDomain');
-              sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
               this.set('model', {
                 certificationCandidate: { hasStartedTest: false, sessionId: 123, subscription: 'DROIT' },
               });
-              const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-              await fillIn(
-                screen.getByRole('textbox', {
-                  name: `${t('pages.certification-start.access-code')} *`,
-                }),
-                'ABC123',
-              );
-              await click(
-                screen.getByRole('checkbox', {
-                  name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-                }),
-              );
-              certificationCourse.save.rejects({
+              this.certificationCourse.save.rejects({
                 errors: [{ status: '403', code: 'CENTER_HABILITATION_ERROR' }],
               });
+              const screen = await renderComponent();
+              await fillAccessCode(screen, 'ABC123');
+              await confirmLanguageSelection(screen);
 
               // when
-              await clickByLabel(t('pages.certification-start.actions.submit'));
+              await submitForm();
 
               // then
               assert.ok(screen.getByText('Vous êtes inscrit à la certification Pix+ Droit.', { exact: false }));
@@ -907,56 +514,21 @@ module('Integration | Component | certification-starter', function (hooks) {
         module('when error status unknown', function () {
           test('should display a generic error message', async function (assert) {
             // given
-            const replaceWithStub = sinon.stub();
-
-            class RouterServiceStub extends Service {
-              replaceWith = replaceWithStub;
-            }
-
-            this.owner.register('service:router', RouterServiceStub);
-            const createRecordStub = sinon.stub();
-
-            class StoreStubService extends Service {
-              createRecord = createRecordStub;
-            }
-
-            this.owner.register('service:store', StoreStubService);
-            const certificationCourse = {
-              id: '123',
-              save: sinon.stub(),
-              deleteRecord: sinon.stub(),
-            };
-            createRecordStub.returns(certificationCourse);
-
-            const currentDomainService = this.owner.lookup('service:currentDomain');
-            sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
-
-            this.set('model', {
-              certificationCandidate: { hasStartedTest: false, sessionId: 123 },
-            });
-            const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
-            await fillIn(
-              screen.getByRole('textbox', {
-                name: `${t('pages.certification-start.access-code')} *`,
-              }),
-              'ABC123',
-            );
-            await click(
-              screen.getByRole('checkbox', {
-                name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
-              }),
-            );
-            certificationCourse.save.throws(new Error("Détails de l'erreur à envoyer à Pix"));
+            const errorDetails = "Détails de l'erreur à envoyer à Pix";
+            this.certificationCourse.save.throws(new Error(errorDetails));
+            const screen = await renderComponent();
+            await fillAccessCode(screen, 'ABC123');
+            await confirmLanguageSelection(screen);
 
             // when
-            await clickByLabel(t('pages.certification-start.actions.submit'));
+            await submitForm();
 
             // then
-            assert.ok(screen.getByText('Une erreur serveur inattendue vient de se produire.'));
-            await click(screen.getByText('Afficher plus de détails :'));
+            assert.ok(screen.getByText(t('pages.certification-start.error-messages.generic')));
+            await click(screen.getByText(t('pages.certification-start.error-messages.unknown.summary-label')));
             const group = screen.getByRole('group');
 
-            assert.ok(group.textContent.includes("Détails de l'erreur à envoyer à Pix"));
+            assert.ok(group.textContent.includes(errorDetails));
           });
         });
       });
@@ -967,16 +539,10 @@ module('Integration | Component | certification-starter', function (hooks) {
     module('when the candidate has only core or complementary subscription', function () {
       test('should not display subscription eligible panel', async function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
-        this.set('model', {
-          certificationCandidate: store.createRecord('certification-candidate', {
-            subscription: 'CORE',
-            doubleCertificationEligibility: false,
-          }),
-        });
+        setCertificationCandidate(this, { subscription: 'CORE', doubleCertificationEligibility: false });
 
         // when
-        const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+        const screen = await renderComponent();
 
         // then
         assert.notOk(screen.queryByText('Vous n’êtes pas éligible à'));
@@ -988,20 +554,14 @@ module('Integration | Component | certification-starter', function (hooks) {
       module('when the candidate is eligible', function () {
         test('should display subscription eligible panel', async function (assert) {
           // given
-          const store = this.owner.lookup('service:store');
-          this.set('model', {
-            certificationCandidate: store.createRecord('certification-candidate', {
-              subscription: 'CLEA',
-              doubleCertificationEligibility: true,
-            }),
-          });
+          setCertificationCandidate(this, { subscription: 'CLEA', doubleCertificationEligibility: true });
 
           // when
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+          const screen = await renderComponent();
 
           // then
           assert.ok(screen.getByText(t('pages.certification-start.core-and-complementary-subscriptions')));
-          assert.ok(screen.getByText('CLéA Numérique'));
+          assert.ok(screen.getByText(t('pages.certification-frameworks.CLEA')));
           assert.notOk(screen.queryByText('Vous n’êtes pas éligible à'));
         });
       });
@@ -1009,21 +569,17 @@ module('Integration | Component | certification-starter', function (hooks) {
       module('when the candidate is not eligible', function () {
         test('should display subscription non eligible panel', async function (assert) {
           // given
-          const store = this.owner.lookup('service:store');
-          this.set('model', {
-            certificationCandidate: store.createRecord('certification-candidate', {
-              subscription: 'CLEA',
-              doubleCertificationEligibility: false,
-            }),
-          });
+          setCertificationCandidate(this, { subscription: 'CLEA', doubleCertificationEligibility: false });
 
           // when
-          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+          const screen = await renderComponent();
 
           // then
           assert.ok(
             screen.getByText(
-              "Vous n'êtes pas éligible à CLéA Numérique. Vous pouvez néanmoins passer votre certification Pix.",
+              t('pages.certification-start.non-eligible-subscription', {
+                subscriptionLabel: t('pages.certification-frameworks.CLEA'),
+              }),
             ),
           );
           assert.ok(screen.queryByText(t('pages.certification-start.core-and-complementary-subscriptions')));

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -637,6 +637,59 @@ module('Integration | Component | certification-starter', function (hooks) {
           assert.ok(screen.getByText('Ce code n’existe pas ou n’est plus valide.'));
         });
 
+        test('should clear the error only when the access code is edited', async function (assert) {
+          // given
+          const replaceWithStub = sinon.stub();
+
+          class RouterServiceStub extends Service {
+            replaceWith = replaceWithStub;
+          }
+
+          this.owner.register('service:router', RouterServiceStub);
+          const createRecordStub = sinon.stub();
+
+          class StoreStubService extends Service {
+            createRecord = createRecordStub;
+          }
+
+          this.owner.register('service:store', StoreStubService);
+          const certificationCourse = {
+            id: '123',
+            save: sinon.stub(),
+            deleteRecord: sinon.stub(),
+          };
+          createRecordStub.returns(certificationCourse);
+
+          const currentDomainService = this.owner.lookup('service:currentDomain');
+          sinon.stub(currentDomainService, 'isFranceDomain').get(() => false);
+
+          this.set('model', {
+            certificationCandidate: { hasStartedTest: false, sessionId: 123 },
+          });
+          const screen = await render(hbs`<CertificationStarter @model={{this.model}} />`);
+          const accessCodeInput = screen.getByRole('textbox', {
+            name: `${t('pages.certification-start.access-code')} *`,
+          });
+          await fillIn(accessCodeInput, 'ABC123');
+          await click(
+            screen.getByRole('checkbox', {
+              name: tWithoutTags('pages.certification-start.language-selector.confirmation-label'),
+            }),
+          );
+          certificationCourse.save.rejects({ errors: [{ status: '404' }] });
+
+          await clickByLabel(t('pages.certification-start.actions.submit'));
+          assert.ok(screen.getByText('Ce code n’existe pas ou n’est plus valide.'));
+
+          await triggerEvent(accessCodeInput, 'keyup');
+
+          assert.ok(screen.getByText('Ce code n’existe pas ou n’est plus valide.'));
+
+          await fillIn(accessCodeInput, 'XYZ789');
+
+          assert.notOk(screen.queryByText('Ce code n’existe pas ou n’est plus valide.'));
+        });
+
         test('should display the appropriate error message when error status is 412', async function (assert) {
           // given
           const replaceWithStub = sinon.stub();


### PR DESCRIPTION
## 🪧 Problème

Dans la page de mot de passe de session, à la soumission avec Enter du composant PixCode, on déclenche un rerender qui annule l’affichage d’une éventuelle erreur.

## 🌈 Proposition

Ne plus déclencher de nettoyage d’erreurs lors de toutes les actions clavier.  

## ✊ Remarques

Je profite de la PR pour alléger le fichier de test.

## 🎉 Pour tester

En RA : 
- Aller jusqu'à la page d'accès à une session de certif
- Ne pas accorder le droit d'entrer dans l'espace surveillant
- En ajoutant le code puis en faisait "Entrée", vérifier que l'erreur est bien visible
