### PR TITLE
[FEATURE] Ajout du second formulaire dans l'encart feedback de fin de parcours (PIX-23506).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import ENV from 'mon-pix/config/environment';
 
+import ContentRelevanceForm from './drawer/content-relevance-form';
 import SatisfactionScore from './drawer/satisfaction-score';
 import ThankYou from './drawer/thank-you';
 
@@ -14,15 +15,30 @@ export default class Drawer extends Component {
 
   @tracked isHidden = false;
   @tracked isHiding = false;
-  @tracked isSubmitted = false;
+  @tracked step = 'satisfaction-score';
+
+  get isContentRelevanceFormStepDisplayed() {
+    return this.step === 'content-relevance-form';
+  }
+
+  get isThankYouStepDisplayed() {
+    return this.step === 'thank-you';
+  }
 
   @action
-  async selectScore(score) {
-    this.isSubmitted = true;
+  showThankYou() {
+    this.step = 'thank-you';
+  }
+
+  @action
+  async submitSatisfactionScore(score) {
     try {
+      this.step = 'content-relevance-form';
+
+      this.satisfactionScore = score;
       await this.requestManager.request({
         url: `${ENV.APP.API_HOST}/api/user-campaign-surveys`,
-        method: 'POST',
+        method: 'PUT',
         body: JSON.stringify({
           data: {
             type: 'user-campaign-surveys',
@@ -34,7 +50,7 @@ export default class Drawer extends Component {
         }),
       });
     } catch {
-      // L'échec de l'appel API n'interrompt pas le flux UI
+      // TODO Ajouter un PixToast d'erreur
     }
   }
 
@@ -51,6 +67,31 @@ export default class Drawer extends Component {
     }
   }
 
+  @action
+  async submitContentRelevanceFormScores(scores) {
+    try {
+      await this.requestManager.request({
+        url: `${ENV.APP.API_HOST}/api/user-campaign-surveys`,
+        method: 'PUT',
+        body: JSON.stringify({
+          data: {
+            type: 'user-campaign-surveys',
+            attributes: {
+              'campaign-id': this.args.campaignId,
+              'satisfaction-score': this.satisfactionScore,
+              'usefulness-score': scores.usefulness,
+              'personalization-score': scores.personalization,
+              'attractiveness-score': scores.attractiveness,
+            },
+          },
+        }),
+      });
+      this.showThankYou();
+    } catch {
+      // TODO Ajouter un PixToast d'erreur
+    }
+  }
+
   <template>
     {{#unless this.isHidden}}
       <section
@@ -59,10 +100,12 @@ export default class Drawer extends Component {
         role="dialog"
         aria-label={{t "pages.skill-review.recommended-engine.drawer.title"}}
       >
-        {{#if this.isSubmitted}}
+        {{#if this.isThankYouStepDisplayed}}
           <ThankYou @onClose={{this.hide}} />
+        {{else if this.isContentRelevanceFormStepDisplayed}}
+          <ContentRelevanceForm @onSubmit={{this.submitContentRelevanceFormScores}} @onHide={{this.hide}} />
         {{else}}
-          <SatisfactionScore @onScoreSelected={{this.selectScore}} @onHide={{this.hide}} />
+          <SatisfactionScore @onScoreSelected={{this.submitSatisfactionScore}} @onHide={{this.hide}} />
         {{/if}}
       </section>
     {{/unless}}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form.gjs
@@ -1,0 +1,119 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { concat, fn, get } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import eq from 'ember-truth-helpers/helpers/eq';
+import modifierDidInsert from 'mon-pix/modifiers/modifier-did-insert';
+
+const SCORES = [1, 2, 3, 4, 5];
+
+const SCALES = [
+  {
+    key: 'usefulness',
+  },
+  {
+    key: 'personalization',
+  },
+  {
+    key: 'attractiveness',
+  },
+];
+
+const TRANSLATION_PREFIX = 'pages.skill-review.recommended-engine.drawer.content-relevance-form';
+
+export default class ContentRelevanceForm extends Component {
+  @tracked usefulness = null;
+  @tracked personalization = null;
+  @tracked attractiveness = null;
+
+  get isSubmitDisabled() {
+    return !SCALES.every((scale) => this[scale.key] !== null);
+  }
+
+  @action
+  selectScore(scaleKey, score) {
+    this[scaleKey] = score;
+  }
+
+  @action
+  submit() {
+    this.args.onSubmit({
+      usefulness: this.usefulness,
+      personalization: this.personalization,
+      attractiveness: this.attractiveness,
+    });
+  }
+
+  @action
+  focusOnInsert(element) {
+    element.focus();
+  }
+
+  <template>
+    <div
+      role="status"
+      class="results-recommendation-engine-drawer__content-relevance-form"
+      tabindex="-1"
+      {{modifierDidInsert this.focusOnInsert}}
+    >
+      <p class="results-recommendation-engine-drawer__content-relevance-form-title">
+        {{t "pages.skill-review.recommended-engine.drawer.content-relevance-form.title"}}
+      </p>
+      <p class="results-recommendation-engine-drawer__content-relevance-form-subtitle">
+        {{t "pages.skill-review.recommended-engine.drawer.content-relevance-form.subtitle"}}
+      </p>
+      <form>
+        <fieldset class="results-recommendation-engine-drawer__content-relevance-form-fieldset">
+          <legend class="results-recommendation-engine-drawer__content-relevance-form-statement">
+            {{t "pages.skill-review.recommended-engine.drawer.content-relevance-form.legend"}}
+          </legend>
+          {{#each SCALES as |scale|}}
+            <fieldset class="results-recommendation-engine-drawer__scale">
+              <legend class="screen-reader-only">{{t (concat TRANSLATION_PREFIX "." scale.key ".legend")}}</legend>
+              <span class="results-recommendation-engine-drawer__scale-label" aria-hidden="true">
+                {{t (concat TRANSLATION_PREFIX "." scale.key ".min-label")}}
+              </span>
+              <div class="results-recommendation-engine-drawer__scale-radios">
+                {{#each SCORES as |score|}}
+                  <PixRadioButton
+                    name={{scale.key}}
+                    @value={{score}}
+                    @screenReaderOnly={{true}}
+                    checked={{eq (get this scale.key) score}}
+                    {{on "click" (fn this.selectScore scale.key score)}}
+                  >
+                    <:label>
+                      {{t
+                        "pages.skill-review.recommended-engine.drawer.content-relevance-form.score-aria-label"
+                        score=score
+                      }}
+                    </:label>
+                  </PixRadioButton>
+                {{/each}}
+              </div>
+              <span class="results-recommendation-engine-drawer__scale-label" aria-hidden="true">
+                {{t (concat TRANSLATION_PREFIX "." scale.key ".max-label")}}
+              </span>
+            </fieldset>
+          {{/each}}
+          <div class="results-recommendation-engine-drawer__content-relevance-form-actions">
+            <PixButton
+              @variant="tertiary"
+              @triggerAction={{@onHide}}
+              aria-label={{t "pages.skill-review.recommended-engine.drawer.hide-aria-label"}}
+            >
+              {{t "pages.skill-review.recommended-engine.drawer.hide"}}
+            </PixButton>
+            <PixButton @variant="primary" @isDisabled={{this.isSubmitDisabled}} @triggerAction={{this.submit}}>
+              {{t "common.actions.send"}}
+            </PixButton>
+          </div>
+        </fieldset>
+      </form>
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/satisfaction-score.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/satisfaction-score.gjs
@@ -31,7 +31,7 @@ export default class SatisfactionScore extends Component {
   }
 
   <template>
-    <form>
+    <form aria-live="polite">
       <fieldset class="results-recommendation-engine-drawer__form">
         <legend class="results-recommendation-engine-drawer__statement">
           {{t "pages.skill-review.recommended-engine.drawer.statement"}}

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
@@ -156,4 +156,86 @@
 
     text-align: center;
   }
+
+  &__content-relevance-form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    @media (not (prefers-reduced-motion: reduce)) {
+      animation: thank-you-enter 0.3s ease;
+    }
+  }
+
+  &__content-relevance-form-title {
+    @extend %pix-title-xs;
+  }
+
+  &__content-relevance-form-subtitle {
+    @extend %pix-body-s;
+
+    margin-bottom: var(--pix-spacing-6x);
+    text-align: center;
+  }
+
+  &__content-relevance-form-fieldset {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__content-relevance-form-statement {
+    @extend %pix-body-l;
+
+    width: 100%;
+    padding-bottom: var(--pix-spacing-2x);
+    font-weight: 700;
+    text-align: center;
+  }
+
+  &__scale {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+
+    &:not(:last-child) {
+      padding-bottom: var(--pix-spacing-2x);
+    }
+  }
+
+  &__scale-label {
+    @extend %pix-body-s;
+
+    width: 6rem;
+  }
+
+  &__scale-label:first-of-type {
+    text-align: right;
+  }
+
+  &__scale-radios {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    justify-content: center;
+
+    // PixUI defines a margin-top to stack radio buttons vertically.
+    // In our case, we want the radio buttons to be stacked horizontally
+    // so we reset the margin-top value.
+    .pix-radio-button + .pix-radio-button {
+      margin-top: 0;
+    }
+  }
+
+  &__content-relevance-form-actions {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    justify-content: center;
+    margin-top: var(--pix-spacing-6x);
+  }
 }

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { click, triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import Drawer from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/drawer';
@@ -17,7 +17,7 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
     this.owner.register('service:current-user', { user: { id: 42 } });
   });
 
-  test('it displays the satisfaction score form by default', async function (assert) {
+  test('it displays the satisfaction score step by default', async function (assert) {
     // when
     const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
 
@@ -25,82 +25,154 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
     assert.dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.statement'))).isVisible();
   });
 
-  module('when user selects a score', function () {
-    test('it displays the thank you message', async function (assert) {
-      // given
-      const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
+  module('on satisfaction step', function () {
+    module('when user selects a satisfaction score', function () {
+      test('it displays the content relevance form', async function (assert) {
+        // given
+        const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
 
-      // when
-      await click(
-        screen.getByRole('button', {
-          name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
-        }),
-      );
+        // when
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
+          }),
+        );
 
-      // then
-      assert.dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.thank-you.title'))).isVisible();
+        // then
+        assert
+          .dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.content-relevance-form.title')))
+          .isVisible();
+      });
+
+      test('it calls PUT /api/user-campaign-surveys with campaignId and satisfactionScore', async function (assert) {
+        // given
+        const screen = await render(<template><Drawer @campaignId={{99}} /></template>);
+
+        // when
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
+          }),
+        );
+
+        // then
+        sinon.assert.calledOnce(this.requestManagerStub.request);
+        const [requestArgs] = this.requestManagerStub.request.firstCall.args;
+        assert.ok(requestArgs.url.endsWith('/api/user-campaign-surveys'));
+        assert.strictEqual(requestArgs.method, 'PUT');
+        const body = JSON.parse(requestArgs.body);
+        assert.strictEqual(body.data.attributes['campaign-id'], 99);
+        assert.strictEqual(body.data.attributes['satisfaction-score'], 5);
+      });
     });
 
-    test('it calls POST /api/user-campaign-surveys with campaignId and satisfactionScore', async function (assert) {
-      // given
-      const screen = await render(<template><Drawer @campaignId={{99}} /></template>);
+    module('when user clicks on "hide" button', function () {
+      test('the drawer is removed', async function (assert) {
+        // given
+        const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
 
-      // when
-      await click(
-        screen.getByRole('button', {
-          name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
-        }),
-      );
+        // when
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.drawer.hide-aria-label') }),
+        );
+        await triggerEvent(document.querySelector('.results-recommendation-engine-drawer'), 'animationend', {
+          animationName: 'drawer-slide-down',
+        });
 
-      // then
-      sinon.assert.calledOnce(this.requestManagerStub.request);
-      const [requestArgs] = this.requestManagerStub.request.firstCall.args;
-      assert.ok(requestArgs.url.endsWith('/api/user-campaign-surveys'));
-      assert.strictEqual(requestArgs.method, 'POST');
-      const body = JSON.parse(requestArgs.body);
-      assert.strictEqual(body.data.attributes['campaign-id'], 99);
-      assert.strictEqual(body.data.attributes['satisfaction-score'], 5);
+        // then
+        assert.dom(screen.queryByText(t('pages.skill-review.recommended-engine.drawer.statement'))).doesNotExist();
+      });
     });
   });
 
-  module('when user clicks on "hide" button', function () {
-    test('the drawer is removed', async function (assert) {
-      // given
-      const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
+  module('on content relevance form step', function () {
+    module('when user submits the content relevance form', function () {
+      test('it displays the thank you step', async function (assert) {
+        // given
+        const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
+          }),
+        );
+        const scoreLabel = t('pages.skill-review.recommended-engine.drawer.content-relevance-form.score-aria-label', {
+          score: 5,
+        });
+        for (const axisLegendKey of ['usefulness', 'personalization', 'attractiveness']) {
+          const scale = within(
+            screen.getByRole('group', {
+              name: t(`pages.skill-review.recommended-engine.drawer.content-relevance-form.${axisLegendKey}.legend`),
+            }),
+          );
+          await click(scale.getByRole('radio', { name: scoreLabel }));
+        }
 
-      // when
-      await click(
-        screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.drawer.hide-aria-label') }),
-      );
-      await triggerEvent(document.querySelector('.results-recommendation-engine-drawer'), 'animationend', {
-        animationName: 'drawer-slide-down',
+        // when
+        await click(screen.getByRole('button', { name: t('common.actions.send') }));
+
+        // then
+        assert.dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.thank-you.title'))).isVisible();
       });
 
-      // then
-      assert.dom(screen.queryByText(t('pages.skill-review.recommended-engine.drawer.statement'))).doesNotExist();
+      test('it calls PUT /api/user-campaign-surveys with campaignId, satisfaction and content relevance scores', async function (assert) {
+        // given
+        const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
+          }),
+        );
+        const scoreLabel = t('pages.skill-review.recommended-engine.drawer.content-relevance-form.score-aria-label', {
+          score: 5,
+        });
+        for (const axisLegendKey of ['usefulness', 'personalization', 'attractiveness']) {
+          const scale = within(
+            screen.getByRole('group', {
+              name: t(`pages.skill-review.recommended-engine.drawer.content-relevance-form.${axisLegendKey}.legend`),
+            }),
+          );
+          await click(scale.getByRole('radio', { name: scoreLabel }));
+        }
+
+        // when
+        await click(screen.getByRole('button', { name: t('common.actions.send') }));
+
+        // then
+        const [requestArgs] = this.requestManagerStub.request.secondCall.args;
+        assert.ok(requestArgs.url.endsWith('/api/user-campaign-surveys'));
+        assert.strictEqual(requestArgs.method, 'PUT');
+        const body = JSON.parse(requestArgs.body);
+        assert.strictEqual(body.data.attributes['campaign-id'], 1);
+        assert.strictEqual(body.data.attributes['usefulness-score'], 5);
+        assert.strictEqual(body.data.attributes['personalization-score'], 5);
+        assert.strictEqual(body.data.attributes['attractiveness-score'], 5);
+        assert.strictEqual(body.data.attributes['satisfaction-score'], 5);
+      });
     });
-  });
 
-  module('when user has submitted a score and clicks close', function () {
-    test('the drawer is removed', async function (assert) {
-      // given
-      const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
-      await click(
-        screen.getByRole('button', {
-          name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
-        }),
-      );
+    module('when user clicks on "hide" button', function () {
+      test('the drawer is removed', async function (assert) {
+        // given
+        const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
+          }),
+        );
 
-      // when
-      await click(
-        screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.drawer.hide-aria-label') }),
-      );
-      await triggerEvent(document.querySelector('.results-recommendation-engine-drawer'), 'animationend', {
-        animationName: 'drawer-slide-down',
+        // when
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.drawer.hide-aria-label') }),
+        );
+        await triggerEvent(document.querySelector('.results-recommendation-engine-drawer'), 'animationend', {
+          animationName: 'drawer-slide-down',
+        });
+
+        // then
+        assert
+          .dom(screen.queryByText(t('pages.skill-review.recommended-engine.drawer.content-relevance-form.title')))
+          .doesNotExist();
       });
-
-      // then
-      assert.dom(screen.queryByText(t('pages.skill-review.recommended-engine.drawer.thank-you.title'))).doesNotExist();
     });
   });
 });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form-test.gjs
@@ -1,0 +1,152 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import ContentRelevanceForm from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
+module(
+  'Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | Drawer | ContentRelevanceForm',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+
+    async function selectScore({ screen, legendKey, scoreLabel }) {
+      const scale = within(screen.getByRole('group', { name: t(legendKey) }));
+      await click(scale.getByRole('radio', { name: scoreLabel }));
+    }
+
+    test('it displays the title, subtitle and the three rating scales', async function (assert) {
+      // when
+      const onSubmit = sinon.stub();
+      const onHide = sinon.stub();
+      const screen = await render(
+        <template><ContentRelevanceForm @onSubmit={{onSubmit}} @onHide={{onHide}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.content-relevance-form.title')))
+        .isVisible();
+      assert
+        .dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.content-relevance-form.subtitle')))
+        .isVisible();
+      assert
+        .dom(
+          screen.getByText(
+            t('pages.skill-review.recommended-engine.drawer.content-relevance-form.usefulness.min-label'),
+          ),
+        )
+        .isVisible();
+      assert
+        .dom(
+          screen.getByText(
+            t('pages.skill-review.recommended-engine.drawer.content-relevance-form.usefulness.max-label'),
+          ),
+        )
+        .isVisible();
+      assert.strictEqual(screen.getAllByRole('radio').length, 15);
+    });
+
+    test('the submit button is disabled until the three scales have a selected score', async function (assert) {
+      // given
+      const onSubmit = sinon.stub();
+      const onHide = sinon.stub();
+      const screen = await render(
+        <template><ContentRelevanceForm @onSubmit={{onSubmit}} @onHide={{onHide}} /></template>,
+      );
+      const submitButton = screen.getByRole('button', { name: t('common.actions.send') });
+      const scoreLabel = t('pages.skill-review.recommended-engine.drawer.content-relevance-form.score-aria-label', {
+        score: 5,
+      });
+
+      // then
+      assert.dom(submitButton).hasAttribute('aria-disabled', 'true');
+
+      // when
+      await selectScore({
+        screen,
+        legendKey: 'pages.skill-review.recommended-engine.drawer.content-relevance-form.usefulness.legend',
+        scoreLabel,
+      });
+      await selectScore({
+        screen,
+        legendKey: 'pages.skill-review.recommended-engine.drawer.content-relevance-form.personalization.legend',
+        scoreLabel,
+      });
+
+      // then
+      assert.dom(submitButton).hasAttribute('aria-disabled', 'true');
+
+      // when
+      await selectScore({
+        screen,
+        legendKey: 'pages.skill-review.recommended-engine.drawer.content-relevance-form.attractiveness.legend',
+        scoreLabel,
+      });
+
+      // then
+      assert.dom(submitButton).doesNotHaveAttribute('aria-disabled', 'true');
+    });
+
+    test('it calls onSubmit with the three selected scores', async function (assert) {
+      // given
+      const onSubmit = sinon.stub();
+      const onHide = sinon.stub();
+      const screen = await render(
+        <template><ContentRelevanceForm @onSubmit={{onSubmit}} @onHide={{onHide}} /></template>,
+      );
+
+      // when
+      await selectScore({
+        screen,
+        legendKey: 'pages.skill-review.recommended-engine.drawer.content-relevance-form.usefulness.legend',
+        scoreLabel: t('pages.skill-review.recommended-engine.drawer.content-relevance-form.score-aria-label', {
+          score: 4,
+        }),
+      });
+      await selectScore({
+        screen,
+        legendKey: 'pages.skill-review.recommended-engine.drawer.content-relevance-form.personalization.legend',
+        scoreLabel: t('pages.skill-review.recommended-engine.drawer.content-relevance-form.score-aria-label', {
+          score: 5,
+        }),
+      });
+      await selectScore({
+        screen,
+        legendKey: 'pages.skill-review.recommended-engine.drawer.content-relevance-form.attractiveness.legend',
+        scoreLabel: t('pages.skill-review.recommended-engine.drawer.content-relevance-form.score-aria-label', {
+          score: 5,
+        }),
+      });
+      await click(screen.getByRole('button', { name: t('common.actions.send') }));
+
+      // then
+      assert.true(
+        onSubmit.calledOnceWithExactly({
+          usefulness: 4,
+          personalization: 5,
+          attractiveness: 5,
+        }),
+      );
+    });
+
+    test('it calls onHide when the quit button is clicked', async function (assert) {
+      // given
+      const onSubmit = sinon.stub();
+      const onHide = sinon.stub();
+      const screen = await render(
+        <template><ContentRelevanceForm @onSubmit={{onSubmit}} @onHide={{onHide}} /></template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.drawer.hide-aria-label') }),
+      );
+
+      // then
+      assert.true(onHide.calledOnce);
+    });
+  },
+);

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2254,6 +2254,27 @@
       "not-finished": "Du kannst deine Ergebnisse noch nicht einsenden, wir haben noch einige Fragen an dich.",
       "recommended-engine": {
         "drawer": {
+          "content-relevance-form": {
+            "attractiveness": {
+              "legend": "Bewerten Sie, wie ansprechend die Inhalte sind, von nicht ansprechend 1 bis ansprechend 5",
+              "max-label": "Ansprechend",
+              "min-label": "Nicht ansprechend"
+            },
+            "legend": "Die empfohlenen Inhalte sind…",
+            "personalization": {
+              "legend": "Bewerten Sie, wie personalisiert die Inhalte sind, von generisch 1 bis personalisiert 5",
+              "max-label": "Personalisiert",
+              "min-label": "Generisch"
+            },
+            "score-aria-label": "{score} von 5",
+            "subtitle": "Wie wäre es, noch weiterzugehen…",
+            "title": "Danke für Ihr Feedback!",
+            "usefulness": {
+              "legend": "Bewerten Sie, wie nützlich die Inhalte sind, von nicht nützlich 1 bis nützlich 5",
+              "max-label": "Nützlich",
+              "min-label": "Nicht nützlich"
+            }
+          },
           "emojis": {
             "dissatisfied": "Nicht relevant",
             "neutral": "Ich habe keine Meinung",
@@ -2264,7 +2285,7 @@
           "hide": "Ausblenden",
           "hide-aria-label": "Feedbackbereich für Empfehlungen zu Lerninhalten ausblenden",
           "instruction": "Klicken Sie auf ein Emoji, um Ihre Meinung zu geben.",
-          "statement": "Erscheinen Ihnen diese empfohlenen Lerninhalte zur Vertiefung Ihres Wissens relevant?",
+          "statement": "Erscheinen Ihnen diese Lerninhalte zur Vertiefung Ihres Wissens relevant?",
           "thank-you": {
             "subtitle": "Geschafft!",
             "title": "Danke für Ihr Feedback!"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2254,6 +2254,27 @@
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
       "recommended-engine": {
         "drawer": {
+          "content-relevance-form": {
+            "attractiveness": {
+              "legend": "Rate how appealing the content is, from not appealing 1 to appealing 5",
+              "max-label": "Appealing",
+              "min-label": "Not appealing"
+            },
+            "legend": "The recommended content is…",
+            "personalization": {
+              "legend": "Rate how personalized the content is, from generic 1 to personalized 5",
+              "max-label": "Personalized",
+              "min-label": "Generic"
+            },
+            "score-aria-label": "{score} out of 5",
+            "subtitle": "How about going further…",
+            "title": "Thank you for your feedback!",
+            "usefulness": {
+              "legend": "Rate how useful the content is, from not useful 1 to useful 5",
+              "max-label": "Useful",
+              "min-label": "Not useful"
+            }
+          },
           "emojis": {
             "dissatisfied": "Not relevant",
             "neutral": "I have no opinion",
@@ -2264,7 +2285,7 @@
           "hide": "Hide",
           "hide-aria-label": "Hide the feedback panel for training content recommendations",
           "instruction": "Click on an emoji to give your feedback.",
-          "statement": "Do these training content recommendations to deepen your knowledge seem relevant to you?",
+          "statement": "Does this training content to deepen your knowledge seem relevant to you?",
           "thank-you": {
             "subtitle": "It's in the bag",
             "title": "Thank you for your feedback!"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2254,6 +2254,27 @@
       "not-finished": "Todavía no puedes enviar tus resultados, aún tenemos algunas preguntas para ti.",
       "recommended-engine": {
         "drawer": {
+          "content-relevance-form": {
+            "attractiveness": {
+              "legend": "Evalúa el atractivo de los contenidos, de poco atractivos 1 a atractivos 5",
+              "max-label": "Atractivos",
+              "min-label": "Poco atractivos"
+            },
+            "legend": "Los contenidos recomendados son…",
+            "personalization": {
+              "legend": "Evalúa la personalización de los contenidos, de genéricos 1 a personalizados 5",
+              "max-label": "Personalizados",
+              "min-label": "Genéricos"
+            },
+            "score-aria-label": "{score} de 5",
+            "subtitle": "¿Y si vamos más allá…?",
+            "title": "¡Gracias por tu opinión!",
+            "usefulness": {
+              "legend": "Evalúa la utilidad de los contenidos, de poco útiles 1 a útiles 5",
+              "max-label": "Útiles",
+              "min-label": "Poco útiles"
+            }
+          },
           "emojis": {
             "dissatisfied": "No pertinente",
             "neutral": "No tengo opinión",
@@ -2264,7 +2285,7 @@
           "hide": "Ocultar",
           "hide-aria-label": "Ocultar el panel de comentarios de las recomendaciones de contenidos formativos",
           "instruction": "Haz clic en un emoji para dar tu opinión.",
-          "statement": "¿Te parecen pertinentes estos contenidos formativos recomendados para profundizar tus conocimientos?",
+          "statement": "¿Te parecen pertinentes estos contenidos formativos para profundizar tus conocimientos?",
           "thank-you": {
             "subtitle": "¡Misión cumplida!",
             "title": "¡Gracias por tu opinión!"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2254,6 +2254,27 @@
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "recommended-engine": {
         "drawer": {
+          "content-relevance-form": {
+            "attractiveness": {
+              "legend": "Évaluez l'attractivité des offres de formation, de pas attirantes 1 à attirantes 5",
+              "max-label": "Attirantes",
+              "min-label": "Pas attirantes"
+            },
+            "legend": "Les offres de formation recommandées sont…",
+            "personalization": {
+              "legend": "Évaluez la personnalisation des offres de formation, de génériques 1 à personnalisées 5",
+              "max-label": "Personnalisées",
+              "min-label": "Génériques"
+            },
+            "score-aria-label": "{score} sur 5",
+            "subtitle": "Et si on allait plus loin…",
+            "title": "Merci pour votre avis !",
+            "usefulness": {
+              "legend": "Évaluez l'utilité des offres de formation, de pas utiles 1 à utiles 5",
+              "max-label": "Utiles",
+              "min-label": "Pas utiles"
+            }
+          },
           "emojis": {
             "dissatisfied": "Pas pertinent",
             "neutral": "Je n’ai pas d’avis",
@@ -2262,14 +2283,14 @@
             "very-satisfied": "Très pertinent"
           },
           "hide": "Masquer",
-          "hide-aria-label": "Fermer l'encart de feedback des recommandations de contenus formatifs",
+          "hide-aria-label": "Fermer l'encart de retours sur la recommandation des offres de formation",
           "instruction": "Cliquez sur un emoji pour donner votre avis.",
           "statement": "Ces offres de formation pour approfondir vos connaissances vous semblent-elles pertinentes ?",
           "thank-you": {
             "subtitle": "C'est dans la boîte",
             "title": "Merci pour votre avis !"
           },
-          "title": "Feedback sur la recommandation de contenu formatif"
+          "title": "Encart de prise de retours sur la recommandation des offres de formation"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2254,6 +2254,27 @@
       "not-finished": "Non è ancora possibile invia i risultati, quindi abbiamo ancora alcune domande per voi.",
       "recommended-engine": {
         "drawer": {
+          "content-relevance-form": {
+            "attractiveness": {
+              "legend": "Valuta quanto sono attraenti i contenuti, da poco attraenti 1 ad attraenti 5",
+              "max-label": "Attraenti",
+              "min-label": "Poco attraenti"
+            },
+            "legend": "I contenuti consigliati sono…",
+            "personalization": {
+              "legend": "Valuta quanto sono personalizzati i contenuti, da generici 1 a personalizzati 5",
+              "max-label": "Personalizzati",
+              "min-label": "Generici"
+            },
+            "score-aria-label": "{score} su 5",
+            "subtitle": "E se andassimo oltre…",
+            "title": "Grazie per il tuo feedback!",
+            "usefulness": {
+              "legend": "Valuta quanto sono utili i contenuti, da poco utili 1 a utili 5",
+              "max-label": "Utili",
+              "min-label": "Poco utili"
+            }
+          },
           "emojis": {
             "dissatisfied": "Non pertinente",
             "neutral": "Non ho un'opinione",
@@ -2264,7 +2285,7 @@
           "hide": "Nascondi",
           "hide-aria-label": "Nascondi il pannello di feedback per le raccomandazioni sui contenuti formativi",
           "instruction": "Clicca su un emoji per dare il tuo parere.",
-          "statement": "Questi contenuti formativi consigliati per approfondire le tue conoscenze ti sembrano pertinenti?",
+          "statement": "Questi contenuti formativi per approfondire le tue conoscenze ti sembrano pertinenti?",
           "thank-you": {
             "subtitle": "Missione compiuta!",
             "title": "Grazie per il tuo feedback!"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2254,6 +2254,27 @@
       "not-finished": "Je kunt je resultaten nog niet opsturen, dus we hebben nog een paar vragen voor je.",
       "recommended-engine": {
         "drawer": {
+          "content-relevance-form": {
+            "attractiveness": {
+              "legend": "Beoordeel hoe aantrekkelijk de inhoud is, van niet aantrekkelijk 1 tot aantrekkelijk 5",
+              "max-label": "Aantrekkelijk",
+              "min-label": "Niet aantrekkelijk"
+            },
+            "legend": "De aanbevolen inhoud is…",
+            "personalization": {
+              "legend": "Beoordeel hoe gepersonaliseerd de inhoud is, van algemeen 1 tot gepersonaliseerd 5",
+              "max-label": "Gepersonaliseerd",
+              "min-label": "Algemeen"
+            },
+            "score-aria-label": "{score} van 5",
+            "subtitle": "Zullen we verdergaan…",
+            "title": "Bedankt voor uw feedback!",
+            "usefulness": {
+              "legend": "Beoordeel hoe nuttig de inhoud is, van niet nuttig 1 tot nuttig 5",
+              "max-label": "Nuttig",
+              "min-label": "Niet nuttig"
+            }
+          },
           "emojis": {
             "dissatisfied": "Niet relevant",
             "neutral": "Ik heb geen mening",
@@ -2264,7 +2285,7 @@
           "hide": "Verbergen",
           "hide-aria-label": "Het feedbackpaneel voor aanbevelingen voor trainingsinhoud verbergen",
           "instruction": "Klik op een emoji om uw mening te geven.",
-          "statement": "Lijkt de aanbevolen trainingsinhoud om uw kennis te verdiepen u relevant?",
+          "statement": "Lijkt de trainingsinhoud om uw kennis te verdiepen u relevant?",
           "thank-you": {
             "subtitle": "Gelukt!",
             "title": "Bedankt voor uw feedback!"


### PR DESCRIPTION
## 🪧 Problème

Le feedmoji (feedback des émojis) est terminé, il ne reste plus que la deuxième étape du feedback, le formulaire de pertinence de contenus.

## 🌈 Proposition

Création d'un formulaire avec : 
- Double niveau de `fieldset/legend`
- les `labels` des radio button sont visuellement masqués mais annoncés par le lecteur d'écran.


## ✊ Remarques

Ajout d'un `aria-live="polite"` dans satisfaction-score (1er step)
=> `aria-live="polite"` sur son `<form>` — annonce l'apparition passive au scroll, sans voler le focus. Comme ce composant est démonté définitivement dès qu'on passe à l'étape suivante, aucune annonce redondante n'est déclenchée par la suite (si on avait positionné ce `aria-live` plus haut)

---

`content-relevance.gjs` : (Nouveau composant) focus dans ce composant ajouté en conséquence directe du clic sur l'emoji. ✅ 
`thank-you.gjs` : (déjà fait dans un autre ticket) focus dans ce composant ajouté en conséquence directe du clic sur "Envoyer". ✅  
`satisfaction-score.gjs` : pas de focus ici (ni tabindex) on ne veut pas que l'utilisateur soit téléporté sur le drawer quand il s'affiche => l'info par aria-live polite suffit ✅ 

## 🎉 Pour tester

Se connecter à Pix App https://app-pr16769.review.pix.fr/ avec dave-comp@example.net / pix123

- Aller sur la campagne `EDUMULTIP`


- Voir le feedback apparaît en fin de parcours au scroll
- Cliquer sur un émoji au hasard

<img width="750" height="61" alt="Capture d’écran 2026-07-15 à 11 05 31" src="https://github.com/user-attachments/assets/858d1523-cf53-465e-9c15-e8c31f771653" />

- Voir le formulaire s'afficher
- Le bouton d'envoie est disabled
- Remplir les radios buttons et voir que le bouton d'envoi est disponible lorsque les 3 lignes sont complétées
- Valider et avoir l'encart de remerciements.
- Coté console, voir l'appel API dans les requêtes (mais en échec puisque pas branché pour le moment)
<img width="1195" height="61" alt="Capture d’écran 2026-07-15 à 11 14 51" src="https://github.com/user-attachments/assets/6ea43aae-f8e4-42cd-b114-5d93b569aafc" />

---

- Tester de nouveau le workflow en masquant l'encart au moment du formulaire pour vérifier que le formulaire se masque
- Puis faire F5 et constater qu'il ne revient plus.

(pour retester, changer d'utilisateur ou de campagne, sinon supprimer la ligne en BDD sur "user-campaign-surveys")