### PR TITLE
[FEATURE] Tracker l'affichage du NPS pour le moteur de recommandations (PIX-23307)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -73,11 +73,13 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     if (this.args.model.hasAnsweredSurvey) {
       return false;
     }
+
     return this._drawerRevealedByScroll || !this.hasTrainings;
   }
 
   @action revealNps() {
     this._drawerRevealedByScroll = true;
+    this.pixMetrics.trackEvent('Moteur de reco - affichage du feedback NPS');
   }
 
   <template>

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -2,6 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import EvaluationResultsRecommendationEngine from 'mon-pix/components/routes/campaigns/assessment/evaluation-results-recommendation-engine';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
@@ -49,6 +50,57 @@ module(
           .exists();
         const trainingTitle = screen.getAllByText('Super training');
         assert.strictEqual(trainingTitle.length, 2);
+      });
+
+      module('tracking', function (hooks) {
+        let observerCallback;
+        let observerInstance;
+
+        hooks.beforeEach(function () {
+          observerInstance = {
+            observe: sinon.stub(),
+            disconnect: sinon.stub(),
+          };
+
+          window.IntersectionObserver = function (callback) {
+            observerCallback = callback;
+            return observerInstance;
+          };
+        });
+
+        hooks.afterEach(function () {
+          delete window.IntersectionObserver;
+          sinon.restore();
+        });
+
+        test('it should send tracking when drawer is displayed', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training],
+          };
+
+          const pixMetrics = this.owner.lookup('service:pix-metrics');
+          pixMetrics.trackEvent = sinon.stub();
+
+          // when
+          await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+          observerCallback([{ isIntersecting: true }]);
+
+          //then
+          sinon.assert.calledWith(pixMetrics.trackEvent, 'Moteur de reco - affichage du feedback NPS');
+          assert.ok(true);
+        });
       });
     });
 


### PR DESCRIPTION
## 🪧 Problème
Actuellement on effectue la demande d'un feedback à l'utilisateur en fin de campagne (qui contient des contenus formatifs recommandés). On souhaite connaître la proportions d'affichage de la demande de feedback qui n'apparait que lorsque l'utilisateur scrolle suffisament.

## 🌈 Proposition
Ajouter du tracking

## ✊ Remarques
N/A

## 🎉 Pour tester

- se connecter avec dave-comp@example.net
- aller sur la campagne [EDUMULTIP](https://app-pr16704.review.pix.fr/campagnes/EDUMULTIP)
- Scroller suffisamment pour que le nps s'affiche
- aller sur plausible
- constater que l'évènement s'affiche bien
