### PR TITLE
[FEATURE] Affiche l'obtention de l'attestation au niveau du suivi du parcours combiné dans PixOrga (PIX-23351)

### DIFF
--- a/api/db/seeds/data/common/organization-builder.js
+++ b/api/db/seeds/data/common/organization-builder.js
@@ -127,7 +127,13 @@ async function _createProOrganization(databaseBuilder) {
       { id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID },
       {
         id: FEATURE_ATTESTATIONS_MANAGEMENT_ID,
-        params: JSON.stringify([ATTESTATIONS.PARENTHOOD, 'MINARM', 'EDUSECU', 'MAIRIEBUREAU']),
+        params: JSON.stringify([
+          ATTESTATIONS.PARENTHOOD,
+          'MINARM',
+          'EDUSECU',
+          'MAIRIEBUREAU',
+          ATTESTATIONS.SIXTH_GRADE,
+        ]),
       },
       { id: FEATURE_PLACES_MANAGEMENT_ID },
       { id: FEATURE_COVER_RATE_ID },

--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -70,8 +70,10 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
   const blueprintSuccessRequirements = combinedCourseData.blueprint.requirements.map((req) => {
     if (req.type === 'evaluation') {
       return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO();
+    } else if (req.type === 'module') {
+      return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: req.moduleId }).toDTO();
     }
-    return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: req.moduleId }).toDTO();
+    return req;
   });
 
   const { id: blueprintQuestId } = buildQuestForCombinedCourse({
@@ -135,8 +137,10 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
   const combinedCourseSuccessRequirements = combinedCourseData.blueprint.requirements.map((req) => {
     if (req.type === 'evaluation') {
       return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ campaignId }).toDTO();
+    } else if (req.type === 'module') {
+      return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: req.moduleId }).toDTO();
     }
-    return CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: req.moduleId }).toDTO();
+    return req;
   });
 
   const { id: combinedCourseQuestId } = buildQuestForCombinedCourse({

--- a/api/db/seeds/data/team-prescription/fixtures/pro-combined-course.js
+++ b/api/db/seeds/data/team-prescription/fixtures/pro-combined-course.js
@@ -1,9 +1,11 @@
 import { faker } from '@faker-js/faker';
 
 import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { OrganizationLearnerParticipationStatuses } from '../../../../../src/quest/domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
+import { REQUIREMENT_TYPES } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
 import { PRO_ORGANIZATION_ID } from '../../common/constants.js';
-import { CAMPAIGN_PRO_COMBINED_COURSE_ID } from '../constants.js';
+import { CAMPAIGN_PRO_COMBINED_COURSE_ID, SIXTH_GRADE_REWARD_ID } from '../constants.js';
 
 export const PRO_COMBINED_COURSE = {
   organizationId: PRO_ORGANIZATION_ID,
@@ -14,7 +16,16 @@ export const PRO_COMBINED_COURSE = {
       { type: 'evaluation' },
       { type: 'module', moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' },
       { type: 'module', moduleId: 'f32a2238-4f65-4698-b486-15d51935d335' },
+      {
+        requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+        data: {
+          cappedTubes: [{ tubeId: 'recrkpItPsNRg2OjJ', level: 2 }],
+          threshold: 50,
+        },
+      },
     ],
+    rewardType: REWARD_TYPES.ATTESTATION,
+    rewardId: SIXTH_GRADE_REWARD_ID,
     description:
       "#Un parcours\n pour découvrir l'essentiel sur l'intelligence artificielle : [comprendre sa définition](http://pix.fr), ses domaines d'application, comment elle fonctionne, ainsi que ses enjeux, notamment en matière d'impact environnemental.",
     surveyUrl: 'http://pix.fr',

--- a/api/src/profile/application/api/profile-reward-api.js
+++ b/api/src/profile/application/api/profile-reward-api.js
@@ -12,6 +12,10 @@ export const findByUserIdAndRewardId = async ({ rewardId, userId }) => {
   return usecases.findByUserIdAndRewardId({ rewardId, userId });
 };
 
+export const findByUserIdsAndRewardId = async ({ rewardId, userIds }) => {
+  return usecases.findByUserIdsAndRewardId({ rewardId, userIds });
+};
+
 export const shareWithOrganization = async ({ userId, profileRewardId, organizationId }) => {
   return usecases.shareProfileReward({ userId, profileRewardId, organizationId });
 };

--- a/api/src/profile/domain/usecases/find-by-user-ids-and-reward-id.js
+++ b/api/src/profile/domain/usecases/find-by-user-ids-and-reward-id.js
@@ -1,0 +1,3 @@
+export const findByUserIdsAndRewardId = ({ rewardId, userIds, profileRewardRepository }) => {
+  return profileRewardRepository.findByUserIdsAndRewardId({ rewardId, userIds });
+};

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -32,6 +32,7 @@ const dependencies = {
 };
 
 import { findByUserIdAndRewardId } from './find-by-user-id-and-reward-id.js';
+import { findByUserIdsAndRewardId } from './find-by-user-ids-and-reward-id.js';
 import { getAllAttestations } from './get-all-attestations.js';
 import { getAttestationDataForUsers } from './get-attestation-data-for-users.js';
 import { getAttestationDetails } from './get-attestation-details.js';
@@ -57,6 +58,7 @@ const usecasesWithoutInjectedDependencies = {
   shareProfileReward,
   getByAttestationKey,
   findByUserIdAndRewardId,
+  findByUserIdsAndRewardId,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/profile/infrastructure/repositories/profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/profile-reward-repository.js
@@ -81,6 +81,14 @@ export const findByUserIdAndRewardId = async ({ rewardId, userId }) => {
   return profileReward ? toDomain(profileReward) : null;
 };
 
+export const findByUserIdsAndRewardId = async ({ rewardId, userIds }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const profileRewards = await knexConn('profile-rewards').whereIn('userId', userIds).where({ rewardId });
+
+  return profileRewards.map(toDomain);
+};
+
 const toDomain = (profileReward) => {
   return new ProfileReward(profileReward);
 };

--- a/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseDetails.js
+++ b/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseDetails.js
@@ -64,6 +64,10 @@ export class CombinedCourseDetails extends CombinedCourse {
     return this.#participation !== null;
   }
 
+  get hasReward() {
+    return Boolean(this.quest.rewardId);
+  }
+
   get campaignIds() {
     return this.quest.successRequirements
       .filter((requirement) => requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS)

--- a/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseDetails.js
+++ b/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseDetails.js
@@ -101,6 +101,7 @@ export class CombinedCourseDetails extends CombinedCourse {
       nbCampaignsCompleted: this.items.filter(
         ({ isCompleted, type }) => isCompleted && type === COMBINED_COURSE_ITEM_TYPES.CAMPAIGN,
       ).length,
+      rewardStatus: this.reward?.status,
     });
   }
 

--- a/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseParticipationDetails.js
+++ b/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseParticipationDetails.js
@@ -13,6 +13,7 @@ export class CombinedCourseParticipationDetails {
     nbModulesCompleted,
     nbCampaignsCompleted,
     hasFormationItem,
+    rewardStatus = null,
   }) {
     this.id = id;
     this.status = status;
@@ -27,5 +28,6 @@ export class CombinedCourseParticipationDetails {
     this.nbCampaigns = nbCampaigns;
     this.nbCampaignsCompleted = nbCampaignsCompleted;
     this.nbModulesCompleted = nbModulesCompleted;
+    this.rewardStatus = rewardStatus;
   }
 }

--- a/api/src/quest/domain/services/combined-course-details-service.js
+++ b/api/src/quest/domain/services/combined-course-details-service.js
@@ -84,21 +84,29 @@ async function getCombinedCourseDetails({
 
 async function getCombinedCourseDetailsForMultipleLearners({
   combinedCourseDetails,
-  organizationLearnerIds,
+  organizationLearners,
   combinedCourseParticipationRepository,
   eligibilityRepository,
   recommendedModuleRepository,
+  profileRewardRepository,
 }) {
+  const organizationLearnerIds = organizationLearners.map((organizationLearner) => organizationLearner.id);
+  const userIds = organizationLearners.map((organizationLearner) => organizationLearner.userId);
+
   const participations = await combinedCourseParticipationRepository.findByLearnerIds({
     organizationLearnerIds,
     combinedCourseId: combinedCourseDetails.id,
   });
 
+  const participationByLearnerId = new Map(
+    participations.map((participation) => [participation.organizationLearnerId, participation]),
+  );
   const learnerIdsWithParticipation = organizationLearnerIds.filter((organizationLearnerId) =>
-    participations.some((participation) => participation.organizationLearnerId === organizationLearnerId),
+    participationByLearnerId.has(organizationLearnerId),
   );
 
   let eligibilitiesByLearnerId = new Map();
+  let profileRewardByUserId = new Map();
 
   if (learnerIdsWithParticipation.length > 0) {
     eligibilitiesByLearnerId = await eligibilityRepository.findByOrganizationAndOrganizationLearnerIds({
@@ -106,42 +114,42 @@ async function getCombinedCourseDetailsForMultipleLearners({
       organizationId: combinedCourseDetails.organizationId,
       moduleIds: combinedCourseDetails.moduleIds,
     });
-  }
 
-  const dataForQuestByLearnerId = new Map();
-  const recommendedModulesByLearnerId = new Map();
-
-  for (const learnerId of learnerIdsWithParticipation) {
-    const eligibility = eligibilitiesByLearnerId.get(learnerId);
-    if (!eligibility) continue;
-
-    const dataForQuest = new DataForQuest({ eligibility });
-    dataForQuestByLearnerId.set(learnerId, dataForQuest);
-
-    const campaignParticipationIds =
-      combinedCourseDetails.quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
-
-    if (campaignParticipationIds.length > 0) {
-      const recommendedModules = await recommendedModuleRepository.findIdsByCampaignParticipationIds({
-        campaignParticipationIds,
-      });
-      recommendedModulesByLearnerId.set(learnerId, recommendedModules);
-    }
+    const profileRewards = await profileRewardRepository.findByUserIdsAndRewardId({
+      rewardId: combinedCourseDetails.quest.rewardId,
+      userIds,
+    });
+    profileRewardByUserId = new Map(profileRewards.map((profileReward) => [profileReward.userId, profileReward]));
   }
 
   const resultsByLearnerId = new Map();
 
-  for (const organizationLearnerId of organizationLearnerIds) {
-    const participation = participations.find(
-      (participation) => participation.organizationLearnerId === organizationLearnerId,
-    );
-    const dataForQuest = dataForQuestByLearnerId.get(organizationLearnerId);
-    const recommendedModuleIdsForUser = recommendedModulesByLearnerId.get(organizationLearnerId) ?? [];
+  for (const organizationLearner of organizationLearners) {
+    const participation = participationByLearnerId.get(organizationLearner.id);
+    const eligibility = eligibilitiesByLearnerId.get(organizationLearner.id);
+
+    let dataForQuest;
+    let recommendedModuleIdsForUser = [];
+
+    if (eligibility) {
+      dataForQuest = new DataForQuest({ eligibility });
+      const campaignParticipationIds =
+        combinedCourseDetails.quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+
+      if (campaignParticipationIds.length > 0) {
+        recommendedModuleIdsForUser = await recommendedModuleRepository.findIdsByCampaignParticipationIds({
+          campaignParticipationIds,
+        });
+      }
+    }
+
+    const profileReward = profileRewardByUserId.get(organizationLearner.userId);
 
     combinedCourseDetails.setDataAndGenerateItems({
       participation,
       recommendedModuleIdsForUser,
       dataForQuest,
+      reward: { obtainedAt: profileReward?.createdAt },
     });
 
     const state = {
@@ -155,7 +163,7 @@ async function getCombinedCourseDetailsForMultipleLearners({
       state.participationDetails = combinedCourseDetails.participationDetails;
     }
 
-    resultsByLearnerId.set(organizationLearnerId, state);
+    resultsByLearnerId.set(organizationLearner.id, state);
   }
 
   return resultsByLearnerId;

--- a/api/src/quest/domain/usecases/find-combined-course-participations.js
+++ b/api/src/quest/domain/usecases/find-combined-course-participations.js
@@ -5,7 +5,7 @@ export const findCombinedCourseParticipations = async ({
   combinedCourseParticipationRepository,
   combinedCourseDetailsService,
 }) => {
-  const { organizationLearnerIds, meta } =
+  const { organizationLearners, meta } =
     await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
       combinedCourseId,
       page,
@@ -17,7 +17,7 @@ export const findCombinedCourseParticipations = async ({
   });
 
   const resultsByLearnerId = await combinedCourseDetailsService.getCombinedCourseDetailsForMultipleLearners({
-    organizationLearnerIds,
+    organizationLearners,
     combinedCourseDetails,
   });
 

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -19,6 +19,7 @@ const { combinedCourseDetailsService: injectedCombinedCourseDetailsService } = i
     moduleRepository: repositories.moduleRepository,
     eligibilityRepository: repositories.eligibilityRepository,
     recommendedModuleRepository: repositories.recommendedModuleRepository,
+    profileRewardRepository: repositories.profileRewardRepository,
   },
 );
 

--- a/api/src/quest/infrastructure/repositories/combined-course-participations/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participations/combined-course-participation-repository.js
@@ -117,7 +117,7 @@ export const findPaginatedCombinedCourseParticipationById = async function ({ co
   const knexConnection = DomainTransaction.getConnection();
 
   const queryBuilder = knexConnection('organization_learner_participations')
-    .select('view-active-organization-learners.id')
+    .select('view-active-organization-learners.id', 'view-active-organization-learners.userId')
     .join(
       'view-active-organization-learners',
       'view-active-organization-learners.id',
@@ -129,11 +129,10 @@ export const findPaginatedCombinedCourseParticipationById = async function ({ co
     })
     .whereNull('organization_learner_participations.deletedAt')
     .orderBy(['lastName', 'firstName']);
-
   queryBuilder.modify(addSearchFilters, filters);
   const { results, pagination } = await fetchPage({ queryBuilder, paginationParams: page });
   return {
-    organizationLearnerIds: results.map((result) => result.id),
+    organizationLearners: results.map((result) => ({ id: result.id, userId: result.userId })),
     meta: pagination,
   };
 };

--- a/api/src/quest/infrastructure/repositories/profile-reward-repository.js
+++ b/api/src/quest/infrastructure/repositories/profile-reward-repository.js
@@ -4,6 +4,10 @@ export const findByUserIdAndRewardId = async ({ rewardId, userId, profileRewardA
   return profileRewardApi.findByUserIdAndRewardId({ rewardId, userId });
 };
 
+export const findByUserIdsAndRewardId = async ({ rewardId, userIds, profileRewardApi }) => {
+  return profileRewardApi.findByUserIdsAndRewardId({ rewardId, userIds });
+};
+
 export const reward = async ({ userId, rewardId, organizationId, profileRewardApi }) => {
   await profileRewardApi.save(userId, rewardId);
 

--- a/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
@@ -9,6 +9,7 @@ const serialize = function (combinedCourse) {
       'code',
       'hasCampaigns',
       'hasModules',
+      'hasReward',
       'campaignIds',
       'combinedCourseParticipations',
       'combinedCourseStatistics',

--- a/api/src/quest/infrastructure/serializers/combined-course-participation-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-participation-serializer.js
@@ -17,6 +17,7 @@ const serialize = function (combinedCourseParticipations, meta) {
       'nbCampaigns',
       'nbModulesCompleted',
       'nbCampaignsCompleted',
+      'rewardStatus',
     ],
     meta,
   }).serialize(combinedCourseParticipations);

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -2,6 +2,7 @@ import { ATTESTATIONS } from '../../../../../src/profile/domain/constants.js';
 import { ProfileReward } from '../../../../../src/profile/domain/models/ProfileReward.js';
 import {
   findByUserIdAndRewardId,
+  findByUserIdsAndRewardId,
   getByAttestationKeyAndUserIds,
   getById,
   getByIds,
@@ -359,6 +360,76 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       expect(result).to.be.an.instanceof(ProfileReward);
       expect(result.id).to.equal(expectedProfileReward.id);
       expect(result.rewardType).to.equal(REWARD_TYPES.ATTESTATION);
+    });
+  });
+  describe('#findByUserIdsAndRewardIds', function () {
+    it('should return the expected profile reward', async function () {
+      // given
+      const attestation = databaseBuilder.factory.buildAttestation({ key: 'key' });
+      const attestation2 = databaseBuilder.factory.buildAttestation({ key: 'key2' });
+      databaseBuilder.factory.buildProfileReward({ rewardId: attestation.id });
+      databaseBuilder.factory.buildProfileReward();
+
+      const user1 = databaseBuilder.factory.buildUser();
+      const user2 = databaseBuilder.factory.buildUser();
+
+      const attestation1User1 = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: user1.id,
+      });
+
+      const attestation1User2 = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: user2.id,
+      });
+
+      databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation2.id,
+        userId: user2.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const results = await findByUserIdsAndRewardId({
+        rewardId: attestation.id,
+        userIds: [user1.id, user2.id],
+      });
+
+      // then
+      expect(results.length).to.equal(2);
+      expect(results[0]).to.be.an.instanceof(ProfileReward);
+      expect(results[0].id).to.equal(attestation1User1.id);
+      expect(results[0].rewardType).to.equal(REWARD_TYPES.ATTESTATION);
+
+      expect(results[1]).to.be.an.instanceof(ProfileReward);
+      expect(results[1].id).to.equal(attestation1User2.id);
+      expect(results[1].rewardType).to.equal(REWARD_TYPES.ATTESTATION);
+    });
+    it('should return an empty array if the reward does not exist', async function () {
+      // given
+      const notExistingRewardId = 12;
+      const user = databaseBuilder.factory.buildUser();
+
+      // when
+      const result = await findByUserIdsAndRewardId({ rewardId: notExistingRewardId, userIds: [user.id] });
+
+      // then
+      expect(result.length).to.equal(0);
+    });
+    it('should return an empty array if no one in the given users has a profile reward', async function () {
+      // given
+      const rewardId = databaseBuilder.factory.buildAttestation().id;
+      const user1Id = databaseBuilder.factory.buildUser().id;
+      const user2Id = databaseBuilder.factory.buildUser().id;
+
+      await databaseBuilder.commit();
+
+      //when
+      const result = await findByUserIdsAndRewardId({ rewardId, userIds: [user1Id, user2Id] });
+
+      // then
+      expect(result.length).to.equal(0);
     });
   });
 });

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -295,7 +295,7 @@ ${organizationId};"{""name"":""Combinix"",""content"":[],""description"":""ma de
 
   describe('GET /api/combined-courses/{combinedCourseId}/participations', function () {
     context('when user has membership in the combined course organization', function () {
-      it('should return the combined course participations with details', async function () {
+      it('should return the combined course participations', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;

--- a/api/tests/quest/integration/domain/services/combined-course-details-service_test.js
+++ b/api/tests/quest/integration/domain/services/combined-course-details-service_test.js
@@ -2,7 +2,9 @@ import sinon from 'sinon';
 
 import { CombinedCourseStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
+import { CombinedCourseRewardStatuses } from '../../../../../src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseReward.js';
 import { OrganizationLearnerParticipationStatuses } from '../../../../../src/quest/domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
 import {
   CampaignCombinedCourseItem,
@@ -29,6 +31,7 @@ const { combinedCourseDetailsService: CombinedCourseDetailsService } = injectDep
     moduleRepository: repositories.moduleRepository,
     eligibilityRepository: repositories.eligibilityRepository,
     recommendedModuleRepository: repositories.recommendedModuleRepository,
+    profileRewardRepository: repositories.profileRewardRepository,
   },
 );
 
@@ -320,7 +323,10 @@ describe('Integration | Quest | Domain | Services | CombinedCourseDetailsService
         combinedCourseId,
       });
       const resultsByLearnerId = await CombinedCourseDetailsService.getCombinedCourseDetailsForMultipleLearners({
-        organizationLearnerIds: [organizationLearnerId, secondLearner.id],
+        organizationLearners: [
+          { id: organizationLearnerId, userId: userId },
+          { id: secondLearner.id, userId: secondLearner.userId },
+        ],
         combinedCourseDetails,
       });
 
@@ -340,6 +346,63 @@ describe('Integration | Quest | Domain | Services | CombinedCourseDetailsService
       expect(secondLearnerResult.items).to.have.lengthOf(3);
       expect(secondLearnerResult.items[0].participationStatus).to.equal(CampaignParticipationStatuses.STARTED);
       expect(secondLearnerResult.items[0].isCompleted).to.equal(false);
+    });
+
+    it('should return the reward status independently for each learner when processing multiple learners', async function () {
+      // given
+      const secondLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      const { id: attestationId } = databaseBuilder.factory.buildAttestation();
+      const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+        rewardId: attestationId,
+        rewardType: REWARD_TYPES.ATTESTATION,
+        successRequirements: [
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ campaignId: campaign.id }).toDTO(),
+        ],
+      });
+      const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+        code,
+        organizationId,
+        questId,
+      });
+
+      databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypeCombinedCourse({
+        combinedCourseId,
+        organizationLearnerId,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+      });
+      databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypeCombinedCourse({
+        combinedCourseId,
+        organizationLearnerId: secondLearner.id,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+      });
+
+      databaseBuilder.factory.buildProfileReward({
+        userId,
+        rewardId: attestationId,
+        rewardType: REWARD_TYPES.ATTESTATION,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const combinedCourseDetails = await CombinedCourseDetailsService.instantiateCombinedCourseDetails({
+        combinedCourseId,
+      });
+      const resultsByLearnerId = await CombinedCourseDetailsService.getCombinedCourseDetailsForMultipleLearners({
+        organizationLearners: [
+          { id: organizationLearnerId, userId: userId },
+          { id: secondLearner.id, userId: secondLearner.userId },
+        ],
+        combinedCourseDetails,
+      });
+
+      // then
+      expect(resultsByLearnerId.get(organizationLearnerId).participationDetails.rewardStatus).to.equal(
+        CombinedCourseRewardStatuses.OBTAINED,
+      );
+      expect(resultsByLearnerId.get(secondLearner.id).participationDetails.rewardStatus).to.equal(
+        CombinedCourseRewardStatuses.STARTED,
+      );
     });
   });
 

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
@@ -1,6 +1,7 @@
 import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
 import { CombinedCourseParticipationDetails } from '../../../../../src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseParticipationDetails.js';
+import { CombinedCourseRewardStatuses } from '../../../../../src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseReward.js';
 import { OrganizationLearnerParticipationStatuses } from '../../../../../src/quest/domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
@@ -11,6 +12,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
 
   beforeEach(async function () {
     const { id: campaignId, organizationId } = databaseBuilder.factory.buildCampaign();
+    const reward = databaseBuilder.factory.buildAttestation({ id: 2 });
     const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
       successRequirements: [
         CombinedCourseBlueprint.buildRequirementForCombinedCourse({ campaignId }).toDTO(),
@@ -18,6 +20,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
           moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
         }).toDTO(),
       ],
+      rewardId: reward.id,
     });
     const combinedCourse = databaseBuilder.factory.buildCombinedCourse({
       code: 'COMBI1',
@@ -38,6 +41,9 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
       combinedCourseId,
       status: CombinedCourseParticipationStatuses.STARTED,
     });
+
+    databaseBuilder.factory.buildProfileReward({ userId: learner1.userId, rewardId: reward.id });
+
     learner2 = databaseBuilder.factory.buildOrganizationLearner({
       firstName: 'Marianne',
       lastName: 'Klee',
@@ -97,6 +103,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
         nbModulesCompleted: 0,
         nbCampaigns: 1,
         nbCampaignsCompleted: 0,
+        rewardStatus: CombinedCourseRewardStatuses.OBTAINED,
       },
       {
         id: participation2.id,
@@ -112,6 +119,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
         nbModulesCompleted: 1,
         nbCampaigns: 1,
         nbCampaignsCompleted: 1,
+        rewardStatus: CombinedCourseRewardStatuses.NOT_OBTAINED,
       },
     ]);
   });
@@ -127,23 +135,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
     expect(meta).deep.equal({ page: 2, pageSize: 1, rowCount: 2, pageCount: 2 });
     expect(combinedCourseParticipations).lengthOf(1);
     expect(combinedCourseParticipations[0]).instanceOf(CombinedCourseParticipationDetails);
-    expect(combinedCourseParticipations).deep.equal([
-      {
-        id: participation2.id,
-        firstName: learner2.firstName,
-        lastName: learner2.lastName,
-        division: learner2.division,
-        group: learner2.group,
-        status: CombinedCourseParticipationStatuses.COMPLETED,
-        createdAt: participation2.createdAt,
-        updatedAt: participation2.updatedAt,
-        hasFormationItem: false,
-        nbModules: 1,
-        nbModulesCompleted: 1,
-        nbCampaigns: 1,
-        nbCampaignsCompleted: 1,
-      },
-    ]);
+    expect(combinedCourseParticipations[0].id).to.equal(participation2.id);
   });
 
   it('should return a list on participations filtered by fullname', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -462,158 +462,167 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
 
     it('should return user ids only for given combinedCourse id', async function () {
       // when
-      const { organizationLearnerIds } =
+      const { organizationLearners } =
         await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
           combinedCourseId,
         });
 
       // then
-      expect(organizationLearnerIds).deep.equal([
-        organizationLearner2.id,
-        organizationLearner3.id,
-        organizationLearner1.id,
+      expect(organizationLearners).deep.equal([
+        { id: organizationLearner2.id, userId: organizationLearner2.userId },
+        { id: organizationLearner3.id, userId: organizationLearner3.userId },
+        { id: organizationLearner1.id, userId: organizationLearner1.userId },
       ]);
     });
 
     it('should return paginated user ids', async function () {
       // when
-      const { organizationLearnerIds } =
+      const { organizationLearners } =
         await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
           combinedCourseId,
           page: { size: 1, number: 3 },
         });
       // then
-      expect(organizationLearnerIds).deep.equal([organizationLearner1.id]);
+      expect(organizationLearners).deep.equal([{ id: organizationLearner1.id, userId: organizationLearner1.userId }]);
     });
 
     it('should not return deleted participations to combined course', async function () {
-      const { organizationLearnerIds } =
+      const { organizationLearners } =
         await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({ combinedCourseId });
-      expect(organizationLearnerIds).to.not.include(organizationLearner4.id);
+      expect(organizationLearners).to.not.include({ id: organizationLearner4.id, userId: organizationLearner4.userId });
     });
 
     describe('filters', function () {
       it('should return participations even with empty filters', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: {},
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([
-          organizationLearner2.id,
-          organizationLearner3.id,
-          organizationLearner1.id,
+        expect(organizationLearners).deep.equal([
+          { id: organizationLearner2.id, userId: organizationLearner2.userId },
+          { id: organizationLearner3.id, userId: organizationLearner3.userId },
+          { id: organizationLearner1.id, userId: organizationLearner1.userId },
         ]);
       });
 
       it('should return participation matching learner lastName', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: { fullName: 'are' },
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([organizationLearner2.id, organizationLearner3.id]);
+        expect(organizationLearners).deep.equal([
+          { id: organizationLearner2.id, userId: organizationLearner2.userId },
+          { id: organizationLearner3.id, userId: organizationLearner3.userId },
+        ]);
       });
 
       it('should return participation matching learner firstName', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: { fullName: 'GEO' },
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([organizationLearner1.id]);
+        expect(organizationLearners).deep.equal([{ id: organizationLearner1.id, userId: organizationLearner1.userId }]);
       });
 
       it('should return participation matching participation status', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: { statuses: [CombinedCourseParticipationStatuses.STARTED] },
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([organizationLearner2.id, organizationLearner1.id]);
+        expect(organizationLearners).deep.equal([
+          { id: organizationLearner2.id, userId: organizationLearner2.userId },
+          { id: organizationLearner1.id, userId: organizationLearner1.userId },
+        ]);
       });
 
       it('should return participations even with empty status filter', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: { statuses: [] },
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([
-          organizationLearner2.id,
-          organizationLearner3.id,
-          organizationLearner1.id,
+        expect(organizationLearners).deep.equal([
+          { id: organizationLearner2.id, userId: organizationLearner2.userId },
+          { id: organizationLearner3.id, userId: organizationLearner3.userId },
+          { id: organizationLearner1.id, userId: organizationLearner1.userId },
         ]);
       });
 
       it('should return participations matching learner division', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: { divisions: ['6eme'] },
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([organizationLearner2.id, organizationLearner1.id]);
+        expect(organizationLearners).deep.equal([
+          { id: organizationLearner2.id, userId: organizationLearner2.userId },
+          { id: organizationLearner1.id, userId: organizationLearner1.userId },
+        ]);
       });
 
       it('should return participations even with empty division filter', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: { divisions: [] },
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([
-          organizationLearner2.id,
-          organizationLearner3.id,
-          organizationLearner1.id,
+        expect(organizationLearners).deep.equal([
+          { id: organizationLearner2.id, userId: organizationLearner2.userId },
+          { id: organizationLearner3.id, userId: organizationLearner3.userId },
+          { id: organizationLearner1.id, userId: organizationLearner1.userId },
         ]);
       });
 
       it('should return participations matching learner group', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: { groups: ['A'] },
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([organizationLearner3.id]);
+        expect(organizationLearners).deep.equal([{ id: organizationLearner3.id, userId: organizationLearner3.userId }]);
       });
 
       it('should return participations even with empty group filter', async function () {
         // when
-        const { organizationLearnerIds } =
+        const { organizationLearners } =
           await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
             combinedCourseId,
             filters: { groups: [] },
           });
 
         // then
-        expect(organizationLearnerIds).deep.equal([
-          organizationLearner2.id,
-          organizationLearner3.id,
-          organizationLearner1.id,
+        expect(organizationLearners).deep.equal([
+          { id: organizationLearner2.id, userId: organizationLearner2.userId },
+          { id: organizationLearner3.id, userId: organizationLearner3.userId },
+          { id: organizationLearner1.id, userId: organizationLearner1.userId },
         ]);
       });
     });

--- a/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
@@ -1257,4 +1257,34 @@ describe('Quest | Unit | Domain | Models | CombinedCourseDetails', function () {
       expect(combinedCourseDetails.isSuccessful()).to.be.false;
     });
   });
+
+  describe('#hasReward', function () {
+    it('should return true when a reward is defined', async function () {
+      const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
+        name,
+        code,
+        organizationId,
+        questId,
+        combinedCourseItems: [],
+        cryptoService,
+        rewardId: 123,
+      });
+
+      expect(combinedCourseDetails.hasReward).to.be.true;
+    });
+
+    it('should return false when no reward is defined', async function () {
+      const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
+        name,
+        code,
+        organizationId,
+        questId,
+        combinedCourseItems: [],
+        cryptoService,
+        rewardId: null,
+      });
+
+      expect(combinedCourseDetails.hasReward).to.be.false;
+    });
+  });
 });

--- a/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseDetails_test.js
@@ -172,6 +172,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseDetails', function () {
         nbModules: 2,
         nbModulesCompleted: 1,
         nbCampaignsCompleted: 1,
+        rewardStatus: null,
       });
     });
 
@@ -228,6 +229,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseDetails', function () {
         nbModules: 2,
         nbModulesCompleted: 0,
         nbCampaignsCompleted: 0,
+        rewardStatus: null,
       });
     });
   });

--- a/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseParticipationDetails_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseParticipationDetails_test.js
@@ -20,6 +20,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseParticipationDetails ',
         nbCampaigns: 2,
         nbModulesCompleted: 3,
         nbCampaignsCompleted: 1,
+        rewardStatus: null,
       };
 
       // when

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
@@ -1,3 +1,4 @@
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { combinedCourseDetailsSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-details-serializer.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
@@ -9,6 +10,8 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-details'
       name: 'Mon parcours',
       code: 'COMBINIX1',
       combinedCourseItems: [{ campaignId: 1 }, { moduleId: 7 }],
+      rewardId: 1,
+      rewardType: REWARD_TYPES.ATTESTATION,
     });
 
     // when
@@ -23,6 +26,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-details'
           'has-campaigns': true,
           'has-modules': true,
           'campaign-ids': [1],
+          'has-reward': true,
         },
         relationships: {
           'combined-course-participations': {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-serializer_test.js
@@ -1,5 +1,6 @@
 import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseParticipationDetails } from '../../../../../src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseParticipationDetails.js';
+import { CombinedCourseRewardStatuses } from '../../../../../src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseReward.js';
 import { combinedCourseParticipationSerializer } from '../../../../../src/quest/infrastructure/serializers/combined-course-participation-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
@@ -19,6 +20,7 @@ describe('CombinedCourseParticipationSerializer', function () {
       nbCampaigns: 1,
       nbModulesCompleted: 0,
       nbCampaignsCompleted: 1,
+      rewardStatus: CombinedCourseRewardStatuses.NOT_OBTAINED,
     });
 
     const serialized = combinedCourseParticipationSerializer.serialize(combinedCourseParticipation);
@@ -40,6 +42,7 @@ describe('CombinedCourseParticipationSerializer', function () {
           'nb-campaigns': 1,
           'nb-modules-completed': 0,
           'nb-campaigns-completed': 1,
+          'reward-status': CombinedCourseRewardStatuses.NOT_OBTAINED,
         },
       },
     });

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -31,7 +31,13 @@ function buildCombinedCourseDetails({
   rewardType = null,
   baseSurveyUrl,
 } = {}) {
-  const combinedCourse = buildCombinedCourse({ name, code, organizationId, questId, baseSurveyUrl });
+  const combinedCourse = buildCombinedCourse({
+    name,
+    code,
+    organizationId,
+    questId,
+    baseSurveyUrl,
+  });
 
   const campaigns = [];
   const modules = [];
@@ -73,6 +79,7 @@ function buildCombinedCourseDetails({
 
   const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest, cryptoService);
   combinedCourseDetails.setItems({ campaigns, modules });
+  combinedCourseDetails.setDataAndGenerateItems({ reward: { rewardId, rewardType: quest.rewardType } });
 
   return combinedCourseDetails;
 }

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -215,6 +215,19 @@ export default class CombinedCourse extends Component {
             </PixTableColumn>
           {{/if}}
 
+          {{#if @hasReward}}
+            <PixTableColumn @context={{context}} @type="text">
+              <:header>
+                {{t "pages.combined-course.table.column.reward"}}
+              </:header>
+              <:cell>
+                <span class={{participation.rewardStatusDisplay.class}}>
+                  <PixIcon @name={{participation.rewardStatusDisplay.icon}} />
+                  {{t participation.rewardStatusDisplay.text}}</span>
+              </:cell>
+            </PixTableColumn>
+          {{/if}}
+
         </:columns>
       </PixTable>
       {{#if @participations.meta}}

--- a/orga/app/models/combined-course-participation.js
+++ b/orga/app/models/combined-course-participation.js
@@ -10,6 +10,29 @@ export default class CombinedCourseParticipation extends Model {
   @attr('number') nbModules;
   @attr('number') nbCampaignsCompleted;
   @attr('number') nbModulesCompleted;
+  @attr('string') rewardStatus;
+
+  get rewardStatusDisplay() {
+    if (this.rewardStatus === 'OBTAINED') {
+      return {
+        icon: 'checkCircle',
+        text: 'pages.combined-course.table.rewards.obtained',
+        class: 'reward reward--obtained',
+      };
+    }
+    if (this.rewardStatus === 'NOT_OBTAINED') {
+      return {
+        icon: 'cancel',
+        text: 'pages.combined-course.table.rewards.not-obtained',
+        class: 'reward reward--not-obtained',
+      };
+    }
+    return {
+      icon: 'acute',
+      text: 'pages.combined-course.table.rewards.in-progress',
+      class: 'reward reward--in-progress',
+    };
+  }
 }
 
 export const COMBINED_COURSE_PARTICIPATION_STATUSES = {

--- a/orga/app/models/combined-course.js
+++ b/orga/app/models/combined-course.js
@@ -7,6 +7,7 @@ export default class CombinedCourse extends Model {
   @attr('number') completedParticipationsCount;
   @attr('boolean') hasCampaigns;
   @attr('boolean') hasModules;
+  @attr('boolean') hasReward;
   @attr({ defaultValue: () => [] }) campaignIds;
 
   @hasMany('combined-course-participation', { async: true, inverse: null }) combinedCourseParticipations;

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -55,6 +55,7 @@
 @use 'components/import-information-banner' as *;
 @use 'components/statistics' as *;
 @use 'components/statistics/cover-rate-gauge' as *;
+@use 'components/participations' as *;
 
 // pages
 @use 'pages/login' as *;

--- a/orga/app/styles/components/participations.scss
+++ b/orga/app/styles/components/participations.scss
@@ -1,0 +1,18 @@
+.reward {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  &--obtained {
+    color: var(--pix-success-700);
+  }
+
+  &--not-obtained {
+    color: var(--pix-error-700);
+  }
+
+  &--in-progress{
+    color: var(--pix-neutral-500);
+  }
+}
+

--- a/orga/app/templates/authenticated/combined-course/participations.gjs
+++ b/orga/app/templates/authenticated/combined-course/participations.gjs
@@ -13,6 +13,7 @@ import CombinedCourseParticipations from 'pix-orga/components/combined-course/pa
     @hasCampaigns={{@model.combinedCourse.hasCampaigns}}
     @hasModules={{@model.combinedCourse.hasModules}}
     @participations={{@model.combinedCourseParticipations}}
+    @hasReward={{@model.combinedCourse.hasReward}}
     @divisions={{@model.divisions}}
     @onFilter={{@controller.triggerFiltering}}
     @fullNameFilter={{@controller.fullName}}

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -20,6 +20,7 @@ module('Integration | Component | combined-course/participations', function (hoo
       nbModules: 5,
       nbCampaignsCompleted: 2,
       nbModulesCompleted: 2,
+      rewardStatus: 'OBTAINED',
     },
     {
       id: 234,
@@ -32,12 +33,14 @@ module('Integration | Component | combined-course/participations', function (hoo
       nbModules: 2,
       nbCampaignsCompleted: 0,
       nbModulesCompleted: 0,
+      rewardStatus: 'NOT_OBTAINED',
     },
   ];
   participations.meta = { page: 1, pageSize: 1, rowCount: 2, pageCount: 2 };
   const onFilter = sinon.stub();
 
   setupIntlRenderingTest(hooks);
+  let store;
 
   hooks.beforeEach(function () {
     const currentUser = this.owner.lookup('service:current-user');
@@ -45,6 +48,7 @@ module('Integration | Component | combined-course/participations', function (hoo
       isManagingStudents: false,
       isSco: false,
     };
+    store = this.owner.lookup('service:store');
   });
 
   module('table', function (hooks) {
@@ -235,23 +239,75 @@ module('Integration | Component | combined-course/participations', function (hoo
         router.transitionTo.calledWith('authenticated.combined-course.participation-detail', participations[0].id),
       );
     });
+
+    test('it should display attestation column when there is a reward linked to the combined course', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @hasReward={{true}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
+      );
+
+      const table = screen.getByRole('table');
+
+      // then
+      assert.ok(
+        within(table).getByRole('columnheader', {
+          name: t('pages.combined-course.table.column.reward'),
+        }),
+      );
+    });
+
+    test('it should not display attestation column when there is no reward linked to the combined course', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @hasReward={{false}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
+      );
+
+      const table = screen.getByRole('table');
+
+      // then
+      assert.notOk(
+        within(table).queryByRole('columnheader', {
+          name: t('pages.combined-course.table.column.reward'),
+        }),
+      );
+    });
   });
 
   test('it should display participation details', async function (assert) {
     // when
+    const participationRecords = [
+      store.createRecord('combined-course-participation', participations[0]),
+      store.createRecord('combined-course-participation', participations[1]),
+    ];
     const screen = await render(
       <template>
         <CombinedCourseParticipations
           @hasCampaigns={{true}}
           @hasModules={{true}}
-          @participations={{participations}}
+          @participations={{participationRecords}}
           @onFilter={{onFilter}}
+          @hasReward={{true}}
         />
       </template>,
     );
 
     const table = screen.getByRole('table');
-
     // then
     assert.ok(
       within(table).getByRole('cell', {
@@ -283,6 +339,18 @@ module('Integration | Component | combined-course/participations', function (hoo
           nbItems: participations[0].nbModules,
         }),
       ),
+    );
+    //obtained
+    assert.ok(
+      within(table).getByRole('cell', {
+        name: t('pages.combined-course.table.rewards.obtained'),
+      }),
+    );
+    // not obtained
+    assert.ok(
+      within(table).getByRole('cell', {
+        name: t('pages.combined-course.table.rewards.not-obtained'),
+      }),
     );
   });
 

--- a/orga/tests/unit/models/combined-course-participation-test.js
+++ b/orga/tests/unit/models/combined-course-participation-test.js
@@ -1,0 +1,52 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../helpers/setup-intl';
+
+module('Unit | Model | combined-course-participation', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('displayedRewardStatus', function () {
+    [
+      {
+        rewardStatus: 'NOT_STARTED',
+        statusTested: 'in progress',
+        expectedTranslationKey: 'pages.combined-course.table.rewards.in-progress',
+        expectedIcon: 'acute',
+        expectedClass: 'reward reward--in-progress',
+      },
+      {
+        rewardStatus: 'STARTED',
+        statusTested: 'in progress',
+        expectedTranslationKey: 'pages.combined-course.table.rewards.in-progress',
+        expectedIcon: 'acute',
+        expectedClass: 'reward reward--in-progress',
+      },
+      {
+        rewardStatus: 'OBTAINED',
+        statusTested: 'obtained',
+        expectedTranslationKey: 'pages.combined-course.table.rewards.obtained',
+        expectedIcon: 'checkCircle',
+        expectedClass: 'reward reward--obtained',
+      },
+      {
+        rewardStatus: 'NOT_OBTAINED',
+        statusTested: 'not obtained',
+        expectedTranslationKey: 'pages.combined-course.table.rewards.not-obtained',
+        expectedIcon: 'cancel',
+        expectedClass: 'reward reward--not-obtained',
+      },
+    ].forEach(function ({ rewardStatus, statusTested, expectedTranslationKey, expectedIcon, expectedClass }) {
+      test(`it should return ${statusTested} reward status for ${rewardStatus} participation`, function (assert) {
+        const store = this.owner.lookup('service:store');
+
+        const participation = store.createRecord('combined-course-participation', { rewardStatus });
+
+        assert.strictEqual(participation.get('rewardStatusDisplay').text, expectedTranslationKey);
+        assert.strictEqual(participation.get('rewardStatusDisplay').icon, expectedIcon);
+        assert.strictEqual(participation.get('rewardStatusDisplay').class, expectedClass);
+      });
+    });
+  });
+});

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1127,11 +1127,17 @@
           "first-name": "Vorname",
           "last-name": "Name",
           "modules": "Module",
+          "reward": "Bescheinigung",
           "status": "Status"
         },
         "description": "Listen der Teilnahmen am Parcours",
         "module-completion": "{nbItemsCompleted, plural, =0 {Kein Modul abgeschlossen auf {nbItems}} =1 {Ein Modul abgeschlossen auf {nbItems}} other {{nbItemsCompleted} Module abgeschlossen auf {nbItems}}}.",
         "no-module": "Keine Module empfohlen.",
+        "rewards": {
+          "in-progress": "Steht noch aus",
+          "not-obtained": "Nicht erhalten",
+          "obtained": "Erhalten"
+        },
         "tooltip": {
           "campaigns-column": "'x / y' gibt den Fortschritt des Teilnehmers an: Er hat x Kampagnen von insgesamt y abgeschlossen. Zum Beispiel bedeutet 1/2, dass er 1 von 2 Kampagnen abgeschlossen hat.",
           "modules-column": "'x / y' zeigt den Fortschritt des Teilnehmers an: Er hat x Module von insgesamt y abgeschlossen. Die Gesamtzahl der Module unterscheidet sich für jeden, je nach den persönlichen Empfehlungen."

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1127,11 +1127,17 @@
           "first-name": "First name",
           "last-name": "Last name",
           "modules": "Modules",
+          "reward": "Attestation",
           "status": "Status"
         },
         "description": "List of learning courses participations",
         "module-completion": "{nbItemsCompleted, plural, =0 {No module completed out of {nbItems}} =1 {One module completed out of {nbItems}} other {{nbItemsCompleted} modules completed out of {nbItems}}}.",
         "no-module": "No modules recommended.",
+        "rewards": {
+          "in-progress": "In progress",
+          "not-obtained": "Not obtained",
+          "obtained": "Obtained"
+        },
         "tooltip": {
           "campaigns-column": "'x / y' indicates the participant’s progress : they have completed x campaigns out of a total of y. For example, 1/2 means they have completed 1 campaign out of 2.",
           "modules-column": "'x / y'  indicates the participant's progress : they have completed x modules out of a total of y. The total number of modules differs for each individual, depending on personalised recommendations."

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1127,11 +1127,17 @@
           "first-name": "Nombre",
           "last-name": "Nombre",
           "modules": "Módulos",
+          "reward": "Certificado",
           "status": "Estado"
         },
         "description": "Lista de participantes",
         "module-completion": "{nbItemsCompleted, plural, =0 {Ningún módulo completado en {nbItems}} =1 {Un módulo completado en {nbItems}} other {{nbItemsCompleted} módulos completados en {nbItems}}}.",
         "no-module": "No se recomienda ningún módulo.",
+        "rewards": {
+          "in-progress": "Pendiente",
+          "not-obtained": "No obtenido",
+          "obtained": "Obtenido"
+        },
         "tooltip": {
           "campaigns-column": "x / y' indica el progreso del participante: ha completado x campañas de un total de y. Por ejemplo, 1/2 significa que ha completado 1 campaña de un total de 2.",
           "modules-column": "x / y\" indica el progreso del participante: ha completado x módulos de un total de y. El número total de módulos difiere para cada participante, en función de las recomendaciones personalizadas."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1127,11 +1127,17 @@
           "first-name": "Prénom",
           "last-name": "Nom",
           "modules": "Modules",
+          "reward": "Attestation",
           "status": "Statut"
         },
         "description": "Listes des participations au parcours",
         "module-completion": "{nbItemsCompleted, plural, =0 {Aucun module complété sur {nbItems}} =1 {Un module complété sur {nbItems}} other {{nbItemsCompleted} modules complétés sur {nbItems}}}.",
         "no-module": "Aucun module recommandé.",
+        "rewards": {
+          "in-progress": "En cours d'obtention",
+          "not-obtained": "Non obtenue",
+          "obtained": "Obtenue"
+        },
         "tooltip": {
           "campaigns-column": "'x / y' indique la progression du participant : il a terminé x campagnes sur un total de y. Par exemple, 1/2 signifie qu'il a terminé 1 campagne sur 2.",
           "modules-column": "'x / y' indique la progression du participant : il a terminé x modules sur un total de y. Le total de modules diffère pour chacun, en fonction des recommandations personnalisées."

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1127,11 +1127,17 @@
           "first-name": "Nome",
           "last-name": "Nome",
           "modules": "Moduli",
+          "reward": "Attestato",
           "status": "Stato"
         },
         "description": "Elenco dei partecipanti",
         "module-completion": "{nbItemsCompleted, plural, =0 { Nessun modulo completato su {nbItems}} =1 {Un modulo completato su {nbItems}} other {{nbItemsCompleted} moduli completati su {nbItems}}}.",
         "no-module": "Nessun modulo consigliato.",
+        "rewards": {
+          "in-progress": "In attesa",
+          "not-obtained": "Non ottenuto",
+          "obtained": "Ottenuto"
+        },
         "tooltip": {
           "campaigns-column": "x / y\" indica i progressi del partecipante: ha completato x campagne su un totale di y. Ad esempio, 1/2 significa che il partecipante ha completato 1 campagna su 2.",
           "modules-column": "x / y\" indica lo stato di avanzamento del partecipante: ha completato x moduli su un totale di y. Il numero totale di moduli varia per ogni partecipante, a seconda delle raccomandazioni personalizzate."

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1127,11 +1127,17 @@
           "first-name": "Voornaam",
           "last-name": "Achternaam",
           "modules": "Modules",
+          "reward": "Verklaring",
           "status": "Status"
         },
         "description": "Lijst van de gecombineerde cursus participaties",
         "module-completion": "{nbItemsCompleted, plural, =0 {geen module voltooid op {nbItems}} =1 {1 van de {nbItems} modules voltooid} other {{nbItemsCompleted} van de {nbItems} modules voltooid}}.",
         "no-module": "Geen aanbevolen module.",
+        "rewards": {
+          "in-progress": "Behandeling",
+          "not-obtained": "Niet behaald",
+          "obtained": "Behaald"
+        },
         "tooltip": {
           "campaigns-column": "'x / y' geeft de voortgang van de deelnemer aan: hij/zij heeft x campagnes voltooid van een totaal van y. Bijvoorbeeld: 1/2 betekent dat hij/zij 1 campagne van de 2 heeft voltooid.",
           "modules-column": "'x / y' geeft de voortgang van de deelnemer aan: hij/zij heeft x modules voltooid van een totaal van y. Het totale aantal modules verschilt per persoon, afhankelijk van de persoonlijke aanbevelingen."


### PR DESCRIPTION
## 🪧 Problème

Comme il est maintenant possible de créer un blueprint avec une attestation, il est maintenant nécessaire de permettre au prescripteur de faire le suivi de l’obtention de l’attestation par les participations au parcours. 

Pour cette itération, on ne va ajouter que la colonne “Attestation” avec les 3 états : 
En cours d’obtention 
Obtenue 
Non obtenue 

## 🌈 Proposition
- On ajoute rewardStatus à CombinedCourseParticipationDetails des models back et front
- On ajoute un getter hasReward à CombinedCourseDetails (à l'image de ce qui se fait pour hasModule).
- On modifie les seeds de COMBINIX1 pour qu'ils puissent prendre un cappedTubeRequirement.


## ✊ Remarques

## 🎉 Pour tester
Pix App
Se connecter avec  le compte d'un premier learner sur COMBINIX1, passer le parcours et tout échouer à la campagne de diag.

Se connecter sur COMBINIX1 avec un 2e learner, passer le parcours et tout réussir
Se connecter sur COMBINIX1 avec un 3e learner et ne pas jouer la campagne

Pix Orga
Se connecter avec le compte [admin-orga@example.net](mailto:admin-orga@example.net)
Cliquer sur “Campagnes”, puis onglet “Parcours apprenant” → cliquer sur le parcours apprenant
Vérifier qu’on a 3 participations, une qui a le statut “Obtenue”, une le “Non obtenue”, une autre le “En cours d’obtention”.
