### PR TITLE
[TECH] Active OpenTelemetry sur les Review Apps

### DIFF
--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -24,6 +24,14 @@
     "PR_NUMBER": {
       "generator": "template",
       "template": "%PR_NUMBER%"
+    },
+    "OTEL_ENABLED": {
+      "description": "Enable Open Telemetry on the review app",
+      "value": "true"
+    },
+    "OTEL_RESOURCE_ATTRIBUTES": {
+      "generator": "template",
+      "template": "deployment.environment=review-pr%PR_NUMBER%"
     }
   },
   "scripts": {


### PR DESCRIPTION
## 🪧 Problème

Open Telemetry n'est pas activé sur les Review Apps

## 🌈 Proposition

On active Open Telemetry et on spécifie le `deployment.environment` pour pointer vers la bonne RA.

## 🎉 Pour tester
- Lancer la RA sur Scalingo (API et App)
- Aller sur l'App
- Vérifier que notre backend Open Telemetry a bien reçu la trace
