### PR TITLE
[TECH] Ajouter un log contenant un condensat du code de vérification à chaque appel du endpoint permettant de récupérer les infos d'une certification par code de vérification (PIX-23462)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -662,6 +662,13 @@ REDIRECTION_URL_SECRET=moduleSecret
 # default: false
 # PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED = false
 
+# Secret salt value used to hash certification verification code for logging it
+#
+# presence: required
+# type: String
+# default: 'local'
+# CERTIFICATION_VERIFICATION_CODE_LOG_HASH_SECRET=
+
 # ===================
 # SAML CONFIGURATION
 # ===================

--- a/api/src/certification/evaluation/application/api/certification-evaluation-api.js
+++ b/api/src/certification/evaluation/application/api/certification-evaluation-api.js
@@ -12,8 +12,9 @@
  * @typedef {import ('../../../../shared/domain/models/Challenge.js').Challenge} Challenge
  */
 import { config } from '../../../../shared/config.js';
-import { getRequestId } from '../../../../shared/infrastructure/execution-context-manager.js';
+import { addCorrelationInfos, getRequestId } from '../../../../shared/infrastructure/execution-context-manager.js';
 import { redisMutex } from '../../../../shared/infrastructure/mutex/RedisMutex.js';
+import { SCOPES } from '../../../../shared/infrastructure/utils/logger.js';
 import { NextChallengeAlreadyComputingError } from '../../domain/errors.js';
 import { usecases } from '../../domain/usecases/index.js';
 
@@ -94,5 +95,9 @@ export async function evaluateAndSaveAnswer({ answer, userId, certificationCours
  * @returns {Promise<void>}
  */
 export async function completeCertificationAssessment({ certificationCourseId, locale }) {
+  addCorrelationInfos({
+    certificationId: certificationCourseId,
+    scope: SCOPES.CERTIFICATION,
+  });
   return usecases.completeCertificationAssessment({ certificationCourseId, locale });
 }

--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -1,6 +1,10 @@
 import dayjs from 'dayjs';
 
+import { config } from '../../../shared/config.js';
+import { addCorrelationInfos } from '../../../shared/infrastructure/execution-context-manager.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
+import { generateHash } from '../../../shared/infrastructure/utils/crypto.js';
+import { SCOPES } from '../../../shared/infrastructure/utils/logger.js';
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { normalizeAndRemoveAccents } from '../../../shared/infrastructure/utils/string-utils.js';
 import { Certificate } from '../domain/models/v3/Certificate.js';
@@ -18,6 +22,12 @@ async function getCertificateByVerificationCode(request, h, dependencies = { cer
 
   let certificate;
   const verificationCode = request.payload.verificationCode;
+  addCorrelationInfos({
+    hashedVerificationCode: generateHash(verificationCode, {
+      salt: config.logging.certificationVerificationCodeLogHashSecret,
+    }),
+    scope: SCOPES.CERTIFICATION,
+  });
 
   const certificationCourse = await usecases.getCertificationCourseByVerificationCode({ verificationCode });
 

--- a/api/src/evaluation/infrastructure/repositories/certification-evaluation-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/certification-evaluation-repository.js
@@ -2,9 +2,6 @@
  * @typedef {import ('./index.js').CertificationEvaluationApi} CertificationEvaluationApi
  */
 
-import { addCorrelationInfo } from '../../../shared/infrastructure/execution-context-manager.js';
-import { SCOPES } from '../../../shared/infrastructure/utils/logger.js';
-
 /**
  * @function
  * @param {object} params
@@ -14,15 +11,9 @@ import { SCOPES } from '../../../shared/infrastructure/utils/logger.js';
  *
  * @returns {Promise<void>}
  */
-export const completeCertificationAssessment = async function ({
-  certificationCourseId,
-  locale,
-  certificationEvaluationApi,
-}) {
-  addCorrelationInfo('certificationId', certificationCourseId);
-  addCorrelationInfo('scope', SCOPES.CERTIFICATION);
+export async function completeCertificationAssessment({ certificationCourseId, locale, certificationEvaluationApi }) {
   return certificationEvaluationApi.completeCertificationAssessment({
     certificationCourseId,
     locale,
   });
-};
+}

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -393,6 +393,8 @@ const configuration = (function () {
       enableLogEndingEventDispatch: toBoolean(process.env.LOG_ENDING_EVENT_DISPATCH),
       opsEventIntervalInSeconds: process.env.OPS_EVENT_INTERVAL_IN_SECONDS || 15,
       debugSections: process.env.LOG_DEBUG?.split(',') ?? [],
+      certificationVerificationCodeLogHashSecret:
+        process.env.CERTIFICATION_VERIFICATION_CODE_LOG_HASH_SECRET || 'local',
     },
     login: {
       temporaryBlockingThresholdFailureCount: _getNumber(

--- a/api/src/shared/infrastructure/execution-context-manager.js
+++ b/api/src/shared/infrastructure/execution-context-manager.js
@@ -163,6 +163,19 @@ export function addCorrelationInfo(path, value) {
 }
 
 /**
+ * Adds or overwrites multiple values using lodash paths (e.g. 'foo.bar').
+ * These values are added to the dedicated correlation metadata object.
+ * Intermediate keys are created automatically if they do not exist.
+ *
+ * @param {Record<string, *>} correlationInfos - An object whose keys are lodash paths and whose values are the corresponding values to store.
+ */
+export function addCorrelationInfos(correlationInfos) {
+  for (const [path, value] of Object.entries(correlationInfos)) {
+    setInContext(CORRELATION_METADATA + '.' + path, value);
+  }
+}
+
+/**
  * Wrap every request execution in an ExecutionContext.
  * @throws {Error} If the Hapi Request prototype cannot be found.
  */

--- a/api/src/shared/infrastructure/utils/crypto.js
+++ b/api/src/shared/infrastructure/utils/crypto.js
@@ -1,9 +1,23 @@
 import crypto from 'node:crypto';
 
-export function generateHash(data) {
+/**
+ * Generates a SHA-256 hash of the data
+ *
+ * @param {string} data
+ * @param {Object} [options]
+ * @param {string} [options.salt]
+ * @returns {string|null}
+ */
+export function generateHash(data, { salt } = {}) {
   if (!data) return null;
 
   const hash = crypto.createHash('sha256');
+
+  if (salt) {
+    hash.update(salt);
+  }
+
   hash.update(data);
+
   return hash.digest('hex');
 }

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -4,7 +4,7 @@ import pino from 'pino';
 import pretty from 'pino-pretty';
 
 import { config } from '../../config.js';
-import { getCorrelationInfo } from '../execution-context-manager.js';
+import { CORRELATION_METADATA, getCorrelationInfo } from '../execution-context-manager.js';
 
 const { logging } = config;
 
@@ -140,6 +140,7 @@ function messageFormatCompact(log, messageKey, _logLevel, { colors }) {
         request_id: req.request_id,
         scriptId: req.scriptId,
         jobId: req.jobId,
+        [CORRELATION_METADATA]: req[CORRELATION_METADATA],
       }),
     );
 

--- a/api/tests/shared/unit/infrastructure/execution-context-manager_test.js
+++ b/api/tests/shared/unit/infrastructure/execution-context-manager_test.js
@@ -1,7 +1,9 @@
+import { expect } from 'chai';
 import sinon from 'sinon';
 
 import {
   addCorrelationInfo,
+  addCorrelationInfos,
   CORRELATION_METADATA,
   executeInContext,
   EXECUTORS,
@@ -11,7 +13,6 @@ import {
   getRequestId,
   setInContext,
 } from '../../../../src/shared/infrastructure/execution-context-manager.js';
-import { expect } from '../../../test-helper.js';
 
 describe('Shared | Unit | Infrastructure | execution-context-manager', function () {
   describe('#getCorrelationContext', function () {
@@ -244,6 +245,91 @@ describe('Shared | Unit | Infrastructure | execution-context-manager', function 
 
       // when
       addCorrelationInfo('sessionId', 456);
+      const result = executeInContext(context, () => {
+        setInContext('irrelevant', 'info');
+        return getCorrelationInfo();
+      });
+
+      // then
+      expect(result).to.deep.equal({
+        request_id: null,
+        user_id: null,
+        jobId: null,
+        scriptId: null,
+        [CORRELATION_METADATA]: null,
+      });
+    });
+  });
+
+  describe('#addCorrelationInfos', function () {
+    it('should add values in given paths destined to be available in correlation info', function () {
+      // given
+      const context = {};
+
+      // when
+      const result = executeInContext(context, () => {
+        setInContext('irrelevant', 'info');
+        addCorrelationInfos({
+          sessionId: 456,
+          userId: 789,
+        });
+        return getCorrelationInfo();
+      });
+
+      // then
+      expect(result).to.deep.equal({
+        request_id: null,
+        user_id: null,
+        jobId: null,
+        scriptId: null,
+        [CORRELATION_METADATA]: {
+          sessionId: 456,
+          userId: 789,
+        },
+      });
+    });
+
+    it('should overwrite value in given path destined to be available in correlation info', function () {
+      // given
+      const context = {};
+
+      // when
+      const result = executeInContext(context, () => {
+        setInContext('irrelevant', 'info');
+        addCorrelationInfos({
+          sessionId: 456,
+          userId: 789,
+        });
+        addCorrelationInfos({
+          sessionId: 111,
+          organizationId: 222,
+        });
+        return getCorrelationInfo();
+      });
+
+      // then
+      expect(result).to.deep.equal({
+        request_id: null,
+        user_id: null,
+        jobId: null,
+        scriptId: null,
+        [CORRELATION_METADATA]: {
+          sessionId: 111,
+          userId: 789,
+          organizationId: 222,
+        },
+      });
+    });
+
+    it('should ignore info added outside of the context', function () {
+      // given
+      const context = {};
+
+      // when
+      addCorrelationInfos({
+        sessionId: 111,
+        organizationId: 222,
+      });
       const result = executeInContext(context, () => {
         setInContext('irrelevant', 'info');
         return getCorrelationInfo();

--- a/api/tests/shared/unit/infrastructure/utils/crypto_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/crypto_test.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+import { generateHash } from '../../../../../src/shared/infrastructure/utils/crypto.js';
+
+describe('Shared | Unit | Utils | crypto', function () {
+  describe('#generateHash', function () {
+    it('returns null when data is missing', function () {
+      expect(generateHash()).to.be.null;
+      expect(generateHash(null)).to.be.null;
+      expect(generateHash('')).to.be.null;
+    });
+
+    it('returns the same hash for the same input', function () {
+      expect(generateHash('hello')).to.equal(generateHash('hello'));
+    });
+
+    it('returns different hashes for different inputs', function () {
+      expect(generateHash('hello')).to.not.equal(generateHash('world'));
+    });
+
+    it('returns a different hash when a salt is provided', function () {
+      expect(generateHash('hello')).to.not.equal(generateHash('hello', { salt: 'my-salt' }));
+    });
+
+    it('returns the same hash for the same data and salt', function () {
+      expect(generateHash('hello', { salt: 'my-salt' })).to.equal(generateHash('hello', { salt: 'my-salt' }));
+    });
+
+    it('returns different hashes for different salts', function () {
+      expect(generateHash('hello', { salt: 'salt-1' })).to.not.equal(generateHash('hello', { salt: 'salt-2' }));
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

L'équipe sécu constate parfois d'importants volumes d'appels sur le endpoint `/api/shared-certification`.
Le code de vérification étant contenu dans le payload, il leur est impossible via Datadog de vérifier si c'est un utilisateur qui insiste avec le même code, ou bien si il s'agit de tentatives de scrapping.
Ils nous ont donc demandé de pouvoir disposer d'un hash du code de vérification afin de vérifier rapidement si on a bien des tentatives sur des codes différents

## 🌈 Proposition

Ajouter dans un log de corrélation le hash du code de vérification (assorti par un petit sel défini en variable d'environnement).
Sur datadog, retrouver les logs concernés via `@pix-metadata.hashedVerificationCode`

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
Afficher les logs chez soi et vérifier la présence du log
Testé en local sur deux codes différents (screen), et aussi avec le même code mais sel différent (pas screen il faudra me croire sur parole ✝️ )
<img width="1845" height="96" alt="image" src="https://github.com/user-attachments/assets/56acf907-1529-44e5-be0a-096924d79172" />

