### PR TITLE
[BUGFIX] Ne pas migrer les utilisateurs anonymisés dans la nouvelle table d'acceptations des CGU (PIX-21748)

### DIFF
--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -1,3 +1,4 @@
+import { REAL_PIX_SUPER_ADMIN_ID } from '../common/constants.js';
 import { OIDC_PROVIDER_EXAMPLE_NET_IDENTITY_PROVIDER } from './constants.js';
 
 function _buildUsers(databaseBuilder) {
@@ -82,9 +83,21 @@ function _buildGarUser(databaseBuilder) {
   });
 }
 
+function _buildAnonymisedUser(databaseBuilder) {
+  databaseBuilder.factory.buildUser({
+    firstName: '(anonymised)',
+    lastName: '(anonymised)',
+    email: null,
+    username: null,
+    hasBeenAnonymised: true,
+    hasBeenAnonymisedBy: REAL_PIX_SUPER_ADMIN_ID,
+  });
+}
+
 export function buildUsers(databaseBuilder) {
   _buildUsers(databaseBuilder);
   _buildOidcUser(databaseBuilder);
   _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder);
   _buildGarUser(databaseBuilder);
+  _buildAnonymisedUser(databaseBuilder);
 }

--- a/api/src/legal-documents/scripts/convert-users-pix-app-cgu-data.js
+++ b/api/src/legal-documents/scripts/convert-users-pix-app-cgu-data.js
@@ -78,6 +78,7 @@ export class ConvertUsersPixAppCguData extends Script {
     return knexConnection('users')
       .select('users.id', 'users.lastTermsOfServiceValidatedAt')
       .where('users.cgu', true)
+      .where('users.hasBeenAnonymised', false)
       .whereNotExists(
         knexConnection
           .select(1)

--- a/api/tests/legal-documents/integration/scripts/convert-users-pix-app-cgu-data.test.js
+++ b/api/tests/legal-documents/integration/scripts/convert-users-pix-app-cgu-data.test.js
@@ -158,6 +158,26 @@ describe('Integration | Legal documents | Scripts | convert-users-pix-app-cgu-da
       });
     });
 
+    context('when a user has been anonymised', function () {
+      it('does not migrate the anonymised user', async function () {
+        // given
+        databaseBuilder.factory.buildUser({
+          cgu: true,
+          hasBeenAnonymised: true,
+          lastTermsOfServiceValidatedAt: new Date('2021-01-01'),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const script = new ConvertUsersPixAppCguData();
+        const options = { dryRun: false, batchSize: 1, throttleDelay: 0 };
+        await script.handle({ options, logger });
+
+        // then
+        expect(logger.info).to.have.been.calledWith('Total users migrated: 0');
+      });
+    });
+
     context('when no legal document is found', function () {
       it('throws an error', async function () {
         // given


### PR DESCRIPTION
## 🪧 Problème

Le script `ConvertUsersPixAppCguData` n'exclut pas les utilisateurs anonymisés de la migration vers la table `legal-document-version-user-acceptances`.

## 🌈 Proposition

Modifier le script `ConvertUsersPixAppCguData` pour exclure de la migration les utilisateurs anonymisés.


## 🎉 Pour tester
### PRE-REQUIS
+ Récupérer l'id de la dernière version des CGU de Pix App dans la table des `legalDocumentVersions`
```sql
SELECT * FROM "legal-document-versions";
```

+ Supprimer les acceptations éventuelles de cette version des cgu :
```sql
DELETE FROM "legal-document-version-user-acceptances"
WHERE "legalDocumentVersionId" = {legalDocumentVersions.id};
```

+ Noter le nombre d'utilisateurs éligibles à la migration : 
```sql
SELECT COUNT(*) FROM "users" 
WHERE "cgu" = true 
AND ("hasBeenAnonymised" = false);
```

### TESTS

+ Lancer le script en dry-run :
```shell
node --env-file=.env src/legal-documents/scripts/convert-users-pix-app-cgu-data.js --dryRun
```

+ Vérifier que le nombre d'utilisateurs à migrer est correct

+ Lancer le script en dry-run avec un batch de `100` :
```shell
node --env-file=.env src/legal-documents/scripts/convert-users-pix-app-cgu-data.js --dryRun --batchSize=100
```

+ Lancer la migration : 
```shell
node --env-file=.env src/legal-documents/scripts/convert-users-pix-app-cgu-data.js
```

+ Vérifier que la table `legal-document-version-user-acceptances` est remplie avec tous les utilisateurs à migrer :
```sql
SELECT COUNT(*) FROM "legal-document-version-user-acceptances" 
WHERE "legalDocumentVersionId" = {legalDocumentVersions.id};
```

+ Récupérer l'id de l'utilisateur anonymisé :
```sql
SELECT * FROM "users" 
WHERE "hasBeenAnonymised" = true;
```
+ Vérifier qu'il n'a pas été migré :
```sql
SELECT COUNT(*) FROM "legal-document-version-user-acceptances" 
WHERE "userId" = {user.id};
```