### PR TITLE
[FEATURE] Modale CF - Revoir la taille de la police du body de "Programme" (PIX-23416)

### DIFF
--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -157,6 +157,8 @@
   }
 
   &__program {
+    @extend %pix-body-m;
+
     color: var(--pix-neutral-800);
     white-space: pre-line;
   }


### PR DESCRIPTION
## 🪧 Problème

Le body, dans l'accordéon "Programme" de la carte de CF du MDR, n'a pas la bonne taille de police.

## 🌈 Proposition

Utiliser la même font-size que celle de l'accordéon "Objectifsé

## ✊ Remarques

RAS

## 🎉 Pour tester

- Ouvrir la modale dans la RA pour n'importe quel CF
- Constater que le body de "Programme" a la même taille de police que dans "Objectifs"