### PR TITLE
[FEATURE] Créer une route pour détacher un centre de certif d'une orga (PIX-22689)

### DIFF
--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -215,6 +215,14 @@ const attachCertificationCenter = async function (request, h) {
   return h.response().code(204);
 };
 
+const detachCertificationCenter = async function (request, h) {
+  const { organizationId } = request.params;
+
+  await usecases.detachCertificationCenterFromOrganization({ organizationId });
+
+  return h.response().code(204);
+};
+
 const organizationAdminController = {
   getTemplateForAddTagsToOrganizations,
   addTagsToOrganizations,
@@ -227,6 +235,7 @@ const organizationAdminController = {
   getOrganizationPlacesStatistics,
   attachChildOrganization,
   detachParentOrganization,
+  detachCertificationCenter,
   getTemplateForAddOrganizationFeatureInBatch,
   addOrganizationFeatureInBatch,
   getOrganizationDetails,

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -617,6 +617,35 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/organizations/{organizationId}/detach-certification-center',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: (request, h) => organizationAdminController.detachCertificationCenter(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, METIER, SUPPORT ou CERTIF permettant un accès à l'application d'administration de Pix**\n" +
+            "- Elle permet de détacher un centre de certification d'une organisation donnée.",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/organizational-entities/domain/usecases/detach-certification-center-from-organization.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/detach-certification-center-from-organization.usecase.js
@@ -1,0 +1,27 @@
+/**
+ * @typedef {import ('./index.js').OrganizationForAdminRepository} OrganizationForAdminRepository
+ */
+
+import { OrganizationNotFound } from '../errors.js';
+
+/**
+ * @param {object} params
+ * @param {number} params.organizationId
+ * @param {OrganizationForAdminRepository} params.organizationForAdminRepository
+ * @returns {Promise<void>}
+ */
+export const detachCertificationCenterFromOrganization = async function ({
+  organizationId,
+  organizationForAdminRepository,
+}) {
+  const existingOrganization = await organizationForAdminRepository.exist({ organizationId });
+  if (!existingOrganization) {
+    throw new OrganizationNotFound({
+      code: 'ORGANIZATION_NOT_FOUND',
+      message: 'Organization does not exist',
+      meta: { organizationId },
+    });
+  }
+
+  await organizationForAdminRepository.detachCertificationCenter({ organizationId });
+};

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -94,6 +94,7 @@ import { createNetwork } from './create-network.usecase.js';
 import { createOrganization } from './create-organization.js';
 import { createOrganizationsWithTagsAndTargetProfiles } from './create-organizations-with-tags-and-target-profiles.usecase.js';
 import { createTag } from './create-tag.js';
+import { detachCertificationCenterFromOrganization } from './detach-certification-center-from-organization.usecase.js';
 import { detachParentOrganizationFromOrganization } from './detach-parent-organization-from-organization.usecase.js';
 import { findAllAdministrationTeams } from './find-all-administration-teams.usecase.js';
 import { findAllOrganizationLearnerTypes } from './find-all-organization-learner-types.refactor.js';
@@ -132,6 +133,7 @@ const usecasesWithoutInjectedDependencies = {
   createOrganization,
   createOrganizationsWithTagsAndTargetProfiles,
   createTag,
+  detachCertificationCenterFromOrganization,
   detachParentOrganizationFromOrganization,
   findPaginatedFilteredNetworks,
   findAllTags,
@@ -163,6 +165,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {addOrganizationFeatureInBatch} addOrganizationFeatureInBatch
  * @property {createCertificationCenter} createCertificationCenter
  * @property {createTag} createTag
+ * @property {detachCertificationCenterFromOrganization} detachCertificationCenterFromOrganization
  * @property {detachParentOrganizationFromOrganization} detachParentOrganizationFromOrganization
  * @property {findPaginatedFilteredCertificationCenters} findPaginatedFilteredCertificationCenters
  * @property {findAttachedOrganizationsForAdmin} findAttachedOrganizationsForAdmin

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -428,6 +428,20 @@ const attachCertificationCenter = async ({ organizationId, certificationCenterId
   });
 };
 
+/**
+ * @type {function}
+ * @param {object} params
+ * @param {number} params.organizationId
+ * @returns {Promise<void>}
+ */
+const detachCertificationCenter = async ({ organizationId }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  await knexConn('fct_structures').where({ organization_id: organizationId }).update({
+    certification_center_id: null,
+  });
+};
+
 async function _addOrUpdateDataProtectionOfficer(knexConn, dataProtectionOfficer) {
   await knexConn(DATA_PROTECTION_OFFICERS_TABLE_NAME)
     .insert(dataProtectionOfficer)
@@ -607,6 +621,7 @@ export const organizationForAdminRepository = {
   archive,
   attachCertificationCenter,
   createProOrganizationInvitation,
+  detachCertificationCenter,
   exist,
   findAttachedByCertificationCenterId,
   findExistingIds,

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1696,6 +1696,37 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       expect(response.statusCode).to.equal(204);
     });
   });
+
+  describe('POST /api/admin/organizations/{id}/detach-certification-center', function () {
+    it('should detach a certification center from a given organization and return http code 204', async function () {
+      // given
+      const server = await createServer();
+
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({
+        certificationCenterId: certificationCenterId,
+      });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'POST',
+        url: `/api/admin/organizations/${organization.id}/detach-certification-center`,
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const organizationFactStructure = await knex('fct_structures')
+        .where({ organization_id: organization.id })
+        .first();
+      expect(organizationFactStructure.certification_center_id).to.be.null;
+      expect(response.statusCode).to.equal(204);
+    });
+  });
 });
 
 function _createMultipartPayload({ boundary, filename, fieldName, contentType, content }) {

--- a/api/tests/organizational-entities/integration/domain/usecases/detach-certification-center-from-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/detach-certification-center-from-organization.usecase.test.js
@@ -1,0 +1,50 @@
+import { OrganizationNotFound } from '../../../../../src/organizational-entities/domain/errors.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+describe('Integration | Organizational Entities | Domain | UseCase | detach-certification-center-from-organization', function () {
+  describe('success case', function () {
+    it('detaches certification center from organization', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({
+        certificationCenterId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.detachCertificationCenterFromOrganization({
+        organizationId: organization.id,
+      });
+
+      // then
+      const organizationFactStructure = await knex('fct_structures')
+        .where({ organization_id: organization.id })
+        .first();
+
+      expect(organizationFactStructure.certification_center_id).to.equal(null);
+    });
+  });
+
+  describe('error cases', function () {
+    context('when organization does not exist', function () {
+      it('throws an OrganizationNotFound error', async function () {
+        // given
+        const unknownOrganizationId = 999;
+
+        // when
+        const error = await catchErr(usecases.detachCertificationCenterFromOrganization)({
+          organizationId: unknownOrganizationId,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(OrganizationNotFound);
+        expect(error.code).to.equal('ORGANIZATION_NOT_FOUND');
+        expect(error.meta.organizationId).to.equal(unknownOrganizationId);
+      });
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -2068,4 +2068,54 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(otherOrganizationFactStructure.certification_center_id).to.be.null;
     });
   });
+
+  describe('#detachCertificationCenter', function () {
+    it('detaches the certification center from the organization through its fact_structure', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({
+        certificationCenterId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await repositories.organizationForAdminRepository.detachCertificationCenter({
+        organizationId: organization.id,
+      });
+
+      // then
+      const organizationFactStructure = await knex('fct_structures')
+        .where({ organization_id: organization.id })
+        .first();
+
+      expect(organizationFactStructure.certification_center_id).to.be.null;
+    });
+
+    it('does not detach certification center from another organization', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({
+        certificationCenterId,
+      });
+      const otherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const { organization: otherOrganization } = databaseBuilder.factory.buildOrganizationWithStructure({
+        certificationCenterId: otherCertificationCenterId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await repositories.organizationForAdminRepository.detachCertificationCenter({
+        organizationId: otherOrganization.id,
+      });
+
+      // then
+      const organizationFactStructure = await knex('fct_structures')
+        .where({ organization_id: organization.id })
+        .first();
+
+      expect(organizationFactStructure.certification_center_id).to.equal(certificationCenterId);
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
@@ -244,4 +244,48 @@ describe('Unit | Organizational Entities | Application | route | Admin | organiz
       });
     });
   });
+
+  describe('POST /api/admin/organizations/{id}/detach-certification-center', function () {
+    describe('when the user authenticated has no role', function () {
+      it('returns a 403 HTTP status code', async function () {
+        // given
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
+
+        sinon.stub(organizationAdminController, 'detachCertificationCenter');
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/organizations/1/detach-certification-center');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(organizationAdminController.detachCertificationCenter);
+      });
+    });
+
+    const authorizedRoles = [
+      { role: 'SuperAdmin', stub: 'checkAdminMemberHasRoleSuperAdmin' },
+      { role: 'Support', stub: 'checkAdminMemberHasRoleSupport' },
+      { role: 'Certif', stub: 'checkAdminMemberHasRoleCertif' },
+      { role: 'Metier', stub: 'checkAdminMemberHasRoleMetier' },
+    ];
+
+    authorizedRoles.forEach(({ role, stub }) => {
+      describe(`when the user has ${role} role`, function () {
+        it('should call controller method', async function () {
+          // given
+          sinon.stub(securityPreHandlers, stub).callsFake((request, h) => h.response(true));
+          securityPreHandlers.hasAtLeastOneAccessOf.callsFake((_handlers) => {
+            return () => true;
+          });
+          sinon.stub(organizationAdminController, 'detachCertificationCenter').returns('ok');
+
+          // when
+          await httpTestServer.request('POST', '/api/admin/organizations/1/detach-certification-center');
+
+          // then
+          sinon.assert.called(organizationAdminController.detachCertificationCenter);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🪧 Problème
Dans le cadre de la gestion des réseaux, nous avons besoin d'une route afin de pouvoir détacher un centre de certification rattaché à une organisation.

## 🌈 Proposition

Créer la route


## 🎉 Pour tester

- Depuis pix admin, trouver une organisation ayant un centre rattaché
- Noter l'id
- Lancer le curl suivant avec l'id de l'organisation

```
TOKEN=$(curl -s -X POST https://admin-pr16703.review.pix.fr/api/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=password&username=superadmin@example.net&password=pix123" \
  | jq -r '.access_token') && \
curl -s -X POST https://admin-pr16703.review.pix.fr/api/admin/organizations/<ID>/detach-certification-center \
  -H "Authorization: Bearer $TOKEN" | jq
```