### PR TITLE
[BUGFIX] Fix du tri de la liste frameworkHistory (PIX-23516)

### DIFF
--- a/admin/app/components/certification-frameworks/certification-framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/framework-history.gjs
@@ -30,7 +30,7 @@ export default class FrameworkHistory extends Component {
   @tracked showVersionDetailModal = false;
 
   get frameworkHistory() {
-    return this.args.frameworkHistory?.history.sort(sortByStartDateNullFirst) ?? [];
+    return this.args.frameworkHistory?.history.sort(sortByStatus);
   }
 
   get hasHistory() {
@@ -215,16 +215,8 @@ export default class FrameworkHistory extends Component {
   </template>
 }
 
-function sortByStartDateNullFirst(historyItemA, historyItemB) {
-  if (historyItemA.startDate === null) {
-    return historyItemB.startDate === null ? historyItemA.id - historyItemB.id : -1;
-  }
-  if (historyItemB.startDate === null) {
-    return 1;
-  }
-
-  if (historyItemA.startDate > historyItemB.startDate) {
-    return -1;
-  }
-  return 1;
+function sortByStatus(frameworkHistoryA, frameworkHistoryB) {
+  if (frameworkHistoryA.status === 'draft') return -1;
+  if (frameworkHistoryA.status === 'active') return 0;
+  return new Date(frameworkHistoryA.expirationDate) > new Date(frameworkHistoryB.experitionDate) ? 1 : 0;
 }


### PR DESCRIPTION
## 🪧 Problème

Le tri utilise les dates d'activation pour définir l'ordre. Ce qui pose problème, car dorénavant nous pouvont avoir une date d'activation sur les versions au status DRAFT


## 🌈 Proposition

Utiliser les status en priorité

## ✊ Remarques

RAS

## 🎉 Pour tester
CI ok
Aller sur la liste des frameworkHistoy dans un scope quelconque et observer l'ordre suivant:
- draft
- active
- achived (par startDate)