### PR TITLE
[FEATURE] : Ajouter une nouvelle colonne "survey" à la table user-campaign-surveys (PIX-23538)

### DIFF
--- a/api/db/migrations/20260713091934_add-survey-column-to-user-campaign-surveys.js
+++ b/api/db/migrations/20260713091934_add-survey-column-to-user-campaign-surveys.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'user-campaign-surveys';
+const COLUMN_NAME = 'survey';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.jsonb(COLUMN_NAME).nullable().comment("Survey's answers");
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, async function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}


### PR DESCRIPTION
## 🪧 Problème
On souhaite pouvoir stocker plusieurs réponse à des questions d'un même formulaire. Il manque une colonne

## 🌈 Proposition
Pour cela, on va stocker les informations de ce formulaire dans une nouvelle colonne survey de la table user-campaign-surveys

## ✊ Remarques
N/A

## 🎉 Pour tester
Jouer les migration en local : `npm run db:reset`
Vérifier en local l'ajout de la colonne de la table `user-campaign-surveys`
Jouer un rollback de la dernière migration : `npm run db:rollback:latest`
Vérifier la disparition de la colonne `user-campaign-surveys`
