### PR TITLE
[FEATURE] Améliorer l'accessibilité de la carte d'un contenu formatif (PIX-23454)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -48,12 +48,7 @@ export default class Card extends Component {
   }
 
   <template>
-    <button
-      class="results-recommendation-engine-training-card"
-      type="button"
-      aria-label={{t "pages.skill-review.recommended-engine.training-card.aria-label"}}
-      {{on "click" this.showModal}}
-    >
+    <div class="results-recommendation-engine-training-card">
       <div class="results-recommendation-engine-training-card-image-hero">
         <img
           class="results-recommendation-engine-training-card-image-hero__editor-logo"
@@ -76,7 +71,13 @@ export default class Card extends Component {
           {{/if}}
         </ul>
       </section>
-    </button>
+      <button
+        class="results-recommendation-engine-training-card__button"
+        type="button"
+        aria-label={{t "pages.skill-review.recommended-engine.training-card.aria-label"}}
+        {{on "click" this.showModal}}
+      ></button>
+    </div>
     <CardModal
       @training={{@training}}
       @deliveryMode={{this.deliveryMode}}

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -35,15 +35,15 @@
   flex-direction: column;
   gap: var(--pix-spacing-4x);
   justify-content: space-between;
-  width: 329px;
-  height: 315px;
+  width: 20.6rem;
+  height: 19.7rem;
   padding: var(--pix-spacing-3x);
   padding-bottom: var(--pix-spacing-6x);
   background-color: var(--pix-neutral-0);
   border-radius: 16px 0 16px 16px;
 
   @include breakpoints.device-is('mobile') {
-    min-width: 280px;
+    min-width: 17.5rem;
   }
 
   &__button:focus {
@@ -86,7 +86,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  height: 127px;
+  height: 7.9rem;
   padding: var(--pix-spacing-7x);
   background-color: var(--pix-primary-10);
   border-radius: 12px;
@@ -94,11 +94,11 @@
   &__editor-logo {
     position: relative;
     z-index: 1;
-    height: 35px;
+    height: 2.2rem;
   }
 
   &__illustration {
-    height: 120px;
+    height: 7.5rem;
   }
 }
 
@@ -111,7 +111,7 @@
     @extend %pix-title-xxs;
 
     display: -webkit-box;
-    min-height: 50px;
+    min-height: 3.1rem;
     overflow: hidden;
     text-align: start;
     text-overflow: ellipsis;
@@ -135,7 +135,7 @@
 
 .results-recommendation-engine-training-card-modal {
   @include breakpoints.device-is('tablet') {
-    width: 742px;
+    width: 46.4rem;
   }
 
   h2 {

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -30,6 +30,7 @@
 .results-recommendation-engine-training-card {
   @extend %pix-shadow-default;
 
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--pix-spacing-4x);
@@ -45,11 +46,25 @@
     min-width: 280px;
   }
 
-  &:active {
-    @extend %pix-shadow-default-pressed;
+  &__button:focus {
+    outline: none;
   }
 
-  &:hover {
+  &__button::before {
+    position: absolute;
+    z-index: 1;
+    border-radius: 16px 0 16px 16px;
+    content: '';
+    inset: 0;
+  }
+
+
+  &__button:active::before {
+      @extend %pix-shadow-default-pressed;
+  }
+
+  &__button:focus::before,
+  &__button:hover::before {
     @extend %pix-shadow-default-hover;
   }
 

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -94,8 +94,9 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         const trainingCardButton = screen.getByRole('button', {
           name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
         });
+
         await click(trainingCardButton);
-        const modal = await screen.findByRole('dialog');
+        const modal = await screen.findByRole('dialog', { name: training.title });
 
         // when
         assert.dom(within(modal).getByRole('button', { name: t('common.no') })).doesNotHaveClass('selected');
@@ -115,7 +116,7 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         await click(within(actionButtons).getByRole('button', { name: t('common.actions.close') }));
         await click(trainingCardButton);
 
-        const reopenedModal = await screen.findByRole('dialog');
+        const reopenedModal = await screen.findByRole('dialog', { name: training.title });
         assert.dom(within(reopenedModal).getByRole('button', { name: t('common.yes') })).doesNotHaveClass('selected');
         assert.dom(within(reopenedModal).getByRole('button', { name: t('common.no') })).hasClass('selected');
       });
@@ -155,7 +156,7 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
             name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
           }),
         );
-        await screen.findByRole('dialog');
+        await screen.findByRole('dialog', { name: training.title });
 
         // then
         sinon.assert.calledWithExactly(trackEventStub, 'Moteur de reco - Clic sur la carte du contenu formatif', {
@@ -180,7 +181,7 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.objectives') }));
 
         // then
-        sinon.assert.callCount(trackEventStub, 4);
+        sinon.assert.callCount(trackEventStub, 5);
 
         // when
         await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.program') }));
@@ -200,7 +201,7 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         await click(screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.modal.program') }));
 
         // then
-        sinon.assert.callCount(trackEventStub, 5);
+        sinon.assert.callCount(trackEventStub, 6);
 
         // when
         await click(

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -1,5 +1,6 @@
 import { render, within } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+// eslint-disable-next-line no-restricted-imports
+import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import TrainingCard from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/training/card';
 import { module, test } from 'qunit';
@@ -22,13 +23,11 @@ module(
 
       // then
       const trainingTitle = screen.getAllByText(training.title);
-      const button = screen.getByRole('button', {
-        name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
-      });
+      const cardContainer = find('.results-recommendation-engine-training-card');
 
       assert.strictEqual(trainingTitle.length, 2);
       assert.dom(screen.getByText('Webinaire')).exists();
-      assert.dom(within(button).getByText('1 jour et 2h')).exists();
+      assert.dom(within(cardContainer).getByText('1 jour et 2h')).exists();
     });
 
     module('when delivery mode is hybrid', function () {
@@ -185,13 +184,12 @@ module(
           );
 
           // when
-          const screen = await render(<template><TrainingCard @training={{training}} /></template>);
+          await render(<template><TrainingCard @training={{training}} /></template>);
 
           // then
-          const button = screen.getByRole('button', {
-            name: t('pages.skill-review.recommended-engine.training-card.aria-label'),
-          });
-          assert.dom(within(button).getByText('3 jours et 1h')).exists();
+          const cardContainer = find('.results-recommendation-engine-training-card');
+
+          assert.dom(within(cardContainer).getByText('3 jours et 1h')).exists();
         });
       });
     });


### PR DESCRIPTION
## 🪧 Problème

Sur la page de résultats d'une campagne de type moteur de reco, le contenu d'une carte d'un contenu formatif ne pouvait pas être lu par le lecteur d'écran.

La cause est qu'on a englobé la carte dans une balise `button`. Cela fait que côté lecteur d'écran, le contenu ne sera pas / ou mal vocalisé. Plus de détails sur cet [article](https://inclusive-components.design/cards/).

Un exemple avec le lecteur d'écran en utilisant la fonctionnalité `Read next item` de Voiceover : 

https://github.com/user-attachments/assets/49c32e58-e37d-4f3f-9ee7-a6ced784f5c6


## 🌈 Proposition

Corriger cela en suivant le tuto défini [ici](https://kittygiraudel.com/2022/04/02/accessible-cards/#css). 

## ✊ Remarques

RAS

## 🎉 Pour tester
### Pré-requis
- Avoir un logiciel de lecteur d'écran. Si besoin voici une cheatsheet pour [Voiceover](https://media.dequeuniversity.com/en/docs/screen-readers-and-input-methods/voiceover-macos-guide.pdf) et [NVDA](https://media.dequeuniversity.com/en/docs/screen-readers-and-input-methods/nvda-guide.pdf)

### Test en RA

- Se connecter avec le compte dave-comp@example.net et passer la campagne EDUMULTIP
- Une fois arrivée sur la page de résultat, ouvrir le logiciel de lecteur d'écran 
- Sur la section des cartes de CFs, utiliser la fonctionnalité `Read next item`(Control + option + flèche droite sur mac) 🚀 
- Constater que chaque texte de la carte est bien lue 🎉 

Une vidéo du correctif : 

https://github.com/user-attachments/assets/74f9835e-1c44-4d80-bc4f-466ff6bc38df
