### PR TITLE
[TECH] Corriger plusieurs tests

### DIFF
--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -1941,6 +1941,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[1].isNeutralized = true;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[2].isNeutralized = true;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[3].isNeutralized = true;
+          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[4].isNeutralized = false;
+          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[5].isNeutralized = false;
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({

--- a/api/tests/certification/session-management/unit/application/invigilator-kit-route_test.js
+++ b/api/tests/certification/session-management/unit/application/invigilator-kit-route_test.js
@@ -12,6 +12,7 @@ describe('Certification | Session Management | Unit | Application | Routes | Inv
     it('should return 200', async function () {
       // when
       sinon.stub(authorization, 'checkUserHaveCertificationCenterMembershipForSession').resolves(true);
+      sinon.stub(authorization, 'checkUserHaveInvigilatorAccessForSession').resolves(true);
       sinon.stub(invigilatorKitController, 'getInvigilatorKitPdf').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
@@ -102,6 +102,7 @@ describe('Unit | UseCase | get-shared-campaign-participation-profile', function 
   context('When user has not shared its profile', function () {
     it('should throw an error', async function () {
       // given
+      const campaignParticipationRepository = { findOneByCampaignIdAndUserId: sinon.stub() };
       campaignParticipationRepository.findOneByCampaignIdAndUserId.withArgs({ userId, campaignId }).resolves(null);
 
       // when

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -70,6 +70,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       usecases.uploadSiecleFile.resolves(uploadedFileEvent);
       const userId = 1;
       request.auth = { credentials: { userId } };
+      request.query.format = 'xml';
       hFake.request = {
         path: '/api/organizations/145/sco-organization-learners/import-siecle',
       };
@@ -91,6 +92,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       usecases.uploadSiecleFile.rejects(uploadedError);
       const userId = 1;
       request.auth = { credentials: { userId } };
+      request.query.format = 'xml';
       hFake.request = {
         path: '/api/organizations/145/sco-organization-learners/import-siecle',
       };

--- a/api/tests/prescription/organization-learner-feature/unit/application/organization-learner-feature-route_test.js
+++ b/api/tests/prescription/organization-learner-feature/unit/application/organization-learner-feature-route_test.js
@@ -17,6 +17,7 @@ describe('Unit | Router | organization-learner-feature-router', function () {
     sinon.stub(securityPreHandlers, 'checkOrganizationHasFeature').callsFake((request, h) => h.response(true));
 
     sinon.stub(organizationLearnerFeaturesController, 'create').resolves(true);
+    sinon.stub(organizationLearnerFeaturesController, 'unlink').resolves(true);
 
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(organizationLearnerFeatureRoute);

--- a/api/tests/quest/unit/application/attestation-route_test.js
+++ b/api/tests/quest/unit/application/attestation-route_test.js
@@ -145,9 +145,12 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
   });
   describe('GET /api/organizations/{organizationId}/attestations', function () {
     it('should fail if user is not a member of the organization', async function () {
-      sinon
-        .stub(securityPreHandlers, 'checkUserBelongsToOrganization')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) =>
+        h
+          .response({ errors: new Error('forbidden') })
+          .code(403)
+          .takeover(),
+      );
 
       const organizationId = 123;
 

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -194,6 +194,7 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
     it('should call prehandlers', async function () {
       // given
       sinon.stub(securityPreHandlers, 'checkOrganizationAccess').returns(() => true);
+      sinon.stub(combinedCourseController, 'createCombinedCourse').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
       httpTestServer.setupAuthentication();

--- a/api/tests/school/unit/application/mission-route_test.js
+++ b/api/tests/school/unit/application/mission-route_test.js
@@ -74,6 +74,7 @@ describe('Unit | Router | mission-route', function () {
       // given
       const mock = sinon.mock(securityPreHandlers);
       mock.expects('checkUserBelongsToOrganization').once().returns(true);
+      sinon.stub(missionController, 'getById').callsFake((request, h) => h.response('ok'));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 


### PR DESCRIPTION
## 🪧 Problème
Suite à un lancement des tests dans un ordre aléatoire, il apparaît que certains tests peuvent échouer. 

## 🌈 Proposition
- Ajouter des stubs manquants
- Ajouter des attributs manquants
- Ajouter des `takeover()` sur certains retours de stubs de prehandler

## ✊ Remarques
Cette PR ne corrige pas tous les tests dans ce cas.