### PR TITLE
[TECH] Retirer le FT pour gérer l'entrée en certification anglaise (PIX-23459).

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -136,11 +136,4 @@ export default {
     defaultValue: false,
     tags: ['backend', 'pix-api'],
   },
-  isCertificationInEnglishEnabled: {
-    type: 'boolean',
-    description: 'Enable English as an available language for Pix certification',
-    defaultValue: false,
-    devDefaultValues: { test: true, reviewApp: true },
-    tags: ['frontend', 'backend', 'team-certif', 'pix-app', 'pix-api'],
-  },
 };

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
@@ -14,7 +14,6 @@ import {
   UnexpectedUserAccountError,
   UserAlreadyLinkedToCandidateInSessionError,
 } from '../../../../shared/domain/errors.js';
-import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 import { CenterHabilitationError } from '../../../shared/domain/errors.js';
 import { CertificationCourse } from '../../../shared/domain/models/CertificationCourse.js';
 
@@ -40,10 +39,7 @@ export const verifyCandidateIdentity = async ({
 }) => {
   const user = await userRepository.get({ id: userId });
 
-  const isEnglishEnabled = await featureToggles.get('isCertificationInEnglishEnabled');
-  const isUserLanguageValid = CertificationCourse.isLanguageAvailableForV3Certification(user.lang, {
-    isEnglishEnabled,
-  });
+  const isUserLanguageValid = CertificationCourse.isLanguageAvailableForV3Certification(user.lang);
   if (!isUserLanguageValid) {
     throw new LanguageNotSupportedError(user.lang);
   }

--- a/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -18,7 +18,6 @@ import {
   UnexpectedUserAccountError,
 } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
-import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 import { SessionNotAccessible } from '../../../session-management/domain/errors.js';
 import { ComplementaryCertificationCourse } from '../../../session-management/domain/models/ComplementaryCertificationCourse.js';
 import { CenterHabilitationError } from '../../../shared/domain/errors.js';
@@ -112,11 +111,8 @@ export async function retrieveLastOrCreateCertificationCourse({
   });
 }
 
-async function _validateUserLocale(userLanguage) {
-  const isEnglishEnabled = await featureToggles.get('isCertificationInEnglishEnabled');
-  const isUserLanguageValid = CertificationCourse.isLanguageAvailableForV3Certification(userLanguage, {
-    isEnglishEnabled,
-  });
+function _validateUserLocale(userLanguage) {
+  const isUserLanguageValid = CertificationCourse.isLanguageAvailableForV3Certification(userLanguage);
 
   if (!isUserLanguageValid) {
     throw new LanguageNotSupportedError(userLanguage);
@@ -183,7 +179,7 @@ async function _startNewCertification({
   locale,
   clientTimezone,
 }) {
-  await _validateUserLocale(locale);
+  _validateUserLocale(locale);
 
   const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId: session.id });
 

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -15,8 +15,6 @@ import { AlgorithmEngineVersion } from './AlgorithmEngineVersion.js';
 
 const Joi = BaseJoi.extend(JoiDate);
 
-const ENGLISH_LOCALE = 'en';
-
 export const V3_CERTIFICATION_AVAILABLE_LOCALES = ['fr-fr', 'fr', 'en'];
 
 export class CertificationCourse {
@@ -308,10 +306,8 @@ export class CertificationCourse {
     return AlgorithmEngineVersion.isV3(this._version);
   }
 
-  static isLanguageAvailableForV3Certification(candidateLanguage, { isEnglishEnabled = false } = {}) {
+  static isLanguageAvailableForV3Certification(candidateLanguage) {
     if (!candidateLanguage) return false;
-
-    if (candidateLanguage === ENGLISH_LOCALE && !isEnglishEnabled) return false;
 
     return V3_CERTIFICATION_AVAILABLE_LOCALES.includes(candidateLanguage);
   }

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-identity_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-identity_test.js
@@ -12,7 +12,6 @@ import {
   UnexpectedUserAccountError,
   UserAlreadyLinkedToCandidateInSessionError,
 } from '../../../../../../src/shared/domain/errors.js';
-import { featureToggles } from '../../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
@@ -128,28 +127,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
       // then
       expect(error).to.be.instanceof(LanguageNotSupportedError);
       expect(error.message).to.equal('Given language is not supported : "Le blop blop martien du sud"');
-    });
-  });
-
-  context('when the user language is english and the english certification feature is disabled', function () {
-    it('should throw a LanguageNotSupportedError', async function () {
-      // given
-      sinon.stub(featureToggles, 'get').withArgs('isCertificationInEnglishEnabled').resolves(false);
-      userRepository.get.withArgs({ id: userId }).resolves(
-        domainBuilder.certification.enrolment.buildUser({
-          id: userId,
-          lang: 'en',
-        }),
-      );
-
-      // when
-      const error = await catchErr(verifyCandidateIdentity)({
-        ...dependencies,
-      });
-
-      // then
-      expect(error).to.be.instanceof(LanguageNotSupportedError);
-      expect(error.message).to.equal('Given language is not supported : "en"');
     });
   });
 

--- a/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -20,7 +20,6 @@ import {
 } from '../../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
-import { featureToggles } from '../../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
@@ -760,57 +759,9 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               });
             });
 
-            context('when the locale is english and the english certification feature is disabled', function () {
-              it('should not create a certification', async function () {
-                // given
-                sinon.stub(featureToggles, 'get').withArgs('isCertificationInEnglishEnabled').resolves(false);
-                const userId = 2;
-
-                const foundSession = domainBuilder.certification.evaluation.buildSession.ongoing({
-                  id: 1,
-                  accessCode: 'accessCode',
-                  version: 3,
-                });
-                sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
-
-                const foundCandidate = domainBuilder.certification.evaluation.buildCandidate({
-                  userId,
-                  sessionId: 1,
-                  authorizedToStart: true,
-                  subscriptionFramework: Frameworks.CORE,
-                });
-                candidateRepository.findByUserIdAndSessionId
-                  .withArgs({ sessionId: 1, userId })
-                  .resolves(foundCandidate);
-
-                certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                  .withArgs({ userId, sessionId: 1 })
-                  .resolves(null);
-
-                const certificationCenter = domainBuilder.buildCertificationCenter({
-                  habilitations: [],
-                });
-                certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-
-                // when
-                const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
-                  sessionId: 1,
-                  accessCode: 'accessCode',
-                  userId,
-                  locale: 'en',
-                  ...injectables,
-                });
-
-                // then
-                expect(certificationCourseRepository.save).not.to.have.been.called;
-                expect(error).to.be.instanceOf(LanguageNotSupportedError);
-              });
-            });
-
-            context('when the locale is english and the english certification feature is enabled', function () {
+            context('when the locale is english', function () {
               it('should create a certification', async function () {
                 // given
-                sinon.stub(featureToggles, 'get').withArgs('isCertificationInEnglishEnabled').resolves(true);
                 const userId = 2;
 
                 const foundSession = domainBuilder.certification.evaluation.buildSession.ongoing({

--- a/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
@@ -298,46 +298,12 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
       expect(isAvailable).to.be.false;
     });
 
-    context('when the english option is not provided', function () {
-      it('should be false for english', function () {
-        // when
-        const isAvailable = CertificationCourse.isLanguageAvailableForV3Certification('en');
+    it('should be true for english', function () {
+      // when
+      const isAvailable = CertificationCourse.isLanguageAvailableForV3Certification('en');
 
-        // then
-        expect(isAvailable).to.be.false;
-      });
-    });
-
-    context('when english is disabled', function () {
-      it('should be false for english', function () {
-        // when
-        const isAvailable = CertificationCourse.isLanguageAvailableForV3Certification('en', {
-          isEnglishEnabled: false,
-        });
-
-        // then
-        expect(isAvailable).to.be.false;
-      });
-
-      it('should still be true for french', function () {
-        // when
-        const isAvailable = CertificationCourse.isLanguageAvailableForV3Certification('fr', {
-          isEnglishEnabled: false,
-        });
-
-        // then
-        expect(isAvailable).to.be.true;
-      });
-    });
-
-    context('when english is enabled', function () {
-      it('should be true for english', function () {
-        // when
-        const isAvailable = CertificationCourse.isLanguageAvailableForV3Certification('en', { isEnglishEnabled: true });
-
-        // then
-        expect(isAvailable).to.be.true;
-      });
+      // then
+      expect(isAvailable).to.be.true;
     });
   });
 });

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -25,7 +25,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'disabled-locales-in-frontend': [],
             'display-catalogue': true,
             'is-async-quest-rewarding-calculation-enabled': false,
-            'is-certification-in-english-enabled': true,
             'is-survey-enabled-for-combined-courses': true,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,

--- a/high-level-tests/e2e-playwright/pages/pix-app/CertificationAccessCodePage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/CertificationAccessCodePage.ts
@@ -8,8 +8,8 @@ export class CertificationAccessCodePage {
     const languageDropdown = this.page.getByRole('button', { name: 'Langue de certification' });
 
     if (await languageDropdown.isVisible()) {
-      // await languageDropdown.click();
-      // await this.page.getByRole('option', { name: 'français - FR' }).click();
+      await languageDropdown.click();
+      await this.page.getByRole('option', { name: 'français - FR' }).click();
 
       const languageConfirmationCheckbox = this.page.getByRole('checkbox', {
         name: /Je confirme être à l'aise dans la langue sélectionnée/,

--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -28,7 +28,6 @@ export default class CertificationStarter extends Component {
   @service intl;
   @service focusedCertificationChallengeWarningManager;
   @service pixCompanion;
-  @service featureToggles;
 
   @tracked inputAccessCode = '';
   @tracked apiErrorMessage = null;
@@ -67,30 +66,17 @@ export default class CertificationStarter extends Component {
     return !this.currentDomain.isFranceDomain;
   }
 
-  get isCertificationInEnglishEnabled() {
-    return Boolean(this.featureToggles.featureToggles?.isCertificationInEnglishEnabled);
-  }
-
-  get isLanguageSelectorDisabled() {
-    return !this.isCertificationInEnglishEnabled;
-  }
-
   get languageOptions() {
-    const options = [
+    return [
       {
         value: VALID_CERTIFICATION_LOCALES.FRENCH,
         label: this.intl.t('pages.certification-start.language-selector.options.french'),
       },
-    ];
-
-    if (this.isCertificationInEnglishEnabled) {
-      options.push({
+      {
         value: VALID_CERTIFICATION_LOCALES.ENGLISH,
         label: this.intl.t('pages.certification-start.language-selector.options.english'),
-      });
-    }
-
-    return options;
+      },
+    ];
   }
 
   get subscriptionLabel() {
@@ -229,17 +215,10 @@ export default class CertificationStarter extends Component {
             @options={{this.languageOptions}}
             @hideDefaultOption={{true}}
             @iconName="language"
-            @isDisabled={{this.isLanguageSelectorDisabled}}
           >
             <:label>{{t "pages.certification-start.language-selector.label"}}</:label>
             <:default as |language|>{{language.label}}</:default>
           </PixSelect>
-
-          {{#unless this.isCertificationInEnglishEnabled}}
-            <PixNotificationAlert @withIcon={{true}} @type="error">
-              <p>{{t "pages.certification-start.language-selector.warning-message"}}</p>
-            </PixNotificationAlert>
-          {{/unless}}
 
           <PixCheckbox
             @class="certification-start-form__lang-confirm-checkbox"

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -8,5 +8,4 @@ export default class FeatureToggle extends Model {
   @attr('boolean') areCombinedCoursesEnabled;
   @attr('array') disabledLocalesInFrontend;
   @attr('boolean') isSessionLogoutEnabled;
-  @attr('boolean') isCertificationInEnglishEnabled;
 }

--- a/mon-pix/tests/integration/components/certification-starter-test.gjs
+++ b/mon-pix/tests/integration/components/certification-starter-test.gjs
@@ -31,11 +31,6 @@ const submitForm = () => clickByLabel(t('pages.certification-start.actions.submi
 const stubFranceDomain = (owner, isFranceDomain) =>
   sinon.stub(owner.lookup('service:currentDomain'), 'isFranceDomain').get(() => isFranceDomain);
 
-const stubCertificationInEnglish = (owner, isEnabled) =>
-  sinon
-    .stub(owner.lookup('service:feature-toggles'), 'featureToggles')
-    .get(() => ({ isCertificationInEnglishEnabled: isEnabled }));
-
 const setCertificationCandidate = (context, attributes) => {
   const store = context.owner.lookup('service:store');
   model = {
@@ -111,37 +106,18 @@ module('Integration | Component | certification-starter', function (hooks) {
           );
         });
 
-        module('when certification in english is enabled', function () {
-          test('should be possible to update the selected language', async function (assert) {
-            // given
-            stubCertificationInEnglish(this.owner, true);
-            const screen = await renderComponent();
+        test('should be possible to update the selected language', async function (assert) {
+          // given
+          const screen = await renderComponent();
 
-            // when
-            await click(screen.getByRole('button', { name: 'Langue de certification' }));
-            await click(screen.getByText('anglais - EN'));
+          // when
+          await click(screen.getByRole('button', { name: 'Langue de certification' }));
+          await click(screen.getByText('anglais - EN'));
 
-            // then
-            assert.ok(
-              screen.getByRole('button', { name: 'Langue de certification' }).textContent.includes('anglais - EN'),
-            );
-            assert.notOk(screen.queryByText(t('pages.certification-start.language-selector.warning-message')));
-          });
-        });
-
-        module('when certification in english is disabled', function () {
-          test('should display the language selector as disabled and a a warning message', async function (assert) {
-            // given
-            stubCertificationInEnglish(this.owner, false);
-
-            // when
-            const screen = await renderComponent();
-
-            // then
-            assert.dom(screen.getByRole('button', { name: 'Langue de certification' })).hasAttribute('aria-disabled');
-            assert.notOk(screen.queryByText('anglais - EN'));
-            assert.ok(screen.getByText(t('pages.certification-start.language-selector.warning-message')));
-          });
+          // then
+          assert.ok(
+            screen.getByRole('button', { name: 'Langue de certification' }).textContent.includes('anglais - EN'),
+          );
         });
 
         module('when the language confirmation checkbox is not checked and code filled', function () {
@@ -289,7 +265,6 @@ module('Integration | Component | certification-starter', function (hooks) {
           routerObserver.replaceWith = sinon.stub();
 
           stubFranceDomain(this.owner, false);
-          stubCertificationInEnglish(this.owner, true);
 
           model = {
             certificationCandidate: { hasStartedTest: false, sessionId: 123 },

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -979,8 +979,7 @@
         "options": {
           "english": "Englisch - EN",
           "french": "Französisch - FR"
-        },
-        "warning-message": "Aufgrund eines technischen Problems ist die Pix-Zertifizierung vorübergehend nicht auf Englisch verfügbar. Wir entschuldigen uns für die Unannehmlichkeiten."
+        }
       },
       "link-to-user-certification": "Meine Zertifizierungen ansehen",
       "non-eligible-subscription": "Du bist nicht für {subscriptionLabel} qualifiziert. Du aknnst dennoch deine Pix-Zertifizierung ablegen.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -979,8 +979,7 @@
         "options": {
           "english": "English - EN",
           "french": "French - FR"
-        },
-        "warning-message": "Due to technical problems, the Pix Certification is momentarily unavailable in English. We apologize for any inconvenience caused."
+        }
       },
       "link-to-user-certification": "See my certificates",
       "non-eligible-subscription": "You are not eligible to {subscriptionLabel}. However, you can still take your Pix Certification.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -979,8 +979,7 @@
         "options": {
           "english": "inglés - EN",
           "french": "francés - FR"
-        },
-        "warning-message": "Debido a un problema técnico, la Certificación Pix no está disponible temporalmente en inglés. Nos disculpamos por las molestias ocasionadas."
+        }
       },
       "link-to-user-certification": "Ver mis certificaciones",
       "non-eligible-subscription": "No eres elegible para {subscriptionLabel}. Sin embargo, puedes presentarte a la certificación Pix.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -979,8 +979,7 @@
         "options": {
           "english": "anglais - EN",
           "french": "français - FR"
-        },
-        "warning-message": "Suite un à problème technique, la Certification Pix est momentanément indisponible en anglais. Nous nous excusons pour la gêne occassionnée."
+        }
       },
       "link-to-user-certification": "Voir mes certifications",
       "non-eligible-subscription": "Vous n'êtes pas éligible à {subscriptionLabel}. Vous pouvez néanmoins passer votre certification Pix.",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -979,8 +979,7 @@
         "options": {
           "english": "inglese - EN",
           "french": "francese - FR"
-        },
-        "warning-message": "A causa di un problema tecnico, la Certificazione Pix è temporaneamente non disponibile in inglese. Ci scusiamo per l'inconveniente."
+        }
       },
       "link-to-user-certification": "Vedi le mie certificazioni",
       "non-eligible-subscription": "Non si ha diritto a {subscriptionLabel}. È tuttavia possibile ottenere la certificazione Pix.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -979,8 +979,7 @@
         "options": {
           "english": "Engels - EN",
           "french": "Frans - FR"
-        },
-        "warning-message": "Vanwege een technisch probleem is de Pix-certificering tijdelijk niet beschikbaar in het Engels. Onze excuses voor het ongemak."
+        }
       },
       "link-to-user-certification": "Bekijk mijn certificaten",
       "non-eligible-subscription": "Je komt niet in aanmerking voor {subscriptionLabel}. Je kunt echter wel je Pix-certificering behalen.",


### PR DESCRIPTION
## 🪧 Problème

Un feature-toggle avait été ajouté pour bloquer les certifications en anglais : https://github.com/1024pix/pix/pull/16646.

Suite à une [nouvelle récupération](https://1024pix.atlassian.net/wiki/spaces/TC1/pages/6206685193/ONE-TIME+R+cup+rer+les+challenges+anglais+de+la+certif+c+ur) des challenges calibrés en anglais, on peut maintenat réouvrir ces certifications.

## 🌈 Proposition

Supprimer le feature-toggle `isCertificationInEnglishEnabled`.

## 🎉 Pour tester

- Aller sur PixApp.org en RA
- Essayer de rentrer dans une certif, en anglais
