### PR TITLE
[FEATURE] Ajout des filtres dans la vue prescrit d'Admin (PIX-23152)

### DIFF
--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -45,9 +45,9 @@ export default class Sidebar extends Component {
         <PixNavigationButton class="sidebar__link" @route="authenticated.users" @icon="infoUser">
           {{t "components.layout.sidebar.users"}}
         </PixNavigationButton>
-        {{!-- <PixNavigationButton class="sidebar__link" @route="authenticated.organization-learners" @icon="infoUser">
+        <PixNavigationButton class="sidebar__link" @route="authenticated.organization-learners" @icon="infoUser">
           {{t "components.layout.sidebar.organization-learners"}}
-        </PixNavigationButton> --}}
+        </PixNavigationButton>
         <PixNavigationButton class="sidebar__link" @route="authenticated.certification-centers" @icon="mapPin">
           {{t "components.layout.sidebar.certification-centers"}}
         </PixNavigationButton>

--- a/admin/app/components/organization-learners/filter-banner.gjs
+++ b/admin/app/components/organization-learners/filter-banner.gjs
@@ -1,0 +1,86 @@
+import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class LearnersFilterBanner extends Component {
+  @service intl;
+  @service router;
+
+  @tracked organizationExternalId = this.router.currentRoute?.queryParams.organizationExternalId;
+  @tracked fullName = this.router.currentRoute?.queryParams.fullName;
+  @tracked hideDisabled = this.router.currentRoute?.queryParams.hideDisabled;
+
+  @action
+  onChangeOrganizationExternalId(event) {
+    this.organizationExternalId = event.target.value === '' ? undefined : event.target.value;
+  }
+
+  @action
+  onChangeFullName(event) {
+    this.fullName = event.target.value === '' ? undefined : event.target.value;
+  }
+
+  @action
+  onChangeHideDisabled() {
+    this.hideDisabled = this.hideDisabled === true ? undefined : true;
+    this.refreshLearnersList();
+  }
+
+  @action
+  clearSearchFields() {
+    this.organizationExternalId = undefined;
+    this.fullName = undefined;
+    this.refreshLearnersList();
+  }
+
+  @action
+  refreshLearnersList() {
+    this.router.transitionTo({
+      queryParams: {
+        organizationExternalId: this.organizationExternalId,
+        fullName: this.fullName,
+        hideDisabled: this.hideDisabled,
+        organizationSort: undefined,
+        birthdateSort: undefined,
+        updatedAtSort: undefined,
+        pageNumber: undefined,
+      },
+    });
+  }
+
+  <template>
+    <PixFilterBanner
+      @title={{t "common.filters.title"}}
+      @clearFiltersLabel={{t "common.filters.actions.clear"}}
+      @onClearFilters={{this.clearSearchFields}}
+      @onLoadFilters={{this.refreshLearnersList}}
+      @loadFiltersLabel={{t "common.filters.actions.load"}}
+    >
+
+      <PixInput @id="fullName" {{on "change" this.onChangeFullName}} @value={{this.fullName}} @size="small">
+        <:label>Prénom/Nom</:label>
+      </PixInput>
+
+      <PixInput
+        @id="organizationExternalId"
+        {{on "change" this.onChangeOrganizationExternalId}}
+        @value={{this.organizationExternalId}}
+        @size="small"
+      >
+        <:label>Orga ID Externe</:label>
+      </PixInput>
+
+      <PixSegmentedControl @onChange={{this.onChangeHideDisabled}} @toggled={{this.hideDisabled}}>
+        <:label>Masquer les prescrits désactivés</:label>
+        <:viewA>Non</:viewA>
+        <:viewB>Oui</:viewB>
+      </PixSegmentedControl>
+    </PixFilterBanner>
+  </template>
+}

--- a/admin/app/components/organization-learners/list-table.gjs
+++ b/admin/app/components/organization-learners/list-table.gjs
@@ -2,132 +2,198 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import formatDate from 'ember-intl/helpers/format-date';
 import t from 'ember-intl/helpers/t';
 
-<template>
-  {{#if @organizationLearners}}
-    <PixTable
-      @variant="admin"
-      @caption={{t "components.organization-learners.list-table.caption"}}
-      @data={{@organizationLearners}}
-      class="table organization-learner-list"
-    >
-      <:columns as |organizationLearner context|>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.first-name"}}
-          </:header>
-          <:cell>
-            {{organizationLearner.firstName}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.last-name"}}
-          </:header>
-          <:cell>
-            {{organizationLearner.lastName}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.birthdate"}}
-          </:header>
-          <:cell>
-            {{formatDate organizationLearner.birthdate}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.national-student-id"}}
-          </:header>
-          <:cell>
-            {{organizationLearner.nationalStudentId}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.division-group"}}
-          </:header>
-          <:cell>
-            {{#if organizationLearner.division}}
-              {{organizationLearner.division}}
-            {{else if organizationLearner.group}}
-              {{organizationLearner.group}}
-            {{/if}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.organization"}}
-          </:header>
-          <:cell>
-            {{#if organizationLearner.organizationId}}
-              <LinkTo
-                @route="authenticated.organizations.get"
-                @model={{organizationLearner.organizationId}}
-                aria-label={{t "components.organization-learners.list-table.view-organization"}}
-              >
-                {{organizationLearner.organizationName}}
-              </LinkTo>
-            {{/if}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.user-id"}}
-          </:header>
-          <:cell>
-            {{#if organizationLearner.userId}}
-              <LinkTo
-                @route="authenticated.users.get"
-                @model={{organizationLearner.userId}}
-                aria-label={{t "components.organization-learners.list-table.view-user"}}
-              >
-                {{organizationLearner.userId}}
-              </LinkTo>
-            {{/if}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.active"}}
-          </:header>
-          <:cell>
-            {{#if organizationLearner.isDisabled}}
-              <span class="organization-learner-list__icon-disabled">
-                <PixIcon
-                  @name="cancel"
-                  @plainIcon={{true}}
-                  @title={{t "components.organization-learners.list-table.headers.inactive"}}
-                />
-              </span>
-            {{else}}
-              <span class="organization-learner-list__icon-active">
-                <PixIcon
-                  @name="checkCircle"
-                  @plainIcon={{true}}
-                  @title={{t "components.organization-learners.list-table.headers.active"}}
-                />
-              </span>
-            {{/if}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "components.organization-learners.list-table.headers.updated-at"}}
-          </:header>
-          <:cell>
-            {{formatDate organizationLearner.updatedAt}}
-          </:cell>
-        </PixTableColumn>
-      </:columns>
-    </PixTable>
+export default class AdminLearnerList extends Component {
+  @service router;
 
-    <PixPagination @pagination={{@organizationLearners.meta}} />
-  {{else}}
-    <div class="table__empty">{{t "common.tables.empty-result"}}</div>
-  {{/if}}
-</template>
+  @tracked organizationSort = this.router.currentRoute?.queryParams.organizationSort;
+  @tracked birthdateSort = this.router.currentRoute?.queryParams.birthdateSort;
+  @tracked updatedAtSort = this.router.currentRoute?.queryParams.updatedAtSort;
+
+  @action
+  sortByOrganizationName() {
+    this.updateSort({ organizationSort: this.organizationSort === 'asc' ? 'desc' : 'asc' });
+  }
+
+  @action
+  sortByBirthdate() {
+    this.updateSort({ birthdateSort: this.birthdateSort === 'asc' ? 'desc' : 'asc' });
+  }
+
+  @action
+  sortByUpdatedAt() {
+    this.updateSort({ updatedAtSort: this.updatedAtSort === 'asc' ? 'desc' : 'asc' });
+  }
+
+  updateSort({ organizationSort, birthdateSort, updatedAtSort }) {
+    this.organizationSort = organizationSort;
+    this.birthdateSort = birthdateSort;
+    this.updatedAtSort = updatedAtSort;
+    this.router.transitionTo({
+      queryParams: {
+        organizationSort: this.organizationSort ?? undefined,
+        birthdateSort: this.birthdateSort ?? undefined,
+        updatedAtSort: this.updatedAtSort ?? undefined,
+        pageNumber: undefined,
+      },
+    });
+  }
+
+  <template>
+    {{#if @organizationLearners}}
+      <PixTable
+        @variant="admin"
+        @caption={{t "components.organization-learners.list-table.caption"}}
+        @data={{@organizationLearners}}
+        class="table organization-learner-list"
+      >
+        <:columns as |organizationLearner context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.organization-learners.list-table.headers.first-name"}}
+            </:header>
+            <:cell>
+              {{organizationLearner.firstName}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.organization-learners.list-table.headers.last-name"}}
+            </:header>
+            <:cell>
+              {{organizationLearner.lastName}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn
+            @onSort={{this.sortByOrganizationName}}
+            @sortOrder={{this.organizationSort}}
+            @context={{context}}
+            @ariaLabelDefaultSort="Trier par orga"
+            @ariaLabelSortAsc="Trier par orga asc"
+            @ariaLabelSortDesc="Trier par orga desc"
+          >
+            <:header>
+              {{t "components.organization-learners.list-table.headers.organization"}}
+            </:header>
+            <:cell>
+              {{#if organizationLearner.organizationId}}
+                <LinkTo
+                  @route="authenticated.organizations.get"
+                  @model={{organizationLearner.organizationId}}
+                  aria-label={{t "components.organization-learners.list-table.view-organization"}}
+                >
+                  {{organizationLearner.organizationName}}
+                </LinkTo>
+              {{else}}
+                {{organizationLearner.organizationName}}
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn
+            @type="number"
+            @onSort={{this.sortByBirthdate}}
+            @sortOrder={{this.birthdateSort}}
+            @context={{context}}
+            @ariaLabelDefaultSort="Trier par birthdate"
+            @ariaLabelSortAsc="Trier par birthdate asc"
+            @ariaLabelSortDesc="Trier par birthdate desc"
+          >
+            <:header>
+              {{t "components.organization-learners.list-table.headers.birthdate"}}
+            </:header>
+            <:cell>
+              {{formatDate organizationLearner.birthdate}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.organization-learners.list-table.headers.national-student-id"}}
+            </:header>
+            <:cell>
+              {{organizationLearner.nationalStudentId}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.organization-learners.list-table.headers.division-group"}}
+            </:header>
+            <:cell>
+              {{#if organizationLearner.division}}
+                {{organizationLearner.division}}
+              {{else if organizationLearner.group}}
+                {{organizationLearner.group}}
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.organization-learners.list-table.headers.user-id"}}
+            </:header>
+            <:cell>
+              {{#if organizationLearner.userId}}
+                <LinkTo
+                  @route="authenticated.users.get"
+                  @model={{organizationLearner.userId}}
+                  aria-label={{t "components.organization-learners.list-table.view-user"}}
+                >
+                  {{organizationLearner.userId}}
+                </LinkTo>
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.organization-learners.list-table.headers.active"}}
+            </:header>
+            <:cell>
+              {{#if organizationLearner.isDisabled}}
+                <span class="organization-learner-list__icon-disabled">
+                  <PixIcon
+                    @name="cancel"
+                    @plainIcon={{true}}
+                    @title={{t "components.organization-learners.list-table.headers.inactive"}}
+                  />
+                </span>
+              {{else}}
+                <span class="organization-learner-list__icon-active">
+                  <PixIcon
+                    @name="checkCircle"
+                    @plainIcon={{true}}
+                    @title={{t "components.organization-learners.list-table.headers.active"}}
+                  />
+                </span>
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn
+            @type="number"
+            @onSort={{this.sortByUpdatedAt}}
+            @sortOrder={{this.updatedAtSort}}
+            @context={{context}}
+            @ariaLabelDefaultSort="Trier par date maj"
+            @ariaLabelSortAsc="Trier par date maj asc"
+            @ariaLabelSortDesc="Trier par date maj desc"
+          >
+            <:header>
+              {{t "components.organization-learners.list-table.headers.updated-at"}}
+            </:header>
+            <:cell>
+              {{formatDate organizationLearner.updatedAt}}
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+
+      <PixPagination @pagination={{@organizationLearners.meta}} />
+    {{else}}
+      <div class="table__empty">{{t "common.tables.empty-result"}}</div>
+    {{/if}}
+  </template>
+}

--- a/admin/app/routes/authenticated/organization-learners/list.js
+++ b/admin/app/routes/authenticated/organization-learners/list.js
@@ -8,6 +8,9 @@ export default class ListRoute extends Route {
   @service store;
 
   queryParams = {
+    organizationExternalId: { refreshModel: true },
+    fullName: { refreshModel: true },
+    hideDisabled: { refreshModel: true },
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
     organizationSort: { refreshModel: true },
@@ -16,11 +19,17 @@ export default class ListRoute extends Route {
   };
 
   async model(params) {
+    if (!(params.organizationExternalId || params.fullName?.length >= 2)) return [];
     try {
       const organizationLearners = await this.store.query('admin-organization-learner', {
         page: {
           number: params.pageNumber ?? DEFAULT_PAGE_NUMBER,
           size: params.pageSize ?? DEFAULT_PAGE_SIZE,
+        },
+        filter: {
+          organizationExternalId: params.organizationExternalId,
+          fullName: params.fullName,
+          hideDisabled: params.hideDisabled,
         },
         sort: {
           organizationSort: params.organizationSort,

--- a/admin/app/routes/authenticated/organization-learners/list.js
+++ b/admin/app/routes/authenticated/organization-learners/list.js
@@ -10,6 +10,9 @@ export default class ListRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    organizationSort: { refreshModel: true },
+    birthdateSort: { refreshModel: true },
+    updatedAtSort: { refreshModel: true },
   };
 
   async model(params) {
@@ -18,6 +21,11 @@ export default class ListRoute extends Route {
         page: {
           number: params.pageNumber ?? DEFAULT_PAGE_NUMBER,
           size: params.pageSize ?? DEFAULT_PAGE_SIZE,
+        },
+        sort: {
+          organizationSort: params.organizationSort,
+          birthdateSort: params.birthdateSort,
+          updatedAtSort: params.updatedAtSort,
         },
       });
       return organizationLearners;

--- a/admin/app/templates/authenticated/organization-learners/list.gjs
+++ b/admin/app/templates/authenticated/organization-learners/list.gjs
@@ -1,10 +1,13 @@
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
+import FilterBanner from 'pix-admin/components/organization-learners/filter-banner';
 import ListTable from 'pix-admin/components/organization-learners/list-table';
 <template>
   {{pageTitle (t "pages.organization-learners-list.page-title")}}
 
   <h1>{{t "pages.organization-learners-list.main-title"}}</h1>
+
+  <FilterBanner />
 
   <ListTable @organizationLearners={{@model}} />
 </template>

--- a/admin/tests/acceptance/authenticated/organization-learners/list-test.js
+++ b/admin/tests/acceptance/authenticated/organization-learners/list-test.js
@@ -1,5 +1,6 @@
-import { visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
@@ -35,7 +36,17 @@ module('Acceptance | authenticated/organization-learners | list', function (hook
       assert.strictEqual(currentURL(), '/organization-learners/list');
     });
 
-    test('it should display organization learners in table', async function (assert) {
+    test('it should not display table if no filter is filled', async function (assert) {
+      // given
+      server.create('admin-organization-learner', { firstName: 'firstname' });
+
+      // when
+      const screen = await visit('/organization-learners/list');
+
+      assert.notOk(screen.queryByRole('table', { name: t('components.organization-learners.list-table.caption') }));
+    });
+
+    test('it should display organization learners in table if one filter is filled', async function (assert) {
       // given
       server.create('admin-organization-learner', {
         firstName: 'firstname',
@@ -66,6 +77,9 @@ module('Acceptance | authenticated/organization-learners | list', function (hook
 
       // when
       const screen = await visit('/organization-learners/list');
+
+      await fillByLabel('Prénom/Nom', 'first');
+      await click(screen.getByRole('button', { name: t('common.filters.actions.load') }));
 
       // then
       assert.ok(screen.getByText('firstname'));

--- a/admin/tests/integration/components/layout/sidebar_test.gjs
+++ b/admin/tests/integration/components/layout/sidebar_test.gjs
@@ -303,13 +303,13 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
     assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.users') })).exists();
   });
 
-  // tes('should contain link to "organization-learners" management page', async function (assert) {
-  //   // when
-  //   const screen = await render(<template><Sidebar /></template>);
+  test('should contain link to "organization-learners" management page', async function (assert) {
+    // when
+    const screen = await render(<template><Sidebar /></template>);
 
-  //   // then
-  //   assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.organization-learners') })).exists();
-  // });
+    // then
+    assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.organization-learners') })).exists();
+  });
 
   test('should contain link to "sessions" management page', async function (assert) {
     // when

--- a/admin/tests/integration/components/organization-learners/filter-banner-test.gjs
+++ b/admin/tests/integration/components/organization-learners/filter-banner-test.gjs
@@ -1,0 +1,137 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import FilterBanner from 'pix-admin/components/organization-learners/filter-banner';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | OrganizationLearners | FilterBanner', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should render filters', async function (assert) {
+    //when
+    const screen = await render(<template><FilterBanner /></template>);
+    //then
+    assert.ok(screen.getByRole('textbox', { name: 'Orga ID Externe' }));
+    assert.ok(screen.getByRole('textbox', { name: 'Prénom/Nom' }));
+    assert.ok(screen.getByRole('radiogroup', { name: 'Masquer les prescrits désactivés' }));
+    assert.ok(screen.getByRole('button', { name: t('common.filters.actions.load') }));
+    assert.ok(screen.getByRole('button', { name: t('common.filters.actions.clear') }));
+  });
+  test('it should filter by organizationExternalId', async function (assert) {
+    //given
+    const router = this.owner.lookup('service:router');
+    const transitionToStub = sinon.stub(router, 'transitionTo');
+    //when
+    const screen = await render(<template><FilterBanner /></template>);
+    await fillIn(screen.getByRole('textbox', { name: 'Orga ID Externe' }), 'ID');
+    await click(screen.getByRole('button', { name: t('common.filters.actions.load') }));
+    //then
+    sinon.assert.calledWith(transitionToStub, {
+      queryParams: {
+        organizationExternalId: 'ID',
+        fullName: undefined,
+        hideDisabled: undefined,
+        organizationSort: undefined,
+        birthdateSort: undefined,
+        updatedAtSort: undefined,
+        pageNumber: undefined,
+      },
+    });
+    assert.ok(true);
+  });
+  test('it should filter by fullName', async function (assert) {
+    //given
+    const router = this.owner.lookup('service:router');
+    const transitionToStub = sinon.stub(router, 'transitionTo');
+    //when
+    const screen = await render(<template><FilterBanner /></template>);
+    await fillIn(screen.getByRole('textbox', { name: 'Prénom/Nom' }), 'attestation');
+    await click(screen.getByRole('button', { name: t('common.filters.actions.load') }));
+    //then
+    sinon.assert.calledWith(transitionToStub, {
+      queryParams: {
+        organizationExternalId: undefined,
+        fullName: 'attestation',
+        hideDisabled: undefined,
+        organizationSort: undefined,
+        birthdateSort: undefined,
+        updatedAtSort: undefined,
+        pageNumber: undefined,
+      },
+    });
+    assert.ok(true);
+  });
+  test('it should hide disabled learners if toggle is on', async function (assert) {
+    //given
+    const router = this.owner.lookup('service:router');
+    const transitionToStub = sinon.stub(router, 'transitionTo');
+    //when
+    const screen = await render(<template><FilterBanner /></template>);
+    const toggle = screen.getByRole('radiogroup', { name: 'Masquer les prescrits désactivés' });
+    await click(within(toggle).getByRole('radio', { name: 'Oui' }));
+    //then
+    sinon.assert.calledWith(transitionToStub, {
+      queryParams: {
+        organizationExternalId: undefined,
+        fullName: undefined,
+        hideDisabled: true,
+        organizationSort: undefined,
+        birthdateSort: undefined,
+        updatedAtSort: undefined,
+        pageNumber: undefined,
+      },
+    });
+    assert.ok(true);
+  });
+  test('it should show disabled learners if toggle is off', async function (assert) {
+    //given
+    const router = this.owner.lookup('service:router');
+    const transitionToStub = sinon.stub(router, 'transitionTo');
+    //when
+    const screen = await render(<template><FilterBanner /></template>);
+    const toggle = screen.getByRole('radiogroup', { name: 'Masquer les prescrits désactivés' });
+    await click(within(toggle).getByRole('radio', { name: 'Oui' }));
+    await click(within(toggle).getByRole('radio', { name: 'Non' }));
+    //then
+    sinon.assert.calledWith(transitionToStub, {
+      queryParams: {
+        organizationExternalId: undefined,
+        fullName: undefined,
+        hideDisabled: undefined,
+        organizationSort: undefined,
+        birthdateSort: undefined,
+        updatedAtSort: undefined,
+        pageNumber: undefined,
+      },
+    });
+    assert.ok(true);
+  });
+  test('it should clear filters but not toggle', async function (assert) {
+    //given
+    const router = this.owner.lookup('service:router');
+    const transitionToStub = sinon.stub(router, 'transitionTo');
+    //when
+    const screen = await render(<template><FilterBanner /></template>);
+    await fillIn(screen.getByRole('textbox', { name: 'Orga ID Externe' }), 'ID');
+    await fillIn(screen.getByRole('textbox', { name: 'Prénom/Nom' }), 'attestation');
+    const toggle = screen.getByRole('radiogroup', { name: 'Masquer les prescrits désactivés' });
+    await click(within(toggle).getByRole('radio', { name: 'Oui' }));
+    await click(screen.getByRole('button', { name: t('common.filters.actions.clear') }));
+    //then
+    sinon.assert.calledWith(transitionToStub, {
+      queryParams: {
+        organizationExternalId: undefined,
+        fullName: undefined,
+        hideDisabled: true,
+        organizationSort: undefined,
+        birthdateSort: undefined,
+        updatedAtSort: undefined,
+        pageNumber: undefined,
+      },
+    });
+    assert.ok(true);
+  });
+});

--- a/admin/tests/integration/components/organization-learners/list-table-test.gjs
+++ b/admin/tests/integration/components/organization-learners/list-table-test.gjs
@@ -1,7 +1,9 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ListTable from 'pix-admin/components/organization-learners/list-table';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -191,6 +193,105 @@ module('Integration | Component | OrganizationLearners | ListTable', function (h
       const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
 
       assert.dom(within(table).getByRole('img', { name: 'Inactif' })).exists();
+    });
+  });
+
+  module('sort', function () {
+    test('it should sort by organizationName asc and desc', async function (assert) {
+      //given
+      const organizationLearners = [store.createRecord('admin-organization-learner')];
+      const router = this.owner.lookup('service:router');
+
+      const transitionToStub = sinon.stub(router, 'transitionTo');
+
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearners}} /></template>);
+      await click(screen.getByRole('button', { name: 'Trier par orga' }));
+
+      sinon.assert.calledWith(transitionToStub, {
+        queryParams: {
+          organizationSort: 'asc',
+          updatedAtSort: undefined,
+          birthdateSort: undefined,
+          pageNumber: undefined,
+        },
+      });
+
+      await click(screen.getByRole('button', { name: 'Trier par orga desc' }));
+
+      sinon.assert.calledWith(transitionToStub, {
+        queryParams: {
+          organizationSort: 'desc',
+          updatedAtSort: undefined,
+          birthdateSort: undefined,
+          pageNumber: undefined,
+        },
+      });
+      assert.ok(true);
+    });
+    test('it should sort by birthdate asc and desc', async function (assert) {
+      //given
+      const organizationLearners = [store.createRecord('admin-organization-learner')];
+      const router = this.owner.lookup('service:router');
+
+      const transitionToStub = sinon.stub(router, 'transitionTo');
+
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearners}} /></template>);
+      await click(screen.getByRole('button', { name: 'Trier par birthdate' }));
+
+      sinon.assert.calledWith(transitionToStub, {
+        queryParams: {
+          organizationSort: undefined,
+          updatedAtSort: undefined,
+          birthdateSort: 'asc',
+          pageNumber: undefined,
+        },
+      });
+
+      await click(screen.getByRole('button', { name: 'Trier par birthdate desc' }));
+
+      sinon.assert.calledWith(transitionToStub, {
+        queryParams: {
+          organizationSort: undefined,
+          updatedAtSort: undefined,
+          birthdateSort: 'desc',
+          pageNumber: undefined,
+        },
+      });
+      assert.ok(true);
+    });
+    test('it should sort by updatedAt asc and desc', async function (assert) {
+      //given
+      const organizationLearners = [store.createRecord('admin-organization-learner')];
+      const router = this.owner.lookup('service:router');
+
+      const transitionToStub = sinon.stub(router, 'transitionTo');
+
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearners}} /></template>);
+      await click(screen.getByRole('button', { name: 'Trier par date maj' }));
+
+      sinon.assert.calledWith(transitionToStub, {
+        queryParams: {
+          organizationSort: undefined,
+          updatedAtSort: 'asc',
+          birthdateSort: undefined,
+          pageNumber: undefined,
+        },
+      });
+
+      await click(screen.getByRole('button', { name: 'Trier par date maj desc' }));
+
+      sinon.assert.calledWith(transitionToStub, {
+        queryParams: {
+          organizationSort: undefined,
+          updatedAtSort: 'desc',
+          birthdateSort: undefined,
+          pageNumber: undefined,
+        },
+      });
+      assert.ok(true);
     });
   });
 });

--- a/admin/tests/integration/templates/authenticated/organization-learners/list-test.gjs
+++ b/admin/tests/integration/templates/authenticated/organization-learners/list-test.gjs
@@ -8,6 +8,19 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Template | admin-organization-learners | list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  test('it should render filters', async function (assert) {
+    //given
+    const model = [];
+    //when
+    const screen = await render(<template><List @model={{model}} /></template>);
+    //then
+    assert.ok(screen.getByRole('textbox', { name: 'Orga ID Externe' }));
+    assert.ok(screen.getByRole('textbox', { name: 'Prénom/Nom' }));
+    assert.ok(screen.getByRole('radiogroup', { name: 'Masquer les prescrits désactivés' }));
+    assert.ok(screen.getByRole('button', { name: t('common.filters.actions.load') }));
+    assert.ok(screen.getByRole('button', { name: t('common.filters.actions.clear') }));
+  });
+
   test('it should render list template', async function (assert) {
     // when
     const store = this.owner.lookup('service:store');

--- a/admin/tests/unit/routes/authenticated/organization-learners/list-test.js
+++ b/admin/tests/unit/routes/authenticated/organization-learners/list-test.js
@@ -16,15 +16,82 @@ module('Unit | Route | authenticated/organization-learners/list', function (hook
       route.store.query = sinon.stub().resolves();
     });
 
+    module('when you add filters', function () {
+      test('it should not call store.query if necessary filters are empty', async function (assert) {
+        // given
+        const params = {
+          organizationExternalId: undefined,
+          fullName: undefined,
+          hideDisabled: true,
+          organizationSort: 'asc',
+          pageNumber: 1,
+          pageSize: 50,
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.notCalled(route.store.query);
+        assert.ok(true);
+      });
+      test('it should call store.query if organizationExternalId is filled', async function (assert) {
+        // given
+        const params = {
+          organizationExternalId: 'SCO',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.called(route.store.query);
+        assert.ok(true);
+      });
+      test('it should call store.query if fullName is filled', async function (assert) {
+        // given
+        const params = {
+          fullName: 'attestation',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.called(route.store.query);
+        assert.ok(true);
+      });
+      test('it should not call store.query if fullName is filled with less than 2 characters', async function (assert) {
+        // given
+        const params = {
+          fullName: 'a',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.notCalled(route.store.query);
+        assert.ok(true);
+      });
+    });
+
     module('when queryParams filters are falsy', function () {
       test('it should call store.query with empty params', async function (assert) {
         // given
-        const params = {};
+        const params = {
+          organizationExternalId: 'SCO',
+        };
         const expectedQueryArgs = {
           sort: {
             organizationSort: undefined,
             birthdateSort: undefined,
             updatedAtSort: undefined,
+          },
+          filter: {
+            organizationExternalId: 'SCO',
+            fullName: undefined,
+            hideDisabled: undefined,
           },
           page: {
             number: 1,
@@ -48,12 +115,20 @@ module('Unit | Route | authenticated/organization-learners/list', function (hook
           organizationSort: 'asc',
           pageNumber: 'somePageNumber',
           pageSize: 'somePageSize',
+          organizationExternalId: 'SCO',
+          fullName: 'attestation',
+          hideDisabled: true,
         };
         const expectedQueryArgs = {
           sort: {
             organizationSort: 'asc',
             birthdateSort: undefined,
             updatedAtSort: undefined,
+          },
+          filter: {
+            organizationExternalId: 'SCO',
+            fullName: 'attestation',
+            hideDisabled: true,
           },
           page: {
             number: 'somePageNumber',

--- a/admin/tests/unit/routes/authenticated/organization-learners/list-test.js
+++ b/admin/tests/unit/routes/authenticated/organization-learners/list-test.js
@@ -21,7 +21,15 @@ module('Unit | Route | authenticated/organization-learners/list', function (hook
         // given
         const params = {};
         const expectedQueryArgs = {
-          page: { number: 1, size: 50 },
+          sort: {
+            organizationSort: undefined,
+            birthdateSort: undefined,
+            updatedAtSort: undefined,
+          },
+          page: {
+            number: 1,
+            size: 50,
+          },
         };
 
         // when
@@ -37,10 +45,16 @@ module('Unit | Route | authenticated/organization-learners/list', function (hook
       test('it should call store.query with defined params', async function (assert) {
         // given
         const params = {
+          organizationSort: 'asc',
           pageNumber: 'somePageNumber',
           pageSize: 'somePageSize',
         };
         const expectedQueryArgs = {
+          sort: {
+            organizationSort: 'asc',
+            birthdateSort: undefined,
+            updatedAtSort: undefined,
+          },
           page: {
             number: 'somePageNumber',
             size: 'somePageSize',

--- a/api/src/prescription/organization-learner/application/learner-list-controller.js
+++ b/api/src/prescription/organization-learner/application/learner-list-controller.js
@@ -31,8 +31,8 @@ const findOrganizationLearnersForAdmin = async function (
   _,
   dependencies = { adminOrganizationLearnerSerializer },
 ) {
-  const { page, filter } = request.query;
-  const { learners, pagination } = await usecases.findOrganizationLearnersForAdmin({ page, filter });
+  const { page, filter, sort } = request.query;
+  const { learners, pagination } = await usecases.findOrganizationLearnersForAdmin({ page, filter, sort });
   return dependencies.adminOrganizationLearnerSerializer.serialize({ learners, pagination });
 };
 

--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -72,6 +72,11 @@ const register = async function (server) {
               fullName: Joi.string().empty(''),
               organizationId: Joi.number().integer().empty(''),
             }).default({}),
+            sort: {
+              organizationSort: Joi.string().empty(''),
+              birthdateSort: Joi.string().empty(''),
+              updatedAtSort: Joi.string().empty(''),
+            },
           }),
         },
         handler: learnerListController.findOrganizationLearnersForAdmin,

--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -70,7 +70,7 @@ const register = async function (server) {
             }).default({}),
             filter: Joi.object({
               fullName: Joi.string().empty(''),
-              organizationId: Joi.number().integer().empty(''),
+              organizationExternalId: Joi.string().empty(''),
             }).default({}),
             sort: {
               organizationSort: Joi.string().empty(''),

--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -71,6 +71,7 @@ const register = async function (server) {
             filter: Joi.object({
               fullName: Joi.string().empty(''),
               organizationExternalId: Joi.string().empty(''),
+              hideDisabled: Joi.boolean().allow(null),
             }).default({}),
             sort: {
               organizationSort: Joi.string().empty(''),

--- a/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-for-admin.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-for-admin.js
@@ -1,5 +1,5 @@
-const findOrganizationLearnersForAdmin = async function ({ page, filter, organizationLearnerRepository }) {
-  return organizationLearnerRepository.findPaginatedLearnersForAdmin({ page, filter });
+const findOrganizationLearnersForAdmin = async function ({ page, filter, sort, organizationLearnerRepository }) {
+  return organizationLearnerRepository.findPaginatedLearnersForAdmin({ page, filter, sort });
 };
 
 export { findOrganizationLearnersForAdmin };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -174,12 +174,12 @@ async function findPaginatedLearnersForAdmin({ page, filter, sort }) {
     .orderByRaw('LOWER("lastName") ASC');
 
   if (filter) {
-    const { fullName, organizationId } = filter;
+    const { fullName, organizationExternalId } = filter;
     if (fullName) {
       filterByFullName(query, fullName, 'firstName', 'lastName');
     }
-    if (organizationId) {
-      query.where({ organizationId });
+    if (organizationExternalId) {
+      query.where({ externalId: organizationExternalId });
     }
   }
 

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -128,8 +128,29 @@ async function findPaginatedLearnersByOrganizationId({ organizationId, page, fil
   return { learners, pagination };
 }
 
-async function findPaginatedLearnersForAdmin({ page, filter }) {
+async function findPaginatedLearnersForAdmin({ page, filter, sort }) {
   const knexConn = DomainTransaction.getConnection();
+
+  const orderByClause = [];
+
+  if (sort?.organizationSort) {
+    orderByClause.push({
+      column: 'organizationName',
+      order: sort.organizationSort,
+    });
+  }
+  if (sort?.birthdateSort) {
+    orderByClause.push({
+      column: 'birthdate',
+      order: sort.birthdateSort,
+    });
+  }
+  if (sort?.updatedAtSort) {
+    orderByClause.push({
+      column: 'updatedAt',
+      order: sort.updatedAtSort,
+    });
+  }
 
   const query = knexConn
     .select(
@@ -148,6 +169,7 @@ async function findPaginatedLearnersForAdmin({ page, filter }) {
     )
     .from('view-active-organization-learners')
     .innerJoin('organizations', 'organizations.id', 'view-active-organization-learners.organizationId')
+    .orderBy(orderByClause)
     .orderByRaw('LOWER("firstName") ASC')
     .orderByRaw('LOWER("lastName") ASC');
 

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -174,12 +174,15 @@ async function findPaginatedLearnersForAdmin({ page, filter, sort }) {
     .orderByRaw('LOWER("lastName") ASC');
 
   if (filter) {
-    const { fullName, organizationExternalId } = filter;
+    const { fullName, organizationExternalId, hideDisabled } = filter;
     if (fullName) {
       filterByFullName(query, fullName, 'firstName', 'lastName');
     }
     if (organizationExternalId) {
       query.where({ externalId: organizationExternalId });
+    }
+    if (hideDisabled) {
+      query.where({ isDisabled: false });
     }
   }
 

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -179,7 +179,8 @@ async function findPaginatedLearnersForAdmin({ page, filter, sort }) {
       filterByFullName(query, fullName, 'firstName', 'lastName');
     }
     if (organizationExternalId) {
-      query.where({ externalId: organizationExternalId });
+      const searchUpperCase = organizationExternalId.trim().toUpperCase();
+      query.whereRaw('UPPER(??) LIKE ?', ['externalId', `${searchUpperCase}`]);
     }
     if (hideDisabled) {
       query.where({ isDisabled: false });

--- a/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
@@ -85,7 +85,7 @@ describe('Acceptance | Application | learner-list-route', function () {
       const params =
         '?filter[fullName]=Annie' +
         '&page[number]=1&page[size]=25' +
-        `&filter[organizationExternalId]=ABC123` +
+        `&filter[organizationExternalId]=Abc123` +
         `&filter[hideDisabled]=true` +
         '&sort[birthdateSort]=desc';
       const request = {

--- a/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
@@ -68,6 +68,11 @@ describe('Acceptance | Application | learner-list-route', function () {
         birthdate: '2001-01-01',
       });
       databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'Annie-Marie',
+        organizationId,
+        isDisabled: true,
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
         firstName: 'Simon',
         organizationId,
       });
@@ -81,6 +86,7 @@ describe('Acceptance | Application | learner-list-route', function () {
         '?filter[fullName]=Annie' +
         '&page[number]=1&page[size]=25' +
         `&filter[organizationExternalId]=ABC123` +
+        `&filter[hideDisabled]=true` +
         '&sort[birthdateSort]=desc';
       const request = {
         method: 'GET',

--- a/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
@@ -55,7 +55,7 @@ describe('Acceptance | Application | learner-list-route', function () {
     it('should return a list of organization learners', async function () {
       //given
       const superAdminId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const organizationId = databaseBuilder.factory.buildOrganization({ externalId: 'ABC123' }).id;
       const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildOrganizationLearner({
         firstName: 'Annie',
@@ -80,7 +80,7 @@ describe('Acceptance | Application | learner-list-route', function () {
       const params =
         '?filter[fullName]=Annie' +
         '&page[number]=1&page[size]=25' +
-        `&filter[organizationId]=${organizationId}` +
+        `&filter[organizationExternalId]=ABC123` +
         '&sort[birthdateSort]=desc';
       const request = {
         method: 'GET',

--- a/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
@@ -57,14 +57,31 @@ describe('Acceptance | Application | learner-list-route', function () {
       const superAdminId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Annie', organizationId });
-      databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Annie-Marie', organizationId });
-      databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Simon', organizationId });
-      databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Annie', organizationId: otherOrganizationId });
+      databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'Annie',
+        organizationId,
+        birthdate: '2000-01-01',
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'Annie-Marie',
+        organizationId,
+        birthdate: '2001-01-01',
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'Simon',
+        organizationId,
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'Annie',
+        organizationId: otherOrganizationId,
+      });
       await databaseBuilder.commit();
 
       const params =
-        '?filter[fullName]=Annie' + '&page[number]=1&page[size]=25' + `&filter[organizationId]=${organizationId}`;
+        '?filter[fullName]=Annie' +
+        '&page[number]=1&page[size]=25' +
+        `&filter[organizationId]=${organizationId}` +
+        '&sort[birthdateSort]=desc';
       const request = {
         method: 'GET',
         url: `/api/admin/organization-learners${params}`,
@@ -77,6 +94,8 @@ describe('Acceptance | Application | learner-list-route', function () {
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.length).to.equal(2);
       expect(response.result.data[0].type).to.equal('admin-organization-learners');
+      expect(response.result.data[0].attributes['first-name']).to.be.equal('Annie-Marie');
+      expect(response.result.data[1].attributes['first-name']).to.be.equal('Annie');
     });
   });
 

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-for-admin_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-for-admin_test.js
@@ -78,4 +78,67 @@ describe('Integration | UseCases | find-paginated-filtered-organization-learners
     expect(learners[0]).to.be.an.instanceOf(OrganizationLearnerOverviewForAdmin);
     expect(learners[0].id).to.be.equal(learner.id);
   });
+
+  context('Sort', function () {
+    let organization;
+    let otherOrganization;
+    let learner1, learner2;
+    beforeEach(async function () {
+      organization = databaseBuilder.factory.buildOrganization({
+        name: 'Observatoire de Pix',
+      });
+      otherOrganization = databaseBuilder.factory.buildOrganization({
+        name: 'PIX',
+      });
+
+      learner1 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        firstName: 'Annie',
+        birthdate: '2000-01-01',
+        updatedAt: new Date('2022-01-01'),
+      });
+      learner2 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: otherOrganization.id,
+        firstName: 'Jean',
+        lastName: 'De Ségazan',
+        birthdate: '2002-01-01',
+        updatedAt: new Date('2020-01-01'),
+      });
+
+      await databaseBuilder.commit();
+    });
+    it('retrieve learners sorted by organization name desc', async function () {
+      //when
+      const result = await usecases.findOrganizationLearnersForAdmin({
+        sort: {
+          organizationSort: 'desc',
+        },
+      });
+      //then
+      expect(result.learners[0].id).to.be.equal(learner2.id);
+      expect(result.learners[1].id).to.be.equal(learner1.id);
+    });
+    it('retrieve learners sorted by birthdate desc', async function () {
+      //when
+      const result = await usecases.findOrganizationLearnersForAdmin({
+        sort: {
+          birthdateSort: 'desc',
+        },
+      });
+      //then
+      expect(result.learners[0].id).to.be.equal(learner2.id);
+      expect(result.learners[1].id).to.be.equal(learner1.id);
+    });
+    it('retrieve learners sorted by updatedAt asc', async function () {
+      //when
+      const result = await usecases.findOrganizationLearnersForAdmin({
+        sort: {
+          updatedAtSort: 'asc',
+        },
+      });
+      //then
+      expect(result.learners[0].id).to.be.equal(learner2.id);
+      expect(result.learners[1].id).to.be.equal(learner1.id);
+    });
+  });
 });

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-for-admin_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-for-admin_test.js
@@ -81,6 +81,35 @@ describe('Integration | UseCases | find-paginated-filtered-organization-learners
     expect(learners[0].id).to.be.equal(learner.id);
   });
 
+  it('should return paginated organization learners not disabled', async function () {
+    const organization = databaseBuilder.factory.buildOrganization();
+    databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Jean',
+      lastName: 'Dion',
+      isDisabled: true,
+    });
+    const learner = databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Jean-René',
+      lastName: 'Michel',
+      organizationId: organization.id,
+      isDisabled: false,
+    });
+    await databaseBuilder.commit();
+
+    const result = await usecases.findOrganizationLearnersForAdmin({
+      page: {
+        size: 2,
+        number: 1,
+      },
+      filter: { hideDisabled: true },
+    });
+    const learners = result.learners;
+
+    expect(learners).lengthOf(1);
+    expect(learners[0]).to.be.an.instanceOf(OrganizationLearnerOverviewForAdmin);
+    expect(learners[0].id).to.be.equal(learner.id);
+  });
+
   context('Sort', function () {
     let organization;
     let otherOrganization;

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-for-admin_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-for-admin_test.js
@@ -53,11 +53,13 @@ describe('Integration | UseCases | find-paginated-filtered-organization-learners
   });
 
   it('should return paginated organization learners filtered by organizationId', async function () {
-    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const organization = databaseBuilder.factory.buildOrganization({
+      externalId: 'ABC123',
+    });
     const learner = databaseBuilder.factory.buildOrganizationLearner({
       firstName: 'Jean-René',
       lastName: 'Michel',
-      organizationId,
+      organizationId: organization.id,
     });
     databaseBuilder.factory.buildOrganizationLearner({
       firstName: 'Jean',
@@ -70,7 +72,7 @@ describe('Integration | UseCases | find-paginated-filtered-organization-learners
         size: 2,
         number: 1,
       },
-      filter: { organizationId },
+      filter: { organizationExternalId: organization.externalId },
     });
     const learners = result.learners;
 

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -805,7 +805,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       expect(result.learners).lengthOf(0);
     });
 
-    it('retrieve all active learners from specific organizationExternalId', async function () {
+    it('retrieve all active learners from specific organizationExternalId with case insensitivity', async function () {
       const otherOrganization = databaseBuilder.factory.buildOrganization({
         externalId: 'ZYX987',
       });
@@ -823,7 +823,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       await databaseBuilder.commit();
 
       const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
-        filter: { organizationExternalId: organization.externalId },
+        filter: { organizationExternalId: 'abc123' },
         page: {},
       });
 
@@ -882,7 +882,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
           size: 1,
           number: 1,
         },
-        filter: { organizationExternalId: 'ABC123', fullName: 'Zoé De Ségazan' },
+        filter: { organizationExternalId: 'AbC123', fullName: 'Zoé De Ségazan' },
       });
 
       expect(result.pagination).to.deep.equal({

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -928,6 +928,111 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         });
       });
     });
+
+    context('Sort', function () {
+      let otherOrganization;
+      let learner1, learner2, learner3;
+      beforeEach(async function () {
+        otherOrganization = databaseBuilder.factory.buildOrganization({
+          name: 'PIX',
+        });
+
+        learner1 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Annie',
+          birthdate: '2000-01-01',
+          updatedAt: new Date('2022-01-01'),
+        });
+        learner2 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Zoé',
+          lastName: 'De Ségazan',
+          birthdate: '2001-01-01',
+          updatedAt: new Date('2021-01-01'),
+        });
+        learner3 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: otherOrganization.id,
+          firstName: 'Jean',
+          lastName: 'De Ségazan',
+          birthdate: '2002-01-01',
+          updatedAt: new Date('2020-01-01'),
+        });
+
+        await databaseBuilder.commit();
+      });
+      it('retrieve learners sorted by organization name asc', async function () {
+        //when
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+          sort: {
+            organizationSort: 'asc',
+          },
+        });
+        //then
+        expect(result.learners[0].id).to.be.equal(learner1.id);
+        expect(result.learners[1].id).to.be.equal(learner2.id);
+        expect(result.learners[2].id).to.be.equal(learner3.id);
+      });
+      it('retrieve learners sorted by organization name desc', async function () {
+        //when
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+          sort: {
+            organizationSort: 'desc',
+          },
+        });
+        //then
+        expect(result.learners[0].id).to.be.equal(learner3.id);
+        expect(result.learners[1].id).to.be.equal(learner1.id);
+        expect(result.learners[2].id).to.be.equal(learner2.id);
+      });
+      it('retrieve learners sorted by birthdate asc', async function () {
+        //when
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+          sort: {
+            birthdateSort: 'asc',
+          },
+        });
+        //then
+        expect(result.learners[0].id).to.be.equal(learner1.id);
+        expect(result.learners[1].id).to.be.equal(learner2.id);
+        expect(result.learners[2].id).to.be.equal(learner3.id);
+      });
+      it('retrieve learners sorted by birthdate desc', async function () {
+        //when
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+          sort: {
+            birthdateSort: 'desc',
+          },
+        });
+        //then
+        expect(result.learners[0].id).to.be.equal(learner3.id);
+        expect(result.learners[1].id).to.be.equal(learner2.id);
+        expect(result.learners[2].id).to.be.equal(learner1.id);
+      });
+      it('retrieve learners sorted by updatedAt asc', async function () {
+        //when
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+          sort: {
+            updatedAtSort: 'asc',
+          },
+        });
+        //then
+        expect(result.learners[0].id).to.be.equal(learner3.id);
+        expect(result.learners[1].id).to.be.equal(learner2.id);
+        expect(result.learners[2].id).to.be.equal(learner1.id);
+      });
+      it('retrieve learners sorted by updatedAt desc', async function () {
+        //when
+        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+          sort: {
+            updatedAtSort: 'desc',
+          },
+        });
+        //then
+        expect(result.learners[0].id).to.be.equal(learner1.id);
+        expect(result.learners[1].id).to.be.equal(learner2.id);
+        expect(result.learners[2].id).to.be.equal(learner3.id);
+      });
+    });
   });
 
   describe('#findUserIdsFromFilters', function () {

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -808,6 +808,71 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       expect(result.learners).lengthOf(2);
     });
 
+    it('retrieve paginated active learners', async function () {
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+      });
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+        page: {
+          size: 1,
+          number: 1,
+        },
+      });
+
+      expect(result.pagination).to.deep.equal({
+        page: 1,
+        pageSize: 1,
+        rowCount: 2,
+        pageCount: 2,
+      });
+    });
+
+    it('retrieve filtered and paginated learners', async function () {
+      const otherOrganization = databaseBuilder.factory.buildOrganization({
+        externalId: 'ZYX987',
+      });
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: otherOrganization.id,
+        firstName: 'Zoé',
+        lastName: 'De Ségazan',
+      });
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+        firstName: 'Zoé',
+      });
+
+      const learner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+        firstName: 'Zoé',
+        lastName: 'De Ségazan',
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+        page: {
+          size: 1,
+          number: 1,
+        },
+        filter: { organizationExternalId: 'ABC123', fullName: 'Zoé De Ségazan' },
+      });
+
+      expect(result.pagination).to.deep.equal({
+        page: 1,
+        pageSize: 1,
+        rowCount: 1,
+        pageCount: 1,
+      });
+      expect(result.learners).to.have.lengthOf(1);
+      expect(result.learners[0].id).to.equal(learner.id);
+    });
+
     context('ordered learners without case sensitive', function () {
       let firstLearner;
 
@@ -863,75 +928,6 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         expect(result.learners[0].id).to.equal(thirdLearner.id);
         expect(result.learners[1].id).to.equal(secondLearner.id);
         expect(result.learners[2].id).to.equal(firstLearner.id);
-      });
-    });
-
-    context('Pagination', function () {
-      it('retrieve paginated all active learners', async function () {
-        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-          organizationId: organization.id,
-        });
-        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-          organizationId: organization.id,
-        });
-
-        await databaseBuilder.commit();
-
-        const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
-          page: {
-            size: 1,
-            number: 1,
-          },
-        });
-
-        expect(result.pagination).to.deep.equal({
-          page: 1,
-          pageSize: 1,
-          rowCount: 2,
-          pageCount: 2,
-        });
-      });
-
-      context('Filtering', function () {
-        it('retrieve filtered and paginated learners', async function () {
-          const otherOrganization = databaseBuilder.factory.buildOrganization({
-            externalId: 'ZYX987',
-          });
-          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-            organizationId: otherOrganization.id,
-            firstName: 'Zoé',
-            lastName: 'De Ségazan',
-          });
-          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-            organizationId: organization.id,
-            firstName: 'Zoé',
-          });
-
-          const learner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-            organizationId: organization.id,
-            firstName: 'Zoé',
-            lastName: 'De Ségazan',
-          });
-
-          await databaseBuilder.commit();
-
-          const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
-            page: {
-              size: 1,
-              number: 1,
-            },
-            filter: { organizationExternalId: 'ABC123', fullName: 'Zoé De Ségazan' },
-          });
-
-          expect(result.pagination).to.deep.equal({
-            page: 1,
-            pageSize: 1,
-            rowCount: 1,
-            pageCount: 1,
-          });
-          expect(result.learners).to.have.lengthOf(1);
-          expect(result.learners[0].id).to.equal(learner.id);
-        });
       });
     });
 

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -767,6 +767,28 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       expect(result.learners[1].id).to.be.equal(learner2.id);
     });
 
+    it('should not return disabled learner if filter is on', async function () {
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        isDisabled: true,
+      });
+      const learner2 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        isDisabled: false,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
+        page: {},
+        filter: { hideDisabled: true },
+      });
+
+      expect(result.learners).lengthOf(1);
+      expect(result.learners[0]).instanceOf(OrganizationLearnerOverviewForAdmin);
+      expect(result.learners[0].id).to.be.equal(learner2.id);
+    });
+
     it('should not return deleted learner', async function () {
       const userId = databaseBuilder.factory.buildUser().id;
 

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -717,7 +717,9 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
     let organization;
 
     beforeEach(async function () {
-      organization = databaseBuilder.factory.buildOrganization();
+      organization = databaseBuilder.factory.buildOrganization({
+        externalId: 'ABC123',
+      });
 
       await databaseBuilder.commit();
     });
@@ -781,8 +783,10 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       expect(result.learners).lengthOf(0);
     });
 
-    it('retrieve all active learners from specific organizationId', async function () {
-      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+    it('retrieve all active learners from specific organizationExternalId', async function () {
+      const otherOrganization = databaseBuilder.factory.buildOrganization({
+        externalId: 'ZYX987',
+      });
       databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
         organizationId: organization.id,
       });
@@ -791,13 +795,13 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         organizationId: organization.id,
       });
       databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-        organizationId: otherOrganizationId,
+        organizationId: otherOrganization.id,
       });
 
       await databaseBuilder.commit();
 
       const result = await organizationLearnerRepository.findPaginatedLearnersForAdmin({
-        filter: { organizationId: organization.id },
+        filter: { organizationExternalId: organization.externalId },
         page: {},
       });
 
@@ -890,9 +894,11 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
       context('Filtering', function () {
         it('retrieve filtered and paginated learners', async function () {
-          const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          const otherOrganization = databaseBuilder.factory.buildOrganization({
+            externalId: 'ZYX987',
+          });
           databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-            organizationId: otherOrganizationId,
+            organizationId: otherOrganization.id,
             firstName: 'Zoé',
             lastName: 'De Ségazan',
           });
@@ -914,7 +920,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
               size: 1,
               number: 1,
             },
-            filter: { organizationId: organization.id, fullName: 'Zoé De Ségazan' },
+            filter: { organizationExternalId: 'ABC123', fullName: 'Zoé De Ségazan' },
           });
 
           expect(result.pagination).to.deep.equal({


### PR DESCRIPTION
## 🪧 Problème

Le support ne peut pas rechercher des prescrits sans utiliser metabase. Il existe une page de vue des prescrits, mais il n’est pas possible de la filtrer.

## 🌈 Proposition

Ajouter des filtres dans la page de vue des prescrits

Pour la v0, on a 2 filtres: Prénom/Nom (en un seul champ) et OrgaExternalId (l’id externe), et un toggle permettant de masquer les prescrits désactivés

Ajout d’un bouton pour effacer les filtres


## ✊ Remarques

Tant qu’aucun filtre n’est appliqué, aucunes données ne s’affichent. Dès qu’un filtre est appliqué (sauf le toggle), on affiche les résultats filtrés

Pour le champ Prénom/Nom, on attend au mois 2 lettres pour afficher des résultats sauf si un autre champ est rempli

Les colonnes Date de naissance, Organisation et Date de màj sont ordonnables

Le filtre organizationExternalId est insensible à la casse, mais doit être exact

## 🎉 Pour tester

Lancer Pix Admin
Cliquer sur l'encart "Prescrits"
Faire plein de tests