### PR TITLE
[TECH] Ajout de teamsToContact et routeDomain aux spans OpenTelemetry

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -118,6 +118,7 @@
     "@opentelemetry/resource-detector-container": "^0.8.11",
     "@opentelemetry/resources": "^2.9.0",
     "@opentelemetry/sdk-node": "^0.215.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@pdf-lib/fontkit": "^1.1.1",
     "@xmldom/xmldom": "^0.9.10",

--- a/api/src/shared/infrastructure/open-telemetry/hapi-tracing.js
+++ b/api/src/shared/infrastructure/open-telemetry/hapi-tracing.js
@@ -17,6 +17,10 @@
  */
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 
+import { config } from '../../config.js';
+import { routeDomainToOwnerTeam } from '../utils/route-domain-to-owner-team.js';
+import { setInheritedAttributes } from './inherited-span-attributes.js';
+
 const tracer = trace.getTracer('hapi');
 
 const INSTRUMENTED = Symbol('pix-hapi-tracing-instrumented');
@@ -31,16 +35,17 @@ const INSTRUMENTED = Symbol('pix-hapi-tracing-instrumented');
  * @param {string} name
  * @param {Record<string, string | number>} attributes
  * @param {OriginalFunction} fn
+ * @param {import('@opentelemetry/api').Context} [parentContext]
  * @returns {ReturnType<OriginalFunction>}
  */
-async function withChildSpan(name, attributes, fn) {
-  if (!trace.getSpan(context.active())) {
+async function withChildSpan(name, attributes, fn, parentContext = context.active()) {
+  if (!trace.getSpan(parentContext)) {
     return fn();
   }
 
-  const span = tracer.startSpan(name, { attributes });
+  const span = tracer.startSpan(name, { attributes }, parentContext);
   try {
-    return await context.with(trace.setSpan(context.active(), span), fn);
+    return await context.with(trace.setSpan(parentContext, span), fn);
   } catch (error) {
     span.recordException(error);
     span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
@@ -54,8 +59,13 @@ function wrapPreHandler(method) {
   if (method[INSTRUMENTED]) return method;
 
   const name = method.name || 'anonymous';
-  function wrapped(_request, _h) {
-    return withChildSpan(`pre-handler - ${name}`, { 'hapi.type': 'pre-handler' }, () => method.apply(this, arguments));
+  function wrapped(request, _h) {
+    return withChildSpan(
+      `pre-handler - ${name}`,
+      { 'hapi.type': 'pre-handler' },
+      () => method.apply(this, arguments),
+      request.app.pixContext,
+    );
   }
   wrapped[INSTRUMENTED] = true;
   return wrapped;
@@ -79,9 +89,12 @@ function wrapController(handler, path, method) {
   if (handler[INSTRUMENTED]) return handler;
 
   const attributes = { 'hapi.type': 'controller', 'http.route': path, 'code.function': handler.name || 'anonymous' };
-  function wrapped(_request, _h) {
-    return withChildSpan(`controller - ${method.toUpperCase()} ${path}`, attributes, () =>
-      handler.apply(this, arguments),
+  function wrapped(request, _h) {
+    return withChildSpan(
+      `controller - ${method.toUpperCase()} ${path}`,
+      attributes,
+      () => handler.apply(this, arguments),
+      request.app.pixContext,
     );
   }
   wrapped[INSTRUMENTED] = true;
@@ -117,7 +130,7 @@ function wrapAuthenticate(authenticate, attributes) {
 
   function wrapped(request, _h) {
     const spanAttributes = { 'hapi.type': 'auth', 'http.route': request.route?.path, ...attributes };
-    return withChildSpan('auth', spanAttributes, () => authenticate.apply(this, arguments));
+    return withChildSpan('auth', spanAttributes, () => authenticate.apply(this, arguments), request.app.pixContext);
   }
   wrapped[INSTRUMENTED] = true;
   return wrapped;
@@ -168,9 +181,11 @@ function instrumentValidation(server) {
       validate && (validate.headers || validate.params || validate.query || validate.payload || validate.state);
     if (!hasValidation) return h.continue;
 
-    request.app.pixValidationSpan = tracer.startSpan('validation', {
-      attributes: { 'hapi.type': 'validation', 'http.route': request.route.path },
-    });
+    request.app.pixValidationSpan = tracer.startSpan(
+      'validation',
+      { attributes: { 'hapi.type': 'validation', 'http.route': request.route.path } },
+      request.app.pixContext,
+    );
     return h.continue;
   });
 
@@ -188,6 +203,30 @@ function instrumentValidation(server) {
 }
 
 /**
+ * Computes attributes derived from the matched route (`routeDomain`, `teamsToContact`, ...) as
+ * early as possible - right after route lookup, before auth/validation run - and stashes them on
+ * `request.app.pixContext` (a `Context` carrying them under `inheritedAttributes`). All spans
+ * created downstream for this request (auth, validation, pre-handlers, controller) are started
+ * with that context as their parent, so `InheritedAttributesSpanProcessor` can copy the attributes
+ * onto every one of them without each call site having to know about them individually.
+ * @param {HapiServer} server
+ */
+function instrumentInheritedAttributes(server) {
+  server.ext('onPreAuth', (request, h) => {
+    if (!trace.getSpan(context.active())) return h.continue;
+
+    const routeDomain = request.route.realm?.plugin;
+    request.app.pixInheritedAttributes = {
+      'pix.routeDomain': routeDomain,
+      'pix.teamsToContact': routeDomainToOwnerTeam(config.routeDomainToOwnerTeamMapping, routeDomain).join(','),
+    };
+    request.app.pixContext = setInheritedAttributes(context.active(), request.app.pixInheritedAttributes);
+
+    return h.continue;
+  });
+}
+
+/**
  * @param {HapiServer} server
  */
 function instrumentHttpResponse(server) {
@@ -196,6 +235,9 @@ function instrumentHttpResponse(server) {
     if (!span) return h.continue;
 
     span.setAttribute('http.route', request.route.path);
+    if (request.app.pixInheritedAttributes) {
+      span.setAttributes(request.app.pixInheritedAttributes);
+    }
     span.updateName(`${request.method.toUpperCase()} ${request.route.path}`);
 
     request.app.traceId = span.spanContext().traceId;
@@ -251,6 +293,8 @@ export function instrumentHapiServer(server) {
     }
     return originalRoute.call(this, routes);
   };
+
+  instrumentInheritedAttributes(server);
 
   instrumentAuth(server);
 

--- a/api/src/shared/infrastructure/open-telemetry/inherited-span-attributes.js
+++ b/api/src/shared/infrastructure/open-telemetry/inherited-span-attributes.js
@@ -1,0 +1,73 @@
+/**
+ * Lets attributes computed once (e.g. mid-request, once routing/auth info is known) be attached
+ * automatically to every span started afterwards within the same request, instead of having to
+ * call `span.setAttribute` on each span individually.
+ *
+ * Producers store attributes on the context with `setInheritedAttributes` and pass the resulting
+ * context down to `tracer.startSpan`/`context.with`. `InheritedAttributesSpanProcessor` then reads
+ * them back from each span's parent context in `onStart` and copies them onto the span.
+ */
+import { createContextKey } from '@opentelemetry/api';
+
+/**
+ * Context key under which inherited attributes are stored, as a plain object mapping attribute
+ * name to value. Not exported for direct use - go through {@link setInheritedAttributes} to write
+ * and {@link InheritedAttributesSpanProcessor} to read.
+ */
+export const INHERITED_ATTRIBUTES_KEY = createContextKey('pix.inheritedAttributes');
+
+/**
+ * Returns a copy of `ctx` with `attributes` merged into whatever inherited attributes it already
+ * carries (later calls win on key conflicts). Does not mutate `ctx`.
+ *
+ * @param {import('@opentelemetry/api').Context} ctx
+ * @param {Record<string, unknown>} attributes
+ * @returns {import('@opentelemetry/api').Context}
+ */
+export function setInheritedAttributes(ctx, attributes) {
+  return ctx.setValue(INHERITED_ATTRIBUTES_KEY, { ...ctx.getValue(INHERITED_ATTRIBUTES_KEY), ...attributes });
+}
+
+/**
+ * A `SpanProcessor` that, on every span start, copies the inherited attributes (if any) carried by
+ * the span's parent context onto the span itself. Register it on the tracer provider (e.g. via
+ * `NodeSDK`'s `spanProcessors` option) alongside the processor(s) actually responsible for
+ * exporting spans - this one only annotates spans, it does not export them.
+ *
+ * @implements {import('@opentelemetry/sdk-trace-base').SpanProcessor}
+ */
+export class InheritedAttributesSpanProcessor {
+  /**
+   * @param {import('@opentelemetry/sdk-trace-base').Span} span
+   * @param {import('@opentelemetry/api').Context} parentContext
+   */
+  onStart(span, parentContext) {
+    const attributes = parentContext.getValue(INHERITED_ATTRIBUTES_KEY);
+    if (attributes) {
+      span.setAttributes(attributes);
+    }
+  }
+
+  /**
+   * No-op: this processor only annotates spans on start, it has nothing to do when they end.
+   */
+  onEnd() {
+    // no-op
+  }
+
+  /**
+   * No-op: this processor holds no buffered data to flush.
+   * @returns {Promise<void>}
+   */
+  async forceFlush() {
+    // no-op
+  }
+
+  /**
+   * No-op: this processor holds no resources to release.
+   * @returns {Promise<void>}
+   */
+  async shutdown() {
+    // no-op
+  }
+}

--- a/api/src/shared/infrastructure/open-telemetry/inherited-span-attributes.js
+++ b/api/src/shared/infrastructure/open-telemetry/inherited-span-attributes.js
@@ -14,7 +14,7 @@ import { createContextKey } from '@opentelemetry/api';
  * name to value. Not exported for direct use - go through {@link setInheritedAttributes} to write
  * and {@link InheritedAttributesSpanProcessor} to read.
  */
-export const INHERITED_ATTRIBUTES_KEY = createContextKey('pix.inheritedAttributes');
+const INHERITED_ATTRIBUTES_KEY = createContextKey('pix.inheritedAttributes');
 
 /**
  * Returns a copy of `ctx` with `attributes` merged into whatever inherited attributes it already

--- a/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
+++ b/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
@@ -9,10 +9,12 @@ import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 import { containerDetector } from '@opentelemetry/resource-detector-container';
 import { envDetector, hostDetector, osDetector, processDetector } from '@opentelemetry/resources';
 import { NodeSDK, resources } from '@opentelemetry/sdk-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 import { config } from '../../config.js';
 import { logger } from '../utils/logger.js';
+import { InheritedAttributesSpanProcessor } from './inherited-span-attributes.js';
 import { scalingoDetector } from './scalingo-detector.js';
 
 const { resourceFromAttributes } = resources;
@@ -37,7 +39,7 @@ export function initializeOpenTelemetry(serviceName) {
       [ATTR_SERVICE_NAME]: serviceName,
     }),
     resourceDetectors: [envDetector, hostDetector, osDetector, processDetector, containerDetector, scalingoDetector],
-    traceExporter,
+    spanProcessors: [new InheritedAttributesSpanProcessor(), new BatchSpanProcessor(traceExporter)],
     metricExporter,
     instrumentations: [
       new HostMetricsInstrumentation(),


### PR DESCRIPTION
## 🪧 Problème

Sur Datadog, afin de savoir quelle équipe est concernée par une erreur, on ajoute aux logs deux données : le `routeDomain` et le `teamsToContact`

Ces données ne sont pas présentes dans les traces Open Telemetry

## 🌈 Proposition

On ajoute en attribut du span de créé pour chaque requête dans Hapi le `routeDomain` et le `teamsToContact`
Comme on risque d'avoir besoin de cette donnée sur un autre span que le span de la requête Hapi, on introduit ici le concept d'attribut héritable par une grape de spans.

## 🎉 Pour tester

- Lancer l'API avec la variable d'environnement OTEL_ENABLED=true
- Lancer un collecteur (et/ou outil de visualisation de traces) OpenTelemetry comme [otel-tui](https://github.com/ymtdzzz/otel-tui) ou [otel-gui](https://github.com/metafab/otel-gui).
- Faire un appel
- Attendre quelques secondes
- Dans l'outil de visualisation de traces, constater que les spans contiennent des attribut `routeDomain` et le `teamsToContact` cohérents.
