### PR TITLE
[TECH] Création des tables nécessaires à l'API du tableau de bord numérique du MEN (PIX-23445)

### DIFF
--- a/api/datamart/migrations/20260715085045_create-men_dashboard_participation_dataset.js
+++ b/api/datamart/migrations/20260715085045_create-men_dashboard_participation_dataset.js
@@ -1,0 +1,38 @@
+const TABLE_NAME = 'men_dashboard_participation_dataset';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('schoolUai');
+    table.index('schoolUai');
+    table.smallint('schoolYear');
+    table.string('academieName');
+    table.string('schoolName');
+    table.string('provinceCode');
+    table.string('schoolYearGroup');
+    table.string('competenceCode');
+    table.string('competenceName');
+    table.integer('participantCount');
+    table.float('standardDeviation');
+    table.float('firstDecileLevel');
+    table.float('firstQuartileLevel');
+    table.float('medianLevel');
+    table.float('thirdQuartileLevel');
+    table.float('ninthDecileLevel');
+    table.float('averageMaxLevelReached');
+    table.float('averageMaxLevelReachable');
+    table.float('coverage');
+    table.date('updatedAt');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/datamart/migrations/20260715085046_create-men_dashboard_certification_dataset.js
+++ b/api/datamart/migrations/20260715085046_create-men_dashboard_certification_dataset.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'men_dashboard_certification_dataset';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('schoolUai');
+    table.index('schoolUai');
+    table.smallint('schoolYear');
+    table.string('academieName');
+    table.string('schoolName');
+    table.string('provinceCode');
+    table.string('schoolYearGroup');
+    table.integer('validatedCertificationCount');
+    table.integer('certificationCount');
+    table.float('averagePixScore');
+    table.string('competenceCode');
+    table.float('avgCompetenceLevel');
+    table.date('updatedAt');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}


### PR DESCRIPTION
## 🪧 Problème

L'API mettant à disposition les données relatives au parcours de rentrée et aux certifications SCO pour le tableau de bord du numérique du MEN nécessite 2 tables dédiées dans le datamart.

## 🌈 Proposition

Création des tables.

## 🎉 Pour tester
Les tables sont bien présentes dans la RA. 
Leur modèle correspond aux tables `data_sco_edupilot_lot_2` et `data_sco_edupilot` qui y seront répliquées. 

```
scalingo -a pix-api-maddo-review-pr16801 --region osc-fr1 pgsql-console
pix_api_mad_6963=> \d tdb_num_back_to_school_campaigns_statistics;
pix_api_mad_6963=> \d tdb_num_certification_statistics;

```
Le rollback des 2 dernières migrations supprime bien les 2 tables créées.

X2 :
```
scalingo -a pix-api-maddo-review-pr16801 --region osc-fr1 run npm run datamart:rollback:latest
```
