### PR TITLE
[TECH] Utiliser FormData natif au lieu de la lib form-data

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -86,7 +86,6 @@
         "eslint-plugin-mocha": "^11.2.0",
         "eslint-plugin-n": "^18.0.0",
         "eslint-plugin-unicorn": "^64.0.0",
-        "form-data": "^4.0.0",
         "jsdoc-to-markdown": "^9.0.0",
         "knip": "^6.17.1",
         "mocha": "^11.7.5",

--- a/api/package.json
+++ b/api/package.json
@@ -168,7 +168,6 @@
     "eslint-plugin-mocha": "^11.2.0",
     "eslint-plugin-n": "^18.0.0",
     "eslint-plugin-unicorn": "^64.0.0",
-    "form-data": "^4.0.0",
     "jsdoc-to-markdown": "^9.0.0",
     "knip": "^6.17.1",
     "mocha": "^11.7.5",

--- a/api/tests/certification/enrolment/unit/application/enrolment-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/enrolment-route_test.js
@@ -1,4 +1,3 @@
-import FormData from 'form-data';
 import sinon from 'sinon';
 
 import { enrolmentController } from '../../../../../src/certification/enrolment/application/enrolment-controller.js';
@@ -7,6 +6,7 @@ import { authorization } from '../../../../../src/certification/shared/applicati
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
+import { convertFormDataToPayload } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Certification | Enrolment | Unit | Application | Routes', function () {
   describe('PUT /api/session/{sessionId}/enrol-students-to-session', function () {
@@ -90,11 +90,13 @@ describe('Certification | Enrolment | Unit | Application | Routes', function () 
     let headers;
     let payload;
 
-    beforeEach(function () {
-      const form = new FormData();
-      form.append('file', Buffer.alloc(0), { filename: 'test-file' });
-      headers = form.getHeaders();
-      payload = form.getBuffer();
+    beforeEach(async function () {
+      const formData = new FormData();
+      formData.append('file', new Blob([Buffer.alloc(0)], { type: 'text/csv' }), 'import-candidates.csv');
+
+      const payloadData = await convertFormDataToPayload(formData);
+      payload = payloadData.payload;
+      headers = new Headers({ 'content-type': payloadData.contentType });
     });
 
     it('should exist', async function () {

--- a/api/tests/certification/enrolment/unit/application/session-mass-import-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/session-mass-import-route_test.js
@@ -1,4 +1,3 @@
-import FormData from 'form-data';
 import sinon from 'sinon';
 
 import { sessionMassImportController } from '../../../../../src/certification/enrolment/application/session-mass-import-controller.js';
@@ -6,17 +5,20 @@ import { sessionMassImportRoute as moduleUnderTest } from '../../../../../src/ce
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect } from '../../../../test-helper.js';
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
+import { convertFormDataToPayload } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Unit | Router | session-mass-import-route', function () {
   describe('POST /api/certification-centers/{certificationCenterId}/sessions/validate-for-mass-import', function () {
     let headers;
     let payload;
 
-    beforeEach(function () {
-      const form = new FormData();
-      form.append('file', Buffer.alloc(0), { filename: 'test-file' });
-      headers = form.getHeaders();
-      payload = form.getBuffer();
+    beforeEach(async function () {
+      const formData = new FormData();
+      formData.append('file', new Blob([Buffer.alloc(0)], { type: 'text/csv' }), 'import-sessions.csv');
+
+      const payloadData = await convertFormDataToPayload(formData);
+      payload = payloadData.payload;
+      headers = new Headers({ 'content-type': payloadData.contentType });
     });
 
     it('should exist', async function () {

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -247,6 +247,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
         assessmentUpdatedAt: new Date('2022-01-01'),
         lastQuestionDate: new Date('2021-09-09'),
       };
+      sinon.useFakeTimers({ now: new Date('2025-03-03'), toFake: ['Date'] });
     });
 
     it('should update lastAnswerAt and certificationCourseUpdatedAt to provided date', function () {

--- a/api/tests/quest/acceptance/application/attestation-route_test.js
+++ b/api/tests/quest/acceptance/application/attestation-route_test.js
@@ -1,5 +1,3 @@
-import FormData from 'form-data';
-
 import { createServer } from '../../../../server.js';
 import { PIX_ADMIN } from '../../../../src/shared/domain/constants.js';
 import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
@@ -7,7 +5,10 @@ import { expect } from '../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../tooling/databases.js';
 import { AttestationTemplateFixture } from '../../../tooling/fixtures/index.js';
 import { mockAttestationStorageUpload } from '../../../tooling/mocks/attestation-storage.mock.js';
-import { generateAuthenticatedUserRequestHeaders } from '../../../tooling/test-utils/http-server.js';
+import {
+  convertFormDataToPayload,
+  generateAuthenticatedUserRequestHeaders,
+} from '../../../tooling/test-utils/http-server.js';
 
 describe('Quest | Acceptance | Application | Attestation Route ', function () {
   let server;
@@ -24,34 +25,33 @@ describe('Quest | Acceptance | Application | Attestation Route ', function () {
         userId = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.SUPER_ADMIN }).id;
         await databaseBuilder.commit();
       });
+
       context('when all parameters are valid', function () {
         it('creates attestation', async function () {
           const templateKey = 'key';
           const templateName = 'name';
           const label = 'label';
 
+          const file = await AttestationTemplateFixture.getFile();
           const formData = new FormData();
           formData.append('templateKey', templateKey);
           formData.append('templateName', templateName);
-          const templateFile = await AttestationTemplateFixture.getFile();
-          formData.append('templateFile', templateFile, {
-            filename: 'attestation-template.pdf',
-            contentType: 'application/pdf',
-          });
+          formData.append('templateFile', new Blob([file], { type: 'application/pdf' }), 'attestation-template.pdf');
           formData.append('label', label);
           mockAttestationStorageUpload({ attestation: { templateName } });
-          const options = {
+
+          const { payload, contentType } = await convertFormDataToPayload(formData);
+
+          // when
+          const response = await server.inject({
             method: 'POST',
             url: '/api/admin/attestations',
             headers: {
-              ...formData.getHeaders(),
+              'content-type': contentType,
               ...generateAuthenticatedUserRequestHeaders({ userId }),
             },
-            payload: formData.getBuffer(),
-          };
-
-          // when
-          const response = await server.inject(options);
+            payload,
+          });
 
           // then
           const createdAttestation = await knex('attestations').where('key', templateKey).first();
@@ -68,21 +68,24 @@ describe('Quest | Acceptance | Application | Attestation Route ', function () {
           const formData = new FormData();
           formData.append('templateKey', 'key');
           formData.append('templateName', 'name');
+          formData.append(
+            'templateFile',
+            new Blob([Buffer.alloc(0)], { type: 'application/jpeg' }),
+            'attestation-template.jpeg',
+          );
 
-          formData.append('templateFile', Buffer.alloc(0), { filename: 'testFile_temp.jpeg' });
+          const { payload, contentType } = await convertFormDataToPayload(formData);
 
-          const options = {
+          // when
+          const response = await server.inject({
             method: 'POST',
             url: '/api/admin/attestations',
             headers: {
-              ...formData.getHeaders(),
+              'Content-Type': contentType,
               ...generateAuthenticatedUserRequestHeaders({ userId }),
             },
-            payload: formData.getBuffer(),
-          };
-
-          // when
-          const response = await server.inject(options);
+            payload,
+          });
 
           // then
           expect(response.statusCode).to.equal(400);

--- a/api/tests/quest/unit/application/attestation-route_test.js
+++ b/api/tests/quest/unit/application/attestation-route_test.js
@@ -1,4 +1,3 @@
-import FormData from 'form-data';
 import sinon from 'sinon';
 
 import { attestationController } from '../../../../src/quest/application/attestation-controller.js';
@@ -8,7 +7,10 @@ import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js
 import { expect } from '../../../test-helper.js';
 import { AttestationTemplateFixture } from '../../../tooling/fixtures/index.js';
 import { HttpTestServer } from '../../../tooling/server/http-test-server.js';
-import { generateAuthenticatedUserRequestHeaders } from '../../../tooling/test-utils/http-server.js';
+import {
+  convertFormDataToPayload,
+  generateAuthenticatedUserRequestHeaders,
+} from '../../../tooling/test-utils/http-server.js';
 
 describe('Quest | Unit | Routes | Attestation Route', function () {
   describe('POST /api/admin/attestations', function () {
@@ -21,17 +23,19 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(attestationRoute);
 
+        const file = await AttestationTemplateFixture.getFile();
         const formData = new FormData();
         formData.append('templateKey', 'my_key');
         formData.append('templateName', 'my_name');
-        formData.append('templateFile', await AttestationTemplateFixture.getFile());
+        formData.append('templateFile', new Blob([file], { type: 'application/pdf' }), 'attestation-template.pdf');
         formData.append('label', 'attestation label');
 
+        const { payload, contentType } = await convertFormDataToPayload(formData);
         const headers = {
-          ...formData.getHeaders(),
+          'content-type': contentType,
           ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
         };
-        const payload = formData.getBuffer();
+
         // when
         await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
 
@@ -44,6 +48,7 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         ]);
       });
     });
+
     describe('when parameters are invalid', function () {
       it('should fail when templateKey is missing', async function () {
         sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
@@ -52,16 +57,17 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(attestationRoute);
 
+        const file = await AttestationTemplateFixture.getFile();
         const formData = new FormData();
         formData.append('templateName', 'my_name');
-        formData.append('templateFile', await AttestationTemplateFixture.getFile());
+        formData.append('templateFile', new Blob([file], { type: 'application/pdf' }), 'attestation-template.pdf');
         formData.append('label', 'label');
 
+        const { payload, contentType } = await convertFormDataToPayload(formData);
         const headers = {
-          ...formData.getHeaders(),
+          'content-type': contentType,
           ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
         };
-        const payload = formData.getBuffer();
 
         // when
         const response = await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
@@ -69,6 +75,7 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         //then
         expect(response.statusCode).to.equal(400);
       });
+
       it('should fail when templateName is missing', async function () {
         sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(attestationController, 'save').resolves('ok');
@@ -76,16 +83,17 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(attestationRoute);
 
+        const file = await AttestationTemplateFixture.getFile();
         const formData = new FormData();
         formData.append('templateKey', 'key');
-        formData.append('templateFile', await AttestationTemplateFixture.getFile());
+        formData.append('templateFile', new Blob([file], { type: 'application/pdf' }), 'attestation-template.pdf');
         formData.append('label', 'label');
 
+        const { payload, contentType } = await convertFormDataToPayload(formData);
         const headers = {
-          ...formData.getHeaders(),
+          'content-type': contentType,
           ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
         };
-        const payload = formData.getBuffer();
 
         // when
         const response = await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
@@ -93,6 +101,7 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         //then
         expect(response.statusCode).to.equal(400);
       });
+
       it('should fail when label is missing', async function () {
         sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(attestationController, 'save').resolves('ok');
@@ -100,16 +109,17 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(attestationRoute);
 
+        const file = await AttestationTemplateFixture.getFile();
         const formData = new FormData();
         formData.append('templateKey', 'key');
         formData.append('templateName', 'my_name');
-        formData.append('templateFile', await AttestationTemplateFixture.getFile());
+        formData.append('templateFile', new Blob([file], { type: 'application/pdf' }), 'attestation-template.pdf');
 
+        const { payload, contentType } = await convertFormDataToPayload(formData);
         const headers = {
-          ...formData.getHeaders(),
+          'content-type': contentType,
           ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
         };
-        const payload = formData.getBuffer();
 
         // when
         const response = await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
@@ -117,6 +127,7 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         //then
         expect(response.statusCode).to.equal(400);
       });
+
       it('should fail when templateFile is missing', async function () {
         sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(attestationController, 'save').resolves('ok');
@@ -129,11 +140,11 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         formData.append('templateKey', 'key');
         formData.append('label', 'label');
 
+        const { payload, contentType } = await convertFormDataToPayload(formData);
         const headers = {
-          ...formData.getHeaders(),
+          'content-type': contentType,
           ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
         };
-        const payload = formData.getBuffer();
 
         // when
         const response = await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
@@ -143,6 +154,7 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
       });
     });
   });
+
   describe('GET /api/organizations/{organizationId}/attestations', function () {
     it('should fail if user is not a member of the organization', async function () {
       sinon

--- a/api/tests/tooling/test-utils/http-server.js
+++ b/api/tests/tooling/test-utils/http-server.js
@@ -4,6 +4,20 @@ import { ApplicationAccessToken } from '../../../src/identity-access-management/
 import { UserAccessToken } from '../../../src/identity-access-management/domain/models/UserAccessToken.js';
 
 /**
+ * Converts a FormData instance to a payload object and content type  for use in HAPI HTTP requests.
+ *
+ * @param {FormData} formData
+ * @returns {{ payload: Buffer; contentType: string }} payload and content-type header
+ */
+export async function convertFormDataToPayload(formData) {
+  const response = new Response(formData);
+  return {
+    payload: Buffer.from(await response.arrayBuffer()),
+    contentType: response.headers.get('content-type'),
+  };
+}
+
+/**
  * For acceptance tests. To be used as `const options = generateInjectOptions; await server.inject(options);`
  *
  * @param {Object} params


### PR DESCRIPTION
## 🪧 Problème

Dans les tests, on utilise la librarie `form-data` pour gérer le payload des upload de fichiers. On peut le faire en utilisant la librarie `FormData` native de node.js.

## 🌈 Proposition

Remplacer l'utilisation de `form-data` par le `FormData` natif de node.js.

Un utilitaire a été ajouté pour convertir le `FormData` en payload des requêtes HAPI:
```js
const formData = new FormData();
const { payload, contentType } = await convertFormDataToPayload(formData);
```

## ✊ Remarques

N/A

## 🎉 Pour tester

Ne touche que le tests, donc la CI doit être OK.