### PR TITLE
[FEATURE] Changement de la condition d'exclusion pour supprimer une version non ACTIVE (PIX-23511)

### DIFF
--- a/api/src/certification/configuration/domain/usecases/delete-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/delete-certification-version.js
@@ -3,6 +3,7 @@
  */
 
 import { CertificationVersionForbiddenDeletionError } from '../errors.js';
+import { VERSION_STATUSES } from '../models/Version.js';
 
 /**
  * @param {object} params
@@ -12,7 +13,7 @@ import { CertificationVersionForbiddenDeletionError } from '../errors.js';
 
 export async function deleteCertificationVersion({ certificationVersionId, versionRepository }) {
   const version = await versionRepository.getById({ id: certificationVersionId });
-  if (version.startDate) {
+  if (version.status === VERSION_STATUSES.ACTIVE) {
     throw new CertificationVersionForbiddenDeletionError();
   }
   await versionRepository.deleteVersion(certificationVersionId);

--- a/api/tests/certification/configuration/integration/domain/usecases/delete-certification-version_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/delete-certification-version_test.js
@@ -1,4 +1,5 @@
 import { CertificationVersionForbiddenDeletionError } from '../../../../../../src/certification/configuration/domain/errors.js';
+import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../../test-helper.js';
@@ -12,6 +13,7 @@ describe('Certification | Configuration | Integration | Domain | UseCase | delet
       scope: SCOPES.CORE,
       startDate: new Date(),
       expirationDate: null,
+      status: VERSION_STATUSES.ACTIVE,
     });
 
     await databaseBuilder.commit();
@@ -28,8 +30,9 @@ describe('Certification | Configuration | Integration | Domain | UseCase | delet
     // given
     const certificationVersion = databaseBuilder.factory.buildCertificationVersion({
       scope: SCOPES.CORE,
-      startDate: null,
+      startDate: new Date(),
       expirationDate: null,
+      status: VERSION_STATUSES.DRAFT,
     });
 
     await databaseBuilder.commit();


### PR DESCRIPTION
## 🪧 Problème

On à introduit la possibilité d'avoir une startDate pour les version en mode DRAFT.
Précédemment, la présence de cette startDate nous permettait de savoir si la version est active ou non.

## 🌈 Proposition

Vérifier le status à la place de la présence de startDate

## ✊ Remarques

RAS

## 🎉 Pour tester

Essayer de supprimer une version DRAFT qui possède une startDate