### PR TITLE
[FEATURE] Refonte design de la page de création de schéma de parcours combiné sur PixAdmin (PIX-23011)

### DIFF
--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -1,19 +1,22 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { and, eq, gt, not, or } from 'ember-truth-helpers';
-import PixFieldset from 'pix-admin/components/ui/pix-fieldset';
 
-import RequirementTag from '../common/combined-courses/requirement-tag';
+import Card from '../card';
 import TubesSelection from '../common/tubes-selection';
 import SelectAttestation from './select-attestation';
 
@@ -22,10 +25,12 @@ export default class CombinedCourseBlueprintForm extends Component {
   @service store;
   @service intl;
   @service router;
-  @tracked itemType = 'targetProfile';
+  @tracked itemType = 'evaluation';
   @tracked itemValue = '';
   @tracked blueprint;
   @tracked selectedTubes;
+  @tracked itemAddDisabled = true;
+  @tracked itemToAdd = null;
 
   constructor() {
     super(...arguments);
@@ -38,46 +43,45 @@ export default class CombinedCourseBlueprintForm extends Component {
   }
 
   @action
-  async addItem(event) {
+  addItem(event) {
     event.preventDefault();
+
+    this.addToContent();
+
+    this.itemValue = null;
+    document.getElementsByName('itemType')[0].focus();
+  }
+
+  addToContent() {
+    this.blueprint.content = [...this.blueprint.content, this.itemToAdd];
+  }
+
+  async previewItem() {
+    this.itemToAdd = null;
+
     try {
-      if (this.itemType === 'targetProfile') {
-        await this.addTargetProfile();
+      if (this.itemType === 'module') {
+        const module = await this.store.findRecord('module', this.itemValue);
+        this.itemToAdd = {
+          type: 'module',
+          value: module.id,
+          label: module.title,
+          shortId: module.shortId,
+          image: module.details.image,
+        };
       } else {
-        await this.addModule();
+        const targetProfile = await this.store.findRecord('target-profile', this.itemValue);
+        this.itemToAdd = {
+          type: 'evaluation',
+          value: Number(this.itemValue),
+          label: targetProfile.internalName,
+          image: targetProfile.imageUrl,
+        };
       }
     } catch (responseError) {
       this.#handleErrorForResource(this.itemType, responseError);
-    } finally {
-      this.itemValue = null;
-      document.getElementsByName('itemType')[0].focus();
+      this.itemAddDisabled = true;
     }
-  }
-
-  async addTargetProfile() {
-    const targetProfile = await this.store.findRecord('target-profile', this.itemValue);
-    this.blueprint.content = [
-      ...this.blueprint.content,
-      {
-        type: 'evaluation',
-        value: Number(this.itemValue),
-        label: targetProfile.internalName,
-      },
-    ];
-  }
-
-  async addModule() {
-    const module = await this.store.findRecord('module', this.itemValue);
-
-    this.blueprint.content = [
-      ...this.blueprint.content,
-      {
-        type: 'module',
-        value: module.id,
-        shortId: module.shortId,
-        label: module.title,
-      },
-    ];
   }
 
   #handleErrorForResource(resourceName, responseError) {
@@ -135,11 +139,22 @@ export default class CombinedCourseBlueprintForm extends Component {
   @action
   setItemType(e) {
     this.itemType = e.target.value;
+    if (this.itemValue === '') {
+      this.itemAddDisabled = true;
+    }
   }
 
   @action
-  setItemValue(e) {
+  async setItemValue(e) {
     this.itemValue = e.target.value;
+
+    if (this.itemValue === '') {
+      this.itemAddDisabled = true;
+      this.itemToAdd = null;
+    } else {
+      this.itemAddDisabled = false;
+      await this.previewItem();
+    }
   }
 
   @action
@@ -151,8 +166,10 @@ export default class CombinedCourseBlueprintForm extends Component {
   }
 
   @action
-  removeRequirement({ type, value }) {
-    this.blueprint.content = this.blueprint.content.filter((item) => item.value !== value || item.type !== type);
+  removeRequirement(value) {
+    this.blueprint.content = this.blueprint.content.filter(
+      (item) => item.id !== value.id || item.shortId !== value.shortId,
+    );
   }
 
   @action
@@ -168,190 +185,295 @@ export default class CombinedCourseBlueprintForm extends Component {
     this.threshold = e.target.value;
   }
 
+  @action
+  goToListPage() {
+    this.router.transitionTo('authenticated.combined-course-blueprints.list');
+  }
+
+  @action
+  getItemColor(type) {
+    return type === 'evaluation' ? 'purple' : 'blue';
+  }
+
   <template>
-    <PixBlock @variant="admin" class="combined-course-page">
+    <form class="combined-course-blueprint-form">
+      <h1 class="combined-course-blueprint-form__title">
+        {{if
+          @updateMode
+          (t "components.combined-course-blueprints.update.title")
+          (t "components.combined-course-blueprints.create.title")
+        }}</h1>
 
-      <form class="combined-course-page__form">
-        <h1 class="combined-course-page__title">
-          {{if
-            @updateMode
-            (t "components.combined-course-blueprints.update.title")
-            (t "components.combined-course-blueprints.create.title")
-          }}</h1>
+      <GeneralInfoSection
+        @blueprint={{this.blueprint}}
+        @setData={{this.setData}}
+        @setAttestation={{this.setAttestation}}
+        @updateMode={{@updateMode}}
+        @model={{@model}}
+      />
 
-        {{#unless @updateMode}}
-          <PixFieldset>
-            <:title>
-              {{t "components.combined-course-blueprints.create.fieldsetElement"}}
-            </:title>
-            <:content>
-              <div class="combined-course-page__fieldset">
-                <PixRadioButton
-                  name="itemType"
-                  @value="targetProfile"
-                  checked={{if (eq this.itemType "targetProfile") "checked"}}
-                  {{on "change" this.setItemType}}
-                >
-                  <:label>{{t "components.combined-course-blueprints.labels.target-profile"}}</:label>
-                </PixRadioButton>
-                <PixRadioButton
-                  name="itemType"
-                  checked={{if (eq this.itemType "module") "checked"}}
-                  @value="module"
-                  {{on "change" this.setItemType}}
-                >
-                  <:label>{{t "components.combined-course-blueprints.labels.module"}}</:label>
-                </PixRadioButton>
-              </div>
-            </:content>
-          </PixFieldset>
+      {{#unless @updateMode}}
+        <ContentSection
+          @setItemType={{this.setItemType}}
+          @addItem={{this.addItem}}
+          @setItemValue={{this.setItemValue}}
+          @blueprint={{this.blueprint}}
+          @updateMode={{@updateMode}}
+          @handleKeyPress={{this.handleKeyPress}}
+          @removeRequirement={{this.removeRequirement}}
+          @itemAddDisabled={{this.itemAddDisabled}}
+          @itemToAdd={{this.itemToAdd}}
+          @getItemColor={{this.getItemColor}}
+        />
+      {{/unless}}
 
-          <div class="combined-course-page__form-addItem">
-            <PixInput
-              @id="itemId"
-              @value={{this.itemValue}}
-              @requiredLabel="Champ obligatoire"
-              {{on "change" this.setItemValue}}
-              {{on "keyup" this.handleKeyPress}}
-              class="combined-course-page__input"
-            >
-              <:label>
-                {{t "components.combined-course-blueprints.labels.itemId"}}
-              </:label>
-            </PixInput>
+      {{#if (or (and (not @updateMode) this.blueprint.rewardId) (and @updateMode this.blueprint.attestationLabel))}}
+        <RewardRequirementsSection
+          @blueprint={{this.blueprint}}
+          @setData={{this.setData}}
+          @updateMode={{@updateMode}}
+          @model={{@model}}
+          @updateTubes={{this.updateTubes}}
+          @onThresholdChange={{this.onThresholdChange}}
+          @selectedTubes={{this.selectedTubes}}
+        />
+      {{/if}}
 
-            <PixButton @triggerAction={{this.addItem}} class="combined-course-page__button">{{t
-                "components.combined-course-blueprints.create.addItemButton"
-              }}</PixButton>
-          </div>
-          <hr class="combined-course-page__separator" />
-        {{/unless}}
-
-        <PixInput
-          @id="internalName"
-          @value={{this.blueprint.internalName}}
-          @requiredLabel="Champ obligatoire"
-          {{on "change" (fn this.setData "internalName")}}
-          class="combined-course-page__input"
-        >
-          <:label>
-            {{t "components.combined-course-blueprints.labels.internal-name"}}
-          </:label>
-        </PixInput>
-
-        <PixInput
-          @id="name"
-          @value={{this.blueprint.name}}
-          @requiredLabel="Champ obligatoire"
-          {{on "change" (fn this.setData "name")}}
-          class="combined-course-page__input"
-        >
-          <:label>
-            {{t "components.combined-course-blueprints.labels.name"}}
-          </:label>
-        </PixInput>
-
-        <PixInput
-          @id="illustration"
-          @value={{this.blueprint.illustration}}
-          {{on "change" (fn this.setData "illustration")}}
-          class="combined-course-page__input"
-        >
-          <:label>
-            {{t "components.combined-course-blueprints.labels.illustration"}}
-
-          </:label>
-        </PixInput>
-
-        <PixTextarea
-          @id="description"
-          @value={{this.blueprint.description}}
-          {{on "change" (fn this.setData "description")}}
-          class="combined-course-page__input"
-          rows="10"
-        >
-          <:label>
-            {{t "components.combined-course-blueprints.labels.description"}}
-
-          </:label>
-        </PixTextarea>
-
-        {{#unless @updateMode}}
-          <SelectAttestation
-            @attestations={{@model.attestations}}
-            @value={{this.blueprint.rewardId}}
-            @onChange={{this.setAttestation}}
-          />
-        {{/unless}}
-
-        {{#if (or (and (not @updateMode) this.blueprint.rewardId) (and @updateMode this.blueprint.attestationLabel))}}
-          <PixTextarea
-            @id="reward-requirements"
-            @value={{this.blueprint.rewardRequirements}}
-            {{on "change" (fn this.setData "rewardRequirements")}}
-            class="combined-course-page__input"
-            rows="5"
-          >
-            <:label>
-              {{t "components.combined-course-blueprints.labels.reward-requirements"}}
-            </:label>
-          </PixTextarea>
-        {{/if}}
-
-        {{#unless @updateMode}}
-          {{#if this.blueprint.rewardId}}
-            <TubesSelection @frameworks={{@model.frameworks}} @onChange={{this.updateTubes}} />
-            {{#if this.selectedTubes.length}}
-              <PixInput
-                @id="blueprintThreshold"
-                class="combined-course-page__threshold"
-                type="number"
-                min="0"
-                max="100"
-                @requiredLabel={{t "common.forms.mandatory"}}
-                {{on "change" this.onThresholdChange}}
-              >
-                <:label>Taux de réussite requis</:label>
-              </PixInput>
-            {{/if}}
-          {{/if}}
-        {{/unless}}
-
-        <PixInput
-          @id="surveyLink"
-          @value={{this.blueprint.surveyLink}}
-          {{on "change" (fn this.setData "surveyLink")}}
-          class="combined-course-page__input"
-          rows="10"
-        >
-          <:label>
-            {{t "components.combined-course-blueprints.labels.survey-link"}}
-          </:label>
-        </PixInput>
-      </form>
-
-      <div class="combined-course-page__items">
-        <h2 class="combined-course-page__title">
-          {{t "components.combined-course-blueprints.create.courseContent"}}</h2>
-
-        {{#if (gt this.blueprint.content.length 0)}}
-          <ul class="combined-course-page__list">
-            {{#each this.blueprint.content as |item|}}
-              <li>
-                <RequirementTag @requirement={{item}} @onRemove={{unless @updateMode this.removeRequirement}} />
-              </li>
-            {{/each}}
-          </ul>
-        {{else}}
-          <p> {{t "components.combined-course-blueprints.create.contentFeedback"}}</p>
-        {{/if}}
-
-        <PixButton class="combined-course-page__button" @triggerAction={{this.save}} @variant="success">{{if
+      <fieldset class="controls">
+        <PixButton class="combined-course-blueprint-form__button" @triggerAction={{this.save}} @variant="secondary">{{t
+            "common.actions.cancel"
+          }}</PixButton>
+        <PixButton class="combined-course-blueprint-form__button" @triggerAction={{this.save}} @variant="success">{{if
             @updateMode
             (t "components.combined-course-blueprints.update.updateButton")
             (t "components.combined-course-blueprints.create.createButton")
           }}</PixButton>
-      </div>
-    </PixBlock>
+      </fieldset>
+    </form>
   </template>
 }
+
+const GeneralInfoSection = <template>
+  <Card
+    class="combined-course-blueprint-form__card"
+    @title={{t "components.combined-course-blueprints.create.generalInfoCardTitle"}}
+  >
+    <PixInput
+      @id="internalName"
+      @value={{@blueprint.internalName}}
+      @requiredLabel="Champ obligatoire"
+      {{on "change" (fn @setData "internalName")}}
+    >
+      <:label>
+        {{t "components.combined-course-blueprints.labels.internal-name"}}
+      </:label>
+    </PixInput>
+
+    <PixInput
+      @id="name"
+      @value={{@blueprint.name}}
+      @requiredLabel="Champ obligatoire"
+      {{on "change" (fn @setData "name")}}
+      @subLabel="Ce titre sera visible par les utilisateurs"
+    >
+      <:label>
+        {{t "components.combined-course-blueprints.labels.name"}}
+      </:label>
+    </PixInput>
+
+    <PixInput @id="illustration" @value={{@blueprint.illustration}} {{on "change" (fn @setData "illustration")}}>
+      <:label>
+        {{t "components.combined-course-blueprints.labels.illustration"}}
+
+      </:label>
+    </PixInput>
+
+    <PixTextarea
+      @id="description"
+      @value={{@blueprint.description}}
+      {{on "change" (fn @setData "description")}}
+      rows="10"
+      @subLabel={{t "components.combined-course-blueprints.labels.description-sublabel"}}
+    >
+      <:label>
+        {{t "components.combined-course-blueprints.labels.description"}}
+      </:label>
+    </PixTextarea>
+    <PixInput @id="surveyLink" @value={{@blueprint.surveyLink}} {{on "change" (fn @setData "surveyLink")}} rows="10">
+      <:label>
+        {{t "components.combined-course-blueprints.labels.survey-link"}}
+      </:label>
+    </PixInput>
+    {{#unless @updateMode}}
+      <SelectAttestation
+        @attestations={{@model.attestations}}
+        @value={{@blueprint.rewardId}}
+        @onChange={{@setAttestation}}
+      />
+    {{/unless}}
+
+  </Card>
+</template>;
+
+const ContentSection = <template>
+  <Card
+    class="combined-course-blueprint-form__card"
+    @title={{t "components.combined-course-blueprints.create.content"}}
+  >
+    <div class="content-section">
+      <div class="content-section__add-items-column">
+        <fieldset class="content-section__add-items-column--options">
+          <legend>{{t "components.combined-course-blueprints.create.fieldsetElement"}}</legend>
+          <PixRadioButton
+            name="itemType"
+            @value="evaluation"
+            checked={{if (eq @itemType "evaluation") "checked"}}
+            {{on "change" @setItemType}}
+          >
+            <:label>{{t "components.combined-course-blueprints.labels.target-profile"}}</:label>
+          </PixRadioButton>
+          <PixRadioButton
+            name="itemType"
+            checked={{if (eq @itemType "module") "checked"}}
+            @value="module"
+            {{on "change" @setItemType}}
+          >
+            <:label>{{t "components.combined-course-blueprints.labels.module"}}</:label>
+          </PixRadioButton>
+        </fieldset>
+        <div class="content-section__add-item">
+          <PixInput
+            @id="itemId"
+            @value={{@itemValue}}
+            @requiredLabel="Champ obligatoire"
+            {{on "change" @setItemValue}}
+            {{on "keyup" @handleKeyPress}}
+            class="combined-course-blueprint-form__input"
+          >
+            <:label>
+              {{t "components.combined-course-blueprints.labels.itemId"}}
+            </:label>
+          </PixInput>
+        </div>
+        {{#if @itemToAdd}}
+          <Card class="combined-course-blueprint-form__card--item-to-add">
+            <div class="combined-course-blueprint-form__card--image">
+              <img src={{@itemToAdd.image}} alt={{@itemToAdd.label}} />
+            </div>
+            <div class="combined-course-blueprint-form__card--item-to-add-text">
+              <PixTag class="combined-course-blueprint-form__card--requirement-tag">{{@itemToAdd.type}}</PixTag>
+              {{#if (eq @itemToAdd.type "module")}}
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://app.recette.pix.fr/modules/{{@requirement.shortId}}/slug/details"
+                >{{@itemToAdd.label}}</a>
+              {{/if}}
+              {{#if (eq @itemToAdd.type "evaluation")}}
+                <LinkTo
+                  @route="authenticated.target-profiles.target-profile.details"
+                  @model={{@requirement.value}}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{@itemToAdd.label}}
+                </LinkTo>
+              {{/if}}
+            </div>
+          </Card>
+        {{/if}}
+        <PixButton
+          @isDisabled={{@itemAddDisabled}}
+          @variant="secondary"
+          @triggerAction={{@addItem}}
+          class="combined-course-blueprint-form__button"
+        >{{t "components.combined-course-blueprints.create.addItemButton"}}</PixButton>
+      </div>
+      <div class="content-section__items-preview-column">
+        <h3 class="content-section__title">
+          {{t "components.combined-course-blueprints.create.courseContent"}}</h3>
+        <div>
+          {{#if (gt @blueprint.content.length 0)}}
+            <PixTable @variant="admin" @data={{@blueprint.content}} class="table">
+              <:columns as |row context|>
+                <PixTableColumn @context={{context}}>
+                  <:header>
+                    {{t "components.combined-course-blueprints.items.item-type-header"}}
+                  </:header>
+                  <:cell>
+                    <PixTag @color={{@getItemColor row.type}}>{{row.type}}</PixTag>
+                  </:cell>
+                </PixTableColumn>
+                <PixTableColumn @context={{context}}>
+                  <:header>
+                    {{t "components.combined-course-blueprints.items.item-name-header"}}
+                  </:header>
+                  <:cell>
+                    {{#if (eq row.type "MODULE")}}
+                      {{row.shortId}}
+                    {{else}}
+                      {{row.id}}
+                    {{/if}}
+                    {{row.label}}
+                  </:cell>
+                </PixTableColumn>
+                <PixTableColumn @context={{context}}>
+                  <:header>
+                    {{t "components.combined-course-blueprints.items.action-header"}}
+                  </:header>
+                  <:cell>
+                    <PixIconButton
+                      @iconName="delete"
+                      @triggerAction={{fn @removeRequirement row}}
+                      @ariaLabel="Supprimer"
+                    />
+                  </:cell>
+                </PixTableColumn>
+              </:columns>
+
+            </PixTable>
+          {{else}}
+            <p> {{t "components.combined-course-blueprints.create.contentFeedback"}}</p>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+  </Card>
+</template>;
+
+const RewardRequirementsSection = <template>
+  <Card
+    class="combined-course-blueprint-form__card"
+    @title={{t "components.combined-course-blueprints.create.attestations"}}
+  >
+    <PixTextarea
+      @id="reward-requirements"
+      @value={{@blueprint.rewardRequirements}}
+      {{on "change" (fn @setData "rewardRequirements")}}
+      rows="10"
+    >
+      <:label>
+        {{t "components.combined-course-blueprints.labels.reward-requirements"}}
+      </:label>
+    </PixTextarea>
+
+    {{#unless @updateMode}}
+      {{#if @blueprint.rewardId}}
+        <TubesSelection @frameworks={{@model.frameworks}} @onChange={{@updateTubes}} />
+        {{#if @selectedTubes.length}}
+          <PixInput
+            @id="blueprintThreshold"
+            class="combined-course-blueprint-form__threshold"
+            type="number"
+            min="0"
+            max="100"
+            @requiredLabel={{t "common.forms.mandatory"}}
+            {{on "change" @onThresholdChange}}
+          >
+            <:label>Taux de réussite requis</:label>
+          </PixInput>
+        {{/if}}
+      {{/if}}
+    {{/unless}}
+  </Card>
+</template>;

--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -1,57 +1,44 @@
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
-import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 
-const getItemColor = (type) => (type === 'evaluation' ? 'purple' : 'blue');
-const getItemType = (type) =>
-  type === 'evaluation'
+function getItemColor(type) {
+  return type === 'evaluation' ? 'purple' : 'blue';
+}
+
+function getItemType(type) {
+  return type === 'evaluation'
     ? 'components.combined-course-blueprints.items.targetProfile'
     : 'components.combined-course-blueprints.items.module';
-
-export default class RequirementTag extends Component {
-  @action
-  onRemove() {
-    this.args.onRemove?.({ type: this.args.requirement.type, value: this.args.requirement.value });
-  }
-
-  get displayRemoveButton() {
-    return this.args.onRemove;
-  }
-
-  <template>
-    <PixTag
-      @color={{getItemColor @requirement.type}}
-      @displayRemoveButton={{this.displayRemoveButton}}
-      @onRemove={{this.onRemove}}
-    >
-      {{#if (eq @requirement.type "evaluation")}}
-        <LinkTo
-          @route="authenticated.target-profiles.target-profile.details"
-          @model={{@requirement.value}}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {{t (getItemType @requirement.type)}}
-          -
-          {{@requirement.value}}
-          -
-          {{@requirement.label}}</LinkTo>
-      {{else}}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://app.recette.pix.fr/modules/{{@requirement.shortId}}/slug/details"
-        >
-          {{t (getItemType @requirement.type)}}
-          -
-          {{@requirement.shortId}}
-          -
-          {{@requirement.label}}
-        </a>
-      {{/if}}
-    </PixTag>
-  </template>
 }
+<template>
+  <PixTag @color={{getItemColor @requirement.type}}>
+    {{#if (eq @requirement.type "evaluation")}}
+      <LinkTo
+        @route="authenticated.target-profiles.target-profile.details"
+        @model={{@requirement.value}}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {{t (getItemType @requirement.type)}}
+        -
+        {{@requirement.value}}
+        -
+        {{@requirement.label}}
+      </LinkTo>
+    {{else}}
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://app.recette.pix.fr/modules/{{@requirement.shortId}}/slug/details"
+      >
+        {{t (getItemType @requirement.type)}}
+        -
+        {{@requirement.shortId}}
+        -
+        {{@requirement.label}}
+      </a>
+    {{/if}}
+  </PixTag>
+</template>

--- a/admin/app/models/module.js
+++ b/admin/app/models/module.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class Module extends Model {
   @attr('string') shortId;
   @attr('string') title;
+  @attr() details;
 }

--- a/admin/app/styles/components/combined-course/form.scss
+++ b/admin/app/styles/components/combined-course/form.scss
@@ -1,41 +1,56 @@
 @use 'pix-design-tokens/typography';
 
-.combined-course-page {
-  display: flex;
-  flex-direction: row;
-  gap: var(--pix-spacing-6x);
-  justify-content: space-around;
-  padding-top: var(--pix-spacing-8x);
-  padding-bottom: var(--pix-spacing-8x);
+.combined-course-blueprint-form {
+  display: inline-flex;
+  flex: 0 1 30rem;
+  flex-direction: column;
+  gap: var(--pix-spacing-5x);
+  align-items: flex-start;
+  width: 100%;
+  padding: var(--pix-spacing-6x);
+
+  &__card {
+    width: 100%;
+
+    &--requirement-tag {
+      width: fit-content;
+    }
+
+    &--image{
+      display: flex;
+      flex-direction: column;
+      width: 30%;
+    }
+
+    &--item-to-add {
+      .card__content {
+        display: flex;
+        flex-direction: row;
+        gap: var(--pix-spacing-3x, 12px);
+        align-items: center;
+        align-self: stretch;
+        padding: var(--pix-spacing-3x, 12px);
+      }
+
+      p {
+        @extend %pix-title-xxs;
+      }
+
+    }
+
+    &--item-to-add-text {
+     display: flex;
+     flex-direction: column;
+     gap: var(--pix-spacing-3x);
+    }
+  }
 
   &__title {
     @extend %pix-title-m;
   }
 
-  &__form {
-    display: inline-flex;
-    flex: 0 1 30rem;
-    flex-direction: column;
-    gap: var(--pix-spacing-6x);
-  }
-
-  &__form-addItem {
-    display: inline-flex;
-    gap: var(--pix-spacing-4x);
-    align-items: end;
-  }
-
-  &__input {
-    max-width: 30rem;
-  }
-
   &__button {
     width: fit-content;
-  }
-
-  &__separator {
-    margin-right: 0;
-    margin-left: 0;
   }
 
   &__list {
@@ -44,26 +59,86 @@
     gap: var(--pix-spacing-3x);
   }
 
-  &__fieldset {
-    display: inline-flex;
-    gap: var(--pix-spacing-4x);
-    align-items: center;
-
-    .pix-radio-button {
-      margin-top: 0;
-    }
-  }
-
-  &__items {
-    display: inline-flex;
-    flex: 0 0 50%;
-    flex-direction: column;
-    gap: var(--pix-spacing-4x);
-  }
-
   &__threshold {
       width: 134px;
-      margin-bottom: 16px;
+      margin-bottom: var(--pix-spacing-4x);
   }
 
 }
+
+.pix-radio-button + .pix-radio-button {
+  margin-top: 0;
+}
+
+.card__content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--pix-spacing-6x);
+      margin-top: var(--pix-spacing-3x);
+      margin-bottom: var(--pix-spacing-4x);
+}
+
+.controls {
+  display: flex;
+  gap: var(--pix-spacing-6x);
+}
+
+.content-section {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-4x);
+    align-self: stretch;
+
+    h3 {
+       @extend %pix-title-xxs;
+    }
+
+    &__add-item {
+    display: inline-flex;
+    gap: var(--pix-spacing-4x);
+    align-items: end;
+
+    label {
+      @extend %pix-body-s;
+
+      margin-bottom: var(--pix-spacing-2x);
+     font-weight: var(--pix-font-bold);
+    }
+
+    .pix-input {
+      width: 100%;
+    }
+  }
+
+  &__add-items-column {
+
+    legend {
+     @extend %pix-body-s;
+
+     margin-bottom: var(--pix-spacing-2x);
+     font-weight: var(--pix-font-bold);
+    }
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-6x);
+    width: 50%;
+
+    &--options {
+    display: flex;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+  }
+  }
+
+
+   &__items-preview-column {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-3x);
+    width: 100%;
+    padding: var(--pix-spacing-6x);
+    background: var(--pix-primary-50);
+    border-radius: var(--pix-spacing-4x);
+  }
+  }

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
@@ -54,7 +54,10 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
       'illustrations/hello.svg',
     );
 
-    await fillIn(screen.getByLabelText(t('components.combined-course-blueprints.labels.description')), 'description');
+    await fillIn(
+      screen.getByLabelText(t('components.combined-course-blueprints.labels.description-sublabel'), { exact: false }),
+      'description',
+    );
 
     await click(
       screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/update-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/update-combined-course-blueprint-test.js
@@ -64,7 +64,10 @@ module('Acceptance | Combined course blueprint | Update', function (hooks) {
       'illustrations/hello.svg',
     );
 
-    await fillIn(screen.getByLabelText(t('components.combined-course-blueprints.labels.description')), 'description');
+    await fillIn(
+      screen.getByLabelText(t('components.combined-course-blueprints.labels.description-sublabel'), { exact: false }),
+      'description',
+    );
     await fillIn(
       screen.getByRole('textbox', { name: t('components.combined-course-blueprints.labels.reward-requirements') }),
       'New reward requirements',

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -15,13 +15,126 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       // given
       const store = this.owner.lookup('service:store');
       const pixToast = this.owner.lookup('service:pixToast');
-      const blueprintStub = { save: sinon.stub().resolves(), content: [] };
+      const blueprintStub = store.createRecord('combined-course-blueprint', {
+        content: [],
+        save: sinon.stub().resolves(),
+      });
       const pixToastSuccessStub = sinon.stub(pixToast, 'sendSuccessNotification');
       const router = this.owner.lookup('service:router');
       sinon.stub(router, 'transitionTo');
       router.transitionTo.resolves();
 
       sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
+      const findRecordStub = sinon.stub(store, 'findRecord');
+      findRecordStub.withArgs('module', 'module-123').resolves({
+        id: 'full-id-module-123',
+        shortId: 'module-123',
+        title: 'module 123',
+        details: { image: 'image' },
+      });
+      findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc', imageUrl: 'imageUrl' });
+
+      const attestations = [
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
+      ];
+      const frameworks = [
+        {
+          id: 123,
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { attestations, frameworks };
+
+      //when
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
+
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
+        1,
+      );
+      await screen.findByRole('link', { name: 'super pc', exact: false });
+
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
+      );
+
+      await screen.findByRole('cell', { name: 'super pc', exact: false });
+
+      await click(screen.getByLabelText(t('components.combined-course-blueprints.labels.module')));
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
+        'module-123',
+      );
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
+      );
+
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.name'), { exact: false }),
+        'name',
+      );
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.internal-name'), { exact: false }),
+        'internalName',
+      );
+
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.illustration')),
+        'illustrations/hello.svg',
+      );
+
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.description'), { exact: false }),
+        'description',
+      );
+
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.survey-link')),
+        'http://survey-link.fr',
+      );
+
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+      );
+
+      await screen.findByRole('listbox');
+
+      await click(screen.getByRole('option', { name: 'Parentalite' }));
+
+      await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
+
+      //then
+      assert.ok(screen.getByRole('heading', { name: t('components.combined-course-blueprints.create.title') }));
+      sinon.assert.calledOnceWith(blueprintStub.save, { adapterOptions: null });
+      assert.ok(findRecordStub.calledTwice);
+      assert.strictEqual(blueprintStub.name, 'name');
+      assert.strictEqual(blueprintStub.internalName, 'internalName');
+      assert.deepEqual(blueprintStub.content, [
+        { type: 'evaluation', value: 1, label: 'super pc', image: 'imageUrl' },
+        { type: 'module', value: 'full-id-module-123', shortId: 'module-123', label: 'module 123', image: 'image' },
+      ]);
+      assert.strictEqual(blueprintStub.illustration, 'illustrations/hello.svg');
+      assert.strictEqual(blueprintStub.description, 'description');
+      assert.strictEqual(blueprintStub.surveyLink, 'http://survey-link.fr');
+      assert.strictEqual(blueprintStub.rewardId, 5);
+      assert.strictEqual(blueprintStub.rewardType, 'ATTESTATION');
+      assert.ok(
+        pixToastSuccessStub.calledOnceWith({
+          message: t('components.combined-course-blueprints.create.notifications.success'),
+        }),
+      );
+      sinon.assert.calledWithExactly(router.transitionTo, 'authenticated.combined-course-blueprints.list');
+    });
+
+    test('it should not allow user to add an item unless type option is checked and item id is filled', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const router = this.owner.lookup('service:router');
+      sinon.stub(router, 'transitionTo');
+      router.transitionTo.resolves();
+
       const findRecordStub = sinon.stub(store, 'findRecord');
       findRecordStub
         .withArgs('module', 'module-123')
@@ -44,73 +157,10 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       //when
       const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
-      await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
-        1,
-      );
-      await click(
-        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
-      );
-      await click(screen.getByLabelText(t('components.combined-course-blueprints.labels.module')));
-      await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
-        'module-123',
-      );
-      await click(
-        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
-      );
-      await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.name'), { exact: false }),
-        'name',
-      );
-      await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.internal-name'), { exact: false }),
-        'internalName',
-      );
-
-      await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.illustration')),
-        'illustrations/hello.svg',
-      );
-
-      await fillIn(screen.getByLabelText(t('components.combined-course-blueprints.labels.description')), 'description');
-
-      await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.survey-link')),
-        'http://survey-link.fr',
-      );
-
-      await click(
-        screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
-      );
-
-      await screen.findByRole('listbox');
-
-      await click(screen.getByRole('option', { name: 'Parentalite' }));
-
-      await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
-
       //then
-      assert.ok(screen.getByRole('heading', { name: t('components.combined-course-blueprints.create.title') }));
-      assert.ok(findRecordStub.calledTwice);
-      sinon.assert.calledOnceWith(blueprintStub.save, { adapterOptions: null });
-      assert.strictEqual(blueprintStub.name, 'name');
-      assert.strictEqual(blueprintStub.internalName, 'internalName');
-      assert.deepEqual(blueprintStub.content, [
-        { type: 'evaluation', value: 1, label: 'super pc' },
-        { type: 'module', value: 'full-id-module-123', shortId: 'module-123', label: 'module 123' },
-      ]);
-      assert.strictEqual(blueprintStub.illustration, 'illustrations/hello.svg');
-      assert.strictEqual(blueprintStub.description, 'description');
-      assert.strictEqual(blueprintStub.surveyLink, 'http://survey-link.fr');
-      assert.strictEqual(blueprintStub.rewardId, 5);
-      assert.strictEqual(blueprintStub.rewardType, 'ATTESTATION');
-      assert.ok(
-        pixToastSuccessStub.calledOnceWith({
-          message: t('components.combined-course-blueprints.create.notifications.success'),
-        }),
-      );
-      sinon.assert.calledWithExactly(router.transitionTo, 'authenticated.combined-course-blueprints.list');
+      assert
+        .dom(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }))
+        .hasAttribute('aria-disabled');
     });
 
     test('it should display tubes selection component only if the user selects an attestation', async function (assert) {
@@ -139,7 +189,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       await screen.findByRole('listbox');
 
       await click(screen.getByRole('option', { name: 'Parentalite' }));
-
       //then
       assert.ok(screen.getByRole('heading', { name: 'Sélection des sujets' }));
       assert.ok(
@@ -290,7 +339,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       );
 
       await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.description')),
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.description-sublabel'), { exact: false }),
         'updatedDescription',
       );
 
@@ -320,6 +369,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       assert.strictEqual(blueprint.rewardId, 5);
       assert.strictEqual(blueprint.rewardType, 'ATTESTATION');
       assert.strictEqual(blueprint.rewardRequirements, 'Updated requirements');
+
       assert.ok(
         pixToastSuccessStub.calledOnceWith({
           message: t('components.combined-course-blueprints.update.notifications.success'),
@@ -479,14 +529,15 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
         1,
       );
-      await click(
-        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
-      );
+
+      assert
+        .dom(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }))
+        .hasAttribute('aria-disabled');
 
       //then
       assert.ok(
         pixToastErrorStub.calledOnceWith({
-          message: t('components.combined-course-blueprints.create.notifications.targetProfileNotFound'),
+          message: t('components.combined-course-blueprints.create.notifications.evaluationNotFound'),
         }),
       );
     });
@@ -510,10 +561,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
         'module-123',
       );
-      await click(
-        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
-      );
-
       //then
       assert.ok(
         pixToastErrorStub.calledOnceWith({
@@ -582,17 +629,19 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       await click(
         screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
       );
+
       await click(screen.getByLabelText(t('components.combined-course-blueprints.labels.module')));
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
         'module123',
       );
+
       await click(
         screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
       );
 
-      assert.ok(screen.getByText(/Profil Cible - 1 - super pc/));
-      assert.ok(screen.getByText('Module - module123 - module 123'));
+      assert.ok(screen.getByText('Profil cible'));
+      assert.ok(screen.getByText('Module'));
     });
     test('it should remove item when user clicks on remove button', async function (assert) {
       // given
@@ -623,11 +672,11 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
       );
 
-      assert.ok(screen.getByText(/Profil Cible - 1 - super pc/));
+      assert.ok(screen.getByRole('cell', { name: /super pc/ }));
       await click(screen.getByRole('button', { name: 'Supprimer' }));
 
       //then
-      assert.notOk(screen.queryByText(/Profil Cible - 1 - super pc/));
+      assert.notOk(screen.queryByRole('cell', { name: /super pc/ }));
     });
   });
 });

--- a/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
+++ b/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
@@ -2,7 +2,6 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import RequirementTag from 'pix-admin/components/common/combined-courses/requirement-tag';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
@@ -36,34 +35,5 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
     assert.ok(screen.getByText(item.value, { exact: false }));
     assert.ok(screen.getByText(item.label, { exact: false }));
     assert.ok(link.getAttribute('href').endsWith(`/target-profiles/${item.value}/details`));
-  });
-
-  test('should call onRemove with value and type when remove button is clicked', async function (assert) {
-    const item = {
-      type: 'module',
-      value: 'full-id-abc-123',
-      shortId: 'abc-123',
-    };
-    const removeStub = sinon.stub();
-
-    const screen = await renderScreen(
-      <template><RequirementTag @requirement={{item}} @onRemove={{removeStub}} /></template>,
-    );
-
-    await screen.getByRole('button').click();
-
-    assert.ok(removeStub.calledOnceWith({ type: item.type, value: item.value }));
-  });
-
-  test('should hide remove button when onRemove is not provided', async function (assert) {
-    const item = {
-      type: 'module',
-      value: 'full-id-abc-123',
-      shortId: 'abc-123',
-    };
-
-    const screen = await renderScreen(<template><RequirementTag @requirement={{item}} /></template>);
-
-    assert.notOk(screen.queryByRole('button'));
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -681,28 +681,35 @@
       },
       "create": {
         "addItemButton": "Add",
+        "attestations": "Attestations",
+        "content": "Content",
         "contentFeedback": "Your course does not have any items yet.",
         "courseContent": "Course content",
         "createButton": "Create combined course blueprint",
         "fieldsetElement": "Choose the element type you want to add :",
+        "generalInfoCardTitle": "General information",
         "notifications": {
           "addItemError": "Oops. Resource not found.",
           "error": "Oops. Something went wrong. Please try again.",
+          "evaluationNotFound": "No target profile found with given id",
           "moduleNotFound": "No module found with given short id",
-          "success": "Combined course blueprint created successfully!",
-          "targetProfileNotFound": "No target profile found with given id"
+          "success": "Combined course blueprint created successfully!"
         },
         "title": "Create a combined course blueprint"
       },
       "items": {
+        "action-header": "Actions",
+        "item-name-header": "Item name",
+        "item-type-header": "Item type",
         "module": "Module",
         "targetProfile": "Target profile",
-        "title": "Course content"
+        "title": "Combined course blueprint content"
       },
       "labels": {
         "attestation": "Attestation",
         "created-at": "Creation date",
         "description": " Description",
+        "description-sublabel": "This description will be seen by users",
         "illustration": "Illustration",
         "internal-name": "Internal name",
         "itemId": "Id",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -689,28 +689,35 @@
       },
       "create": {
         "addItemButton": "Ajouter",
+        "attestations": "Les attestations",
+        "content": "Le contenu",
         "contentFeedback": "Votre parcours n'a aucun élément ajouté.",
         "courseContent": "Contenu du parcours",
         "createButton": "Créer le schéma de parcours",
         "fieldsetElement": "Choisissez le type d'élément à ajouter :",
+        "generalInfoCardTitle": "Informations générales",
         "notifications": {
           "addItemError": "Oups. Une erreur est survenue lors de l'ajout de la ressource.",
           "error": "Oups. Une erreur est survenue lors de la création du schéma de parcours.",
+          "evaluationNotFound": "Il n'existe pas de profil cible avec l'identifiant saisi",
           "moduleNotFound": "Il n'existe pas de module avec l'identifiant saisi",
-          "success": "Création du schéma de parcours réussie !",
-          "targetProfileNotFound": "Il n'existe pas de profil cible avec l'identifiant saisi"
+          "success": "Création du schéma de parcours réussie !"
         },
-        "title": "Créer un schéma de parcours"
+        "title": "Création d'un schéma de parcours"
       },
       "items": {
+        "action-header": "Actions",
+        "item-name-header": "Nom de l'élément",
+        "item-type-header": "Type d'élément",
         "module": "Module",
         "targetProfile": "Profil Cible",
-        "title": "Contenu du parcours"
+        "title": "Contenu du schéma de parcours"
       },
       "labels": {
         "attestation": "Attestation",
         "created-at": "Date de création",
         "description": "Description",
+        "description-sublabel": "Cette description sera visible par les utilisateurs",
         "illustration": "Illustration",
         "internal-name": "Nom interne",
         "itemId": "Identifiant",


### PR DESCRIPTION
## 🪧 Problème
Le design et l'UX de notre page de création de schéma de parcours combiné côté Admin avait grand besoin d'une refonte 🖌️ 👩‍🎨 .

## 🌈 Proposition
On suit la maquette proposée : https://www.figma.com/design/DgjTafZnGjt7bo87YUsi19/-WORK--Parcours-combin%C3%A9?node-id=4451-3108&p=f&m=dev

## ✊ Remarques
Le code a été refacto avec la création de 3 composants privés (un par section).
On a également modifié le comportement du composant RequirementTag pour les besoins de la refonte de la page.

## 🎉 Pour tester
Créer un schéma de parcours avec tous les attributs remplis et s'assurer que la création se passe bien avec une vérif en base.
