### PR TITLE
[TECH] Remplir la table des sujets de version de certif (PIX-23526).

### DIFF
--- a/api/db/database-builder/factory/build-certification-version-tube.js
+++ b/api/db/database-builder/factory/build-certification-version-tube.js
@@ -1,0 +1,20 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+/**
+ * @param {Object} params
+ * @param {string} params.tubeId
+ * @param {number} params.versionId
+ */
+const buildCertificationVersionTube = function ({ tubeId, versionId } = {}) {
+  const values = {
+    tube_id: tubeId,
+    version_id: versionId,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'certification_versions_tubes',
+    values,
+  });
+};
+
+export { buildCertificationVersionTube };

--- a/api/db/seeds/data/team-certification/shared/common-certification-versions.js
+++ b/api/db/seeds/data/team-certification/shared/common-certification-versions.js
@@ -5,7 +5,7 @@ import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../src/certificati
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { FRENCH_SPOKEN } from '../../../../../src/shared/domain/services/locale-service.js';
-import { createVersion, linkChallengesAndVersionFromTubeIds } from '../tools/certification-version.js';
+import { createVersion, seedVersionChallengesAndTubes } from '../tools/certification-version.js';
 import { UnseedableError } from './UnseedableError.js';
 /**
  * @property {{ expiredVersionId: string, currentVersionId: string }} coreVersion
@@ -85,7 +85,7 @@ export class CommonCertificationVersions {
           ],
           competencesScoringConfiguration: null,
         });
-        await linkChallengesAndVersionFromTubeIds({ databaseBuilder, challengeIds, versionId: currentVersion.id });
+        await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: currentVersion.id });
 
         await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
         this.pixPlusDroitVersion.currentVersionId = currentVersion.id;
@@ -126,7 +126,7 @@ export class CommonCertificationVersions {
           competencesScoringConfiguration: null,
         });
 
-        await linkChallengesAndVersionFromTubeIds({ databaseBuilder, challengeIds, versionId: currentVersion.id });
+        await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: currentVersion.id });
 
         await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
 
@@ -167,7 +167,7 @@ export class CommonCertificationVersions {
           competencesScoringConfiguration: null,
         });
 
-        await linkChallengesAndVersionFromTubeIds({ databaseBuilder, challengeIds, versionId: currentVersion.id });
+        await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: currentVersion.id });
 
         await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
 
@@ -273,7 +273,7 @@ export class CommonCertificationVersions {
       globalScoringConfiguration: [{ bounds: { max: 8, min: 1 }, meshLevel: 0 }],
       competencesScoringConfiguration: null,
     });
-    await linkChallengesAndVersionFromTubeIds({ databaseBuilder, challengeIds: [], versionId: expiredVersion.id });
+    await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds: [], versionId: expiredVersion.id });
 
     await databaseBuilder.commit();
 
@@ -320,7 +320,7 @@ export class CommonCertificationVersions {
       globalScoringConfiguration: GLOBAL_SCORING_CONFIGURATION,
       competencesScoringConfiguration,
     });
-    await linkChallengesAndVersionFromTubeIds({ databaseBuilder, challengeIds, versionId: currentVersion.id });
+    await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: currentVersion.id });
 
     await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
 

--- a/api/db/seeds/data/team-certification/tools/certification-version.js
+++ b/api/db/seeds/data/team-certification/tools/certification-version.js
@@ -48,8 +48,22 @@ export async function createVersion({
   return createdVersion;
 }
 
-export async function linkChallengesAndVersionFromTubeIds({ databaseBuilder, challengeIds, versionId }) {
+export async function seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId }) {
+  if (challengeIds.length === 0) {
+    return;
+  }
+
   for (const challengeId of challengeIds) {
     databaseBuilder.factory.buildCertificationFrameworksChallenge({ challengeId, versionId });
+  }
+
+  const tubeIds = await databaseBuilder
+    .knex({ skills: 'learningcontent.skills' })
+    .join({ challenges: 'learningcontent.challenges' }, 'challenges.skillId', 'skills.id')
+    .whereIn('challenges.id', challengeIds)
+    .pluck('skills.tubeId');
+
+  for (const tubeId of new Set(tubeIds)) {
+    databaseBuilder.factory.buildCertificationVersionTube({ tubeId, versionId });
   }
 }

--- a/api/scripts/certification/fill-tube-ids-for-existing-versions.js
+++ b/api/scripts/certification/fill-tube-ids-for-existing-versions.js
@@ -1,0 +1,65 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class FillTubeIdsForExistingVersions extends Script {
+  constructor() {
+    super({
+      description: 'Retro-fill tube-ids for existing versions in certification_versions_tubes',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info(`Script execution started with options ${JSON.stringify(options)}`);
+
+    const trx = await knex.transaction();
+
+    try {
+      const versionIds = await trx('certification_versions').pluck('id');
+
+      let addedTubeIdsCount = 0;
+      for (const versionId of versionIds) {
+        const versionChallengeIds = await trx('certification-frameworks-challenges').pluck('challengeId').where({
+          versionId,
+        });
+
+        const skillIds = await trx('learningcontent.challenges')
+          .pluck('skillId')
+          .distinct('skillId')
+          .whereIn('id', versionChallengeIds);
+
+        const tubeIds = await trx('learningcontent.skills').pluck('tubeId').distinct('tubeId').whereIn('id', skillIds);
+
+        const dataToInsert = tubeIds.map((tubeId) => ({ tube_id: tubeId, version_id: versionId }));
+        logger.info(`Version ID ${versionId} : ${dataToInsert.length} tubeIds are going to be processed`);
+
+        await trx.batchInsert('certification_versions_tubes', dataToInsert);
+
+        addedTubeIdsCount += dataToInsert.length;
+      }
+
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(`dryRun true : a total of ${addedTubeIdsCount} tubeIds would be added`);
+        return;
+      }
+
+      await trx.commit();
+      logger.info(`dryRun false : a total of ${addedTubeIdsCount} tubeIds were added`);
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FillTubeIdsForExistingVersions);

--- a/api/tests/scripts/integration/certification/fill-tube-ids-for-existing-versions_test.js
+++ b/api/tests/scripts/integration/certification/fill-tube-ids-for-existing-versions_test.js
@@ -1,0 +1,131 @@
+import sinon from 'sinon';
+
+import { FillTubeIdsForExistingVersions } from '../../../../scripts/certification/fill-tube-ids-for-existing-versions.js';
+import { expect } from '../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../tooling/databases.js';
+import { buildLearningContent as learningContentBuilder } from '../../../tooling/learning-content-builder/index.js';
+
+describe('Integration | Scripts | Certification | fill-tube-ids-for-existing-versions', function () {
+  let script;
+  let logger;
+
+  beforeEach(function () {
+    script = new FillTubeIdsForExistingVersions();
+    logger = { info: sinon.stub(), warn: sinon.stub() };
+  });
+
+  function buildTwoVersionsWithTubes() {
+    const areas = [
+      {
+        id: 'recArea0',
+        code: '66',
+        competences: [
+          {
+            id: 'recCompetence0',
+            index: '1.1',
+            tubes: [
+              {
+                id: 'recTube0',
+                skills: [
+                  { id: 'recSkill0_0', challenges: [{ id: 'recChallenge0_0' }] },
+                  { id: 'recSkill0_1', challenges: [{ id: 'recChallenge0_1' }] },
+                ],
+              },
+              {
+                id: 'recTube1',
+                skills: [{ id: 'recSkill1_0', challenges: [{ id: 'recChallenge1_0' }] }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const learningContentObjects = learningContentBuilder.fromAreas(areas);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+
+    const version1 = databaseBuilder.factory.buildCertificationVersion();
+    const version2 = databaseBuilder.factory.buildCertificationVersion();
+    for (const challengeId of ['recChallenge0_0', 'recChallenge0_1', 'recChallenge1_0']) {
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({ versionId: version1.id, challengeId });
+    }
+    databaseBuilder.factory.buildCertificationFrameworksChallenge({
+      versionId: version2.id,
+      challengeId: 'recChallenge1_0',
+    });
+
+    return { version1, version2 };
+  }
+
+  describe('#handle', function () {
+    context('when dryRun is false', function () {
+      it('should persist the tubes for every version', async function () {
+        // given
+        const { version1, version2 } = buildTwoVersionsWithTubes();
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: false } });
+
+        // then
+        expect(logger.info.firstCall).to.have.been.calledWith('Script execution started with options {"dryRun":false}');
+
+        const certificationVersionsTubes = await knex('certification_versions_tubes');
+        expect(certificationVersionsTubes).to.have.deep.members([
+          { tube_id: 'recTube0', version_id: version1.id },
+          { tube_id: 'recTube1', version_id: version1.id },
+          { tube_id: 'recTube1', version_id: version2.id },
+        ]);
+
+        expect(logger.info).to.have.been.calledWith(`Version ID ${version1.id} : 2 tubeIds are going to be processed`);
+        expect(logger.info).to.have.been.calledWith(`Version ID ${version2.id} : 1 tubeIds are going to be processed`);
+        expect(logger.info.lastCall).to.have.been.calledWith('dryRun false : a total of 3 tubeIds were added');
+      });
+    });
+
+    context('when dryRun is true', function () {
+      it('should not modify the database', async function () {
+        // given
+        const { version1, version2 } = buildTwoVersionsWithTubes();
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ logger, options: { dryRun: true } });
+
+        // then
+        expect(logger.info.firstCall).to.have.been.calledWith('Script execution started with options {"dryRun":true}');
+
+        const certificationVersionsTubes = await knex('certification_versions_tubes');
+        expect(certificationVersionsTubes.length).to.equal(0);
+
+        expect(logger.info).to.have.been.calledWith(`Version ID ${version1.id} : 2 tubeIds are going to be processed`);
+        expect(logger.info).to.have.been.calledWith(`Version ID ${version2.id} : 1 tubeIds are going to be processed`);
+        expect(logger.info.lastCall).to.have.been.calledWith('dryRun true : a total of 3 tubeIds would be added');
+      });
+    });
+
+    context('when an error occurs during insertion', function () {
+      it('should rollback the transaction and rethrow the error', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationVersion();
+        await databaseBuilder.commit();
+
+        const dbError = new Error('DB insertion error');
+        const originalTransaction = knex.transaction.bind(knex);
+        let transaction;
+        sinon.stub(knex, 'transaction').callsFake(async () => {
+          transaction = await originalTransaction();
+          sinon.stub(transaction, 'batchInsert').rejects(dbError);
+          sinon.spy(transaction, 'rollback');
+          return transaction;
+        });
+
+        // when / then
+        await expect(script.handle({ logger, options: { dryRun: false } })).to.be.rejectedWith('DB insertion error');
+        expect(transaction.rollback).to.have.been.calledOnce;
+
+        const certificationVersionsTubes = await knex('certification_versions_tubes');
+        expect(certificationVersionsTubes.length).to.equal(0);
+      });
+    });
+  });
+});

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-core-version.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-core-version.ts
@@ -1,5 +1,7 @@
 import { Knex } from 'knex';
 
+import { buildVersionTubes } from './build-version-tubes.ts';
+
 const competencesScoringValues = [
   { bounds: { max: -2, min: -9007199254740991 }, competenceLevel: 0 },
   { bounds: { max: -1, min: -2 }, competenceLevel: 1 },
@@ -76,6 +78,8 @@ export async function buildCoreVersion(knex: Knex) {
       versionId,
     });
   }
+
+  await buildVersionTubes(knex, versionId);
 }
 
 function* generateBoundedValue(min: number, max: number, step: number) {

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-droit-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-droit-data.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex';
 
 import { CERTIFICATIONS_DATA } from '../../db-data.ts';
+import { buildVersionTubes } from './build-version-tubes.ts';
 
 export async function buildPixPlusDroitData(knex: Knex) {
   const [{ id: versionId }] = await knex('certification_versions')
@@ -44,6 +45,8 @@ export async function buildPixPlusDroitData(knex: Knex) {
       versionId,
     });
   }
+
+  await buildVersionTubes(knex, versionId);
 }
 
 function* generateBoundedValue(min: number, max: number, step: number) {

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-edu-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-edu-data.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex';
 
 import { CERTIFICATIONS_DATA } from '../../db-data.ts';
+import { buildVersionTubes } from './build-version-tubes.ts';
 
 export async function buildPixPlusEduData(knex: Knex) {
   const [{ id: versionId }] = await knex('certification_versions')
@@ -39,6 +40,8 @@ export async function buildPixPlusEduData(knex: Knex) {
       versionId,
     });
   }
+
+  await buildVersionTubes(knex, versionId);
 }
 
 function* generateBoundedValue(min: number, max: number, step: number) {

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-pro-sante-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-pro-sante-data.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex';
 
 import { CERTIFICATIONS_DATA } from '../../db-data.ts';
+import { buildVersionTubes } from './build-version-tubes.ts';
 
 export async function buildPixPlusProSanteData(knex: Knex) {
   const [{ id: versionId }] = await knex('certification_versions')
@@ -44,6 +45,8 @@ export async function buildPixPlusProSanteData(knex: Knex) {
       versionId,
     });
   }
+
+  await buildVersionTubes(knex, versionId);
 }
 
 function* generateBoundedValue(min: number, max: number, step: number) {

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-version-tubes.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-version-tubes.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+export async function buildVersionTubes(knex: Knex, versionId: number) {
+  const tubeRows: { tubeId: string }[] = await knex('certification-frameworks-challenges')
+    .distinct()
+    .select({ tubeId: 'learningcontent.skills.tubeId' })
+    .join(
+      'learningcontent.challenges',
+      'learningcontent.challenges.id',
+      'certification-frameworks-challenges.challengeId',
+    )
+    .join('learningcontent.skills', 'learningcontent.skills.id', 'learningcontent.challenges.skillId')
+    .where('certification-frameworks-challenges.versionId', versionId);
+
+  if (tubeRows.length === 0) {
+    return;
+  }
+
+  await knex('certification_versions_tubes').insert(
+    tubeRows.map(({ tubeId }) => ({ tube_id: tubeId, version_id: versionId })),
+  );
+}


### PR DESCRIPTION
## 🪧 Problème

On a ajouté une nouvelle table `certification_versions_tubes` pour être la source de référence du référentiel des versions de certif.

Cette table est pour l'instant vide.

## 🌈 Proposition

Utiliser un script pour remplir cette table.

## 🎉 Pour tester

Lancer le script en local et constater que la table est bien remplie.
