### PR TITLE
[FEATURE] Afficher un bouton pour délier le centre de certif sur la page d'une orga (PIX-22690)

### DIFF
--- a/admin/app/components/organizations/attached-certification-center.gjs
+++ b/admin/app/components/organizations/attached-certification-center.gjs
@@ -1,35 +1,118 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import ENV from 'pix-admin/config/environment';
 
-<template>
-  {{#if @attachedCertificationCenters.length}}
-    <PixTable
-      @variant="admin"
-      @caption={{t "components.organizations.attached-certification-center.table.caption"}}
-      @data={{@attachedCertificationCenters}}
+export default class AttachedCertificationCenter extends Component {
+  @service intl;
+  @service pixToast;
+  @service requestManager;
+  @service router;
+
+  @tracked showDetachModal = false;
+
+  get certificationCenterToDetach() {
+    return this.args.attachedCertificationCenters.firstObject;
+  }
+
+  @action
+  openDetachModal() {
+    this.showDetachModal = true;
+  }
+
+  @action
+  closeDetachModal() {
+    this.showDetachModal = false;
+  }
+
+  @action
+  async detachCertificationCenter() {
+    try {
+      await this.requestManager.request({
+        url: `${ENV.APP.API_HOST}/api/admin/organizations/${this.args.organizationId}/detach-certification-center`,
+        method: 'POST',
+      });
+      await this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.organizations.attached-certification-center.actions.detach.success'),
+      });
+      this.router.refresh(this.router.currentRouteName);
+    } catch {
+      await this.pixToast.sendErrorNotification({
+        message: this.intl.t('common.notifications.generic-error'),
+      });
+    } finally {
+      this.closeDetachModal();
+    }
+  }
+
+  <template>
+    {{#if @attachedCertificationCenters.length}}
+      <PixTable
+        @variant="admin"
+        @caption={{t "components.organizations.attached-certification-center.table.caption"}}
+        @data={{@attachedCertificationCenters}}
+      >
+        <:columns as |certificationCenter context|>
+          <PixTableColumn @context={{context}}>
+            <:header>{{t "components.organizations.attached-certification-center.table.headers.id"}}</:header>
+            <:cell>
+              <LinkTo @route="authenticated.certification-centers.get" @model={{certificationCenter.id}}>
+                {{certificationCenter.id}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>{{t "components.organizations.attached-certification-center.table.headers.name"}}</:header>
+            <:cell>{{certificationCenter.name}}</:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>{{t "components.organizations.attached-certification-center.table.headers.external-id"}}</:header>
+            <:cell>{{certificationCenter.externalId}}</:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>{{t "components.organizations.attached-certification-center.table.headers.actions"}}</:header>
+            <:cell>
+              <PixButton @variant="error" @size="small" @triggerAction={{this.openDetachModal}}>
+                {{t "components.organizations.attached-certification-center.actions.detach.button"}}
+              </PixButton>
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    {{else}}
+      <p>{{t "components.organizations.attached-certification-center.empty"}}</p>
+    {{/if}}
+
+    <PixModal
+      @title={{t "components.organizations.attached-certification-center.actions.detach.confirm-modal-title"}}
+      @iconName="warning"
+      @onCloseButtonClick={{this.closeDetachModal}}
+      @showModal={{this.showDetachModal}}
     >
-      <:columns as |certificationCenter context|>
-        <PixTableColumn @context={{context}}>
-          <:header>{{t "components.organizations.attached-certification-center.table.headers.id"}}</:header>
-          <:cell>
-            <LinkTo @route="authenticated.certification-centers.get" @model={{certificationCenter.id}}>
-              {{certificationCenter.id}}
-            </LinkTo>
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>{{t "components.organizations.attached-certification-center.table.headers.name"}}</:header>
-          <:cell>{{certificationCenter.name}}</:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>{{t "components.organizations.attached-certification-center.table.headers.external-id"}}</:header>
-          <:cell>{{certificationCenter.externalId}}</:cell>
-        </PixTableColumn>
-      </:columns>
-    </PixTable>
-  {{else}}
-    <p>{{t "components.organizations.attached-certification-center.empty"}}</p>
-  {{/if}}
-</template>
+      <:content>
+        <p>
+          {{t
+            "components.organizations.attached-certification-center.actions.detach.confirm-modal-message"
+            certificationCenterName=this.certificationCenterToDetach.name
+            htmlSafe=true
+          }}
+        </p>
+      </:content>
+      <:footer>
+        <PixButton @variant="secondary" @triggerAction={{this.closeDetachModal}}>
+          {{t "common.actions.cancel"}}
+        </PixButton>
+        <PixButton @variant="error" @triggerAction={{this.detachCertificationCenter}}>
+          {{t "common.actions.confirm"}}
+        </PixButton>
+      </:footer>
+    </PixModal>
+  </template>
+}

--- a/admin/app/routes/authenticated/organizations/get/attached-certification-centers.js
+++ b/admin/app/routes/authenticated/organizations/get/attached-certification-centers.js
@@ -6,6 +6,9 @@ export default class AttachedCertificationCenter extends Route {
 
   async model() {
     const organization = this.modelFor('authenticated.organizations.get');
-    return this.store.query('attached-certification-center', { organizationId: organization.id });
+    const attachedCertificationCenters = await this.store.query('attached-certification-center', {
+      organizationId: organization.id,
+    });
+    return { attachedCertificationCenters, organizationId: organization.id };
   }
 }

--- a/admin/app/templates/authenticated/organizations/get/attached-certification-centers.gjs
+++ b/admin/app/templates/authenticated/organizations/get/attached-certification-centers.gjs
@@ -1,3 +1,8 @@
 import AttachedCertificationCenter from 'pix-admin/components/organizations/attached-certification-center';
 
-<template><AttachedCertificationCenter @attachedCertificationCenters={{@model}} /></template>
+<template>
+  <AttachedCertificationCenter
+    @attachedCertificationCenters={{@model.attachedCertificationCenters}}
+    @organizationId={{@model.organizationId}}
+  />
+</template>

--- a/admin/tests/acceptance/authenticated/organizations/get/attached-certification-center-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/attached-certification-center-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import setupIntl from 'pix-admin/tests/helpers/setup-intl';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
@@ -37,6 +38,37 @@ module('Acceptance | Organizations | Attached Certification Center', function (h
 
       // then
       assert.strictEqual(currentURL(), `/certification-centers/${certificationCenter.id}`);
+    });
+
+    test('detaching a certification center shows a success notification', async function (assert) {
+      // given
+      const certificationCenter = this.server.create('certification-center', { id: '100', name: 'Centre Pix Paris' });
+      const organizationId = this.server.create('organization', {
+        name: 'Orga avec CDC',
+        features: { PLACES_MANAGEMENT: { active: false } },
+      }).id;
+      this.server.create('attached-certification-center', {
+        id: certificationCenter.id,
+        organizationId,
+        name: certificationCenter.name,
+        externalId: 'EXT-001',
+      });
+
+      const screen = await visit(`/organizations/${organizationId}/attached-certification-centers`);
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: t('components.organizations.attached-certification-center.actions.detach.button'),
+        }),
+      );
+      await screen.findByRole('dialog');
+      await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+
+      // then
+      assert
+        .dom(screen.getByText(t('components.organizations.attached-certification-center.actions.detach.success')))
+        .exists();
     });
   });
 });

--- a/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
+++ b/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
@@ -1,8 +1,20 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl/test-support';
 import AttachedCertificationCenter from 'pix-admin/components/organizations/attached-certification-center';
+import ENV from 'pix-admin/config/environment';
 import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+class State {
+  @tracked attachedCertificationCenters;
+
+  constructor(attachedCertificationCenters) {
+    this.attachedCertificationCenters = attachedCertificationCenters;
+  }
+}
 
 module('Integration | Component | organizations/attached-certification-center', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -71,6 +83,13 @@ module('Integration | Component | organizations/attached-certification-center', 
           }),
         )
         .exists();
+      assert
+        .dom(
+          screen.getByRole('columnheader', {
+            name: t('components.organizations.attached-certification-center.table.headers.actions'),
+          }),
+        )
+        .exists();
     });
 
     test('it displays the certification centers in a table', async function (assert) {
@@ -115,6 +134,143 @@ module('Integration | Component | organizations/attached-certification-center', 
 
       // then
       assert.dom(screen.getByRole('link', { name: '123' })).hasAttribute('href', '/certification-centers/123');
+    });
+
+    module('when detaching a certification center', function (hooks) {
+      let requestManager;
+      let pixToast;
+      let router;
+
+      hooks.beforeEach(function () {
+        requestManager = this.owner.lookup('service:requestManager');
+        sinon.stub(requestManager, 'request');
+
+        pixToast = this.owner.lookup('service:pixToast');
+        sinon.stub(pixToast, 'sendSuccessNotification').resolves();
+        sinon.stub(pixToast, 'sendErrorNotification').resolves();
+
+        router = this.owner.lookup('service:router');
+        sinon.stub(router, 'refresh');
+      });
+
+      test('it opens a confirmation modal when clicking the detach button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certificationCenter = store.createRecord('attached-certification-center', {
+          id: '123',
+          name: 'Centre Pix',
+          externalId: 'EXT-456',
+        });
+        const attachedCertificationCenter = [certificationCenter];
+
+        // when
+        const screen = await render(
+          <template>
+            <AttachedCertificationCenter
+              @attachedCertificationCenters={{attachedCertificationCenter}}
+              @organizationId="42"
+            />
+          </template>,
+        );
+        await click(
+          screen.getByRole('button', {
+            name: t('components.organizations.attached-certification-center.actions.detach.button'),
+          }),
+        );
+        await screen.findByRole('dialog');
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: t('components.organizations.attached-certification-center.actions.detach.confirm-modal-title'),
+            }),
+          )
+          .exists();
+      });
+
+      test('it detaches the certification center and removes the table when confirming the modal', async function (assert) {
+        // given
+        requestManager.request.resolves();
+
+        const store = this.owner.lookup('service:store');
+        const certificationCenter = store.createRecord('attached-certification-center', {
+          id: '123',
+          name: 'Centre Pix',
+          externalId: 'EXT-456',
+        });
+        const state = new State([certificationCenter]);
+        router.refresh.callsFake(() => {
+          state.attachedCertificationCenters = [];
+        });
+
+        const screen = await render(
+          <template>
+            <AttachedCertificationCenter
+              @attachedCertificationCenters={{state.attachedCertificationCenters}}
+              @organizationId="42"
+            />
+          </template>,
+        );
+        await click(
+          screen.getByRole('button', {
+            name: t('components.organizations.attached-certification-center.actions.detach.button'),
+          }),
+        );
+        await screen.findByRole('dialog');
+        await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+
+        // then
+        assert.true(
+          requestManager.request.calledWith({
+            url: `${ENV.APP.API_HOST}/api/admin/organizations/42/detach-certification-center`,
+            method: 'POST',
+          }),
+        );
+        assert.true(
+          pixToast.sendSuccessNotification.calledWith({
+            message: t('components.organizations.attached-certification-center.actions.detach.success'),
+          }),
+        );
+        assert.dom(screen.queryByRole('table')).doesNotExist();
+      });
+
+      test('it displays an error notification and keeps the table when detaching fails', async function (assert) {
+        // given
+        requestManager.request.rejects();
+
+        const store = this.owner.lookup('service:store');
+        const certificationCenter = store.createRecord('attached-certification-center', {
+          id: '123',
+          name: 'Centre Pix',
+          externalId: 'EXT-456',
+        });
+        const attachedCertificationCenter = [certificationCenter];
+
+        const screen = await render(
+          <template>
+            <AttachedCertificationCenter
+              @attachedCertificationCenters={{attachedCertificationCenter}}
+              @organizationId="42"
+            />
+          </template>,
+        );
+        await click(
+          screen.getByRole('button', {
+            name: t('components.organizations.attached-certification-center.actions.detach.button'),
+          }),
+        );
+        await screen.findByRole('dialog');
+        await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+
+        // then
+        assert.true(
+          pixToast.sendErrorNotification.calledWith({
+            message: t('common.notifications.generic-error'),
+          }),
+        );
+        assert.dom(screen.getByRole('table')).exists();
+      });
     });
   });
 });

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -413,6 +413,7 @@ export default function routes() {
   this.get('/admin/organizations/:id/certification-centers', getOrganizationAttachedCertificationCenters);
   this.get('/admin/organizations/:id/statistics', getOrganizationStatistics);
   this.post('/admin/organizations/:id/archive', archiveOrganization);
+  this.post('/admin/organizations/:id/detach-certification-center', () => new Response(204));
 
   this.get('/admin/frameworks');
   this.get('/admin/frameworks/:id/areas', findFrameworkAreas);

--- a/admin/tests/unit/routes/authenticated/organizations/get/attached-certification-center-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/attached-certification-center-test.js
@@ -16,7 +16,7 @@ module('Unit | Route | authenticated/organizations/get/attached-certification-ce
   });
 
   module('#model', function () {
-    test('it calls store.query with the organizationId and returns the result', async function (assert) {
+    test('it calls store.query with the organizationId and returns the certification centers with the organizationId', async function (assert) {
       // given
       const certificationCenters = [{ id: '1', name: 'Centre Pix' }];
       route.modelFor = sinon.stub().returns({ id: '42' });
@@ -27,7 +27,7 @@ module('Unit | Route | authenticated/organizations/get/attached-certification-ce
 
       // then
       sinon.assert.calledWith(route.store.query, 'attached-certification-center', { organizationId: '42' });
-      assert.strictEqual(result, certificationCenters);
+      assert.deepEqual(result, { attachedCertificationCenters: certificationCenters, organizationId: '42' });
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -896,10 +896,19 @@
         "recently-used-tags": "List of tags recently used with {tagName}"
       },
       "attached-certification-center": {
+        "actions": {
+          "detach": {
+            "button": "Detach",
+            "confirm-modal-message": "Are you sure you want to detach the certification center <strong>{certificationCenterName}</strong> from this organization?",
+            "confirm-modal-title": "Detach a certification center",
+            "success": "The certification center has been successfully detached."
+          }
+        },
         "empty": "No certification center attached.",
         "table": {
           "caption": "Certification center attached to the organisation.",
           "headers": {
+            "actions": "Actions",
             "external-id": "External ID",
             "id": "ID",
             "name": "Name"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -904,10 +904,19 @@
         "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"
       },
       "attached-certification-center": {
+        "actions": {
+          "detach": {
+            "button": "Détacher",
+            "confirm-modal-message": "Êtes-vous sûr de vouloir détacher le centre de certification <strong>{certificationCenterName}</strong> de cette organisation ?",
+            "confirm-modal-title": "Détacher un centre de certification",
+            "success": "Le centre de certification a été détaché avec succès."
+          }
+        },
         "empty": "Aucun centre de certification rattaché.",
         "table": {
           "caption": "Centre de certification rattaché à l'organisation.",
           "headers": {
+            "actions": "Actions",
             "external-id": "Identifiant externe",
             "id": "ID du centre",
             "name": "Nom du centre de certification rattaché"


### PR DESCRIPTION
## 🪧 Problème

Dans le cadre de la gestion des réseaux, nous avons besoin de pouvoir détacher un centre de certification rattaché à une organisation.

## 🌈 Proposition

Ajouter un bouton dans le tableau "Lien certif" dans pix admin

## ✊ Remarques

suite de #16703 

## 🎉 Pour tester
- Dans pix-admin, trouver une organisation avec un centre de certification attaché

- Aller dans l'onglet "Lien certif"
<img width="1296" height="839" alt="image" src="https://github.com/user-attachments/assets/6111461f-130f-42ff-8f2b-2320a7749443" />

- Constater un bouton "Détacher"

- Au clic, une modale de confirmation s'ouvre

- A la confirmation, le centre de certification est détaché
