### PR TITLE
[BUGFIX] La souscription par défaut lors de l'inscription individuelle d'un candidat doit toujours être à la certification coeur (PIX-23512)

### DIFF
--- a/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
@@ -206,7 +206,7 @@ export default class EnrolledCandidates extends Component {
   }
 
   _createCertificationCandidateRecord(certificationCandidateData) {
-    if (certificationCandidateData.subscription === '') {
+    if (!certificationCandidateData.subscription) {
       certificationCandidateData.subscription = 'CORE';
     }
     return {

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -101,6 +101,10 @@ function routes() {
   this.post('/sessions/:id/certification-candidates', function (schema, request) {
     const sessionId = request.params.id;
     const requestBody = JSON.parse(request.requestBody);
+
+    if (!requestBody.data.attributes.subscription) {
+      return new Response(400);
+    }
     return schema.certificationCandidates.create({
       ...requestBody.data.attributes,
       sessionId,

--- a/certif/tests/acceptance/session-add-candidate-test.js
+++ b/certif/tests/acceptance/session-add-candidate-test.js
@@ -12,35 +12,16 @@ module('Acceptance | Session Add Candidate', function (hooks) {
   const sessionId = 123;
   let allowedCertificationCenterAccess;
 
-  hooks.beforeEach(async function () {
-    allowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
-      type: 'PRO',
+  test('it should add a candidate without any complementary subscription', async function (assert) {
+    // given
+    _setupCertificationCenter({
+      server,
+      sessionId,
       habilitations: [
         { id: 1, label: 'Pix+ Droit', key: 'DROIT' },
         { id: 2, label: 'CléA Numérique', key: 'CLEA' },
       ],
     });
-    const certificationPointOfContact = server.create('certification-point-of-contact', {
-      firstName: 'Eddy',
-      lastName: 'Taurial',
-      allowedCertificationCenterAccesses: [allowedCertificationCenterAccess],
-      pixCertifTermsOfServiceAccepted: true,
-    });
-    server.create('session-enrolment', {
-      id: sessionId,
-      certificationCenterId: allowedCertificationCenterAccess.id,
-    });
-
-    server.create('session-management', {
-      id: sessionId,
-    });
-
-    server.createList('country', 1);
-    await authenticateSession(certificationPointOfContact.id);
-  });
-
-  test('it should add a candidate without any complementary subscription', async function (assert) {
-    // given
     const screen = await visit(`/sessions/${sessionId}/candidats`);
 
     // when
@@ -63,8 +44,39 @@ module('Acceptance | Session Add Candidate', function (hooks) {
     assert.dom(screen.getByRole('cell', { name: 'Certification Pix' })).exists();
   });
 
+  test('it should add a candidate without any complementary subscription even if certificationCenter has no habilitations', async function (assert) {
+    // given
+    _setupCertificationCenter({ server, sessionId, habilitations: [] });
+    const screen = await visit(`/sessions/${sessionId}/candidats`);
+
+    // when
+    await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+    await fillIn(screen.getByLabelText('Nom de naissance *'), 'Quatorze');
+    await fillIn(screen.getByLabelText('Prénom *'), 'Louis');
+    await click(screen.getByLabelText('Homme'));
+    await fillIn(screen.getByLabelText('Date de naissance *'), '2000-01-01');
+    await click(screen.getByLabelText('Pays de naissance *'));
+    await click(screen.getByText('Portugal'));
+    await fillIn(screen.getByLabelText('Commune de naissance *'), 'Paris');
+    await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
+
+    // then
+    assert.dom(screen.getByRole('cell', { name: 'Quatorze' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Louis' })).exists();
+    assert.dom(screen.getByRole('cell', { name: '01/01/2000' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Certification Pix' })).exists();
+  });
+
   test('it should add a candidate with a complementary subscription', async function (assert) {
     // given
+    _setupCertificationCenter({
+      server,
+      sessionId,
+      habilitations: [
+        { id: 1, label: 'Pix+ Droit', key: 'DROIT' },
+        { id: 2, label: 'CléA Numérique', key: 'CLEA' },
+      ],
+    });
     const screen = await visit(`/sessions/${sessionId}/candidats`);
 
     // when
@@ -85,4 +97,28 @@ module('Acceptance | Session Add Candidate', function (hooks) {
     assert.dom(screen.getByRole('cell', { name: '01/01/2000' })).exists();
     assert.dom(screen.getByRole('cell', { name: 'Pix+ Droit' })).exists();
   });
+
+  async function _setupCertificationCenter({ server, sessionId, habilitations }) {
+    allowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
+      type: 'PRO',
+      habilitations,
+    });
+    const certificationPointOfContact = server.create('certification-point-of-contact', {
+      firstName: 'Eddy',
+      lastName: 'Taurial',
+      allowedCertificationCenterAccesses: [allowedCertificationCenterAccess],
+      pixCertifTermsOfServiceAccepted: true,
+    });
+    server.create('session-enrolment', {
+      id: sessionId,
+      certificationCenterId: allowedCertificationCenterAccess.id,
+    });
+
+    server.create('session-management', {
+      id: sessionId,
+    });
+
+    server.createList('country', 1);
+    await authenticateSession(certificationPointOfContact.id);
+  }
 });


### PR DESCRIPTION
## 🪧 Problème

[<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->](https://1024pix.slack.com/archives/C06AQ1DDRUM/p1783511296668459)

> On a eu deux tickets avec un message d'erreur lors de l'inscription manuelle des candidats
> On a essayé de reproduire l'erreur en recette et on a eu le même message
> En ods ça fonctionne par contre, donc en attendant la résolution on va leur proposer ça
> Pour info, le premier ticket reçu date d'hier

## 🌈 Proposition

Nous constatons que dans le cas de centre de certification PRO, si nous n'avons aucune habilitation, la valeur par défaut de souscription devrait être `CORE`, mais ne l'est pas.

Modification du code pour garantir que la valeur par défaut est bien `CORE`.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

Aller en certif avec un centre pro qui n'a pas d'habilitation sur des certifications complémentaires
inscrire un candidat à une certification
constater que ça fonctionne (que le candidat est bien inscrit sur une certification cœur