### PR TITLE
[TECH] Supprime la dépendance hash-int.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -37,7 +37,6 @@
         "fast-levenshtein": "^3.0.0",
         "file-type": "^22.0.0",
         "hapi-swagger": "^17.3.2",
-        "hash-int": "^1.0.0",
         "html-validate": "^11.0.0",
         "i18n": "^0.15.0",
         "iconv-lite": "^0.7.0",
@@ -7853,12 +7852,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/hash-int": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hash-int/-/hash-int-1.0.0.tgz",
-      "integrity": "sha512-U1cDrvoPTR+AWCeFLXm0UjEcsgz74N5H4lQ3PjwDCIaLHgiXRmfsvq15/HGSjNAkig/bZMcESqg93ax9alWhkg==",
-      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -119,7 +119,6 @@
     "fast-levenshtein": "^3.0.0",
     "file-type": "^22.0.0",
     "hapi-swagger": "^17.3.2",
-    "hash-int": "^1.0.0",
     "html-validate": "^11.0.0",
     "i18n": "^0.15.0",
     "iconv-lite": "^0.7.0",

--- a/api/src/evaluation/domain/services/pick-challenge-service.js
+++ b/api/src/evaluation/domain/services/pick-challenge-service.js
@@ -1,5 +1,3 @@
-import hashInt from 'hash-int';
-
 import { fallbackChallengeLocales } from '../../../shared/domain/services/locale-service.js';
 
 const NON_EXISTING_ITEM = null;
@@ -37,3 +35,18 @@ const findPreferablyValidatedChallengesWithLocale = (localeChallenges, locale) =
   });
   return challengesWithGivenLocale.length > 0 ? challengesWithGivenLocale : preferablyValidatedChallenges;
 };
+
+// returns pseudo random integer from a given seed
+function hashInt(x) {
+  const A = new Uint32Array(1);
+  A[0] = x | 0;
+  A[0] -= A[0] << 6;
+  A[0] ^= A[0] >>> 17;
+  A[0] -= A[0] << 9;
+  A[0] ^= A[0] << 4;
+  A[0] -= A[0] << 3;
+  A[0] ^= A[0] << 10;
+  A[0] ^= A[0] >>> 15;
+
+  return A[0];
+}


### PR DESCRIPTION
## 🪧 Problème

La dépendance `hash-int` est (très) vieille (> 13 ans).

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌈 Proposition

Cette dépendance contient uniquement une fonction permettant de générer un nombre à partir d'une seed.
Comme elle est utilisée uniquement dans le service `pick-challenge`, on duplique cette fonction dans le service et on supprime la dépendance.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ✊ Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester


<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
