### PR TITLE
[TECH] Ajout du request-id dans les traces OpenTelemetry

### DIFF
--- a/api/src/shared/infrastructure/open-telemetry/hapi-tracing.js
+++ b/api/src/shared/infrastructure/open-telemetry/hapi-tracing.js
@@ -220,6 +220,20 @@ function instrumentHttpResponse(server) {
 }
 
 /**
+ * @param {HapiServer} server
+ */
+function instrumentRequestId(server) {
+  server.ext('onPreHandler', (request, h) => {
+    const span = trace.getActiveSpan();
+    if (!span) return h.continue;
+
+    span.setAttribute('http.request.id', request.headers['x-request-id']);
+
+    return h.continue;
+  });
+}
+
+/**
  * Instruments a freshly created Hapi server so that spans are created for `pre` handlers,
  * controllers (route handlers), authentication and payload/query/params validation. Must be
  * called before any route, auth scheme/strategy or plugin is registered on the server.
@@ -243,4 +257,6 @@ export function instrumentHapiServer(server) {
   instrumentValidation(server);
 
   instrumentHttpResponse(server);
+
+  instrumentRequestId(server);
 }


### PR DESCRIPTION
## 🪧 Problème

Pendant la période de transition entre Datadog et un backend Open Telemetry, on peut avoir besoin de lier les informations entre les deux plateformes.

## 🌈 Proposition

On ajoute en attribut du span de créé pour chaque requête dans Hapi le request_id.

## 🎉 Pour tester

- Lancer l'API avec la variable d'environnement OTEL_ENABLED=true
- Lancer un collecteur (et/ou outil de visualisation de traces) OpenTelemetry comme [otel-tui](https://github.com/ymtdzzz/otel-tui) ou [otel-gui](https://github.com/metafab/otel-gui).
- Faire un appel
- Attendre quelques secondes
- Dans l'outil de visualisation de traces, constater que les spans root (ceux pour Hapi) contiennent un attribut request_id.
