### PR TITLE
[BUGFIX] Corriger l'affichage de la page de recommandation sur Safari (PIX-234419).

### DIFF
--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -70,6 +70,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
   height: 127px;
   padding: var(--pix-spacing-7x);
   background-color: var(--pix-primary-10);

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -235,9 +235,6 @@
   }
 
   &__feedback {
-    display: flex;
-    gap: var(--pix-spacing-2x);
-    align-items: center;
 
     .selected {
       color: var(--pix-neutral-0);
@@ -274,6 +271,7 @@
       @extend %pix-body-m;
 
       float: left;
+      margin: var(--pix-spacing-1x) var(--pix-spacing-2x) 0 0;
     }
   }
 


### PR DESCRIPTION
## 🪧 Problème

On a constaté des erreurs d'affichage sur Safari, dans la page de fin de parcours (moteur de reco) sur Pix App.

- Les illustrations
- le positionnement du feedback dans la modale

<img width="586" height="431" alt="Capture d’écran 2026-07-03 à 11 20 43" src="https://github.com/user-attachments/assets/6beadb43-a726-4de3-afb6-a02b0dce22c1" />
<img width="517" height="236" alt="Capture d’écran 2026-07-03 à 11 20 26" src="https://github.com/user-attachments/assets/97b2ccb3-f60d-477a-9955-a55a57caf50a" />

## 🌈 Proposition

Les corriger : 

- J'applique un 100% à la div qui porte les illustrations
- Je supprime le display flex du feedback, je laisse le float left qui fixe la balise legend à gauche des boutons.

## ✊ Remarques


Pourquoi le `display flex` sur le feedback de la modale pose problème ? (Fonctionne sur les autres navigateurs et pas sur Safari)                                                       

Claude répond 

```
C'est la présence de la balise <legend> qui pose problème.
                                                                
  ★ Insight ─────────────────────────────────────
  Le modèle de rendu spécial de <legend> : La <legend> est l'un des rares éléments HTML qui a un comportement de rendu défini par le navigateur, pas par le CSS. Le browser la positionne toujours en haut du border du <fieldset>, en la faisant "chevaucher" la bordure. Ce n'est ni vraiment un block, ni vraiment un inline — c'est une catégorie à part.
  ─────────────────────────────────────────────────
  
  Voici la problématique concrète :

  1. <legend> résiste au CSS normal
  Dans un <fieldset> classique (display: block), la <legend> est extraite du flux normal et positionnée par le navigateur sur le bord supérieur.
  Elle ignore la plupart des propriétés de positionnement CSS standard.

  2. float: left comme "hack" historique
  float: left a deux effets sur la <legend> :
  - Il la fait participer au flux normal (en sortant du mode de rendu spécial du fieldset)
  - Il la rend block-level avec les autres éléments qui peuvent se placer à côté 
  
  Dans ce code, l'intention était : légende à gauche, boutons thumbs à droite sur la même ligne — comme si c'était une ligne de formulaire inline.

  3. Pourquoi ça casse en Safari
  La spec CSS dit explicitement : float est ignoré sur les flex items. Chrome/Firefox l'appliquent quand même (non-standard), Safari respecte la
  spec. Résultat : dans Safari, la <legend> se comporte comme un flex item normal dans la rangée, au lieu d'être flottée à gauche.

```



## 🎉 Pour tester

- Aller sur Pix App sur Firefox ET Safari (comparer les navigateurs)
- Constater que les illustrations prennent toute la place sur la card
- Constater que le feedback est inline
- Check en mobile que tout est bon aussi