### PR TITLE
[FEATURE] Corriger certaines interactions avec les filtres du catalogue (PIX-23515)

### DIFF
--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -51,14 +51,14 @@ export default class List extends Component {
   }
 
   get categoriesOptions() {
-    return [...new Set(this.args.courses.flatMap((item) => (item.category ? item.category : [])))].map((item) => ({
+    return [...new Set(this.filteredItems.flatMap((item) => (item.category ? item.category : [])))].map((item) => ({
       label: this.intl.t(`pages.campaign-creation.tags.${item}`),
       value: item,
     }));
   }
 
   get areasOptions() {
-    return [...new Set(this.args.courses.flatMap((item) => (item.areas ? item.areas : [])))]
+    return [...new Set(this.filteredItems.flatMap((item) => (item.areas ? item.areas : [])))]
       .sort((a, b) => a.code.localeCompare(b.code, this.locale.currentLanguage, { numeric: true }))
       .map((area) => ({
         label: `${area.code}. ${area.title}`,
@@ -69,7 +69,7 @@ export default class List extends Component {
   get competencesOptions() {
     return [
       ...new Set(
-        this.args.courses
+        this.filteredItems
           .flatMap((item) => (item.areas ? item.areas : []))
           .flatMap((area) => (area.competences ? area.sortedCompetences : [])),
       ),

--- a/orga/app/routes/authenticated/catalogue/list.js
+++ b/orga/app/routes/authenticated/catalogue/list.js
@@ -7,6 +7,7 @@ export default class AuthenticatedCatalogueFilter extends Route {
   @service router;
 
   #currentOrgaId = null;
+  #previousType = null;
 
   queryParams = {
     targetProfileId: { refreshModel: true },
@@ -52,6 +53,17 @@ export default class AuthenticatedCatalogueFilter extends Route {
       this.store.unloadAll('course');
     }
     this.#currentOrgaId = orgId;
+  }
+
+  setupController(controller, model, transition) {
+    super.setupController(controller, model, transition);
+    if (this.#previousType !== null && this.#previousType !== model.type) {
+      controller.search = '';
+      controller.category = '';
+      controller.areas = [];
+      controller.competences = [];
+    }
+    this.#previousType = model.type;
   }
 
   resetController(controller, isExiting) {

--- a/orga/tests/acceptance/catalogue-test.js
+++ b/orga/tests/acceptance/catalogue-test.js
@@ -1,6 +1,6 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import { within } from '@testing-library/dom';
+import { waitFor, within } from '@testing-library/dom';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'pix-orga/tests/test-support/setup-mirage';
@@ -14,19 +14,21 @@ module('Acceptance | Catalogue page', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
-  let course1, course2;
+  let course1, course2, area1;
 
   hooks.beforeEach(async function () {
     const user = createUserManagingStudents('ADMIN');
     createPrescriberByUser({ user });
     await authenticateSession(user.id);
     server.create('feature-toggle', { id: '0', displayCatalogue: true });
+    area1 = server.create('area', { id: 'area1', code: '1', title: 'Area 1', competenceIds: [] });
     course1 = server.create('course', {
       id: 1,
       name: 'Ma super formation',
       type: 'targetProfile',
       nbTubes: 5,
       category: 'PREDEFINED',
+      areas: [area1],
     });
     server.create('target-profile-overview', {
       id: 1,
@@ -66,5 +68,22 @@ module('Acceptance | Catalogue page', function (hooks) {
     await click(screen.getByRole('link', { name: t('pages.catalogue.modal.open-modal', { name: course2.name }) }));
     const dialog = await screen.findByRole('dialog');
     assert.ok(within(dialog).getByRole('heading', { name: course2.name }));
+  });
+
+  test('it should reset filter when changing tabs', async function (assert) {
+    // given
+    const screen = await visit(`/catalogue`);
+
+    await click(screen.getByRole('button', { name: t('pages.catalogue.filters.areas.label') }));
+    await waitFor(() => screen.findByRole('menu'));
+    await click(screen.getByRole('checkbox', { name: `${area1.code}. ${area1.title}` }));
+
+    // when
+    await click(screen.getByRole('link', { name: t('pages.catalogue.tab-filters.blueprints') }));
+    await click(screen.getByRole('link', { name: t('pages.catalogue.tab-filters.all') }));
+
+    // then
+    assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
+    assert.dom(screen.getByRole('heading', { level: 3, name: 'Mon parcours combiné' })).exists();
   });
 });

--- a/orga/tests/integration/components/catalogue/list-test.gjs
+++ b/orga/tests/integration/components/catalogue/list-test.gjs
@@ -321,10 +321,34 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
         assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
       });
+
+      module('when a tab is selected', function () {
+        test('it only display areas of the filtered courses', async function (assert) {
+          // given
+          const updateFilter = sinon.stub();
+          const area1 = store.createRecord('area', { id: 1, title: 'area1', code: '1', competences: [] });
+          const area2 = store.createRecord('area', { id: 2, title: 'area2', code: '2', competences: [] });
+
+          const courses = [
+            { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+            { name: 'Ma super formation', type: 'targetProfile', category: 'OTHER', nbModules: 2, areas: [area2] },
+          ];
+
+          // when
+          const screen = await render(
+            <template><List @updateFilter={{updateFilter}} @courses={{courses}} @type="blueprint" /></template>,
+          );
+          await click(screen.getByRole('button', { name: t('pages.catalogue.filters.areas.label') }));
+          await waitFor(() => screen.findByRole('menu'));
+          // then
+          assert.dom(screen.getByRole('menuitem', { name: `${area1.code}. ${area1.title}` })).exists();
+          assert.dom(screen.queryByRole('menuitem', { name: `${area2.code}. ${area2.title}` })).doesNotExist();
+        });
+      });
     });
 
     module('competences filter', function () {
-      test('it disables filter when there are no compentences to filter', async function (assert) {
+      test('it disables filter when there are no competences to filter', async function (assert) {
         // given
         const updateFilter = sinon.stub();
         const search = 'combiné';
@@ -429,6 +453,32 @@ module('Integration | Component | Catalogue::List', function (hooks) {
         // then
         assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
         assert.dom(screen.getByRole('heading', { level: 3, name: 'Ma super formation' })).exists();
+      });
+
+      module('when a tab is selected', function () {
+        test('it only display areas of the filtered courses', async function (assert) {
+          // given
+          const updateFilter = sinon.stub();
+          const comp1 = store.createRecord('competence', { id: 1, name: 'comp1', index: '1.1' });
+          const comp2 = store.createRecord('competence', { id: 2, name: 'comp2', index: '2.1' });
+          const area1 = store.createRecord('area', { id: 1, title: 'area1', code: '1', competences: [comp1] });
+          const area2 = store.createRecord('area', { id: 2, title: 'area2', code: '2', competences: [comp2] });
+
+          const courses = [
+            { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2, areas: [area1] },
+            { name: 'Ma super formation', type: 'targetProfile', category: 'OTHER', nbModules: 2, areas: [area2] },
+          ];
+
+          // when
+          const screen = await render(
+            <template><List @updateFilter={{updateFilter}} @courses={{courses}} @type="blueprint" /></template>,
+          );
+          await click(screen.getByRole('button', { name: t('pages.catalogue.filters.competences.label') }));
+          await waitFor(() => screen.findByRole('menu'));
+          // then
+          assert.dom(screen.getByRole('menuitem', { name: `${comp1.index} ${comp1.name}` })).exists();
+          assert.dom(screen.queryByRole('menuitem', { name: `${comp2.index} ${comp2.name}` })).doesNotExist();
+        });
       });
     });
 

--- a/orga/tests/mirage/models.js
+++ b/orga/tests/mirage/models.js
@@ -79,7 +79,9 @@ export default {
   competence: Model.extend({
     thematics: hasMany('thematic'),
   }),
-  course: Model.extend(),
+  course: Model.extend({
+    areas: hasMany('area'),
+  }),
   combinedCourseBlueprintItem: Model.extend(),
   combinedCourseBlueprintOverview: Model.extend({ items: hasMany('combinedCourseBlueprintItem') }),
   targetProfileOverview: Model.extend({ badges: hasMany('badge'), frameworks: hasMany('framework') }),

--- a/orga/tests/mirage/serializers.js
+++ b/orga/tests/mirage/serializers.js
@@ -12,6 +12,7 @@ import campaignProfile from './serializers/campaign-profile';
 import campaignProfilesCollectionParticipationSummary from './serializers/campaign-profiles-collection-participation-summary';
 import combinedCourse from './serializers/combined-course';
 import competence from './serializers/competence';
+import course from './serializers/course';
 import framework from './serializers/framework';
 import informationBanner from './serializers/information-banner';
 import membership from './serializers/membership';
@@ -41,6 +42,7 @@ export default {
   campaignProfilesCollectionParticipationSummary,
   combinedCourse,
   competence,
+  course,
   framework,
   informationBanner,
   membership,

--- a/orga/tests/mirage/serializers/course.js
+++ b/orga/tests/mirage/serializers/course.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+const _include = ['areas'];
+
+export default ApplicationSerializer.extend({
+  include: _include,
+});


### PR DESCRIPTION
## 🪧 Problème
Actuellement lorsqu’on change d’onglet dans le catalogue et qu’on revient sur un onglet avec des champs remplis, les champs gardent leur valeur et ne sont pas réinitialisés.

Également, en changeant d’onglet pour n’afficher que des parcours d’un type, on récupère des domaines et des compétences qui n’existent sur aucun des parcours du type sélectionnés, mais sur l’autre.

## 🌈 Proposition
- Réinitialiser les champs au changement d’onglet
- Filtrer les domaines et compétences récupérées pour qu’elles concernent le type de parcours sélectionné au niveau de l’onglet

## ✊ Remarques
Explications de Claude pour le premier point:
<img width="1819" height="435" alt="image" src="https://github.com/user-attachments/assets/4f6c4404-1983-4003-a066-db2da0729812" />

## 🎉 Pour tester
Aller sur Pix Orga
Aller sur la page du catalogue
Remplir chaque filtre
Changer d’onglet et revenir sur l’onglet avec les filtres remplis
Les filtres ont été réinitialisés

Aller sur l’onglet d’un type de parcours spécifique
Vérifier que les multi select domaine et compétence ne contiennent pas les domaines et compétences contenus uniquement sur l’autre type de parcours.
(Vérifier qu’on a moins d’options / des options différentes dans ces multi select en fonction du type) 
