### PR TITLE
[TECH] Ajouter un script pour rattacher des centres de certifications à des organisations (PIX-22687)

### DIFF
--- a/api/src/organizational-entities/scripts/attach-certification-centers-to-organizations.js
+++ b/api/src/organizational-entities/scripts/attach-certification-centers-to-organizations.js
@@ -1,0 +1,195 @@
+import { setTimeout } from 'node:timers/promises';
+
+import Joi from 'joi';
+import _ from 'lodash';
+
+import { csvFileParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { batchUpdate } from '../../shared/infrastructure/utils/knex-utils.js';
+import { organizationForAdminRepository } from '../infrastructure/repositories/organization-for-admin.repository.js';
+
+export const csvSchema = [
+  {
+    name: 'organization_id',
+    schema: Joi.number().empty(['', null]).required().messages({ 'any.required': 'organization_id is required' }),
+  },
+  {
+    name: 'certification_center_id',
+    schema: Joi.number()
+      .empty(['', null])
+      .required()
+      .messages({ 'any.required': 'certification_center_id is required' }),
+  },
+];
+
+const DEFAULT_BATCH_SIZE = 1000;
+const DEFAULT_THROTTLE_DELAY = 300;
+
+export class AttachCertificationCentersToOrganizationsScript extends Script {
+  constructor() {
+    super({
+      description: 'Attach certification centers to organizations.',
+      permanent: true,
+      options: {
+        file: {
+          type: 'string',
+          describe: 'CSV file path',
+          demandOption: true,
+          requiresArg: true,
+          coerce: csvFileParser(csvSchema),
+        },
+        batchSize: {
+          type: 'number',
+          describe: 'Size of the batch of users to process',
+          default: DEFAULT_BATCH_SIZE,
+        },
+        throttleDelay: {
+          type: 'number',
+          describe: 'Delay between batches in milliseconds',
+          default: DEFAULT_THROTTLE_DELAY,
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Executes the script in dry run mode',
+          default: true,
+        },
+      },
+    });
+  }
+  async handle({ options, logger }) {
+    const { file, batchSize, throttleDelay, dryRun } = options;
+
+    if (dryRun) {
+      logger.info('Dry run mode: TRUE. Nothing will be committed to database.');
+    }
+
+    logger.info('Checking for duplicates ids...');
+    const allOrganizationIds = file.map((item) => item.organization_id);
+    const organizationIdsDuplicates = allOrganizationIds.filter(
+      (id, index) => allOrganizationIds.indexOf(id) !== index && allOrganizationIds.lastIndexOf(id) === index,
+    );
+
+    if (organizationIdsDuplicates.length) {
+      throw new Error(
+        `Organization ids ${organizationIdsDuplicates.join(', ')} have duplicates. Please ensure all organization ids are unique in the file.`,
+      );
+    }
+
+    const allCertificationCenterIds = file.map((item) => item.certification_center_id);
+    const certificationCenterIdsDuplicates = allCertificationCenterIds.filter(
+      (id, index) =>
+        allCertificationCenterIds.indexOf(id) !== index && allCertificationCenterIds.lastIndexOf(id) === index,
+    );
+
+    if (certificationCenterIdsDuplicates.length) {
+      throw new Error(
+        `Certification center ids ${certificationCenterIdsDuplicates.join(', ')} have duplicates. Please ensure all certification center ids are unique in the file.`,
+      );
+    }
+
+    const batches = _.chunk(file, batchSize);
+
+    let batchCount = 1;
+
+    logger.info(`${file.length} rows to process in ${batches.length} batch(es) of ${batchSize}.`);
+
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+
+      for (const batch of batches) {
+        logger.info(`Batch #${batchCount}/${batches.length} (${batch.length} rows)`);
+        batchCount++;
+
+        logger.info('Verifying organizations ids...');
+        const organizationIds = batch.map((row) => row.organization_id);
+        const certificationCenterIds = batch.map((row) => row.certification_center_id);
+
+        const existingOrganizationIds = await organizationForAdminRepository.findExistingIds({
+          ids: organizationIds,
+        });
+
+        if (existingOrganizationIds.length !== organizationIds.length) {
+          const missingOrganizationIds = organizationIds.filter((id) => !existingOrganizationIds.includes(id));
+          throw new Error(`Organizations with ids ${missingOrganizationIds.join(', ')} do not exist.`);
+        }
+
+        logger.info('Verifying organization structures...');
+        const organizationsWithStructureIds = await knexConn('fct_structures')
+          .select('organization_id')
+          .whereIn('organization_id', organizationIds)
+          .pluck('organization_id');
+
+        if (organizationsWithStructureIds.length !== organizationIds.length) {
+          const organizationsWithoutStructureIds = organizationIds.filter(
+            (id) => !organizationsWithStructureIds.includes(id),
+          );
+          throw new Error(
+            `Organizations with ids ${organizationsWithoutStructureIds.join(
+              ', ',
+            )} do not have a structure and cannot be attached to a certification center.`,
+          );
+        }
+
+        logger.info('Verifying certification centers ids...');
+        const existingCertificationCenterIds = await knexConn('certification-centers')
+          .select('id')
+          .whereIn('id', certificationCenterIds)
+          .pluck('id');
+
+        if (existingCertificationCenterIds.length !== certificationCenterIds.length) {
+          const missingCertificationCenterIds = certificationCenterIds.filter(
+            (id) => !existingCertificationCenterIds.includes(id),
+          );
+          throw new Error(`Certification centers with ids ${missingCertificationCenterIds.join(', ')} do not exist.`);
+        }
+
+        logger.info('Checking if organizations are not already attached...');
+        const alreadyAttachedOrganizationsIds = await knexConn('fct_structures')
+          .select('organization_id')
+          .whereIn('organization_id', organizationIds)
+          .whereNotNull('certification_center_id')
+          .pluck('organization_id');
+
+        if (alreadyAttachedOrganizationsIds.length) {
+          throw new Error(
+            `Organizations with ids ${alreadyAttachedOrganizationsIds.join(', ')} already have an attached certification center.`,
+          );
+        }
+
+        logger.info('Checking if certification centers are not already attached...');
+        const alreadyAttachedCertificationCentersIds = await knexConn('fct_structures')
+          .select('certification_center_id')
+          .whereIn('certification_center_id', certificationCenterIds)
+          .whereNotNull('organization_id')
+          .pluck('certification_center_id');
+
+        if (alreadyAttachedCertificationCentersIds.length) {
+          throw new Error(
+            `Certification centers with ids ${alreadyAttachedCertificationCentersIds.join(', ')} already have an attached organization.`,
+          );
+        }
+
+        logger.info('All checks ok, starting process of attachment...');
+        await batchUpdate({
+          tableName: 'fct_structures',
+          primaryKeyName: 'organization_id',
+          rows: batch,
+          chunkSize: batchSize,
+        });
+
+        await setTimeout(throttleDelay);
+      }
+
+      if (dryRun) {
+        logger.info(`Dry run mode. ${file.length} organizations to be attached to certification centers.`);
+        await knexConn.rollback();
+      } else {
+        logger.info(`${file.length} organizations attached to certification centers.`);
+      }
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, AttachCertificationCentersToOrganizationsScript);

--- a/api/tests/organizational-entities/integration/scripts/attach-certification-centers-to-organizations.test.js
+++ b/api/tests/organizational-entities/integration/scripts/attach-certification-centers-to-organizations.test.js
@@ -1,0 +1,288 @@
+import * as url from 'node:url';
+
+import sinon from 'sinon';
+
+import { expect } from '../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../tooling/databases.js';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+import { AttachCertificationCentersToOrganizationsScript } from '../../../../src/organizational-entities/scripts/attach-certification-centers-to-organizations.js';
+import { catchErr } from '../../../tooling/test-utils/error.js';
+
+describe('Integration | Organizational Entities | Scripts | Attach certification centers to organizations', function () {
+  it('parses CSV file correctly', async function () {
+    // given
+    const testCsvFile = `${currentDirectory}files/orga_cdc_attachment_test_file.csv`;
+    const script = new AttachCertificationCentersToOrganizationsScript();
+    const expectedFileData = [
+      { organization_id: 1, certification_center_id: 10 },
+      { organization_id: 2, certification_center_id: 20 },
+      { organization_id: 3, certification_center_id: 30 },
+      { organization_id: 4, certification_center_id: 40 },
+      { organization_id: 5, certification_center_id: 50 },
+      { organization_id: 6, certification_center_id: 60 },
+      { organization_id: 7, certification_center_id: 70 },
+      { organization_id: 8, certification_center_id: 80 },
+      { organization_id: 9, certification_center_id: 90 },
+    ];
+
+    // when
+    const { options } = script.metaInfo;
+    const fileData = await options.file.coerce(testCsvFile);
+
+    // then
+    expect(fileData).to.deep.equal(expectedFileData);
+  });
+
+  describe('#handle', function () {
+    let script;
+    let logger;
+
+    beforeEach(function () {
+      script = new AttachCertificationCentersToOrganizationsScript();
+      logger = { info: sinon.stub(), error: sinon.stub() };
+    });
+
+    describe('Error cases', function () {
+      context('File integrity', function () {
+        context('When there are duplicates in organization ids', function () {
+          it('throws an error with the duplicate ids', async function () {
+            const file = [
+              { organization_id: 1, certification_center_id: 10 },
+              { organization_id: 1, certification_center_id: 20 },
+              { organization_id: 2, certification_center_id: 20 },
+            ];
+
+            // when
+            const error = await catchErr(script.handle)({ options: { file, batchSize: 2 }, logger });
+
+            // then
+            expect(error).to.be.an.instanceOf(Error);
+            expect(error.message).to.equal(
+              'Organization ids 1 have duplicates. Please ensure all organization ids are unique in the file.',
+            );
+          });
+        });
+
+        context('When there are duplicates in certification centers ids', function () {
+          it('throws an error with the duplicate ids', async function () {
+            const file = [
+              { organization_id: 1, certification_center_id: 10 },
+              { organization_id: 2, certification_center_id: 10 },
+              { organization_id: 3, certification_center_id: 20 },
+              { organization_id: 4, certification_center_id: 20 },
+            ];
+
+            // when
+            const error = await catchErr(script.handle)({ options: { file, batchSize: 2 }, logger });
+
+            // then
+            expect(error).to.be.an.instanceOf(Error);
+            expect(error.message).to.equal(
+              'Certification center ids 10, 20 have duplicates. Please ensure all certification center ids are unique in the file.',
+            );
+          });
+        });
+      });
+      context('When some organizations do not exist', function () {
+        it('throws an error with the missing organization ids', async function () {
+          // given
+          const file = [
+            { organization_id: 1, certification_center_id: 10 },
+            { organization_id: 2, certification_center_id: 20 },
+            { organization_id: 3, certification_center_id: 30 },
+          ];
+
+          databaseBuilder.factory.buildOrganization({ id: 1 });
+
+          await databaseBuilder.commit();
+
+          // when
+          const error = await catchErr(script.handle)({ options: { file, batchSize: 3 }, logger });
+
+          // then
+          expect(error).to.be.an.instanceOf(Error);
+          expect(error.message).to.equal('Organizations with ids 2, 3 do not exist.');
+        });
+      });
+
+      context('When some certification centers do not exist', function () {
+        it('throws an error with the missing certification center ids', async function () {
+          // given
+          const file = [
+            { organization_id: 1, certification_center_id: 10 },
+            { organization_id: 2, certification_center_id: 20 },
+            { organization_id: 3, certification_center_id: 30 },
+          ];
+
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 1 } });
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 2 } });
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 3 } });
+
+          databaseBuilder.factory.buildCertificationCenter({ id: 10 });
+
+          await databaseBuilder.commit();
+
+          // when
+          const error = await catchErr(script.handle)({ options: { file, batchSize: 3 }, logger });
+
+          // then
+          expect(error).to.be.an.instanceOf(Error);
+          expect(error.message).to.equal('Certification centers with ids 20, 30 do not exist.');
+        });
+      });
+
+      context('When some organizations do not have a structure', function () {
+        it('throws an error with the organization ids', async function () {
+          // given
+          const file = [
+            { organization_id: 1, certification_center_id: 10 },
+            { organization_id: 2, certification_center_id: 20 },
+            { organization_id: 3, certification_center_id: 30 },
+          ];
+
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 1 } });
+          databaseBuilder.factory.buildOrganization({ id: 2 });
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 3 } });
+          await databaseBuilder.commit();
+
+          // when
+          const error = await catchErr(script.handle)({ options: { file, batchSize: 3 }, logger });
+
+          // then
+          expect(error).to.be.an.instanceOf(Error);
+          expect(error.message).to.equal(
+            'Organizations with ids 2 do not have a structure and cannot be attached to a certification center.',
+          );
+        });
+      });
+
+      context('When some organizations already have an attached certification center', function () {
+        it('throws an error with organization ids', async function () {
+          // given
+          databaseBuilder.factory.buildCertificationCenter({ id: 10 });
+          databaseBuilder.factory.buildCertificationCenter({ id: 20 });
+          databaseBuilder.factory.buildCertificationCenter({ id: 30 });
+          databaseBuilder.factory.buildCertificationCenter({ id: 40 });
+
+          databaseBuilder.factory.buildOrganizationWithStructure({
+            organizationData: { id: 1 },
+            certificationCenterId: 10,
+          });
+          databaseBuilder.factory.buildOrganizationWithStructure({
+            organizationData: { id: 2 },
+            certificationCenterId: 20,
+          });
+
+          await databaseBuilder.commit();
+
+          const file = [
+            { organization_id: 1, certification_center_id: 30 },
+            { organization_id: 2, certification_center_id: 40 },
+          ];
+
+          // when
+          const error = await catchErr(script.handle)({ options: { file, batchSize: 3 }, logger });
+
+          // then
+          expect(error).to.be.an.instanceOf(Error);
+          expect(error.message).to.equal('Organizations with ids 1, 2 already have an attached certification center.');
+        });
+      });
+
+      context('When some certification centers already have an attached organization', function () {
+        it('throws an error with certification center ids', async function () {
+          // given
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 1 } });
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 2 } });
+
+          databaseBuilder.factory.buildCertificationCenter({ id: 10 });
+          databaseBuilder.factory.buildCertificationCenter({ id: 20 });
+
+          databaseBuilder.factory.buildOrganizationWithStructure({
+            organizationData: { id: 3 },
+            certificationCenterId: 10,
+          });
+          databaseBuilder.factory.buildOrganizationWithStructure({
+            organizationData: { id: 4 },
+            certificationCenterId: 20,
+          });
+
+          await databaseBuilder.commit();
+
+          const file = [
+            { organization_id: 1, certification_center_id: 10 },
+            { organization_id: 2, certification_center_id: 20 },
+          ];
+
+          // when
+          const error = await catchErr(script.handle)({ options: { file, batchSize: 3 }, logger });
+
+          // then
+          expect(error).to.be.an.instanceOf(Error);
+          expect(error.message).to.equal(
+            'Certification centers with ids 10, 20 already have an attached organization.',
+          );
+        });
+      });
+    });
+
+    describe('Success', function () {
+      context('when dryRun is set to false', function () {
+        it('should attach organizations to certification centers', async function () {
+          // given
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 1 } });
+          databaseBuilder.factory.buildCertificationCenter({ id: 10 });
+
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 2 } });
+          databaseBuilder.factory.buildCertificationCenter({ id: 20 });
+
+          await databaseBuilder.commit();
+
+          const file = [
+            { organization_id: 1, certification_center_id: 10 },
+            { organization_id: 2, certification_center_id: 20 },
+          ];
+
+          // when
+          await script.handle({ options: { file, batchSize: 1, dryRun: false }, logger });
+
+          // then
+          const fct_structures = await knex('fct_structures').select('organization_id', 'certification_center_id');
+          expect(fct_structures).to.deep.equal([
+            { organization_id: 1, certification_center_id: 10 },
+            { organization_id: 2, certification_center_id: 20 },
+          ]);
+        });
+      });
+
+      context('when dryRun is set to true', function () {
+        it('should not attach organizations to certification centers', async function () {
+          // given
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 1 } });
+          databaseBuilder.factory.buildCertificationCenter({ id: 10 });
+
+          databaseBuilder.factory.buildOrganizationWithStructure({ organizationData: { id: 2 } });
+          databaseBuilder.factory.buildCertificationCenter({ id: 20 });
+
+          await databaseBuilder.commit();
+
+          const file = [
+            { organization_id: 1, certification_center_id: 10 },
+            { organization_id: 2, certification_center_id: 20 },
+          ];
+
+          // when
+          await script.handle({ options: { file, batchSize: 1, dryRun: true }, logger });
+
+          // then
+          const fct_structures = await knex('fct_structures').select('organization_id', 'certification_center_id');
+          expect(fct_structures).to.deep.equal([
+            { organization_id: 1, certification_center_id: null },
+            { organization_id: 2, certification_center_id: null },
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/scripts/files/orga_cdc_attachment_test_file.csv
+++ b/api/tests/organizational-entities/integration/scripts/files/orga_cdc_attachment_test_file.csv
@@ -1,0 +1,10 @@
+organization_id,certification_center_id
+1,10
+2,20
+3,30
+4,40
+5,50
+6,60
+7,70
+8,80
+9,90


### PR DESCRIPTION
## 🪧 Problème

Il est désormais possible de rattacher une organisation à un centre de certification sur Pix Admin. Mais cette action se fait à la main via l'interface de Pix Admin. Il nous faut un moyen de pouvoir effectuer les rattachements de l'existant de façon automatisée.

## 🌈 Proposition

Faire un script qui prendra en entrée un fichier CSV avec deux colonnes: `organization_id` et `certification_center_id`. Ce script effectuera le rattachement en masse.

## ✊ Remarques

Gestion des erreurs:
- vérification de l'existence des ids d'organisations et centres de certif
- si une orga ou un centre de certif est déjà rattachée, on lève une erreur
- options disponibles sur le script:
	- `--dryRun=false` (`true` par défaut)
	- `--batchSize=5` (`1000` par défaut)
	- `--throttleDelay=1000` (`300`ms par défaut)

Pour info, le fichier CSV de prod à partir duquel le script sera executé contiendra environ 13000 lignes.

## 🎉 Pour tester

- préparer un fichier csv avec plusieurs organisations et centres de certif à rattacher
- en local, lancer le script en passant le fichier en entrée:
`node --env-file-if-exists=.env src/organizational-entities/scripts/attach-certification-centers-to-organizations.js --file ./test.csv --batchSize=1`
- constater les logs et que le mode `dryRun` était bien par défaut (aucune insertion en base)
- rejouer le script avec le `dryRun` en false pour effectuer les rattachements
- ne pas hésiter à tester les différents cas d'erreur:
	- doublons d'ids
	- ids non existants
	- ids déjà rattachés
	- colonnes manquantes
	- valeurs non remplies

Exemple de fichier CSV valide à utiliser (ids existants en dev)
```
organization_id;certification_center_id
8000;8000
8001;8001
8002;8002
8003;5000
```
