### PR TITLE
[FEATURE] Afficher la demande de feedback utilisateur (PIX-23305).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import ENV from 'mon-pix/config/environment';
 
 import SatisfactionScore from './drawer/satisfaction-score';
@@ -55,6 +56,8 @@ export default class Drawer extends Component {
       <section
         class="results-recommendation-engine-drawer {{if this.isHiding 'results-recommendation-engine-drawer--hiding'}}"
         {{on "animationend" this.onAnimationEnd}}
+        role="dialog"
+        aria-label={{t "pages.skill-review.recommended-engine.drawer.title"}}
       >
         {{#if this.isSubmitted}}
           <ThankYou @onClose={{this.hide}} />

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -70,6 +70,9 @@ export default class EvaluationResultsRecommendationEngine extends Component {
   }
 
   get shouldShowNps() {
+    if (this.args.model.hasAnsweredSurvey) {
+      return false;
+    }
     return this._drawerRevealedByScroll || !this.hasTrainings;
   }
 

--- a/mon-pix/app/routes/campaigns/assessment/results.js
+++ b/mon-pix/app/routes/campaigns/assessment/results.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import ENV from 'mon-pix/config/environment';
 
 export default class ResultsRoute extends Route {
   @service currentUser;
@@ -7,6 +8,7 @@ export default class ResultsRoute extends Route {
   @service store;
   @service router;
   @service featureToggles;
+  @service requestManager;
 
   beforeModel(transition) {
     this.session.requireAuthenticationAndApprovedTermsOfService(transition);
@@ -35,6 +37,8 @@ export default class ResultsRoute extends Route {
         await this.currentUser.load();
       }
 
+      const hasAnsweredSurvey = campaign.recommendationEngine ? await this._hasAnsweredSurvey(campaign.id) : false;
+
       return {
         campaign,
         campaignParticipationResult,
@@ -42,11 +46,24 @@ export default class ResultsRoute extends Route {
         showTrainings: false,
         trainings,
         questResults,
+        hasAnsweredSurvey,
       };
     } catch (error) {
       if (error.errors?.[0]?.status === '412') {
         this.router.transitionTo('campaigns.entry-point', campaign.code);
       } else throw error;
+    }
+  }
+
+  async _hasAnsweredSurvey(campaignId) {
+    try {
+      const { content } = await this.requestManager.request({
+        url: `${ENV.APP.API_HOST}/api/campaigns/${campaignId}/has-answered-survey`,
+        method: 'GET',
+      });
+      return content.hasAnswered;
+    } catch {
+      return false;
     }
   }
 }

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -21,6 +21,7 @@ import getChallenges from './routes/get-challenges';
 import getCombinedCourses from './routes/get-combined-courses';
 import getCompetenceEvaluationsByAssessment from './routes/get-competence-evaluations-by-assessment';
 import getFeatureToggles from './routes/get-feature-toggles';
+import getHasAnsweredSurvey from './routes/get-has-answered-survey';
 import getInformationBanners from './routes/get-information-banners';
 import getOrganizationsToJoin from './routes/get-organizations-to-join';
 import getProgression from './routes/get-progression';
@@ -92,6 +93,7 @@ function routes() {
   this.get('/assessments/:id/competence-evaluations', getCompetenceEvaluationsByAssessment);
 
   this.get('/campaigns', getCampaigns);
+  this.get('/campaigns/:campaignId/has-answered-survey', getHasAnsweredSurvey);
 
   this.get('/certificate-summaries', getCertificateSummaries);
   this.get('/certifications', getCertifications);

--- a/mon-pix/mirage/routes/get-has-answered-survey.js
+++ b/mon-pix/mirage/routes/get-has-answered-survey.js
@@ -1,0 +1,3 @@
+export default function () {
+  return { hasAnswered: false };
+}

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -244,21 +244,27 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         server.get('/campaigns/:campaignId/has-answered-survey', () => ({ hasAnswered: false }));
 
         // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
-        assert.dom('.results-recommendation-engine-drawer').exists();
+        assert
+          .dom(screen.getByRole('dialog', { name: t('pages.skill-review.recommended-engine.drawer.title') }))
+          .exists();
       });
 
-      test('should not display the drawer when user has already answered the survey', async function (assert) {
-        // given
-        server.get('/campaigns/:campaignId/has-answered-survey', () => ({ hasAnswered: true }));
+      module('when user has already answered the survey', function () {
+        test('should not display the drawer', async function (assert) {
+          // given
+          server.get('/campaigns/:campaignId/has-answered-survey', () => ({ hasAnswered: true }));
 
-        // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+          // when
+          const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
-        // then
-        assert.dom('.results-recommendation-engine-drawer').doesNotExist();
+          // then
+          assert
+            .dom(screen.queryByRole('dialog', { name: t('pages.skill-review.recommended-engine.drawer.title') }))
+            .doesNotExist();
+        });
       });
     });
   });
@@ -309,10 +315,12 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
 
     test('should not display the NPS drawer nor call has-answered-survey', async function (assert) {
       // when
-      await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+      const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
       // then
-      assert.dom('.results-recommendation-engine-drawer').doesNotExist();
+      assert
+        .dom(screen.queryByRole('dialog', { name: t('pages.skill-review.recommended-engine.drawer.title') }))
+        .doesNotExist();
       const requests = server.pretender.handledRequests.filter(({ url }) => url.includes('has-answered-survey'));
       assert.strictEqual(requests.length, 0, 'Request to GET has-answered-survey should not be done');
     });

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -237,6 +237,30 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         assert.dom(screen.queryByText(campaign.title)).doesNotExist();
       });
     });
+
+    module('regarding the NPS drawer', function () {
+      test('should display the drawer when user has not answered the survey', async function (assert) {
+        // given
+        server.get('/campaigns/:campaignId/has-answered-survey', () => ({ hasAnswered: false }));
+
+        // when
+        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+        // then
+        assert.dom('.results-recommendation-engine-drawer').exists();
+      });
+
+      test('should not display the drawer when user has already answered the survey', async function (assert) {
+        // given
+        server.get('/campaigns/:campaignId/has-answered-survey', () => ({ hasAnswered: true }));
+
+        // when
+        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+        // then
+        assert.dom('.results-recommendation-engine-drawer').doesNotExist();
+      });
+    });
   });
 
   module('when campaign does not have recommendationEngine enabled', function (hooks) {
@@ -281,6 +305,16 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
 
       // then
       assert.dom('.evaluation-results-recommendation-engine').doesNotExist();
+    });
+
+    test('should not display the NPS drawer nor call has-answered-survey', async function (assert) {
+      // when
+      await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+      // then
+      assert.dom('.results-recommendation-engine-drawer').doesNotExist();
+      const requests = server.pretender.handledRequests.filter(({ url }) => url.includes('has-answered-survey'));
+      assert.strictEqual(requests.length, 0, 'Request to GET has-answered-survey should not be done');
     });
   });
 });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2267,7 +2267,8 @@
           "thank-you": {
             "subtitle": "Geschafft!",
             "title": "Danke für Ihr Feedback!"
-          }
+          },
+          "title": "Feedback zur Empfehlung von Lerninhalten"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2267,7 +2267,8 @@
           "thank-you": {
             "subtitle": "It's in the bag",
             "title": "Thank you for your feedback!"
-          }
+          },
+          "title": "Feedback on the training content recommendation"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2267,7 +2267,8 @@
           "thank-you": {
             "subtitle": "¡Misión cumplida!",
             "title": "¡Gracias por tu opinión!"
-          }
+          },
+          "title": "Comentarios sobre la recomendación de contenido formativo"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2267,7 +2267,8 @@
           "thank-you": {
             "subtitle": "C'est dans la boite",
             "title": "Merci pour votre avis !"
-          }
+          },
+          "title": "Feedback sur la recommandation de contenu formatif"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2267,7 +2267,8 @@
           "thank-you": {
             "subtitle": "Missione compiuta!",
             "title": "Grazie per il tuo feedback!"
-          }
+          },
+          "title": "Feedback sulla raccomandazione di contenuti formativi"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2267,7 +2267,8 @@
           "thank-you": {
             "subtitle": "Gelukt!",
             "title": "Bedankt voor uw feedback!"
-          }
+          },
+          "title": "Feedback over de aanbeveling voor trainingsinhoud"
         },
         "modal": {
           "actions": {


### PR DESCRIPTION
## 🪧 Problème
Actuellement la demande de feedback est systématique à la fin d'une campagne qui utilise le moteur de recommandations. Cela est agaçant.

## 🌈 Proposition
Récupérer l'information qui indique le status de réponse de l'utilisateur (appel `GET /api/campaigns/{campaignId}/has-answered`).
Si l'utilisateur a déjà envoyé un feedback, on ne lui repropose pas.

## ✊ Remarques
N/A

## 🎉 Pour tester

- se connecter avec dave-comp@example.net
- aller sur la campagne [EDUMULTIP](https://app-pr16704.review.pix.fr/campagnes/EDUMULTIP)
- constater qu'un appel réseau est effectué et répond `{ hasAnswered : false }`
- repondre à l'enquête. Rafraîchir la page.
- constater qu'un appel réseau est effectué et répond `{ hasAnswered : true }`
- l'enquête n'apparait plus
