### PR TITLE
[TECH] Création d'une table de jointure tubes_versions (PIX-23480).

### DIFF
--- a/api/db/migrations/20260708073135_tube_version.js
+++ b/api/db/migrations/20260708073135_tube_version.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'certification_versions_tubes';
+const TUBE_VERSION_ID_COLUMN_NAME = 'tube_id';
+const VERSION_ID_COLUMN_NAME = 'version_id';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string(TUBE_VERSION_ID_COLUMN_NAME).comment('Tube identifier');
+    table.integer(VERSION_ID_COLUMN_NAME).references('certification_versions.id').comment('Version identifier');
+    table.primary([VERSION_ID_COLUMN_NAME, TUBE_VERSION_ID_COLUMN_NAME]);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+}


### PR DESCRIPTION
## 🪧 Problème

Actuellement, lorsque nous créons une version, nous sélectionnons des sujets (`tubes`) à partir duquel nous cherchons les `challenges` correspondant que nous enregistrons en BDD dans la table `certification-frameworks-challenges`.
Maintenant que nous pouvons créer des nouvelles versions "brouillon" longtemps en amont de leur calibrations, il nous faut pouvoir nous assurer que nous ne créons pas un delta trop important entre les `certification-frameworks-challenges` qui sont créés suite à la sélection des tubes et la liste des potentiels challenges calibrés dans le futur.

Exemple: 

- Nous créons 100 challenges dans la table `certification-frameworks-challenges` lors de la création d'une version.
- Les mois passent et une calibration contenant 112 challenges est prête
Avec le système actuel, nous n'enregistrons la calibration que des 100 challenges initialement sauvegardés.

## 🌈 Proposition

Nous souhaitons faire en sorte que ce delta n'existe plus. Pour cela, nous nous rapprochons de l'intention utilisateur et souhaitons enregistrer les sujets choisis, et non les challenges.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

- La nouvelle table est créée lors de la migration
- La table est supprimée après rollback