### PR TITLE
[TECH] Ajouter PGBOUNCER_DATABASE_URL pour brancher PGBouncer

### DIFF
--- a/api/datamart/knexfile.js
+++ b/api/datamart/knexfile.js
@@ -1,4 +1,4 @@
-import { buildPostgresEnvironment } from '../db/utils/build-postgres-environment.js';
+import { buildPostgresEnvironment, setConnectionString } from '../db/utils/build-postgres-environment.js';
 import { loadEnvFileIfExists } from '../src/shared/load-env-file-if-exists.js';
 
 loadEnvFileIfExists();
@@ -14,15 +14,7 @@ const baseConfiguration = {
 
 const environments = {
   development: buildPostgresEnvironment(baseConfiguration),
-
-  test: buildPostgresEnvironment({
-    ...baseConfiguration,
-    connection: {
-      ...baseConfiguration.connection,
-      connectionString: process.env.TEST_DATAMART_DATABASE_URL,
-    },
-  }),
-
+  test: setConnectionString(process.env.TEST_DATAMART_DATABASE_URL, buildPostgresEnvironment(baseConfiguration)),
   production: buildPostgresEnvironment(baseConfiguration),
 };
 

--- a/api/datawarehouse/knexfile.js
+++ b/api/datawarehouse/knexfile.js
@@ -1,4 +1,4 @@
-import { buildPostgresEnvironment } from '../db/utils/build-postgres-environment.js';
+import { buildPostgresEnvironment, setConnectionString } from '../db/utils/build-postgres-environment.js';
 import { loadEnvFileIfExists } from '../src/shared/load-env-file-if-exists.js';
 
 loadEnvFileIfExists();
@@ -13,15 +13,7 @@ const baseConfiguration = {
 
 const environments = {
   development: buildPostgresEnvironment(baseConfiguration),
-
-  test: buildPostgresEnvironment({
-    ...baseConfiguration,
-    connection: {
-      ...baseConfiguration.connection,
-      connectionString: process.env.TEST_DATAWAREHOUSE_DATABASE_URL,
-    },
-  }),
-
+  test: setConnectionString(process.env.TEST_DATAWAREHOUSE_DATABASE_URL, buildPostgresEnvironment(baseConfiguration)),
   production: buildPostgresEnvironment(baseConfiguration),
 };
 

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -1,10 +1,10 @@
 import { config } from '../src/shared/config.js';
 import { DatabaseConnection } from './database-connection.js';
 import { databaseConnections } from './database-connections.js';
-import knexConfigs from './knexfile.js';
+import { knexConfigWithPgBouncer } from './knexfile.js';
 
 const { environment } = config;
-const databaseConnection = new DatabaseConnection(knexConfigs[environment]);
+const databaseConnection = new DatabaseConnection(knexConfigWithPgBouncer[environment]);
 const configuredLiveKnex = databaseConnection.knex;
 
 databaseConnections.addConnection(databaseConnection);

--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -1,5 +1,5 @@
 import { loadEnvFileIfExists } from '../src/shared/load-env-file-if-exists.js';
-import { buildPostgresEnvironment } from './utils/build-postgres-environment.js';
+import { buildPostgresEnvironment, setConnectionString } from './utils/build-postgres-environment.js';
 
 loadEnvFileIfExists();
 
@@ -23,16 +23,18 @@ const baseConfiguration = {
   },
 };
 
-export default {
+const defaultKnexConfig = {
   development: buildPostgresEnvironment(baseConfiguration),
-
-  test: buildPostgresEnvironment({
-    ...baseConfiguration,
-    connection: {
-      ...baseConfiguration.connection,
-      connectionString: process.env.TEST_DATABASE_URL,
-    },
-  }),
-
+  test: setConnectionString(process.env.TEST_DATABASE_URL, buildPostgresEnvironment(baseConfiguration)),
   production: buildPostgresEnvironment(baseConfiguration),
 };
+
+export const knexConfigWithPgBouncer = {
+  ...defaultKnexConfig,
+  production: setConnectionString(
+    process.env.PGBOUNCER_DATABASE_URL ?? process.env.DATABASE_URL,
+    buildPostgresEnvironment(baseConfiguration),
+  ),
+};
+
+export default defaultKnexConfig;

--- a/api/db/utils/build-postgres-environment.js
+++ b/api/db/utils/build-postgres-environment.js
@@ -29,3 +29,9 @@ export function buildPostgresEnvironment({
     },
   };
 }
+
+export function setConnectionString(connectionString, configuration) {
+  const updatedConfiguration = structuredClone(configuration);
+  updatedConfiguration.connection.connectionString = connectionString;
+  return updatedConfiguration;
+}

--- a/api/sample.env
+++ b/api/sample.env
@@ -72,8 +72,7 @@ DATADOG_API_KEY=nokey
 # default: development in npm start task, test in npm test task
 # NODE_ENV=development
 
-# URL of the PostgreSQL database used for storing users data (filled-in or
-# generated).
+# URL of the PostgreSQL database
 #
 # If not present, the application will crash during API boostrap.
 #
@@ -81,6 +80,13 @@ DATADOG_API_KEY=nokey
 # type: Url
 # default: none
 DATABASE_URL=postgresql://postgres@localhost/pix
+
+# URL of the PGBouncer
+#
+# presence: optional
+# type: Url
+# default: none
+# PGBOUNCER_DATABASE_URL=
 
 # URL of the PostgreSQL database used for API local testing.
 #
@@ -1272,7 +1278,7 @@ DAY_BEFORE_RETRYING=
 # default: 0
 # DATABASE_CONNECTION_TIMEOUT_MS=
 
-# Response timeout in milliseconds. Help me Benjamin I am not sure about this one.
+# Response timeout in milliseconds.
 # Put 0 to set no timeout at all.
 #
 # presence: optional


### PR DESCRIPTION
## 🪧 Problème

Pour mettre en place `pgbouncer` nous avons besoin de configurer 2 types de connexion à la base de données : 
- Une connexion directe pour les migrations
- Une connexion via `pgbouncer` pour les connexion du serveur de l'API

## 🌈 Proposition

Ajout de la variable d’environnement `PGBOUNCER_DATABASE_URL`, `DATABASE_URL` doit toujours pointée sur l’URL de la base en direct.
- `PGBOUNCER_DATABASE_URL` est utilisé pour les connexions vers PGBouncer pour le serveur de l’API
- `DATABASE_URL` est utilisé pour les connexions en direct pour les migrations.

Si la variable `PGBOUNCER_DATABASE_URL` n'est pas définie, on utilise par défaut `DATABASE_URL`. (pour les environnements locaux, RA et tests)

## ✊ Remarques

N/A

## 🎉 Pour tester

- Testé sur la RA en branchant `pix-pgbouncer-integration`
