### PR TITLE
[BUGFIX] Forcer la pleine largeur de la carte de parcours dans la page de création de campagne (PIX-23466)

### DIFF
--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -20,7 +20,6 @@
 }
 
 .form__field-with-info {
-
   .pix-multi-select {
     @include breakpoints.device-is('desktop') {
       width: 140px;
@@ -47,8 +46,13 @@
       flex-direction: column;
       align-items: flex-start;
 
-      &__label, .course-card {
+      &__label,
+      .course-card {
         margin-bottom: var(--pix-spacing-4x);
+      }
+
+      .course-card {
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
## 🪧 Problème

Une nouvelle page de création de parcours intégrant le catalogue est en cours de développement. Une fois un parcours sélectionné, dans le cas où le titre de ce parcours est trop court, la carte ne prend pas toute la largeur du formulaire, ne donnant pas le design attendu.

## 🌈 Proposition

Forcer la pleine largeur pour cette carte de parcours dans la nouvelle page de création de campagne.

## 🎉 Pour tester

Se connecter à Pix Orga
Se rendre sur le catalogue
Sélectionner un élément du catalogue avec un titre court (qui tient en 2/3 mots) 
Accéder via cet élément à la page de création de campagne
Voir que la carte prend la même largeur que le formulaire désormais