### PR TITLE
[TECH] Permettre d'effectuer les requêtes SQL via PgBouncer ou en direct selon un feature toggle.

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -136,4 +136,10 @@ export default {
     defaultValue: false,
     tags: ['backend', 'pix-api'],
   },
+  pooledDbConnectionPercentage: {
+    type: 'number',
+    description: 'Percentage of SQL queries executed through pool connection (PgBouncer)',
+    defaultValue: 0,
+    tags: ['backend', 'pix-api'],
+  },
 };

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -1,16 +1,40 @@
 import { config } from '../src/shared/config.js';
+import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
 import { DatabaseConnection } from './database-connection.js';
 import { databaseConnections } from './database-connections.js';
-import { knexConfigWithPgBouncer } from './knexfile.js';
+import defaultKnexConfig, { knexConfigWithPgBouncer } from './knexfile.js';
 
 const { environment } = config;
-const databaseConnection = new DatabaseConnection(knexConfigWithPgBouncer[environment]);
-const configuredLiveKnex = databaseConnection.knex;
+const pooledDatabaseConnection = new DatabaseConnection(knexConfigWithPgBouncer[environment]);
 
-databaseConnections.addConnection(databaseConnection);
+const directDatabaseConnection = new DatabaseConnection(defaultKnexConfig[environment]);
 
-async function disconnect() {
-  return databaseConnection.disconnect();
+databaseConnections.addConnection(pooledDatabaseConnection);
+databaseConnections.addConnection(directDatabaseConnection);
+
+const pooledDbConnectionPercentage = featureToggles.use('pooledDbConnectionPercentage');
+let sqlQueryCount = 0;
+
+export function getDb() {
+  const db = sqlQueryCount < pooledDbConnectionPercentage.value ? pooledDatabaseConnection : directDatabaseConnection;
+
+  if (sqlQueryCount >= 99) {
+    sqlQueryCount = 0;
+  } else {
+    sqlQueryCount++;
+  }
+
+  return db.knex;
 }
 
-export { databaseConnection, disconnect, configuredLiveKnex as knex };
+export const databaseConnection = {
+  async emptyAllTables() {
+    await directDatabaseConnection.emptyAllTables();
+  },
+  async disconnect() {
+    await directDatabaseConnection.disconnect();
+  },
+  async prepare() {
+    await directDatabaseConnection.prepare();
+  },
+};

--- a/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
+++ b/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
@@ -9,7 +9,7 @@ import { ABORT_REASONS } from '../../../../../src/certification/shared/domain/co
 import { CertificationReport } from '../../../../../src/certification/shared/domain/models/CertificationReport.js';
 import { pickAnswerStatusService } from '../../../../../src/certification/shared/domain/services/pick-answer-status-service.js';
 import { FRENCH_SPOKEN } from '../../../../../src/shared/domain/services/locale-service.js';
-import { knex } from '../../../../knex-database-connection.js';
+import { getDb } from '../../../../knex-database-connection.js';
 
 /**
  * @param {Object} params
@@ -26,7 +26,11 @@ export default async function publishSessionWithValidatedCertification({
 }) {
   const session = await enrolmentUseCases.getSession({ sessionId });
 
-  const version = await knex('certification_versions').where('expirationDate', null).andWhere('scope', 'CORE').first();
+  const version = await getDb()
+    .from('certification_versions')
+    .where('expirationDate', null)
+    .andWhere('scope', 'CORE')
+    .first();
 
   const reports = [];
 
@@ -104,9 +108,10 @@ export default async function publishSessionWithValidatedCertification({
 
     await databaseBuilder.commit();
 
-    await knex('certification-courses')
-      .where('id', certificationCourse._id)
-      .update({ lastAnswerAt: lastAnswerCreatedAt.toDate() });
+    await getDb()
+      .update({ lastAnswerAt: lastAnswerCreatedAt.toDate() })
+      .from('certification-courses')
+      .where('id', certificationCourse._id);
 
     const report = new CertificationReport({
       certificationCourseId: certificationCourse._id,

--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -12,7 +12,7 @@ import {
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { Membership } from '../../../../src/shared/domain/models/Membership.js';
 import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
-import { knex } from '../../../knex-database-connection.js';
+import { getDb } from '../../../knex-database-connection.js';
 import {
   AEFE_TAG,
   COUNTRY_FRANCE_CODE,
@@ -40,8 +40,9 @@ async function buildParenthoodQuest(databaseBuilder) {
     label: 'Parentalité',
   });
 
-  const cappedTubes = await knex('target-profile_tubes')
+  const cappedTubes = await getDb()
     .select('tubeId', 'level')
+    .from('target-profile_tubes')
     .where('targetProfileId', TARGET_PROFILE_NO_BADGES_NO_STAGES_ID);
 
   databaseBuilder.factory.buildQuest({

--- a/api/install-pgbench.sh
+++ b/api/install-pgbench.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /tmp
+apt-get download postgresql-16
+dpkg -x postgresql-16_*.deb /app/pg
+export PATH=/app/pg/usr/lib/postgresql/16/bin:$PATH
+export LD_LIBRARY_PATH=/app/pg/usr/lib/postgresql/16/lib:$LD_LIBRARY_PATH

--- a/api/package.json
+++ b/api/package.json
@@ -57,7 +57,7 @@
     "lint:js:uncached": "eslint .",
     "lint:format": "oxfmt --check",
     "lint:format:fix": "oxfmt",
-    "postdeploy": "DEBUG=knex:query npm run db:migrate",
+    "postdeploy": "DEBUG=knex:query npm run db:migrate && ./install-pgbench.sh",
     "postdeploy:datamart": "DEBUG=knex:query npm run datamart:create && DEBUG=knex:query npm run datamart:migrate",
     "postdeploy:maddo": "node scripts/wait-for-api-deployment && npm run datamart:migrate",
     "scalingo-postbuild": "node scripts/generate-cron > cron.json && node scripts/generate-procfile",

--- a/api/scripts/certification/add-competence-ids-to-scoring-configurations.js
+++ b/api/scripts/certification/add-competence-ids-to-scoring-configurations.js
@@ -1,4 +1,4 @@
-import { knex } from '../../db/knex-database-connection.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
@@ -29,8 +29,9 @@ export class AddCompetenceIdsToScoringConfigurations extends Script {
       competenceList.map((competence) => [competence.index, competence.id]),
     );
 
-    const coreConfigurations = await knex('certification_versions')
+    const coreConfigurations = await getDb()
       .select('id', 'competencesScoringConfiguration')
+      .from('certification_versions')
       .whereNotNull('competencesScoringConfiguration')
       .whereRaw('"competencesScoringConfiguration"::text != \'null\'');
 

--- a/api/scripts/certification/correct-certification-courses-firstnames-bad-encoding.js
+++ b/api/scripts/certification/correct-certification-courses-firstnames-bad-encoding.js
@@ -1,4 +1,4 @@
-import { knex } from '../../db/knex-database-connection.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 
@@ -23,7 +23,7 @@ export class CorrectCertificationCoursesFirstnamesBadEncoding extends Script {
     const { dryRun } = options;
     logger.info(`Script execution started with options ${JSON.stringify(options)}`);
 
-    const trx = await knex.transaction();
+    const trx = await getDb().transaction();
 
     try {
       const correctedCertificationCourseIds = await correctFirstNames(trx, 'certification-courses');
@@ -60,7 +60,7 @@ async function correctFirstNames(trx, tableName) {
   for (const { badAccent, goodAccent } of badlyEncodedAccents) {
     const updatedRows = await trx(tableName)
       .where('firstName', 'like', `%${badAccent}%`)
-      .update({ firstName: knex.raw('REPLACE(??, ?, ?)', ['firstName', badAccent, goodAccent]) })
+      .update({ firstName: getDb().raw('REPLACE(??, ?, ?)', ['firstName', badAccent, goodAccent]) })
       .returning('id');
 
     updatedRows.forEach(({ id }) => correctedIds.add(id));

--- a/api/scripts/certification/duplicate-english-core-calibration-with-new-ids.js
+++ b/api/scripts/certification/duplicate-english-core-calibration-with-new-ids.js
@@ -1,4 +1,4 @@
-import { knex } from '../../db/knex-database-connection.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 
@@ -22,11 +22,12 @@ export class DuplicateEnglishCoreCalibrationWithNewIds extends Script {
     const { dryRun } = options;
     logger.info(`Script execution started`);
 
-    const englishChallenges = await knex('certification-frameworks-challenges')
+    const englishChallenges = await getDb()
+      .from('certification-frameworks-challenges')
       .join('certification_versions', 'certification_versions.id', 'certification-frameworks-challenges.versionId')
       .join(
         { lc_challenges: 'learningcontent.challenges' },
-        knex.raw('lc_challenges.id = "certification-frameworks-challenges"."challengeId" || \'-EN\''),
+        getDb().raw('lc_challenges.id = "certification-frameworks-challenges"."challengeId" || \'-EN\''),
       )
       .where('certification_versions.scope', 'CORE')
       .whereNull('certification_versions.expirationDate')
@@ -46,7 +47,7 @@ export class DuplicateEnglishCoreCalibrationWithNewIds extends Script {
       versionId: challenge.versionId,
     }));
 
-    const trx = await knex.transaction();
+    const trx = await getDb().transaction();
 
     try {
       await trx.batchInsert('certification-frameworks-challenges', newChallenges);

--- a/api/scripts/certification/fill-sessions-date-with-first-certification.js
+++ b/api/scripts/certification/fill-sessions-date-with-first-certification.js
@@ -1,6 +1,6 @@
 import { setTimeout } from 'node:timers/promises';
 
-import { knex } from '../../db/knex-database-connection.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
@@ -45,7 +45,7 @@ export class FillSessionsDateWithFirstCertification extends Script {
     logger.info(`Script execution started with options ${JSON.stringify(options)}`);
     let cntTotalSessionsHandled = 0;
     let currentStartId = startId;
-    const [{ max }] = await knex('sessions').max('id');
+    const [{ max }] = await getDb().from('sessions').max('id');
     let sessionDataToProcess = await findNextSessionsToProcess(currentStartId, chunkSize);
     while (currentStartId <= max) {
       try {
@@ -81,7 +81,7 @@ export class FillSessionsDateWithFirstCertification extends Script {
 }
 
 async function findNextSessionsToProcess(startId, chunkSize) {
-  const results = await knex.raw(
+  const results = await getDb().raw(
     `
       SELECT
         sessions.id,

--- a/api/scripts/certification/fix-validated-v3-assessment-results-with-zero-score.js
+++ b/api/scripts/certification/fix-validated-v3-assessment-results-with-zero-score.js
@@ -1,4 +1,4 @@
-import { knex } from '../../db/knex-database-connection.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { AutoJuryCommentKeys } from '../../src/certification/shared/domain/models/JuryComment.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
@@ -24,7 +24,7 @@ export class FixValidatedV3AssessmentResultsWithZeroScoreScript extends Script {
     const { dryRun } = options;
     logger.info(`Script execution started with options ${JSON.stringify(options)}`);
 
-    const trx = await knex.transaction();
+    const trx = await getDb().transaction();
 
     try {
       const updatedIds = await fixValidatedResultsWithZeroScore(trx);

--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -1,7 +1,11 @@
+import * as url from 'node:url';
+
 import lodash from 'lodash';
 
-import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { databaseConnections } from '../../db/database-connections.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { checkCsvHeader, parseCsv } from '../helpers/csvHelpers.js';
 /**
  * Usage: node scripts/certification/import-certification-cpf-cities.js path/file.csv
  * File is semi-colon separated values, headers being:
@@ -10,9 +14,7 @@ import { logger } from '../../src/shared/infrastructure/utils/logger.js';
  *
  * File downloaded from https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/ (Export au format CSV)
  **/
-import { checkCsvHeader, parseCsv } from '../helpers/csvHelpers.js';
 const { uniqBy, values } = lodash;
-import * as url from 'node:url';
 
 const wordsToReplace = [
   {
@@ -408,6 +410,7 @@ async function main(filePath) {
     logger.info('✅ ');
 
     logger.info('Inserting cities in database... ');
+    const knex = getDb();
     trx = await knex.transaction();
     await trx('certification-cpf-cities').del();
     const batchInfo = await knex.batchInsert('certification-cpf-cities', cities).transacting(trx);
@@ -433,7 +436,7 @@ async function main(filePath) {
       logger.error(error);
       process.exitCode = 1;
     } finally {
-      await disconnect();
+      await databaseConnections.disconnect();
     }
   }
 })();

--- a/api/scripts/certification/import-certification-cpf-countries.js
+++ b/api/scripts/certification/import-certification-cpf-countries.js
@@ -6,7 +6,8 @@ import * as url from 'node:url';
 
 import _ from 'lodash';
 
-import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { databaseConnections } from '../../db/database-connections.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { normalizeAndSortChars } from '../../src/shared/infrastructure/utils/string-utils.js';
 import { parseCsv } from '../helpers/csvHelpers.js';
 
@@ -80,6 +81,7 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
 
 async function main(filePath) {
   console.log('Starting script import-certification-cpf-countries');
+  const knex = getDb();
   const trx = await knex.transaction();
 
   try {
@@ -119,7 +121,7 @@ async function main(filePath) {
       console.error(error);
       process.exitCode = 1;
     } finally {
-      await disconnect();
+      await databaseConnections.disconnect();
     }
   }
 })();

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -2,14 +2,16 @@ import * as url from 'node:url';
 
 import _ from 'lodash';
 
-import { disconnect, knex } from '../db/knex-database-connection.js';
+import { databaseConnections } from '../db/database-connections.js';
+import { getDb } from '../db/knex-database-connection.js';
 import { Membership } from '../src/shared/domain/models/Membership.js';
 import { PromiseUtils } from '../src/shared/infrastructure/utils/promise-utils.js';
 import { parseCsvWithHeader } from './helpers/csvHelpers.js';
 
 async function getCertificationCenterIdWithMembershipsUserIdByExternalId(externalId) {
-  const certificationCenterIdWithMemberships = await knex('certification-centers')
+  const certificationCenterIdWithMemberships = await getDb()
     .select('certification-centers.id', 'certification-center-memberships.userId')
+    .from('certification-centers')
     .leftJoin(
       'certification-center-memberships',
       'certification-centers.id',
@@ -27,8 +29,9 @@ async function getCertificationCenterIdWithMembershipsUserIdByExternalId(externa
 }
 
 async function getAdminMembershipsUserIdByOrganizationExternalId(externalId) {
-  const adminMemberships = await knex('memberships')
+  const adminMemberships = await getDb()
     .select('memberships.userId')
+    .from('memberships')
     .innerJoin('organizations', 'memberships.organizationId', 'organizations.id')
     .innerJoin('users', 'users.id', 'memberships.userId')
     .where('organizationRole', Membership.roles.ADMIN)
@@ -68,7 +71,7 @@ async function prepareDataForInsert(rawExternalIds) {
 }
 
 async function createCertificationCenterMemberships(certificationCenterMemberships) {
-  return knex.batchInsert('certification-center-memberships', certificationCenterMemberships);
+  return getDb().batchInsert('certification-center-memberships', certificationCenterMemberships);
 }
 
 const modulePath = url.fileURLToPath(import.meta.url);
@@ -100,7 +103,7 @@ async function main() {
       console.error(error);
       process.exitCode = 1;
     } finally {
-      await disconnect();
+      await databaseConnections.disconnect();
     }
   }
 })();

--- a/api/scripts/data-generation/add-many-divisions-and-students-to-sco-organization.js
+++ b/api/scripts/data-generation/add-many-divisions-and-students-to-sco-organization.js
@@ -2,7 +2,8 @@ import * as url from 'node:url';
 
 import _ from 'lodash';
 
-import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { databaseConnections } from '../../db/database-connections.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { OrganizationLearner } from '../../src/prescription/learner-management/domain/models/OrganizationLearner.js';
 import { OrganizationLearnersCouldNotBeSavedError } from '../../src/shared/domain/errors.js';
 import { generateCode } from '../../src/shared/infrastructure/utils/code-generator.js';
@@ -40,6 +41,7 @@ async function addManyDivisionsAndStudentsToScoCertificationCenter(numberOfDivis
   });
 
   try {
+    const knex = getDb();
     await knex.batchInsert('organization-learners', manyStudents);
   } catch {
     throw new OrganizationLearnersCouldNotBeSavedError();
@@ -68,7 +70,7 @@ async function main() {
       console.error(error);
       process.exitCode = 1;
     } finally {
-      await disconnect();
+      await databaseConnections.disconnect();
     }
   }
 })();

--- a/api/scripts/data-generation/add-many-fake-members-related-to-one-organization.js
+++ b/api/scripts/data-generation/add-many-fake-members-related-to-one-organization.js
@@ -5,7 +5,8 @@ import { MembershipUpdateError } from '../../src/shared/domain/errors.js';
 const { times } = lodash;
 import * as url from 'node:url';
 
-import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { databaseConnections } from '../../db/database-connections.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { UserCantBeCreatedError } from '../../src/identity-access-management/domain/errors.js';
 import { ForbiddenAccess } from '../../src/shared/domain/errors.js';
 
@@ -48,7 +49,7 @@ async function addManyMembersToExistingOrganization({ numberOfUsers }) {
   const manyUsers = times(numberOfUsers, _buildUser);
 
   try {
-    await knex.batchInsert('users', manyUsers).transacting(DomainTransaction.emptyTransaction().knexTransaction);
+    await getDb().batchInsert('users', manyUsers).transacting(DomainTransaction.emptyTransaction().knexTransaction);
   } catch {
     throw new UserCantBeCreatedError();
   }
@@ -56,7 +57,7 @@ async function addManyMembersToExistingOrganization({ numberOfUsers }) {
   const manyMemberShips = times(numberOfUsers, _buildMembership);
 
   try {
-    await knex
+    await getDb()
       .batchInsert('memberships', manyMemberShips)
       .transacting(DomainTransaction.emptyTransaction().knexTransaction);
   } catch {
@@ -90,7 +91,7 @@ async function main() {
       console.error(error);
       process.exitCode = 1;
     } finally {
-      await disconnect();
+      await databaseConnections.disconnect();
     }
   }
 })();

--- a/api/scripts/data-generation/add-many-students-to-sco-certification-center.js
+++ b/api/scripts/data-generation/add-many-students-to-sco-certification-center.js
@@ -2,7 +2,8 @@ import * as url from 'node:url';
 
 import _ from 'lodash';
 
-import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { databaseConnections } from '../../db/database-connections.js';
+import { getDb } from '../../db/knex-database-connection.js';
 import { OrganizationLearner } from '../../src/prescription/learner-management/domain/models/OrganizationLearner.js';
 import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
 import { OrganizationLearnersCouldNotBeSavedError } from '../../src/shared/domain/errors.js';
@@ -25,6 +26,7 @@ function _buildOrganizationLearner(iteration) {
 async function addManyStudentsToScoCertificationCenter(numberOfStudents) {
   const manyStudents = _.times(numberOfStudents, _buildOrganizationLearner);
   try {
+    const knex = getDb();
     await knex
       .batchInsert('organization-learners', manyStudents)
       .transacting(DomainTransaction.emptyTransaction().knexTransaction);
@@ -54,7 +56,7 @@ async function main() {
       console.error(error);
       process.exitCode = 1;
     } finally {
-      await disconnect();
+      await databaseConnections.disconnect();
     }
   }
 })();

--- a/api/server.js
+++ b/api/server.js
@@ -4,7 +4,7 @@ import { parse } from 'neoqs';
 
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { databaseConnections } from './db/database-connections.js';
-import { knex } from './db/knex-database-connection.js';
+import { getDb } from './db/knex-database-connection.js';
 import { announcementRoutes } from './src/announcements/routes.js';
 import { bannerRoutes } from './src/banner/routes.js';
 import {
@@ -171,7 +171,7 @@ const enableOpsMetrics = async function (server, metrics) {
     });
   };
 
-  const client = knex.client;
+  const client = getDb().client;
   gaugeConnections(client.pool)();
 
   client.pool.on('createSuccess', gaugeConnections(client.pool));

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -4,7 +4,7 @@ import { parse } from 'neoqs';
 
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { databaseConnections } from './db/database-connections.js';
-import { knex } from './db/knex-database-connection.js';
+import { getDb } from './db/knex-database-connection.js';
 import { livretScolaireRoute } from './src/certification/results/application/livret-scolaire-route.js';
 import { parcoursupRoute } from './src/certification/results/application/parcoursup-route.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
@@ -121,7 +121,7 @@ const enableOpsMetrics = async function (server, metrics) {
     });
   };
 
-  const client = knex.client;
+  const client = getDb().client;
   gaugeConnections(client.pool)();
 
   client.pool.on('createSuccess', gaugeConnections(client.pool));

--- a/api/src/learning-content/infrastructure/repositories/framework-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/framework-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { getDb } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
 import { Framework } from '../../domain/models/Framework.js';
@@ -14,7 +14,7 @@ class FrameworkRepository extends LearningContentRepository {
   }
 
   async list() {
-    const frameworkDtos = await knex.select('*').from(tableName).orderBy('name');
+    const frameworkDtos = await getDb().select('*').from(tableName).orderBy('name');
     return frameworkDtos.map(toDomain);
   }
 
@@ -22,7 +22,7 @@ class FrameworkRepository extends LearningContentRepository {
    * @param {string} name
    */
   async getByName(name) {
-    const frameworkDto = await knex.select('*').from(tableName).where('name', name).first();
+    const frameworkDto = await getDb().select('*').from(tableName).where('name', name).first();
     if (!frameworkDto) {
       logger.warn({ frameworkName: name }, 'Référentiel introuvable');
       throw new NotFoundError(`Framework not found for name ${name}`);
@@ -31,7 +31,7 @@ class FrameworkRepository extends LearningContentRepository {
   }
 
   async findByIds(ids) {
-    const frameworkDtos = await knex.select('*').from(tableName).whereIn('id', ids).orderBy('name');
+    const frameworkDtos = await getDb().select('*').from(tableName).whereIn('id', ids).orderBy('name');
     return frameworkDtos.map(toDomain);
   }
 

--- a/api/src/organizational-entities/scripts/create-structure-for-every-organization.js
+++ b/api/src/organizational-entities/scripts/create-structure-for-every-organization.js
@@ -1,6 +1,6 @@
 import { setTimeout } from 'node:timers/promises';
 
-import { knex } from '../../../db/knex-database-connection.js';
+import { getDb } from '../../../db/knex-database-connection.js';
 import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 
@@ -55,7 +55,7 @@ export class CreateStructureForEveryOrganizationScript extends Script {
     let createdStructuresTotalCount = 0;
 
     while (chunkToProcess.length > 0) {
-      const trx = await knex.transaction();
+      const trx = await getDb().transaction();
 
       try {
         let createdStructuresInChunkCount = 0;
@@ -102,7 +102,7 @@ export class CreateStructureForEveryOrganizationScript extends Script {
 }
 
 async function _findOrganizationsLackingStructure() {
-  const organizationsLackingStructures = await knex
+  const organizationsLackingStructures = await getDb()
     .select('id', 'fct_structures.organization_id')
     .from('organizations')
     .leftJoin('fct_structures', 'fct_structures.organization_id', 'organizations.id')

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { getDb } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { OrganizationImportStatus } from '../../domain/models/OrganizationImportStatus.js';
 import { OrganizationImportDetail } from '../../domain/read-models/OrganizationImportDetail.js';
@@ -54,10 +54,13 @@ const save = async function (organizationImport) {
   const attributes = { ...organizationImport, errors: _stringifyErrors(organizationImport.errors) };
 
   if (organizationImport.id) {
-    const updatedRows = await knex('organization-imports').update(attributes).where({ id: organizationImport.id });
+    const updatedRows = await getDb()
+      .from('organization-imports')
+      .update(attributes)
+      .where({ id: organizationImport.id });
     if (updatedRows === 0) throw new Error();
   } else {
-    await knex('organization-imports').insert(attributes);
+    await getDb().insert(attributes).into('organization-imports');
   }
 };
 

--- a/api/src/prescription/scripts/delete-and-anonymise-organization-learners.js
+++ b/api/src/prescription/scripts/delete-and-anonymise-organization-learners.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { getDb } from '../../../db/knex-database-connection.js';
 import { commaSeparatedNumberParser } from '../../shared/application/scripts/parsers.js';
 import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
@@ -26,11 +26,12 @@ export class DeleteAndAnonymiseOrganizationLearnerScript extends Script {
 
     logger.info(`Anonymize ${options.organizationLearnerIds.length} learners`);
 
-    const organizationLearnerOfOrganizationIds = await knex('view-active-organization-learners')
+    const organizationLearnerOfOrganizationIds = await getDb()
       .select({
         organizationId: 'organizationId',
-        organizationLearnerIds: knex.raw('array_agg("view-active-organization-learners".id)'),
+        organizationLearnerIds: getDb().raw('array_agg("view-active-organization-learners".id)'),
       })
+      .from('view-active-organization-learners')
       .whereIn('id', options.organizationLearnerIds)
       .groupBy('organizationId');
 

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import { knex } from '../../../db/knex-database-connection.js';
+import { getDb } from '../../../db/knex-database-connection.js';
 import { featureToggles } from '../infrastructure/feature-toggles/index.js';
 
 /**
@@ -32,7 +32,7 @@ class DomainTransaction {
       return lambda();
     }
     let domainTransaction;
-    return knex
+    return getDb()
       .transaction((trx) => {
         domainTransaction = new DomainTransaction(trx);
         return asyncLocalStorage.run({ transaction: domainTransaction }, lambda, domainTransaction);
@@ -86,7 +86,7 @@ class DomainTransaction {
       const domainTransaction = store.transaction;
       return domainTransaction.knexTransaction;
     }
-    return knex;
+    return getDb();
   }
 
   static emptyTransaction() {

--- a/api/src/shared/infrastructure/utils/filter-utils.js
+++ b/api/src/shared/infrastructure/utils/filter-utils.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { getDb } from '../../../../db/knex-database-connection.js';
 
 const DISTANCE = 0.8;
 
@@ -8,7 +8,7 @@ const filterByFullName = function (queryBuilder, search, firstName, lastName) {
     //the search is performed by pg_search which uses the distances between the pattern and the data
     //if the distance is too large then pg-search won't find anything
     //this is why the others where are used
-    this.where(knex.raw(`CONCAT (??, ' ', ??) <-> ?`, [firstName, lastName, searchLowerCase]), '<=', DISTANCE);
+    this.where(getDb().raw(`CONCAT (??, ' ', ??) <-> ?`, [firstName, lastName, searchLowerCase]), '<=', DISTANCE);
     this.orWhereRaw('LOWER(??) LIKE ?', [firstName, `%${searchLowerCase}%`]);
     this.orWhereRaw('LOWER(??) LIKE ?', [lastName, `%${searchLowerCase}%`]);
   });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
@@ -1,9 +1,8 @@
-import { knex } from '../../../../../../db/knex-database-connection.js';
 import * as calibratedChallengeRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
-import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-assessment-history-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-assessment-history-repository_test.js
@@ -1,9 +1,8 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../../db/knex-database-connection.js';
 import { save } from '../../../../../../src/certification/evaluation/infrastructure/repositories/certification-assessment-history-repository.js';
 import { expect } from '../../../../../test-helper.js';
-import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Integration | Infrastructure | Repository | CertificationChallengeCapacityRepository', function () {

--- a/api/tests/db/integration/infrastructure/knex-database-performance-monitoring_test.js
+++ b/api/tests/db/integration/infrastructure/knex-database-performance-monitoring_test.js
@@ -1,9 +1,9 @@
 import sinon from 'sinon';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { config } from '../../../../src/shared/config.js';
 import { executeInContext, getInContext } from '../../../../src/shared/infrastructure/execution-context-manager.js';
 import { expect } from '../../../test-helper.js';
+import { knex } from '../../../tooling/databases.js';
 const selectQuery = knex.raw('SELECT 1 as value');
 
 describe('Integration | Infrastructure | knex-database-performance-monitoring', function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-certification-center.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-certification-center.usecase.test.js
@@ -1,11 +1,10 @@
 import sinon from 'sinon';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import { expect } from '../../../../test-helper.js';
-import { databaseBuilder } from '../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | archive-certification-center', function () {
   it('archives the certification center and related data', async function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-certification-centers-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-certification-centers-in-batch.usecase.test.js
@@ -1,11 +1,10 @@
 import sinon from 'sinon';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { ArchiveCertificationCentersInBatchError } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import { expect } from '../../../../test-helper.js';
-import { databaseBuilder } from '../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | archive-certification-centers-in-batch', function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/create-network.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-network.usecase.test.js
@@ -1,11 +1,10 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import {
   NetworkAlreadyExistError,
   OrganizationNotFound,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
-import { databaseBuilder } from '../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -1,7 +1,6 @@
 import pick from 'lodash/pick.js';
 import sinon from 'sinon';
 
-import { knex } from '../../../../../../db/knex-database-connection.js';
 import { CampaignParticipant } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipant.js';
 import { CampaignToStartParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignToStartParticipation.js';
 import * as campaignParticipantRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js';
@@ -18,7 +17,7 @@ import {
 } from '../../../../../../src/shared/domain/errors.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
-import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 const campaignParticipationDBAttributes = [

--- a/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
+++ b/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import sinon from 'sinon';
 
-import { knex } from '../../../../../../db/knex-database-connection.js';
 import * as categories from '../../../../../../src/prescription/organization-place/domain/constants/organization-places-categories.js';
 import { OrganizationPlacesLotForManagement } from '../../../../../../src/prescription/organization-place/domain/models/OrganizationPlacesLotForManagement.js';
 import { OrganizationPlacesLotManagement } from '../../../../../../src/prescription/organization-place/domain/read-models/OrganizationPlacesLotManagement.js';
@@ -9,7 +8,7 @@ import { PlacesLot } from '../../../../../../src/prescription/organization-place
 import * as organizationPlacesLotRepository from '../../../../../../src/prescription/organization-place/infrastructure/repositories/organization-places-lot-repository.js';
 import { DeletedError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
-import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Repository | Organization Places Lot', function () {

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-bond-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-bond-repository_test.js
@@ -1,7 +1,6 @@
-import { knex } from '../../../../../../db/knex-database-connection.js';
 import * as targetProfileBondRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-bond-repository.js';
 import { expect } from '../../../../../test-helper.js';
-import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 
 describe('Integration | Repository | Target Profile Management | Target Profile ', function () {
   describe('#update', function () {
@@ -24,7 +23,7 @@ describe('Integration | Repository | Target Profile Management | Target Profile 
       await targetProfileBondRepository.update(targetProfile);
 
       // then
-      const result = await knex
+      const result = await knex()
         .select('organizationId')
         .from('target-profile-shares')
         .where('targetProfileId', targetProfile.id);

--- a/api/tests/team/integration/domain/usecases/archive-certification-center-data.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/archive-certification-center-data.usecase.test.js
@@ -1,8 +1,7 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
-import { databaseBuilder } from '../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 
 describe('Integration | Team | Domain | UseCase | archive-certification-center-data', function () {
   describe('#archiveCertificationCenterData', function () {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -8,7 +8,7 @@ import nock from 'nock';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
-import { disconnect as disconnectKnex } from '../db/knex-database-connection.js';
+import { databaseConnections } from '../db/database-connections.js';
 import * as moduleRepository from '../src/devcomp/infrastructure/repositories/module-repository.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
@@ -78,7 +78,7 @@ after(async function () {
   } catch {
     // pgBoss is not available on unit tests
   }
-  await disconnectKnex();
+  await databaseConnections.disconnect();
 });
 /* eslint-enable mocha/no-top-level-hooks */
 

--- a/api/tests/tooling/databases.js
+++ b/api/tests/tooling/databases.js
@@ -4,9 +4,10 @@ import { DatamartBuilder } from '../../datamart/datamart-builder/datamart-builde
 import { knex as datamartKnex } from '../../datamart/knex-database-connection.js';
 import { knex as datawarehouseKnex } from '../../datawarehouse/knex-database-connection.js';
 import { DatabaseBuilder } from '../../db/database-builder/database-builder.js';
-import { knex } from '../../db/knex-database-connection.js';
+import { getDb } from '../../db/knex-database-connection.js';
 
 // Init Database builders
+const knex = getDb();
 const databaseBuilder = await DatabaseBuilder.create({ knex });
 databaseBuilder.factory.learningContent.injectNock(nock); // TEMPORARY WORKAROUND
 

--- a/high-level-tests/e2e/cypress.config.cjs
+++ b/high-level-tests/e2e/cypress.config.cjs
@@ -25,12 +25,15 @@ async function setupNodeEvents(cypressOn, config) {
   );
 
   on("task", {
-    async "db:fixture"(data) {
-      const file = require(`./cypress/fixtures/${data}.json`);
-      const { knex } = await import("../../api/db/knex-database-connection.js");
+    async "db:fixture"(table) {
+      const file = require(`./cypress/fixtures/${table}.json`);
+      const { getDb } = await import(
+        "../../api/db/knex-database-connection.js"
+      );
+      const knex = await getDb();
 
       for (const row of file) {
-        await knex(data).insert(row);
+        await knex.insert(row).into(table);
       }
 
       return knex


### PR DESCRIPTION
## 🪧 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On souhaite utiliser PGBouncer pour améliorer la stabilité des connexions à la base de donnés.
Il n'est actuellement pas possible de déployer cette connexion de manière progressive (soit on utilise la connexion directe, soit on utilise la connexion via PGBouncer).

## 🌈 Proposition

On transforme l'objet `knex` exporté depuis `knex-database-connection` en une fonction `getDb` qui permet de servir le knex de la connexion directe ou le knex de la connexion à PGBouncer.

On ajouter un feature toggle de type `number` dont la valeur représente le pourcentage de requêtes SQL effectuées via la connexion à PGBouncer.
Quand cette valeur vaut 0, toutes les requêtes utilisent la connexion directe.
Quand cette valeur vaut 100, toutes les requêtes utilisent la connexion à PGBouncer.
Quand cette valeur vaut 20, les 20 premières requêtes utilisent la connexion à PGBouncer, les 80 suivantes utilisent la connexion directe, puis les 20 suivantes la connexion à PGBouncer et ainsi de suite.

On utilise un compteur en mémoire que l'on réinitialise quand il atteind 100 et qu'on incrémente à chaque récupération de la connexion à la base de données.


## ✊ Remarques

On peut également utiliser un compteur dans un RedisStorage afin de partager le compteur entre tous les conteneurs, mais cela rendrait le code qui récupère `knex` (la fonction `getDb`) asynchrone, entrainant beaucoup de modifications de code.

## 🎉 Pour tester

La review app a été branchée à l'application `pix-pgbouncer-integration`, elle-même connectée à l'addon PG de la review app.

Il faut ensuite faire des essais avec du traffic et des valeurs différentes du feature toggle.