### PR TITLE
[FEATURE] Cache de release : ajouter la colonne version (PIX-23343)

### DIFF
--- a/api/db/database-builder/factory/learning-content/build-module.js
+++ b/api/db/database-builder/factory/learning-content/build-module.js
@@ -92,7 +92,7 @@ export function buildModuleWithNoDefaultValues({
   return values;
 }
 
-function buildModuleInDB({ id, shortId, slug, title, isBeta, visibility, details, sections, glossary }) {
+function buildModuleInDB({ id, shortId, slug, title, isBeta, visibility, details, sections, glossary, version }) {
   const values = {
     id,
     shortId,
@@ -103,6 +103,7 @@ function buildModuleInDB({ id, shortId, slug, title, isBeta, visibility, details
     ...details,
     sections: JSON.stringify(sections),
     glossary: JSON.stringify(glossary),
+    version,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'learningcontent.modules',

--- a/api/db/migrations/20260710090052_create-modules-version-column.js
+++ b/api/db/migrations/20260710090052_create-modules-version-column.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'learningcontent.modules';
+const COLUMN_NAME = 'version';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).nullable().comment('Module’s version');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+}

--- a/api/tests/learning-content/integration/application/jobs/create-learning-content-job-controller_test.js
+++ b/api/tests/learning-content/integration/application/jobs/create-learning-content-job-controller_test.js
@@ -1804,6 +1804,7 @@ describe('Learning Content | Integration | Application | Jobs | Create release',
                   '<p>Le chat, plus spécifiquement désigné sous le nom de chat domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des félins (Félidés).</p>',
               },
             ],
+            version: null,
           },
           {
             id: '6282925d-4775-4bca-b513-4c3009ec5887',
@@ -1825,6 +1826,7 @@ describe('Learning Content | Integration | Application | Jobs | Create release',
                 definition: '<p>Le gravier c’est des petits cailloux.</p>',
               },
             ],
+            version: null,
           },
         ]);
         expect(lcmsApiCall.isDone()).to.be.true;

--- a/api/tests/learning-content/integration/application/jobs/refresh-learning-content-job-controller_test.js
+++ b/api/tests/learning-content/integration/application/jobs/refresh-learning-content-job-controller_test.js
@@ -1805,6 +1805,7 @@ describe('Learning Content | Integration | Application | Jobs | Refresh', functi
                   '<p>Le chat, plus spécifiquement désigné sous le nom de chat domestique, est une espèce de mammifères de l’Ordre des Carnivores, de la famille des félins (Félidés).</p>',
               },
             ],
+            version: null,
           },
           {
             id: '6282925d-4775-4bca-b513-4c3009ec5887',
@@ -1826,6 +1827,7 @@ describe('Learning Content | Integration | Application | Jobs | Refresh', functi
                 definition: '<p>Le gravier c’est des petits cailloux.</p>',
               },
             ],
+            version: null,
           },
         ]);
         expect(lcmsApiCall.isDone()).to.be.true;


### PR DESCRIPTION
## 🪧 Problème

On veut stocker le numéro de version de module reçu dans la release ou dans le patch de release dans le cache LCMS.

Ajouter dans la table `learningcontent.modules` une colonne `version` de type chaîne de caractères.

La colonne doit être nullable dans un premier temps.

## 🌈 Proposition

Ajouter la colonne.

## ✊ Remarques

N/A

## 🎉 Pour tester

Tests au vert.