### PR TITLE
[TECH] Ajout des métriques OpenTelemetry sur les jobs PGBOSS

### DIFF
--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -107,6 +107,8 @@ export class JobClient {
 
       instrumentJobController(moduleName, ModuleClass);
 
+      instrumentJobController(moduleName, ModuleClass);
+
       if (!jobGroups.includes(job.jobGroup) && !this.#isTestOnly) continue;
 
       if (job.isJobEnabled) {

--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -7,7 +7,7 @@ import { PgBoss } from 'pg-boss';
 import { config } from '../../config.js';
 import { executeInContext, EXECUTORS } from '../execution-context-manager.js';
 import { DatadogMetrics } from '../metrics/datadog-metrics.js';
-import { instrumentJobController } from '../open-telemetry/job-tracing.js';
+import { instrumentJobController, registerPgBossMetrics } from '../open-telemetry/job-tracing.js';
 import { importNamedExportFromFile } from '../utils/import-named-exports-from-directory.js';
 import { child } from '../utils/logger.js';
 import { MonitoredJobHandler } from './MonitoredJobHandler.js';
@@ -76,6 +76,7 @@ export class JobClient {
 
     if (worker) {
       await this.#registerJobs(jobGroups);
+      registerPgBossMetrics(this);
     }
 
     this.#isInitialized = true;
@@ -253,5 +254,15 @@ export class JobClient {
       stats.global.all += row.count;
     }
     return stats;
+  }
+
+  async getOldestPendingJobAges() {
+    const { rows } = await this.#pgBoss.getDb().executeSql(`
+      SELECT name, EXTRACT(EPOCH FROM (now() - MIN(created_on))) AS "ageInSeconds"
+      FROM pgboss.job
+      WHERE state IN ('created', 'retry')
+      GROUP BY name
+    `);
+    return rows;
   }
 }

--- a/api/src/shared/infrastructure/open-telemetry/job-tracing.js
+++ b/api/src/shared/infrastructure/open-telemetry/job-tracing.js
@@ -1,3 +1,5 @@
+import { metrics } from '@opentelemetry/api';
+
 import { getInContext } from '../execution-context-manager.js';
 import { otelProxy } from './otel_proxy.js';
 
@@ -18,4 +20,37 @@ function instrumentJobHandle(jobName, jobControllerClass) {
  */
 export function instrumentJobController(jobName, jobControllerClass) {
   instrumentJobHandle(jobName, jobControllerClass);
+}
+
+const JOB_STATES = ['created', 'pending', 'retry', 'active', 'cancelled', 'failed'];
+
+export function registerPgBossMetrics(jobClient) {
+  const meter = metrics.getMeter('pgboss');
+
+  meter
+    .createObservableGauge('pgboss.queue.jobs', {
+      description: 'Number of pg-boss jobs per queue and state ("active" jobs are the ones currently in progress)',
+      unit: '{job}',
+    })
+    .addCallback(async (observableResult) => {
+      const stats = await jobClient.getQueuesStats();
+      for (const [queueName, queueStats] of Object.entries(stats)) {
+        if (queueName === 'global') continue;
+        for (const state of JOB_STATES) {
+          observableResult.observe(queueStats[state], { 'pgboss.queue.name': queueName, 'pgboss.job.state': state });
+        }
+      }
+    });
+
+  meter
+    .createObservableGauge('pgboss.queue.oldest_pending_job_age', {
+      description: 'Age in seconds of the oldest job still waiting to run (state "created" or "retry") per queue',
+      unit: 's',
+    })
+    .addCallback(async (observableResult) => {
+      const ages = await jobClient.getOldestPendingJobAges();
+      for (const { name, ageInSeconds } of ages) {
+        observableResult.observe(ageInSeconds, { 'pgboss.queue.name': name });
+      }
+    });
 }

--- a/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
+++ b/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
@@ -285,4 +285,36 @@ describe('Unit | JobClient', function () {
       });
     });
   });
+
+  context('#getOldestPendingJobAges', function () {
+    it('returns the age in seconds of the oldest pending job per queue', async function () {
+      // given
+      const pgBossStub = new FakePgBoss();
+      const executeSql = sinon.stub().resolves({
+        rows: [
+          { name: 'FirstJob', ageInSeconds: 42 },
+          { name: 'SecondJob', ageInSeconds: 3600 },
+        ],
+      });
+      sinon.stub(pgBossStub, 'getDb').returns({ executeSql });
+
+      const jobClient = new JobClient();
+      await jobClient.initialize(
+        {
+          jobGroups: [JobGroup.DEFAULT],
+          worker: true,
+        },
+        () => pgBossStub,
+      );
+
+      // when
+      const ages = await jobClient.getOldestPendingJobAges();
+
+      // then
+      expect(ages).to.deep.equal([
+        { name: 'FirstJob', ageInSeconds: 42 },
+        { name: 'SecondJob', ageInSeconds: 3600 },
+      ]);
+    });
+  });
 });

--- a/api/tests/shared/unit/infrastructure/open-telemetry/pgboss-metrics_test.js
+++ b/api/tests/shared/unit/infrastructure/open-telemetry/pgboss-metrics_test.js
@@ -1,0 +1,66 @@
+import { metrics } from '@opentelemetry/api';
+import sinon from 'sinon';
+
+import { registerPgBossMetrics } from '../../../../../src/shared/infrastructure/open-telemetry/job-tracing.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Infrastructure | Open Telemetry | pgboss-metrics', function () {
+  let instrumentsByName;
+
+  beforeEach(function () {
+    instrumentsByName = {};
+    const meterStub = {
+      createObservableGauge: sinon.stub().callsFake((name) => {
+        instrumentsByName[name] = { addCallback: sinon.stub() };
+        return instrumentsByName[name];
+      }),
+    };
+    sinon.stub(metrics, 'getMeter').returns(meterStub);
+  });
+
+  afterEach(function () {
+    metrics.getMeter.restore();
+  });
+
+  it('registers an observable gauge for queue job counts per state', async function () {
+    // given
+    const jobClient = {
+      getQueuesStats: sinon.stub().resolves({
+        global: { created: 999 },
+        FirstJob: { created: 1, retry: 2, active: 3, completed: 4, cancelled: 5, failed: 6 },
+      }),
+      getOldestPendingJobAges: sinon.stub().resolves([]),
+    };
+    const observe = sinon.stub();
+
+    // when
+    registerPgBossMetrics(jobClient);
+    const callback = instrumentsByName['pgboss.queue.jobs'].addCallback.firstCall.args[0];
+    await callback({ observe });
+
+    // then
+    expect(observe).to.have.been.calledWith(1, { 'pgboss.queue.name': 'FirstJob', 'pgboss.job.state': 'created' });
+    expect(observe).to.have.been.calledWith(2, { 'pgboss.queue.name': 'FirstJob', 'pgboss.job.state': 'retry' });
+    expect(observe).to.have.been.calledWith(3, { 'pgboss.queue.name': 'FirstJob', 'pgboss.job.state': 'active' });
+    expect(observe).to.have.been.calledWith(5, { 'pgboss.queue.name': 'FirstJob', 'pgboss.job.state': 'cancelled' });
+    expect(observe).to.have.been.calledWith(6, { 'pgboss.queue.name': 'FirstJob', 'pgboss.job.state': 'failed' });
+    expect(observe).to.not.have.been.calledWith(sinon.match.any, sinon.match({ 'pgboss.queue.name': 'global' }));
+  });
+
+  it('registers an observable gauge for the oldest pending job age per queue', async function () {
+    // given
+    const jobClient = {
+      getQueuesStats: sinon.stub().resolves({}),
+      getOldestPendingJobAges: sinon.stub().resolves([{ name: 'FirstJob', ageInSeconds: 120 }]),
+    };
+    const observe = sinon.stub();
+
+    // when
+    registerPgBossMetrics(jobClient);
+    const callback = instrumentsByName['pgboss.queue.oldest_pending_job_age'].addCallback.firstCall.args[0];
+    await callback({ observe });
+
+    // then
+    expect(observe).to.have.been.calledWith(120, { 'pgboss.queue.name': 'FirstJob' });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

L'état des queues utilisées par PGBoss ne sont pas remontées via OpenTelemetry

## 🌈 Proposition

On ajoute des exports de métriques sur l'état des queues.

## 🎉 Pour tester

- Lancer l'API avec la variable d'environnement OTEL_ENABLED=true
- Lancer le worker
- Lancer un collecteur (et/ou outil de visualisation de traces) OpenTelemetry comme [otel-tui](https://github.com/ymtdzzz/otel-tui) ou [otel-gui](https://github.com/metafab/otel-gui).
- Déclencher des jobs, par exemple, en valorisant la variable d'env LLM_DELETE_CHATS_JOB_CRON à "* * * * *"
- Attendre quelques secondes
- Dans l'outil de visualisation de traces, constater que les métriques PGBoss remontent bien.