### PR TITLE
[FEATURE] Ajouter un script pour dupliquer un module (PIX-23439)

### DIFF
--- a/api/src/devcomp/domain/usecases/duplicate-module.js
+++ b/api/src/devcomp/domain/usecases/duplicate-module.js
@@ -1,0 +1,41 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function duplicateModule({ moduleData }) {
+  const duplicated = _recursivelyRegenerateUuids(moduleData);
+  duplicated.shortId = randomBytes(4).toString('hex');
+  duplicated.slug = `${moduleData.slug}-copie`;
+  duplicated.title = `${moduleData.title} (copie)`;
+  return duplicated;
+}
+
+export { duplicateModule };
+
+function _recursivelyRegenerateUuids(node) {
+  if (Array.isArray(node)) {
+    return _recursivelyRegenerateUuidsInArray(node);
+  }
+
+  const nodeIsAnObject = node !== null && typeof node === 'object';
+  if (nodeIsAnObject) {
+    return _recursivelyRegenerateUuidsInObject(node);
+  }
+
+  return node;
+}
+
+function _recursivelyRegenerateUuidsInArray(node) {
+  return node.map(_recursivelyRegenerateUuids);
+}
+
+function _recursivelyRegenerateUuidsInObject(node) {
+  return Object.fromEntries(
+    Object.entries(node).map(([propertyName, propertyValue]) => {
+      const isPropertyAnUuid =
+        propertyName === 'id' && typeof propertyValue === 'string' && UUID_REGEX.test(propertyValue);
+      const newValue = isPropertyAnUuid ? randomUUID() : _recursivelyRegenerateUuids(propertyValue);
+      return [propertyName, newValue];
+    }),
+  );
+}

--- a/api/src/devcomp/scripts/duplicate-module.js
+++ b/api/src/devcomp/scripts/duplicate-module.js
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { duplicateModule } from '../domain/usecases/duplicate-module.js';
+
+export class DuplicateModule extends Script {
+  constructor() {
+    super({
+      description:
+        'Duplique un module Modulix (fichier JSON du dossier learning-content/modules) en régénérant tous les identifiants UUID, le shortId, le slug et le titre.',
+      permanent: true,
+      options: {
+        source: {
+          type: 'string',
+          describe: 'Le nom du fichier module source à dupliquer (ex: bac-a-sable.json)',
+          demandOption: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const { source } = options;
+
+    const modulePath = fileURLToPath(import.meta.url);
+    const __dirname = dirname(modulePath);
+    const modulesDir = join(__dirname, '../infrastructure/datasources/learning-content/modules');
+    const sourcePath = join(modulesDir, source);
+    const fileNameWithoutExtension = basename(source, '.json');
+    const targetPath = join(modulesDir, `${fileNameWithoutExtension}_copie.json`);
+
+    _assertSourceFileExistsAndHasJSONExtension(sourcePath);
+    _assertTargetFileDoesNotExist(targetPath);
+
+    // eslint-disable-next-line n/no-sync
+    const moduleData = JSON.parse(fs.readFileSync(sourcePath, 'utf-8'));
+    const duplicatedModuleData = duplicateModule({ moduleData });
+
+    const duplicatedModuleContent = JSON.stringify(duplicatedModuleData, null, 2);
+    // eslint-disable-next-line n/no-sync
+    fs.writeFileSync(targetPath, `${duplicatedModuleContent}\n`);
+
+    logger.info(`Module dupliqué : ${targetPath}`);
+    logger.info('Pensez à lancer "npm run modulix:test" pour valider le nouveau module.');
+  }
+}
+
+function _assertSourceFileExistsAndHasJSONExtension(sourcePath) {
+  if (!sourcePath.endsWith('.json')) {
+    throw new Error(`Le fichier source doit avoir l'extension .json (reçu : "${sourcePath}")`);
+  }
+
+  // eslint-disable-next-line n/no-sync
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Le fichier source "${sourcePath}" n'existe pas.`);
+  }
+}
+
+function _assertTargetFileDoesNotExist(targetPath) {
+  // eslint-disable-next-line n/no-sync
+  if (fs.existsSync(targetPath)) {
+    throw new Error(`Le fichier cible "${targetPath}" existe déjà.`);
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, DuplicateModule);

--- a/api/tests/devcomp/unit/domain/usecases/duplicate-module_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/duplicate-module_test.js
@@ -1,0 +1,109 @@
+import { duplicateModule } from '../../../../../src/devcomp/domain/usecases/duplicate-module.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | duplicate-module', function () {
+  describe('#duplicateModule', function () {
+    it('should set a new slug suffixed with "-copie"', function () {
+      // given
+      const moduleData = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        shortId: '6a68bf32',
+      };
+
+      // when
+      const result = duplicateModule({ moduleData });
+
+      // then
+      expect(result.slug).to.equal('bac-a-sable-copie');
+    });
+
+    it('should set a new title suffixed with " (copie)"', function () {
+      // given
+      const moduleData = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        shortId: '6a68bf32',
+      };
+
+      // when
+      const result = duplicateModule({ moduleData });
+
+      // then
+      expect(result.title).to.equal('Bac à sable (copie)');
+    });
+
+    it('should generate a new 8-character hexadecimal shortId', function () {
+      // given
+      const moduleData = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        shortId: '6a68bf32',
+      };
+
+      // when
+      const result = duplicateModule({ moduleData });
+
+      // then
+      expect(result.shortId).to.match(/^[0-9a-f]{8}$/);
+      expect(result.shortId).to.not.equal(moduleData.shortId);
+    });
+
+    it('should regenerate all UUID ids found in the module data', function () {
+      // given
+      const moduleData = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        shortId: '6a68bf32',
+        sections: [{ id: 'cfaefec9-e185-43b8-8258-e8beff6dd56b', grains: [] }],
+      };
+
+      // when
+      const result = duplicateModule({ moduleData });
+
+      // then
+      expect(result.id).to.not.equal(moduleData.id);
+      expect(result.sections[0].id).to.not.equal(moduleData.sections[0].id);
+    });
+
+    it('should not mutate the original module data', function () {
+      // given
+      const moduleData = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        shortId: '6a68bf32',
+      };
+      const originalCopy = JSON.parse(JSON.stringify(moduleData));
+
+      // when
+      duplicateModule({ moduleData });
+
+      // then
+      expect(moduleData).to.deep.equal(originalCopy);
+    });
+
+    it('should leave non-UUID id values unchanged', function () {
+      // given
+      const moduleData = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        shortId: '6a68bf32',
+        sections: [{ id: 'section-1', grains: [{ id: '1', proposals: [{ id: '1' }, { id: '2' }] }] }],
+      };
+
+      // when
+      const result = duplicateModule({ moduleData });
+
+      // then
+      expect(result.sections[0].id).to.equal('section-1');
+      expect(result.sections[0].grains[0].id).to.equal('1');
+      expect(result.sections[0].grains[0].proposals[0].id).to.equal('1');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/scripts/duplicate-module_test.js
+++ b/api/tests/devcomp/unit/scripts/duplicate-module_test.js
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+
+import sinon from 'sinon';
+
+import { DuplicateModule } from '../../../../src/devcomp/scripts/duplicate-module.js';
+import { expect } from '../../../test-helper.js';
+import { catchErr } from '../../../tooling/test-utils/error.js';
+
+describe('Unit | Scripts | Duplicate Module', function () {
+  describe('DuplicateModule', function () {
+    describe('#handle', function () {
+      afterEach(function () {
+        sinon.restore();
+      });
+
+      it('should read the source module, duplicate it, and write the result next to it', async function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'bac-a-sable',
+          title: 'Bac à sable',
+          shortId: '6a68bf32',
+        };
+        sinon.stub(fs, 'existsSync').callsFake((path) => path.endsWith('bac-a-sable.json'));
+        sinon.stub(fs, 'readFileSync').returns(JSON.stringify(moduleData));
+        sinon.stub(fs, 'writeFileSync');
+        const logger = { info: sinon.stub() };
+        const script = new DuplicateModule();
+
+        // when
+        await script.handle({ options: { source: 'bac-a-sable.json' }, logger });
+
+        // then
+        // eslint-disable-next-line n/no-sync
+        expect(fs.readFileSync).to.have.been.calledWith(sinon.match(/bac-a-sable\.json$/), 'utf-8');
+        const [writtenPath, writtenContent] = fs.writeFileSync.firstCall.args;
+        expect(writtenPath).to.match(/bac-a-sable_copie\.json$/);
+        const writtenModuleData = JSON.parse(writtenContent);
+        expect(writtenModuleData.slug).to.equal('bac-a-sable-copie');
+        expect(writtenModuleData.title).to.equal('Bac à sable (copie)');
+        expect(writtenModuleData.id).to.not.equal(moduleData.id);
+      });
+
+      it('should log the created file path and a reminder to run modulix:test', async function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'bac-a-sable',
+          title: 'Bac à sable',
+          shortId: '6a68bf32',
+        };
+        sinon.stub(fs, 'existsSync').callsFake((path) => path.endsWith('bac-a-sable.json'));
+        sinon.stub(fs, 'readFileSync').returns(JSON.stringify(moduleData));
+        sinon.stub(fs, 'writeFileSync');
+        const logger = { info: sinon.stub() };
+        const script = new DuplicateModule();
+
+        // when
+        await script.handle({ options: { source: 'bac-a-sable.json' }, logger });
+
+        // then
+        expect(logger.info).to.have.been.calledWith(sinon.match(/^Module dupliqué : .*bac-a-sable_copie\.json$/));
+        expect(logger.info).to.have.been.calledWith(
+          'Pensez à lancer "npm run modulix:test" pour valider le nouveau module.',
+        );
+      });
+
+      it('should throw when the source file does not exist', async function () {
+        // given
+        sinon.stub(fs, 'existsSync').returns(false);
+        const logger = { info: sinon.stub() };
+        const script = new DuplicateModule();
+
+        // when
+        const err = await catchErr(script.handle.bind(script))({ options: { source: 'missing.json' }, logger });
+
+        // then
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.match(/n'existe pas\.$/);
+      });
+
+      it('should throw when the target file already exists', async function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'bac-a-sable',
+          title: 'Bac à sable',
+          shortId: '6a68bf32',
+        };
+        sinon.stub(fs, 'existsSync').returns(true);
+        sinon.stub(fs, 'readFileSync').returns(JSON.stringify(moduleData));
+        const logger = { info: sinon.stub() };
+        const script = new DuplicateModule();
+
+        // when
+        const err = await catchErr(script.handle.bind(script))({ options: { source: 'bac-a-sable.json' }, logger });
+
+        // then
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.match(/existe déjà\.$/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Contexte

Début de la contextualisation prévue semaine du 6 juillet. D’autres besoins à venir pour les TPE/PME pour l’IA (date non encore définie, pour potentiellement novembre en prod).

## Besoin

On souhaite pouvoir dupliquer un module en changeant tous les uuuuuuids de façon rapide pour éviter les collisions.

## Solution

Script à créer côté dev si besoin occasionnel sinon bouton à prévoir dans modulix/pix editor

## Remarques

Documentation :
https://1024pix.atlassian.net/wiki/spaces/DEVCOMP/pages/6237716484/Duplication+de+modules

## Comment tester

1. Lancer le script avec un nom de fichier de modules
```shell
node api/src/devcomp/scripts/duplicate-module.js --source CYPhishing_NOV.json
```
2. Constater que `slug`, `title`, `shortId` et tous les  UUID ont été régénérés
3. Constater que les ids numériques des propositions n'ont pas changé
4. Gestion d'erreurs : fichier source manquant, fichier cible déjà existant