### PR TITLE
[TECH] Ajout de métriques OpenTelemetry manuelles Hapi

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -38,6 +38,7 @@
         "@opentelemetry/resource-detector-container": "^0.8.11",
         "@opentelemetry/resources": "^2.9.0",
         "@opentelemetry/sdk-logs": "^0.215.0",
+        "@opentelemetry/sdk-metrics": "^2.9.0",
         "@opentelemetry/sdk-node": "^0.215.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@pdf-lib/fontkit": "^1.1.1",
@@ -3106,6 +3107,22 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
+      "integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
       "version": "0.215.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.215.0.tgz",
@@ -3139,6 +3156,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
+      "integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
@@ -3261,22 +3294,6 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
-      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-prometheus": {
       "version": "0.215.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.215.0.tgz",
@@ -3309,6 +3326,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
+      "integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
@@ -3712,6 +3745,22 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
+      "integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/protobufjs": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
@@ -3848,13 +3897,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
-      "integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.0",
-        "@opentelemetry/resources": "2.7.0"
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -3863,20 +3912,19 @@
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
-      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
@@ -3969,6 +4017,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
+      "integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace": {

--- a/api/package.json
+++ b/api/package.json
@@ -120,6 +120,7 @@
     "@opentelemetry/resource-detector-container": "^0.8.11",
     "@opentelemetry/resources": "^2.9.0",
     "@opentelemetry/sdk-logs": "^0.215.0",
+    "@opentelemetry/sdk-metrics": "^2.9.0",
     "@opentelemetry/sdk-node": "^0.215.0",
     "@opentelemetry/sdk-trace-base": "^2.7.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",

--- a/api/src/shared/infrastructure/open-telemetry/hapi-tracing.js
+++ b/api/src/shared/infrastructure/open-telemetry/hapi-tracing.js
@@ -16,6 +16,7 @@
  *   returns is wrapped in its own span.
  */
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
+import { metrics } from '@opentelemetry/api';
 
 import { config } from '../../config.js';
 import { routeDomainToOwnerTeam } from '../utils/route-domain-to-owner-team.js';
@@ -276,6 +277,26 @@ function instrumentRequestId(server) {
 }
 
 /**
+ * @param {HapiServer} server
+ */
+export function instrumentActiveRequestsCount(server) {
+  const meter = metrics.getMeter('hapi');
+  const activeRequestsHistogram = meter.createHistogram('hapi.activeRequests', { unit: 'request' });
+  let activeRequestsCount = 0;
+
+  server.ext('onRequest', (_req, h) => {
+    activeRequestsCount++;
+    activeRequestsHistogram.record(activeRequestsCount);
+    return h.continue;
+  });
+
+  server.ext('onPostResponse', (_req, h) => {
+    activeRequestsCount--;
+    return h.continue;
+  });
+}
+
+/**
  * Instruments a freshly created Hapi server so that spans are created for `pre` handlers,
  * controllers (route handlers), authentication and payload/query/params validation. Must be
  * called before any route, auth scheme/strategy or plugin is registered on the server.
@@ -303,4 +324,6 @@ export function instrumentHapiServer(server) {
   instrumentHttpResponse(server);
 
   instrumentRequestId(server);
+
+  instrumentActiveRequestsCount(server);
 }

--- a/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
+++ b/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
@@ -8,9 +8,16 @@ import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 import { containerDetector } from '@opentelemetry/resource-detector-container';
-import { envDetector, hostDetector, osDetector, processDetector } from '@opentelemetry/resources';
+import {
+  envDetector,
+  hostDetector,
+  osDetector,
+  processDetector,
+  resourceFromAttributes,
+} from '@opentelemetry/resources';
 import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
-import { NodeSDK, resources } from '@opentelemetry/sdk-node';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { NodeSDK } from '@opentelemetry/sdk-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
@@ -18,8 +25,6 @@ import { config } from '../../config.js';
 import { logger } from '../utils/logger.js';
 import { InheritedAttributesSpanProcessor } from './inherited-span-attributes.js';
 import { scalingoDetector } from './scalingo-detector.js';
-
-const { resourceFromAttributes } = resources;
 
 export function initializeOpenTelemetry(serviceName) {
   if (!config.logging.otelEnabled) {
@@ -35,7 +40,15 @@ export function initializeOpenTelemetry(serviceName) {
 
   const logExporter = new OTLPLogExporter();
   const traceExporter = new OTLPTraceExporter();
-  const metricExporter = new OTLPMetricExporter();
+  const metricExporter = new OTLPMetricExporter({
+    compression: 'gzip',
+    temporalityPreference: 0 /* 'AggregationTemporality.DELTA' = 0 */,
+  });
+
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: metricExporter,
+    exportIntervalMillis: 30_000,
+  });
 
   const sdk = new NodeSDK({
     resource: resourceFromAttributes({
@@ -43,8 +56,8 @@ export function initializeOpenTelemetry(serviceName) {
     }),
     resourceDetectors: [envDetector, hostDetector, osDetector, processDetector, containerDetector, scalingoDetector],
     spanProcessors: [new InheritedAttributesSpanProcessor(), new BatchSpanProcessor(traceExporter)],
-    metricExporter,
     logRecordProcessors: [new BatchLogRecordProcessor(logExporter)],
+    metricReaders: [metricReader],
     instrumentations: [
       new HostMetricsInstrumentation(),
       new HttpInstrumentation(),

--- a/api/tests/shared/unit/infrastructure/open-telemetry/hapi-metrics_test.js
+++ b/api/tests/shared/unit/infrastructure/open-telemetry/hapi-metrics_test.js
@@ -1,0 +1,46 @@
+import { metrics } from '@opentelemetry/api';
+import sinon from 'sinon';
+
+import { instrumentActiveRequestsCount } from '../../../../../src/shared/infrastructure/open-telemetry/hapi-tracing.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Infrastructure | OpenTelemetry | hapi-metrics', function () {
+  let meterStub, recordStub;
+  beforeEach(function () {
+    recordStub = sinon.stub();
+    meterStub = {
+      createHistogram: sinon.stub().returns({ record: recordStub }),
+    };
+    sinon.stub(metrics, 'getMeter').returns(meterStub);
+  });
+
+  afterEach(function () {
+    metrics.getMeter.restore();
+  });
+
+  it('registers a histogram for active requests count', async function () {
+    // given
+    let startRequest, endRequest;
+    const req = {},
+      h = {};
+    const hapiServer = {
+      ext: sinon.stub().callsFake((event, cb) => {
+        if (event === 'onRequest') startRequest = cb.bind(null, req, h);
+        if (event === 'onPostResponse') endRequest = cb.bind(null, req, h);
+      }),
+    };
+
+    // when
+    instrumentActiveRequestsCount(hapiServer);
+    startRequest();
+    startRequest();
+    endRequest();
+    startRequest();
+    endRequest();
+    endRequest();
+
+    // then
+    expect(meterStub.createHistogram).to.have.been.calledWith('hapi.activeRequests', { unit: 'request' });
+    expect(recordStub.getCalls().flatMap(({ args }) => args)).to.deep.equal([1, 2, 2]);
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

Aujourd'hui avons un manque de visibilité sur le nombre de requêtes HTTP que traite chaque conteneur de l'API. On se base sur des données dérivées, qui peuvent être approximatives.

## 🌈 Proposition

Création d'une métrique [histogramme](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram) `hapi.activeRequests`.
Cet histogramme est collecté et vidé toutes les 30 secondes.
Il nous permet de connaître le nombre maximum de requêtes qui se sont exécutées en parallèle, ainsi que le nombre total de requêtes pendant cet intervalle.

<img width="614" height="656" alt="image" src="https://github.com/user-attachments/assets/73af3a39-dabe-4ba1-8482-50b3ea19d584" />


## 📝 Remarques
> [!TIP]
> Si nous souhaitons avoir un intervalle plus petit que 30 secondes (donc une meilleure précision), il ne faudrait pas réduire la valeur de `exportIntervalMillis`, mais plutôt écrire notre propre `MetricReader`.

## 🎉 Pour tester
- Lancer l'API avec la variable d'environnement `OTEL_ENABLED=true`
- Lancer `mon-pix`
- Lancer un collecteur (et/ou outil de visualisation de métriques) OpenTelemetry comme [`otel-tui`](https://github.com/ymtdzzz/otel-tui).
- Se connecter à Pix App
- Attendre quelques secondes.
- Dans l'outil de visualisation de métriques, constater que plusieurs métriques ayant un nom qui commence par `hapi.activeRequests` sont visibles.
- Constater que les valeurs de ces métriques sont plausibles.