### PR TITLE
[TECH] Réduit les contraintes lié à la souscription pour permettre la suppression (PIX-23412)

### DIFF
--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -4,8 +4,6 @@ import BaseJoi from 'joi';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { authorization } from '../../shared/application/pre-handlers/authorization.js';
-import { SUBSCRIPTION_TYPES } from '../../shared/domain/constants.js';
-import { Frameworks } from '../../shared/domain/models/Frameworks.js';
 import { certificationCandidateController } from './certification-candidate-controller.js';
 
 const Joi = BaseJoi.extend(JoiDate);
@@ -43,18 +41,7 @@ const register = async function (server) {
                   'date.format': 'CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID',
                 }),
                 'organization-learner-id': Joi.number().empty(null).forbidden(),
-                subscription: Joi.string().valid(...Object.values(Frameworks)),
-                subscriptions: Joi.array()
-                  .items(
-                    Joi.object({
-                      type: Joi.string().valid(...Object.values(SUBSCRIPTION_TYPES)),
-                      complementaryCertificationKey: Joi.string()
-                        .valid(...Object.values(Frameworks))
-                        .allow(null),
-                    }),
-                  )
-                  .min(1)
-                  .max(2),
+                subscription: Joi.string().empty(['', null]).required(),
               },
               relationships: Joi.any(),
             },

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
@@ -1,5 +1,5 @@
 import { createServer } from '../../../../../server.js';
-import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../../../src/certification/shared/domain/constants.js';
+import { BILLING_MODES } from '../../../../../src/certification/shared/domain/constants.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
@@ -91,37 +91,6 @@ describe('Acceptance | Controller | Certification | Enrolment | session-controll
       it('should respond with a 201 and save the candidate with the correct subscription', async function () {
         // when
         const response = await server.inject(options);
-
-        // then
-        const candidateId = parseInt(response.result.data.id);
-        expect(response.statusCode).to.equal(201);
-        const savedCandidate = await knex('certification-candidates').where({ id: candidateId }).first();
-        expect(savedCandidate.subscription).to.equal(Frameworks.CLEA);
-      });
-    });
-
-    context('with legacy subscriptions array format', function () {
-      it('should respond with a 201 and derive subscription from subscriptions array', async function () {
-        // given
-        const legacyOptions = {
-          ...options,
-          payload: {
-            data: {
-              ...options.payload.data,
-              attributes: {
-                ...options.payload.data.attributes,
-                subscription: undefined,
-                subscriptions: [
-                  { type: SUBSCRIPTION_TYPES.COMPLEMENTARY, complementaryCertificationKey: Frameworks.CLEA },
-                  { type: SUBSCRIPTION_TYPES.CORE, complementaryCertificationKey: null },
-                ],
-              },
-            },
-          },
-        };
-
-        // when
-        const response = await server.inject(legacyOptions);
 
         // then
         const candidateId = parseInt(response.result.data.id);

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
@@ -94,7 +94,9 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
 
       // then
       expect(deserializedCandidate).to.deepEqualInstance(
-        domainBuilder.certification.enrolment.buildCandidate({ ...candidateData }),
+        domainBuilder.certification.enrolment.buildCandidate({
+          ...candidateData,
+        }),
       );
     });
 


### PR DESCRIPTION
## 🪧 Problème

Nous enregistrons les souscriptions directement dans la table candidates, plus besoin d'une table spécifique.

## 🌈 Proposition

Réduire la contrainte sur la route pour préparer la suppression.

## ✊ Remarques

C'est un `revert` de ce commit 404387f6e09406107631fc3065034660cba481b1

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
