### PR TITLE
[TECH] Ajout d'un espace pour l'encart dans la page de fin de parcours (PIX-23530).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
@@ -56,15 +56,24 @@ export default class Drawer extends Component {
 
   @action
   hide() {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      this.finishHiding();
+      return;
+    }
+
     this.isHiding = true;
   }
 
   @action
   onAnimationEnd(event) {
     if (event.animationName === 'drawer-slide-down') {
-      this.isHidden = true;
-      this.isHiding = false;
+      this.finishHiding();
     }
+  }
+
+  finishHiding() {
+    this.isHidden = true;
+    this.isHiding = false;
   }
 
   @action

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
@@ -56,6 +56,8 @@ export default class Drawer extends Component {
 
   @action
   hide() {
+    this.args.onHide?.();
+
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       this.finishHiding();
       return;

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -22,6 +22,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
   }
 
   @tracked _drawerRevealedByScroll = false;
+  @tracked _expandedDrawer = false;
 
   @action onCardClick({ trainingId }) {
     this.pixMetrics.trackEvent('Moteur de reco - Clic sur la carte du contenu formatif', {
@@ -76,13 +77,25 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     return this._drawerRevealedByScroll;
   }
 
+  get shouldExpandDrawer() {
+    return this.shouldShowNps && this._expandedDrawer;
+  }
+
   @action revealNps() {
     this._drawerRevealedByScroll = true;
+    this._expandedDrawer = true;
     this.pixMetrics.trackEvent('Moteur de reco - affichage du feedback NPS');
   }
 
+  @action collapseDrawer() {
+    this._expandedDrawer = false;
+  }
+
   <template>
-    <main role="main" class="evaluation-results-recommendation-engine">
+    <main
+      class="evaluation-results-recommendation-engine
+        {{if this.shouldExpandDrawer 'evaluation-results-recommendation-engine--drawer-expanded'}}"
+    >
       <header class="evaluation-results__header">
         <img class="evaluation-results-header__logo" src="/images/pix-logo-dark.svg" alt="{{t 'common.pix'}}" />
         <h1 class="evaluation-results-header__title">
@@ -119,7 +132,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
       {{/if}}
 
       {{#if this.shouldShowNps}}
-        <Drawer @campaignId={{@model.campaign.id}} />
+        <Drawer @campaignId={{@model.campaign.id}} @onHide={{this.collapseDrawer}} />
       {{/if}}
     </main>
   </template>

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -4,7 +4,15 @@
 @use 'pix-design-tokens/shadows';
 
 .evaluation-results-recommendation-engine {
-  padding: var(--pix-spacing-3x) var(--pix-spacing-3x) var(--pix-spacing-6x) var(--pix-spacing-3x);
+  padding: var(--pix-spacing-3x) var(--pix-spacing-3x) var(--pix-spacing-12x) var(--pix-spacing-3x);
+
+  @media (not (prefers-reduced-motion: reduce)) {
+    transition: padding-bottom 0.4s ease;
+  }
+
+  &--drawer-expanded {
+    padding-bottom: 323px;
+  }
 }
 
 .evaluation-results-hero-recommendation-engine {

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click, settled } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import EvaluationResultsRecommendationEngine from 'mon-pix/components/routes/campaigns/assessment/evaluation-results-recommendation-engine';
 import { module, test } from 'qunit';
@@ -21,7 +22,21 @@ module(
       });
     });
 
-    module('when campaign has trainings', function () {
+    module('when campaign has trainings', function (hooks) {
+      let observerCallback;
+      let observerInstance;
+
+      hooks.beforeEach(function () {
+        observerInstance = {
+          observe: sinon.stub(),
+          disconnect: sinon.stub(),
+        };
+
+        window.IntersectionObserver = function (callback) {
+          observerCallback = callback;
+          return observerInstance;
+        };
+      });
       test('should display trainings', async function (assert) {
         // given
         const training = store.createRecord('training', {
@@ -53,21 +68,6 @@ module(
       });
 
       module('tracking', function (hooks) {
-        let observerCallback;
-        let observerInstance;
-
-        hooks.beforeEach(function () {
-          observerInstance = {
-            observe: sinon.stub(),
-            disconnect: sinon.stub(),
-          };
-
-          window.IntersectionObserver = function (callback) {
-            observerCallback = callback;
-            return observerInstance;
-          };
-        });
-
         hooks.afterEach(function () {
           delete window.IntersectionObserver;
           sinon.restore();
@@ -101,6 +101,83 @@ module(
           sinon.assert.calledWith(pixMetrics.trackEvent, 'Moteur de reco - affichage du feedback NPS');
           assert.ok(true);
         });
+      });
+
+      module('when user has already answered to survey', function () {
+        test('it should not display drawer, nor expand the padding-bottom when trainings become visible', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training],
+            hasAnsweredSurvey: true,
+          };
+
+          // when
+          const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+          observerCallback([{ isIntersecting: true }]);
+          await settled();
+
+          // then
+          assert
+            .dom(screen.queryByRole('dialog', { name: t('pages.skill-review.recommended-engine.drawer.title') }))
+            .doesNotExist();
+          assert
+            .dom(screen.getByRole('main'))
+            .doesNotHaveClass('evaluation-results-recommendation-engine--drawer-expanded');
+        });
+      });
+
+      test('it should display the drawer and expand the padding-bottom, then collapse them when user hides survey', async function (assert) {
+        // given
+        const training = store.createRecord('training', {
+          title: 'Super training',
+          duration: { days: 1, hours: 1, minutes: 1 },
+        });
+
+        const model = {
+          campaign,
+          campaignParticipationResult: {
+            campaignParticipationBadges: [Symbol('badges')],
+            competenceResults: [Symbol('competences')],
+            reload: () => {},
+          },
+          trainings: [training],
+        };
+
+        // when
+        const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByRole('main'))
+          .doesNotHaveClass('evaluation-results-recommendation-engine--drawer-expanded');
+
+        // when
+        observerCallback([{ isIntersecting: true }]);
+        await settled();
+
+        // then
+        assert.dom(screen.getByRole('main')).hasClass('evaluation-results-recommendation-engine--drawer-expanded');
+
+        // when
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.drawer.hide-aria-label') }),
+        );
+
+        // then
+        assert
+          .dom(screen.getByRole('main'))
+          .doesNotHaveClass('evaluation-results-recommendation-engine--drawer-expanded');
       });
     });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
@@ -88,6 +88,42 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         // then
         assert.dom(screen.queryByText(t('pages.skill-review.recommended-engine.drawer.statement'))).doesNotExist();
       });
+
+      test('it calls onHide as soon as the button is clicked, before the animation ends', async function (assert) {
+        // given
+        const onHide = sinon.stub();
+        const screen = await render(<template><Drawer @campaignId={{1}} @onHide={{onHide}} /></template>);
+
+        // when
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.drawer.hide-aria-label') }),
+        );
+
+        // then
+        sinon.assert.calledOnce(onHide);
+        assert.ok(true);
+      });
+
+      module('when user prefers reduced motion', function (hooks) {
+        hooks.beforeEach(function () {
+          this.matchMediaStub.returns({ matches: true });
+        });
+
+        test('the drawer is removed without waiting for an animationend event', async function (assert) {
+          // given
+          const onHide = sinon.stub();
+          const screen = await render(<template><Drawer @campaignId={{1}} @onHide={{onHide}} /></template>);
+
+          // when
+          await click(
+            screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.drawer.hide-aria-label') }),
+          );
+
+          // then
+          assert.dom(screen.queryByText(t('pages.skill-review.recommended-engine.drawer.statement'))).doesNotExist();
+          sinon.assert.calledOnce(onHide);
+        });
+      });
     });
   });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
@@ -15,6 +15,12 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
     this.owner.register('service:request-manager', this.requestManagerStub, { instantiate: false });
 
     this.owner.register('service:current-user', { user: { id: 42 } });
+
+    this.matchMediaStub = sinon.stub(window, 'matchMedia').returns({ matches: false });
+  });
+
+  hooks.afterEach(function () {
+    this.matchMediaStub.restore();
   });
 
   test('it displays the satisfaction score step by default', async function (assert) {


### PR DESCRIPTION
## 🪧 Problème

Le feedmoji s'affiche devant les autres éléments de la page. Si l'utilisateur scrolle jusqu'en bas de la page, il empêche de voir les éléments.

## 🌈 Proposition

Ajout d'un padding bottom en fin de page pour que les éléments soient visible même quand le feedmoji est toujours là

## ✊ Remarques

Un bug a été détecté et corrigé ici: 
Quand l'utilisateur réduit les animations sur son appareil, alors les animations sont désactivés.  

Le déclencheur qui ferme le drawer côté JS est `onAnimationEnd`, lié à l'événement DOM animationend — un événement **qui ne se produit jamais s'il n'y a pas d'animation**. Un utilisateur ayant réduit les animations dans son OS cliquait sur « fermer » sans que rien ne se passe jamais.

L'action `hide()` vérifie désormais `window.matchMedia('(prefers-reduced-motion: reduce)').matches` — le même pattern déjà utilisé ailleurs dans mon-pix (stepper.gjs, qab-card.gjs, modulix-auto-scroll.js) — et court-circuite directement vers `finishHiding()` sans attendre l'événement d'animation.

## 🎉 Pour tester

- Tester AVEC et sans la réduction des animation activé 

https://github.com/user-attachments/assets/04ac3f20-8236-4192-8aa3-887d83e29fa4


- Aller sur la page de fin de parcours, voir le nps apparaître
- Aller au bout de la page, voir un espace conséquent pour qu'on voit le dernier élément de la page
- Masquer le feedmoji et constater que l'espace s'est réduit
- Faire F5, aller en bout de page et cliquer sur un émoji
- Voir que le formulaire ne masque pas non plus l'élément derrière
- Masquer et constater que l'espace s'est réduit
- Faire F5, aller en bout de page et constater que l'espace s'est réduit


Exemple vidéo avec Réduction des animation activé ✅ 

https://github.com/user-attachments/assets/5a5a7df9-770f-42c3-a8ca-edac7034713b

