### PR TITLE
[BUGFIX] Ne pas afficher l'encart de feedback dans le cas où il n'y a pas de contenus formatifs recommandés (PIX-23443)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -73,8 +73,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     if (this.args.model.hasAnsweredSurvey) {
       return false;
     }
-
-    return this._drawerRevealedByScroll || !this.hasTrainings;
+    return this._drawerRevealedByScroll;
   }
 
   @action revealNps() {

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -238,7 +238,43 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
       });
     });
 
-    module('regarding the NPS drawer', function () {
+    module('regarding the NPS drawer', function (hooks) {
+      let observerCallback;
+      let observerInstance;
+
+      hooks.beforeEach(function () {
+        server.create('training', {
+          campaignParticipation,
+          title: 'Formation test',
+          link: 'https://example.net/',
+          type: 'webinaire',
+          duration: { hours: 2, days: 1, minutes: 0 },
+          deliveryMode: 'remote',
+          editorName: 'Éditeur test',
+          editorLogoUrl: 'https://example.net/logo.svg',
+          objectives: ['Objectif 1'],
+          program: 'Programme test',
+          description: 'Description test',
+          registrationRequired: false,
+          isRelevant: null,
+        });
+
+        observerInstance = {
+          observe: sinon.stub(),
+          disconnect: sinon.stub(),
+        };
+
+        window.IntersectionObserver = function (callback) {
+          observerCallback = callback;
+          return observerInstance;
+        };
+      });
+
+      hooks.afterEach(function () {
+        delete window.IntersectionObserver;
+        sinon.restore();
+      });
+
       test('should display the drawer when user has not answered the survey', async function (assert) {
         // given
         server.get('/campaigns/:campaignId/has-answered-survey', () => ({ hasAnswered: false }));
@@ -247,8 +283,9 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
+        observerCallback([{ isIntersecting: true }]);
         assert
-          .dom(screen.getByRole('dialog', { name: t('pages.skill-review.recommended-engine.drawer.title') }))
+          .dom(await screen.findByRole('dialog', { name: t('pages.skill-review.recommended-engine.drawer.title') }))
           .exists();
       });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -105,7 +105,7 @@ module(
     });
 
     module('when campaign has no training', function () {
-      test('should display nothing', async function (assert) {
+      test('should not display trainings section and the drawer', async function (assert) {
         // given
         const model = {
           campaign,
@@ -123,6 +123,10 @@ module(
         // then
         assert
           .dom(screen.queryByRole('heading', { name: t('pages.skill-review.tabs.trainings.title'), level: 2 }))
+          .doesNotExist();
+
+        assert
+          .dom(screen.queryByRole('dialog', { name: t('pages.skill-review.recommended-engine.drawer.title') }))
           .doesNotExist();
       });
     });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -9,6 +9,28 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 module('Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | Trainings', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  let observerCallback;
+  let observerOptions;
+  let observerInstance;
+
+  hooks.beforeEach(function () {
+    observerInstance = {
+      observe: sinon.stub(),
+      disconnect: sinon.stub(),
+    };
+
+    window.IntersectionObserver = function (callback, options) {
+      observerCallback = callback;
+      observerOptions = options;
+      return observerInstance;
+    };
+  });
+
+  hooks.afterEach(function () {
+    delete window.IntersectionObserver;
+    sinon.restore();
+  });
+
   test('it should display the trainings list', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
@@ -35,29 +57,7 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
     assert.dom(screen.getByText(t('pages.skill-review.recommended-engine.trainings.description'))).isVisible();
   });
 
-  module('when the section becomes fully visible', function (hooks) {
-    let observerCallback;
-    let observerOptions;
-    let observerInstance;
-
-    hooks.beforeEach(function () {
-      observerInstance = {
-        observe: sinon.stub(),
-        disconnect: sinon.stub(),
-      };
-
-      window.IntersectionObserver = function (callback, options) {
-        observerCallback = callback;
-        observerOptions = options;
-        return observerInstance;
-      };
-    });
-
-    hooks.afterEach(function () {
-      delete window.IntersectionObserver;
-      sinon.restore();
-    });
-
+  module('when the section becomes fully visible', function () {
     test('it calls @onFullyVisible', async function (assert) {
       // given
       const onFullyVisible = sinon.stub();


### PR DESCRIPTION
## 🪧 Problème

Sur une campagne de type moteur de recommandation, l'encart pour faire un feedback s'affiche quand il n'y a pas de contenus formatifs

## 🌈 Proposition
Corriger cela.

## ✊ Remarques

RAS

## 🎉 Pour tester
### En local
- Modifier la [réponse](https://github.com/1024pix/pix/blob/dev/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js#L15) de la route qui récupère les contenus formatifs recommandés pour une campagne en mettant un [] à la place trainings.
- Lancer Pix App et se connecter avec le compte `dave-comp@example.net`
- Passer la campagne EDUMULTIP
- Remarquer, sur la page de résultats, qu'il n'y a pas de contenus formatifs affichés ni d'encart pour faire un feedback 👻 