### PR TITLE
[FEATURE] Pouvoir rattacher un centre de certification à une organisation depuis Pix Admin (PIX-22633)

### DIFF
--- a/admin/app/components/organizations/attached-certification-center.gjs
+++ b/admin/app/components/organizations/attached-certification-center.gjs
@@ -9,7 +9,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import AttachedCertificationCenterForm from 'pix-admin/components/organizations/attached-certification-centers/attach-certification-center-form';
-import ENV from 'pix-admin/config/environment';
 import { organizationRequestsBuilder } from 'pix-admin/requests-builders/organization-requests-builder';
 
 export default class AttachedCertificationCenter extends Component {
@@ -77,11 +76,11 @@ export default class AttachedCertificationCenter extends Component {
 
   @action
   async detachCertificationCenter() {
+    const detachCertificationCenterRequest = organizationRequestsBuilder.buildDetachCertificationCenterRequest({
+      organizationId: this.args.organizationId,
+    });
     try {
-      await this.requestManager.request({
-        url: `${ENV.APP.API_HOST}/api/admin/organizations/${this.args.organizationId}/detach-certification-center`,
-        method: 'POST',
-      });
+      await this.requestManager.request(detachCertificationCenterRequest);
       await this.pixToast.sendSuccessNotification({
         message: this.intl.t('components.organizations.attached-certification-center.actions.detach.success'),
       });

--- a/admin/app/components/organizations/attached-certification-center.gjs
+++ b/admin/app/components/organizations/attached-certification-center.gjs
@@ -8,7 +8,9 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import AttachedCertificationCenterForm from 'pix-admin/components/organizations/attached-certification-centers/attach-certification-center-form';
 import ENV from 'pix-admin/config/environment';
+import { organizationRequestsBuilder } from 'pix-admin/requests-builders/organization-requests-builder';
 
 export default class AttachedCertificationCenter extends Component {
   @service intl;
@@ -18,8 +20,8 @@ export default class AttachedCertificationCenter extends Component {
 
   @tracked showDetachModal = false;
 
-  get certificationCenterToDetach() {
-    return this.args.attachedCertificationCenters.firstObject;
+  get attachedCertificationCenter() {
+    return this.args.attachedCertificationCenters[0];
   }
 
   @action
@@ -30,6 +32,47 @@ export default class AttachedCertificationCenter extends Component {
   @action
   closeDetachModal() {
     this.showDetachModal = false;
+  }
+
+  @action
+  async handleAttachCertificationCenter(certificationCenterId) {
+    const attachCertificationCenterRequest = organizationRequestsBuilder.buildAttachCertificationCenterRequest({
+      organizationId: this.args.organizationId,
+      certificationCenterId,
+    });
+
+    try {
+      await this.requestManager.request(attachCertificationCenterRequest);
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.organizations.attached-certification-center.notifications.attach-success'),
+      });
+      this.router.refresh(this.router.currentRouteName);
+    } catch (responseError) {
+      const error = responseError?.errors?.[0];
+      let message;
+
+      switch (error?.code) {
+        case 'NON_EXISTING_CERTIFICATION_CENTER':
+          message = this.intl.t(
+            'components.organizations.attached-certification-center.notifications.errors.NON_EXISTING_CERTIFICATION_CENTER',
+            { certificationCenterId: error.meta.certificationCenterId },
+          );
+          break;
+        case 'ALREADY_ATTACHED_CERTIFICATION_CENTER':
+          message = this.intl.t(
+            'components.organizations.attached-certification-center.notifications.errors.ALREADY_ATTACHED_CERTIFICATION_CENTER',
+            {
+              certificationCenterId: error.meta.certificationCenterId,
+              alreadyAttachedOrganizationId: error.meta.alreadyAttachedOrganizationId,
+            },
+          );
+          break;
+        default:
+          message = this.intl.t('common.notifications.generic-error');
+      }
+
+      this.pixToast.sendErrorNotification({ message });
+    }
   }
 
   @action
@@ -53,7 +96,7 @@ export default class AttachedCertificationCenter extends Component {
   }
 
   <template>
-    {{#if @attachedCertificationCenters.length}}
+    {{#if this.attachedCertificationCenter}}
       <PixTable
         @variant="admin"
         @caption={{t "components.organizations.attached-certification-center.table.caption"}}
@@ -87,7 +130,8 @@ export default class AttachedCertificationCenter extends Component {
         </:columns>
       </PixTable>
     {{else}}
-      <p>{{t "components.organizations.attached-certification-center.empty"}}</p>
+      <AttachedCertificationCenterForm @onFormSubmitted={{this.handleAttachCertificationCenter}} />
+
     {{/if}}
 
     <PixModal
@@ -100,7 +144,7 @@ export default class AttachedCertificationCenter extends Component {
         <p>
           {{t
             "components.organizations.attached-certification-center.actions.detach.confirm-modal-message"
-            certificationCenterName=this.certificationCenterToDetach.name
+            certificationCenterName=this.attachedCertificationCenter.name
             htmlSafe=true
           }}
         </p>

--- a/admin/app/components/organizations/attached-certification-centers/attach-certification-center-form.gjs
+++ b/admin/app/components/organizations/attached-certification-centers/attach-certification-center-form.gjs
@@ -1,0 +1,39 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { on } from '@ember/modifier';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class AttachCertificationCenterForm extends Component {
+  @tracked certificationCenterId;
+
+  onCertificationCenterIdToAttachChange = (event) => {
+    this.certificationCenterId = event.target.value;
+  };
+
+  submitForm = (event) => {
+    event.preventDefault();
+    this.args.onFormSubmitted(this.certificationCenterId);
+  };
+
+  <template>
+    <form
+      aria-label={{t "components.organizations.attached-certification-center.attach-form.name"}}
+      class="attach-certification-center-form"
+      {{on "submit" this.submitForm}}
+    >
+      <PixInput
+        type="number"
+        @id="attached-certification-center"
+        @subLabel={{t "components.organizations.attached-certification-center.attach-form.input-sublabel"}}
+        @value={{this.certificationCenterId}}
+        @requiredLabel={{t "common.fields.required-field"}}
+        {{on "change" this.onCertificationCenterIdToAttachChange}}
+      >
+        <:label>{{t "components.organizations.attached-certification-center.attach-form.input-label"}}</:label>
+      </PixInput>
+      <PixButton @size="small" @type="submit">{{t "common.actions.validate"}}</PixButton>
+    </form>
+  </template>
+}

--- a/admin/app/components/organizations/attached-certification-centers/attach-certification-center-form.scss
+++ b/admin/app/components/organizations/attached-certification-centers/attach-certification-center-form.scss
@@ -1,0 +1,5 @@
+.attach-certification-center-form {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: flex-end;
+}

--- a/admin/app/requests-builders/organization-requests-builder.js
+++ b/admin/app/requests-builders/organization-requests-builder.js
@@ -1,0 +1,19 @@
+import ENV from 'pix-admin/config/environment';
+
+export const organizationRequestsBuilder = {
+  /**
+   * Builds request object for attach-certification-centers action
+   * @type {function}
+   * @param {object} params
+   * @param {number} params.organizationId
+   * @param {number} params.certificationCenterId
+   * @return {{url: string, method: string, body: string}}
+   */
+  buildAttachCertificationCenterRequest: ({ organizationId, certificationCenterId }) => {
+    return {
+      url: `${ENV.APP.API_HOST}/api/admin/organizations/${organizationId}/attach-certification-centers`,
+      method: 'POST',
+      body: JSON.stringify({ certificationCenterId }),
+    };
+  },
+};

--- a/admin/app/requests-builders/organization-requests-builder.js
+++ b/admin/app/requests-builders/organization-requests-builder.js
@@ -16,4 +16,18 @@ export const organizationRequestsBuilder = {
       body: JSON.stringify({ certificationCenterId }),
     };
   },
+
+  /**
+   * Builds request object for detach-certification-centers action
+   * @type {function}
+   * @param {object} params
+   * @param {number} params.organizationId
+   * @return {{url: string, method: string}}
+   */
+  buildDetachCertificationCenterRequest: ({ organizationId }) => {
+    return {
+      url: `${ENV.APP.API_HOST}/api/admin/organizations/${organizationId}/detach-certification-center`,
+      method: 'POST',
+    };
+  },
 };

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -123,3 +123,4 @@
 @use 'organizations/head-information' as *;
 @use 'organizations/network/actions-section' as *;
 @use 'organizations/statistics' as *;
+@use 'organizations/attached-certification-centers/attach-certification-center-form' as *

--- a/admin/tests/acceptance/authenticated/organizations/get/attached-certification-center-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/attached-certification-center-test.js
@@ -1,5 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { click, currentURL } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import setupIntl from 'pix-admin/tests/helpers/setup-intl';
@@ -69,6 +69,33 @@ module('Acceptance | Organizations | Attached Certification Center', function (h
       assert
         .dom(screen.getByText(t('components.organizations.attached-certification-center.actions.detach.success')))
         .exists();
+    });
+    test('attaches a certification-center to an organization', async function (assert) {
+      // given
+      this.server.create('certification-center', { id: '123', name: 'Centre Pix Paris' });
+      const organizationId = this.server.create('organization', {
+        name: 'Orga avec CDC',
+        features: { PLACES_MANAGEMENT: { active: false } },
+      }).id;
+
+      const screen = await visit(`/organizations/${organizationId}/attached-certification-centers`);
+
+      // when
+      const input = screen.getByRole(
+        'spinbutton',
+        t('components.organizations.attached-certification-center.attach-form.input-label'),
+      );
+      await fillIn(input, '123');
+
+      const validateButton = screen.getByRole('button', { name: t('common.actions.validate') });
+      await click(validateButton);
+
+      // then
+      assert
+        .dom(screen.getByText(t('components.organizations.attached-certification-center.notifications.attach-success')))
+        .exists();
+
+      assert.dom(screen.getByRole('cell', { name: 'Centre Pix Paris' })).exists();
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/organizations/get/network-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/network-test.js
@@ -131,7 +131,7 @@ module('Acceptance | Organizations | Network', function (hooks) {
     });
   });
 
-  module.skip('when user has role "CERTIF"', function () {
+  module('when user has role "CERTIF"', function () {
     test('it should not display actions section', async function (assert) {
       await authenticateAdminMemberWithRole({ isCertif: true })(server);
       const parentOrganizationId = this.server.create('organization', {

--- a/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
+++ b/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
@@ -1,5 +1,5 @@
-import { render } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { render, within } from '@1024pix/ember-testing-library';
+import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl/test-support';
 import AttachedCertificationCenter from 'pix-admin/components/organizations/attached-certification-center';
@@ -18,9 +18,23 @@ class State {
 
 module('Integration | Component | organizations/attached-certification-center', function (hooks) {
   setupIntlRenderingTest(hooks);
+  let store, requestManager, pixToast, router;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    requestManager = this.owner.lookup('service:requestManager');
+    sinon.stub(requestManager, 'request');
+
+    pixToast = this.owner.lookup('service:pixToast');
+    sinon.stub(pixToast, 'sendSuccessNotification').resolves();
+    sinon.stub(pixToast, 'sendErrorNotification').resolves();
+
+    router = this.owner.lookup('service:router');
+    sinon.stub(router, 'refresh');
+  });
 
   module('when there is no attached certification center', function () {
-    test('it displays an empty message', async function (assert) {
+    test('it displays a form to attach a certification center', async function (assert) {
       // given
       const attachedCertificationCenter = [];
 
@@ -32,128 +46,203 @@ module('Integration | Component | organizations/attached-certification-center', 
       );
 
       // then
-      assert.dom(screen.getByText(t('components.organizations.attached-certification-center.empty'))).exists();
-    });
-  });
-
-  module('when there are attached certification centers', function () {
-    test('it displays the table with caption and column headers', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certificationCenter = store.createRecord('attached-certification-center', {
-        id: '123',
-        name: 'Centre Pix',
-        externalId: 'EXT-456',
-      });
-      const attachedCertificationCenters = [certificationCenter];
-
-      // when
-      const screen = await render(
-        <template>
-          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenters}} />
-        </template>,
-      );
-
-      // then
       assert
         .dom(
-          screen.getByRole('table', {
-            name: t('components.organizations.attached-certification-center.table.caption'),
-          }),
-        )
-        .exists();
-      assert
-        .dom(
-          screen.getByRole('columnheader', {
-            name: t('components.organizations.attached-certification-center.table.headers.id'),
-          }),
-        )
-        .exists();
-      assert
-        .dom(
-          screen.getByRole('columnheader', {
-            name: t('components.organizations.attached-certification-center.table.headers.name'),
-          }),
-        )
-        .exists();
-      assert
-        .dom(
-          screen.getByRole('columnheader', {
-            name: t('components.organizations.attached-certification-center.table.headers.external-id'),
-          }),
-        )
-        .exists();
-      assert
-        .dom(
-          screen.getByRole('columnheader', {
-            name: t('components.organizations.attached-certification-center.table.headers.actions'),
+          screen.getByRole('form', {
+            name: t('components.organizations.attached-certification-center.attach-form.name'),
           }),
         )
         .exists();
     });
 
-    test('it displays the certification centers in a table', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certificationCenter = store.createRecord('attached-certification-center', {
-        id: '123',
-        name: 'Centre Pix',
-        externalId: 'EXT-456',
+    module('when attaching a certification center', function () {
+      test('it sends a success notification and refreshes model', async function (assert) {
+        // given
+        requestManager.request.resolves({ response: { ok: true, status: 204 } });
+
+        const organization = store.createRecord('organization');
+        const attachedCertificationCenters = [];
+
+        // when
+        const screen = await render(
+          <template>
+            <AttachedCertificationCenter
+              @attachedCertificationCenters={{attachedCertificationCenters}}
+              @organization={{organization}}
+            />
+          </template>,
+        );
+
+        const input = screen.getByRole(
+          'spinbutton',
+          t('components.organizations.attached-certification-center.attach-form.input-label'),
+        );
+        await fillIn(input, '123');
+
+        const validateButton = screen.getByRole('button', { name: t('common.actions.validate') });
+        await click(validateButton);
+
+        // then
+        assert.ok(
+          pixToast.sendSuccessNotification.calledWithExactly({
+            message: t('components.organizations.attached-certification-center.notifications.attach-success'),
+          }),
+        );
+        router.refresh.called;
       });
-      const attachedCertificationCenter = [certificationCenter];
 
-      // when
-      const screen = await render(
-        <template>
-          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
-        </template>,
-      );
+      module('error cases', function () {
+        test('it sends an error notification if certification center does not exist', async function (assert) {
+          // given
+          const organization = store.createRecord('organization');
+          const attachedCertificationCenters = [];
 
-      // then
-      assert.dom(screen.getByRole('cell', { name: '123' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Centre Pix' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'EXT-456' })).exists();
+          requestManager.request.rejects({
+            errors: [{ code: 'NON_EXISTING_CERTIFICATION_CENTER', meta: { certificationCenterId: '1' } }],
+          });
+
+          // when
+          const screen = await render(
+            <template>
+              <AttachedCertificationCenter
+                @attachedCertificationCenters={{attachedCertificationCenters}}
+                @organization={{organization}}
+              />
+            </template>,
+          );
+
+          const form = screen.getByRole('form');
+          await triggerEvent(form, 'submit');
+
+          // then
+          assert.ok(
+            pixToast.sendErrorNotification.calledWithExactly({
+              message: t(
+                'components.organizations.attached-certification-center.notifications.errors.NON_EXISTING_CERTIFICATION_CENTER',
+                { certificationCenterId: '1' },
+              ),
+            }),
+          );
+        });
+
+        test('it sends an error notification if certification center is already attached', async function (assert) {
+          // given
+          const organization = store.createRecord('organization');
+          const attachedCertificationCenters = [];
+
+          requestManager.request.rejects({
+            errors: [
+              {
+                code: 'ALREADY_ATTACHED_CERTIFICATION_CENTER',
+                meta: { certificationCenterId: '1', alreadyAttachedOrganizationId: '42' },
+              },
+            ],
+          });
+
+          // when
+          const screen = await render(
+            <template>
+              <AttachedCertificationCenter
+                @attachedCertificationCenters={{attachedCertificationCenters}}
+                @organization={{organization}}
+              />
+            </template>,
+          );
+
+          const form = screen.getByRole('form');
+          await triggerEvent(form, 'submit');
+
+          // then
+          assert.ok(
+            pixToast.sendErrorNotification.calledWithExactly({
+              message: t(
+                'components.organizations.attached-certification-center.notifications.errors.ALREADY_ATTACHED_CERTIFICATION_CENTER',
+                { certificationCenterId: '1', alreadyAttachedOrganizationId: '42' },
+              ),
+            }),
+          );
+        });
+      });
     });
 
-    test('it displays a link to the certification center page', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certificationCenter = store.createRecord('attached-certification-center', {
-        id: '123',
-        name: 'Centre Pix',
-        externalId: 'EXT-456',
-      });
-      const attachedCertificationCenter = [certificationCenter];
+    module('when there are attached certification centers', function () {
+      test('it does not display a form to attach a certification center', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certificationCenter = store.createRecord('attached-certification-center', {
+          id: '123',
+          name: 'Centre Pix',
+          externalId: 'EXT-456',
+        });
+        const attachedCertificationCenters = [certificationCenter];
 
-      // when
-      const screen = await render(
-        <template>
-          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
-        </template>,
-      );
+        // when
+        const screen = await render(
+          <template>
+            <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenters}} />
+          </template>,
+        );
 
-      // then
-      assert.dom(screen.getByRole('link', { name: '123' })).hasAttribute('href', '/certification-centers/123');
-    });
-
-    module('when detaching a certification center', function (hooks) {
-      let requestManager;
-      let pixToast;
-      let router;
-
-      hooks.beforeEach(function () {
-        requestManager = this.owner.lookup('service:requestManager');
-        sinon.stub(requestManager, 'request');
-
-        pixToast = this.owner.lookup('service:pixToast');
-        sinon.stub(pixToast, 'sendSuccessNotification').resolves();
-        sinon.stub(pixToast, 'sendErrorNotification').resolves();
-
-        router = this.owner.lookup('service:router');
-        sinon.stub(router, 'refresh');
+        // then
+        assert.dom(screen.queryByRole('form', { name: 'Rattacher un centre de certification' })).doesNotExist();
       });
 
-      test('it opens a confirmation modal when clicking the detach button', async function (assert) {
+      test('it displays the table with caption and column headers', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certificationCenter = store.createRecord('attached-certification-center', {
+          id: '123',
+          name: 'Centre Pix',
+          externalId: 'EXT-456',
+        });
+        const attachedCertificationCenters = [certificationCenter];
+
+        // when
+        const screen = await render(
+          <template>
+            <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenters}} />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('table', {
+              name: t('components.organizations.attached-certification-center.table.caption'),
+            }),
+          )
+          .exists();
+        assert
+          .dom(
+            screen.getByRole('columnheader', {
+              name: t('components.organizations.attached-certification-center.table.headers.id'),
+            }),
+          )
+          .exists();
+        assert
+          .dom(
+            screen.getByRole('columnheader', {
+              name: t('components.organizations.attached-certification-center.table.headers.name'),
+            }),
+          )
+          .exists();
+        assert
+          .dom(
+            screen.getByRole('columnheader', {
+              name: t('components.organizations.attached-certification-center.table.headers.external-id'),
+            }),
+          )
+          .exists();
+        assert
+          .dom(
+            screen.getByRole('columnheader', {
+              name: t('components.organizations.attached-certification-center.table.headers.actions'),
+            }),
+          )
+          .exists();
+      });
+
+      test('it displays the certification centers in a table', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const certificationCenter = store.createRecord('attached-certification-center', {
@@ -166,79 +255,18 @@ module('Integration | Component | organizations/attached-certification-center', 
         // when
         const screen = await render(
           <template>
-            <AttachedCertificationCenter
-              @attachedCertificationCenters={{attachedCertificationCenter}}
-              @organizationId="42"
-            />
+            <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
           </template>,
         );
-        await click(
-          screen.getByRole('button', {
-            name: t('components.organizations.attached-certification-center.actions.detach.button'),
-          }),
-        );
-        await screen.findByRole('dialog');
 
         // then
-        assert
-          .dom(
-            screen.getByRole('heading', {
-              name: t('components.organizations.attached-certification-center.actions.detach.confirm-modal-title'),
-            }),
-          )
-          .exists();
+        assert.dom(screen.getByRole('cell', { name: '123' })).exists();
+        assert.dom(screen.getByRole('cell', { name: 'Centre Pix' })).exists();
+        assert.dom(screen.getByRole('cell', { name: 'EXT-456' })).exists();
       });
 
-      test('it detaches the certification center and removes the table when confirming the modal', async function (assert) {
+      test('it displays a link to the certification center page', async function (assert) {
         // given
-        requestManager.request.resolves();
-
-        const store = this.owner.lookup('service:store');
-        const certificationCenter = store.createRecord('attached-certification-center', {
-          id: '123',
-          name: 'Centre Pix',
-          externalId: 'EXT-456',
-        });
-        const state = new State([certificationCenter]);
-        router.refresh.callsFake(() => {
-          state.attachedCertificationCenters = [];
-        });
-
-        const screen = await render(
-          <template>
-            <AttachedCertificationCenter
-              @attachedCertificationCenters={{state.attachedCertificationCenters}}
-              @organizationId="42"
-            />
-          </template>,
-        );
-        await click(
-          screen.getByRole('button', {
-            name: t('components.organizations.attached-certification-center.actions.detach.button'),
-          }),
-        );
-        await screen.findByRole('dialog');
-        await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
-
-        // then
-        assert.true(
-          requestManager.request.calledWith({
-            url: `${ENV.APP.API_HOST}/api/admin/organizations/42/detach-certification-center`,
-            method: 'POST',
-          }),
-        );
-        assert.true(
-          pixToast.sendSuccessNotification.calledWith({
-            message: t('components.organizations.attached-certification-center.actions.detach.success'),
-          }),
-        );
-        assert.dom(screen.queryByRole('table')).doesNotExist();
-      });
-
-      test('it displays an error notification and keeps the table when detaching fails', async function (assert) {
-        // given
-        requestManager.request.rejects();
-
         const store = this.owner.lookup('service:store');
         const certificationCenter = store.createRecord('attached-certification-center', {
           id: '123',
@@ -247,29 +275,138 @@ module('Integration | Component | organizations/attached-certification-center', 
         });
         const attachedCertificationCenter = [certificationCenter];
 
+        // when
         const screen = await render(
           <template>
-            <AttachedCertificationCenter
-              @attachedCertificationCenters={{attachedCertificationCenter}}
-              @organizationId="42"
-            />
+            <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
           </template>,
         );
-        await click(
-          screen.getByRole('button', {
-            name: t('components.organizations.attached-certification-center.actions.detach.button'),
-          }),
-        );
-        await screen.findByRole('dialog');
-        await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
 
         // then
-        assert.true(
-          pixToast.sendErrorNotification.calledWith({
-            message: t('common.notifications.generic-error'),
-          }),
-        );
-        assert.dom(screen.getByRole('table')).exists();
+        assert.dom(screen.getByRole('link', { name: '123' })).hasAttribute('href', '/certification-centers/123');
+      });
+
+      module('when detaching a certification center', function () {
+        test('it opens a confirmation modal when clicking the detach button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const certificationCenter = store.createRecord('attached-certification-center', {
+            id: '123',
+            name: 'Centre Pix',
+            externalId: 'EXT-456',
+          });
+          const attachedCertificationCenter = [certificationCenter];
+
+          // when
+          const screen = await render(
+            <template>
+              <AttachedCertificationCenter
+                @attachedCertificationCenters={{attachedCertificationCenter}}
+                @organizationId="42"
+              />
+            </template>,
+          );
+          await click(
+            screen.getByRole('button', {
+              name: t('components.organizations.attached-certification-center.actions.detach.button'),
+            }),
+          );
+          const modal = await screen.findByRole('dialog');
+
+          // then
+          assert
+            .dom(
+              within(modal).getByRole('heading', {
+                name: t('components.organizations.attached-certification-center.actions.detach.confirm-modal-title'),
+              }),
+            )
+            .exists();
+
+          assert.dom(within(modal).getByText('Centre Pix')).exists();
+        });
+
+        test('it detaches the certification center and removes the table when confirming the modal', async function (assert) {
+          // given
+          requestManager.request.resolves();
+
+          const store = this.owner.lookup('service:store');
+          const certificationCenter = store.createRecord('attached-certification-center', {
+            id: '123',
+            name: 'Centre Pix',
+            externalId: 'EXT-456',
+          });
+          const state = new State([certificationCenter]);
+          router.refresh.callsFake(() => {
+            state.attachedCertificationCenters = [];
+          });
+
+          const screen = await render(
+            <template>
+              <AttachedCertificationCenter
+                @attachedCertificationCenters={{state.attachedCertificationCenters}}
+                @organizationId="42"
+              />
+            </template>,
+          );
+          await click(
+            screen.getByRole('button', {
+              name: t('components.organizations.attached-certification-center.actions.detach.button'),
+            }),
+          );
+          await screen.findByRole('dialog');
+          await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+
+          // then
+          assert.true(
+            requestManager.request.calledWith({
+              url: `${ENV.APP.API_HOST}/api/admin/organizations/42/detach-certification-center`,
+              method: 'POST',
+            }),
+          );
+          assert.true(
+            pixToast.sendSuccessNotification.calledWith({
+              message: t('components.organizations.attached-certification-center.actions.detach.success'),
+            }),
+          );
+          assert.dom(screen.queryByRole('table')).doesNotExist();
+        });
+
+        test('it displays an error notification and keeps the table when detaching fails', async function (assert) {
+          // given
+          requestManager.request.rejects();
+
+          const store = this.owner.lookup('service:store');
+          const certificationCenter = store.createRecord('attached-certification-center', {
+            id: '123',
+            name: 'Centre Pix',
+            externalId: 'EXT-456',
+          });
+          const attachedCertificationCenter = [certificationCenter];
+
+          const screen = await render(
+            <template>
+              <AttachedCertificationCenter
+                @attachedCertificationCenters={{attachedCertificationCenter}}
+                @organizationId="42"
+              />
+            </template>,
+          );
+          await click(
+            screen.getByRole('button', {
+              name: t('components.organizations.attached-certification-center.actions.detach.button'),
+            }),
+          );
+          await screen.findByRole('dialog');
+          await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+
+          // then
+          assert.true(
+            pixToast.sendErrorNotification.calledWith({
+              message: t('common.notifications.generic-error'),
+            }),
+          );
+          assert.dom(screen.getByRole('table')).exists();
+        });
       });
     });
   });

--- a/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
+++ b/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
@@ -3,7 +3,6 @@ import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl/test-support';
 import AttachedCertificationCenter from 'pix-admin/components/organizations/attached-certification-center';
-import ENV from 'pix-admin/config/environment';
 import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -357,12 +356,7 @@ module('Integration | Component | organizations/attached-certification-center', 
           await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
 
           // then
-          assert.true(
-            requestManager.request.calledWith({
-              url: `${ENV.APP.API_HOST}/api/admin/organizations/42/detach-certification-center`,
-              method: 'POST',
-            }),
-          );
+          assert.true(requestManager.request.called);
           assert.true(
             pixToast.sendSuccessNotification.calledWith({
               message: t('components.organizations.attached-certification-center.actions.detach.success'),

--- a/admin/tests/integration/components/organizations/attached-certification-centers/attach-certification-center-form-test.gjs
+++ b/admin/tests/integration/components/organizations/attached-certification-centers/attach-certification-center-form-test.gjs
@@ -1,0 +1,107 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import AttachedCertificationCenterForm from 'pix-admin/components/organizations/attached-certification-centers/attach-certification-center-form';
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | organizations/attached-certification-centers/attach-certification-center-form',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+
+    module('Render', function () {
+      test('it displays a form with an input and a button', async function (assert) {
+        // when
+        const screen = await render(<template><AttachedCertificationCenterForm /></template>);
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('form', {
+              name: t('components.organizations.attached-certification-center.attach-form.name'),
+            }),
+          )
+          .exists();
+        assert
+          .dom(
+            screen.getByRole('spinbutton', {
+              name: (value) =>
+                value.includes(t('components.organizations.attached-certification-center.attach-form.input-label')),
+            }),
+          )
+          .exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.validate') })).exists();
+      });
+    });
+
+    module('behaviour', function () {
+      test('it updates input value when typing', async function (assert) {
+        // when
+        const screen = await render(<template><AttachedCertificationCenterForm /></template>);
+
+        const input = screen.getByRole(
+          'spinbutton',
+          t('components.organizations.attached-certification-center.attach-form.input-label'),
+        );
+
+        await fillIn(input, '123');
+
+        // then
+        assert.dom(input).hasValue('123');
+      });
+
+      test('it does not allow to type text in input', async function (assert) {
+        // when
+        const screen = await render(<template><AttachedCertificationCenterForm /></template>);
+
+        const input = screen.getByRole(
+          'spinbutton',
+          t('components.organizations.attached-certification-center.attach-form.input-label'),
+        );
+
+        // then
+        assert.dom(input).hasAttribute('type', 'number');
+      });
+
+      test('it should submit form with certificationCenterId', async function (assert) {
+        // given
+        const onFormSubmitted = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template><AttachedCertificationCenterForm @onFormSubmitted={{onFormSubmitted}} /></template>,
+        );
+
+        const input = screen.getByRole(
+          'spinbutton',
+          t('components.organizations.attached-certification-center.attach-form.input-label'),
+        );
+        await fillIn(input, '123');
+
+        const validateButton = screen.getByRole('button', { name: t('common.actions.validate') });
+        await click(validateButton);
+
+        // then
+        assert.ok(onFormSubmitted.calledOnceWithExactly('123'));
+      });
+
+      test('it should not submit form if certificationCenterId is not provided', async function (assert) {
+        // given
+        const onFormSubmitted = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template><AttachedCertificationCenterForm @onFormSubmitted={{onFormSubmitted}} /></template>,
+        );
+
+        const validateButton = screen.getByRole('button', { name: t('common.actions.validate') });
+        await click(validateButton);
+
+        // then
+        assert.ok(onFormSubmitted.notCalled);
+      });
+    });
+  },
+);

--- a/admin/tests/mirage/handlers/organizations.js
+++ b/admin/tests/mirage/handlers/organizations.js
@@ -1,3 +1,5 @@
+import { Response } from 'miragejs';
+
 import { applyPagination, getPaginationFromQueryParams } from './pagination-utils';
 
 function getOrganizationPlaces(schema) {
@@ -109,8 +111,25 @@ function getOrganizationAttachedCertificationCenters(schema, request) {
   return schema.attachedCertificationCenters.where({ organizationId });
 }
 
+function attachCertificationCenterToOrganization(schema, request) {
+  const organizationId = request.params.id;
+  const payload = JSON.parse(request.requestBody);
+  const certificationCenterId = payload.certificationCenterId;
+
+  const certificationCenter = schema.certificationCenters.findBy({ id: certificationCenterId });
+
+  schema.create('attached-certification-center', {
+    id: certificationCenterId,
+    organizationId,
+    name: certificationCenter.name,
+  });
+
+  return new Response(204);
+}
+
 export {
   archiveOrganization,
+  attachCertificationCenterToOrganization,
   findOrganizationCampaigns,
   findPaginatedFilteredOrganizations,
   findPaginatedOrganizationMemberships,

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -26,6 +26,7 @@ import { createNetwork, findAllFilteredNetworks, updateNetwork } from './handler
 import { createOrganizationMembership } from './handlers/organization-memberships';
 import {
   archiveOrganization,
+  attachCertificationCenterToOrganization,
   findOrganizationCampaigns,
   findPaginatedFilteredOrganizations,
   findPaginatedOrganizationMemberships,
@@ -414,6 +415,7 @@ export default function routes() {
   this.get('/admin/organizations/:id/statistics', getOrganizationStatistics);
   this.post('/admin/organizations/:id/archive', archiveOrganization);
   this.post('/admin/organizations/:id/detach-certification-center', () => new Response(204));
+  this.post('/admin/organizations/:id/attach-certification-centers', attachCertificationCenterToOrganization);
 
   this.get('/admin/frameworks');
   this.get('/admin/frameworks/:id/areas', findFrameworkAreas);

--- a/admin/tests/unit/requests-builders/organization-requests-builder-test.js
+++ b/admin/tests/unit/requests-builders/organization-requests-builder-test.js
@@ -28,4 +28,24 @@ module('Unit | Requests Builders | organization-requests-builder', function (hoo
       assert.deepEqual(builtRequest, expectedBuiltRequest);
     });
   });
+
+  module('#buildDetachCertificationCenterRequest', function () {
+    test('it builds correct request', function (assert) {
+      // given
+      const organizationId = 42;
+
+      const expectedBuiltRequest = {
+        url: `${ENV.APP.API_HOST}/api/admin/organizations/42/detach-certification-center`,
+        method: 'POST',
+      };
+
+      // when
+      const builtRequest = organizationRequestsBuilder.buildDetachCertificationCenterRequest({
+        organizationId,
+      });
+
+      // then
+      assert.deepEqual(builtRequest, expectedBuiltRequest);
+    });
+  });
 });

--- a/admin/tests/unit/requests-builders/organization-requests-builder-test.js
+++ b/admin/tests/unit/requests-builders/organization-requests-builder-test.js
@@ -1,0 +1,31 @@
+import { setupTest } from 'ember-qunit';
+import ENV from 'pix-admin/config/environment';
+import { organizationRequestsBuilder } from 'pix-admin/requests-builders/organization-requests-builder';
+import { module, test } from 'qunit';
+
+module('Unit | Requests Builders | organization-requests-builder', function (hooks) {
+  setupTest(hooks);
+
+  module('#buildAttachCertificationCenterRequest', function () {
+    test('it builds correct request', function (assert) {
+      // given
+      const organizationId = 42;
+      const certificationCenterId = 17;
+
+      const expectedBuiltRequest = {
+        url: `${ENV.APP.API_HOST}/api/admin/organizations/42/attach-certification-centers`,
+        method: 'POST',
+        body: JSON.stringify({ certificationCenterId: 17 }),
+      };
+
+      // when
+      const builtRequest = organizationRequestsBuilder.buildAttachCertificationCenterRequest({
+        organizationId,
+        certificationCenterId,
+      });
+
+      // then
+      assert.deepEqual(builtRequest, expectedBuiltRequest);
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/organizations/get/attached-certification-centers-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/attached-certification-centers-test.js
@@ -18,16 +18,19 @@ module('Unit | Route | authenticated/organizations/get/attached-certification-ce
   module('#model', function () {
     test('it calls store.query with the organizationId and returns the certification centers with the organizationId', async function (assert) {
       // given
-      const certificationCenters = [{ id: '1', name: 'Centre Pix' }];
-      route.modelFor = sinon.stub().returns({ id: '42' });
-      route.store = { query: sinon.stub().resolves(certificationCenters) };
+      const organization = { id: '42' };
+      const attachedCertificationCenters = [{ id: '1', name: 'Centre Pix' }];
+      route.modelFor = sinon.stub().returns(organization);
+      route.store = { query: sinon.stub().resolves(attachedCertificationCenters) };
 
       // when
       const result = await route.model();
 
       // then
-      sinon.assert.calledWith(route.store.query, 'attached-certification-center', { organizationId: '42' });
-      assert.deepEqual(result, { attachedCertificationCenters: certificationCenters, organizationId: '42' });
+      sinon.assert.calledWith(route.store.query, 'attached-certification-center', {
+        organizationId: organization.id,
+      });
+      assert.deepEqual(result, { attachedCertificationCenters, organizationId: '42' });
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -905,7 +905,19 @@
             "success": "The certification center has been successfully detached."
           }
         },
+        "attach-form": {
+          "input-label": "Attach a certification center",
+          "input-sublabel": "ID of the center",
+          "name": "Attach a certification center"
+        },
         "empty": "No certification center attached.",
+        "notifications": {
+          "attach-success": "The certification center has been successfully attached to the organization.",
+          "errors": {
+            "ALREADY_ATTACHED_CERTIFICATION_CENTER": "Certification center {certificationCenterId} is already attached to organisation {alreadyAttachedOrganizationId}.",
+            "NON_EXISTING_CERTIFICATION_CENTER": "Certification center {certificationCenterId} does not exist."
+          }
+        },
         "table": {
           "caption": "Certification center attached to the organisation.",
           "headers": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -913,7 +913,19 @@
             "success": "Le centre de certification a été détaché avec succès."
           }
         },
+        "attach-form": {
+          "input-label": "Rattacher un centre de certification",
+          "input-sublabel": "ID du centre",
+          "name": "Rattacher un centre de certification"
+        },
         "empty": "Aucun centre de certification rattaché.",
+        "notifications": {
+          "attach-success": "Le centre de certification a bien été rattaché à l'organisation.",
+          "errors": {
+            "ALREADY_ATTACHED_CERTIFICATION_CENTER": "Le centre de certification {certificationCenterId} est déjà rattaché à l'organisation {alreadyAttachedOrganizationId}.",
+            "NON_EXISTING_CERTIFICATION_CENTER": "Le centre de certification {certificationCenterId} n'existe pas."
+          }
+        },
         "table": {
           "caption": "Centre de certification rattaché à l'organisation.",
           "headers": {


### PR DESCRIPTION
## 🪧 Problème

On veut pouvoir rattacher un centre de certification à une organisation depuis Pix Admin.
## 🌈 Proposition

Sur la page d'une organisation, dans l'onglet **Lien certif** ajouter un formulaire pour renseigner un ID de centre de certification pour le rattacher.

## ✊ Remarques


## 🎉 Pour tester
Dans Pix Admin, connecté avec n'import quel rôle:
- naviguer sur la page d'une organisation qui n'a pas de centre de certif associé
- sur l'onglet Lien certif, constater le nouveau formulaire
- remplir avec un ID de centre de certif
- constater le rattachement 

Cas d'erreur:
- remplir avec un ID de centre de certif qui n'existe pas
- remplir avec un ID de centre de certif déjà rattaché
- constater les messages d'erreur
