### PR TITLE
[FEATURE] Ajouter les tooltips dans les émojis pour le feedback de fin de parcours (PIX-23457).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/satisfaction-score.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/satisfaction-score.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -6,11 +7,21 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 const EMOJIS = [
-  { score: 1, emoji: '😖', labelKey: 'pages.skill-review.recommended-engine.drawer.emojis.very-dissatisfied' },
+  {
+    score: 1,
+    emoji: '😖',
+    labelKey: 'pages.skill-review.recommended-engine.drawer.emojis.very-dissatisfied',
+    showLabel: true,
+  },
   { score: 2, emoji: '😒', labelKey: 'pages.skill-review.recommended-engine.drawer.emojis.dissatisfied' },
   { score: 3, emoji: '😐', labelKey: 'pages.skill-review.recommended-engine.drawer.emojis.neutral' },
   { score: 4, emoji: '🙂', labelKey: 'pages.skill-review.recommended-engine.drawer.emojis.satisfied' },
-  { score: 5, emoji: '😍', labelKey: 'pages.skill-review.recommended-engine.drawer.emojis.very-satisfied' },
+  {
+    score: 5,
+    emoji: '😍',
+    labelKey: 'pages.skill-review.recommended-engine.drawer.emojis.very-satisfied',
+    showLabel: true,
+  },
 ];
 
 export default class SatisfactionScore extends Component {
@@ -30,14 +41,28 @@ export default class SatisfactionScore extends Component {
         </p>
         <div class="results-recommendation-engine-drawer__emojis">
           {{#each EMOJIS as |satisfaction|}}
-            <button
-              type="button"
-              class="results-recommendation-engine-drawer__emoji-button"
-              aria-label={{t satisfaction.labelKey}}
-              {{on "click" (fn this.selectScore satisfaction.score)}}
-            >
-              <span aria-hidden="true">{{satisfaction.emoji}}</span>
-            </button>
+            <div class="results-recommendation-engine-drawer__emoji-wrapper">
+              <PixTooltip @position="top" @isInline={{true}} @isTriggerElementFocusable={{true}}>
+                <:triggerElement>
+                  <button
+                    type="button"
+                    class="results-recommendation-engine-drawer__emoji-button"
+                    aria-label={{t satisfaction.labelKey}}
+                    {{on "click" (fn this.selectScore satisfaction.score)}}
+                  >
+                    <span aria-hidden="true">{{satisfaction.emoji}}</span>
+                  </button>
+                </:triggerElement>
+                <:tooltip>
+                  {{t satisfaction.labelKey}}
+                </:tooltip>
+              </PixTooltip>
+              {{#if satisfaction.showLabel}}
+                <span class="results-recommendation-engine-drawer__emoji-label" aria-hidden="true">
+                  {{t satisfaction.labelKey}}
+                </span>
+              {{/if}}
+            </div>
           {{/each}}
         </div>
         <PixButton

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
@@ -1,4 +1,5 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
 
 @keyframes drawer-slide-up {
   from {
@@ -64,6 +65,30 @@
     flex-direction: row;
     gap: var(--pix-spacing-2x);
     align-items: center;
+    padding-bottom: var(--pix-spacing-8x);
+
+    @include breakpoints.device-is('mobile') {
+      gap: var(--pix-spacing-4x);
+    }
+  }
+
+  &__emoji-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__emoji-label {
+    @extend %pix-body-xs;
+
+    position: absolute;
+    top: calc(100% + var(--pix-spacing-1x));
+    left: 50%;
+    width: max-content;
+    max-width: 4.5rem;
+    line-height: 14px;
+    transform: translateX(-50%);
   }
 
   &__emoji-button {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer/satisfaction-score-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer/satisfaction-score-test.gjs
@@ -76,6 +76,62 @@ module(
         .isVisible();
     });
 
+    test('it displays a tooltip for each emoji button', async function (assert) {
+      // given
+      const noop = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><SatisfactionScore @onScoreSelected={{noop}} @onHide={{noop}} /></template>,
+      );
+
+      // then
+      const tooltips = screen.getAllByRole('tooltip', { hidden: true });
+      assert.strictEqual(tooltips.length, 5);
+      assert.dom(tooltips[0]).hasText(t('pages.skill-review.recommended-engine.drawer.emojis.very-dissatisfied'));
+      assert.dom(tooltips[1]).hasText(t('pages.skill-review.recommended-engine.drawer.emojis.dissatisfied'));
+      assert.dom(tooltips[2]).hasText(t('pages.skill-review.recommended-engine.drawer.emojis.neutral'));
+      assert.dom(tooltips[3]).hasText(t('pages.skill-review.recommended-engine.drawer.emojis.satisfied'));
+      assert.dom(tooltips[4]).hasText(t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'));
+    });
+
+    [
+      {
+        label: 'very-dissatisfied',
+        length: 2,
+      },
+      {
+        label: 'dissatisfied',
+        length: 1,
+      },
+      {
+        label: 'neutral',
+        length: 1,
+      },
+      {
+        label: 'satisfied',
+        length: 1,
+      },
+      {
+        label: 'very-satisfied',
+        length: 2,
+      },
+    ].forEach((emoji) => {
+      test('it displays labels only under the first (very-dissatisfied) and last (very-satisfied) emoji buttons', async function (assert) {
+        // given
+        const noop = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template><SatisfactionScore @onScoreSelected={{noop}} @onHide={{noop}} /></template>,
+        );
+
+        // then
+        const emojiLabel = screen.getAllByText(t(`pages.skill-review.recommended-engine.drawer.emojis.${emoji.label}`));
+        assert.strictEqual(emojiLabel.length, emoji.length);
+      });
+    });
+
     module('when user clicks an emoji', function () {
       test('it calls onScoreSelected with the corresponding score', async function (assert) {
         // given

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2255,16 +2255,16 @@
       "recommended-engine": {
         "drawer": {
           "emojis": {
-            "dissatisfied": "Ich mag es nicht",
+            "dissatisfied": "Nicht relevant",
             "neutral": "Ich habe keine Meinung",
-            "satisfied": "Ich mag es",
-            "very-dissatisfied": "Ich mag es gar nicht",
-            "very-satisfied": "Ich liebe es"
+            "satisfied": "Relevant",
+            "very-dissatisfied": "Überhaupt nicht relevant",
+            "very-satisfied": "Sehr relevant"
           },
           "hide": "Ausblenden",
           "hide-aria-label": "Feedbackbereich für Empfehlungen zu Lerninhalten ausblenden",
           "instruction": "Klicken Sie auf ein Emoji, um Ihre Meinung zu geben.",
-          "statement": "Ich schätze die Inhalte, die mir empfohlen werden, um weiterzumachen.",
+          "statement": "Erscheinen Ihnen diese empfohlenen Lerninhalte zur Vertiefung Ihres Wissens relevant?",
           "thank-you": {
             "subtitle": "Geschafft!",
             "title": "Danke für Ihr Feedback!"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2255,16 +2255,16 @@
       "recommended-engine": {
         "drawer": {
           "emojis": {
-            "dissatisfied": "I don't like it",
+            "dissatisfied": "Not relevant",
             "neutral": "I have no opinion",
-            "satisfied": "I like it",
-            "very-dissatisfied": "I don't like it at all",
-            "very-satisfied": "I love it"
+            "satisfied": "Relevant",
+            "very-dissatisfied": "Not relevant at all",
+            "very-satisfied": "Very relevant"
           },
           "hide": "Hide",
           "hide-aria-label": "Hide the feedback panel for training content recommendations",
           "instruction": "Click on an emoji to give your feedback.",
-          "statement": "I appreciate the content recommended to me to go further.",
+          "statement": "Do these training content recommendations to deepen your knowledge seem relevant to you?",
           "thank-you": {
             "subtitle": "It's in the bag",
             "title": "Thank you for your feedback!"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2255,16 +2255,16 @@
       "recommended-engine": {
         "drawer": {
           "emojis": {
-            "dissatisfied": "No me gusta",
+            "dissatisfied": "No pertinente",
             "neutral": "No tengo opinión",
-            "satisfied": "Me gusta",
-            "very-dissatisfied": "No me gusta nada",
-            "very-satisfied": "Me encanta"
+            "satisfied": "Pertinente",
+            "very-dissatisfied": "Para nada pertinente",
+            "very-satisfied": "Muy pertinente"
           },
           "hide": "Ocultar",
           "hide-aria-label": "Ocultar el panel de comentarios de las recomendaciones de contenidos formativos",
           "instruction": "Haz clic en un emoji para dar tu opinión.",
-          "statement": "Aprecio los contenidos que me recomiendan para ir más lejos.",
+          "statement": "¿Te parecen pertinentes estos contenidos formativos recomendados para profundizar tus conocimientos?",
           "thank-you": {
             "subtitle": "¡Misión cumplida!",
             "title": "¡Gracias por tu opinión!"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2266,7 +2266,7 @@
           "instruction": "Cliquez sur un emoji pour donner votre avis.",
           "statement": "J'apprécie les contenus qui me sont recommandés pour aller plus loin.",
           "thank-you": {
-            "subtitle": "C'est dans la boite",
+            "subtitle": "C'est dans la boîte",
             "title": "Merci pour votre avis !"
           },
           "title": "Feedback sur la recommandation de contenu formatif"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2255,16 +2255,16 @@
       "recommended-engine": {
         "drawer": {
           "emojis": {
-            "dissatisfied": "Je n'apprécie pas",
-            "neutral": "Je n'ai pas d'avis",
-            "satisfied": "J'aime bien",
-            "very-dissatisfied": "Je n'apprécie pas du tout",
-            "very-satisfied": "J'adore"
+            "dissatisfied": "Pas pertinent",
+            "neutral": "Je n’ai pas d’avis",
+            "satisfied": "Pertinent",
+            "very-dissatisfied": "Pas du tout pertinent",
+            "very-satisfied": "Très pertinent"
           },
           "hide": "Masquer",
           "hide-aria-label": "Fermer l'encart de feedback des recommandations de contenus formatifs",
           "instruction": "Cliquez sur un emoji pour donner votre avis.",
-          "statement": "J'apprécie les contenus qui me sont recommandés pour aller plus loin.",
+          "statement": "Ces offres de formation pour approfondir vos connaissances vous semblent-elles pertinentes ?",
           "thank-you": {
             "subtitle": "C'est dans la boîte",
             "title": "Merci pour votre avis !"

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2255,16 +2255,16 @@
       "recommended-engine": {
         "drawer": {
           "emojis": {
-            "dissatisfied": "Non mi piace",
+            "dissatisfied": "Non pertinente",
             "neutral": "Non ho un'opinione",
-            "satisfied": "Mi piace",
-            "very-dissatisfied": "Non mi piace per niente",
-            "very-satisfied": "Lo adoro"
+            "satisfied": "Pertinente",
+            "very-dissatisfied": "Per niente pertinente",
+            "very-satisfied": "Molto pertinente"
           },
           "hide": "Nascondi",
           "hide-aria-label": "Nascondi il pannello di feedback per le raccomandazioni sui contenuti formativi",
           "instruction": "Clicca su un emoji per dare il tuo parere.",
-          "statement": "Apprezzo i contenuti consigliati per andare oltre.",
+          "statement": "Questi contenuti formativi consigliati per approfondire le tue conoscenze ti sembrano pertinenti?",
           "thank-you": {
             "subtitle": "Missione compiuta!",
             "title": "Grazie per il tuo feedback!"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2255,16 +2255,16 @@
       "recommended-engine": {
         "drawer": {
           "emojis": {
-            "dissatisfied": "Ik vind het niet leuk",
+            "dissatisfied": "Niet relevant",
             "neutral": "Ik heb geen mening",
-            "satisfied": "Ik vind het leuk",
-            "very-dissatisfied": "Ik vind het helemaal niet leuk",
-            "very-satisfied": "Ik ben er dol op"
+            "satisfied": "Relevant",
+            "very-dissatisfied": "Helemaal niet relevant",
+            "very-satisfied": "Zeer relevant"
           },
           "hide": "Verbergen",
           "hide-aria-label": "Het feedbackpaneel voor aanbevelingen voor trainingsinhoud verbergen",
           "instruction": "Klik op een emoji om uw mening te geven.",
-          "statement": "Ik waardeer de aanbevolen inhoud om verder te gaan.",
+          "statement": "Lijkt de aanbevolen trainingsinhoud om uw kennis te verdiepen u relevant?",
           "thank-you": {
             "subtitle": "Gelukt!",
             "title": "Bedankt voor uw feedback!"


### PR DESCRIPTION
## 🪧 Problème

L'encart de feedback manque d'informations concernant les émojis. Seuls, ils sont peu explicites. Il faut leur ajouter des labels pour dire ce qu'ils expriment.

## 🌈 Proposition

Ajouter ces labels via les tooltips. Ces derniers n'apparaissent pas en mobile mais les deux labels sous les émojis informe à minima ce que représente les emojis.

## ✊ Remarques

J'ai constaté que le tooltip ne permettait pas le focus direct sur le bouton. On doit donc Tab 2 fois pour accéder au bouton et valider.

Mettre tabindex=-1 sur PixTooltip ne fonctionne pas, c'est la span dedans qu'il faut viser, celle-ci ayant un tabindex=0.

=> L'idéal est de le modifier sur Pix-UI, un ticket a été créé

## 🎉 Pour tester
- Aller sur Pix App => parcours EDUMULTIP
- Afficher l'encart et passer au hover sur les émojis
- Faire de même en focus
- Voir le comportement en mobile


https://github.com/user-attachments/assets/a5cdaad0-7c4d-43f0-a993-6d9963963722


