### PR TITLE
[TECH] :broom: Supprime une fonction inutilisée `isPixPlus()` (pix-8011)

### DIFF
--- a/api/src/certification/shared/domain/models/CertificationChallenge.js
+++ b/api/src/certification/shared/domain/models/CertificationChallenge.js
@@ -1,4 +1,4 @@
-class CertificationChallenge {
+export class CertificationChallenge {
   constructor({
     id,
     associatedSkillName,
@@ -25,5 +25,3 @@ class CertificationChallenge {
     this.createdAt = createdAt;
   }
 }
-
-export { CertificationChallenge };

--- a/api/src/certification/shared/domain/models/CertificationChallengeWithType.js
+++ b/api/src/certification/shared/domain/models/CertificationChallengeWithType.js
@@ -1,6 +1,6 @@
 import { Type } from '../../../../shared/domain/models/Challenge.js';
 
-class CertificationChallengeWithType {
+export class CertificationChallengeWithType {
   constructor({
     id,
     associatedSkillName,
@@ -32,13 +32,7 @@ class CertificationChallengeWithType {
     this.isNeutralized = false;
   }
 
-  isPixPlus() {
-    return Boolean(this.certifiableBadgeKey);
-  }
-
   skipAutomatically() {
     this.hasBeenSkippedAutomatically = true;
   }
 }
-
-export { CertificationChallengeWithType };

--- a/api/tests/certification/shared/unit/domain/models/CertificationChallengeWithType_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationChallengeWithType_test.js
@@ -75,32 +75,4 @@ describe('Unit | Domain | Models | CertificationChallengeWithType', function () 
       expect(certificationChallengeWithType.isNeutralized).to.be.false;
     });
   });
-
-  describe('#isPixPlus', function () {
-    it('return true when challenge was picked for a pix plus certification', function () {
-      // given
-      const certificationChallengeWithType = domainBuilder.buildCertificationChallengeWithType({
-        certifiableBadgeKey: 'someValue',
-      });
-
-      // when
-      const isPixPlus = certificationChallengeWithType.isPixPlus();
-
-      // then
-      expect(isPixPlus).to.be.true;
-    });
-
-    it('return false when challenge was picked for a regular pix certification', function () {
-      // given
-      const certificationChallengeWithType = domainBuilder.buildCertificationChallengeWithType({
-        certifiableBadgeKey: null,
-      });
-
-      // when
-      const isPixPlus = certificationChallengeWithType.isPixPlus();
-
-      // then
-      expect(isPixPlus).to.be.false;
-    });
-  });
 });


### PR DESCRIPTION
## 🪧 Problème

Dans le tableau de dette technique il y a une référence au ticket https://1024pix.atlassian.net/browse/PIX-8011 où l'on évoque 

> Actuellement chaque candidat de session ne peut avoir qu’une certification complémentaire.

avec comme proposition de solution

> Depuis qu’on a une seule certif complementaire par certif, on pourrait ne plus avoir `certificationChallenge.certifiableBadgeKey` et le remplacer par `certificationChallenge.isPixPlus`

Dans la table `certification-challenges` nous stockons toujours `certifiableBadgeKey`

## 🌈 Proposition

Supprimer la fonction `certificationChallenge.isPixPlus()` qui n'est utilisé par personnes.

## ✊ Remarques

Il n'y a plus qu'un endroit où l'on se sert de `certifiableBadgeKey`, c'est pour retrouver les challenges d'une certification complémentaire en v2 pour refaire le scoring... 
Très rarement utilisé, mais il faut maintenir ce code pour les cas où. 

## 🎉 Pour tester

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
