### PR TITLE
[TECH] Améliorer les traces OpenTelemetry avec l'injection de dépendances

### DIFF
--- a/api/src/announcements/domain/usecases/index.js
+++ b/api/src/announcements/domain/usecases/index.js
@@ -1,4 +1,5 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as announcementRepository from '../../infrastructure/repositories/announcement-repository.js';
 
 const dependencies = {
@@ -13,6 +14,6 @@ const usecasesWithoutInjectedDependencies = {
   updateAnnouncement,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/banner/domain/usecases/index.js
+++ b/api/src/banner/domain/usecases/index.js
@@ -1,4 +1,5 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as informationBannerRepository from '../../infrastructure/repositories/information-banner-repository.js';
 
 /**
@@ -17,7 +18,7 @@ const usecasesWithoutInjectedDependencies = {
   getInformationBanner,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 /**
  * @typedef {dependencies} dependencies

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -4,6 +4,7 @@ import * as skillRepository from '../../../../shared/infrastructure/repositories
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import * as targetProfileHistoryRepository from '../../../shared/infrastructure/repositories/target-profile-history-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
 import * as centerRepository from '../../infrastructure/repositories/center-repository.js';
 import * as certificationInfoRepository from '../../infrastructure/repositories/certification-info-repository.js';
@@ -92,7 +93,7 @@ const usecasesWithoutInjectedDependencies = {
   updateVersion,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 /**
  * @typedef {dependencies} dependencies

--- a/api/src/certification/enrolment/application/services/index.js
+++ b/api/src/certification/enrolment/application/services/index.js
@@ -1,4 +1,5 @@
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { enrolmentRepositories } from '../../infrastructure/repositories/index.js';
 
 const dependencies = {
@@ -11,6 +12,6 @@ const servicesWithoutInjectedDependencies = {
   registerCandidateParticipation,
 };
 
-const services = injectDependencies(servicesWithoutInjectedDependencies, dependencies);
+const services = injectDependencies(servicesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { services };

--- a/api/src/certification/enrolment/domain/usecases/index.js
+++ b/api/src/certification/enrolment/domain/usecases/index.js
@@ -11,6 +11,7 @@ import * as certificationCpfService from '../../../shared/domain/services/certif
 import * as sessionValidator from '../../../shared/domain/validators/session-validator.js';
 import * as certificationCenterRepository from '../../../shared/infrastructure/repositories/certification-center-repository.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as eventAdapter from '../../infrastructure/adapters/event-adapter.js';
 import { enrolmentRepositories } from '../../infrastructure/repositories/index.js';
 import * as certificationCandidatesOdsService from '../services/certification-candidates-ods-service.js';
@@ -152,6 +153,6 @@ const usecasesWithoutInjectedDependencies = {
   verifyCandidateIdentity,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/certification/enrolment/infrastructure/repositories/index.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/index.js
@@ -4,6 +4,7 @@ import * as sessionManagementRepository from '../../../session-management/infras
 import * as certificationCenterRepository from '../../../shared/infrastructure/repositories/certification-center-repository.js';
 import * as targetProfileHistoryRepository from '../../../shared/infrastructure/repositories/target-profile-history-repository.js';
 import * as userRepository from '../../../shared/infrastructure/repositories/user-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as candidateRepository from './candidate-repository.js';
 import * as centerRepository from './center-repository.js';
 import * as certificationCpfCityRepository from './certification-cpf-city-repository.js';
@@ -49,6 +50,6 @@ const repositoriesWithoutInjectedDependencies = {
   complementaryCertificationBadgeWithOffsetVersionRepository,
 };
 
-const enrolmentRepositories = injectDependencies(repositoriesWithoutInjectedDependencies, {});
+const enrolmentRepositories = injectDependencies(repositoriesWithoutInjectedDependencies, {}, boundedContext);
 
 export { enrolmentRepositories };

--- a/api/src/certification/evaluation/domain/services/index.js
+++ b/api/src/certification/evaluation/domain/services/index.js
@@ -10,6 +10,7 @@ import * as certificationCourseRepository from '../../../shared/infrastructure/r
 import * as competenceMarkRepository from '../../../shared/infrastructure/repositories/competence-mark-repository.js';
 import * as complementaryCertificationBadgesRepository from '../../../shared/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../../shared/infrastructure/repositories/complementary-certification-course-result-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as calibratedChallengeRepository from '../../infrastructure/repositories/calibrated-challenge-repository.js';
 import * as candidateRepository from '../../infrastructure/repositories/candidate-repository.js';
 import * as certificationAssessmentHistoryRepository from '../../infrastructure/repositories/certification-assessment-history-repository.js';
@@ -77,7 +78,7 @@ const servicesWithoutInjectedDependencies = {
   handleV3CertificationScoring,
 };
 
-const injectedServices = injectDependencies(servicesWithoutInjectedDependencies, dependencies);
+const injectedServices = injectDependencies(servicesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export const services = {
   ...injectedServices,

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -16,6 +16,7 @@ import * as certificationCourseRepository from '../../../shared/infrastructure/r
 import * as sharedCompetenceMarkRepository from '../../../shared/infrastructure/repositories/competence-mark-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../../shared/infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as userRepository from '../../../shared/infrastructure/repositories/user-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as assessmentSheetRepository from '../../infrastructure/repositories/assessment-sheet-repository.js';
 import * as calibratedChallengeRepository from '../../infrastructure/repositories/calibrated-challenge-repository.js';
 import * as candidateRepository from '../../infrastructure/repositories/candidate-repository.js';
@@ -119,6 +120,6 @@ const usecasesWithoutInjectedDependencies = {
   evaluateAndSaveAnswer,
   createLiveAlert,
 };
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/certification/results/domain/usecases/index.js
+++ b/api/src/certification/results/domain/usecases/index.js
@@ -2,6 +2,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import * as sessionEnrolmentRepository from '../../../enrolment/infrastructure/repositories/session-repository.js';
 import * as sharedCertificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
 import * as certificationReportRepository from '../../../shared/infrastructure/repositories/certification-report-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as certificateRepository from '../../infrastructure/repositories/certificate-repository.js';
 import * as certificateSummaryRepository from '../../infrastructure/repositories/certificate-summary-repository.js';
 import * as certificationCourseRepository from '../../infrastructure/repositories/certification-course-repository.js';
@@ -88,6 +89,6 @@ const usecasesWithoutInjectedDependencies = {
   getShareableCertificate,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -7,6 +7,7 @@ import { createLiveAlert } from '../../../evaluation/domain/usecases/create-live
 import * as certificationBadgesService from '../../../shared/domain/services/certification-badges-service.js';
 import * as certificationCpfService from '../../../shared/domain/services/certification-cpf-service.js';
 import * as certificationCenterRepository from '../../../shared/infrastructure/repositories/certification-center-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import {
   answerRepository,
   assessmentRepository,
@@ -218,6 +219,6 @@ const usecasesWithoutInjectedDependencies = {
   updateEduV3ExternalJuryResult,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/certification/session-management/infrastructure/repositories/index.js
+++ b/api/src/certification/session-management/infrastructure/repositories/index.js
@@ -17,6 +17,7 @@ import * as certificationCourseRepository from '../../../shared/infrastructure/r
 import * as certificationReportRepository from '../../../shared/infrastructure/repositories/certification-report-repository.js';
 import * as sharedCompetenceMarkRepository from '../../../shared/infrastructure/repositories/competence-mark-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../../shared/infrastructure/repositories/complementary-certification-course-result-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as certificationCandidateForSupervisingRepository from './certification-candidate-for-supervising-repository.js';
 import * as certificationCandidateRepository from './certification-candidate-repository.js';
 import * as certificationCenterAccessRepository from './certification-center-access-repository.js';
@@ -134,7 +135,7 @@ const dependencies = {
   certificationCenterAccessApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 export {
   answerRepository,
   assessmentRepository,

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -10,6 +10,7 @@ import * as skillRepository from '../../../shared/infrastructure/repositories/sk
 import * as tubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as moduleIssueReportRepository from '../../infrastructure/repositories/module-issue-report-repository.js';
 import * as targetProfileTrainingRepository from '../../infrastructure/repositories/target-profile-training-repository.js';
@@ -106,6 +107,6 @@ const usecasesWithoutInjectedDependencies = {
   verifyExistingUserCampaignSurvey,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/devcomp/infrastructure/repositories/index.js
+++ b/api/src/devcomp/infrastructure/repositories/index.js
@@ -1,4 +1,5 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import moduleDatasource from '../datasources/learning-content/module-datasource.js';
 import * as elementAnswerRepository from './element-answer-repository.js';
 import * as elementRepository from './element-repository.js';
@@ -34,6 +35,6 @@ const dependencies = {
   moduleDatasource,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -16,6 +16,7 @@ import * as courseRepository from '../../../shared/infrastructure/repositories/c
 import * as knowledgeElementRepository from '../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { answerJobRepository } from '../../infrastructure/repositories/answer-job-repository.js';
 import * as badgeAcquisitionRepository from '../../infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeCriteriaRepository from '../../infrastructure/repositories/badge-criteria-repository.js';
@@ -149,6 +150,6 @@ const usecasesWithoutInjectedDependencies = {
   updateLastQuestionState,
 };
 
-const evaluationUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const evaluationUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { evaluationUsecases };

--- a/api/src/evaluation/infrastructure/repositories/index.js
+++ b/api/src/evaluation/infrastructure/repositories/index.js
@@ -5,6 +5,7 @@ import * as campaignApi from '../../../prescription/campaign/application/api/cam
 import * as targetProfileApi from '../../../prescription/target-profile/application/api/target-profile-api.js';
 import { fromDatasourceObject } from '../../../shared/infrastructure/adapters/solution-adapter.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { getCorrection } from '../../domain/services/solution/solution-service-qrocm-dep.js';
 import * as autonomousCourseRepository from './autonomous-course-repository.js';
 import * as autonomousCourseTargetProfileRepository from './autonomous-course-target-profile-repository.js';
@@ -32,6 +33,6 @@ const dependencies = {
   certificationEvaluationApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -22,6 +22,7 @@ import { auditLoggingJobRepository } from '../../../shared/infrastructure/reposi
 import * as organizationRepository from '../../../shared/infrastructure/repositories/organization-repository.js';
 import * as userLoginRepository from '../../infrastructure/repositories/user-login-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as emailRepository from '../../../shared/mail/infrastructure/repositories/email.repository.js';
 import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 import * as membershipRepository from '../../../team/infrastructure/repositories/membership.repository.js';
@@ -232,6 +233,6 @@ const usecasesWithoutInjectedDependencies = {
   validateUserAccountEmail,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { oidcAuthenticationServiceRegistry, usecases };

--- a/api/src/learning-content/domain/usecases/index.js
+++ b/api/src/learning-content/domain/usecases/index.js
@@ -1,4 +1,5 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { createLearningContentRelease } from './create-learning-content-release.js';
 import { dependencies } from './dependencies.js';
 import { findFrameworksByIds } from './find-frameworks-by-ids.js';
@@ -22,4 +23,4 @@ const usecasesWithoutInjectedDependencies = {
   scheduleRefreshLearningContentJob,
 };
 
-export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);

--- a/api/src/legal-documents/domain/usecases/index.js
+++ b/api/src/legal-documents/domain/usecases/index.js
@@ -1,5 +1,6 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as legalDocumentRepository from '../../infrastructure/repositories/legal-document.repository.js';
 import * as userRepository from '../../infrastructure/repositories/user.repository.js';
 import * as userAcceptanceRepository from '../../infrastructure/repositories/user-acceptance.repository.js';
@@ -24,6 +25,6 @@ const usecasesWithoutInjectedDependencies = {
   getLegalDocumentStatusByUserId,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/llm/domain/usecases/index.js
+++ b/api/src/llm/domain/usecases/index.js
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { redisMutex } from '../../../shared/infrastructure/mutex/RedisMutex.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as repositories from '../../infrastructure/repositories/index.js';
 
 const dependencies = {
@@ -18,4 +19,4 @@ const usecasesWithoutInjectedDependencies = {
   startChat,
 };
 
-export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);

--- a/api/src/maddo/domain/usecases/index.js
+++ b/api/src/maddo/domain/usecases/index.js
@@ -1,6 +1,7 @@
 import * as authenticationMethodRepository from '../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import * as campaignsAPI from '../../../prescription/campaign/application/api/campaigns-api.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';
 import * as clientApplicationRepository from '../../infrastructure/repositories/client-application-repository.js';
 import * as oidcProviderRepository from '../../infrastructure/repositories/oidc-provider-repository.js';
@@ -30,6 +31,6 @@ const usecasesWithoutInjectedDependencies = {
   getCampaignParticipations,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -7,6 +7,7 @@ import * as countryRepository from '../../../shared/infrastructure/repositories/
 import * as featureRepository from '../../../shared/infrastructure/repositories/feature-repository.js';
 import * as organizationRepository from '../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as administrationTeamRepository from '../../infrastructure/repositories/administration-team-repository.js';
 import * as certificationCenterRepository from '../../infrastructure/repositories/certification-center.repository.js';
 import { certificationCenterApiRepository } from '../../infrastructure/repositories/certification-center-api.repository.js';
@@ -182,6 +183,6 @@ const usecasesWithoutInjectedDependencies = {
 /**
  * @type {OrganizationalEntitiesUsecases}
  */
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/organizational-entities/infrastructure/repositories/index.js
+++ b/api/src/organizational-entities/infrastructure/repositories/index.js
@@ -3,6 +3,7 @@ import * as campaignApi from '../../../prescription/campaign/application/api/cam
 import * as learnerApi from '../../../prescription/learner-management/application/api/learners-api.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as organizationApi from '../../../team/application/api/organization.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { certificationCenterApiRepository } from './certification-center-api.repository.js';
 import { organizationForAdminRepository } from './organization-for-admin.repository.js';
 const repositoriesWithoutInjectedDependencies = {
@@ -17,6 +18,6 @@ const dependencies = {
   campaignStatsApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -24,6 +24,7 @@ import * as stageAcquisitionRepository from '../../../stages/infrastructure/repo
 import * as stageCollectionRepository from '../../../stages/infrastructure/repositories/stage-collection-repository.js';
 import * as stageRepository from '../../../stages/infrastructure/repositories/stage-repository.js';
 import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as campaignAssessmentParticipationRepository from '../../infrastructure/repositories/campaign-assessment-participation-repository.js';
 import * as campaignAssessmentParticipationResultRepository from '../../infrastructure/repositories/campaign-assessment-participation-result-repository.js';
 import * as campaignParticipationOverviewRepository from '../../infrastructure/repositories/campaign-participation-overview-repository.js';
@@ -141,6 +142,6 @@ const usecasesWithoutInjectedDependencies = {
   getCampaignParticipationStatistics,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/index.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/index.js
@@ -1,5 +1,6 @@
 import * as organizationFeatureAPI from '../../../../organizational-entities/application/api/organization-features-api.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as campaignParticipantRepository from './campaign-participant-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
@@ -10,6 +11,6 @@ const dependencies = {
   organizationFeatureAPI,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -25,6 +25,7 @@ import * as learningContentRepository from '../../../shared/infrastructure/repos
 import * as stageAcquisitionRepository from '../../../stages/infrastructure/repositories/stage-acquisition-repository.js';
 import * as stageCollectionRepository from '../../../stages/infrastructure/repositories/stage-collection-repository.js';
 import * as stageRepository from '../../../stages/infrastructure/repositories/stage-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as campaignAdministrationRepository from '../../infrastructure/repositories/campaign-administration-repository.js';
 import * as campaignAssessmentParticipationResultListRepository from '../../infrastructure/repositories/campaign-assessment-participation-result-list-repository.js';
 import * as campaignCollectiveResultRepository from '../../infrastructure/repositories/campaign-collective-result-repository.js';
@@ -166,6 +167,6 @@ const usecasesWithoutInjectedDependencies = {
   getParticipationsCountByMasteryRate,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/prescription/campaign/infrastructure/repositories/index.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/index.js
@@ -2,6 +2,7 @@ import * as organizationFeatureAPI from '../../../../organizational-entities/app
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import * as organizationApi from '../../../../team/application/api/organization.js';
 import * as targetProfileApi from '../../../target-profile/application/api/target-profile-api.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as campaignToJoinRepository from './campaign-to-join-repository.js';
 import * as organizationMembershipRepository from './organization-membership-repository.js';
 import * as targetProfileRepository from './target-profile-repository.js';
@@ -18,6 +19,6 @@ const dependencies = {
   targetProfileApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -18,6 +18,7 @@ import * as campaignRepository from '../../../campaign/infrastructure/repositori
 import * as campaignParticipationRepositoryFromBC from '../../../campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import * as libOrganizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import * as registrationOrganizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/registration-organization-learner-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { repositories } from '../../infrastructure/repositories/index.js';
 import { importFromFregataJobRepository } from '../../infrastructure/repositories/jobs/import-from-fregata-job-repository.js';
 import { importFromGenericFileJobRepository } from '../../infrastructure/repositories/jobs/import-from-generic-file-job-repository.js';
@@ -142,6 +143,6 @@ const usecasesWithoutInjectedDependencies = {
   validateSiecleFile,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/prescription/learner-management/infrastructure/repositories/index.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/index.js
@@ -1,5 +1,6 @@
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as organizationFeatureRepository from './organization-feature-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
@@ -10,6 +11,6 @@ const dependencies = {
   organizationFeatureApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/prescription/organization-learner-feature/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner-feature/domain/usecases/index.js
@@ -3,6 +3,7 @@ import * as organizationRepository from '../../../../shared/infrastructure/repos
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import * as organizationLearnerFeatureRepository from '../../../organization-learner/infrastructure/repositories/organization-learner-feature-repository.js';
 import * as organizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/organization-learner-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 
 const dependencies = {
   organizationRepository,
@@ -19,6 +20,6 @@ const usecasesWithoutInjectedDependencies = {
   unlinkOrganizationLearnerFeature,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -35,6 +35,7 @@ import * as groupRepository from '../../../campaign/infrastructure/repositories/
 import * as campaignParticipationOverviewRepository from '../../../campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js';
 import * as organizationLearnerImportFormatRepository from '../../../learner-management/infrastructure/repositories/organization-learner-import-format-repository.js';
 import * as prescriptionOrganizationLearnerRepository from '../../../learner-management/infrastructure/repositories/organization-learner-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as analysisRepository from '../../infrastructure/repositories/analysis-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as organizationLearnerActivityRepository from '../../infrastructure/repositories/organization-learner-activity-repository.js';
@@ -139,6 +140,6 @@ const usecasesWithoutInjectedDependencies = {
   unblockOrganizationLearnerAccount,
   updateOrganizationLearnerDependentUserPassword,
 };
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/index.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/index.js
@@ -2,6 +2,7 @@ import * as organizationApi from '../../../../organizational-entities/applicatio
 import * as attestationsApi from '../../../../profile/application/api/attestations-api.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import * as organizationLearnerImportFormatRepository from '../../../learner-management/infrastructure/repositories/organization-learner-import-format-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as organizationLearnerRepository from './organization-learner-repository.js';
 import * as organizationToJoinRepository from './organization-to-join-repository.js';
 
@@ -16,6 +17,6 @@ const dependencies = {
   organizationLearnerImportFormatRepository,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/prescription/organization-place/domain/usecases/index.js
+++ b/api/src/prescription/organization-place/domain/usecases/index.js
@@ -2,6 +2,7 @@ import * as organizationFeatureApi from '../../../../organizational-entities/app
 import * as organizationLearnerRepository from '../../../../prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as organizationPlacesLotRepository from '../../infrastructure/repositories/organization-places-lot-repository.js';
 
 const dependencies = {
@@ -27,6 +28,6 @@ const usecasesWithoutInjectedDependencies = {
   getOrganizationPlacesStatistics,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/prescription/stages/domain/usecases/index.js
+++ b/api/src/prescription/stages/domain/usecases/index.js
@@ -5,6 +5,7 @@ import knowledgeElementForParticipationService from '../../../../prescription/sh
 import * as targetProfileAdministrationRepository from '../../../../prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as stageAcquisitionRepository from '../../infrastructure/repositories/stage-acquisition-repository.js';
 import * as stageCollectionForTargetProfileRepository from '../../infrastructure/repositories/stage-collection-repository.js';
 import * as stageRepository from '../../infrastructure/repositories/stage-repository.js';
@@ -37,6 +38,6 @@ const usecasesWithoutInjectedDependencies = {
   updateStage,
 };
 
-const stageUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const stageUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { stageUsecases };

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import * as learningContentConversionService from '../../../shared/domain/services/learning-content-conversion-service.js';
 import * as learningContentRepository from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as organizationsToAttachToTargetProfileRepository from '../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js';
 import * as targetProfileAdministrationRepository from '../../infrastructure/repositories/target-profile-administration-repository.js';
 import * as targetProfileBondRepository from '../../infrastructure/repositories/target-profile-bond-repository.js';
@@ -71,6 +72,6 @@ const usecasesWithoutInjectedDependencies = {
   updateTargetProfile,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -11,6 +11,7 @@ import { auditLoggingJobRepository } from '../../../shared/infrastructure/reposi
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 import * as membershipRepository from '../../../team/infrastructure/repositories/membership.repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as campaignParticipationsApiRepository from '../../infrastructure/repositories/campaign-participations-api.repository.js';
 import * as candidatesApiRepository from '../../infrastructure/repositories/candidates-api.repository.js';
 import * as learnersApiRepository from '../../infrastructure/repositories/learners-api.repository.js';
@@ -48,6 +49,6 @@ const usecasesWithoutInjectedDependencies = {
 
 const dependencies = Object.assign({}, repositories, services);
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -8,6 +8,7 @@ import * as knowledgeElementRepository from '../../../shared/infrastructure/repo
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
 import * as stringUtils from '../../../shared/infrastructure/utils/string-utils.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as attestationRepository from '../../infrastructure/repositories/attestation-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import * as organizationProfileRewardRepository from '../../infrastructure/repositories/organizations-profile-reward-repository.js';
@@ -59,6 +60,6 @@ const usecasesWithoutInjectedDependencies = {
   findByUserIdAndRewardId,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/profile/infrastructure/repositories/index.js
+++ b/api/src/profile/infrastructure/repositories/index.js
@@ -1,5 +1,6 @@
 import * as usersApi from '../../../../src/identity-access-management/application/api/users-api.js';
 import { injectDependencies } from '../../../../src/shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as userRepository from './user-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
@@ -10,6 +11,6 @@ const dependencies = {
   usersApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -4,6 +4,7 @@ import * as membershipRepository from '../../../shared/infrastructure/repositori
 import * as organizationFeatureRepository from '../../../shared/infrastructure/repositories/organization-feature-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as combinedCourseBlueprintRepository from '../../infrastructure/repositories/combined-course-blueprints/combined-course-blueprint-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
@@ -20,6 +21,7 @@ const { combinedCourseDetailsService: injectedCombinedCourseDetailsService } = i
     eligibilityRepository: repositories.eligibilityRepository,
     recommendedModuleRepository: repositories.recommendedModuleRepository,
   },
+  boundedContext,
 );
 
 const dependencies = {
@@ -126,6 +128,6 @@ const usecasesWithoutInjectedDependencies = {
   isCombinedCourseBlueprintInOrganization,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -13,6 +13,7 @@ import * as rewardApi from '../../../profile/application/api/reward-api.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import * as accessCodeRepository from '../../../shared/infrastructure/repositories/access-code-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { AttestationStorage } from '../storage/attestation-storage.js';
 import * as attestationRepository from './attestation-repository.js';
 import * as campaignParticipationRepository from './campaign-participation-repository.js';
@@ -76,6 +77,6 @@ const dependencies = {
   attestationStorage: AttestationStorage.createClient(),
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/school/domain/usecases/index.js
+++ b/api/src/school/domain/usecases/index.js
@@ -4,6 +4,7 @@ import * as assessmentRepository from '../../../shared/infrastructure/repositori
 import * as challengeRepository from '../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as activityAnswerRepository from '../../infrastructure/repositories/activity-answer-repository.js';
 import * as activityRepository from '../../infrastructure/repositories/activity-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
@@ -65,6 +66,6 @@ const usecasesWithoutInjectedDependencies = {
   playMission,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/school/infrastructure/repositories/index.js
+++ b/api/src/school/infrastructure/repositories/index.js
@@ -1,5 +1,6 @@
 import * as organizationLearnerApi from '../../../prescription/organization-learner/application/api/organization-learners-api.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as missionLearnerRepository from '../../infrastructure/repositories/mission-learner-repository.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import * as schoolRepository from '../../infrastructure/repositories/school-repository.js';
@@ -14,6 +15,6 @@ const dependencies = {
   organizationLearnerApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/shared/domain/usecases/index.js
+++ b/api/src/shared/domain/usecases/index.js
@@ -4,6 +4,7 @@ import * as certificationCompanionAlertRepository from '../../../certification/s
 import * as challengeToPlayApi from '../../../evaluation/application/api/challenge-to-play-api.js';
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import * as badgeRepository from '../../../evaluation/infrastructure/repositories/badge-repository.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as answerRepository from '../../infrastructure/repositories/answer-repository.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as competenceRepository from '../../infrastructure/repositories/competence-repository.js';
@@ -37,6 +38,6 @@ const usecasesWithoutInjectedDependencies = {
   updateLastQuestionState,
 };
 
-const sharedUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const sharedUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { sharedUsecases };

--- a/api/src/shared/infrastructure/open-telemetry/otel_proxy.js
+++ b/api/src/shared/infrastructure/open-telemetry/otel_proxy.js
@@ -1,5 +1,6 @@
 import { trace } from '@opentelemetry/api';
 
+import { config } from '../../config.js';
 import { DomainError } from '../../domain/errors.js';
 const otelProxySymbol = Symbol('otelProxy');
 
@@ -59,6 +60,14 @@ function wrapFunction(func, target, methodName, defaultAttributes) {
 function wrapObject(resource, name, defaultAttributes) {
   if (isAlreadyProxied(resource)) return resource;
 
+  // Wrapping a method or a nested object allocates a new closure/Proxy, so
+  // it's cached per property here - without it, every single property
+  // access (not just every call) would pay that allocation cost again.
+  // Keyed by the raw value too, so a property reassigned at runtime (e.g. a
+  // swapped-out dependency) still gets re-wrapped instead of serving a proxy
+  // over the old value.
+  const wrappedMembers = new Map(); // prop -> { rawValue, wrapped }
+
   return new Proxy(resource, {
     get: (target, prop) => {
       if (prop === otelProxySymbol) {
@@ -66,12 +75,23 @@ function wrapObject(resource, name, defaultAttributes) {
       }
 
       const value = target[prop];
+      const cached = wrappedMembers.get(prop);
+      if (cached && cached.rawValue === value) {
+        return cached.wrapped;
+      }
 
+      // Only cache the wrapping itself (closure/Proxy allocation), not
+      // plain values - those are returned straight from `target` so
+      // mutations to the underlying resource stay visible through the proxy.
       if (typeof value === 'function') {
-        return wrapFunction(value, target, `${name}->${prop.toString()}`, defaultAttributes);
+        const wrapped = wrapFunction(value, target, `${name}->${prop.toString()}`, defaultAttributes);
+        wrappedMembers.set(prop, { rawValue: value, wrapped });
+        return wrapped;
       }
       if (typeof value === 'object' && value !== null) {
-        return wrapObject(value, name, defaultAttributes);
+        const wrapped = wrapObject(value, name, defaultAttributes);
+        wrappedMembers.set(prop, { rawValue: value, wrapped });
+        return wrapped;
       }
 
       return value;
@@ -90,6 +110,9 @@ function wrapObject(resource, name, defaultAttributes) {
  * @returns {object|Function} A proxy (or wrapped function) that behaves like `resource` but emits spans.
  */
 export function otelProxy(resource, name, defaultAttributes) {
+  if (!config.logging.otelEnabled) {
+    return resource;
+  }
   if (typeof resource === 'function') {
     return wrapFunction(resource, null, name, defaultAttributes);
   }

--- a/api/src/shared/infrastructure/repositories/index.js
+++ b/api/src/shared/infrastructure/repositories/index.js
@@ -1,4 +1,5 @@
 import * as certificationEvaluationApi from '../../../certification/evaluation/application/api/certification-evaluation-api.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { injectDependencies } from '../utils/dependency-injection.js';
 import * as certificationEvaluationRepository from './certification-evaluation-repository.js';
 import * as countryRepository from './country-repository.js';
@@ -25,6 +26,6 @@ const dependencies = {
   certificationEvaluationApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/src/shared/infrastructure/utils/dependency-injection.js
+++ b/api/src/shared/infrastructure/utils/dependency-injection.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 
+import { otelProxy } from '../open-telemetry/otel_proxy.js';
+
 function injectDefaults(defaults, targetFn) {
   return (args) => targetFn(Object.assign(Object.create(defaults), args));
 }
@@ -28,18 +30,39 @@ function injectDefaults(defaults, targetFn) {
  */
 
 /**
+ * @typedef {{
+ *   name: string
+ * }} BoundedContext
+ */
+
+/**
  * @template {object} ObjectToBeInjected
  * @template {object} DependenciesToInject
  * @param {ObjectToBeInjected} toBeInjected - An object (or nested objects) of functions.
  * @param {DependenciesToInject} dependencies - An object of dependencies to inject.
+ * @param {BoundedContext=} boundedContext
  * @returns {Inject<ObjectToBeInjected, DependenciesToInject>} The input object, but functions now only require dependencies that haven't been injected.
  */
-export function injectDependencies(toBeInjected, dependencies) {
-  return _.mapValues(toBeInjected, (value) => {
-    if (_.isFunction(value)) {
-      return _.partial(injectDefaults, dependencies, value)();
-    } else {
-      return injectDependencies(value, dependencies);
-    }
-  });
+export function injectDependencies(toBeInjected, dependencies, boundedContext = { name: 'unknown' }) {
+  const defaultAttributes = {
+    'boundedContext.name': boundedContext.name,
+  };
+  const wrappedDependencies = Object.fromEntries(
+    Object.entries(dependencies).map(([name, value]) => [
+      name,
+      value ? otelProxy(value, name, defaultAttributes) : value,
+    ]),
+  );
+  const injected = Object.fromEntries(
+    Object.entries(toBeInjected).map(([name, value]) => {
+      if (_.isFunction(value)) {
+        const wrapped = otelProxy(value, `${boundedContext.name}->${name}`, defaultAttributes);
+        return [name, _.partial(injectDefaults, wrappedDependencies, wrapped)()];
+      } else {
+        return [name, injectDependencies(value, dependencies)];
+      }
+    }),
+  );
+
+  return injected;
 }

--- a/api/src/shared/infrastructure/utils/otel_proxy.js
+++ b/api/src/shared/infrastructure/utils/otel_proxy.js
@@ -1,0 +1,100 @@
+import { trace } from '@opentelemetry/api';
+
+import { DomainError } from '../../domain/errors.js';
+const otelProxySymbol = Symbol('otelProxy');
+
+function isAlreadyProxied(resource) {
+  return resource[otelProxySymbol] === true;
+}
+
+function wrapFunction(func, target, methodName, defaultAttributes) {
+  if (isAlreadyProxied(func)) return func;
+
+  const wrapped = function (...args) {
+    const tracer = trace.getTracer('otel-proxy');
+    return tracer.startActiveSpan(methodName, (span) => {
+      if (defaultAttributes) {
+        span.setAttributes(defaultAttributes);
+      }
+      try {
+        const result = func.apply(target, args);
+        if (result instanceof Promise) {
+          return result
+            .then((result) => {
+              span.end();
+              return result;
+            })
+            .catch((error) => {
+              span.recordException(error);
+              if (!(error instanceof DomainError)) {
+                span.setStatus({
+                  code: 2 /* SpanStatusCode.ERROR */,
+                  message: error.message,
+                });
+              }
+              span.end();
+              throw error;
+            });
+        }
+        span.end();
+        return result;
+      } catch (error) {
+        span.recordException(error);
+        if (!(error instanceof DomainError)) {
+          span.setStatus({
+            code: 2 /* SpanStatusCode.ERROR */,
+            message: error.message,
+          });
+        }
+        span.end();
+        throw error;
+      }
+    });
+  };
+
+  wrapped[otelProxySymbol] = true;
+  return wrapped;
+}
+
+function wrapObject(resource, name, defaultAttributes) {
+  if (isAlreadyProxied(resource)) return resource;
+
+  return new Proxy(resource, {
+    get: (target, prop) => {
+      if (prop === otelProxySymbol) {
+        return true;
+      }
+
+      const value = target[prop];
+
+      if (typeof value === 'function') {
+        return wrapFunction(value, target, `${name}->${prop.toString()}`, defaultAttributes);
+      }
+      if (typeof value === 'object' && value !== null) {
+        return wrapObject(value, name, defaultAttributes);
+      }
+
+      return value;
+    },
+  });
+}
+
+/**
+ * Wraps an object or function with an OpenTelemetry proxy that automatically
+ * creates a span around each method call (or the call itself, if `resource`
+ * is a function).
+ *
+ * @param {object|Function} resource - The object whose methods should be traced, or a function to trace directly.
+ * @param {string} name - Base name used to build span names (e.g. `${name}->${methodName}`).
+ * @param {Record<string, unknown>} [defaultAttributes] - Attributes set on every span created by this proxy.
+ * @returns {object|Function} A proxy (or wrapped function) that behaves like `resource` but emits spans.
+ */
+export function otelProxy(resource, name, defaultAttributes) {
+  if (typeof resource === 'function') {
+    return wrapFunction(resource, null, name, defaultAttributes);
+  }
+  if (typeof resource === 'object') {
+    return wrapObject(resource, name, defaultAttributes);
+  }
+  return resource;
+}

--- a/api/src/team/domain/usecases/index.js
+++ b/api/src/team/domain/usecases/index.js
@@ -5,6 +5,7 @@ import * as certificationCenterRepository from '../../../certification/shared/in
 import { refreshTokenRepository } from '../../../identity-access-management/infrastructure/repositories/refresh-token.repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as certificationCenterInvitationRepository from '../../infrastructure/repositories/certification-center-invitation-repository.js';
 import { certificationCenterInvitedUserRepository } from '../../infrastructure/repositories/certification-center-invited-user.repository.js';
 import { certificationCenterMembershipRepository } from '../../infrastructure/repositories/certification-center-membership.repository.js';
@@ -131,6 +132,6 @@ const usecasesWithoutInjectedDependencies = {
   updateMembership,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { usecases };

--- a/api/src/team/infrastructure/repositories/index.js
+++ b/api/src/team/infrastructure/repositories/index.js
@@ -1,5 +1,6 @@
 import { injectDependencies } from '../../../../src/shared/infrastructure/utils/dependency-injection.js';
 import * as legalDocumentApi from '../../../legal-documents/application/api/legal-documents-api.js';
+import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { prescriberRepository } from './prescriber-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
@@ -10,6 +11,6 @@ const dependencies = {
   legalDocumentApi,
 };
 
-const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies, boundedContext);
 
 export { repositories };

--- a/api/tests/shared/unit/infrastructure/utils/otel_proxy_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/otel_proxy_test.js
@@ -1,0 +1,137 @@
+import { trace } from '@opentelemetry/api';
+import sinon from 'sinon';
+
+import { config } from '../../../../../src/shared/config.js';
+import { otelProxy } from '../../../../../src/shared/infrastructure/utils/otel_proxy.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Infrastructure | Utils | otelProxy', function () {
+  let spanStub;
+  let tracerStub;
+  let otelEnabled;
+
+  beforeEach(function () {
+    spanStub = {
+      end: sinon.stub(),
+      recordException: sinon.stub(),
+      setStatus: sinon.stub(),
+    };
+    tracerStub = {
+      startActiveSpan: sinon.stub().callsFake((name, cb) => cb(spanStub)),
+    };
+    sinon.stub(trace, 'getTracer').returns(tracerStub);
+    otelEnabled = config.logging.otelEnabled;
+    config.logging.otelEnabled = true;
+  });
+
+  afterEach(function () {
+    config.logging.otelEnabled = otelEnabled;
+  });
+
+  describe('when resource is a function', function () {
+    it('should wrap the function and create a span', function () {
+      const fn = sinon.stub().returns(42);
+
+      const wrapped = otelProxy(fn, 'myFunc');
+      const result = wrapped('a', 'b');
+
+      expect(result).to.equal(42);
+      expect(fn).to.have.been.calledWith('a', 'b');
+      expect(trace.getTracer).to.have.been.calledWith('otel-proxy');
+      expect(tracerStub.startActiveSpan).to.have.been.calledWith('myFunc');
+      expect(spanStub.end).to.have.been.calledOnce;
+    });
+
+    it('should end span after promise resolves', async function () {
+      const fn = sinon.stub().resolves('async-result');
+
+      const wrapped = otelProxy(fn, 'asyncFunc');
+      const result = await wrapped();
+
+      expect(result).to.equal('async-result');
+      expect(spanStub.end).to.have.been.calledOnce;
+    });
+
+    it('should record exception and end span when promise rejects', async function () {
+      const error = new Error('async-error');
+      const fn = sinon.stub().rejects(error);
+
+      const wrapped = otelProxy(fn, 'failingAsyncFunc');
+
+      await expect(wrapped()).to.be.rejectedWith('async-error');
+      expect(spanStub.recordException).to.have.been.calledWith(error);
+      expect(spanStub.end).to.have.been.calledOnce;
+    });
+
+    it('should record exception and end span when function throws synchronously', function () {
+      const error = new Error('sync-error');
+      const fn = sinon.stub().throws(error);
+
+      const wrapped = otelProxy(fn, 'throwingFunc');
+
+      expect(() => wrapped()).to.throw('sync-error');
+      expect(spanStub.recordException).to.have.been.calledWith(error);
+      expect(spanStub.end).to.have.been.calledOnce;
+    });
+
+    it('should not wrap an already proxied function again', function () {
+      const fn = sinon.stub().returns(1);
+
+      const wrapped = otelProxy(fn, 'func');
+      const wrappedAgain = otelProxy(wrapped, 'func');
+
+      expect(wrappedAgain).to.equal(wrapped);
+    });
+  });
+
+  describe('when resource is an object', function () {
+    it('should wrap object methods and create spans', function () {
+      const obj = { doSomething: sinon.stub().returns('done') };
+
+      const proxied = otelProxy(obj, 'myObj');
+      const result = proxied.doSomething('arg');
+
+      expect(result).to.equal('done');
+      expect(obj.doSomething).to.have.been.calledWith('arg');
+      expect(tracerStub.startActiveSpan).to.have.been.calledWith('myObj->doSomething');
+      expect(spanStub.end).to.have.been.calledOnce;
+    });
+
+    it('should return primitive properties as-is', function () {
+      const obj = { count: 5, label: 'test' };
+
+      const proxied = otelProxy(obj, 'myObj');
+
+      expect(proxied.count).to.equal(5);
+      expect(proxied.label).to.equal('test');
+    });
+
+    it('should recursively wrap nested objects', function () {
+      const nested = { inner: sinon.stub().returns('nested-result') };
+      const obj = { child: nested };
+
+      const proxied = otelProxy(obj, 'myObj');
+      const result = proxied.child.inner();
+
+      expect(result).to.equal('nested-result');
+      expect(tracerStub.startActiveSpan).to.have.been.calledWith('myObj->inner');
+    });
+
+    it('should not wrap an already proxied object again', function () {
+      const obj = { foo: sinon.stub() };
+
+      const proxied = otelProxy(obj, 'myObj');
+      const proxiedAgain = otelProxy(proxied, 'myObj');
+
+      expect(proxiedAgain).to.equal(proxied);
+    });
+
+    it('should return null properties as-is', function () {
+      const obj = { empty: null };
+
+      const proxied = otelProxy(obj, 'myObj');
+
+      expect(proxied.empty).to.be.null;
+    });
+  });
+});

--- a/api/tests/shared/unit/infrastructure/utils/otel_proxy_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/otel_proxy_test.js
@@ -2,7 +2,7 @@ import { trace } from '@opentelemetry/api';
 import sinon from 'sinon';
 
 import { config } from '../../../../../src/shared/config.js';
-import { otelProxy } from '../../../../../src/shared/infrastructure/utils/otel_proxy.js';
+import { otelProxy } from '../../../../../src/shared/infrastructure/open-telemetry/otel_proxy.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Infrastructure | Utils | otelProxy', function () {


### PR DESCRIPTION
## 🪧 Problème

Nous avons des traces OpenTelemetry, mais elle ne contiennent que des spans correspondant à des appels réseaux.

## 🌈 Proposition

Afin d'obtenir des traces à la maille des fonctions de notre code, on souhaite s'insérer dans la mécanique d'injection de dépendances, qui interagit avec nos usecases, repositories, services et utilitaires.

On utilise une nouvelle fonction, appelée `otelProxy`, qui va automatiquement créer des spans en wrappant toutes nos fonctions et nos objets existants, à l'aide d'un `Proxy` JavaScript.

<img width="1092" height="472" alt="image" src="https://github.com/user-attachments/assets/de451ca5-5f6b-4936-a1e1-f98fd33f40f2" />

> Exemple d'une trace qui contient des spans de fonctions, automatiquement crées par `otelProxy`. Visualisée dans otel-tui.

## ✊ Remarques

On a décidé de se baser manuellement sur les fichiers `dependencies.json` afin de détecter le bounded context correspondant à chaque fonction, mais il y a des faux positifs. On estime que ce n'est pas grave pour l'instant.
Cette information nous permettra de pouvoir filtrer nos traces en fonction du bounded context.

## 🎉 Pour tester
- Lancer l'API avec la variable d'environnement `OTEL_ENABLED=true`
- Lancer `mon-pix`
- Lancer un collecteur (et/ou outil de visualisation de traces) OpenTelemetry comme [`otel-tui`](https://github.com/ymtdzzz/otel-tui) ou [`otel-gui`](https://github.com/metafab/otel-gui).
- Se rendre sur la page d'accueil.
- Attendre quelques secondes.
- Dans l'outil de visualisation de traces, constater que plusieurs traces sont visibles.
- Ouvrir une des traces.
- Constater que des spans correspondant à des fonctions du code sont visibles.
