### PR TITLE
[TECH] Améliorer le temps de traitement du endpoint maddo /api/organizations/{id}/campaigns

### DIFF
--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -1,4 +1,3 @@
-import { getChallengeLocale } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 
 export async function getOrganizations(request, h, dependencies = { findOrganizations: usecases.findOrganizations }) {
@@ -8,12 +7,10 @@ export async function getOrganizations(request, h, dependencies = { findOrganiza
 
 export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
   const { page } = request.query;
-  const locale = getChallengeLocale(request);
   const requestedOrganizationId = request.params.organizationId;
   const result = await dependencies.findCampaigns({
     organizationId: requestedOrganizationId,
     page,
-    locale,
   });
   return h.response(result).code(200);
 }

--- a/api/src/maddo/domain/usecases/find-campaigns.js
+++ b/api/src/maddo/domain/usecases/find-campaigns.js
@@ -1,3 +1,3 @@
-export async function findCampaigns({ organizationId, campaignRepository, page, locale }) {
-  return campaignRepository.findByOrganizationId(organizationId, page, locale);
+export async function findCampaigns({ organizationId, campaignRepository, page }) {
+  return campaignRepository.findByOrganizationId(organizationId, page);
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -2,12 +2,12 @@ import * as campaignAPI from '../../../prescription/campaign/application/api/cam
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
-export async function findByOrganizationId(organizationId, page, locale) {
-  const campaigns = await campaignAPI.findAllForOrganization({
+export async function findByOrganizationId(organizationId, page) {
+  const campaigns = await campaignAPI.findAllSummariesForOrganization({
     organizationId,
-    withCoverRate: false,
+    withTargetProfileName: true,
+    withArchived: false,
     page,
-    locale,
   });
   return {
     page: toPage(campaigns.meta),

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -183,6 +183,8 @@ export const findAllForOrganization = async (payload) => {
  * @typedef CampaignSummaryListPayload
  * @type {object}
  * @property {number} organizationId
+ * @property {boolean} withTargetProfileName
+ * @property {boolean} withArchived
  * @property {PageDefinition} page
  */
 
@@ -190,7 +192,8 @@ export const findAllForOrganization = async (payload) => {
  * @function
  * @name findAllSummariesForOrganization
  * @description Lists an organization's campaigns with only their core attributes (no participation
- * counts, owner or target profile joins).
+ * counts or owner joins).
+ * Can include the targetProfileName if withTargetProfileName is true
  *
  * @param {CampaignSummaryListPayload} payload
  * @returns {Promise<CampaignListResponse>}
@@ -198,6 +201,8 @@ export const findAllForOrganization = async (payload) => {
 export const findAllSummariesForOrganization = async (payload) => {
   const { models: campaigns, meta } = await usecases.findPaginatedOrganizationCampaignSummaries({
     organizationId: payload.organizationId,
+    withTargetProfileName: payload.withTargetProfileName ?? false,
+    withArchived: payload.withArchived ?? true,
     page: payload.page,
   });
 

--- a/api/src/prescription/campaign/domain/usecases/find-paginated-organization-campaign-summaries.js
+++ b/api/src/prescription/campaign/domain/usecases/find-paginated-organization-campaign-summaries.js
@@ -1,6 +1,14 @@
-const findPaginatedOrganizationCampaignSummaries = async ({ organizationId, page, campaignReportRepository }) =>
+const findPaginatedOrganizationCampaignSummaries = async ({
+  organizationId,
+  withTargetProfileName,
+  withArchived,
+  page,
+  campaignReportRepository,
+}) =>
   await campaignReportRepository.findAllPaginatedSummariesByOrganizationId({
     organizationId,
+    withTargetProfileName,
+    withArchived,
     page,
   });
 

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -161,14 +161,36 @@ const findPaginatedFilteredByOrganizationId = async function ({
   return { models: campaignReports, meta: { ...pagination, hasCampaigns } };
 };
 
-const findAllPaginatedSummariesByOrganizationId = async function ({ organizationId, page }) {
+const findAllPaginatedSummariesByOrganizationId = async function ({
+  organizationId,
+  withTargetProfileName = false,
+  withArchived = true,
+  page,
+}) {
   const knexConn = DomainTransaction.getConnection();
 
   const query = knexConn('campaigns')
-    .select('id', 'name', 'code', 'type', 'createdAt', 'archivedAt')
+    .select(
+      'campaigns.id',
+      'campaigns.name',
+      'campaigns.code',
+      'campaigns.type',
+      'campaigns.createdAt',
+      'campaigns.archivedAt',
+    )
     .where({ organizationId })
     .whereNull('deletedAt')
     .orderBy('createdAt', 'DESC');
+
+  if (withTargetProfileName) {
+    query
+      .select('target-profiles.name as targetProfileName')
+      .leftJoin('target-profiles', 'campaigns.targetProfileId', 'target-profiles.id');
+  }
+
+  if (!withArchived) {
+    query.whereNull('archivedAt');
+  }
 
   const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
@@ -13,34 +13,39 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
       const campaign1 = databaseBuilder.factory.buildCampaign({
         organizationId: organization.id,
         targetProfileId: targetProfile.id,
+        createdAt: new Date('2026-01-01'),
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+        createdAt: new Date('2026-01-02'),
+        archivedAt: new Date('2026-01-03'),
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+        createdAt: new Date('2026-01-02'),
+        deletedAt: new Date('2026-01-03'),
       });
       const campaign2 = databaseBuilder.factory.buildCampaign({
         organizationId: organization.id,
         targetProfileId: targetProfile.id,
+        createdAt: new Date('2026-01-03'),
       });
       databaseBuilder.factory.buildCampaign({ organizationId: otherOrganizationId });
 
       await databaseBuilder.commit();
 
       // when
-      const { campaigns, page } = await findByOrganizationId(organization.id, { number: 1, size: 2 }, 'en');
+      const { campaigns, page } = await findByOrganizationId(organization.id, { number: 1, size: 10 });
 
       // then
       expect(page).to.deep.equal({
         number: 1,
-        size: 2,
+        size: 10,
         count: 1,
       });
       expect(campaigns).to.deep.equal([
-        new Campaign({
-          id: campaign1.id,
-          name: campaign1.name,
-          type: campaign1.type,
-          targetProfileName: targetProfile.name,
-          code: campaign1.code,
-          createdAt: campaign1.createdAt,
-          archivedAt: campaign1.archivedAt,
-        }),
         new Campaign({
           id: campaign2.id,
           name: campaign2.name,
@@ -49,6 +54,15 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
           code: campaign2.code,
           archivedAt: campaign2.archivedAt,
           createdAt: campaign2.createdAt,
+        }),
+        new Campaign({
+          id: campaign1.id,
+          name: campaign1.name,
+          type: campaign1.type,
+          targetProfileName: targetProfile.name,
+          code: campaign1.code,
+          createdAt: campaign1.createdAt,
+          archivedAt: campaign1.archivedAt,
         }),
       ]);
     });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1212,6 +1212,7 @@ describe('Integration | Repository | Campaign-Report', function () {
         organizationId,
         name: 'Oldest',
         createdAt: new Date('2020-01-01'),
+        archivedAt: new Date('2020-03-01'),
       });
       const newest = databaseBuilder.factory.buildCampaign({
         organizationId,
@@ -1241,12 +1242,104 @@ describe('Integration | Repository | Campaign-Report', function () {
       // when
       const { models, meta } = await campaignReportRepository.findAllPaginatedSummariesByOrganizationId({
         organizationId,
+        withTargetProfileName: false,
         page: { number: 1, size: 10 },
       });
 
       // then
       expect(models.map(({ id }) => id)).to.deep.equal([kept.id]);
       expect(meta.rowCount).to.equal(1);
+    });
+
+    describe('when withTargetProfileName is true', function () {
+      it('should return targetProfileName for campaigns with a target profile', async function () {
+        // given
+        const oldest = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          name: 'Oldest',
+          createdAt: new Date('2020-01-01'),
+          targetProfileId: null,
+        });
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const newest = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          name: 'Newest',
+          createdAt: new Date('2023-01-01'),
+          targetProfileId: targetProfile.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { models, meta } = await campaignReportRepository.findAllPaginatedSummariesByOrganizationId({
+          organizationId,
+          withTargetProfileName: true,
+          page: { number: 1, size: 10 },
+        });
+
+        // then
+        expect(models).to.deep.equal([
+          {
+            id: newest.id,
+            name: newest.name,
+            code: newest.code,
+            type: newest.type,
+            createdAt: newest.createdAt,
+            archivedAt: newest.archivedAt,
+            targetProfileName: targetProfile.name,
+          },
+          {
+            id: oldest.id,
+            name: oldest.name,
+            code: oldest.code,
+            type: oldest.type,
+            createdAt: oldest.createdAt,
+            archivedAt: oldest.archivedAt,
+            targetProfileName: null,
+          },
+        ]);
+        expect(meta).to.deep.equal({ page: 1, pageCount: 1, pageSize: 10, rowCount: 2 });
+      });
+    });
+
+    describe('when withArchived is false', function () {
+      it('should not return archived campaigns', async function () {
+        // given
+        databaseBuilder.factory.buildCampaign({
+          organizationId,
+          name: 'Oldest',
+          createdAt: new Date('2020-01-01'),
+          targetProfileId: null,
+        });
+        const archived = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          name: 'Archived',
+          createdAt: new Date('2022-01-01'),
+          archivedAt: new Date('2022-03-01'),
+        });
+        databaseBuilder.factory.buildCampaign({
+          organizationId,
+          name: 'Newest',
+          createdAt: new Date('2023-01-01'),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { models, meta } = await campaignReportRepository.findAllPaginatedSummariesByOrganizationId({
+          organizationId,
+          withArchived: false,
+          page: { number: 1, size: 10 },
+        });
+
+        // then
+        expect(models.length).to.equal(2);
+        expect(models.find(({ id }) => id === archived.id)).to.be.undefined;
+        expect(meta).to.deep.equal({
+          page: 1,
+          pageCount: 1,
+          pageSize: 10,
+          rowCount: 2,
+        });
+      });
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -296,7 +296,7 @@ describe('Unit | API | Campaigns', function () {
 
       sinon
         .stub(usecases, 'findPaginatedOrganizationCampaignSummaries')
-        .withArgs({ organizationId, page })
+        .withArgs({ organizationId, withTargetProfileName: false, withArchived: true, page })
         .resolves({ models: [campaignInformation1], meta });
 
       // when


### PR DESCRIPTION
## 🪧 Problème
Le endpoint utilisé par France Travail pour récupérer les campagnes d'une organisation prend plusieurs dizaines de secondes. 

## 🌈 Proposition
Utiliser une requête custom plutôt que de passer par l'API interne qui remonte beaucoup trop d'informations pour notre usage ici.

## ✊ Remarques
On passe de:
```
select distinct "campaigns"."id",
                "campaigns"."id",
                "campaigns"."name",
                "campaigns"."code",
                "campaigns"."type",
                "campaigns"."archivedAt",
                "campaigns"."createdAt",
                "users"."id"                                                                                               as "ownerId",
                "users"."firstName"                                                                                        as "ownerFirstName",
                "users"."lastName"                                                                                         as "ownerLastName",
                "target-profiles"."name"                                                                                   as "targetProfileName",
                COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND
                                       "campaign-participations"."isImproved" IS FALSE AND
                                       "campaign-participations"."deletedAt" IS NULL) OVER (partition by "campaigns"."id") AS "participationsCount",
                COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND
                                       "campaign-participations"."status" = 'SHARED' AND
                                       "campaign-participations"."isImproved" IS FALSE AND
                                       "campaign-participations"."deletedAt" IS NULL) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"
from "campaigns"
         inner join "users" on "users"."id" = "campaigns"."ownerId"
         left join "target-profiles" on "target-profiles"."id" = "campaigns"."targetProfileId"
         left join "campaign-participations" on "campaign-participations"."campaignId" = "campaigns"."id"
where "campaigns"."organizationId" = ?
  and "campaigns"."deletedAt" is null
  and "campaigns"."archivedAt" is null
order by "campaigns"."createdAt" DESC
limit ?;
```

à ça:

```
select "campaigns"."id",
       "campaigns"."name",
       "campaigns"."type",
       "target-profiles"."name" as "targetProfileName",
       "campaigns"."code",
       "campaigns"."createdAt",
       "campaigns"."archivedAt"
from "campaigns"
         left join "target-profiles" on "campaigns"."targetProfileId" = "target-profiles"."id"
where "campaigns"."organizationId" = ?
  and "campaigns"."deletedAt" is null
  and "campaigns"."archivedAt" is null
order by "campaigns"."createdAt" DESC
limit ?;
````

## 🎉 Pour tester
```
ACCESS_TOKEN=$(curl -X 'POST' -s \
  'https://pix-api-maddo-review-pr16754.osc-fr1.scalingo.io/api/application/token' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=meta campaigns' | jq -r ".access_token")
```

```
curl https://pix-api-maddo-review-pr16754.osc-fr1.scalingo.io/api/organizations/1000/campaigns -H "Authorization: Bearer $ACCESS_TOKEN" | jq
```
