### PR TITLE
[TECH] Réduire au silence les alertes de dépréciations Ember de Pix Admin (PIX-23510)

### DIFF
--- a/admin/app/app.js
+++ b/admin/app/app.js
@@ -1,3 +1,5 @@
+import './deprecation-workflow.js';
+
 import Application from '@ember/application';
 import setupInspector from '@embroider/legacy-inspector-support/ember-source-4.12';
 import loadInitializers from 'ember-load-initializers';

--- a/admin/app/deprecation-workflow.js
+++ b/admin/app/deprecation-workflow.js
@@ -1,0 +1,22 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  workflow: [
+    {
+      handler: 'silence',
+      matchId: 'warp-drive.deprecate-tracking-package',
+    },
+    {
+      handler: 'silence',
+      matchId: 'importing-inject-from-ember-service',
+    },
+    {
+      handler: 'silence',
+      matchId: 'warp-drive:deprecate-legacy-request-methods',
+    },
+    {
+      handler: 'silence',
+      matchId: 'warp-drive.ember-inflector',
+    },
+  ],
+});

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "pix-admin",
       "version": "5.451.0",
-      "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.27",
@@ -29,6 +28,7 @@
         "ember-cli-app-version": "^7.0.0",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-dependency-checker": "^3.3.3",
+        "ember-cli-deprecation-workflow": "^4.0.1",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-sass": "^11.0.1",
         "ember-cookies": "^1.3.0",
@@ -14031,6 +14031,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-4.0.1.tgz",
+      "integrity": "sha512-XJzUZVXyb6/nFKU7GzGRlHlcAl4KtkioBTjfuIHp1aysbRZ6XxYLSPtP090EbOxQBtYwAPsH2kPAtPS86tL2RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.9",
+        "decorator-transforms": "^2.2.2"
       }
     },
     "node_modules/ember-cli-get-component-path-option": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -60,6 +60,7 @@
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.3",
+    "ember-cli-deprecation-workflow": "^4.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cookies": "^1.3.0",


### PR DESCRIPTION
## 🪧 Problème
Sur Pix Admin, la console de développement est polluée par les nombreuses alertes de dépréciations Ember.

## 🌈 Proposition

Les rendre silencieuses en configurant un deprecation-workflow. Suite de cette PR sur Pix Orga https://github.com/1024pix/pix/pull/16476

## ✊ Remarques

- Par rapport à la configuration sur Pix Orga, une dépréciation a été ajoutée au tableau workflow : `ember-inflector`.
- Le deprecation-workflow permet de remettre à la demande une alerte pour chaque dépréciation listée (`handler: 'log'`) voire de lever une erreur et d'empêcher le build de l'application (`handler: 'throw'`). Ceci sera utile lorsque le moment d'adresser les dépréciations sera venu.

## 🎉 Pour tester

Sur Pix Admin en local, ouvrir la console dans le navigateur, et constater que celle-ci est nettoyée des alertes.
