### PR TITLE
[BUGFIX] Groupe la create de job pour l'audit logger (PIX-23373)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -1,12 +1,21 @@
+import _ from 'lodash';
+
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { AuditLoggingJob } from '../../../../shared/domain/models/jobs/AuditLoggingJob.js';
+import {
+  CampaignParticipationLoggerContext,
+  OrganizationLearnerLoggerContext,
+} from '../../../shared/domain/constants.js';
 import { OrganizationLearnerList } from '../models/OrganizationLearnerList.js';
+
+const CHUNK_SIZE = 1000;
 
 const deleteOrganizationLearners = async function ({
   organizationLearnerIds,
   userId,
   organizationId,
   userRole,
+  learnerToDeleteChunkSize = CHUNK_SIZE,
   client,
   organizationLearnerRepository,
   organizationLearnerImportFormatRepository,
@@ -39,6 +48,8 @@ const deleteOrganizationLearners = async function ({
     userId,
   );
 
+  const learnerToDeleteJobBatches = _.chunk(organizationLearnersToDelete, learnerToDeleteChunkSize);
+
   const importFormat = await organizationLearnerImportFormatRepository.get(organizationId);
   const organizationProfileRewards = await organizationsProfileRewardRepository.getByOrganizationId({ organizationId });
 
@@ -59,13 +70,15 @@ const deleteOrganizationLearners = async function ({
       organizationLearner.delete(userId, importFormat);
       organizationLearnersToUpdate.push(organizationLearner.dataToUpdateOnDeletion);
       organizationProfileRewardsToUpdate.push(...organizationLearnerRewards);
+    }
 
+    for (const learnerToDeleteBatch of learnerToDeleteJobBatches) {
       auditLoggingJobs.push(
-        AuditLoggingJob.forUser({
+        AuditLoggingJob.forUsers({
           client,
-          action: organizationLearner.loggerContext,
+          action: OrganizationLearnerLoggerContext.DELETION,
           role: userRole,
-          userId: organizationLearner.id,
+          userIds: learnerToDeleteBatch.map(({ id }) => id),
           updatedByUserId: userId,
           data: {},
         }),
@@ -82,13 +95,15 @@ const deleteOrganizationLearners = async function ({
       campaignParticipation.delete(userId);
       campaignParticipationsToDelete.push(campaignParticipation.dataToUpdateOnDeletion);
       allCampaignParticipationIds.push(campaignParticipation.id);
-
+    }
+    const participationToDeleteJobBatches = _.chunk(campaignParticipations, learnerToDeleteChunkSize);
+    for (const participationToDeleteJobBatch of participationToDeleteJobBatches) {
       auditLoggingJobs.push(
-        AuditLoggingJob.forUser({
+        AuditLoggingJob.forUsers({
           client,
-          action: campaignParticipation.loggerContext,
+          action: CampaignParticipationLoggerContext.DELETION,
           role: userRole,
-          userId: campaignParticipation.id,
+          userIds: participationToDeleteJobBatch.map(({ id }) => id),
           updatedByUserId: userId,
           data: {},
         }),

--- a/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
@@ -7,8 +7,7 @@ import {
   CampaignTypes,
   OrganizationLearnerLoggerContext,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
-import { CLIENTS, PIX_ORGA } from '../../../../../../src/shared/domain/constants.js';
-import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
+import { CLIENTS, ORGANIZATION_FEATURE, PIX_ORGA } from '../../../../../../src/shared/domain/constants.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { AuditLoggingJob } from '../../../../../../src/shared/domain/models/jobs/AuditLoggingJob.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../src/shared/infrastructure/execution-context-manager.js';
@@ -315,12 +314,64 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
     expect(assessments).deep.equal([assessment1.id, assessment2.id]);
   });
 
-  it('should publish an event to historize action', async function () {
+  it('should publish batch event to historize action', async function () {
+    // given
+    const campaignParticipation2 = buildCampaignParticipation({
+      organizationLearnerId: organizationLearner2.id,
+      participantExternalId,
+      userId: organizationLearner2.userId,
+    });
+    await databaseBuilder.commit();
+
     // when
     await usecases.deleteOrganizationLearners({
       userId: adminUserId,
-      organizationLearnerIds: [organizationLearner1.id],
+      organizationLearnerIds: [organizationLearner1.id, organizationLearner2.id],
       organizationId,
+      userRole: 'ORGA_ADMIN',
+      client: 'PIX_ORGA',
+    });
+
+    // then
+    await expect(AuditLoggingJob.name).to.have.been.performed.withJobPayloads([
+      {
+        client: 'PIX_ORGA',
+        action: OrganizationLearnerLoggerContext.DELETION,
+        role: 'ORGA_ADMIN',
+        userId: adminUserId,
+        occurredAt: now.toISOString(),
+        targetUserIds: [organizationLearner1.id, organizationLearner2.id],
+        data: {},
+        correlationContext: EMPTY_CORRELATION_INFO,
+      },
+      {
+        client: 'PIX_ORGA',
+        action: CampaignParticipationLoggerContext.DELETION,
+        role: 'ORGA_ADMIN',
+        userId: adminUserId,
+        occurredAt: now.toISOString(),
+        targetUserIds: [campaignParticipation1.id, campaignParticipation2.id],
+        data: {},
+        correlationContext: EMPTY_CORRELATION_INFO,
+      },
+    ]);
+  });
+
+  it('should publish an event to historize action according batch size', async function () {
+    // given
+    const campaignParticipation2 = buildCampaignParticipation({
+      organizationLearnerId: organizationLearner2.id,
+      participantExternalId,
+      userId: organizationLearner2.userId,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.deleteOrganizationLearners({
+      userId: adminUserId,
+      organizationLearnerIds: [organizationLearner1.id, organizationLearner2.id],
+      organizationId,
+      learnerToDeleteChunkSize: 1,
       userRole: 'ORGA_ADMIN',
       client: 'PIX_ORGA',
     });
@@ -339,11 +390,31 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
       },
       {
         client: 'PIX_ORGA',
+        action: OrganizationLearnerLoggerContext.DELETION,
+        role: 'ORGA_ADMIN',
+        userId: adminUserId,
+        occurredAt: now.toISOString(),
+        targetUserIds: [organizationLearner2.id],
+        data: {},
+        correlationContext: EMPTY_CORRELATION_INFO,
+      },
+      {
+        client: 'PIX_ORGA',
         action: CampaignParticipationLoggerContext.DELETION,
         role: 'ORGA_ADMIN',
         userId: adminUserId,
         occurredAt: now.toISOString(),
         targetUserIds: [campaignParticipation1.id],
+        data: {},
+        correlationContext: EMPTY_CORRELATION_INFO,
+      },
+      {
+        client: 'PIX_ORGA',
+        action: CampaignParticipationLoggerContext.DELETION,
+        role: 'ORGA_ADMIN',
+        userId: adminUserId,
+        occurredAt: now.toISOString(),
+        targetUserIds: [campaignParticipation2.id],
         data: {},
         correlationContext: EMPTY_CORRELATION_INFO,
       },


### PR DESCRIPTION
## 🪧 Problème

Actuellement on crée un job d'audit logger par suppression d'element, or dans le cas d'organisation avec beaucoup de prescrit, cela peut provoquer des timeouts

## 🌈 Proposition

Utiliser la fonction de l'audit logger qui permet de creer un job pour plusieur id 

## ✊ Remarques



## 🎉 Pour tester

- Supprimer une orga 
- valider qu'on a tout les actions correctement loggé dans l'audti logger
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
