### PR TITLE
[FEATURE] Ajouter un session ID aux access et refresh tokens (PIX-23089)

### DIFF
--- a/api/src/identity-access-management/domain/models/RefreshToken.js
+++ b/api/src/identity-access-management/domain/models/RefreshToken.js
@@ -1,21 +1,36 @@
 import crypto from 'node:crypto';
 
+import Joi from 'joi';
+
 import { config } from '../../../shared/config.js';
+import { validateEntity } from '../../../shared/domain/validators/entity-validator.js';
 
 const SEPARATOR = ':';
 
 export class RefreshToken {
-  constructor({ userId, source, value, audience }) {
+  constructor({ userId, value, audience, sessionId, source }) {
     this.userId = userId;
-    this.source = source;
     this.value = value;
     this.audience = audience;
+    this.sessionId = sessionId;
+    this.source = source;
+
+    validateEntity(
+      Joi.object({
+        userId: Joi.number().required(),
+        value: Joi.string().required(),
+        audience: Joi.string().required(),
+        sessionId: Joi.string().required(),
+        source: Joi.string().optional(),
+      }),
+      this,
+    );
   }
 
-  static generate({ userId, source, audience }) {
+  static generate({ userId, source, audience, sessionId }) {
     const uuid = crypto.randomUUID();
     const value = [userId, uuid].filter(Boolean).join(SEPARATOR);
-    return new RefreshToken({ userId, source, value, audience });
+    return new RefreshToken({ userId, source, value, audience, sessionId });
   }
 
   get expirationDelaySeconds() {

--- a/api/src/identity-access-management/domain/models/UserAccessToken.js
+++ b/api/src/identity-access-management/domain/models/UserAccessToken.js
@@ -1,42 +1,85 @@
+import Joi from 'joi';
+
 import { config } from '../../../shared/config.js';
 import { InvalidInputDataError } from '../../../shared/domain/errors.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
+import { validateEntity } from '../../../shared/domain/validators/entity-validator.js';
 
 export class UserAccessToken {
-  constructor({ userId, source, audience }) {
+  constructor({ userId, audience, sessionId, source }) {
     this.userId = userId;
-    this.source = source;
     this.audience = audience;
+    this.sessionId = sessionId;
+    this.source = source;
+
+    validateEntity(
+      Joi.object({
+        userId: Joi.number().required(),
+        audience: Joi.string().required(),
+        sessionId: Joi.string().required(),
+        source: Joi.string().optional(),
+      }),
+      this,
+    );
   }
 
   static decode(accessToken) {
     const decoded = tokenService.getDecodedToken(accessToken, config.authentication.secret);
     if (!decoded) throw new InvalidInputDataError();
 
-    return new UserAccessToken({ userId: decoded.user_id, source: decoded.source, audience: decoded.aud });
+    return new UserAccessToken({
+      userId: decoded.user_id,
+      source: decoded.source,
+      audience: decoded.aud,
+      sessionId: decoded.sid,
+    });
   }
 
-  static generateUserToken({ userId, source, audience }) {
+  static generateUserToken({ userId, source, audience, sessionId }) {
     const expirationDelaySeconds = config.authentication.accessTokenLifespanMs / 1000;
-    const accessToken = UserAccessToken.generate({ userId, source, audience, expirationDelaySeconds });
+    const accessToken = UserAccessToken.generate({ userId, source, audience, expirationDelaySeconds, sessionId });
     return { accessToken, expirationDelaySeconds };
   }
 
-  static generateAnonymousUserToken({ userId, audience }) {
+  static generateAnonymousUserToken({ userId, audience, sessionId }) {
     const expirationDelaySeconds = config.anonymous.accessTokenLifespanMs / 1000;
-    const accessToken = UserAccessToken.generate({ userId, source: 'pix', audience, expirationDelaySeconds });
+    const accessToken = UserAccessToken.generate({
+      userId,
+      source: 'pix',
+      audience,
+      expirationDelaySeconds,
+      sessionId,
+    });
     return { accessToken, expirationDelaySeconds };
   }
 
-  static generateSamlUserToken({ userId, audience }) {
+  static generateSamlUserToken({ userId, audience, sessionId }) {
     const expirationDelaySeconds = config.saml.accessTokenLifespanMs / 1000;
-    const accessToken = UserAccessToken.generate({ userId, source: 'external', audience, expirationDelaySeconds });
+    const accessToken = UserAccessToken.generate({
+      userId,
+      source: 'external',
+      audience,
+      expirationDelaySeconds,
+      sessionId,
+    });
     return { accessToken, expirationDelaySeconds };
   }
 
-  static generate({ userId, source, audience, expirationDelaySeconds }) {
+  /**
+   * @param {number} userId
+   * @param {string} audience
+   * @param {string} sessionId
+   * @param {number|string} expiresIn expressed in seconds or a string describing a time span, 60, ex. "2 days", "10h", "7d"
+   * @returns {Object} containing the accessToken and the expirationDelaySeconds
+   */
+  static generateOidcUserToken({ userId, audience, sessionId, expiresIn }) {
+    const accessToken = UserAccessToken.generate({ userId, audience, sessionId, expirationDelaySeconds: expiresIn });
+    return { accessToken, expirationDelaySeconds: expiresIn };
+  }
+
+  static generate({ userId, source, audience, expirationDelaySeconds, sessionId }) {
     return tokenService.encodeToken(
-      { user_id: userId, source, aud: audience },
+      { user_id: userId, source, aud: audience, sid: sessionId },
       config.authentication.secret,
       expirationDelaySeconds,
     );

--- a/api/src/identity-access-management/domain/models/UserAccessToken.js
+++ b/api/src/identity-access-management/domain/models/UserAccessToken.js
@@ -1,4 +1,5 @@
 import { config } from '../../../shared/config.js';
+import { InvalidInputDataError } from '../../../shared/domain/errors.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 
 export class UserAccessToken {
@@ -10,7 +11,7 @@ export class UserAccessToken {
 
   static decode(accessToken) {
     const decoded = tokenService.getDecodedToken(accessToken, config.authentication.secret);
-    if (!decoded) return new UserAccessToken({});
+    if (!decoded) throw new InvalidInputDataError();
 
     return new UserAccessToken({ userId: decoded.user_id, source: decoded.source, audience: decoded.aud });
   }

--- a/api/src/identity-access-management/domain/services/authentication-session.service.js
+++ b/api/src/identity-access-management/domain/services/authentication-session.service.js
@@ -1,8 +1,19 @@
+import crypto from 'node:crypto';
+
 import { config } from '../../../shared/config.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
+
 const authenticationSessionTemporaryStorage = temporaryStorage.withPrefix('authentication-session:');
 
 const EXPIRATION_DELAY_SECONDS = config.authenticationSession.temporaryStorage.expirationDelaySeconds;
+
+/**
+ * @typedef {function} generateSessionId
+ * @return {string}
+ */
+const generateSessionId = function () {
+  return crypto.randomUUID();
+};
 
 /**
  * @typedef {function} getByKey
@@ -40,7 +51,8 @@ const update = function (key, value) {
  * @property {getByKey} getByKey
  * @property {save} save
  * @property {update} update
+ * @property {generateSessionId} generateSessionId
  */
-const authenticationSessionService = { getByKey, save, update };
+const authenticationSessionService = { getByKey, save, update, generateSessionId };
 
 export { authenticationSessionService };

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -5,7 +5,6 @@ import lodash from 'lodash';
 import ms from 'ms';
 import * as client from 'openid-client';
 
-import { config } from '../../../shared/config.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OidcError, OidcMissingFieldsError } from '../../../shared/domain/errors.js';
 import { AuthenticationSessionContent } from '../../../shared/domain/models/AuthenticationSessionContent.js';
@@ -89,9 +88,7 @@ export class OidcAuthenticationService {
 
     this.claimManager = new ClaimManager({ claimMapping, additionalClaims });
 
-    const accessTokenLifespanSeconds = this.accessTokenLifespanMs / 1000;
-    this.accessTokenJwtOptions = { expiresIn: accessTokenLifespanSeconds };
-    this.sessionDurationSeconds = accessTokenLifespanSeconds;
+    this.sessionDurationSeconds = this.accessTokenLifespanMs / 1000;
   }
 
   get code() {
@@ -196,14 +193,6 @@ export class OidcAuthenticationService {
 
       throw new OidcError({ message: 'Error during exchangeCodeForTokens' });
     }
-  }
-
-  createAccessToken({ userId, audience }) {
-    return jsonwebtoken.sign(
-      { user_id: userId, aud: audience },
-      config.authentication.secret,
-      this.accessTokenJwtOptions,
-    );
   }
 
   async saveIdToken({ idToken, userId }) {

--- a/api/src/identity-access-management/domain/usecases/authenticate-anonymous-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-anonymous-user.usecase.js
@@ -11,6 +11,7 @@ import { UserToCreate } from '../models/UserToCreate.js';
  *   campaignToJoinRepository,
  *   userToCreateRepository,
  *   tokenService
+ *   authenticationSessionService
  * }} params
  * @return {Promise<string>}
  * @throws {UserCantBeCreatedError}
@@ -22,6 +23,7 @@ export const authenticateAnonymousUser = async function ({
   audience,
   campaignToJoinRepository,
   userToCreateRepository,
+  authenticationSessionService,
 }) {
   const campaign = await campaignToJoinRepository.getByCode({ code: campaignCode });
   if (!campaign.isSimplifiedAccess) {
@@ -31,6 +33,8 @@ export const authenticateAnonymousUser = async function ({
   const userToCreate = UserToCreate.createAnonymous({ lang, locale });
   const anonymousUser = await userToCreateRepository.create({ user: userToCreate });
 
-  const { accessToken } = UserAccessToken.generateAnonymousUserToken({ userId: anonymousUser.id, audience });
+  const sessionId = authenticationSessionService.generateSessionId();
+
+  const { accessToken } = UserAccessToken.generateAnonymousUserToken({ userId: anonymousUser.id, audience, sessionId });
   return accessToken;
 };

--- a/api/src/identity-access-management/domain/usecases/authenticate-for-saml.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-for-saml.usecase.js
@@ -21,6 +21,7 @@ import { UserReconciliationSamlIdToken } from '../models/UserReconciliationSamlI
  * @param {RequestedApplication} params.requestedApplication,
  * @param {TokenService} params.tokenService
  * @param {PixAuthenticationService} params.pixAuthenticationService
+ * @param {AuthenticationSessionService} params.authenticationSessionService
  * @param {ObfuscationService} params.obfuscationService
  * @param {AuthenticationMethodRepository} params.authenticationMethodRepository
  * @param {UserRepository} params.userRepository
@@ -37,6 +38,7 @@ async function authenticateForSaml({
   requestedApplication,
   tokenService,
   pixAuthenticationService,
+  authenticationSessionService,
   obfuscationService,
   authenticationMethodRepository,
   userRepository,
@@ -69,7 +71,12 @@ async function authenticateForSaml({
       throw new UserShouldChangePasswordError(undefined, passwordExpirationToken);
     }
 
-    const { accessToken } = UserAccessToken.generateSamlUserToken({ userId: userFromCredentials.id, audience });
+    const sessionId = authenticationSessionService.generateSessionId();
+    const { accessToken } = UserAccessToken.generateSamlUserToken({
+      userId: userFromCredentials.id,
+      audience,
+      sessionId,
+    });
 
     await _updateLastLoggedDates({
       user: userFromCredentials,

--- a/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
@@ -1,6 +1,7 @@
 import lodash from 'lodash';
 
 import { ForbiddenAccess } from '../../../shared/domain/errors.js';
+import { UserAccessToken } from '../models/UserAccessToken.js';
 
 const { omit } = lodash;
 
@@ -102,7 +103,16 @@ async function authenticateOidcUser({
 
   await _updateUserLocaleIfNeeded({ user, locale, userRepository });
 
-  const pixAccessToken = oidcAuthenticationService.createAccessToken({ userId: user.id, audience });
+  const sessionId = authenticationSessionService.generateSessionId();
+
+  const expiresIn = oidcAuthenticationService.sessionDurationSeconds;
+
+  const { accessToken: pixAccessToken } = UserAccessToken.generateOidcUserToken({
+    userId: user.id,
+    audience,
+    sessionId,
+    expiresIn,
+  });
 
   let logoutUrlUUID;
   if (oidcAuthenticationService.shouldCloseSession) {

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.usecase.js
@@ -22,6 +22,7 @@ import { UserAccessToken } from '../models/UserAccessToken.js';
  * @param {string} params.locale
  * @param {RefreshTokenRepository} params.refreshTokenRepository
  * @param {PixAuthenticationService} params.pixAuthenticationService
+ * @param {AuthenticationSessionService} params.authenticationSessionService
  * @param {UserRepository} params.userRepository
  * @param {UserLoginRepository} params.userLoginRepository
  * @param {AuthenticationMethodRepository} params.authenticationMethodRepository
@@ -40,6 +41,7 @@ const authenticateUser = async function ({
   locale,
   refreshTokenRepository,
   pixAuthenticationService,
+  authenticationSessionService,
   userRepository,
   userLoginRepository,
   authenticationMethodRepository,
@@ -67,13 +69,16 @@ const authenticateUser = async function ({
 
     await _assertAccessToRequestedApplication({ requestedApplication, user, adminMemberRepository });
 
-    const refreshToken = RefreshToken.generate({ userId: user.id, source, audience });
+    const sessionId = authenticationSessionService.generateSessionId();
+
+    const refreshToken = RefreshToken.generate({ userId: user.id, source, audience, sessionId });
     await refreshTokenRepository.save({ refreshToken });
 
     const { accessToken, expirationDelaySeconds } = UserAccessToken.generateUserToken({
       userId: user.id,
       source,
       audience,
+      sessionId,
     });
 
     await _updateUserLocaleIfNeeded({ user, locale, userRepository });

--- a/api/src/identity-access-management/domain/usecases/create-access-token-from-refresh-token.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-access-token-from-refresh-token.usecase.js
@@ -38,6 +38,7 @@ const createAccessTokenFromRefreshToken = async function ({
     userId: foundRefreshToken.userId,
     source: foundRefreshToken.source,
     audience,
+    sessionId: foundRefreshToken.sessionId,
   });
 };
 

--- a/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
@@ -1,5 +1,6 @@
 import { UserAlreadyExistsWithAuthenticationMethodError } from '../../../shared/domain/errors.js';
 import { AuthenticationKeyExpired } from '../errors.js';
+import { UserAccessToken } from '../models/UserAccessToken.js';
 import { UserToCreate } from '../models/UserToCreate.js';
 
 /**
@@ -86,7 +87,15 @@ async function createOidcUser({
     userLoginRepository,
   });
 
-  const accessToken = oidcAuthenticationService.createAccessToken({ userId, audience });
+  const sessionId = authenticationSessionService.generateSessionId();
+  const expiresIn = oidcAuthenticationService.sessionDurationSeconds;
+
+  const { accessToken } = UserAccessToken.generateOidcUserToken({
+    userId,
+    audience,
+    sessionId,
+    expiresIn,
+  });
 
   let logoutUrlUUID;
   if (oidcAuthenticationService.shouldCloseSession) {

--- a/api/src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js
+++ b/api/src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js
@@ -9,6 +9,7 @@ const getSamlAuthenticationRedirectionUrl = async function ({
   userLoginRepository,
   authenticationMethodRepository,
   lastUserApplicationConnectionsRepository,
+  authenticationSessionService,
   config,
   audience,
   requestedApplication,
@@ -36,7 +37,8 @@ const getSamlAuthenticationRedirectionUrl = async function ({
       externalUser,
     });
 
-    const { accessToken } = UserAccessToken.generateSamlUserToken({ userId: user.id, audience });
+    const sessionId = authenticationSessionService.generateSessionId();
+    const { accessToken } = UserAccessToken.generateSamlUserToken({ userId: user.id, sessionId, audience });
     return `/connexion/gar#${encodeURIComponent(accessToken)}`;
   }
 

--- a/api/src/identity-access-management/domain/usecases/reconcile-oidc-user-for-admin.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/reconcile-oidc-user-for-admin.usecase.js
@@ -4,6 +4,7 @@
 
 import { AuthenticationKeyExpired, DifferentExternalIdentifierError } from '../errors.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { UserAccessToken } from '../models/UserAccessToken.js';
 
 /**
  * @param {Object} params
@@ -72,8 +73,10 @@ export const reconcileOidcUserForAdmin = async function ({
     userLoginRepository,
   });
 
-  const accessToken = await oidcAuthenticationService.createAccessToken({ userId, audience });
+  const sessionId = authenticationSessionService.generateSessionId();
+  const expiresIn = oidcAuthenticationService.sessionDurationSeconds;
 
+  const { accessToken } = await UserAccessToken.generateOidcUserToken({ userId, audience, sessionId, expiresIn });
   return accessToken;
 };
 

--- a/api/src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js
@@ -1,6 +1,7 @@
 import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
 import { AuthenticationKeyExpired, MissingUserAccountError } from '../errors.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { UserAccessToken } from '../models/UserAccessToken.js';
 
 /**
  * @typedef {function} reconcileOidcUserUseCase
@@ -81,8 +82,16 @@ export const reconcileOidcUser = async function ({
     lastUserApplicationConnectionsRepository,
     userLoginRepository,
   });
+  const sessionId = authenticationSessionService.generateSessionId();
 
-  const accessToken = await oidcAuthenticationService.createAccessToken({ userId, audience });
+  const expiresIn = oidcAuthenticationService.sessionDurationSeconds;
+
+  const { accessToken } = UserAccessToken.generateOidcUserToken({
+    userId,
+    audience,
+    sessionId,
+    expiresIn,
+  });
 
   let logoutUrlUUID;
   if (oidcAuthenticationService.shouldCloseSession) {

--- a/api/src/identity-access-management/infrastructure/repositories/refresh-token.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/refresh-token.repository.js
@@ -41,11 +41,11 @@ async function findAllByUserId({ userId }) {
  * @return {Promise<void>}
  */
 async function save({ refreshToken }) {
-  const { value, userId, source, expirationDelaySeconds, audience } = refreshToken;
+  const { value, userId, source, expirationDelaySeconds, audience, sessionId } = refreshToken;
 
   await refreshTokenTemporaryStorage.save({
     key: value,
-    value: { type: 'refresh_token', userId, source, audience },
+    value: { type: 'refresh_token', userId, source, audience, sessionId },
     expirationDelaySeconds,
   });
 

--- a/api/src/prescription/organization-learner/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/src/prescription/organization-learner/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -29,6 +29,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   libOrganizationLearnerRepository,
   prescriptionOrganizationLearnerRepository,
   lastUserApplicationConnectionsRepository,
+  authenticationSessionService,
   studentRepository,
 }) {
   const { firstName, lastName, samlId } = UserReconciliationSamlIdToken.decode(token);
@@ -123,7 +124,9 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
     userLoginRepository,
   });
 
-  const { accessToken } = UserAccessToken.generateSamlUserToken({ userId: tokenUserId, audience });
+  const sessionId = authenticationSessionService.generateSessionId();
+
+  const { accessToken } = UserAccessToken.generateSamlUserToken({ userId: tokenUserId, audience, sessionId });
 
   return accessToken;
 };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -1,3 +1,4 @@
+import { authenticationSessionService } from '../../../../identity-access-management/domain/services/authentication-session.service.js';
 import * as obfuscationService from '../../../../identity-access-management/domain/services/obfuscation-service.js';
 import * as passwordGenerator from '../../../../identity-access-management/domain/services/password-generator.service.js';
 import * as userService from '../../../../identity-access-management/domain/services/user-service.js';
@@ -47,6 +48,7 @@ import * as supOrganizationParticipantRepository from '../../infrastructure/repo
 
 const dependencies = {
   analysisRepository,
+  authenticationSessionService,
   divisionRepository,
   cryptoService,
   emailValidationDemandRepository,

--- a/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -57,7 +57,12 @@ describe('Integration | Identity Access Management | Domain | UseCase | anonymiz
 
     await databaseBuilder.commit();
 
-    const refreshToken = RefreshToken.generate({ userId, source: 'pix' });
+    const refreshToken = RefreshToken.generate({
+      userId,
+      audience: 'https://app.pix.fr',
+      source: 'pix',
+      sessionId: 'random-session-id',
+    });
     await refreshTokenRepository.save({ refreshToken });
 
     // when

--- a/api/tests/identity-access-management/integration/domain/usecases/authenticate-anonymous-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/authenticate-anonymous-user.usecase.test.js
@@ -1,4 +1,5 @@
 import { UserCantBeCreatedError } from '../../../../../src/identity-access-management/domain/errors.js';
+import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
@@ -24,6 +25,8 @@ describe('Integration | Identity Access Management | Domain | UseCase | authenti
 
     // then
     expect(accessToken).to.be.a('string');
+    const decodedAccessToken = UserAccessToken.decode(accessToken);
+    expect(decodedAccessToken.sessionId).to.be.a('string');
 
     const user = await knex('users').where({ isAnonymous: true }).first();
     expect(user.firstName).to.equal('');

--- a/api/tests/identity-access-management/integration/domain/usecases/authenticate-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/authenticate-user.usecase.test.js
@@ -6,6 +6,7 @@ import {
   PixAdminLoginFromPasswordDisabledError,
   UserShouldChangePasswordError,
 } from '../../../../../src/identity-access-management/domain/errors.js';
+import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { config } from '../../../../../src/shared/config.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
@@ -46,9 +47,12 @@ describe('Integration | Identity Access Management | Domain | UseCase | authenti
       // then
       expect(result).to.be.an.instanceOf(Object);
       expect(result).to.have.all.keys('accessToken', 'refreshToken', 'expirationDelaySeconds');
-      expect(result.accessToken).to.be.a.string;
-      expect(result.refreshToken).to.be.a.string;
+      expect(result.accessToken).to.be.a('string');
+      expect(result.refreshToken).to.be.a('string');
       expect(result.expirationDelaySeconds).to.be.a('number');
+
+      const decodedAccessToken = UserAccessToken.decode(result.accessToken);
+      expect(decodedAccessToken.sessionId).to.be.a('string');
     });
 
     it('saves the last dates of login', async function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/create-access-token-from-refresh-token.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-access-token-from-refresh-token.usecase.test.js
@@ -1,4 +1,5 @@
 import { RefreshToken } from '../../../../../src/identity-access-management/domain/models/RefreshToken.js';
+import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { refreshTokenRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/refresh-token.repository.js';
 import { UnauthorizedError } from '../../../../../src/shared/application/errors/http-errors.js';
@@ -23,8 +24,9 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
       // given
       const source = 'pix';
       const audience = 'https://app.pix.fr';
+      const sessionId = 'session-id';
 
-      const refreshToken = RefreshToken.generate({ userId, source, audience });
+      const refreshToken = RefreshToken.generate({ userId, source, audience, sessionId });
       await refreshTokenRepository.save({ refreshToken });
 
       // when
@@ -37,6 +39,8 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
       // then
       expect(accessToken).to.be.a('string');
       expect(expirationDelaySeconds).to.be.a('number');
+      const decodedAccessToken = UserAccessToken.decode(accessToken);
+      expect(decodedAccessToken.sessionId).to.equal(sessionId);
     });
   });
 
@@ -67,7 +71,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
       const audience = 'https://app.pix.fr';
       const badAudience = 'https://orga.pix.fr';
 
-      const refreshToken = RefreshToken.generate({ userId, source, audience });
+      const refreshToken = RefreshToken.generate({ userId, source, audience, sessionId: 'session-id' });
       await refreshTokenRepository.save({ refreshToken });
 
       // when
@@ -91,7 +95,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
       const audience = 'https://app.pix.fr';
       const newLocale = 'fr-BE';
 
-      const refreshToken = RefreshToken.generate({ userId, source, audience });
+      const refreshToken = RefreshToken.generate({ userId, source, audience, sessionId: 'session-id' });
       await refreshTokenRepository.save({ refreshToken });
 
       // when
@@ -114,7 +118,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
       const audience = 'https://app.pix.fr';
       const initialLocale = 'fr-FR';
 
-      const refreshToken = RefreshToken.generate({ userId, source, audience });
+      const refreshToken = RefreshToken.generate({ userId, source, audience, sessionId: 'session-id' });
       await refreshTokenRepository.save({ refreshToken });
 
       // when

--- a/api/tests/identity-access-management/integration/domain/usecases/revoke-access-for-users.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/revoke-access-for-users.usecase.test.js
@@ -11,7 +11,12 @@ describe('Integration | Identity Access Management | Domain | UseCase | revoke-a
     const userId = databaseBuilder.factory.buildUser().id;
     const authenticationMethod =
       databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
-    const refreshToken = RefreshToken.generate({ userId, source: 'pix' });
+    const refreshToken = RefreshToken.generate({
+      userId,
+      audience: 'https://app.dev.pix.fr',
+      source: 'pix',
+      sessionId: 'random-session-id',
+    });
     await refreshTokenRepository.save({ refreshToken });
     await databaseBuilder.commit();
 
@@ -35,7 +40,12 @@ describe('Integration | Identity Access Management | Domain | UseCase | revoke-a
     it('revokes access token only', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      const refreshToken = RefreshToken.generate({ userId, source: 'pix' });
+      const refreshToken = RefreshToken.generate({
+        userId,
+        source: 'pix',
+        audience: 'https://app.dev.pix.fr',
+        sessionId: 'random-session-id',
+      });
       await refreshTokenRepository.save({ refreshToken });
       await databaseBuilder.commit();
 

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/refresh-token.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/refresh-token.repository.test.js
@@ -16,18 +16,20 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     it('finds refresh token data for token', async function () {
       // given
       const refreshToken = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken });
 
       const refreshToken2 = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://certif.pixfr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken: refreshToken2 });
 
@@ -43,31 +45,34 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     it('finds all refresh token data for an user id', async function () {
       // given
       const refreshToken = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://orga.pix.fr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken });
 
       const refreshToken2 = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken: refreshToken2 });
 
       const refreshToken3 = RefreshToken.generate({
-        userId: 'userId2!',
+        userId: 222222,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken: refreshToken3 });
 
       // when
-      const result = await refreshTokenRepository.findAllByUserId({ userId: 'userId!' });
+      const result = await refreshTokenRepository.findAllByUserId({ userId: 111111 });
 
       // then
       expect(result).to.deep.equal([refreshToken2, refreshToken]);
@@ -78,17 +83,18 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     it('saves a refresh token', async function () {
       // given
       const refreshToken = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
 
       // when
       await refreshTokenRepository.save({ refreshToken });
 
       // then
-      const result = await refreshTokenRepository.findAllByUserId({ userId: 'userId!' });
+      const result = await refreshTokenRepository.findAllByUserId({ userId: 111111 });
       expect(result).to.deep.equal([refreshToken]);
     });
   });
@@ -97,17 +103,19 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     it('revokes a refresh token', async function () {
       // given
       const refreshToken1 = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken: refreshToken1 });
       const refreshToken2 = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://orga.pix.fr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken: refreshToken2 });
 
@@ -115,7 +123,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       await refreshTokenRepository.revokeByToken({ token: refreshToken1.value });
 
       // then
-      const result = await refreshTokenRepository.findAllByUserId({ userId: 'userId!' });
+      const result = await refreshTokenRepository.findAllByUserId({ userId: 111111 });
       expect(result).to.deep.equal([refreshToken2]);
     });
   });
@@ -124,24 +132,27 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     it('revokes all refresh tokens for a user ID', async function () {
       // given
       const refreshToken1 = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken: refreshToken1 });
       const refreshToken2 = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 111111,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken: refreshToken2 });
       const refreshToken3 = RefreshToken.generate({
-        userId: 'userId2!',
+        userId: 222222,
         scope: 'scope!',
         source: 'source!',
         audience: 'https://certif.pixfr',
+        sessionId: 'sessionId!',
       });
       await refreshTokenRepository.save({ refreshToken: refreshToken3 });
 
@@ -149,10 +160,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       await refreshTokenRepository.revokeAllByUserId({ userId: refreshToken1.userId });
 
       // then
-      const userTokensDeleted = await refreshTokenRepository.findAllByUserId({ userId: 'userId!' });
+      const userTokensDeleted = await refreshTokenRepository.findAllByUserId({ userId: 111111 });
       expect(userTokensDeleted).to.deep.equal([]);
 
-      const otherUserTokens = await refreshTokenRepository.findAllByUserId({ userId: 'userId2!' });
+      const otherUserTokens = await refreshTokenRepository.findAllByUserId({ userId: 222222 });
       expect(otherUserTokens).to.deep.equal([refreshToken3]);
     });
   });

--- a/api/tests/identity-access-management/unit/domain/models/RefreshToken.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/RefreshToken.test.js
@@ -17,17 +17,19 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
     it('builds a refresh token model', function () {
       // when
       const refreshToken = new RefreshToken({
-        userId: 'userId!',
+        userId: 123456,
         source: 'source!',
         value: 'token!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
 
       // then
       expect(refreshToken.value).to.equal('token!');
-      expect(refreshToken.userId).to.equal('userId!');
+      expect(refreshToken.userId).to.equal(123456);
       expect(refreshToken.source).to.equal('source!');
       expect(refreshToken.audience).to.equal('https://app.pix.fr');
+      expect(refreshToken.sessionId).to.equal('sessionId!');
       expect(refreshToken.expirationDelaySeconds).to.equal(defaultRefreshTokenLifespanMs / 1000);
     });
   });
@@ -39,12 +41,15 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
 
       // when
       const refreshToken = RefreshToken.generate({
-        userId: 'userId!',
+        userId: 12345,
+        audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
         source: 'source!',
       });
 
       // then
-      expect(refreshToken.value).to.equal('userId!:XXX-123-456');
+      expect(refreshToken.value).to.equal('12345:XXX-123-456');
+      expect(refreshToken.sessionId).to.equal('sessionId!');
     });
   });
 
@@ -52,10 +57,11 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
     it('returns true with same audience otherwise false', function () {
       // given
       const refreshToken = new RefreshToken({
-        userId: 'userId!',
+        userId: 123456,
         source: 'source!',
         value: 'token!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
 
       // when

--- a/api/tests/identity-access-management/unit/domain/models/UserAccessToken.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserAccessToken.test.js
@@ -2,7 +2,9 @@ import sinon from 'sinon';
 
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { config } from '../../../../../src/shared/config.js';
+import { InvalidInputDataError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Identity Access Management | Domain | Model | RefreshToken', function () {
   beforeEach(function () {
@@ -34,15 +36,12 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
       });
     });
 
-    it('returns empty object for invalid token', function () {
+    it('throws an InvalidInputDataError for an invalid token', async function () {
       // given / when
-      const decoded = UserAccessToken.decode('invalid.token');
+      const decodeError = await catchErr(UserAccessToken.decode)('invalid.token');
 
       // then
-      expect(decoded).to.be.instanceOf(UserAccessToken);
-      expect(decoded.userId).to.be.undefined;
-      expect(decoded.audience).to.be.undefined;
-      expect(decoded.source).to.be.undefined;
+      expect(decodeError).to.be.instanceOf(InvalidInputDataError);
     });
   });
 

--- a/api/tests/identity-access-management/unit/domain/models/UserAccessToken.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserAccessToken.test.js
@@ -6,7 +6,7 @@ import { InvalidInputDataError } from '../../../../../src/shared/domain/errors.j
 import { expect } from '../../../../test-helper.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
-describe('Unit | Identity Access Management | Domain | Model | RefreshToken', function () {
+describe('Unit | Identity Access Management | Domain | Model | UserAccessToken', function () {
   beforeEach(function () {
     sinon.stub(config.authentication, 'secret').value('secret!');
     sinon.stub(config.authentication, 'accessTokenLifespanMs').value(3600000);
@@ -18,10 +18,11 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
     it('decodes a valid token', function () {
       // given
       const token = UserAccessToken.generate({
-        userId: 'userId!',
+        userId: 123456,
         source: 'source!',
         audience: 'audience!',
         expirationDelaySeconds: 1000,
+        sessionId: 'ABC-123-321',
       });
 
       // when
@@ -30,9 +31,10 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
       // then
       expect(decoded).to.be.instanceOf(UserAccessToken);
       expect(decoded).to.deep.include({
-        userId: 'userId!',
+        userId: 123456,
         source: 'source!',
         audience: 'audience!',
+        sessionId: 'ABC-123-321',
       });
     });
 
@@ -49,10 +51,11 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
     it('builds an access token', function () {
       // given / when
       const token = UserAccessToken.generate({
-        userId: 'userId!',
+        userId: 123456,
         source: 'source!',
         audience: 'https://app.pix.fr',
         expirationDelaySeconds: 1000,
+        sessionId: 'sessionId!',
       });
 
       // then
@@ -60,9 +63,10 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
 
       const decoded = UserAccessToken.decode(token);
       expect(decoded).to.deep.include({
-        userId: 'userId!',
+        userId: 123456,
         source: 'source!',
         audience: 'https://app.pix.fr',
+        sessionId: 'sessionId!',
       });
     });
   });
@@ -71,9 +75,10 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
     it('returns an access token and expiration delay', function () {
       // given / when
       const { accessToken, expirationDelaySeconds } = UserAccessToken.generateUserToken({
-        userId: 'userId!',
+        userId: 123456,
         source: 'source!',
         audience: 'audience!',
+        sessionId: 'sessionId!',
       });
 
       // then
@@ -82,9 +87,10 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
 
       const decoded = UserAccessToken.decode(accessToken);
       expect(decoded).to.deep.include({
-        userId: 'userId!',
+        userId: 123456,
         source: 'source!',
         audience: 'audience!',
+        sessionId: 'sessionId!',
       });
     });
   });
@@ -93,8 +99,9 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
     it('returns an access token and expiration delay', function () {
       // given / when
       const { accessToken, expirationDelaySeconds } = UserAccessToken.generateAnonymousUserToken({
-        userId: 'userId!',
+        userId: 123456,
         audience: 'audience!',
+        sessionId: 'sessionId!',
       });
 
       // then
@@ -103,9 +110,10 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
 
       const decoded = UserAccessToken.decode(accessToken);
       expect(decoded).to.deep.include({
-        userId: 'userId!',
+        userId: 123456,
         source: 'pix',
         audience: 'audience!',
+        sessionId: 'sessionId!',
       });
     });
   });
@@ -114,8 +122,9 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
     it('returns an access token and expiration delay', function () {
       // given / when
       const { accessToken, expirationDelaySeconds } = UserAccessToken.generateSamlUserToken({
-        userId: 'userId!',
+        userId: 123456,
         audience: 'audience!',
+        sessionId: 'sessionId!',
       });
 
       // then
@@ -124,9 +133,34 @@ describe('Unit | Identity Access Management | Domain | Model | RefreshToken', fu
 
       const decoded = UserAccessToken.decode(accessToken);
       expect(decoded).to.deep.include({
-        userId: 'userId!',
+        userId: 123456,
         source: 'external',
         audience: 'audience!',
+        sessionId: 'sessionId!',
+      });
+    });
+  });
+
+  describe('UserAccessToken.generateOidcUserToken', function () {
+    it('returns an access token and expiration delay', function () {
+      // given / when
+      const accessTokenLifespanSeconds = 48 * 60 * 60;
+      const { accessToken, expirationDelaySeconds } = UserAccessToken.generateOidcUserToken({
+        userId: 123456,
+        audience: 'audience!',
+        sessionId: 'sessionId!',
+        expiresIn: accessTokenLifespanSeconds,
+      });
+
+      // then
+      expect(accessToken).to.be.a('string');
+      expect(expirationDelaySeconds).to.equal(accessTokenLifespanSeconds);
+
+      const decoded = UserAccessToken.decode(accessToken);
+      expect(decoded).to.deep.include({
+        userId: 123456,
+        audience: 'audience!',
+        sessionId: 'sessionId!',
       });
     });
   });

--- a/api/tests/identity-access-management/unit/domain/services/authentication-session.service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/authentication-session.service.test.js
@@ -72,4 +72,23 @@ describe('Unit | Identity Access Management | Domain | Service | authentication-
       });
     });
   });
+
+  describe('#generateSessionId', function () {
+    it('returns a string', function () {
+      // when
+      const sessionId = authenticationSessionService.generateSessionId();
+
+      // then
+      expect(sessionId).to.be.a('string');
+    });
+
+    it('returns a different value on each call', function () {
+      // when
+      const firstSessionId = authenticationSessionService.generateSessionId();
+      const secondSessionId = authenticationSessionService.generateSessionId();
+
+      // then
+      expect(firstSessionId).to.not.equal(secondSessionId);
+    });
+  });
 });

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -1,5 +1,4 @@
 import jsonwebtoken from 'jsonwebtoken';
-import ms from 'ms';
 import sinon from 'sinon';
 
 import { OIDC_ERRORS } from '../../../../../src/identity-access-management/domain/constants/oidc-errors.js';
@@ -155,29 +154,6 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(result).to.be.false;
       });
-    });
-  });
-
-  describe('#createAccessToken', function () {
-    it('creates access token with user id and audience', function () {
-      // given
-      const userId = 42;
-      const accessToken = Symbol('valid access token');
-      const audience = 'https://admin.pix.fr';
-      const payload = { user_id: userId, aud: audience };
-      const jwtOptions = { expiresIn: ms('48h') / 1000 };
-      sinon
-        .stub(jsonwebtoken, 'sign')
-        .withArgs(payload, settings.authentication.secret, jwtOptions)
-        .returns(accessToken);
-
-      const oidcAuthenticationService = new OidcAuthenticationService(settings.oidcExampleNet, { openidClient });
-
-      // when
-      const result = oidcAuthenticationService.createAccessToken({ userId, audience });
-
-      // then
-      expect(result).to.equal(accessToken);
     });
   });
 

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
@@ -24,6 +24,7 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 describe('Unit | Identity Access Management | Domain | UseCase | authenticate-for-saml', function () {
   let lastUserApplicationConnectionsRepository;
   let pixAuthenticationService;
+  let authenticationSessionService;
   let obfuscationService;
   let authenticationMethodRepository;
   let userRepository;
@@ -34,6 +35,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
   beforeEach(function () {
     pixAuthenticationService = {
       getUserByUsernameAndPassword: sinon.stub(),
+    };
+    authenticationSessionService = {
+      generateSessionId: sinon.stub().returns('random-session-id'),
     };
     obfuscationService = {
       getObfuscatedAuthenticationMethod: sinon.stub(),
@@ -76,7 +80,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
 
       sinon
         .stub(UserAccessToken, 'generateSamlUserToken')
-        .withArgs({ userId: user.id, audience })
+        .withArgs({ userId: user.id, audience, sessionId: 'random-session-id' })
         .returns({ accessToken: expectedToken });
 
       // when
@@ -87,6 +91,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
         expectedUserId: user.id,
         audience,
         pixAuthenticationService,
+        authenticationSessionService,
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
@@ -124,7 +129,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
 
       sinon
         .stub(UserAccessToken, 'generateSamlUserToken')
-        .withArgs({ userId: user.id, audience })
+        .withArgs({ userId: user.id, audience, sessionId: 'random-session-id' })
         .returns({ accessToken: expectedToken });
 
       // when
@@ -135,6 +140,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
         expectedUserId: user.id,
         audience,
         pixAuthenticationService,
+        authenticationSessionService,
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
@@ -180,6 +186,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
         externalUserToken: 'an external user token',
         expectedUserId,
         pixAuthenticationService,
+        authenticationSessionService,
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
@@ -258,6 +265,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
           externalUserToken,
           expectedUserId: user.id,
           pixAuthenticationService,
+          authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
           userLoginRepository,

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import { POLE_EMPLOI } from '../../../../../src/identity-access-management/domain/constants/oidc-identity-providers.js';
 import { AuthenticationMethod } from '../../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
+import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { authenticateOidcUser } from '../../../../../src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { AuthenticationSessionContent } from '../../../../../src/shared/domain/models/AuthenticationSessionContent.js';
@@ -22,12 +23,14 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     let lastUserApplicationConnectionsRepository;
     let oidcAuthenticationServiceRegistry;
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
+    const accessTokenLifespanSeconds = 48 * 60 * 60;
 
     beforeEach(function () {
       oidcAuthenticationService = {
         identityProvider: 'OIDC_EXAMPLE_NET',
-        createAccessToken: sinon.stub(),
         shouldCloseSession: true,
+        accessTokenLifespanMs: accessTokenLifespanSeconds * 1000,
+        sessionDurationSeconds: accessTokenLifespanSeconds,
         saveIdToken: sinon.stub(),
         createAuthenticationComplement: sinon.stub(),
         exchangeCodeForTokens: sinon.stub(),
@@ -41,6 +44,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
         updateLastLoggedAtByIdentityProvider: sinon.stub(),
       };
       authenticationSessionService = {
+        generateSessionId: sinon.stub().returns('random-session-id'),
         save: sinon.stub(),
       };
       userRepository = { findByExternalIdentifier: sinon.stub(), update: sinon.stub() };
@@ -165,6 +169,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
 
       it('does not create an access token, nor saves the id token in storage, nor updates the last logged date', async function () {
         // given
+        sinon.stub(UserAccessToken, 'generateOidcUserToken');
         _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
         userRepository.findByExternalIdentifier.resolves(null);
 
@@ -183,7 +188,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
 
         // then
         expect(oidcAuthenticationService.saveIdToken).to.not.have.been.called;
-        expect(oidcAuthenticationService.createAccessToken).to.not.have.been.called;
+        expect(UserAccessToken.generateOidcUserToken).to.not.have.been.called;
         expect(userLoginRepository.updateLastLoggedAt).to.not.have.been.called;
       });
     });
@@ -295,12 +300,14 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
     const audience = 'https://app.pix.fr';
     const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
+    const accessTokenLifespanSeconds = 48 * 60 * 60;
 
     beforeEach(function () {
       oidcAuthenticationService = {
         identityProvider: POLE_EMPLOI.code,
         shouldCloseSession: true,
-        createAccessToken: sinon.stub(),
+        accessTokenLifespanMs: accessTokenLifespanSeconds * 1000,
+        sessionDurationSeconds: accessTokenLifespanSeconds,
         saveIdToken: sinon.stub(),
         createAuthenticationComplement: sinon.stub(),
         exchangeCodeForTokens: sinon.stub(),
@@ -316,6 +323,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
 
       authenticationSessionService = {
         save: sinon.stub(),
+        generateSessionId: sinon.stub().returns('random-session-id'),
       };
 
       userRepository = { findByExternalIdentifier: sinon.stub(), update: sinon.stub() };
@@ -365,6 +373,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           userId: 1,
           identityProvider: oidcAuthenticationService.identityProvider,
         });
+        expect(authenticationSessionService.generateSessionId).to.have.been.calledOnce;
         expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
           userId: 1,
           identityProvider: oidcAuthenticationService.identityProvider,
@@ -384,15 +393,16 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           .withArgs({ externalIdentityId, identityProvider: oidcAuthenticationService.identityProvider })
           .resolves(user);
         oidcAuthenticationService.createAuthenticationComplement.returns(undefined);
-        oidcAuthenticationService.createAccessToken
-          .withArgs({ userId: 10, audience })
-          .returns('accessTokenForExistingExternalUser');
+        sinon
+          .stub(UserAccessToken, 'generateOidcUserToken')
+          .withArgs({ userId: 10, audience, sessionId: 'random-session-id', expiresIn: accessTokenLifespanSeconds })
+          .returns({ accessToken: 'accessTokenForExistingExternalUser' });
         oidcAuthenticationService.saveIdToken
           .withArgs({ idToken: sessionContent.idToken, userId: 10 })
           .resolves('logoutUrlUUID');
 
         // when
-        const accessToken = await authenticateOidcUser({
+        const authenticationResult = await authenticateOidcUser({
           requestedApplication,
           stateReceived: 'state',
           stateSent: 'state',
@@ -408,9 +418,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
         });
 
         // then
-        sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
         sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
-        expect(accessToken).to.deep.equal({
+        expect(authenticationResult).to.deep.equal({
           pixAccessToken: 'accessTokenForExistingExternalUser',
           logoutUrlUUID: 'logoutUrlUUID',
           isAuthenticationComplete: true,
@@ -480,12 +489,14 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     let lastUserApplicationConnectionsRepository;
     let oidcAuthenticationServiceRegistry;
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
+    const accessTokenLifespanSeconds = 48 * 60 * 60;
 
     beforeEach(function () {
       oidcAuthenticationService = {
         identityProvider: POLE_EMPLOI.code,
-        createAccessToken: sinon.stub(),
         shouldCloseSession: true,
+        accessTokenLifespanMs: accessTokenLifespanSeconds * 1000,
+        sessionDurationSeconds: accessTokenLifespanSeconds,
         saveIdToken: sinon.stub(),
         createAuthenticationComplement: sinon.stub(),
         exchangeCodeForTokens: sinon.stub(),
@@ -500,6 +511,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
       };
       authenticationSessionService = {
         save: sinon.stub(),
+        generateSessionId: sinon.stub().returns('random-session-id'),
       };
       userRepository = { findByExternalIdentifier: sinon.stub(), update: sinon.stub() };
 

--- a/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
@@ -1,8 +1,10 @@
 import sinon from 'sinon';
 
 import { AuthenticationKeyExpired } from '../../../../../src/identity-access-management/domain/errors.js';
+import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { createOidcUser } from '../../../../../src/identity-access-management/domain/usecases/create-oidc-user.usecase.js';
 import { UserAlreadyExistsWithAuthenticationMethodError } from '../../../../../src/shared/domain/errors.js';
+import { RequestedApplication } from '../../../../../src/shared/infrastructure/utils/network.js';
 import { expect } from '../../../../test-helper.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
@@ -13,6 +15,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
   let authenticationSessionService;
   let oidcAuthenticationService;
   let oidcAuthenticationServiceRegistry;
+  let userLoginRepository;
+  let lastUserApplicationConnectionsRepository;
+  const accessTokenLifespanSeconds = 48 * 60 * 60;
 
   beforeEach(function () {
     authenticationMethodRepository = {
@@ -26,18 +31,28 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
 
     authenticationSessionService = {
       getByKey: sinon.stub(),
+      generateSessionId: sinon.stub().returns('random-session-id'),
     };
 
     oidcAuthenticationService = {
       shouldCloseSession: true,
+      accessTokenLifespanMs: accessTokenLifespanSeconds * 1000,
+      sessionDurationSeconds: accessTokenLifespanSeconds,
       getUserInfo: sinon.stub(),
       createUserAccount: sinon.stub(),
-      createAccessToken: sinon.stub(),
       saveIdToken: sinon.stub(),
     };
 
     oidcAuthenticationServiceRegistry = {
       getOidcProviderServiceByCode: sinon.stub().returns(oidcAuthenticationService),
+    };
+
+    userLoginRepository = {
+      updateLastLoggedAt: sinon.stub().resolves(),
+    };
+
+    lastUserApplicationConnectionsRepository = {
+      upsert: sinon.stub().resolves(),
     };
   });
 
@@ -87,6 +102,65 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
       // then
       expect(error).to.be.instanceOf(UserAlreadyExistsWithAuthenticationMethodError);
       expect(error.message).to.equal('Authentication method already exists for this external identifier.');
+    });
+  });
+
+  context('when the user account is created', function () {
+    it('returns the access token and the logout url uuid', async function () {
+      // given
+      const identityProvider = 'SOME_IDP';
+      const audience = 'https://app.pix.fr';
+      const userId = 'CREATED_USER_ID';
+      const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
+      const sessionContent = { idToken: 'idToken' };
+      const userInfo = { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'duGAR' };
+
+      authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
+        sessionContent,
+        userInfo,
+      });
+      authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider
+        .withArgs({ externalIdentifier: 'duGAR', identityProvider })
+        .resolves(null);
+      oidcAuthenticationService.createUserAccount.resolves(userId);
+      sinon.stub(UserAccessToken, 'generateOidcUserToken').returns({ accessToken: 'accessToken' });
+      oidcAuthenticationService.saveIdToken
+        .withArgs({ idToken: sessionContent.idToken, userId })
+        .resolves('logoutUrlUUID');
+
+      // when
+      const result = await createOidcUser({
+        identityProvider,
+        authenticationKey: 'AUTHENTICATION_KEY',
+        locale: 'fr-FR',
+        audience,
+        authenticationSessionService,
+        oidcAuthenticationServiceRegistry,
+        legalDocumentApiRepository,
+        authenticationMethodRepository,
+        userToCreateRepository,
+        userLoginRepository,
+        lastUserApplicationConnectionsRepository,
+        requestedApplication,
+      });
+
+      // then
+      expect(legalDocumentApiRepository.acceptPixAppTos).to.have.been.calledWithExactly({ userId });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId });
+      expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+        userId,
+        identityProvider,
+      });
+      expect(UserAccessToken.generateOidcUserToken).to.have.been.calledWithExactly({
+        userId,
+        audience,
+        sessionId: 'random-session-id',
+        expiresIn: accessTokenLifespanSeconds,
+      });
+      expect(result).to.deep.equal({
+        accessToken: 'accessToken',
+        logoutUrlUUID: 'logoutUrlUUID',
+      });
     });
   });
 });

--- a/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
@@ -15,6 +15,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   let userLoginRepository;
   let authenticationMethodRepository;
   let lastUserApplicationConnectionsRepository;
+  let authenticationSessionService;
   let samlSettings;
   const audience = 'https://app.pix.fr';
   const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
@@ -32,6 +33,10 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       findOneByUserIdAndIdentityProvider: sinon.stub(),
       updateLastLoggedAtByIdentityProvider: sinon.stub(),
       update: sinon.stub(),
+    };
+
+    authenticationSessionService = {
+      generateSessionId: sinon.stub().returns('random-session-id'),
     };
 
     samlSettings = {
@@ -107,7 +112,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
 
       sinon
         .stub(UserAccessToken, 'generateSamlUserToken')
-        .withArgs({ userId: 1, audience })
+        .withArgs({ userId: 1, sessionId: 'random-session-id', audience })
         .returns({ accessToken: 'access-token' });
 
       // when
@@ -118,6 +123,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         userLoginRepository,
         authenticationMethodRepository,
         lastUserApplicationConnectionsRepository,
+        authenticationSessionService,
         config: samlSettings,
         requestedApplication,
       });
@@ -149,6 +155,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         userLoginRepository,
         authenticationMethodRepository,
         lastUserApplicationConnectionsRepository,
+        authenticationSessionService,
         config: samlSettings,
         requestedApplication,
       });
@@ -192,6 +199,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLoginRepository,
           authenticationMethodRepository,
           lastUserApplicationConnectionsRepository,
+          authenticationSessionService,
           config: samlSettings,
           requestedApplication,
         });
@@ -230,6 +238,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLoginRepository,
           authenticationMethodRepository,
           lastUserApplicationConnectionsRepository,
+          authenticationSessionService,
           config: samlSettings,
           requestedApplication,
         });
@@ -267,6 +276,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLoginRepository,
           authenticationMethodRepository,
           lastUserApplicationConnectionsRepository,
+          authenticationSessionService,
           config: samlSettings,
           requestedApplication,
         });
@@ -304,6 +314,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLoginRepository,
           authenticationMethodRepository,
           lastUserApplicationConnectionsRepository,
+          authenticationSessionService,
           config: samlSettings,
           requestedApplication,
         });

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user-for-admin.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user-for-admin.usecase.test.js
@@ -4,7 +4,10 @@ import {
   AuthenticationKeyExpired,
   DifferentExternalIdentifierError,
 } from '../../../../../src/identity-access-management/domain/errors.js';
+import { AuthenticationMethod } from '../../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
+import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { reconcileOidcUserForAdmin } from '../../../../../src/identity-access-management/domain/usecases/reconcile-oidc-user-for-admin.usecase.js';
+import { RequestedApplication } from '../../../../../src/shared/infrastructure/utils/network.js';
 import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
@@ -12,9 +15,13 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-user-for-admin', function () {
   const identityProvider = 'genericOidcProviderCode';
   const audience = 'https://admin.pix.fr';
+  const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
+  const accessTokenLifespanSeconds = 48 * 60 * 60;
 
   let authenticationMethodRepository;
   let userRepository;
+  let userLoginRepository;
+  let lastUserApplicationConnectionsRepository;
   let authenticationSessionService;
   let oidcAuthenticationService;
 
@@ -25,10 +32,13 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
       updateLastLoggedAtByIdentityProvider: sinon.stub(),
     };
     userRepository = { getByEmail: sinon.stub() };
-    authenticationSessionService = { getByKey: sinon.stub() };
+    userLoginRepository = { updateLastLoggedAt: sinon.stub() };
+    lastUserApplicationConnectionsRepository = { upsert: sinon.stub() };
+    authenticationSessionService = { getByKey: sinon.stub(), generateSessionId: sinon.stub() };
     oidcAuthenticationService = {
       identityProvider,
-      createAccessToken: sinon.stub(),
+      accessTokenLifespanMs: accessTokenLifespanSeconds * 1000,
+      sessionDurationSeconds: accessTokenLifespanSeconds,
       createAuthenticationComplement: sinon.stub(),
     };
   });
@@ -82,6 +92,61 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
 
       // then
       expect(error).to.be.instanceOf(DifferentExternalIdentifierError);
+    });
+  });
+
+  context('when user is reconciled', function () {
+    it('creates the authentication method and returns a pix access token including a session id', async function () {
+      // given
+      const userId = 1;
+      const externalIdentifier = '123abc';
+      userRepository.getByEmail.resolves({ email: 'anne@example.net', id: userId });
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(null);
+      authenticationSessionService.getByKey.resolves({
+        sessionContent: {},
+        userInfo: { externalIdentityId: externalIdentifier },
+      });
+      oidcAuthenticationService.createAuthenticationComplement.returns(
+        new AuthenticationMethod.OidcAuthenticationComplement({
+          accessToken: 'accessToken',
+          expiredDate: new Date(),
+        }),
+      );
+
+      authenticationSessionService.generateSessionId.returns('random-session-id');
+      sinon
+        .stub(UserAccessToken, 'generateOidcUserToken')
+        .withArgs({ userId, audience, sessionId: 'random-session-id', expiresIn: accessTokenLifespanSeconds })
+        .returns({ accessToken: 'pixAccessToken' });
+
+      // when
+      const accessToken = await reconcileOidcUserForAdmin({
+        authenticationKey: 'authenticationKey',
+        email: 'anne@example.net',
+        identityProvider,
+        audience,
+        oidcAuthenticationService,
+        authenticationSessionService,
+        authenticationMethodRepository,
+        userRepository,
+        userLoginRepository,
+        lastUserApplicationConnectionsRepository,
+        requestedApplication,
+      });
+
+      // then
+      expect(authenticationMethodRepository.create).to.have.been.calledOnce;
+      const { authenticationMethod } = authenticationMethodRepository.create.firstCall.args[0];
+      expect(authenticationMethod).to.deep.contain({ identityProvider, externalIdentifier, userId });
+
+      expect(authenticationSessionService.generateSessionId).to.have.been.calledOnce;
+      expect(UserAccessToken.generateOidcUserToken).to.have.been.calledWithExactly({
+        userId,
+        audience,
+        sessionId: 'random-session-id',
+        expiresIn: accessTokenLifespanSeconds,
+      });
+      expect(accessToken).to.equal('pixAccessToken');
     });
   });
 });

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
@@ -6,6 +6,7 @@ import {
   MissingUserAccountError,
 } from '../../../../../src/identity-access-management/domain/errors.js';
 import { AuthenticationMethod } from '../../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
+import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { reconcileOidcUser } from '../../../../../src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js';
 import { AlreadyExistingEntityError } from '../../../../../src/shared/domain/errors.js';
 import { RequestedApplication } from '../../../../../src/shared/infrastructure/utils/network.js';
@@ -15,6 +16,7 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-user', function () {
   const audience = 'https://app.pix.fr';
   const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
+  const accessTokenLifespanSeconds = 48 * 60 * 60;
 
   context('when identityProvider is generic', function () {
     let authenticationMethodRepository,
@@ -31,17 +33,20 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
       userLoginRepository = {
         updateLastLoggedAt: sinon.stub(),
       };
-      authenticationSessionService = { getByKey: sinon.stub() };
+      authenticationSessionService = {
+        generateSessionId: sinon.stub().returns('random-session-id'),
+        getByKey: sinon.stub(),
+      };
       oidcAuthenticationService = {
         identityProvider,
-        createAccessToken: sinon.stub(),
+        accessTokenLifespanMs: accessTokenLifespanSeconds * 1000,
+        sessionDurationSeconds: accessTokenLifespanSeconds,
         saveIdToken: sinon.stub(),
         createAuthenticationComplement: sinon.stub(),
       };
       oidcAuthenticationServiceRegistry = {
         getOidcProviderServiceByCode: sinon.stub().returns(oidcAuthenticationService),
       };
-
       lastUserApplicationConnectionsRepository = {
         upsert: sinon.stub(),
       };
@@ -178,6 +183,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
         }),
       );
 
+      sinon.stub(UserAccessToken, 'generateOidcUserToken').returns({ accessToken: 'accessToken' });
+
       // when
       await reconcileOidcUser({
         authenticationKey: 'authenticationKey',
@@ -198,6 +205,13 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
       expect(authenticationMethod.authenticationComplement).to.be.instanceOf(
         AuthenticationMethod.OidcAuthenticationComplement,
       );
+      expect(authenticationSessionService.generateSessionId).to.have.been.calledOnce;
+      expect(UserAccessToken.generateOidcUserToken).to.have.been.calledWithExactly({
+        userId: 1,
+        audience: 'https://app.pix.fr',
+        sessionId: 'random-session-id',
+        expiresIn: accessTokenLifespanSeconds,
+      });
     });
 
     it('saves the last user connection', async function () {
@@ -253,17 +267,23 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
       userLoginRepository,
       lastUserApplicationConnectionsRepository;
 
+    const accessTokenLifespanSeconds = 48 * 60 * 60;
+
     beforeEach(function () {
       identityProvider = POLE_EMPLOI.code;
       authenticationMethodRepository = { create: sinon.stub(), updateLastLoggedAtByIdentityProvider: sinon.stub() };
       userLoginRepository = {
         updateLastLoggedAt: sinon.stub(),
       };
-      authenticationSessionService = { getByKey: sinon.stub() };
+      authenticationSessionService = {
+        generateSessionId: sinon.stub(),
+        getByKey: sinon.stub(),
+      };
       oidcAuthenticationService = {
         identityProvider,
         shouldCloseSession: true,
-        createAccessToken: sinon.stub(),
+        accessTokenLifespanMs: accessTokenLifespanSeconds * 1000,
+        sessionDurationSeconds: accessTokenLifespanSeconds,
         saveIdToken: sinon.stub(),
         createAuthenticationComplement: sinon.stub(),
       };
@@ -331,7 +351,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
           expiredDate: new Date(),
         }),
       );
-      oidcAuthenticationService.createAccessToken.withArgs({ userId, audience }).returns('accessToken');
+      authenticationSessionService.generateSessionId.returns('random-session-id');
+      sinon.stub(UserAccessToken, 'generateOidcUserToken').returns({ accessToken: 'accessToken' });
       oidcAuthenticationService.saveIdToken
         .withArgs({ idToken: sessionContent.idToken, userId })
         .resolves('logoutUrlUUID');
@@ -350,7 +371,12 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
       });
 
       // then
-      expect(oidcAuthenticationService.createAccessToken).to.be.calledOnce;
+      expect(UserAccessToken.generateOidcUserToken).to.be.calledWithExactly({
+        userId,
+        audience,
+        sessionId: 'random-session-id',
+        expiresIn: accessTokenLifespanSeconds,
+      });
       expect(oidcAuthenticationService.saveIdToken).to.be.calledOnce;
       expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId });
       expect(result).to.deep.equal({

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -20,6 +20,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
   let libOrganizationLearnerRepository;
   let studentRepository;
   let lastUserApplicationConnectionsRepository;
+  let authenticationSessionService;
   const audience = 'https://app.pix.fr';
   const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
@@ -48,6 +49,9 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
     };
     libOrganizationLearnerRepository = {
       updateUserIdWhereNull: sinon.stub(),
+    };
+    authenticationSessionService = {
+      generateSessionId: sinon.stub().returns('random-session-id'),
     };
   });
 
@@ -79,6 +83,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         libOrganizationLearnerRepository,
         studentRepository,
         lastUserApplicationConnectionsRepository,
+        authenticationSessionService,
         requestedApplication,
       });
 
@@ -110,7 +115,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
 
       sinon
         .stub(UserAccessToken, 'generateSamlUserToken')
-        .withArgs({ userId: user.id, audience })
+        .withArgs({ userId: user.id, audience, sessionId: 'random-session-id' })
         .returns({ accessToken: token });
 
       // when
@@ -128,6 +133,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         libOrganizationLearnerRepository,
         studentRepository,
         lastUserApplicationConnectionsRepository,
+        authenticationSessionService,
         requestedApplication,
       });
 
@@ -164,6 +170,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         libOrganizationLearnerRepository,
         studentRepository,
         lastUserApplicationConnectionsRepository,
+        authenticationSessionService,
         requestedApplication,
       });
 
@@ -187,7 +194,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
 
       sinon
         .stub(UserAccessToken, 'generateSamlUserToken')
-        .withArgs({ userId: user.id, audience })
+        .withArgs({ userId: user.id, audience, sessionId: 'random-session-id' })
         .returns({ accessToken: token });
 
       // when
@@ -205,6 +212,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         libOrganizationLearnerRepository,
         studentRepository,
         lastUserApplicationConnectionsRepository,
+        authenticationSessionService,
         requestedApplication,
       });
 

--- a/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -88,7 +88,12 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
 
     await databaseBuilder.commit();
 
-    const refreshToken = RefreshToken.generate({ userId, source: 'pix' });
+    const refreshToken = RefreshToken.generate({
+      userId,
+      source: 'pix',
+      audience: 'https://app.dev.pix.fr',
+      sessionId: 'random-session-id',
+    });
     await refreshTokenRepository.save({ refreshToken });
 
     // when


### PR DESCRIPTION
## 🪧 Problème
Dans le cadre de l'Epix de session logout et de révocation des access tokens, on veut que les différentes sessions d’un même compte utilisateur soient indépendantes. 

Dans le ticket présent, on amorce un travail préparatoire d'ajout d'un session ID aux access tokens et refresh tokens.

## 🌈 Proposition
Pour tous les cas de login, générer une sessionId et ajouter la propriété sid aux JWT. Lors du login d’un utilisateur, ajouter la propriété sid (pour sessionId) à tous les tokens générés par Pix API pour les utilisateurs se connectant, c’est à dire pour les AccessTokens et pour les RefreshTokens.

## 🎉 Pour tester
Dans le fichier `.env` de l'api, passez la valeur de l'ACCESS_TOKEN_LIFESPAN à 30 secondes.
Ne réduisez pas la valeur de l'access token dans les configurations des fournisseurs d'accès OIDC/SAML car seul l'access token est émis dans ces scénarios.

Checklist à adapter à chaque scénario de connexion ci-dessous :

Pour toutes les connexions :
  -- Se connecter avec un compte Pix existant (email/mot de passe) → login réussi, accessToken (et le cas échéant refreshToken) renvoyés.
-- **Décoder l'accessToken → sid présent.**

Pour les connexions PIX (email-mot de passe ou username-mot de passe): 
-- Vérifier dans redis que le le sid du refresh token est identique au sid de l'access token (même session, deux tokens) :
`KEYS "temporary-storage:refresh-tokens:*"`
copier la clé de votre utilisateur (avec son id),  et 
`GET "temporary-storage:refresh-tokens:<userId>:xxxxxx-xxxx-xxxx-xxxxxxxxx"`
-- Attendre le renouvellement de l'access token, et vérifier que le sid de du nouvel access token reste identique à celui du début.
-- Se déconnecter et se reconnecter avec le même compte → nouveau sid, différent du précédent.

Information : seules les routes de connexion via username ou email renvoient un access token. Les connexions via OIDC, GAR ou en tant qu'utilisateur anonyme n'en renvoient pas (sauf quand l'utilisateur anonyme s'inscrit après sa campagne).

1. Connexion classique email/mot de passe OU username/mot de passe (usecases **authenticateUser** et **createAccessTokenFromRefreshToken**). 
2. Création compte PIX via OIDC (usecases **createOidcUser**)
3. Connexion d'un utilisateur disposant d'une méthode de connexion OIDC (usecase **authenticateOidcUser**)
4. Ajout d'une nouvelle méthode de connexion OIDC pour un utilisateur ayant déjà un compte PIX (usecase **reconcileOidcUser**)

5. Ajout d'une nouvelle méthode de connexion OIDC sur Pix Admin (usecase **reconcileOidcUserForAdmin**)
Modifier le mail du user Superadmin pour y mettre votre adresse mail pix
Depuis https://admin.dev.pix.fr/ se connecter via sso
6. Début d'une session à accès simplifié (usecase **authenticateAnonymousUser**) puis
7. Non régression : Création de compte après le passage d'une campagne à accès simplifié (usecase upgradeToRealUser)
Vérifier que sid n'a pas changé (l'utilisateur garde la même session en passant d'anonyme à non anonyme)
:warning: l'upgrade donne lieu à un nouvel appel /token > nouvel access token et nouveau sid

8. Création de compte via le GAR pour un utilisateur sco n'ayant pas de compte PIX (usecase **createUserAndReconcileToOrganizationLearnerFromExternalUser**, route POST /api/sco-organization-learners/external)
Connectez-vous via le GAR, avec un learner non encore réconcilié (= non encore user), par exemple Harry Potter ou Edward Elric, puis entrez le code de campagne SCOBADGE1 et la date de naissance 12/12/2012

9. Connexion via le gar d'un élève ayant déjà un compte PIX et une méthode de connexion GAR (usecase **getSamlAuthenticationRedirection**, route POST /saml/assert - utilisée dans toutes les connexions GAR mais on peutpar exemple la tester ici)
Reconnectez-vous via le gar, avec un élève remplissant ces conditions, comme celui pour lequel vous venez de créer un compte.
10. Connexion via le gar pour un utilisateur ayant déjà un compte PIX et une méthode de connexion username/mot de passe mais pas de méthode de connexion GAR. (usecase **authenticateForSaml**, route POST /api/token-from-external-user)
Connectez-vous via le GAR, avec un learner sans médiacentre comme Kirua Zoldik, 06/06/2013, identifiant : hunter.0202. Sur la double mire sco entrez cet identifiant. 
11. Non régression : Création de compte par accès direct à une campagne pour un utilisateur sco n'ayant pas de compte PIX (usecase createAndReconcileUserToOrganizationLearner, route POST /api/sco-organization-learners/dependent). 
créer une campagne de collecte de Profils sur Pix Orga , dans l'orga Collège House Of The Dragon.
Aller sur https://app.dev.pix.fr/campagnes/{code de la campagne}
L'utilisateur n'a pas de compte, il doit en créer un à partir d'un learner non encore réconcilié (= non encore user) : par exemple Harry Potter ou Edward Elric. Partie gauche de la double mire > On lui donne un username et il entre un mot de passe. Le login proprement dit se fait dans une requête séparée avec le username et le mot de passe qu’il vient de saisir, il faut vérifier que cette connexion fonctionne et contient bien un sid. 
