### PR TITLE
[TECH] Enlever le commentaire de corrélation dans les requêtes SQL enregistrées dans les traces OpenTelemetry

### DIFF
--- a/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
+++ b/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
@@ -45,6 +45,10 @@ export function initializeOpenTelemetry(serviceName) {
       new PgInstrumentation({
         requireParentSpan: true,
         enhancedDatabaseReporting: true,
+        requestHook(span, pgRequest) {
+          const statementWithoutComment = pgRequest.query.text.replace(/\/\* .* \*\/ /, '');
+          span.setAttribute('db.statement', statementWithoutComment);
+        },
       }),
       new FsInstrumentation({
         requireParentSpan: true,


### PR DESCRIPTION
## 🪧 Problème

Les requêtes SQL envoyées à la base de données commencent par un commentaire donnant des informations de corrélation: 
<img width="645" height="75" alt="image" src="https://github.com/user-attachments/assets/e2604f31-6658-441e-a9fe-2bc0f9b373cd" />

Ces informations sont principalement redondantes avec celles déjà disponible sur les spans des traces et complique la lecture de la requête.

## 🌈 Proposition

Enlever le commentaire du texte qui est enregistré dans l'attribut `db.statement` de la span générée par `@opentelemetry/instrumentation-pg` :
<img width="343" height="77" alt="image" src="https://github.com/user-attachments/assets/3cfb2a9c-c0f7-49e4-a451-a5928fb6590f" />


## 🎉 Pour tester

- Lancer l'API avec la variable d'environnement OTEL_ENABLED=true
- Lancer un collecteur (et/ou outil de visualisation de traces) OpenTelemetry comme [otel-tui](https://github.com/ymtdzzz/otel-tui) ou [otel-gui](https://github.com/metafab/otel-gui).
- Lancer `mon-pix`, et se connecter.
- Attendre quelques secondes
- Dans l'outil de visualisation de traces, constater que les spans de requêtes PostgreSQL ne contiennent pas de commentaire dans leur attribut `db.statement`.
