### PR TITLE
[FEATURE] Ajoute la date de création d'un centre à la page de détails d'un centre de certification (PIX-23437).

### DIFF
--- a/admin/app/components/certification-centers/information-view.gjs
+++ b/admin/app/components/certification-centers/information-view.gjs
@@ -7,6 +7,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import formatDate from 'ember-intl/helpers/format-date';
 import sortBy from 'lodash/sortBy';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 import ENV from 'pix-admin/config/environment';
@@ -105,6 +106,15 @@ export default class InformationView extends Component {
         </:label>
         <:value>
           {{@certificationCenter.dataProtectionOfficerEmail}}
+        </:value>
+      </DescriptionList.ItemWithHTMLElement>
+
+      <DescriptionList.ItemWithHTMLElement>
+        <:label>
+          {{t "pages.certification-centers.information-view.list.createdAt"}}
+        </:label>
+        <:value>
+          {{formatDate @certificationCenter.createdAt}}
         </:value>
       </DescriptionList.ItemWithHTMLElement>
 

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -15,6 +15,7 @@ export default class CertificationCenter extends Model {
   @attr() externalId;
   @attr() archivedAt;
   @attr() archivistFullName;
+  @attr() createdAt;
   @attr() dataProtectionOfficerFirstName;
   @attr() dataProtectionOfficerLastName;
   @attr() dataProtectionOfficerEmail;

--- a/admin/tests/integration/components/certification-centers/information-view-test.gjs
+++ b/admin/tests/integration/components/certification-centers/information-view-test.gjs
@@ -31,6 +31,7 @@ module('Integration | Component | certification-centers/information-view', funct
       dataProtectionOfficerLastName: 'Number',
       dataProtectionOfficerEmail: 'lucky@example.net',
       habilitations: [pixDroitHabilitation],
+      createdAt: new Date('2023-07-27'),
     });
 
     // when
@@ -55,6 +56,7 @@ module('Integration | Component | certification-centers/information-view', funct
     assert.strictEqual(screen.getAllByTitle('Délégué à la protection des données').length, 2);
     assert.dom(screen.getByLabelText('Habilité pour Pix+Droit')).exists();
     assert.dom(screen.getByLabelText('Non habilité pour Cléa')).exists();
+    assert.dom(screen.getByText('27/07/2023')).exists();
   });
 
   test('it should show button to direct user to metabase dashboard', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1407,6 +1407,7 @@
         },
         "is-archived-warning": "Archived at {archivedAt} by {archivedBy}.",
         "list": {
+          "createdAt": "Created at",
           "dpo": "DPO",
           "dpo-definition": "Data Protection Officer",
           "dpo-email": "E-mail address of ",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1425,6 +1425,7 @@
         },
         "is-archived-warning": "Archivé le {archivedAt} par {archivedBy}.",
         "list": {
+          "createdAt": "Date de création",
           "dpo": "DPO",
           "dpo-definition": "Délégué à la protection des données",
           "dpo-email": "Adresse e-mail du ",

--- a/api/src/certification/enrolment/domain/models/Center.js
+++ b/api/src/certification/enrolment/domain/models/Center.js
@@ -15,14 +15,16 @@ export class Center {
    * @param {CenterTypes} props.type
    * @param {Array<Habilitation>} props.habilitations center habilitations
    * @param {MatchingOrganization | null} props.matchingOrganization
+   * @param {Date} createdAt
    */
-  constructor({ id, name, externalId, type, habilitations, matchingOrganization }) {
+  constructor({ id, name, externalId, type, habilitations, createdAt, matchingOrganization }) {
     this.id = id;
     this.name = name;
     this.type = type;
     this.externalId = externalId;
     this.habilitations = habilitations ?? [];
     this.matchingOrganization = matchingOrganization;
+    this.createdAt = createdAt;
   }
 
   get isSco() {

--- a/api/src/organizational-entities/domain/models/factories/CenterForAdminFactory.js
+++ b/api/src/organizational-entities/domain/models/factories/CenterForAdminFactory.js
@@ -20,7 +20,7 @@ export class CenterForAdminFactory {
         habilitations: center.habilitations?.map((habilitation) => new Habilitation(habilitation)) ?? [],
         name: center.name,
         externalId: center.externalId,
-        createdAt: undefined,
+        createdAt: center.createdAt,
         updatedAt: undefined,
         archivedAt: center.archivedAt,
       },

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -215,7 +215,10 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
     let expectedCertificationCenter;
 
     beforeEach(async function () {
-      expectedCertificationCenter = databaseBuilder.factory.buildCertificationCenter({ id: 1234 });
+      expectedCertificationCenter = databaseBuilder.factory.buildCertificationCenter({
+        id: 1234,
+        createdAt: new Date('2020-01-01'),
+      });
       databaseBuilder.factory.buildComplementaryCertification({
         id: 4567,
         key: 'certif comp',
@@ -259,7 +262,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
               name: 'some name',
               type: 'SUP',
               'external-id': 'EX123',
-              'created-at': undefined,
+              'created-at': new Date('2020-01-01'),
               'archived-at': null,
               'archivist-full-name': null,
               'data-protection-officer-first-name': undefined,

--- a/api/tests/organizational-entities/unit/domain/models/factories/CenterForAdminFactory_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/factories/CenterForAdminFactory_test.js
@@ -10,6 +10,7 @@ describe('Unit | Organizational Entities | Domain | Models | Factories | CenterF
     const habilitation = { complementaryCertificationId: 12, key: 'A_KEY', label: 'This is a key' };
     const center = domainBuilder.certification.enrolment.buildCenter({
       habilitations: [new Habilitation(habilitation)],
+      createdAt: new Date('2022-01-01'),
     });
     const dataProtectionOfficer =
       domainBuilder.buildDataProtectionOfficer.buildDataProtectionOfficerWithCertificationCenterId();
@@ -25,7 +26,7 @@ describe('Unit | Organizational Entities | Domain | Models | Factories | CenterF
           habilitations: [new Habilitation(habilitation)],
           name: center.name,
           externalId: center.externalId,
-          createdAt: undefined,
+          createdAt: center.createdAt,
           updatedAt: undefined,
         },
         dataProtectionOfficer: {

--- a/api/tests/tooling/domain-builder/factory/build-center.js
+++ b/api/tests/tooling/domain-builder/factory/build-center.js
@@ -9,6 +9,7 @@ const buildCenter = function ({
   habilitations,
   features,
   matchingOrganization = null,
+  createdAt,
 } = {}) {
   return new Center({
     id,
@@ -18,6 +19,7 @@ const buildCenter = function ({
     habilitations,
     features,
     matchingOrganization,
+    createdAt,
   });
 };
 


### PR DESCRIPTION
## 🪧 Problème
La date de création d'un centre de certification était absente de l'affichage de la page de détails d'un centre.

## 🌈 Proposition
Afficher la date de création

## 🎉 Pour tester
Démarrer Pix Admin
Se connecter avec un utilisateur qui a les droits (superadmin)
Afficher la page de détail d'un centre de certification
Constater que le champ date de création affiche la date de création du centre 
