### PR TITLE
[BUGFIX] Ajout de statuts manquants dans les créations de versions dans les tests E2E (PIX-23418).

### DIFF
--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-droit-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-droit-data.ts
@@ -7,6 +7,7 @@ export async function buildPixPlusDroitData(knex: Knex) {
     .insert({
       scope: CERTIFICATIONS_DATA.DROIT,
       startDate: new Date('2024-10-19'),
+      status: 'active',
       expirationDate: null,
       assessmentDuration: 120,
       minimumAnswersRequiredToValidateACertification: 20,

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-edu-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-edu-data.ts
@@ -8,6 +8,7 @@ export async function buildPixPlusEduData(knex: Knex) {
       scope: CERTIFICATIONS_DATA.EDU_1ER_DEGRE,
       startDate: new Date('2024-10-19'),
       expirationDate: null,
+      status: 'active',
       assessmentDuration: 120,
       minimumAnswersRequiredToValidateACertification: 20,
       globalScoringConfiguration: JSON.stringify([{ bounds: { max: 8, min: 3 }, meshLevel: 0 }]),

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-pro-sante-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-pro-sante-data.ts
@@ -7,6 +7,7 @@ export async function buildPixPlusProSanteData(knex: Knex) {
     .insert({
       scope: CERTIFICATIONS_DATA.PRO_SANTE,
       startDate: new Date('2024-10-19'),
+      status: 'active',
       expirationDate: null,
       assessmentDuration: 120,
       minimumAnswersRequiredToValidateACertification: 20,


### PR DESCRIPTION
## 🪧 Problème

Il manque des statuts dans les créations de versions dans les tests E2E.

## 🌈 Proposition

Rajout de versions actives

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

Tests verts ✅ 
