### PR TITLE
[TECH] Remplace XML buffer to string.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -70,7 +70,6 @@
         "saxpath": "^0.6.5",
         "undici": "8.4.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-        "xml-buffer-tostring": "^0.2.0",
         "xml2js": "^0.6.0",
         "xmlbuilder2": "^4.0.0",
         "yargs": "^18.0.0"
@@ -12940,27 +12939,6 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "license": "MIT"
-    },
-    "node_modules/xml-buffer-tostring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/xml-buffer-tostring/-/xml-buffer-tostring-0.2.0.tgz",
-      "integrity": "sha512-roMgv6PdOTO/e14e+ekwDqEQK9yFD6BMm/6eJhEjzptvVsS0QzBUxjGvmh0bI/RuEE2a6WaybZhc6Tjl6iwtzA==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.4.19"
-      }
-    },
-    "node_modules/xml-buffer-tostring/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/xml-crypto": {
       "version": "6.1.2",

--- a/api/package.json
+++ b/api/package.json
@@ -152,7 +152,6 @@
     "saxpath": "^0.6.5",
     "undici": "8.4.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "xml-buffer-tostring": "^0.2.0",
     "xml2js": "^0.6.0",
     "xmlbuilder2": "^4.0.0",
     "yargs": "^18.0.0"

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
@@ -1,12 +1,9 @@
 import buffer from 'node:buffer';
 import * as fs from 'node:fs/promises';
 
-import xmlBufferTostring from 'xml-buffer-tostring';
-
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
 import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 
-const { xmlEncoding } = xmlBufferTostring;
 const { Buffer } = buffer;
 
 const DEFAULT_FILE_ENCODING = 'UTF-8';
@@ -15,9 +12,40 @@ const ERRORS = {
   INVALID_FILE: 'INVALID_FILE',
 };
 
-async function detectEncoding(path) {
+export async function detectEncoding(path) {
   const firstLine = await readFirstLine(path);
-  return xmlEncoding(Buffer.from(firstLine)) || DEFAULT_FILE_ENCODING;
+  return detectXmlEncoding(Buffer.from(firstLine));
+}
+
+function detectXmlEncoding(buffer) {
+  const encoding = detectXmlEncodingFromBOM(buffer);
+  if (encoding) {
+    return encoding;
+  }
+
+  return detectXmlEncodingFromTag(buffer) ?? DEFAULT_FILE_ENCODING;
+}
+
+function detectXmlEncodingFromBOM(buffer) {
+  if (buffer.length >= 4) {
+    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0xfe && buffer[3] === 0xff) return 'UTF-32BE';
+    if (buffer[0] === 0xff && buffer[1] === 0xfe && buffer[2] === 0x00 && buffer[3] === 0x00) return 'UTF-32LE';
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xef && buffer[1] === 0xbb && buffer[2] === 0xbf) {
+    return 'UTF-8';
+  }
+  if (buffer.length >= 2) {
+    if (buffer[0] === 0xfe && buffer[1] === 0xff) return 'UTF-16BE';
+    if (buffer[0] === 0xff && buffer[1] === 0xfe) return 'UTF-16LE';
+  }
+}
+
+function detectXmlEncodingFromTag(buffer) {
+  const head = buffer.toString('LATIN1');
+  const match = head.match(/<\?xml[^>]*encoding=["']([^"']+)["']/i);
+  if (match) {
+    return match[1].toLowerCase();
+  }
 }
 
 async function readFirstLine(path) {
@@ -34,4 +62,3 @@ async function readFirstLine(path) {
 
   return buffer;
 }
-export { detectEncoding };

--- a/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/detect-encoding_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/detect-encoding_test.js
@@ -17,7 +17,7 @@ describe('detect-encoding', function () {
   });
 
   context('when encoding specified in the xml file', function () {
-    it('should return the default encoding', async function () {
+    it('should return the specified encoding', async function () {
       const path = `${__dirname}files/xml/unknown-encoding.xml`;
       const encoding = await detectEncoding(path);
       expect(encoding).to.equal('x-macthai');


### PR DESCRIPTION
## 🪧 Problème

On détecte l'encodage des fichiers XML utilisés dans les imports avec la dépendance `xml-buffer-tostring` qui est ancienne et peu maintenue.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌈 Proposition

La détection de l'encodage est basée sur 2 mécanismes :
- on regarde si l'encodage est défini dans les premiers octets du fichier (BOM)
- on regarde l'encodage spécifié par la balise `encoding` dans le fichier XML lui-même

Ces 2 conditions sont facilement réalisables sans librairie externe, on décide donc d'implémenter notre propre fonction de détection d'encodage.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ✊ Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

Tester fonctionnellement l'import via fichiers avec des fichiers dont les encodages sont classiques et plus exotiques.
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
