### PR TITLE
[TECH] Remplacer @json2csv/plainjs par @json2csv/node

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -25,7 +25,6 @@
         "@hapi/yar": "^11.0.3",
         "@joi/date": "^2.1.1",
         "@json2csv/node": "^7.0.2",
-        "@json2csv/plainjs": "^7.0.2",
         "@pdf-lib/fontkit": "^1.1.1",
         "@xmldom/xmldom": "^0.9.10",
         "bcrypt": "^6.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -107,7 +107,6 @@
     "@hapi/yar": "^11.0.3",
     "@joi/date": "^2.1.1",
     "@json2csv/node": "^7.0.2",
-    "@json2csv/plainjs": "^7.0.2",
     "@pdf-lib/fontkit": "^1.1.1",
     "@xmldom/xmldom": "^0.9.10",
     "bcrypt": "^6.0.0",

--- a/api/src/certification/enrolment/application/session-mass-import-controller.js
+++ b/api/src/certification/enrolment/application/session-mass-import-controller.js
@@ -48,7 +48,7 @@ const getTemplate = async function (request, h) {
   const { habilitationLabels, shouldDisplayBillingModeColumns } = await usecases.getMassImportTemplateInformation({
     centerId: request.params.certificationCenterId,
   });
-  const csvTemplateFileContent = getCsvHeaders({
+  const csvTemplateFileContent = await getCsvHeaders({
     habilitationLabels,
     shouldDisplayBillingModeColumns,
   });

--- a/api/src/certification/enrolment/infrastructure/utils/sessions-import.js
+++ b/api/src/certification/enrolment/infrastructure/utils/sessions-import.js
@@ -1,20 +1,13 @@
-import { Parser } from '@json2csv/plainjs';
-
+import { generateCSVTemplate } from '../../../../shared/infrastructure/serializers/csv/csv-template.js';
 import {
   COMPLEMENTARY_CERTIFICATION_SUFFIX,
   headers,
 } from '../../../shared/infrastructure/utils/csv/sessions-import.js';
 
-function getCsvHeaders({ habilitationLabels, shouldDisplayBillingModeColumns = true }) {
+async function getCsvHeaders({ habilitationLabels, shouldDisplayBillingModeColumns = true }) {
   const complementaryCertificationsHeaders = _getComplementaryCertificationsHeaders(habilitationLabels);
   const fields = _getHeadersAsArray(complementaryCertificationsHeaders, shouldDisplayBillingModeColumns);
-  const json2csvParser = new Parser({
-    withBOM: true,
-    includeEmptyRows: false,
-    fields,
-    delimiter: ';',
-  });
-  return json2csvParser.parse([]);
+  return generateCSVTemplate(fields);
 }
 
 function _getComplementaryCertificationsHeaders(habilitationLabels) {

--- a/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
+++ b/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
@@ -24,7 +24,7 @@ async function anonymizeGarData(request, h) {
 const getTemplateForAnonymizeGarData = async function (request, h) {
   const fields = ANONYMIZE_GAR_DATA_HEADER.columns.map(({ name }) => name);
 
-  const csvTemplateFileContent = generateCSVTemplate(fields);
+  const csvTemplateFileContent = await generateCSVTemplate(fields);
 
   return h
     .response(csvTemplateFileContent)

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
@@ -18,7 +18,7 @@ const archiveCertificationCenter = async function (request, h) {
 };
 
 const getTemplateForArchiveInBatch = async function (request, h) {
-  const csvTemplateFileContent = generateCSVTemplate(requiredFieldNamesForCertificationCenterBatchArchive);
+  const csvTemplateFileContent = await generateCSVTemplate(requiredFieldNamesForCertificationCenterBatchArchive);
 
   return h
     .response(csvTemplateFileContent)

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -21,7 +21,7 @@ const ADD_TAGS_TO_ORGANIZATIONS_HEADER = organizationTagCsvParser.CSV_HEADER;
 
 const getTemplateForAddTagsToOrganizations = async function (request, h) {
   const fields = ADD_TAGS_TO_ORGANIZATIONS_HEADER.columns.map(({ name }) => name);
-  const csvTemplateFileContent = generateCSVTemplate(fields);
+  const csvTemplateFileContent = await generateCSVTemplate(fields);
 
   return h
     .response(csvTemplateFileContent)
@@ -63,7 +63,7 @@ const detachParentOrganization = async function (request, h) {
 
 const getTemplateForAddOrganizationFeatureInBatch = async function (request, h) {
   const fields = ORGANIZATION_FEATURES_HEADER.columns.map(({ name }) => name);
-  const csvTemplateFileContent = generateCSVTemplate(fields);
+  const csvTemplateFileContent = await generateCSVTemplate(fields);
 
   return h
     .response(csvTemplateFileContent)
@@ -91,7 +91,7 @@ const create = async function (request) {
 };
 
 const getTemplateForCreateOrganizationsInBatch = async function (request, h) {
-  const csvTemplateFileContent = generateCSVTemplate(requiredFieldNamesForOrganizationsImport);
+  const csvTemplateFileContent = await generateCSVTemplate(requiredFieldNamesForOrganizationsImport);
 
   return h
     .response(csvTemplateFileContent)
@@ -109,7 +109,7 @@ const createInBatch = async function (request, h) {
 };
 
 const getTemplateForArchiveOrganizationsInBatch = async function (request, h) {
-  const csvTemplateFileContent = generateCSVTemplate(requiredFieldNamesForOrganizationBatchArchive);
+  const csvTemplateFileContent = await generateCSVTemplate(requiredFieldNamesForOrganizationBatchArchive);
 
   return h
     .response(csvTemplateFileContent)
@@ -146,7 +146,7 @@ const getOrganizationPlacesStatistics = async function (
 
 const getTemplateForUpdateOrganizationsInBatch = async function (request, h) {
   const fields = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name);
-  const csvTemplateFileContent = generateCSVTemplate(fields);
+  const csvTemplateFileContent = await generateCSVTemplate(fields);
 
   return h
     .response(csvTemplateFileContent)

--- a/api/src/prescription/campaign/application/campaign-administration-controller.js
+++ b/api/src/prescription/campaign/application/campaign-administration-controller.js
@@ -14,9 +14,9 @@ import * as csvCampaignsIdsParser from '../infrastructure/serializers/csv/csv-ca
 import { campaignManagementSerializer } from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
 import { campaignReportSerializer } from '../infrastructure/serializers/jsonapi/campaign-report-serializer.js';
 
-const getTemplateForCreateCampaigns = (request, h) => {
+const getTemplateForCreateCampaigns = async (request, h) => {
   const fields = CAMPAIGNS_HEADER.columns.map(({ name }) => name);
-  const csvTemplateFileContent = generateCSVTemplate(fields);
+  const csvTemplateFileContent = await generateCSVTemplate(fields);
 
   return h
     .response(csvTemplateFileContent)

--- a/api/src/quest/application/quest-controller.js
+++ b/api/src/quest/application/quest-controller.js
@@ -17,7 +17,7 @@ const getQuestResults = async function (request, h, dependencies = { questResult
 
 const getTemplateForCreateOrUpdateQuestsInBatch = async function (request, h) {
   const fields = QUEST_HEADER.columns.map(({ name }) => name);
-  const csvTemplateFileContent = generateCSVTemplate(fields);
+  const csvTemplateFileContent = await generateCSVTemplate(fields);
 
   return h
     .response(csvTemplateFileContent)

--- a/api/src/shared/infrastructure/serializers/csv/csv-template.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-template.js
@@ -1,11 +1,11 @@
-import { Parser } from '@json2csv/plainjs';
+import { AsyncParser } from '@json2csv/node';
 
-export function generateCSVTemplate(fields) {
-  const json2csvParser = new Parser({
+export async function generateCSVTemplate(fields) {
+  const json2csvParser = new AsyncParser({
     withBOM: true,
     includeEmptyRows: false,
     fields,
     delimiter: ';',
   });
-  return json2csvParser.parse([]);
+  return json2csvParser.parse([]).promise();
 }

--- a/api/src/shared/load-env-file-if-exists.js
+++ b/api/src/shared/load-env-file-if-exists.js
@@ -1,11 +1,11 @@
-import { existsSync } from 'node:fs';
 import * as url from 'node:url';
 
 const envFilePath = url.fileURLToPath(new URL('../../.env', import.meta.url));
 
 export function loadEnvFileIfExists() {
-  // eslint-disable-next-line n/no-sync
-  if (existsSync(envFilePath)) {
+  try {
     process.loadEnvFile(envFilePath);
+  } catch {
+    // we ignore the error when file does not exist
   }
 }

--- a/api/tests/certification/enrolment/integration/infrastructure/utils/sessions-import_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/utils/sessions-import_test.js
@@ -6,11 +6,11 @@ describe('Integration | Infrastructure | Files | sessions-import', function () {
   context('#getCsvHeaders', function () {
     context('when should display billing mode', function () {
       context('when no habilitation labels are passed', function () {
-        it('should return the correct values without complementary certification columns', function () {
+        it('should return the correct values without complementary certification columns', async function () {
           // when
           const habilitationLabels = [];
           const shouldDisplayBillingModeColumns = true;
-          const result = getCsvHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
+          const result = await getCsvHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
 
           // then
           const expectedResult = `${BOM_CHAR}"Numéro de session préexistante";"* Nom du site";"* Nom de la salle";"* Date de début (format: JJ/MM/AAAA)";"* Heure de début (heure locale format: HH:MM)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: JJ/MM/AAAA)";"* Sexe (M ou F)";"Code INSEE de la commune de naissance";"Code postal de la commune de naissance";"Nom de la commune de naissance";"* Pays de naissance";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant externe";"Temps majoré ? (exemple format: 33%)";"* Tarification part Pix (Gratuite, Prépayée ou Payante)";"Code de prépaiement (si Tarification part Pix Prépayée)"`;
@@ -19,13 +19,13 @@ describe('Integration | Infrastructure | Files | sessions-import', function () {
       });
 
       context('when habilitation labels are passed', function () {
-        it('should return the correct values with complementary certification columns', function () {
+        it('should return the correct values with complementary certification columns', async function () {
           // given
           const habilitationLabels = ['Pix 1', 'Pix 2'];
           const shouldDisplayBillingModeColumns = true;
 
           // when
-          const result = getCsvHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
+          const result = await getCsvHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
 
           // then
           const expectedResult = `${BOM_CHAR}"Numéro de session préexistante";"* Nom du site";"* Nom de la salle";"* Date de début (format: JJ/MM/AAAA)";"* Heure de début (heure locale format: HH:MM)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: JJ/MM/AAAA)";"* Sexe (M ou F)";"Code INSEE de la commune de naissance";"Code postal de la commune de naissance";"Nom de la commune de naissance";"* Pays de naissance";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant externe";"Temps majoré ? (exemple format: 33%)";"* Tarification part Pix (Gratuite, Prépayée ou Payante)";"Code de prépaiement (si Tarification part Pix Prépayée)";"Pix 1 ('oui' ou laisser vide)";"Pix 2 ('oui' ou laisser vide)"`;
@@ -35,11 +35,11 @@ describe('Integration | Infrastructure | Files | sessions-import', function () {
     });
 
     context('when should not display billing mode', function () {
-      it('should return the correct values without billing mode columns', function () {
+      it('should return the correct values without billing mode columns', async function () {
         // when
         const habilitationLabels = [];
         const shouldDisplayBillingModeColumns = false;
-        const result = getCsvHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
+        const result = await getCsvHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
 
         // then
         const expectedResult = `${BOM_CHAR}"Numéro de session préexistante";"* Nom du site";"* Nom de la salle";"* Date de début (format: JJ/MM/AAAA)";"* Heure de début (heure locale format: HH:MM)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: JJ/MM/AAAA)";"* Sexe (M ou F)";"Code INSEE de la commune de naissance";"Code postal de la commune de naissance";"Nom de la commune de naissance";"* Pays de naissance";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant externe";"Temps majoré ? (exemple format: 33%)"`;

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-template_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-template_test.js
@@ -5,8 +5,8 @@ const BOM_CHAR = '\ufeff';
 
 describe('Unit | Serializer | CSV | csv-template', function () {
   describe('#generateCSVTemplate', function () {
-    it('should return template with columns', function () {
-      const template = generateCSVTemplate(['Column1', 'Column2']);
+    it('should return template with columns', async function () {
+      const template = await generateCSVTemplate(['Column1', 'Column2']);
 
       expect(template).to.equal(`${BOM_CHAR}"Column1";"Column2"`);
     });


### PR DESCRIPTION
## 🪧 Problème

La librairie `@json2csv/plainjs` utilisée pour convertir un json en csv est synchrone et bloquante ([source](https://juanjodiaz.github.io/json2csv/#/parsers/parser)) :
> This loads the entire JSON in memory and do the whole processing in-memory while blocking Javascript event loop. For that reason is rarely a good reason to use it until your data is very small or your application doesn't do anything else.

## 🌈 Proposition

On utilise aussi la librairie **`@json2csv/node`** dans le code et celle-ci n'est pas bloquante (asynchrone).

Remplacer `@json2csv/plainjs` par **`@json2csv/node`** (qui existe déjà dans le package.json)

## ✊ Remarques

**Scout:** ne pas utiliser `fs.existSync` dans `loadEnvFileIfExists` pour diminuer les risques de blocage de l'event loop.

## 🎉 Pour tester

Les tests doivent passer.
