### PR TITLE
[TECH] Réflexion domaine : déplacement des repositories correspondant aux entités

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -1,4 +1,4 @@
-import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
+import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-courses/combined-course-repository.js';
 import { CLIENTS, PIX_ORGA } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { AuditLoggingJob } from '../../../../shared/domain/models/jobs/AuditLoggingJob.js';

--- a/api/src/prescription/campaign/domain/usecases/get-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign.js
@@ -1,4 +1,4 @@
-import { findByCampaignId } from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
+import { findByCampaignId } from '../../../../quest/infrastructure/repositories/combined-courses/combined-course-repository.js';
 
 const getCampaign = async function ({
   campaignId,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-management-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-management-repository.js
@@ -1,4 +1,4 @@
-import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
+import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-courses/combined-course-repository.js';
 import { CAMPAIGN_FEATURES } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -11,7 +11,7 @@ import { userToCreateRepository } from '../../../../identity-access-management/i
 import * as organizationFeaturesAPI from '../../../../organizational-entities/application/api/organization-features-api.js';
 import { tagRepository } from '../../../../organizational-entities/infrastructure/repositories/tag.repository.js';
 import * as libOrganizationLearnerRepository from '../../../../prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
-import * as combinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
+import * as combinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-courses/combined-course-repository.js';
 import * as questRepository from '../../../../quest/infrastructure/repositories/quest-repository.js';
 import { cryptoService } from '../../../../shared/domain/services/crypto-service.js';
 import { tokenService } from '../../../../shared/domain/services/token-service.js';

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -1,4 +1,4 @@
-import * as combinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
+import * as combinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-courses/combined-course-repository.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { TargetProfileSummaryForAdmin } from '../../domain/models/TargetProfileSummaryForAdmin.js';

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -4,7 +4,7 @@ import * as membershipRepository from '../../../shared/infrastructure/repositori
 import * as organizationFeatureRepository from '../../../shared/infrastructure/repositories/organization-feature-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import * as combinedCourseBlueprintRepository from '../../infrastructure/repositories/combined-course-blueprint-repository.js';
+import * as combinedCourseBlueprintRepository from '../../infrastructure/repositories/combined-course-blueprints/combined-course-blueprint-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import combinedCourseDetailsService from '../services/combined-course-details-service.js';

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprints/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprints/combined-course-blueprint-repository.js
@@ -1,13 +1,13 @@
 import difference from 'lodash/difference.js';
 
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../shared/domain/errors.js';
-import { CombinedCourseBlueprint } from '../../domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
-import { Quest } from '../../domain/models/quests/entities/Quest.js';
-import * as questRepository from './quest-repository.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { CombinedCourseBlueprint } from '../../../domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
+import { Quest } from '../../../domain/models/quests/entities/Quest.js';
+import * as questRepository from '../quest-repository.js';
 
 /**
- * @returns {Promise<import('../../domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js').CombinedCourseBlueprint[]>}
+ * @returns {Promise<import('../../../domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js').CombinedCourseBlueprint[]>}
  */
 
 export async function findAll() {

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprints/target-profile-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprints/target-profile-repository.js
@@ -1,4 +1,4 @@
-import { TargetProfile } from '../../domain/models/combined-course-blueprints/entities/TargetProfile.js';
+import { TargetProfile } from '../../../domain/models/combined-course-blueprints/entities/TargetProfile.js';
 
 export const findByIds = async function ({ ids, targetProfilesApi }) {
   const targetProfiles = await targetProfilesApi.getByIds(ids);

--- a/api/src/quest/infrastructure/repositories/combined-course-participations/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participations/combined-course-participation-repository.js
@@ -1,12 +1,12 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { filterByFullName } from '../../../shared/infrastructure/utils/filter-utils.js';
-import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
-import { CombinedCourseParticipation } from '../../domain/models/combined-course-participations/entities/CombinedCourseParticipation.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
+import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
+import { CombinedCourseParticipation } from '../../../domain/models/combined-course-participations/entities/CombinedCourseParticipation.js';
 import {
   OrganizationLearnerParticipation,
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
-} from '../../domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
+} from '../../../domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
 
 export const save = async function ({ organizationLearnerId, combinedCourseId }) {
   const knexConnection = DomainTransaction.getConnection();

--- a/api/src/quest/infrastructure/repositories/combined-course-participations/organization-learner-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participations/organization-learner-participation-repository.js
@@ -1,8 +1,8 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import {
   OrganizationLearnerParticipation,
   OrganizationLearnerParticipationTypes,
-} from '../../domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
+} from '../../../domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
 
 export const findByOrganizationLearnerIdAndModuleIds = async ({ organizationLearnerId, moduleIds }) => {
   const participationById = await findByOrganizationLearnerIdsAndModuleIds({

--- a/api/src/quest/infrastructure/repositories/combined-courses/campaign-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-courses/campaign-repository.js
@@ -1,5 +1,5 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { Campaign } from '../../domain/models/combined-courses/entities/Campaign.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { Campaign } from '../../../domain/models/combined-courses/entities/Campaign.js';
 
 export const getByCode = async function ({ code, campaignsApi }) {
   const campaign = await campaignsApi.getByCode(code);

--- a/api/src/quest/infrastructure/repositories/combined-courses/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-courses/combined-course-repository.js
@@ -1,8 +1,8 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../shared/domain/errors.js';
-import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
-import { CombinedCourse } from '../../domain/models/combined-courses/entities/CombinedCourse.js';
-import { Quest } from '../../domain/models/quests/entities/Quest.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
+import { CombinedCourse } from '../../../domain/models/combined-courses/entities/CombinedCourse.js';
+import { Quest } from '../../../domain/models/quests/entities/Quest.js';
 
 const getByCode = async ({ code }) => {
   const knexConn = DomainTransaction.getConnection();

--- a/api/src/quest/infrastructure/repositories/combined-courses/module-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-courses/module-repository.js
@@ -1,4 +1,4 @@
-import { Module } from '../../domain/models/combined-courses/entities/Module.js';
+import { Module } from '../../../domain/models/combined-courses/entities/Module.js';
 
 export const getByIds = async ({ moduleIds, modulesApi }) => {
   const modules = await modulesApi.getModulesByIds({ moduleIds });

--- a/api/src/quest/infrastructure/repositories/course-repository.js
+++ b/api/src/quest/infrastructure/repositories/course-repository.js
@@ -3,7 +3,7 @@ import * as areaRepository from '../../../shared/infrastructure/repositories/are
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import * as tubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
 import { COURSE_ITEM_TYPES, CourseItem } from '../../domain/models/combined-courses/value-objects/CourseItem.js';
-import * as combinedCourseBlueprintRepository from './combined-course-blueprint-repository.js';
+import * as combinedCourseBlueprintRepository from './combined-course-blueprints/combined-course-blueprint-repository.js';
 
 export const findByOrganizationId = async ({ organizationId, locale }) => {
   const [blueprints, sharedTargetProfiles] = await Promise.all([

--- a/api/src/quest/infrastructure/repositories/eligibility-repository.js
+++ b/api/src/quest/infrastructure/repositories/eligibility-repository.js
@@ -1,6 +1,6 @@
 import { Eligibility } from '../../domain/models/quests/aggregates/Eligibility.js';
 // We import this repository here to avoid calling it in both dependencies and repositories in ./index.js
-import * as questOrganizationLearnerParticipationRepository from './organization-learner-participation-repository.js';
+import * as questOrganizationLearnerParticipationRepository from './combined-course-participations/organization-learner-participation-repository.js';
 export const find = async ({ userId, organizationLearnerWithParticipationApi }) => {
   const result = await organizationLearnerWithParticipationApi.find({ userIds: [userId] });
   return result.map(toDomain);

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -16,22 +16,22 @@ import { injectDependencies } from '../../../shared/infrastructure/utils/depende
 import { AttestationStorage } from '../storage/attestation-storage.js';
 import * as attestationRepository from './attestation-repository.js';
 import * as campaignParticipationRepository from './campaign-participation-repository.js';
-import * as campaignRepository from './campaign-repository.js';
 import * as combinedCourseBlueprintShareRepository from './combined-course-blueprint-share-repository.js';
+import * as targetProfileRepository from './combined-course-blueprints/target-profile-repository.js';
 import * as combinedCourseDetailsRepository from './combined-course-details-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
-import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
-import * as combinedCourseRepository from './combined-course-repository.js';
+import * as combinedCourseParticipationRepository from './combined-course-participations/combined-course-participation-repository.js';
+import * as organizationLearnerParticipationRepository from './combined-course-participations/organization-learner-participation-repository.js';
+import * as campaignRepository from './combined-courses/campaign-repository.js';
+import * as combinedCourseRepository from './combined-courses/combined-course-repository.js';
+import * as moduleRepository from './combined-courses/module-repository.js';
 import * as courseRepository from './course-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
-import * as moduleRepository from './module-repository.js';
-import * as organizationLearnerParticipationRepository from './organization-learner-participation-repository.js';
 import * as profileRewardRepository from './profile-reward-repository.js';
 import * as questRepository from './quest-repository.js';
 import * as recommendedModuleRepository from './recommended-module-repository.js';
 import * as rewardRepository from './reward-repository.js';
 import * as successRepository from './success-repository.js';
-import * as targetProfileRepository from './target-profile-repository.js';
 import * as userRepository from './user-repository.js';
 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-to-join_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-to-join_test.js
@@ -2,7 +2,7 @@ import * as campaignRepository from '../../../../../../src/prescription/campaign
 import { OrganizationToJoin } from '../../../../../../src/prescription/organization-learner/domain/models/OrganizationToJoin.js';
 import { getOrganizationToJoin } from '../../../../../../src/prescription/organization-learner/domain/usecases/get-organization-to-join.js';
 import { repositories } from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/index.js';
-import * as combinedCourseRepository from '../../../../../../src/quest/infrastructure/repositories/combined-course-repository.js';
+import * as combinedCourseRepository from '../../../../../../src/quest/infrastructure/repositories/combined-courses/combined-course-repository.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 

--- a/api/tests/quest/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/campaign-repository_test.js
@@ -1,5 +1,5 @@
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
-import * as campaignRepository from '../../../../../src/quest/infrastructure/repositories/campaign-repository.js';
+import * as campaignRepository from '../../../../../src/quest/infrastructure/repositories/combined-courses/campaign-repository.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -7,7 +7,7 @@ import {
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
-import * as combinedCourseBluePrintRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprint-repository.js';
+import * as combinedCourseBluePrintRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprints/combined-course-blueprint-repository.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -6,7 +6,7 @@ import {
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
 } from '../../../../../src/quest/domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
-import * as combinedCourseParticipationRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participation-repository.js';
+import * as combinedCourseParticipationRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participations/combined-course-participation-repository.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -7,7 +7,7 @@ import {
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
-import * as combinedCourseRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-repository.js';
+import * as combinedCourseRepository from '../../../../../src/quest/infrastructure/repositories/combined-courses/combined-course-repository.js';
 import * as questRepository from '../../../../../src/quest/infrastructure/repositories/quest-repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
@@ -7,7 +7,7 @@ import {
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
 } from '../../../../../src/quest/domain/models/combined-course-participations/entities/OrganizationLearnerParticipation.js';
-import * as organizationLearnerParticipationRepository from '../../../../../src/quest/infrastructure/repositories/organization-learner-participation-repository.js';
+import * as organizationLearnerParticipationRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participations/organization-learner-participation-repository.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 

--- a/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
 import { Campaign } from '../../../../../src/quest/domain/models/combined-courses/entities/Campaign.js';
-import * as campaignRepository from '../../../../../src/quest/infrastructure/repositories/campaign-repository.js';
+import * as campaignRepository from '../../../../../src/quest/infrastructure/repositories/combined-courses/campaign-repository.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Repositories | campaign', function () {

--- a/api/tests/quest/unit/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/module-repository_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
 import { Module } from '../../../../../src/quest/domain/models/combined-courses/entities/Module.js';
-import * as moduleRepository from '../../../../../src/quest/infrastructure/repositories/module-repository.js';
+import * as moduleRepository from '../../../../../src/quest/infrastructure/repositories/combined-courses/module-repository.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Repositories | Module Repository', function () {

--- a/api/tests/quest/unit/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/target-profile-repository_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
 import { TargetProfile } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/TargetProfile.js';
-import * as targetProfileRepository from '../../../../../src/quest/infrastructure/repositories/target-profile-repository.js';
+import * as targetProfileRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprints/target-profile-repository.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Repositories | target-profile', function () {


### PR DESCRIPTION
## 🪧 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On continue notre réflexion sur l'orga du domaine. On commence à étendre le découpage établi jusque là en dehors de la couche domaine.

## 🌈 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Déplacer les repositories correspondant aux entities de domaine, dans des sous-dossiers de la couche infra reflétant le découpage domaine

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
CI au vert
