### PR TITLE
[FEATURE] Éviter à un candidat de reprendre sa certif 24h après son début (PIX-23458).

### DIFF
--- a/api/src/certification/evaluation/domain/models/AssessmentSheet.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSheet.js
@@ -11,8 +11,6 @@ import { ABORT_REASONS } from '../../../shared/domain/constants/abort-reasons.js
 export const STATES = Assessment.states;
 export const STATES_OF_LAST_QUESTION = Assessment.statesOfLastQuestion;
 
-const MAXIMAL_CERTIFICATION_DURATION_IN_MS = 24 * 60 * 60 * 1000; // 24h
-
 export class AssessmentSheet {
   /**
    * @param {object} params
@@ -131,10 +129,6 @@ export class AssessmentSheet {
     if (this.isChallengeAlreadyAnswered(answer.challengeId)) {
       throw new ChallengeAlreadyAnsweredError();
     }
-  }
-
-  hasCertificationDurationExceeded() {
-    return Date.now() - this.startedAt.getTime() > MAXIMAL_CERTIFICATION_DURATION_IN_MS;
   }
 
   endDueToCertificationDurationExceeded() {

--- a/api/src/certification/evaluation/domain/services/certification-duration-service.js
+++ b/api/src/certification/evaluation/domain/services/certification-duration-service.js
@@ -1,0 +1,9 @@
+const MAXIMAL_CERTIFICATION_DURATION_IN_MS = 24 * 60 * 60 * 1000; // 24h
+
+/**
+ * @param {Date} startDate
+ * @returns {boolean}
+ */
+export function isDurationExceeded(startDate) {
+  return Date.now() - startDate.getTime() > MAXIMAL_CERTIFICATION_DURATION_IN_MS;
+}

--- a/api/src/certification/evaluation/domain/usecases/evaluate-and-save-answer.js
+++ b/api/src/certification/evaluation/domain/usecases/evaluate-and-save-answer.js
@@ -1,6 +1,7 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { EmptyAnswerError, ForbiddenAccess, NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationDurationExceededError } from '../errors.js';
+import { isDurationExceeded } from '../services/certification-duration-service.js';
 
 export async function evaluateAndSaveAnswer({
   answer,
@@ -24,7 +25,7 @@ export async function evaluateAndSaveAnswer({
 
   assessmentSheet.checkIfCandidateCanAnswer({ answer, userId });
 
-  if (assessmentSheet.hasCertificationDurationExceeded()) {
+  if (isDurationExceeded(assessmentSheet.startedAt)) {
     assessmentSheet.endDueToCertificationDurationExceeded();
     await assessmentSheetRepository.update(assessmentSheet);
     throw new CertificationDurationExceededError();

--- a/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -2,6 +2,7 @@
  * @typedef {import('./index.js').AssessmentRepository} AssessmentRepository
  * @typedef {import('./index.js').CandidateRepository} CandidateRepository
  * @typedef {import('./index.js').CertificationCourseRepository} CertificationCourseRepository
+ * @typedef {import('./index.js').AssessmentSheetRepository} AssessmentSheetRepository
  * @typedef {import('./index.js').CertificationCenterRepository} CertificationCenterRepository
  * @typedef {import('./index.js').SessionRepository} SessionRepository
  * @typedef {import('./index.js').VersionApi} VersionApi
@@ -25,6 +26,8 @@ import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmE
 import { CertificationCourse } from '../../../shared/domain/models/CertificationCourse.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
+import { CertificationDurationExceededError } from '../errors.js';
+import { isDurationExceeded } from '../services/certification-duration-service.js';
 
 const DEFAULT_LOCALE = 'fr-fr';
 
@@ -34,6 +37,7 @@ const DEFAULT_LOCALE = 'fr-fr';
  * @param {AssessmentRepository} params.assessmentRepository
  * @param {CandidateRepository} params.candidateRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository
+ * @param {AssessmentSheetRepository} params.assessmentSheetRepository
  * @param {CertificationCenterRepository} params.certificationCenterRepository
  * @param {SessionRepository} params.sessionRepository
  * @param {VersionApi} params.versionApi
@@ -48,6 +52,7 @@ export async function retrieveLastOrCreateCertificationCourse({
   assessmentRepository,
   candidateRepository,
   certificationCourseRepository,
+  assessmentSheetRepository,
   sessionRepository,
   certificationCenterRepository,
   versionApi,
@@ -72,6 +77,8 @@ export async function retrieveLastOrCreateCertificationCourse({
       userId,
       sessionId,
     });
+
+  await _endCourseIfDurationExceeded({ existingCertificationCourse, assessmentSheetRepository });
 
   _validateCandidateIsAuthorizedToStart(candidate, existingCertificationCourse);
 
@@ -113,6 +120,25 @@ async function _validateUserLocale(userLanguage) {
 
   if (!isUserLanguageValid) {
     throw new LanguageNotSupportedError(userLanguage);
+  }
+}
+
+/**
+ * @param {object} params
+ * @param {CertificationCourse} params.existingCertificationCourse
+ * @param {AssessmentSheetRepository} params.assessmentSheetRepository
+ */
+async function _endCourseIfDurationExceeded({ existingCertificationCourse, assessmentSheetRepository }) {
+  if (existingCertificationCourse && isDurationExceeded(existingCertificationCourse.getStartDate())) {
+    const assessmentSheet = await assessmentSheetRepository.findByCertificationCourseId(
+      existingCertificationCourse.getId(),
+    );
+    if (assessmentSheet) {
+      assessmentSheet.endDueToCertificationDurationExceeded();
+      await assessmentSheetRepository.update(assessmentSheet);
+    }
+
+    throw new CertificationDurationExceededError();
   }
 }
 

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -159,10 +159,6 @@ export class CertificationCourse {
     });
   }
 
-  reportIssue(issueReport) {
-    this._certificationIssueReports.push(issueReport);
-  }
-
   rejectForFraud() {
     this._isRejectedForFraud = true;
   }
@@ -177,10 +173,6 @@ export class CertificationCourse {
 
   adjustForAccessibility(isAdjustmentNeeded) {
     this._isAdjustedForAccessibility = !!isAdjustmentNeeded;
-  }
-
-  isAdjustementNeeded() {
-    return this._isAdjustedForAccessibility;
   }
 
   abort(reason) {
@@ -263,14 +255,6 @@ export class CertificationCourse {
 
   isPublished() {
     return this._isPublished;
-  }
-
-  doesBelongTo(userId) {
-    return this._userId === userId;
-  }
-
-  getAbortReason() {
-    return this._abortReason;
   }
 
   getId() {

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -426,10 +426,15 @@ function _createNonExistingCertifCourseSetup({ learningContent, sessionId, userI
   return { certificationCandidate };
 }
 
-function _createExistingCertifCourseSetup({ learningContent, userId, sessionId, version = 2 }) {
+function _createExistingCertifCourseSetup({ learningContent, userId, sessionId, version = 2, createdAt = new Date() }) {
   const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
   databaseBuilder.factory.learningContent.build(learningContentObjects);
-  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, version }).id;
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+    userId,
+    sessionId,
+    version,
+    createdAt,
+  }).id;
   databaseBuilder.factory.buildAssessment({ userId, certificationCourseId });
 
   const candidate = databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId, authorizedToStart: true });

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -359,35 +359,6 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
     });
   });
 
-  context('#hasCertificationDurationExceeded', function () {
-    let clock;
-    const now = new Date('2026-01-02T00:00:00Z');
-
-    beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
-    });
-
-    it('returns true when the certification has been started for more than 24 hours', function () {
-      const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
-        startedAt: new Date('2025-12-31T23:00:00Z'),
-      });
-
-      expect(assessmentSheet.hasCertificationDurationExceeded()).to.be.true;
-    });
-
-    it('returns false when the certification has been started for less than 24 hours', function () {
-      const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
-        startedAt: new Date('2026-01-01T23:00:00Z'),
-      });
-
-      expect(assessmentSheet.hasCertificationDurationExceeded()).to.be.false;
-    });
-  });
-
   context('#endDueToCertificationDurationExceeded', function () {
     let clock, assessmentSheetBaseData;
     const now = new Date();

--- a/api/tests/certification/evaluation/unit/domain/services/certification-duration-service_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/certification-duration-service_test.js
@@ -1,0 +1,54 @@
+import sinon from 'sinon';
+
+import { isDurationExceeded } from '../../../../../../src/certification/evaluation/domain/services/certification-duration-service.js';
+import { expect } from '../../../../../test-helper.js';
+
+const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
+
+describe('Unit | Certification | Evaluation | Domain | Service | certification-duration', function () {
+  describe('#isDurationExceeded', function () {
+    let clock;
+    const now = new Date('2026-01-02T00:00:00Z');
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('returns true when the elapsed duration exceeds 24 hours by one millisecond', function () {
+      // given
+      const startDate = new Date(now.getTime() - TWENTY_FOUR_HOURS_IN_MS - 1);
+
+      // when
+      const result = isDurationExceeded(startDate);
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('returns false when exactly 24 hours have elapsed since the start date', function () {
+      // given
+      const startDate = new Date(now.getTime() - TWENTY_FOUR_HOURS_IN_MS);
+
+      // when
+      const result = isDurationExceeded(startDate);
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('returns false when less than 24 hours have elapsed since the start date', function () {
+      // given
+      const startDate = new Date(now.getTime() - (TWENTY_FOUR_HOURS_IN_MS - 1));
+
+      // when
+      const result = isDurationExceeded(startDate);
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+});

--- a/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -1,5 +1,7 @@
 import sinon from 'sinon';
 
+import { CertificationDurationExceededError } from '../../../../../../src/certification/evaluation/domain/errors.js';
+import { AssessmentSheet } from '../../../../../../src/certification/evaluation/domain/models/AssessmentSheet.js';
 import { retrieveLastOrCreateCertificationCourse } from '../../../../../../src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js';
 import { SessionNotAccessible } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { ComplementaryCertificationCourse } from '../../../../../../src/certification/session-management/domain/models/ComplementaryCertificationCourse.js';
@@ -30,6 +32,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
   const sessionRepository = {};
   const assessmentRepository = {};
+  const assessmentSheetRepository = {};
   const competenceRepository = {};
   const candidateRepository = {};
   const certificationCourseRepository = {};
@@ -41,6 +44,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
   const injectables = {
     assessmentRepository,
+    assessmentSheetRepository,
     competenceRepository,
     candidateRepository,
     certificationCourseRepository,
@@ -64,6 +68,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     candidateRepository.update = sinon.stub();
     certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId = sinon.stub();
     certificationCourseRepository.save = sinon.stub();
+    assessmentSheetRepository.findByCertificationCourseId = sinon.stub();
+    assessmentSheetRepository.update = sinon.stub();
     sessionRepository.get = sinon.stub();
     sessionRepository.update = sinon.stub();
     placementProfileService.getPlacementProfile = sinon.stub();
@@ -186,7 +192,11 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               .withArgs({ sessionId: 1, userId: 2 })
               .resolves(candidateNotAuthorizedToStart);
 
-            const existingCertificationCourse = domainBuilder.buildCertificationCourse({ userId: 2, sessionId: 1 });
+            const existingCertificationCourse = domainBuilder.buildCertificationCourse({
+              userId: 2,
+              sessionId: 1,
+              createdAt: new Date(),
+            });
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
               .withArgs({ userId: 2, sessionId: 1 })
               .resolves(existingCertificationCourse);
@@ -270,6 +280,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
             const existingCertificationCourse = domainBuilder.buildCertificationCourse({
               userId: 2,
               sessionId: 1,
+              createdAt: new Date(),
             });
             existingCertificationCourse.adjustForAccessibility = sinon.stub();
 
@@ -328,6 +339,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               userId: 2,
               sessionId: 1,
               version: AlgorithmEngineVersion.V3,
+              createdAt: new Date(),
             });
             existingCertificationCourse.adjustForAccessibility = sinon.stub();
 
@@ -357,6 +369,113 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 authorizedToStart: false,
               }),
             );
+          });
+
+          context('when the certification duration has been exceeded', function () {
+            it('ends the assessment and throws a CertificationDurationExceededError', async function () {
+              // given
+              const foundSession = domainBuilder.certification.evaluation.buildSession.ongoing({
+                id: 1,
+                accessCode: 'accessCode',
+              });
+              sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
+
+              const foundCandidate = domainBuilder.certification.evaluation.buildCandidate({
+                userId: 2,
+                sessionId: 1,
+                authorizedToStart: true,
+                subscriptionFramework: Frameworks.CORE,
+              });
+              candidateRepository.findByUserIdAndSessionId
+                .withArgs({ sessionId: 1, userId: 2 })
+                .resolves(foundCandidate);
+
+              const existingCertificationCourse = domainBuilder.buildCertificationCourse({
+                id: 99,
+                userId: 2,
+                sessionId: 1,
+                createdAt: new Date('2025-12-30T00:00:00Z'),
+              });
+              certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                .withArgs({ userId: 2, sessionId: 1 })
+                .resolves(existingCertificationCourse);
+
+              const assessmentSheet = new AssessmentSheet({
+                certificationCourseId: 99,
+                assessmentId: 88,
+                state: Assessment.states.STARTED,
+                startedAt: new Date('2025-12-30T00:00:00Z'),
+                answers: [],
+              });
+              assessmentSheetRepository.findByCertificationCourseId.withArgs(99).resolves(assessmentSheet);
+
+              const version = domainBuilder.certification.configuration.buildVersion();
+              versionApi.getByFrameworkAndDate.resolves(version);
+
+              // when
+              const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
+                sessionId: 1,
+                accessCode: 'accessCode',
+                userId: 2,
+                locale: 'fr',
+                ...injectables,
+              });
+
+              // then
+              expect(error).to.be.an.instanceOf(CertificationDurationExceededError);
+              expect(assessmentSheet.state).to.equal(Assessment.states.ENDED_DUE_TO_DURATION_EXCEEDED);
+              expect(assessmentSheetRepository.update).to.have.been.calledOnceWith(assessmentSheet);
+              expect(candidateRepository.update).not.to.have.been.called;
+            });
+
+            context('when no assessment sheet is found', function () {
+              it('throws a CertificationDurationExceededError without updating', async function () {
+                // given
+                const foundSession = domainBuilder.certification.evaluation.buildSession.ongoing({
+                  id: 1,
+                  accessCode: 'accessCode',
+                });
+                sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
+
+                const foundCandidate = domainBuilder.certification.evaluation.buildCandidate({
+                  userId: 2,
+                  sessionId: 1,
+                  authorizedToStart: true,
+                  subscriptionFramework: Frameworks.CORE,
+                });
+                candidateRepository.findByUserIdAndSessionId
+                  .withArgs({ sessionId: 1, userId: 2 })
+                  .resolves(foundCandidate);
+
+                const existingCertificationCourse = domainBuilder.buildCertificationCourse({
+                  id: 99,
+                  userId: 2,
+                  sessionId: 1,
+                  createdAt: new Date('2025-12-30T00:00:00Z'),
+                });
+                certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                  .withArgs({ userId: 2, sessionId: 1 })
+                  .resolves(existingCertificationCourse);
+
+                assessmentSheetRepository.findByCertificationCourseId.withArgs(99).resolves(null);
+
+                const version = domainBuilder.certification.configuration.buildVersion();
+                versionApi.getByFrameworkAndDate.resolves(version);
+
+                // when
+                const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
+                  sessionId: 1,
+                  accessCode: 'accessCode',
+                  userId: 2,
+                  locale: 'fr',
+                  ...injectables,
+                });
+
+                // then
+                expect(error).to.be.an.instanceOf(CertificationDurationExceededError);
+                expect(assessmentSheetRepository.update).not.to.have.been.called;
+              });
+            });
           });
         });
 

--- a/api/tests/certification/evaluation/unit/infrastructure/serializers/certification-course-serializer_test.js
+++ b/api/tests/certification/evaluation/unit/infrastructure/serializers/certification-course-serializer_test.js
@@ -12,23 +12,21 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
       const assessment = new Assessment({
         id: 'assessment_id',
       });
-      const certificationCourse = new CertificationCourse({
-        id: 1,
-        assessment: assessment,
-        challenges: ['challenge1', 'challenge2'],
-        certificationIssueReports: [],
-        version: 2,
-        isAdjustedForAccessibility: true,
-      });
-
       const issueReport = new CertificationIssueReport({
         id: 1234,
         description: "Signalement de l'examinateur",
         category: CertificationIssueReportCategory.OTHER,
-        certificationCourseId: certificationCourse.getId(),
+        certificationCourseId: 1,
       });
 
-      certificationCourse.reportIssue(issueReport);
+      const certificationCourse = new CertificationCourse({
+        id: 1,
+        assessment: assessment,
+        challenges: ['challenge1', 'challenge2'],
+        certificationIssueReports: [issueReport],
+        version: 2,
+        isAdjustedForAccessibility: true,
+      });
 
       const jsonCertificationCourseWithAssessment = {
         data: {

--- a/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
@@ -340,34 +340,4 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
       });
     });
   });
-
-  describe('#adjustForAccessibility', function () {
-    describe('when an adjustment is needed', function () {
-      it('sets the certification adjustment property to true', function () {
-        // given
-        const certificationCourse = new CertificationCourse();
-        const isAdjustmentNeeded = true;
-
-        // when
-        certificationCourse.adjustForAccessibility(isAdjustmentNeeded);
-
-        // then
-        expect(certificationCourse.isAdjustementNeeded()).to.be.true;
-      });
-    });
-
-    describe('when an adjustment is not needed', function () {
-      it('sets the certification adjustment property to false', function () {
-        // given
-        const certificationCourse = new CertificationCourse();
-        const isAdjustmentNeeded = false;
-
-        // when
-        certificationCourse.adjustForAccessibility(isAdjustmentNeeded);
-
-        // then
-        expect(certificationCourse.isAdjustementNeeded()).to.be.false;
-      });
-    });
-  });
 });

--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -185,6 +185,8 @@ export default class CertificationStarter extends Component {
       const interpolationValues =
         errorCode === 'CENTER_HABILITATION_ERROR' ? { subscription: this.subscriptionLabel, htmlSafe: true } : {};
       this.apiErrorMessage = this.intl.t(FORBIDDEN_ERROR_MESSAGE_KEYS[errorCode], interpolationValues);
+    } else if (errorCode === 'CERTIFICATION_DURATION_EXCEEDED') {
+      this.apiErrorMessage = this.intl.t('pages.certification-start.error-messages.duration-exceeded');
     } else {
       this.technicalErrorInformation = `${error.message} ${error.stack}`;
       this.apiErrorMessage = this.intl.t('pages.certification-start.error-messages.generic');

--- a/mon-pix/tests/integration/components/certification-starter-test.gjs
+++ b/mon-pix/tests/integration/components/certification-starter-test.gjs
@@ -457,6 +457,22 @@ module('Integration | Component | certification-starter', function (hooks) {
           assert.ok(screen.getByText(t('pages.certification-start.error-messages.session-not-accessible')));
         });
 
+        test('should display the appropriate error message when the certification duration has been exceeded', async function (assert) {
+          // given
+          this.certificationCourse.save.rejects({
+            errors: [{ status: '409', code: 'CERTIFICATION_DURATION_EXCEEDED' }],
+          });
+          const screen = await renderComponent();
+          await fillAccessCode(screen, 'ABC123');
+          await confirmLanguageSelection(screen);
+
+          // when
+          await submitForm();
+
+          // then
+          assert.ok(screen.getByText(t('pages.certification-start.error-messages.duration-exceeded')));
+        });
+
         module('when error status is 403', function () {
           test('should display the appropriate error message when error candidate not authorized to join session', async function (assert) {
             // given

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -964,6 +964,7 @@
         "access-code-error": "Dieser Code existiert nicht oder ist nicht mehr gültig.",
         "candidate-not-authorized-to-resume": "Bitte wende dich an deine Aufsichtsperson, damit diese die Wiederaufnahme deines Tests genehmigt.",
         "candidate-not-authorized-to-start": "Deine Aufsichtsperson hat deine Anwesenheit im Testraum nicht bestätigt. Du kannst daher noch nicht mit deinem Zertifizierungstest beginnen. Bitte informiere deine Aufsichtsperson.",
+        "duration-exceeded": "Die maximale Dauer deines Zertifizierungstests wurde überschritten. Du kannst ihn nicht mehr fortsetzen.",
         "generic": "Ein unerwarteter Serverfehler ist aufgetreten.",
         "missing-code": "Dein Zugangscode ist nicht ausgefüllt.",
         "session-not-accessible": "Die Zertifizierungssitzung ist nicht mehr zugänglich.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -964,6 +964,7 @@
         "access-code-error": "This code does not exist or is no longer valid.",
         "candidate-not-authorized-to-resume": "Please contact your invigilator to resume your certification test.",
         "candidate-not-authorized-to-start": "Your invigilator has not confirmed your presence in the test room. Therefore, you cannot start your certification test yet. Please inform your invigilator.",
+        "duration-exceeded": "The maximum duration of your certification test has been exceeded. You can no longer resume it.",
         "generic": "An unexpected server error has occurred.",
         "missing-code": "You have not entered your access code.",
         "session-not-accessible": "The certification session is no longer available.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -964,6 +964,7 @@
         "access-code-error": "Este código no existe o ya no es válido.",
         "candidate-not-authorized-to-resume": "Ponte en contacto con el supervisor para que autorice la reanudación de tu examen.",
         "candidate-not-authorized-to-start": "El supervisor no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al vigilante.",
+        "duration-exceeded": "Se ha superado la duración máxima de tu prueba de certificación. Ya no puedes reanudarla.",
         "generic": "Acaba de producirse un error inesperado en el servidor.",
         "missing-code": "No has introducido tu código de acceso.",
         "session-not-accessible": "La sesión de certificación ya no está disponible.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -964,6 +964,7 @@
         "access-code-error": "Ce code n’existe pas ou n’est plus valide.",
         "candidate-not-authorized-to-resume": "Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test.",
         "candidate-not-authorized-to-start": "Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.",
+        "duration-exceeded": "La durée maximale de votre test de certification a été dépassée. Vous ne pouvez plus le reprendre.",
         "generic": "Une erreur serveur inattendue vient de se produire.",
         "missing-code": "Votre code d'accès n'est pas renseigné.",
         "session-not-accessible": "La session de certification n'est plus accessible.",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -964,6 +964,7 @@
         "access-code-error": "Questo codice non esiste o non è più valido.",
         "candidate-not-authorized-to-resume": "Contatta il sorvegliante per autorizzare la ripresa della prova.",
         "candidate-not-authorized-to-start": "Il sorvegliante non ha confermato la tua presenza in aula. Pertanto, non è ancora possibile iniziare il test di certificazione. Informa il sorvegliante.",
+        "duration-exceeded": "La durata massima della tua prova di certificazione è stata superata. Non puoi più riprenderla.",
         "generic": "Si è appena verificato un errore inatteso del server.",
         "missing-code": "Il codice di accesso non è stato inserito.",
         "session-not-accessible": "La sessione di certificazione non è più accessibile.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -964,6 +964,7 @@
         "access-code-error": "Deze code bestaat niet of is niet langer geldig.",
         "candidate-not-authorized-to-resume": "Neem contact op met je surveillant om toestemming te vragen om je toets te hervatten.",
         "candidate-not-authorized-to-start": "Je surveillant heeft je aanwezigheid in de testruimte nog niet bevestigd. Je kunt daarom nog niet beginnen met je certificeringstoets. Stel je surveillant hiervan op de hoogte.",
+        "duration-exceeded": "De maximale duur van je certificeringstoets is overschreden. Je kunt de toets niet meer hervatten.",
         "generic": "Er is zojuist een onverwachte serverfout opgetreden.",
         "missing-code": "You have not entered your access code.",
         "session-not-accessible": "De certificeringssessie is niet langer toegankelijk.",


### PR DESCRIPTION
## 🪧 Problème

Après https://github.com/1024pix/pix/pull/16725 - où on évitait à un candidat de répondre 24h après le début de sa certif - on veut maintenant éviter à un candidat de repasser par le formulaire de mot de passe de session pour la reprendre, après 24h.

## 🌈 Proposition

Empêcher un candidat de reprendre sa certification dès 24h après son début.

## 🎉 Pour tester

Plus facilement reproductible en local :
- Démarrer une certification 
- Modifier sa date de début pour qu'elle soit au moins 24h avant
- Retenter de rentrer en session
- Ce qu'on est censé obtenir : 

<img width="706" height="404" alt="image" src="https://github.com/user-attachments/assets/8cbf8eef-cd85-4bdb-bdb9-aa7b68e0b7c7" />

