### PR TITLE
[TECH]  Suppression de la table `certification subscriptions` (Pix-22978)

### DIFF
--- a/api/db/migrations/20260710133939_remove-certification-subscriptions-table.js
+++ b/api/db/migrations/20260710133939_remove-certification-subscriptions-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-subscriptions';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.integer('complementaryCertificationId').references('complementary-certifications.id').notNullable();
+    table.integer('certificationCandidateId').references('certification-candidates.id').notNullable();
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.text('type').notNull().defaultTo('COMPLEMENTARY');
+    table.index('certificationCandidateId');
+    table.index(['complementaryCertificationId', 'certificationCandidateId']);
+  });
+}

--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -256,6 +256,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     const expectedCandidates = candidateList.map((candidate) => {
       return domainBuilder.certification.enrolment.buildCandidate({
         ...candidate,
+        subscription: Frameworks.CORE,
       });
     });
     expect(actualCandidates).to.deep.equal(expectedCandidates);
@@ -294,13 +295,17 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       candidateList = _buildCandidateList({
         sessionId: sessionData.id,
         billingModes: [BILLING_MODES.FREE, BILLING_MODES.FREE],
-        subscriptions: [Frameworks.EDU_1ER_DEGRE, Frameworks.CLEA],
       });
-      const expectedCandidates = candidateList.map((candidate) => {
-        return domainBuilder.certification.enrolment.buildCandidate({
-          ...candidate,
-        });
-      });
+      const expectedCandidates = [
+        domainBuilder.certification.enrolment.buildCandidate({
+          ...candidateList[0],
+          subscription: Frameworks.EDU_1ER_DEGRE,
+        }),
+        domainBuilder.certification.enrolment.buildCandidate({
+          ...candidateList[1],
+          subscription: Frameworks.CLEA,
+        }),
+      ];
 
       // when
       const actualCandidates =
@@ -385,6 +390,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     const expectedCandidates = candidateList.map((candidate) => {
       return domainBuilder.certification.enrolment.buildCandidate({
         ...candidate,
+        subscription: Frameworks.CORE,
       });
     });
 
@@ -431,13 +437,14 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     const expectedCandidates = candidateList.map((candidate) => {
       return domainBuilder.certification.enrolment.buildCandidate({
         ...candidate,
+        subscription: Frameworks.CORE,
       });
     });
     expect(actualCandidates).to.deep.equal(expectedCandidates);
   });
 });
 
-function _buildCandidateList({ billingModes = [], sessionId, subscriptions = [] }) {
+function _buildCandidateList({ billingModes = [], sessionId }) {
   const candidates = [];
   candidates.push({
     id: null,
@@ -458,7 +465,7 @@ function _buildCandidateList({ billingModes = [], sessionId, subscriptions = [] 
     extraTimePercentage: 0.15,
     billingMode: billingModes[0] ? billingModes[0] : null,
     prepaymentCode: null,
-    subscription: subscriptions[0] ? subscriptions[0] : Frameworks.CORE,
+    subscription: Frameworks.CORE,
     organizationLearnerId: null,
     userId: null,
   });
@@ -481,7 +488,7 @@ function _buildCandidateList({ billingModes = [], sessionId, subscriptions = [] 
     extraTimePercentage: null,
     billingMode: billingModes[1] ? billingModes[1] : null,
     prepaymentCode: null,
-    subscription: subscriptions[1] ? subscriptions[1] : Frameworks.CORE,
+    subscription: Frameworks.CORE,
     organizationLearnerId: null,
     userId: null,
   });

--- a/api/tests/certification/enrolment/integration/domain/services/register-candidate-participation-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/register-candidate-participation-service_test.js
@@ -22,6 +22,11 @@ describe('Integration | Application | Service | register-candidate-participation
         userId: null,
         reconciledAt: null,
       });
+      databaseBuilder.factory.buildComplementaryCertification({ id: 1234 });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId,
+        complementaryCertificationId: 1234,
+      });
 
       await databaseBuilder.commit();
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-for-supervising-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-for-supervising-repository_test.js
@@ -304,7 +304,6 @@ describe('Integration | Repository | SessionForSupervising', function () {
           assessmentId: assessmentWithChallengeLiveAlert.id,
         });
 
-        databaseBuilder.factory.buildCertificationCandidate();
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -168,7 +168,6 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         // given
         databaseBuilder.factory.buildCertificationCenter({ id: 345 });
         databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
-        databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
         databaseBuilder.factory.buildInvigilatorAccess({ userId, sessionId: 121 });
         await databaseBuilder.commit();
 


### PR DESCRIPTION
## 🪧 Problème

La table `certification-subscriptions` n'est plus utilisée.

## 🌈 Proposition

Supprimer la table `certification-subscriptions`

## ✊ Remarques

En attente de la PR #16786 

## 🎉 Pour tester

:heavy_check_mark: CI Verte