### PR TITLE
[FEATURE] Afficher la bannière pour prévenir de la fermeture des espaces SCO (PIX-23528).

### DIFF
--- a/certif/app/components/layout/banners.gjs
+++ b/certif/app/components/layout/banners.gjs
@@ -1,1 +1,39 @@
-<template></template>
+import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+const SCO_ACCESS_SUSPENSION_DATE = new Date('2026-07-16T21:59:59Z');
+const NON_BREAKING_SPACE = String.fromCharCode(160);
+
+export default class Banners extends Component {
+  @service router;
+  @service currentUser;
+  @service intl;
+
+  get isBeforeScoAccessSuspensionDate() {
+    return new Date() < SCO_ACCESS_SUSPENSION_DATE;
+  }
+
+  get scoAccessSuspensionDate() {
+    return this.intl.formatDate(SCO_ACCESS_SUSPENSION_DATE, { format: 'LL' }).replaceAll(' ', NON_BREAKING_SPACE);
+  }
+
+  get shouldDisplaySCOInformationBanner() {
+    const isOnFinalizationPage = this.router.currentRouteName === 'authenticated.sessions.finalize';
+    return (
+      this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents &&
+      this.isBeforeScoAccessSuspensionDate &&
+      !this.currentUser.currentAllowedCertificationCenterAccess.isAccessRestricted &&
+      !isOnFinalizationPage
+    );
+  }
+
+  <template>
+    {{#if this.shouldDisplaySCOInformationBanner}}
+      <PixBannerAlert @type='warning' @canCloseBanner={{false}} class='banners'>
+        {{t 'pages.sco.banner.information' suspensionDate=this.scoAccessSuspensionDate htmlSafe=true}}
+      </PixBannerAlert>
+    {{/if}}
+  </template>
+}

--- a/certif/tests/acceptance/authenticated-test.js
+++ b/certif/tests/acceptance/authenticated-test.js
@@ -1,10 +1,11 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
+import setupIntl from '../helpers/setup-intl';
 import {
   authenticateSession,
   createCertificationPointOfContactWithTermsOfServiceAccepted,
@@ -261,10 +262,24 @@ module('Acceptance | authenticated', function (hooks) {
   });
 
   module('Banners', function () {
-    module('certification opening dates banner', function () {
+    module('SCO access suspension banner', function (hooks) {
+      let clock;
+      let expectedSuspensionDate;
+
+      hooks.beforeEach(function () {
+        expectedSuspensionDate = this.owner
+          .lookup('service:intl')
+          .formatDate(new Date('2026-07-16T00:00:00Z'), { format: 'LL' });
+      });
+
+      hooks.afterEach(function () {
+        clock?.restore();
+      });
+
       module('when certification center is SCO isManagingStudent', function () {
-        test('it should not display the banner', async function (assert) {
+        test('it should display the banner when the suspension date is in the future', async function (assert) {
           // given
+          clock = sinon.useFakeTimers({ now: new Date('2026-07-10'), toFake: ['Date'] });
           const certificationPointOfContact =
             createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted();
           await authenticateSession(certificationPointOfContact.id);
@@ -273,13 +288,32 @@ module('Acceptance | authenticated', function (hooks) {
           const screen = await visit('/sessions');
 
           // then
-          assert.dom(screen.queryByText('La Certification Pix se déroulera du', { exact: false })).doesNotExist();
+          const suspensionDate = screen.getByText(expectedSuspensionDate);
+          assert.dom(suspensionDate).hasTagName('strong');
+          assert
+            .dom(suspensionDate.parentElement)
+            .hasText(/^\s*Conformément au calendrier ministériel de passage des Certifications Pix/);
+        });
+
+        test('it should not display the banner when the suspension date has passed', async function (assert) {
+          // given
+          clock = sinon.useFakeTimers({ now: new Date('2026-07-16T22:00:00Z'), toFake: ['Date'] });
+          const certificationPointOfContact =
+            createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted();
+          await authenticateSession(certificationPointOfContact.id);
+
+          // when
+          const screen = await visit('/sessions');
+
+          // then
+          assert.dom(screen.queryByText(expectedSuspensionDate)).doesNotExist();
         });
       });
 
       module('when certification center is not SCO isManagingStudent', function () {
         test('it should not display the banner', async function (assert) {
           // given
+          clock = sinon.useFakeTimers({ now: new Date('2026-07-10'), toFake: ['Date'] });
           const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
           await authenticateSession(certificationPointOfContact.id);
 
@@ -287,15 +321,7 @@ module('Acceptance | authenticated', function (hooks) {
           const screen = await visit('/sessions');
 
           // then
-          assert
-            .dom(
-              screen.queryByText(
-                (content) =>
-                  content.startsWith('La Certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 ') &&
-                  content.endsWith('Collèges : du 17 mars au 13 juin 2025.'),
-              ),
-            )
-            .doesNotExist();
+          assert.dom(screen.queryByText(expectedSuspensionDate)).doesNotExist();
         });
       });
     });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -295,6 +295,9 @@
       "page-title": "Logout"
     },
     "sco": {
+      "banner": {
+        "information": "In accordance with the ministerial schedule for taking the Pix Certifications, access to the Pix Certif platform for middle and high schools will be suspended from <strong>{suspensionDate}</strong>. Please finalise your sessions for the year as soon as possible."
+      },
       "enrol-candidates-in-session": {
         "certification-candidates-sco": {
           "actions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -295,6 +295,9 @@
       "page-title": "Déconnexion"
     },
     "sco": {
+      "banner": {
+        "information": "Conformément au calendrier ministériel de passage des Certifications Pix, les accès à la plateforme Pix Certif des collèges et des lycées vont être suspendus à partir du <strong>{suspensionDate}</strong>. Pensez à finaliser dès que possible vos sessions de l’année."
+      },
       "enrol-candidates-in-session": {
         "certification-candidates-sco": {
           "actions": {


### PR DESCRIPTION
## 🪧 Problème

Certains centres ont toujours des sessions à finaliser et ils ne peuvent le faire une fois que les espaces Pix Certif sont clos.

On veut donc être sûrs qu’ils aient l’information concernant la date de clôture pour qu’ils puissent faire le nécessaire avant la fermeture.

## 🌈 Proposition

Afficher sur les espaces Pix Certif SCO des collèges et des lycées le message suivant dans un bandeau orange : “Conformément au calendrier ministériel de passage des Certifications Pix, les accès à la plateforme Pix Certif des collèges et des lycées vont être suspendus à partir du 16 juillet 2026. Pensez à finaliser dès que possible vos sessions de l'année.”.

## ✊ Remarques

Il a été décidé de fixer la date dans le code et de conditionner l'affichage de la bannière en fonction.

- Si la date est dans le futur : on affiche la bannière.
- Si la date est passée, on cache la bannière. 

## 🎉 Pour tester

- Visiter Certif en RA et choisir un centre SCO managing student
- Visualiser la bannière
