### PR TITLE
[TECH] Refactorer le composant de création de campagne dans Pix Orga (PIX-23366)

### DIFF
--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -1,66 +1,27 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
-import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import { eq, not, or } from 'ember-truth-helpers';
-import { ID_PIX_TYPES } from 'pix-orga/helpers/id-pix-types.js';
 
 import displayCampaignErrors from '../../helpers/display-campaign-errors';
-import CourseCard from '../catalogue/course-card';
 import ExplanationCard from '../ui/explanation-card';
 import FormField from '../ui/form-field';
+import FormSection from '../ui/form-section';
 import PixFieldset from '../ui/pix-fieldset';
+import AssessmentGoalCustomization from './create-form/assessment-goal-customization';
+import AssessmentGoalSettings from './create-form/assessment-goal-settings';
+import CombinedCourseGoalSettings from './create-form/combined-course-goal-settings';
+import ProfilesCollectionGoalCustomization from './create-form/profiles-collection-goal-customization';
+import ProfilesCollectionGoalSettings from './create-form/profiles-collection-goal-settings';
 
 export default class CreateForm extends Component {
   @service currentUser;
-  @service intl;
-  @service locale;
-  @service store;
-
-  @tracked wantIdPix = Boolean(this.args.campaign.externalIdLabel);
-
-  get isMultipleSendingAssessmentEnabled() {
-    return this.currentUser.prescriber.enableMultipleSendingAssessment;
-  }
 
   get isComputeLearnerCertificabilityEnabled() {
     return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
-  }
-
-  get campaignOwnerOptions() {
-    if (!this.args.membersSortedByFullName) return [];
-
-    return this.args.membersSortedByFullName.map((member) => ({ value: member.id, label: member.fullName }));
-  }
-
-  get isMultipleSendingEnabled() {
-    const isMulipleSendingsAllowed =
-      Boolean(this.args.campaign.course) && this.isMultipleSendingAssessmentEnabled && !this.isCombinedCourseGoal;
-
-    return this.isCampaignGoalProfileCollection || isMulipleSendingsAllowed;
-  }
-
-  get multipleSendingWording() {
-    if (this.isCampaignGoalProfileCollection) {
-      return {
-        label: 'pages.campaign-creation.multiple-sendings.profiles.question-label',
-        info: 'pages.campaign-creation.multiple-sendings.profiles.info',
-      };
-    } else {
-      return {
-        label: 'pages.campaign-creation.multiple-sendings.assessments.question-label',
-        info: 'pages.campaign-creation.multiple-sendings.assessments.info',
-      };
-    }
   }
 
   get isSubmitDisabled() {
@@ -83,82 +44,14 @@ export default class CreateForm extends Component {
     return this.args.campaign.type === 'COMBINED_COURSE';
   }
 
-  get isExternalIdSelectedChecked() {
-    return this.wantIdPix === true;
+  get isAssessmentGoalSelected() {
+    return this.isCampaignGoalAssessment || this.isCampaignGoalExam;
   }
 
-  get isExternalIdTypeNotSelectedChecked() {
-    return this.args.campaign.externalIdType === '';
-  }
-
-  get displayCampaignNameField() {
-    return Boolean(this.args.campaign.course) || this.isCampaignGoalProfileCollection;
-  }
-
-  get displayOwnerField() {
-    return (Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal) || this.isCampaignGoalProfileCollection;
-  }
-
-  get displayExternalUserIdField() {
-    return (Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal) || this.isCampaignGoalProfileCollection;
-  }
-
-  get displayCourseSelection() {
-    return this.isCombinedCourseGoal || this.isCampaignGoalAssessment || this.isCampaignGoalExam;
-  }
-
-  get displayTitleField() {
-    return Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal;
-  }
-
-  get displayLandingPageInfo() {
-    return (Boolean(this.args.campaign.course) && !this.isCombinedCourseGoal) || this.isCampaignGoalProfileCollection;
-  }
-
-  get catalogueCourseSelectionTab() {
-    if (this.isCombinedCourseGoal) {
-      return 'blueprint';
-    }
-    if (this.isCampaignGoalAssessment || this.isCampaignGoalExam) {
-      return 'targetProfile';
-    }
-    return 'all';
-  }
-
-  get displayExamModeField() {
-    return (
-      this.currentUser.prescriber.enableCampaignWithoutUserProfile &&
-      Boolean(this.args.campaign.course) &&
-      !this.isCombinedCourseGoal
-    );
-  }
-
-  @action
-  askLabelIdPix() {
-    this.wantIdPix = true;
-    this.args.campaign.externalIdLabel = '';
-    this.args.campaign.externalIdType = '';
-  }
-
-  @action
-  doNotAskLabelIdPix() {
-    this.wantIdPix = false;
-    this.args.campaign.externalIdLabel = null;
-    this.args.campaign.externalIdType = '';
-  }
-
-  @action
-  selectMultipleSendingsStatus(value) {
-    this.args.campaign.multipleSendings = value;
-  }
-
-  @action
-  selectExamModeStatus(value) {
-    if (value) {
-      this.args.campaign.setType('EXAM');
-    } else {
-      this.args.campaign.setType('ASSESSMENT');
-    }
+  get displaysCustomizationSection() {
+    if (this.isCampaignGoalProfileCollection) return true;
+    if (this.isAssessmentGoalSelected) return Boolean(this.args.campaign.course);
+    return false;
   }
 
   @action
@@ -170,29 +63,6 @@ export default class CreateForm extends Component {
     } else if (event.target.value === 'combined-course') {
       this.args.campaign.setType('COMBINED_COURSE');
     }
-  }
-
-  @action
-  onChangeCampaignValue(key, event) {
-    this.args.campaign[key] = event.target.value;
-  }
-
-  @action
-  onChangeCampaignOwner(newOwnerId) {
-    const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerId === member.id);
-    if (selectedMember) {
-      this.args.campaign.ownerId = selectedMember.id;
-    }
-  }
-
-  @action
-  onChangeCampaignCustomLandingPageText(event) {
-    this.args.campaign.customLandingPageText = event.target.value;
-  }
-
-  @action
-  onChangeIdPixType(event) {
-    this.args.campaign.externalIdType = event.target.value;
   }
 
   @action
@@ -208,350 +78,107 @@ export default class CreateForm extends Component {
         {{t "common.form.mandatory-fields"}}
       </p>
 
-      <FormField>
-        <:default>
-          <PixFieldset @required={{true}} aria-labelledby="campaign-goal" role="radiogroup">
-            <:title>{{t "pages.campaign-creation.purpose.label"}}</:title>
-            <:content>
-              <PixRadioButton
-                name="campaign-goal"
-                @value="assess-participants"
-                {{on "change" this.setCampaignGoal}}
-                aria-describedby="campaign-goal-assessment-info"
-                checked={{this.isCampaignGoalAssessment}}
-              >
-                <:label>{{t "pages.campaign-creation.purpose.assessment"}}</:label>
-              </PixRadioButton>
-
-              <PixRadioButton
-                name="campaign-goal"
-                @value="combined-course"
-                {{on "change" this.setCampaignGoal}}
-                aria-describedby="combined-course-info"
-                checked={{this.isCombinedCourseGoal}}
-              >
-                <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
-              </PixRadioButton>
-
-              <PixRadioButton
-                name="campaign-goal"
-                @value="collect-participants-profile"
-                {{on "change" this.setCampaignGoal}}
-                aria-describedby="campaign-goal-profiles-collection-info"
-                checked={{this.isCampaignGoalProfileCollection}}
-              >
-                <:label>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:label>
-              </PixRadioButton>
-
-              {{#if @errors.type}}
-                <div class="form__error error-message">
-                  {{displayCampaignErrors @errors.type}}
-                </div>
-              {{/if}}
-            </:content>
-          </PixFieldset>
-        </:default>
-        <:information>
-          {{#if this.isCampaignGoalAssessment}}
-            <ExplanationCard id="campaign-goal-assessment-info">
-              <:title>{{t "pages.campaign-creation.purpose.assessment"}}</:title>
-
-              <:message>{{t "pages.campaign-creation.purpose.assessment-info"}}</:message>
-            </ExplanationCard>
-          {{else if this.isCombinedCourseGoal}}
-            <ExplanationCard id="combined-course-info">
-              <:title>{{t "pages.campaign-creation.purpose.combined-course"}}</:title>
-
-              <:message>{{t "pages.campaign-creation.purpose.combined-course-info"}}</:message>
-            </ExplanationCard>
-          {{else if this.isCampaignGoalProfileCollection}}
-            <ExplanationCard id="campaign-goal-profiles-collection-info">
-              <:title>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:title>
-
-              <:message>
-                {{t "pages.campaign-creation.purpose.profiles-collection-info"}}
-                {{#if this.isComputeLearnerCertificabilityEnabled}}
-                  {{t
-                    "pages.campaign-creation.purpose.profiles-collection-info-certificability-calculation"
-                    linkClasses="link link--banner link--bold link--underlined"
-                    htmlSafe=true
-                  }}
-                {{/if}}
-              </:message>
-            </ExplanationCard>
-          {{/if}}
-        </:information>
-      </FormField>
-
-      {{#if this.displayCourseSelection}}
+      <FormSection @title={{t "pages.campaign-creation.settings.title"}}>
         <FormField>
           <:default>
-            <div class="campaign-creation-form__course-selection">
-              <PixFieldset @required={{true}}>
-                <:title>{{t "pages.campaign-creation.course-label"}}</:title>
-                <:content>
-                  {{#if @campaign.course}}
-                    <CourseCard @course={{@campaign.course}} @type={{@campaign.course.type}} />
+            <PixFieldset @required={{true}} aria-labelledby="campaign-goal" role="radiogroup">
+              <:title>{{t "pages.campaign-creation.purpose.label"}}</:title>
+              <:content>
+                <PixRadioButton
+                  name="campaign-goal"
+                  @value="assess-participants"
+                  {{on "change" this.setCampaignGoal}}
+                  aria-describedby="campaign-goal-assessment-info"
+                  checked={{this.isCampaignGoalAssessment}}
+                >
+                  <:label>{{t "pages.campaign-creation.purpose.assessment"}}</:label>
+                </PixRadioButton>
+
+                <PixRadioButton
+                  name="campaign-goal"
+                  @value="combined-course"
+                  {{on "change" this.setCampaignGoal}}
+                  aria-describedby="combined-course-info"
+                  checked={{this.isCombinedCourseGoal}}
+                >
+                  <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
+                </PixRadioButton>
+
+                <PixRadioButton
+                  name="campaign-goal"
+                  @value="collect-participants-profile"
+                  {{on "change" this.setCampaignGoal}}
+                  aria-describedby="campaign-goal-profiles-collection-info"
+                  checked={{this.isCampaignGoalProfileCollection}}
+                >
+                  <:label>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:label>
+                </PixRadioButton>
+
+                {{#if @errors.type}}
+                  <div class="form__error error-message">
+                    {{displayCampaignErrors @errors.type}}
+                  </div>
+                {{/if}}
+              </:content>
+            </PixFieldset>
+          </:default>
+          <:information>
+            {{#if this.isCampaignGoalAssessment}}
+              <ExplanationCard id="campaign-goal-assessment-info">
+                <:title>{{t "pages.campaign-creation.purpose.assessment"}}</:title>
+
+                <:message>{{t "pages.campaign-creation.purpose.assessment-info"}}</:message>
+              </ExplanationCard>
+            {{else if this.isCombinedCourseGoal}}
+              <ExplanationCard id="combined-course-info">
+                <:title>{{t "pages.campaign-creation.purpose.combined-course"}}</:title>
+
+                <:message>{{t "pages.campaign-creation.purpose.combined-course-info"}}</:message>
+              </ExplanationCard>
+            {{else if this.isCampaignGoalProfileCollection}}
+              <ExplanationCard id="campaign-goal-profiles-collection-info">
+                <:title>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:title>
+
+                <:message>
+                  {{t "pages.campaign-creation.purpose.profiles-collection-info"}}
+                  {{#if this.isComputeLearnerCertificabilityEnabled}}
+                    {{t
+                      "pages.campaign-creation.purpose.profiles-collection-info-certificability-calculation"
+                      linkClasses="link link--banner link--bold link--underlined"
+                      htmlSafe=true
+                    }}
                   {{/if}}
-                  <PixButtonLink
-                    @route="authenticated.catalogue.list"
-                    @model={{this.catalogueCourseSelectionTab}}
-                    @variant="primary-bis"
-                  >{{t "pages.campaign-creation.course-selection-label"}}</PixButtonLink>
-                </:content>
-              </PixFieldset>
-            </div>
-            {{#if (or @errors.targetProfile @errors.blueprint)}}
-              <div class="form__error error-message">
-                <span>{{t "api-error-messages.campaign-creation.target-profile-required"}}</span>
-              </div>
+                </:message>
+              </ExplanationCard>
             {{/if}}
-          </:default>
+          </:information>
         </FormField>
-      {{/if}}
 
-      {{#if this.displayCampaignNameField}}
-        <FormField>
-          <PixInput
-            @id="campaign-name"
-            @name="campaign-name"
-            @requiredLabel={{t "common.form.mandatory-fields-title"}}
-            type="text"
-            class="input"
-            maxlength="255"
-            {{on "change" (fn this.onChangeCampaignValue "name")}}
-            @value={{@campaign.name}}
-            required={{true}}
-            aria-required={{true}}
-          >
-            <:label>{{t "pages.campaign-creation.name.label"}}</:label>
-          </PixInput>
+        {{#if this.isAssessmentGoalSelected}}
+          <AssessmentGoalSettings
+            @campaign={{@campaign}}
+            @errors={{@errors}}
+            @membersSortedByFullName={{@membersSortedByFullName}}
+          />
+        {{else if this.isCombinedCourseGoal}}
+          <CombinedCourseGoalSettings @campaign={{@campaign}} @errors={{@errors}} />
+        {{else if this.isCampaignGoalProfileCollection}}
+          <ProfilesCollectionGoalSettings
+            @campaign={{@campaign}}
+            @errors={{@errors}}
+            @membersSortedByFullName={{@membersSortedByFullName}}
+          />
+        {{/if}}
+      </FormSection>
 
-          {{#if @errors.name}}
-            <div class="form__error error-message">
-              {{displayCampaignErrors @errors.name}}
-            </div>
+      {{#if this.displaysCustomizationSection}}
+        <FormSection @title={{t "pages.campaign-creation.customization.title"}}>
+          {{#if this.isAssessmentGoalSelected}}
+            <AssessmentGoalCustomization @campaign={{@campaign}} />
+          {{else if this.isCampaignGoalProfileCollection}}
+            <ProfilesCollectionGoalCustomization @campaign={{@campaign}} />
           {{/if}}
-        </FormField>
-      {{/if}}
-
-      {{#if this.displayOwnerField}}
-        <FormField>
-          <:default>
-            <PixSelect
-              class="pix-select-owner"
-              @options={{this.campaignOwnerOptions}}
-              @onChange={{this.onChangeCampaignOwner}}
-              @value="{{@campaign.ownerId}}"
-              @isSearchable={{true}}
-              @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
-              @locale={{this.locale.currentLocale}}
-              @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
-              @requiredLabel={{t "common.form.mandatory-fields-title"}}
-              @hideDefaultOption={{true}}
-            >
-              <:label>{{t "pages.campaign-creation.owner.label"}}</:label>
-            </PixSelect>
-
-          </:default>
-
-          <:information>
-            <ExplanationCard>
-              <:title>{{t "pages.campaign-creation.owner.title"}}</:title>
-
-              <:message>{{t "pages.campaign-creation.owner.info"}}</:message>
-            </ExplanationCard>
-
-          </:information>
-        </FormField>
-      {{/if}}
-
-      {{#if this.displayExamModeField}}
-        <FormField>
-          <:default>
-            <PixFieldset @required={{true}} aria-labelledby="exam-mode-label" role="radiogroup">
-              <:title>{{t "pages.campaign-creation.exam-mode.label"}}</:title>
-              <:content>
-                <PixRadioButton
-                  name="exam-mode-label"
-                  @value="false"
-                  {{on "change" (fn this.selectExamModeStatus false)}}
-                  aria-describedby="campaign-goal-exam-info"
-                  checked={{not this.isCampaignGoalExam}}
-                >
-                  <:label>{{t "pages.campaign-creation.no"}}</:label>
-                </PixRadioButton>
-
-                <PixRadioButton
-                  name="exam-mode-label"
-                  @value="true"
-                  {{on "change" (fn this.selectExamModeStatus true)}}
-                  aria-describedby="campaign-goal-exam-info"
-                  checked={{this.isCampaignGoalExam}}
-                >
-                  <:label>{{t "pages.campaign-creation.yes"}}</:label>
-                </PixRadioButton>
-              </:content>
-            </PixFieldset>
-          </:default>
-          <:information>
-            <ExplanationCard id="campaign-goal-exam-info">
-              <:title>{{t "pages.campaign-creation.purpose.exam"}}</:title>
-              <:message>
-                {{t "pages.campaign-creation.purpose.exam-info"}}
-              </:message>
-            </ExplanationCard>
-          </:information>
-        </FormField>
-      {{/if}}
-
-      {{#if this.isMultipleSendingEnabled}}
-        <FormField>
-          <:default>
-            <PixFieldset @required={{true}} aria-labelledby="multiple-sendings-label" role="radiogroup">
-              <:title>{{t this.multipleSendingWording.label}}</:title>
-              <:content>
-                <PixRadioButton
-                  name="multiple-sendings-label"
-                  @value="false"
-                  {{on "change" (fn this.selectMultipleSendingsStatus false)}}
-                  aria-describedby="multiple-sendings-info"
-                  checked={{not @campaign.multipleSendings}}
-                >
-                  <:label>{{t "pages.campaign-creation.no"}}</:label>
-                </PixRadioButton>
-
-                <PixRadioButton
-                  name="multiple-sendings-label"
-                  @value="true"
-                  {{on "change" (fn this.selectMultipleSendingsStatus true)}}
-                  aria-describedby="multiple-sendings-info"
-                  checked={{@campaign.multipleSendings}}
-                >
-                  <:label>{{t "pages.campaign-creation.yes"}}</:label>
-                </PixRadioButton>
-              </:content>
-            </PixFieldset>
-          </:default>
-          <:information>
-            <ExplanationCard id="multiple-sendings-info">
-              <:title>{{t "pages.campaign-creation.multiple-sendings.info-title"}}</:title>
-
-              <:message>
-                {{t this.multipleSendingWording.info}}
-                {{#if @campaign.targetProfile.areKnowledgeElementsResettable}}
-                  {{t "pages.campaign-creation.multiple-sendings.knowledge-elements-resettable"}}
-                {{/if}}
-              </:message>
-            </ExplanationCard>
-          </:information>
-        </FormField>
-      {{/if}}
-
-      {{#if this.displayExternalUserIdField}}
-        <FormField>
-          <PixFieldset aria-labelledby="external-ids-label" role="radiogroup">
-            <:title>{{t "pages.campaign-creation.external-id-label.question-label"}}</:title>
-            <:content>
-              <PixRadioButton
-                name="external-id-label"
-                @value="false"
-                {{on "change" this.doNotAskLabelIdPix}}
-                checked={{not this.isExternalIdSelectedChecked}}
-              >
-                <:label>{{t "pages.campaign-creation.no"}}</:label>
-              </PixRadioButton>
-              <PixRadioButton
-                name="external-id-label"
-                @value="true"
-                {{on "change" this.askLabelIdPix}}
-                checked={{this.isExternalIdSelectedChecked}}
-              >
-                <:label>{{t "pages.campaign-creation.yes"}}</:label>
-              </PixRadioButton>
-            </:content>
-          </PixFieldset>
-        </FormField>
-      {{/if}}
-
-      {{#if this.wantIdPix}}
-        <FormField>
-          <PixFieldset @required={{true}} aria-labelledby="external-ids-types" role="radiogroup">
-            <:title>{{t "pages.campaign-creation.external-id-type.question-label"}}</:title>
-            <:content>
-              <PixRadioButton
-                name="external-id-types"
-                @value="EMAIL"
-                {{on "change" (fn this.onChangeCampaignValue "externalIdType")}}
-                checked={{eq @campaign.externalIdType "EMAIL"}}
-              >
-                <:label>{{t ID_PIX_TYPES.EMAIL}}</:label>
-
-              </PixRadioButton>
-              <PixRadioButton
-                name="external-id-types"
-                @value="STRING"
-                {{on "change" (fn this.onChangeCampaignValue "externalIdType")}}
-                checked={{eq @campaign.externalIdType "STRING"}}
-              >
-                <:label>{{t ID_PIX_TYPES.STRING}}</:label>
-              </PixRadioButton>
-              {{#if @errors.externalIdType}}
-                <div class="form__error error-message">
-                  {{displayCampaignErrors @errors.externalIdType}}
-                </div>
-              {{/if}}
-            </:content>
-          </PixFieldset>
-        </FormField>
-        <FormField>
-          <PixInput
-            @id="external-id-label"
-            @name="external-id-label"
-            @subLabel={{t "pages.campaign-creation.external-id-label.suggestion"}}
-            maxlength="255"
-            @requiredLabel={{t "pages.campaign-creation.external-id-label.required"}}
-            {{on "change" (fn this.onChangeCampaignValue "externalIdLabel")}}
-            @value={{@campaign.externalIdLabel}}
-          >
-            <:label>{{t "pages.campaign-creation.external-id-label.label"}}</:label>
-          </PixInput>
-
-          {{#if @errors.externalIdLabel}}
-            <div class="form__error error-message">
-              {{displayCampaignErrors @errors.externalIdLabel}}
-            </div>
-          {{/if}}
-        </FormField>
-      {{/if}}
-
-      {{#if this.displayTitleField}}
-        <FormField>
-          <PixInput
-            @id="campaign-title"
-            @name="campaign-title"
-            @subLabel={{t "pages.campaign-creation.test-title.sublabel"}}
-            maxlength="50"
-            {{on "change" (fn this.onChangeCampaignValue "title")}}
-            @value={{@campaign.title}}
-          >
-            <:label>{{t "pages.campaign-creation.test-title.label"}}</:label></PixInput>
-        </FormField>
-      {{/if}}
-
-      {{#if this.displayLandingPageInfo}}
-        <FormField>
-          <PixTextarea
-            @id="custom-landing-page-text"
-            @maxlength="5000"
-            @value={{@campaign.customLandingPageText}}
-            @subLabel={{t "pages.campaign-creation.landing-page-text.sublabel"}}
-            {{on "change" this.onChangeCampaignCustomLandingPageText}}
-            rows="8"
-          >
-            <:label>{{t "pages.campaign-creation.landing-page-text.label"}}</:label>
-          </PixTextarea>
-        </FormField>
+        </FormSection>
       {{/if}}
 
       <div class="form__validation">
@@ -563,12 +190,6 @@ export default class CreateForm extends Component {
           {{t "pages.campaign-creation.actions.create"}}
         </PixButton>
       </div>
-
-      {{#if this.wantIdPix}}
-        <div class="gdpr-information-external-id">
-          {{t "pages.campaign-creation.legal-warning"}}
-        </div>
-      {{/if}}
     </form>
   </template>
 }

--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -561,12 +561,12 @@ export default class CreateForm extends Component {
           <PixInput
             @id="campaign-title"
             @name="campaign-title"
-            @subLabel={{t "pages.campaign-creation.test-title.sublabel"}}
+            @subLabel={{t "pages.campaign-creation.course-title.sublabel"}}
             maxlength="50"
             {{on "change" (fn this.onChangeCampaignValue "title")}}
             @value={{@campaign.title}}
           >
-            <:label>{{t "pages.campaign-creation.test-title.label"}}</:label></PixInput>
+            <:label>{{t "pages.campaign-creation.course-title.label"}}</:label></PixInput>
         </FormField>
       {{/if}}
 

--- a/orga/app/components/campaign/create-form/assessment-goal-customization.gjs
+++ b/orga/app/components/campaign/create-form/assessment-goal-customization.gjs
@@ -18,12 +18,12 @@ export default class AssessmentGoalCustomization extends Component {
       <PixInput
         @id="campaign-title"
         @name="campaign-title"
-        @subLabel={{t "pages.campaign-creation.test-title.sublabel"}}
+        @subLabel={{t "pages.campaign-creation.course-title.sublabel"}}
         maxlength="50"
         {{on "change" this.onChangeCampaignTitle}}
         @value={{@campaign.title}}
       >
-        <:label>{{t "pages.campaign-creation.test-title.label"}}</:label></PixInput>
+        <:label>{{t "pages.campaign-creation.course-title.label"}}</:label></PixInput>
     </FormField>
 
     <LandingPageText @campaign={{@campaign}} />

--- a/orga/app/components/campaign/create-form/assessment-goal-customization.gjs
+++ b/orga/app/components/campaign/create-form/assessment-goal-customization.gjs
@@ -1,0 +1,31 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import FormField from '../../ui/form-field';
+import LandingPageText from './landing-page-text';
+
+export default class AssessmentGoalCustomization extends Component {
+  @action
+  onChangeCampaignTitle(event) {
+    this.args.campaign.title = event.target.value;
+  }
+
+  <template>
+    <FormField>
+      <PixInput
+        @id="campaign-title"
+        @name="campaign-title"
+        @subLabel={{t "pages.campaign-creation.test-title.sublabel"}}
+        maxlength="50"
+        {{on "change" this.onChangeCampaignTitle}}
+        @value={{@campaign.title}}
+      >
+        <:label>{{t "pages.campaign-creation.test-title.label"}}</:label></PixInput>
+    </FormField>
+
+    <LandingPageText @campaign={{@campaign}} />
+  </template>
+}

--- a/orga/app/components/campaign/create-form/assessment-goal-settings.gjs
+++ b/orga/app/components/campaign/create-form/assessment-goal-settings.gjs
@@ -1,0 +1,101 @@
+import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
+
+import ExplanationCard from '../../ui/explanation-card';
+import FormField from '../../ui/form-field';
+import PixFieldset from '../../ui/pix-fieldset';
+import CampaignName from './campaign-name';
+import CampaignOwner from './campaign-owner';
+import CourseSelection from './course-selection';
+import ExternalId from './external-id';
+import MultipleSendings from './multiple-sendings';
+
+export default class AssessmentGoalSettings extends Component {
+  @service currentUser;
+
+  get isExamModeFieldEnabled() {
+    return this.currentUser.prescriber.enableCampaignWithoutUserProfile;
+  }
+
+  get isMultipleSendingAssessmentEnabled() {
+    return this.currentUser.prescriber.enableMultipleSendingAssessment;
+  }
+
+  get isCampaignGoalExam() {
+    return this.args.campaign.type === 'EXAM';
+  }
+
+  @action
+  selectExamModeStatus(value) {
+    if (value) {
+      this.args.campaign.setType('EXAM');
+    } else {
+      this.args.campaign.setType('ASSESSMENT');
+    }
+  }
+
+  <template>
+    <CourseSelection @campaign={{@campaign}} @errors={{@errors}} @tab="targetProfile" />
+
+    {{#if @campaign.course}}
+      <CampaignName @campaign={{@campaign}} @errors={{@errors}} />
+
+      <CampaignOwner @campaign={{@campaign}} @membersSortedByFullName={{@membersSortedByFullName}} />
+
+      {{#if this.isExamModeFieldEnabled}}
+        <FormField>
+          <:default>
+            <PixFieldset @required={{true}} aria-labelledby="exam-mode-label" role="radiogroup">
+              <:title>{{t "pages.campaign-creation.exam-mode.label"}}</:title>
+              <:content>
+                <PixRadioButton
+                  name="exam-mode-label"
+                  @value="false"
+                  {{on "change" (fn this.selectExamModeStatus false)}}
+                  aria-describedby="campaign-goal-exam-info"
+                  checked={{not this.isCampaignGoalExam}}
+                >
+                  <:label>{{t "pages.campaign-creation.no"}}</:label>
+                </PixRadioButton>
+
+                <PixRadioButton
+                  name="exam-mode-label"
+                  @value="true"
+                  {{on "change" (fn this.selectExamModeStatus true)}}
+                  aria-describedby="campaign-goal-exam-info"
+                  checked={{this.isCampaignGoalExam}}
+                >
+                  <:label>{{t "pages.campaign-creation.yes"}}</:label>
+                </PixRadioButton>
+              </:content>
+            </PixFieldset>
+          </:default>
+          <:information>
+            <ExplanationCard id="campaign-goal-exam-info">
+              <:title>{{t "pages.campaign-creation.purpose.exam"}}</:title>
+              <:message>
+                {{t "pages.campaign-creation.purpose.exam-info"}}
+              </:message>
+            </ExplanationCard>
+          </:information>
+        </FormField>
+      {{/if}}
+
+      {{#if this.isMultipleSendingAssessmentEnabled}}
+        <MultipleSendings
+          @campaign={{@campaign}}
+          @labelKey="pages.campaign-creation.multiple-sendings.assessments.question-label"
+          @infoKey="pages.campaign-creation.multiple-sendings.assessments.info"
+        />
+      {{/if}}
+
+      <ExternalId @campaign={{@campaign}} @errors={{@errors}} />
+    {{/if}}
+  </template>
+}

--- a/orga/app/components/campaign/create-form/campaign-name.gjs
+++ b/orga/app/components/campaign/create-form/campaign-name.gjs
@@ -1,0 +1,40 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import displayCampaignErrors from '../../../helpers/display-campaign-errors';
+import FormField from '../../ui/form-field';
+
+export default class CampaignName extends Component {
+  @action
+  onChange(event) {
+    this.args.campaign.name = event.target.value;
+  }
+
+  <template>
+    <FormField>
+      <PixInput
+        @id="campaign-name"
+        @name="campaign-name"
+        @requiredLabel={{t "common.form.mandatory-fields-title"}}
+        type="text"
+        class="input"
+        maxlength="255"
+        {{on "change" this.onChange}}
+        @value={{@campaign.name}}
+        required={{true}}
+        aria-required={{true}}
+      >
+        <:label>{{t "pages.campaign-creation.name.label"}}</:label>
+      </PixInput>
+
+      {{#if @errors.name}}
+        <div class="form__error error-message">
+          {{displayCampaignErrors @errors.name}}
+        </div>
+      {{/if}}
+    </FormField>
+  </template>
+}

--- a/orga/app/components/campaign/create-form/campaign-owner.gjs
+++ b/orga/app/components/campaign/create-form/campaign-owner.gjs
@@ -1,0 +1,57 @@
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import ExplanationCard from '../../ui/explanation-card';
+import FormField from '../../ui/form-field';
+
+export default class CampaignOwner extends Component {
+  @service locale;
+
+  get campaignOwnerOptions() {
+    if (!this.args.membersSortedByFullName) return [];
+
+    return this.args.membersSortedByFullName.map((member) => ({ value: member.id, label: member.fullName }));
+  }
+
+  @action
+  onChangeCampaignOwner(newOwnerId) {
+    const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerId === member.id);
+    if (selectedMember) {
+      this.args.campaign.ownerId = selectedMember.id;
+    }
+  }
+
+  <template>
+    <FormField>
+      <:default>
+        <PixSelect
+          class="pix-select-owner"
+          @options={{this.campaignOwnerOptions}}
+          @onChange={{this.onChangeCampaignOwner}}
+          @value="{{@campaign.ownerId}}"
+          @isSearchable={{true}}
+          @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
+          @locale={{this.locale.currentLocale}}
+          @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
+          @requiredLabel={{t "common.form.mandatory-fields-title"}}
+          @hideDefaultOption={{true}}
+        >
+          <:label>{{t "pages.campaign-creation.owner.label"}}</:label>
+        </PixSelect>
+
+      </:default>
+
+      <:information>
+        <ExplanationCard>
+          <:title>{{t "pages.campaign-creation.owner.title"}}</:title>
+
+          <:message>{{t "pages.campaign-creation.owner.info"}}</:message>
+        </ExplanationCard>
+
+      </:information>
+    </FormField>
+  </template>
+}

--- a/orga/app/components/campaign/create-form/combined-course-goal-settings.gjs
+++ b/orga/app/components/campaign/create-form/combined-course-goal-settings.gjs
@@ -1,0 +1,10 @@
+import CampaignName from './campaign-name';
+import CourseSelection from './course-selection';
+
+<template>
+  <CourseSelection @campaign={{@campaign}} @errors={{@errors}} @tab="blueprint" />
+
+  {{#if @campaign.course}}
+    <CampaignName @campaign={{@campaign}} @errors={{@errors}} />
+  {{/if}}
+</template>

--- a/orga/app/components/campaign/create-form/course-selection.gjs
+++ b/orga/app/components/campaign/create-form/course-selection.gjs
@@ -1,0 +1,32 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { t } from 'ember-intl';
+import { or } from 'ember-truth-helpers';
+
+import CourseCard from '../../catalogue/course-card';
+import FormField from '../../ui/form-field';
+import PixFieldset from '../../ui/pix-fieldset';
+
+<template>
+  <FormField>
+    <:default>
+      <div class="campaign-creation-form__course-selection">
+        <PixFieldset @required={{true}}>
+          <:title>{{t "pages.campaign-creation.course-label"}}</:title>
+          <:content>
+            {{#if @campaign.course}}
+              <CourseCard @course={{@campaign.course}} @type={{@campaign.course.type}} />
+            {{/if}}
+            <PixButtonLink @route="authenticated.catalogue.list" @model={{@tab}} @variant="primary-bis">
+              {{t "pages.campaign-creation.course-selection-label"}}
+            </PixButtonLink>
+          </:content>
+        </PixFieldset>
+      </div>
+      {{#if (or @errors.targetProfile @errors.blueprint)}}
+        <div class="form__error error-message">
+          <span>{{t "api-error-messages.campaign-creation.target-profile-required"}}</span>
+        </div>
+      {{/if}}
+    </:default>
+  </FormField>
+</template>

--- a/orga/app/components/campaign/create-form/external-id.gjs
+++ b/orga/app/components/campaign/create-form/external-id.gjs
@@ -1,0 +1,126 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { eq, not } from 'ember-truth-helpers';
+import { ID_PIX_TYPES } from 'pix-orga/helpers/id-pix-types.js';
+
+import displayCampaignErrors from '../../../helpers/display-campaign-errors';
+import FormField from '../../ui/form-field';
+import PixFieldset from '../../ui/pix-fieldset';
+
+export default class ExternalId extends Component {
+  @tracked wantIdPix = Boolean(this.args.campaign.externalIdLabel);
+
+  get isExternalIdSelectedChecked() {
+    return this.wantIdPix === true;
+  }
+
+  @action
+  askLabelIdPix() {
+    this.wantIdPix = true;
+    this.args.campaign.externalIdLabel = '';
+    this.args.campaign.externalIdType = '';
+  }
+
+  @action
+  doNotAskLabelIdPix() {
+    this.wantIdPix = false;
+    this.args.campaign.externalIdLabel = null;
+    this.args.campaign.externalIdType = '';
+  }
+
+  @action
+  onChangeExternalIdType(event) {
+    this.args.campaign.externalIdType = event.target.value;
+  }
+
+  @action
+  onChangeExternalIdLabel(event) {
+    this.args.campaign.externalIdLabel = event.target.value;
+  }
+
+  <template>
+    <FormField>
+      <PixFieldset aria-labelledby="external-ids-label" role="radiogroup">
+        <:title>{{t "pages.campaign-creation.external-id-label.question-label"}}</:title>
+        <:content>
+          <PixRadioButton
+            name="external-id-label"
+            @value="false"
+            {{on "change" this.doNotAskLabelIdPix}}
+            checked={{not this.isExternalIdSelectedChecked}}
+          >
+            <:label>{{t "pages.campaign-creation.no"}}</:label>
+          </PixRadioButton>
+          <PixRadioButton
+            name="external-id-label"
+            @value="true"
+            {{on "change" this.askLabelIdPix}}
+            checked={{this.isExternalIdSelectedChecked}}
+          >
+            <:label>{{t "pages.campaign-creation.yes"}}</:label>
+          </PixRadioButton>
+        </:content>
+      </PixFieldset>
+    </FormField>
+
+    {{#if this.wantIdPix}}
+      <FormField>
+        <PixFieldset @required={{true}} aria-labelledby="external-ids-types" role="radiogroup">
+          <:title>{{t "pages.campaign-creation.external-id-type.question-label"}}</:title>
+          <:content>
+            <PixRadioButton
+              name="external-id-types"
+              @value="EMAIL"
+              {{on "change" this.onChangeExternalIdType}}
+              checked={{eq @campaign.externalIdType "EMAIL"}}
+            >
+              <:label>{{t ID_PIX_TYPES.EMAIL}}</:label>
+
+            </PixRadioButton>
+            <PixRadioButton
+              name="external-id-types"
+              @value="STRING"
+              {{on "change" this.onChangeExternalIdType}}
+              checked={{eq @campaign.externalIdType "STRING"}}
+            >
+              <:label>{{t ID_PIX_TYPES.STRING}}</:label>
+            </PixRadioButton>
+            {{#if @errors.externalIdType}}
+              <div class="form__error error-message">
+                {{displayCampaignErrors @errors.externalIdType}}
+              </div>
+            {{/if}}
+          </:content>
+        </PixFieldset>
+      </FormField>
+      <FormField>
+        <PixInput
+          @id="external-id-label"
+          @name="external-id-label"
+          @subLabel={{t "pages.campaign-creation.external-id-label.suggestion"}}
+          maxlength="255"
+          @requiredLabel={{t "pages.campaign-creation.external-id-label.required"}}
+          {{on "change" this.onChangeExternalIdLabel}}
+          @value={{@campaign.externalIdLabel}}
+        >
+          <:label>{{t "pages.campaign-creation.external-id-label.label"}}</:label>
+        </PixInput>
+
+        {{#if @errors.externalIdLabel}}
+          <div class="form__error error-message">
+            {{displayCampaignErrors @errors.externalIdLabel}}
+          </div>
+        {{/if}}
+      </FormField>
+
+      <div class="gdpr-information-external-id">
+        {{t "pages.campaign-creation.legal-warning"}}
+      </div>
+    {{/if}}
+  </template>
+}

--- a/orga/app/components/campaign/create-form/landing-page-text.gjs
+++ b/orga/app/components/campaign/create-form/landing-page-text.gjs
@@ -1,0 +1,29 @@
+import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import FormField from '../../ui/form-field';
+
+export default class LandingPageText extends Component {
+  @action
+  onChange(event) {
+    this.args.campaign.customLandingPageText = event.target.value;
+  }
+
+  <template>
+    <FormField>
+      <PixTextarea
+        @id="custom-landing-page-text"
+        @maxlength="5000"
+        @value={{@campaign.customLandingPageText}}
+        @subLabel={{t "pages.campaign-creation.landing-page-text.sublabel"}}
+        {{on "change" this.onChange}}
+        rows="8"
+      >
+        <:label>{{t "pages.campaign-creation.landing-page-text.label"}}</:label>
+      </PixTextarea>
+    </FormField>
+  </template>
+}

--- a/orga/app/components/campaign/create-form/multiple-sendings.gjs
+++ b/orga/app/components/campaign/create-form/multiple-sendings.gjs
@@ -1,0 +1,61 @@
+import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
+
+import ExplanationCard from '../../ui/explanation-card';
+import FormField from '../../ui/form-field';
+import PixFieldset from '../../ui/pix-fieldset';
+
+export default class MultipleSendings extends Component {
+  @action
+  selectMultipleSendingsStatus(value) {
+    this.args.campaign.multipleSendings = value;
+  }
+
+  <template>
+    <FormField>
+      <:default>
+        <PixFieldset @required={{true}} aria-labelledby="multiple-sendings-label" role="radiogroup">
+          <:title>{{t @labelKey}}</:title>
+          <:content>
+            <PixRadioButton
+              name="multiple-sendings-label"
+              @value="false"
+              {{on "change" (fn this.selectMultipleSendingsStatus false)}}
+              aria-describedby="multiple-sendings-info"
+              checked={{not @campaign.multipleSendings}}
+            >
+              <:label>{{t "pages.campaign-creation.no"}}</:label>
+            </PixRadioButton>
+
+            <PixRadioButton
+              name="multiple-sendings-label"
+              @value="true"
+              {{on "change" (fn this.selectMultipleSendingsStatus true)}}
+              aria-describedby="multiple-sendings-info"
+              checked={{@campaign.multipleSendings}}
+            >
+              <:label>{{t "pages.campaign-creation.yes"}}</:label>
+            </PixRadioButton>
+          </:content>
+        </PixFieldset>
+      </:default>
+      <:information>
+        <ExplanationCard id="multiple-sendings-info">
+          <:title>{{t "pages.campaign-creation.multiple-sendings.info-title"}}</:title>
+
+          <:message>
+            {{t @infoKey}}
+            {{#if @campaign.targetProfile.areKnowledgeElementsResettable}}
+              {{t "pages.campaign-creation.multiple-sendings.knowledge-elements-resettable"}}
+            {{/if}}
+          </:message>
+        </ExplanationCard>
+      </:information>
+    </FormField>
+  </template>
+}

--- a/orga/app/components/campaign/create-form/profiles-collection-goal-customization.gjs
+++ b/orga/app/components/campaign/create-form/profiles-collection-goal-customization.gjs
@@ -1,0 +1,3 @@
+import LandingPageText from './landing-page-text';
+
+<template><LandingPageText @campaign={{@campaign}} /></template>

--- a/orga/app/components/campaign/create-form/profiles-collection-goal-settings.gjs
+++ b/orga/app/components/campaign/create-form/profiles-collection-goal-settings.gjs
@@ -1,0 +1,18 @@
+import CampaignName from './campaign-name';
+import CampaignOwner from './campaign-owner';
+import ExternalId from './external-id';
+import MultipleSendings from './multiple-sendings';
+
+<template>
+  <CampaignName @campaign={{@campaign}} @errors={{@errors}} />
+
+  <CampaignOwner @campaign={{@campaign}} @membersSortedByFullName={{@membersSortedByFullName}} />
+
+  <MultipleSendings
+    @campaign={{@campaign}}
+    @labelKey="pages.campaign-creation.multiple-sendings.profiles.question-label"
+    @infoKey="pages.campaign-creation.multiple-sendings.profiles.info"
+  />
+
+  <ExternalId @campaign={{@campaign}} @errors={{@errors}} />
+</template>

--- a/orga/app/components/ui/form-section.gjs
+++ b/orga/app/components/ui/form-section.gjs
@@ -1,0 +1,6 @@
+<template>
+  <div class="form-section">
+    <h2 class="form-section__title">{{@title}}</h2>
+    {{yield}}
+  </div>
+</template>

--- a/orga/app/styles/components/ui/form-section.scss
+++ b/orga/app/styles/components/ui/form-section.scss
@@ -1,0 +1,13 @@
+@use 'pix-design-tokens/typography';
+
+.form-section {
+  & + & {
+    margin-top: var(--pix-spacing-6x);
+  }
+
+  &__title {
+    @extend %pix-subtitle-l;
+
+    margin-bottom: var(--pix-spacing-6x);
+  }
+}

--- a/orga/app/styles/components/ui/index.scss
+++ b/orga/app/styles/components/ui/index.scss
@@ -10,6 +10,7 @@
 @use 'explanation-card';
 @use 'pix-fieldset';
 @use 'form-field';
+@use 'form-section';
 @use 'last-participation-date-tooltip';
 @use 'action-bar';
 @use 'tooltip-with-icon';

--- a/orga/tests/acceptance/campaign-creation-catalogue-test.js
+++ b/orga/tests/acceptance/campaign-creation-catalogue-test.js
@@ -187,7 +187,7 @@ module('Acceptance | Campaign Creation (catalogue)', function (hooks) {
 
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
 
-      const title = `${t('pages.campaign-creation.test-title.label')} ${t('pages.campaign-creation.test-title.sublabel')}`;
+      const title = `${t('pages.campaign-creation.course-title.label')} ${t('pages.campaign-creation.course-title.sublabel')}`;
 
       await fillByLabel(title, 'Savoir rechercher');
       await clickByName('Non');

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -130,7 +130,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
       await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
 
-      const title = `${t('pages.campaign-creation.test-title.label')} ${t('pages.campaign-creation.test-title.sublabel')}`;
+      const title = `${t('pages.campaign-creation.course-title.label')} ${t('pages.campaign-creation.course-title.sublabel')}`;
 
       await fillByLabel(title, 'Savoir rechercher');
       await clickByName('Non');

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -111,7 +111,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       const customizationSection = screen.getByRole('heading', {
         name: t('pages.campaign-creation.customization.title'),
       }).parentElement;
-      assert.dom(within(customizationSection).getByText(t('pages.campaign-creation.test-title.label'))).exists();
+      assert.dom(within(customizationSection).getByText(t('pages.campaign-creation.course-title.label'))).exists();
       assert
         .dom(
           within(customizationSection).getByLabelText(t('pages.campaign-creation.landing-page-text.label'), {

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -1,10 +1,9 @@
 import { clickByName, fillByLabel, render, within } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CreateForm from 'pix-orga/components/campaign/create-form-catalogue';
-import { assert, module, test } from 'qunit';
+import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -13,14 +12,13 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   setupIntlRenderingTest(hooks);
 
   const data = {};
-  let store;
   const createCampaignSpy = (event) => {
     event.preventDefault();
   };
   const cancelSpy = () => {};
 
   hooks.beforeEach(function () {
-    store = this.owner.lookup('service:store');
+    const store = this.owner.lookup('service:store');
     const prescriber = store.createRecord('prescriber', {
       firstName: 'Adam',
       lastName: 'Troisjour',
@@ -40,6 +38,144 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     data.defaultMembers = [prescriber];
     data.campaign = store.createRecord('campaign', { ownerId: prescriber.id });
     data.errors = {};
+  });
+
+  module('when grouping fields into sections', function () {
+    test('it always displays a "Paramétrage" section containing the campaign goal field', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      const settingsSection = screen.getByRole('heading', {
+        name: t('pages.campaign-creation.settings.title'),
+      }).parentElement;
+      assert
+        .dom(within(settingsSection).getByRole('radiogroup', { name: t('pages.campaign-creation.purpose.label') }))
+        .exists();
+    });
+
+    test('it does not display the "Personnalisation" section until a course is selected for an assessment goal', async function (assert) {
+      // given
+      data.campaign.type = 'ASSESSMENT';
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.queryByRole('heading', { name: t('pages.campaign-creation.customization.title') }))
+        .doesNotExist();
+    });
+
+    test('it displays the "Personnalisation" section with the title and landing page fields once a course is selected for an assessment goal', async function (assert) {
+      // given
+      data.campaign.type = 'ASSESSMENT';
+      data.campaign.course = this.owner
+        .lookup('service:store')
+        .createRecord('course', { name: 'targetProfile1', id: '123', type: 'targetProfile' });
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      const customizationSection = screen.getByRole('heading', {
+        name: t('pages.campaign-creation.customization.title'),
+      }).parentElement;
+      assert.dom(within(customizationSection).getByText(t('pages.campaign-creation.test-title.label'))).exists();
+      assert
+        .dom(
+          within(customizationSection).getByLabelText(t('pages.campaign-creation.landing-page-text.label'), {
+            exact: false,
+          }),
+        )
+        .exists();
+    });
+
+    test('it displays the "Personnalisation" section with the landing page field for a profiles collection goal', async function (assert) {
+      // given
+      data.campaign.type = 'PROFILES_COLLECTION';
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      const customizationSection = screen.getByRole('heading', {
+        name: t('pages.campaign-creation.customization.title'),
+      }).parentElement;
+      assert
+        .dom(
+          within(customizationSection).getByLabelText(t('pages.campaign-creation.landing-page-text.label'), {
+            exact: false,
+          }),
+        )
+        .exists();
+    });
+
+    test('it never displays the "Personnalisation" section for a combined course goal', async function (assert) {
+      // given
+      data.campaign.type = 'COMBINED_COURSE';
+      data.campaign.course = this.owner
+        .lookup('service:store')
+        .createRecord('course', { name: 'Mon parcours combiné', id: '123', type: 'blueprint' });
+
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.queryByRole('heading', { name: t('pages.campaign-creation.customization.title') }))
+        .doesNotExist();
+    });
   });
 
   test('it displays campaign goals', async function (assert) {
@@ -81,7 +217,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       assert.dom(button).hasAria('disabled', 'true');
     });
 
-    test('it should not display course selection nor campaign name input', async function (assert) {
+    test('it should not display any campaign goal fields', async function (assert) {
       // when
       const screen = await render(
         <template>
@@ -103,7 +239,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     });
   });
 
-  test('it enables the submit button profile collection is selected', async function (assert) {
+  test('it enables the submit button when profile collection is selected', async function (assert) {
     data.campaign.type = 'PROFILES_COLLECTION';
     // when
     const screen = await render(
@@ -121,30 +257,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     // then
     const button = screen.getByRole('button', { name: t('pages.campaign-creation.actions.create') });
     assert.dom(button).doesNotHaveAria('disabled');
-  });
-
-  test("it displays campaign's name", async function (assert) {
-    // given
-    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-    data.campaign.name = 'Campagne de test';
-    data.campaign.type = 'ASSESSMENT';
-
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    assert
-      .dom(screen.getByLabelText(t('pages.campaign-creation.name.label'), { exact: false }))
-      .hasValue('Campagne de test');
   });
 
   test('[a11y] it displays a message that some inputs are required', async function (assert) {
@@ -171,871 +283,10 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       .exists();
   });
 
-  module('when campaign is of type ASSESSMENT', function (hooks) {
-    hooks.beforeEach(function () {
-      data.campaign.type = 'ASSESSMENT';
-    });
-
-    test('it hides owner field if no course selected', async function () {
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
-    });
-
-    test('it hides multiple sending field if no course selected', async function () {
-      // given
-      data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert
-        .dom(
-          screen.queryByRole('radiogroup', {
-            name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
-          }),
-        )
-        .doesNotExist();
-    });
-
-    test('it hides campaign title until user select a course', async function (assert) {
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert
-        .dom(screen.queryByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false }))
-        .doesNotExist();
-    });
-
-    test('it hides landing page until user select a course', async function () {
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert
-        .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
-        .doesNotExist();
-    });
-
-    test('it hides exam mode field until user select a course', async function () {
-      // given
-      data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.queryByText(t('pages.campaign-creation.exam-mode.label'))).doesNotExist();
-      assert.dom(screen.queryByText(t('pages.campaign-creation.purpose.exam-info'))).doesNotExist();
-    });
-
-    test(`it has ASSESSMENT checked`, async function (assert) {
-      // given
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.assessment'))).isChecked();
-    });
-
-    test("it displays owner fields and auto complete owner field with owner's full name", async function (assert) {
-      // given
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      assert.dom(screen.getByText(t('pages.campaign-creation.owner.info'))).exists();
-      assert.dom(screen.getAllByText(t('pages.campaign-creation.owner.title'))[0]).exists();
-      await click(screen.getByLabelText(t('pages.campaign-creation.owner.label'), { exact: false }));
-
-      await screen.findByRole('listbox');
-
-      // then
-      assert.dom(screen.getByRole('option', { name: 'Adam Troisjour', selected: true })).exists();
-    });
-
-    test('it fills course fields', async function (assert) {
-      // given
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile', name: 'yolo' });
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('heading', {
-            name: data.campaign.course.name,
-          }),
-        )
-        .exists();
-    });
-
-    test('it fills multiple sendings fields', async function (assert) {
-      // given
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
-      data.campaign.multipleSendings = true;
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      const radiogroup = screen.getByRole('radiogroup', {
-        name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
-      });
-      assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
-    });
-
-    test('it explains which informations will be visible to organization-learners', async function () {
-      // given
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      const testTitleSublabel = screen.getAllByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), {
-        exact: false,
-      })[0];
-      const landingPageSublabel = screen.getAllByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), {
-        exact: false,
-      })[1];
-
-      assert.ok(testTitleSublabel);
-      assert.ok(landingPageSublabel);
-    });
-
-    test('it displays fields for campaign title', async function (assert) {
-      // given
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.purpose.assessment'));
-
-      // then
-      assert.dom(screen.getByText(t('pages.campaign-creation.test-title.label'))).exists();
-      assert.dom(screen.getByText(t('pages.campaign-creation.purpose.label'))).exists();
-    });
-
-    test(`it displays the purpose explanation of an ASSESSMENT campaign`, async function (assert) {
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.purpose.assessment'));
-
-      // then
-      assert.dom(screen.getByText(t('pages.campaign-creation.purpose.assessment-info'))).exists();
-    });
-
-    test(`it displays the activate exam mode field and info`, async function (assert) {
-      // given
-      data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.getByText(t('pages.campaign-creation.exam-mode.label'))).exists();
-      assert.dom(screen.getByText(t('pages.campaign-creation.purpose.exam-info'))).exists();
-      const radiogroup = screen.getByRole('radiogroup', { name: t('pages.campaign-creation.exam-mode.label') });
-      assert.dom(within(radiogroup).getByRole('radio', { name: 'Non' })).isChecked();
-    });
-
-    test(`it set the campaign's type to EXAM when the user activate the exam mode`, async function (assert) {
-      // given
-      data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // when
-      const examModeField = screen.getByRole('radiogroup', { name: t('pages.campaign-creation.exam-mode.label') });
-      await click(within(examModeField).getByRole('radio', { name: 'Oui' }));
-
-      // then
-      assert.strictEqual(data.campaign.type, 'EXAM');
-    });
-
-    module('when the user has selected a course', function () {
-      test('it displays informations about the course', async function (assert) {
-        // given
-        const course = store.createRecord('course', {
-          id: '1',
-          name: 'targetProfile1',
-          type: 'targetProfile',
-          nbTubes: 3,
-          isSimplifiedAccess: true,
-        });
-        data.campaign.course = course;
-
-        // when
-        const screen = await render(
-          <template>
-            <CreateForm
-              @campaign={{data.campaign}}
-              @onSubmit={{createCampaignSpy}}
-              @onCancel={{cancelSpy}}
-              @errors={{data.errors}}
-              @membersSortedByFullName={{data.defaultMembers}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByText(t('pages.catalogue.card.tag.target-profile'))).exists();
-        assert.dom(screen.getByRole('heading', { name: course.name })).exists();
-        assert.dom(screen.getByText(t('pages.catalogue.card.tubes-count', { count: course.nbTubes }))).exists();
-        assert.dom(screen.getByText(t('pages.catalogue.card.simplified-access'))).exists();
-      });
-
-      module('when the user wants to select another course', function () {
-        test('it redirects to /catalogue/targetProfile', async function (assert) {
-          // given
-          data.campaign.course = store.createRecord('course', {
-            id: '1',
-            name: 'targetProfile1',
-            type: 'targetProfile',
-            nbTubes: 3,
-            isSimplifiedAccess: true,
-          });
-
-          // when
-          const screen = await render(
-            <template>
-              <CreateForm
-                @campaign={{data.campaign}}
-                @onSubmit={{createCampaignSpy}}
-                @onCancel={{cancelSpy}}
-                @errors={{data.errors}}
-                @membersSortedByFullName={{data.defaultMembers}}
-              />
-            </template>,
-          );
-
-          // then
-          assert
-            .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
-            .hasAttribute('href', '/catalogue/targetProfile');
-        });
-      });
-    });
-  });
-
-  module(`when campaign is of type combined course`, function () {
-    test(`it not displays external id fields`, async function (assert) {
-      // given
-      data.campaign.type = 'COMBINED_COURSE';
-      data.campaign.course = store.createRecord('course', {
-        id: '1',
-        name: 'Mon schéma de parcours combiné',
-        type: 'blueprint',
-        nbModules: 3,
-        isSimplifiedAccess: true,
-      });
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert
-        .dom(screen.queryByRole('radiogroup', { name: t('pages.campaign-creation.external-id-label.question-label') }))
-        .doesNotExist();
-    });
-
-    test(`it has combined course goal checked and not display owner fields`, async function (assert) {
-      const campaignType = {
-        status: 'COMBINED_COURSE',
-        purpose: 'pages.campaign-creation.purpose.combined-course',
-      };
-      // given
-      data.campaign.type = campaignType.status;
-      data.campaign.course = store.createRecord('course', {
-        id: '1',
-        name: 'Mon schéma de parcours combiné',
-        type: 'blueprint',
-        nbModules: 3,
-        isSimplifiedAccess: true,
-      });
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.getByLabelText(t(campaignType.purpose))).isChecked();
-      assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
-      assert.dom(screen.queryByText(t('pages.campaign-creation.owner.title'))).doesNotExist();
-    });
-
-    test('it redirects to /catalogue/blueprint', async function (assert) {
-      // given
-
-      data.campaign.course = store.createRecord('course', {
-        id: '1',
-        name: 'blueprint1',
-        type: 'blueprint',
-        nbModules: 3,
-        isSimplifiedAccess: true,
-      });
-      data.campaign.type = 'COMBINED_COURSE';
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert
-        .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
-        .hasAttribute('href', '/catalogue/blueprint');
-    });
-  });
-
-  test('it not displays EXAM type when feature is not enable', async function () {
-    // given
-    data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: false, params: null };
-
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    assert.notOk(screen.queryByLabelText(t('pages.campaign-creation.purpose.exam')));
-  });
-
-  module('when campaign is of type PROFILES_COLLECTION', function () {
-    test('it has PROFILES_COLLECTION checked', async function (assert) {
-      // given
-      data.campaign.type = 'PROFILES_COLLECTION';
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.profiles-collection'))).isChecked();
-    });
-
-    test('it fills multiple sendings fields', async function (assert) {
-      // given
-      data.campaign.type = 'PROFILES_COLLECTION';
-      data.campaign.multipleSendings = true;
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      const radiogroup = screen.getByRole('radiogroup', {
-        name: t('pages.campaign-creation.multiple-sendings.profiles.question-label'),
-      });
-      assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
-    });
-  });
-
-  module('when user choose to create a campaign of type PROFILES_COLLECTION', () => {
-    test('it not displays fields for campaign title and target profile', async function (assert) {
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
-
-      // then
-      assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
-      assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
-    });
-
-    test('it displays fields for enabling multiple sendings', async function (assert) {
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
-
-      // then
-      assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.question-label'))).exists();
-      assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.info'))).exists();
-    });
-
-    test('it displays the purpose explanation of a profiles collection campaign', async function (assert) {
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
-
-      // then
-      assert.dom(screen.getByText(t('pages.campaign-creation.purpose.profiles-collection-info'))).exists();
-      assert.dom(screen.queryByText(t('pages.campaign-creation.purpose.assessment-info'))).doesNotExist();
-    });
-  });
-
-  module('when user choose to create a campaign of type COMBINED_COURSE', () => {
-    test('it not displays fields for campaign title and target profile', async function (assert) {
-      // when
-
-      data.campaign.course = store.createRecord('course', {
-        id: '1',
-        name: 'Blueprint 1',
-        type: 'blueprint',
-      });
-      data.campaign.type = 'COMBINED_COURSE';
-
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
-    });
-  });
-
-  test('it fills external user ID selection (yes)', async function (assert) {
-    // given
-    data.campaign.externalIdLabel = 'Numéro étudiant';
-    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    // then
-    const externalIdentifier = screen
-      .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
-      .closest('fieldset');
-    const element = within(externalIdentifier).getByRole('radio', { name: t('pages.campaign-creation.yes') });
-
-    assert.dom(element).isChecked();
-    assert
-      .dom(screen.getByLabelText(t('pages.campaign-creation.external-id-label.label'), { exact: false }))
-      .hasValue('Numéro étudiant');
-  });
-
-  test('it fills external user ID selection (no)', async function (assert) {
-    // given
-    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-    data.campaign.externalIdLabel = null;
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    // then
-    const externalIdentifier = screen
-      .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
-      .closest('fieldset');
-    const element = within(externalIdentifier).getByRole('radio', { name: t('pages.campaign-creation.no') });
-
-    assert.dom(element).isChecked();
-  });
-
-  module('when user has not chosen yet to ask or not an external user ID', function () {
-    test('it fills the default external user ID selection', async function (assert) {
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      const externalIdentifier = screen
-        .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
-        .closest('fieldset');
-
-      assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.no'))).isChecked();
-      assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.yes'))).isNotChecked();
-    });
-
-    test('it not displays gdpr footnote', async function (assert) {
-      // when
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.queryByText(t('pages.campaign-creation.legal-warning'))).doesNotExist();
-    });
-  });
-
-  module('when user choose not to ask an external user ID', function () {
-    test('it not displays gdpr footnote either', async function (assert) {
-      // when
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.no'));
-
-      // then
-      assert.dom(screen.queryByText(t('pages.campaign-creation.legal-warning'))).doesNotExist();
-    });
-  });
-
-  module('when user choose to ask an external user ID', function () {
-    test('it displays gdpr footnote', async function (assert) {
-      // when
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.yes'));
-
-      // then
-      assert.dom(screen.getByText(t('pages.campaign-creation.legal-warning'))).exists();
-    });
-
-    test('it sets the external id as required', async function (assert) {
-      // when
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.yes'));
-
-      // then
-      const label = screen.getByLabelText(new RegExp(t('pages.campaign-creation.external-id-label.label')));
-      assert.true(label.hasAttribute('aria-required', false));
-    });
-    test('it asks for external id type', async function (assert) {
-      // when
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.yes'));
-
-      // then
-      const radioGroup = screen.getByRole('radiogroup', {
-        name: t('pages.campaign-creation.external-id-type.question-label'),
-      });
-      assert.ok(radioGroup);
-    });
-
-    test('it updates campaign model when select a type', async function (assert) {
-      // when
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.yes'));
-
-      const checkedRadio = screen.getByLabelText(t('pages.campaign-settings.external-user-id-types.email'));
-      await checkedRadio.click();
-      assert.strictEqual(data.campaign.externalIdType, 'EMAIL');
-    });
-  });
-
-  test('it fills campaign title', async function (assert) {
+  test('it has ASSESSMENT checked and displays its purpose explanation', async function (assert) {
     // given
     data.campaign.type = 'ASSESSMENT';
-    data.campaign.title = 'Mon titre de parcours';
-    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
+
     // when
     const screen = await render(
       <template>
@@ -1049,85 +300,71 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       </template>,
     );
 
-    assert
-      .dom(screen.getByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false }))
-      .hasValue('Mon titre de parcours');
-  });
-
-  module('landing page customization', function () {
-    test('it hides landing page info for combinedCourse', async function () {
-      // given
-      data.campaign.course = store.createRecord('course', { type: 'blueprint' });
-      data.campaign.type = 'COMBINED_COURSE';
-
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      // then
-      assert
-        .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
-        .doesNotExist();
-    });
-  });
-
-  test('it fills campaign landing page text', async function (assert) {
-    // given
-    data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-    data.campaign.type = 'ASSESSMENT';
-    data.campaign.customLandingPageText = 'Mon texte de landing page';
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    assert
-      .dom(screen.getByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
-      .hasValue('Mon texte de landing page');
-  });
-
-  test('it sends campaign creation action when submitted', async function (assert) {
-    // given
-
-    data.campaign.course = store.createRecord('course', { name: 'targetProfile1', id: '123', type: 'targetProfile' });
-    const createCampaignSpy = sinon.stub();
-
-    await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-    await fillByLabel(`${t('pages.campaign-creation.name.label')} *`, 'Ma campagne');
-    await clickByName(t('pages.campaign-creation.purpose.assessment'));
-
-    // when
-    await clickByName(t('pages.campaign-creation.actions.create'));
-
-    sinon.assert.calledWithExactly(createCampaignSpy, data.campaign);
     // then
-    assert.ok(true);
+    assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.assessment'))).isChecked();
+    assert.dom(screen.getByText(t('pages.campaign-creation.purpose.assessment-info'))).exists();
+  });
+
+  test('it has combined course goal checked and displays its purpose explanation', async function (assert) {
+    // given
+    data.campaign.type = 'COMBINED_COURSE';
+
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.combined-course'))).isChecked();
+    assert.dom(screen.getByText(t('pages.campaign-creation.purpose.combined-course-info'))).exists();
+  });
+
+  test('it has PROFILES_COLLECTION checked', async function (assert) {
+    // given
+    data.campaign.type = 'PROFILES_COLLECTION';
+
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+
+    assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.profiles-collection'))).isChecked();
+  });
+
+  test('it displays the purpose explanation of a profiles collection campaign', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+    await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+
+    // then
+    assert.dom(screen.getByText(t('pages.campaign-creation.purpose.profiles-collection-info'))).exists();
+    assert.dom(screen.queryByText(t('pages.campaign-creation.purpose.assessment-info'))).doesNotExist();
   });
 
   test('it not displays the explanation of automatic compute certificability if the feature is not activated', async function (assert) {
@@ -1170,6 +407,35 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     assert.dom(screen.getByRole('link', { name: 'Élèves' })).exists();
   });
 
+  test('it sends campaign creation action when submitted', async function (assert) {
+    // given
+    data.campaign.course = this.owner
+      .lookup('service:store')
+      .createRecord('course', { name: 'targetProfile1', id: '123', type: 'targetProfile' });
+    const createCampaignSpy = sinon.stub();
+
+    await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.defaultMembers}}
+        />
+      </template>,
+    );
+    await clickByName(t('pages.campaign-creation.purpose.assessment'));
+    await fillByLabel(`${t('pages.campaign-creation.name.label')} *`, 'Ma campagne');
+
+    // when
+    await clickByName(t('pages.campaign-creation.actions.create'));
+
+    sinon.assert.calledWithExactly(createCampaignSpy, data.campaign);
+    // then
+    assert.ok(true);
+  });
+
   module('when there are errors', function () {
     test('it displays errors messages when the campaign purpose fields is empty', async function (assert) {
       // given
@@ -1185,8 +451,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
       data.errors = campaignWithErrors.errors;
 
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      data.campaign.type = 'ASSESSMENT';
       // when
       const screen = await render(
         <template>
@@ -1199,82 +463,9 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
           />
         </template>,
       );
-      await clickByName(t('pages.campaign-creation.yes'));
+
       // then
       assert.dom(screen.getByText(t('api-error-messages.campaign-creation.purpose-required'))).exists();
-    });
-
-    test('it displays errors messages when the name, and external user id fields are empty', async function (assert) {
-      // given
-      const campaignWithErrors = EmberObject.create({
-        errors: {
-          name: [
-            {
-              message: 'CAMPAIGN_NAME_IS_REQUIRED',
-            },
-          ],
-          externalIdLabel: [
-            {
-              message: 'EXTERNAL_USER_ID_IS_REQUIRED',
-            },
-          ],
-        },
-      });
-
-      data.errors = campaignWithErrors.errors;
-
-      data.campaign.course = store.createRecord('course', { type: 'targetProfile' });
-      data.campaign.type = 'ASSESSMENT';
-      // when
-      const screen = await render(
-        <template>
-          <CreateForm
-            @campaign={{data.campaign}}
-            @onSubmit={{createCampaignSpy}}
-            @onCancel={{cancelSpy}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.defaultMembers}}
-          />
-        </template>,
-      );
-      await clickByName(t('pages.campaign-creation.yes'));
-
-      // then
-      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.name-required'))).exists();
-      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.external-user-id-required'))).exists();
-    });
-
-    ['targetProfile', 'blueprint'].forEach((error) => {
-      test(`it displays error message when the ${error} course field is empty`, async function (assert) {
-        // given
-        const campaignWithErrors = EmberObject.create({
-          errors: {
-            [error]: [
-              {
-                message: 'TARGET_PROFILE_IS_REQUIRED',
-              },
-            ],
-          },
-        });
-        data.errors = campaignWithErrors.errors;
-
-        // when
-        const screen = await render(
-          <template>
-            <CreateForm
-              @campaign={{data.campaign}}
-              @onSubmit={{createCampaignSpy}}
-              @onCancel={{cancelSpy}}
-              @errors={{data.errors}}
-              @membersSortedByFullName={{data.defaultMembers}}
-            />
-          </template>,
-        );
-        await clickByName(t('pages.campaign-creation.purpose.assessment'));
-
-        // then
-        assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
-      });
     });
   });
 });

--- a/orga/tests/integration/components/campaign/create-form-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-test.gjs
@@ -290,7 +290,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await clickByName(t(campaignType.purpose));
 
         // then
-        assert.dom(screen.getByText(t('pages.campaign-creation.test-title.label'))).exists();
+        assert.dom(screen.getByText(t('pages.campaign-creation.course-title.label'))).exists();
         assert.dom(screen.getByText(t('pages.campaign-creation.purpose.label'))).exists();
       });
 
@@ -917,7 +917,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
 
       // then
-      assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
+      assert.dom(screen.queryByText(t('pages.campaign-creation.course-title.label'))).doesNotExist();
       assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
     });
 
@@ -990,7 +990,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(t('pages.campaign-creation.purpose.combined-course'));
 
       // then
-      assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
+      assert.dom(screen.queryByText(t('pages.campaign-creation.course-title.label'))).doesNotExist();
       assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
       await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
       await clickByName(t('pages.campaign-creation.purpose.combined-course'));
@@ -1230,7 +1230,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     assert
-      .dom(screen.getByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false }))
+      .dom(screen.getByLabelText(t('pages.campaign-creation.course-title.label'), { exact: false }))
       .hasValue('Mon titre de parcours');
   });
 

--- a/orga/tests/integration/components/campaign/create-form/assessment-goal-customization-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/assessment-goal-customization-test.gjs
@@ -20,7 +20,7 @@ module('Integration | Component | Campaign::CreateForm::AssessmentGoalCustomizat
     const screen = await render(<template><AssessmentGoalCustomization @campaign={{data.campaign}} /></template>);
 
     // then
-    assert.dom(screen.getByText(t('pages.campaign-creation.test-title.label'))).exists();
+    assert.dom(screen.getByText(t('pages.campaign-creation.course-title.label'))).exists();
     const sublabels = screen.getAllByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), {
       exact: false,
     });
@@ -36,7 +36,7 @@ module('Integration | Component | Campaign::CreateForm::AssessmentGoalCustomizat
 
     // then
     assert
-      .dom(screen.getByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false }))
+      .dom(screen.getByLabelText(t('pages.campaign-creation.course-title.label'), { exact: false }))
       .hasValue('Mon titre de parcours');
   });
 

--- a/orga/tests/integration/components/campaign/create-form/assessment-goal-customization-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/assessment-goal-customization-test.gjs
@@ -1,0 +1,55 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import AssessmentGoalCustomization from 'pix-orga/components/campaign/create-form/assessment-goal-customization';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::AssessmentGoalCustomization', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    data.campaign = store.createRecord('campaign', { type: 'ASSESSMENT' });
+  });
+
+  test('it displays fields for campaign title and landing page with matching sublabels', async function (assert) {
+    // when
+    const screen = await render(<template><AssessmentGoalCustomization @campaign={{data.campaign}} /></template>);
+
+    // then
+    assert.dom(screen.getByText(t('pages.campaign-creation.test-title.label'))).exists();
+    const sublabels = screen.getAllByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), {
+      exact: false,
+    });
+    assert.strictEqual(sublabels.length, 2);
+  });
+
+  test('it fills campaign title', async function (assert) {
+    // given
+    data.campaign.title = 'Mon titre de parcours';
+
+    // when
+    const screen = await render(<template><AssessmentGoalCustomization @campaign={{data.campaign}} /></template>);
+
+    // then
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false }))
+      .hasValue('Mon titre de parcours');
+  });
+
+  test('it fills campaign landing page text', async function (assert) {
+    // given
+    data.campaign.customLandingPageText = 'Mon texte de landing page';
+
+    // when
+    const screen = await render(<template><AssessmentGoalCustomization @campaign={{data.campaign}} /></template>);
+
+    // then
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
+      .hasValue('Mon texte de landing page');
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/assessment-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/assessment-goal-settings-test.gjs
@@ -1,0 +1,237 @@
+import { clickByName, render, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import AssessmentGoalSettings from 'pix-orga/components/campaign/create-form/assessment-goal-settings';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::AssessmentGoalSettings', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    const prescriber = store.createRecord('prescriber', {
+      firstName: 'Adam',
+      lastName: 'Troisjour',
+      id: '1',
+      features: {
+        MULTIPLE_SENDING_ASSESSMENT: { active: false, params: null },
+        CAMPAIGN_WITHOUT_USER_PROFILE: { active: false, params: null },
+      },
+    });
+
+    class CurrentUserStub extends Service {
+      prescriber = prescriber;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    data.prescriber = prescriber;
+    data.membersSortedByFullName = [prescriber];
+    data.campaign = store.createRecord('campaign', { ownerId: prescriber.id, type: 'ASSESSMENT' });
+    data.errors = {};
+  });
+
+  test('it hides owner, multiple-sendings and exam mode fields if no course is selected', async function (assert) {
+    // given
+    data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
+    data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
+
+    // when
+    const screen = await render(
+      <template>
+        <AssessmentGoalSettings
+          @campaign={{data.campaign}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.membersSortedByFullName}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
+    assert
+      .dom(
+        screen.queryByRole('radiogroup', {
+          name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+        }),
+      )
+      .doesNotExist();
+    assert.dom(screen.queryByText(t('pages.campaign-creation.exam-mode.label'))).doesNotExist();
+  });
+
+  module('when a course is selected', function (hooks) {
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+      data.campaign.course = store.createRecord('course', {
+        id: '1',
+        name: 'targetProfile1',
+        type: 'targetProfile',
+        nbTubes: 3,
+        isSimplifiedAccess: true,
+      });
+    });
+
+    test('it displays informations about the course', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <AssessmentGoalSettings
+            @campaign={{data.campaign}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.membersSortedByFullName}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('pages.catalogue.card.tag.target-profile'))).exists();
+      assert.dom(screen.getByRole('heading', { name: data.campaign.course.name })).exists();
+    });
+
+    test('it redirects to /catalogue/targetProfile', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <AssessmentGoalSettings
+            @campaign={{data.campaign}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.membersSortedByFullName}}
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+        .hasAttribute('href', '/catalogue/targetProfile');
+    });
+
+    test("it displays owner fields and auto complete owner field with owner's full name", async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <AssessmentGoalSettings
+            @campaign={{data.campaign}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.membersSortedByFullName}}
+          />
+        </template>,
+      );
+
+      assert.dom(screen.getByText(t('pages.campaign-creation.owner.info'))).exists();
+      await click(screen.getByLabelText(t('pages.campaign-creation.owner.label'), { exact: false }));
+      await screen.findByRole('listbox');
+
+      // then
+      assert.dom(screen.getByRole('option', { name: 'Adam Troisjour', selected: true })).exists();
+    });
+
+    test('it fills multiple sendings fields when the feature is enabled', async function (assert) {
+      // given
+      data.prescriber.features.MULTIPLE_SENDING_ASSESSMENT = { active: true, params: null };
+      data.campaign.multipleSendings = true;
+
+      // when
+      const screen = await render(
+        <template>
+          <AssessmentGoalSettings
+            @campaign={{data.campaign}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.membersSortedByFullName}}
+          />
+        </template>,
+      );
+
+      // then
+      const radiogroup = screen.getByRole('radiogroup', {
+        name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+      });
+      assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
+    });
+
+    test('it does not display the exam mode field when the feature is not enabled', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <AssessmentGoalSettings
+            @campaign={{data.campaign}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.membersSortedByFullName}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.queryByText(t('pages.campaign-creation.exam-mode.label'))).doesNotExist();
+    });
+
+    module('when the exam mode feature is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        data.prescriber.features.CAMPAIGN_WITHOUT_USER_PROFILE = { active: true, params: null };
+      });
+
+      test('it displays the exam mode field and its explanation', async function (assert) {
+        // when
+        const screen = await render(
+          <template>
+            <AssessmentGoalSettings
+              @campaign={{data.campaign}}
+              @errors={{data.errors}}
+              @membersSortedByFullName={{data.membersSortedByFullName}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(t('pages.campaign-creation.exam-mode.label'))).exists();
+        assert.dom(screen.getByText(t('pages.campaign-creation.purpose.exam-info'))).exists();
+      });
+
+      test("it sets the campaign's type to EXAM when the user activates the exam mode", async function (assert) {
+        // given
+        const screen = await render(
+          <template>
+            <AssessmentGoalSettings
+              @campaign={{data.campaign}}
+              @errors={{data.errors}}
+              @membersSortedByFullName={{data.membersSortedByFullName}}
+            />
+          </template>,
+        );
+
+        // when
+        const examModeField = screen.getByRole('radiogroup', { name: t('pages.campaign-creation.exam-mode.label') });
+        await click(within(examModeField).getByRole('radio', { name: t('pages.campaign-creation.yes') }));
+
+        // then
+        assert.strictEqual(data.campaign.type, 'EXAM');
+      });
+    });
+
+    test('it displays errors messages for name and external user id when they are empty', async function (assert) {
+      // given
+      data.errors = {
+        name: [{ message: 'CAMPAIGN_NAME_IS_REQUIRED' }],
+      };
+
+      // when
+      const screen = await render(
+        <template>
+          <AssessmentGoalSettings
+            @campaign={{data.campaign}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.membersSortedByFullName}}
+          />
+        </template>,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      // then
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.name-required'))).exists();
+    });
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/campaign-name-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/campaign-name-test.gjs
@@ -1,0 +1,57 @@
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import CampaignName from 'pix-orga/components/campaign/create-form/campaign-name';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::CampaignName', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    data.campaign = store.createRecord('campaign');
+    data.errors = {};
+  });
+
+  test("it displays campaign's name", async function (assert) {
+    // given
+    data.campaign.name = 'Campagne de test';
+
+    // when
+    const screen = await render(
+      <template><CampaignName @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.name.label'), { exact: false }))
+      .hasValue('Campagne de test');
+  });
+
+  test('it updates the campaign name on input', async function (assert) {
+    // given
+    await render(<template><CampaignName @campaign={{data.campaign}} @errors={{data.errors}} /></template>);
+
+    // when
+    await fillByLabel(`${t('pages.campaign-creation.name.label')} *`, 'Ma campagne');
+
+    // then
+    assert.strictEqual(data.campaign.name, 'Ma campagne');
+  });
+
+  test('it displays an error message when the name field is empty', async function (assert) {
+    // given
+    data.errors = { name: [{ message: 'CAMPAIGN_NAME_IS_REQUIRED' }] };
+
+    // when
+    const screen = await render(
+      <template><CampaignName @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByText(t('api-error-messages.campaign-creation.name-required'))).exists();
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/campaign-owner-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/campaign-owner-test.gjs
@@ -1,0 +1,66 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import CampaignOwner from 'pix-orga/components/campaign/create-form/campaign-owner';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::CampaignOwner', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    const prescriber = store.createRecord('prescriber', {
+      firstName: 'Adam',
+      lastName: 'Troisjour',
+      id: '1',
+    });
+    data.campaign = store.createRecord('campaign', { ownerId: prescriber.id });
+    data.membersSortedByFullName = [prescriber];
+  });
+
+  test("it displays owner fields and auto complete owner field with owner's full name", async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <CampaignOwner @campaign={{data.campaign}} @membersSortedByFullName={{data.membersSortedByFullName}} />
+      </template>,
+    );
+
+    assert.dom(screen.getByText(t('pages.campaign-creation.owner.info'))).exists();
+    assert.dom(screen.getAllByText(t('pages.campaign-creation.owner.title'))[0]).exists();
+    await click(screen.getByLabelText(t('pages.campaign-creation.owner.label'), { exact: false }));
+
+    await screen.findByRole('listbox');
+
+    // then
+    assert.dom(screen.getByRole('option', { name: 'Adam Troisjour', selected: true })).exists();
+  });
+
+  test('it updates campaign owner on select', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const secondMember = store.createRecord('prescriber', {
+      firstName: 'Jean',
+      lastName: 'Dupont',
+      id: '2',
+    });
+    data.membersSortedByFullName = [...data.membersSortedByFullName, secondMember];
+
+    // when
+    const screen = await render(
+      <template>
+        <CampaignOwner @campaign={{data.campaign}} @membersSortedByFullName={{data.membersSortedByFullName}} />
+      </template>,
+    );
+    await click(screen.getByLabelText(t('pages.campaign-creation.owner.label'), { exact: false }));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'Jean Dupont' }));
+
+    // then
+    assert.strictEqual(data.campaign.ownerId, '2');
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/combined-course-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/combined-course-goal-settings-test.gjs
@@ -79,7 +79,9 @@ module('Integration | Component | Campaign::CreateForm::CombinedCourseGoalSettin
     assert
       .dom(screen.queryByRole('radiogroup', { name: t('pages.campaign-creation.external-id-label.question-label') }))
       .doesNotExist();
-    assert.dom(screen.queryByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false })).doesNotExist();
+    assert
+      .dom(screen.queryByLabelText(t('pages.campaign-creation.course-title.label'), { exact: false }))
+      .doesNotExist();
     assert
       .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
       .doesNotExist();

--- a/orga/tests/integration/components/campaign/create-form/combined-course-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/combined-course-goal-settings-test.gjs
@@ -57,33 +57,4 @@ module('Integration | Component | Campaign::CreateForm::CombinedCourseGoalSettin
     // then
     assert.dom(screen.getByLabelText(t('pages.campaign-creation.name.label'), { exact: false })).exists();
   });
-
-  test('it never displays owner, external id, title nor landing page fields', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    data.campaign.course = store.createRecord('course', {
-      id: '1',
-      name: 'Mon schéma de parcours combiné',
-      type: 'blueprint',
-      nbModules: 3,
-      isSimplifiedAccess: true,
-    });
-
-    // when
-    const screen = await render(
-      <template><CombinedCourseGoalSettings @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
-    );
-
-    // then
-    assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
-    assert
-      .dom(screen.queryByRole('radiogroup', { name: t('pages.campaign-creation.external-id-label.question-label') }))
-      .doesNotExist();
-    assert
-      .dom(screen.queryByLabelText(t('pages.campaign-creation.course-title.label'), { exact: false }))
-      .doesNotExist();
-    assert
-      .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
-      .doesNotExist();
-  });
 });

--- a/orga/tests/integration/components/campaign/create-form/combined-course-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/combined-course-goal-settings-test.gjs
@@ -1,0 +1,87 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import CombinedCourseGoalSettings from 'pix-orga/components/campaign/create-form/combined-course-goal-settings';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::CombinedCourseGoalSettings', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    data.campaign = store.createRecord('campaign');
+    data.errors = {};
+  });
+
+  test('it redirects to /catalogue/blueprint for course selection', async function (assert) {
+    // when
+    const screen = await render(
+      <template><CombinedCourseGoalSettings @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert
+      .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+      .hasAttribute('href', '/catalogue/blueprint');
+  });
+
+  test('it does not display the campaign name field until a course is selected', async function (assert) {
+    // when
+    const screen = await render(
+      <template><CombinedCourseGoalSettings @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.queryByLabelText(t('pages.campaign-creation.name.label'), { exact: false })).doesNotExist();
+  });
+
+  test('it displays the campaign name field once a course is selected', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    data.campaign.course = store.createRecord('course', {
+      id: '1',
+      name: 'Mon schéma de parcours combiné',
+      type: 'blueprint',
+      nbModules: 3,
+      isSimplifiedAccess: true,
+    });
+
+    // when
+    const screen = await render(
+      <template><CombinedCourseGoalSettings @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByLabelText(t('pages.campaign-creation.name.label'), { exact: false })).exists();
+  });
+
+  test('it never displays owner, external id, title nor landing page fields', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    data.campaign.course = store.createRecord('course', {
+      id: '1',
+      name: 'Mon schéma de parcours combiné',
+      type: 'blueprint',
+      nbModules: 3,
+      isSimplifiedAccess: true,
+    });
+
+    // when
+    const screen = await render(
+      <template><CombinedCourseGoalSettings @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.queryByText(t('pages.campaign-creation.owner.info'))).doesNotExist();
+    assert
+      .dom(screen.queryByRole('radiogroup', { name: t('pages.campaign-creation.external-id-label.question-label') }))
+      .doesNotExist();
+    assert.dom(screen.queryByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false })).doesNotExist();
+    assert
+      .dom(screen.queryByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
+      .doesNotExist();
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/course-selection-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/course-selection-test.gjs
@@ -1,0 +1,85 @@
+import { render } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+import { t } from 'ember-intl/test-support';
+import CourseSelection from 'pix-orga/components/campaign/create-form/course-selection';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::CourseSelection', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    data.campaign = store.createRecord('campaign');
+    data.errors = {};
+  });
+
+  test('it does not display a course card nor an error when no course is selected', async function (assert) {
+    // when
+    const screen = await render(
+      <template><CourseSelection @campaign={{data.campaign}} @errors={{data.errors}} @tab="targetProfile" /></template>,
+    );
+
+    // then
+    assert.dom(screen.queryByRole('heading')).doesNotExist();
+    assert.dom(screen.queryByText(t('api-error-messages.campaign-creation.target-profile-required'))).doesNotExist();
+  });
+
+  test('it displays informations about the selected course', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    data.campaign.course = store.createRecord('course', {
+      id: '1',
+      name: 'targetProfile1',
+      type: 'targetProfile',
+      nbTubes: 3,
+      isSimplifiedAccess: true,
+    });
+
+    // when
+    const screen = await render(
+      <template><CourseSelection @campaign={{data.campaign}} @errors={{data.errors}} @tab="targetProfile" /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByText(t('pages.catalogue.card.tag.target-profile'))).exists();
+    assert.dom(screen.getByRole('heading', { name: data.campaign.course.name })).exists();
+    assert
+      .dom(screen.getByText(t('pages.catalogue.card.tubes-count', { count: data.campaign.course.nbTubes })))
+      .exists();
+    assert.dom(screen.getByText(t('pages.catalogue.card.simplified-access'))).exists();
+  });
+
+  test('it redirects to the catalogue tab given as argument', async function (assert) {
+    // when
+    const screen = await render(
+      <template><CourseSelection @campaign={{data.campaign}} @errors={{data.errors}} @tab="blueprint" /></template>,
+    );
+
+    // then
+    assert
+      .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+      .hasAttribute('href', '/catalogue/blueprint');
+  });
+
+  test('it displays an error message when the course is missing', async function (assert) {
+    // given
+    const campaignWithErrors = EmberObject.create({
+      errors: {
+        targetProfile: [{ message: 'TARGET_PROFILE_IS_REQUIRED' }],
+      },
+    });
+    data.errors = campaignWithErrors.errors;
+
+    // when
+    const screen = await render(
+      <template><CourseSelection @campaign={{data.campaign}} @errors={{data.errors}} @tab="targetProfile" /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByText(t('api-error-messages.campaign-creation.target-profile-required'))).exists();
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/external-id-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/external-id-test.gjs
@@ -1,0 +1,130 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+
+import ExternalId from '../../../../../app/components/campaign/create-form/external-id.gjs';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::ExternalId', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    data.campaign = store.createRecord('campaign');
+    data.errors = {};
+  });
+
+  test('it fills external user ID selection (yes)', async function (assert) {
+    // given
+    data.campaign.externalIdLabel = 'Numéro étudiant';
+
+    // when
+    const screen = await render(
+      <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    const element = screen.getByRole('radio', { name: t('pages.campaign-creation.yes') });
+    assert.dom(element).isChecked();
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.external-id-label.label'), { exact: false }))
+      .hasValue('Numéro étudiant');
+  });
+
+  test('it fills external user ID selection (no) by default', async function (assert) {
+    // given
+    data.campaign.externalIdLabel = null;
+
+    // when
+    const screen = await render(
+      <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    const element = screen.getByRole('radio', { name: t('pages.campaign-creation.no') });
+    assert.dom(element).isChecked();
+  });
+
+  test('it not displays external id type nor gdpr footnote by default', async function (assert) {
+    // when
+    const screen = await render(
+      <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert
+      .dom(screen.queryByRole('radiogroup', { name: t('pages.campaign-creation.external-id-type.question-label') }))
+      .doesNotExist();
+    assert.dom(screen.queryByText(t('pages.campaign-creation.legal-warning'))).doesNotExist();
+  });
+
+  test('it displays external id type and gdpr footnote once the user asks for an external id', async function (assert) {
+    // given
+    const screen = await render(
+      <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // when
+    await clickByName(t('pages.campaign-creation.yes'));
+
+    // then
+    assert
+      .dom(screen.getByRole('radiogroup', { name: t('pages.campaign-creation.external-id-type.question-label') }))
+      .exists();
+    assert.dom(screen.getByText(t('pages.campaign-creation.legal-warning'))).exists();
+  });
+
+  test('it clears the external id label and type when the user declines', async function (assert) {
+    // given
+    data.campaign.externalIdLabel = 'Numéro étudiant';
+    data.campaign.externalIdType = 'EMAIL';
+
+    const screen = await render(
+      <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // when
+    await clickByName(t('pages.campaign-creation.no'));
+
+    // then
+    assert.strictEqual(data.campaign.externalIdLabel, null);
+    assert.strictEqual(data.campaign.externalIdType, '');
+    assert.dom(screen.queryByText(t('pages.campaign-creation.legal-warning'))).doesNotExist();
+  });
+
+  test('it updates campaign model when select a type', async function (assert) {
+    // given
+    const screen = await render(
+      <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+    await clickByName(t('pages.campaign-creation.yes'));
+
+    // when
+    await screen.getByLabelText(t('pages.campaign-settings.external-user-id-types.email')).click();
+
+    // then
+    assert.strictEqual(data.campaign.externalIdType, 'EMAIL');
+  });
+
+  test('it displays errors messages for external id type and label', async function (assert) {
+    // given
+    const campaignWithErrors = EmberObject.create({
+      errors: {
+        externalIdLabel: [{ message: 'EXTERNAL_USER_ID_IS_REQUIRED' }],
+      },
+    });
+    data.errors = campaignWithErrors.errors;
+
+    // when
+    const screen = await render(
+      <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+    await clickByName(t('pages.campaign-creation.yes'));
+
+    // then
+    assert.dom(screen.getByText(t('api-error-messages.campaign-creation.external-user-id-required'))).exists();
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/landing-page-text-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/landing-page-text-test.gjs
@@ -1,0 +1,53 @@
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import LandingPageText from 'pix-orga/components/campaign/create-form/landing-page-text';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::LandingPageText', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    data.campaign = store.createRecord('campaign');
+  });
+
+  test('it fills campaign landing page text', async function (assert) {
+    // given
+    data.campaign.customLandingPageText = 'Mon texte de landing page';
+
+    // when
+    const screen = await render(<template><LandingPageText @campaign={{data.campaign}} /></template>);
+
+    // then
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
+      .hasValue('Mon texte de landing page');
+  });
+
+  test('it updates campaign.customLandingPageText on input', async function (assert) {
+    // given
+    await render(<template><LandingPageText @campaign={{data.campaign}} /></template>);
+
+    // when
+    await fillByLabel(t('pages.campaign-creation.landing-page-text.label'), 'Mon texte de landing page', {
+      exact: false,
+    });
+
+    // then
+    assert.strictEqual(data.campaign.customLandingPageText, 'Mon texte de landing page');
+  });
+
+  test('it displays the sublabel', async function (assert) {
+    // when
+    const screen = await render(<template><LandingPageText @campaign={{data.campaign}} /></template>);
+
+    // then
+    assert
+      .dom(screen.getByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), { exact: false }))
+      .exists();
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/multiple-sendings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/multiple-sendings-test.gjs
@@ -1,0 +1,97 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import MultipleSendings from 'pix-orga/components/campaign/create-form/multiple-sendings';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::MultipleSendings', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    data.campaign = store.createRecord('campaign');
+    data.labelKey = 'pages.campaign-creation.multiple-sendings.assessments.question-label';
+    data.infoKey = 'pages.campaign-creation.multiple-sendings.assessments.info';
+  });
+
+  test('it displays the given wording', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <MultipleSendings @campaign={{data.campaign}} @labelKey={{data.labelKey}} @infoKey={{data.infoKey}} />
+      </template>,
+    );
+
+    // then
+    assert
+      .dom(
+        screen.getByRole('radiogroup', {
+          name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+        }),
+      )
+      .exists();
+    assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.assessments.info'))).exists();
+  });
+
+  test('it checks "yes" when the campaign already allows multiple sendings', async function (assert) {
+    // given
+    data.campaign.multipleSendings = true;
+
+    // when
+    const screen = await render(
+      <template>
+        <MultipleSendings @campaign={{data.campaign}} @labelKey={{data.labelKey}} @infoKey={{data.infoKey}} />
+      </template>,
+    );
+
+    // then
+    const radiogroup = screen.getByRole('radiogroup', {
+      name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+    });
+    assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
+  });
+
+  test('it updates campaign.multipleSendings when the user selects an option', async function (assert) {
+    // given
+    const screen = await render(
+      <template>
+        <MultipleSendings @campaign={{data.campaign}} @labelKey={{data.labelKey}} @infoKey={{data.infoKey}} />
+      </template>,
+    );
+
+    // when
+    const radiogroup = screen.getByRole('radiogroup', {
+      name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+    });
+    await click(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes')));
+
+    // then
+    assert.true(data.campaign.multipleSendings);
+  });
+
+  test('it displays an additional info when knowledge elements are resettable', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    data.campaign.targetProfile = store.createRecord('target-profile', { areKnowledgeElementsResettable: true });
+
+    // when
+    const screen = await render(
+      <template>
+        <MultipleSendings @campaign={{data.campaign}} @labelKey={{data.labelKey}} @infoKey={{data.infoKey}} />
+      </template>,
+    );
+
+    // then
+    assert
+      .dom(
+        screen.getByText(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'), {
+          exact: false,
+        }),
+      )
+      .exists();
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-customization-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-customization-test.gjs
@@ -1,0 +1,37 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ProfilesCollectionGoalCustomization from 'pix-orga/components/campaign/create-form/profiles-collection-goal-customization';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::ProfilesCollectionGoalCustomization', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    data.campaign = store.createRecord('campaign');
+  });
+
+  test('it displays the landing page field without any course selection', async function (assert) {
+    // when
+    const screen = await render(
+      <template><ProfilesCollectionGoalCustomization @campaign={{data.campaign}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false })).exists();
+  });
+
+  test('it never displays the campaign title field', async function (assert) {
+    // when
+    const screen = await render(
+      <template><ProfilesCollectionGoalCustomization @campaign={{data.campaign}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.queryByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false })).doesNotExist();
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-customization-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-customization-test.gjs
@@ -32,6 +32,8 @@ module('Integration | Component | Campaign::CreateForm::ProfilesCollectionGoalCu
     );
 
     // then
-    assert.dom(screen.queryByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false })).doesNotExist();
+    assert
+      .dom(screen.queryByLabelText(t('pages.campaign-creation.course-title.label'), { exact: false }))
+      .doesNotExist();
   });
 });

--- a/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-customization-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-customization-test.gjs
@@ -24,16 +24,4 @@ module('Integration | Component | Campaign::CreateForm::ProfilesCollectionGoalCu
     // then
     assert.dom(screen.getByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false })).exists();
   });
-
-  test('it never displays the campaign title field', async function (assert) {
-    // when
-    const screen = await render(
-      <template><ProfilesCollectionGoalCustomization @campaign={{data.campaign}} /></template>,
-    );
-
-    // then
-    assert
-      .dom(screen.queryByLabelText(t('pages.campaign-creation.course-title.label'), { exact: false }))
-      .doesNotExist();
-  });
 });

--- a/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-settings-test.gjs
@@ -1,0 +1,80 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ProfilesCollectionGoalSettings from 'pix-orga/components/campaign/create-form/profiles-collection-goal-settings';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::ProfilesCollectionGoalSettings', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    const prescriber = store.createRecord('prescriber', {
+      firstName: 'Adam',
+      lastName: 'Troisjour',
+      id: '1',
+    });
+    data.campaign = store.createRecord('campaign', { ownerId: prescriber.id });
+    data.membersSortedByFullName = [prescriber];
+    data.errors = {};
+  });
+
+  test('it displays the campaign name, owner and external id fields without any course selection', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <ProfilesCollectionGoalSettings
+          @campaign={{data.campaign}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.membersSortedByFullName}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByLabelText(t('pages.campaign-creation.name.label'), { exact: false })).exists();
+    assert.dom(screen.getAllByText(t('pages.campaign-creation.owner.title'))[0]).exists();
+    assert
+      .dom(screen.getByRole('radiogroup', { name: t('pages.campaign-creation.external-id-label.question-label') }))
+      .exists();
+    assert
+      .dom(screen.queryByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+      .doesNotExist();
+  });
+
+  test('it displays fields for enabling multiple sendings with the profiles wording', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <ProfilesCollectionGoalSettings
+          @campaign={{data.campaign}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.membersSortedByFullName}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.question-label'))).exists();
+    assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.info'))).exists();
+  });
+
+  test('it never displays the campaign title field', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <ProfilesCollectionGoalSettings
+          @campaign={{data.campaign}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.membersSortedByFullName}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.queryByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false })).doesNotExist();
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-settings-test.gjs
@@ -61,22 +61,4 @@ module('Integration | Component | Campaign::CreateForm::ProfilesCollectionGoalSe
     assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.question-label'))).exists();
     assert.dom(screen.getByText(t('pages.campaign-creation.multiple-sendings.profiles.info'))).exists();
   });
-
-  test('it never displays the campaign title field', async function (assert) {
-    // when
-    const screen = await render(
-      <template>
-        <ProfilesCollectionGoalSettings
-          @campaign={{data.campaign}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.membersSortedByFullName}}
-        />
-      </template>,
-    );
-
-    // then
-    assert
-      .dom(screen.queryByLabelText(t('pages.campaign-creation.course-title.label'), { exact: false }))
-      .doesNotExist();
-  });
 });

--- a/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/profiles-collection-goal-settings-test.gjs
@@ -75,6 +75,8 @@ module('Integration | Component | Campaign::CreateForm::ProfilesCollectionGoalSe
     );
 
     // then
-    assert.dom(screen.queryByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false })).doesNotExist();
+    assert
+      .dom(screen.queryByLabelText(t('pages.campaign-creation.course-title.label'), { exact: false }))
+      .doesNotExist();
   });
 });

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -751,6 +751,10 @@
       "copy-of": "Kopieren von",
       "course-label": "Einen Kurs auswählen",
       "course-selection-label": "Einen Kurs auswählen",
+      "course-title": {
+        "label": "Titel der Strecke",
+        "sublabel": "Dieses Feld wird den Teilnehmern der Kampagne angezeigt."
+      },
       "customization": {
         "title": "Anpassung"
       },
@@ -826,10 +830,6 @@
       "target-profiles-label": "Eine Strecke auswählen",
       "target-profiles-list-label": "Was möchten Sie testen?",
       "target-profiles-search-placeholder": "Nach Namen suchen",
-      "test-title": {
-        "label": "Titel der Strecke",
-        "sublabel": "Dieses Feld wird den Teilnehmern der Kampagne angezeigt."
-      },
       "title": "Erstellen einer Kampagne",
       "yes": "Ja"
     },

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -751,6 +751,9 @@
       "copy-of": "Kopieren von",
       "course-label": "Einen Kurs auswählen",
       "course-selection-label": "Einen Kurs auswählen",
+      "customization": {
+        "title": "Anpassung"
+      },
       "exam-mode": {
         "label": "Möchten Sie den Testmodus aktivieren?"
       },
@@ -802,6 +805,9 @@
         "profiles-collection": "Sammeln Sie die Pix-Profile der Teilnehmer",
         "profiles-collection-info": "Eine Profilsammelkampagne ruft die Profile der Teilnehmer ab: Niveaustufen pro Fertigkeit und Pix-Score.",
         "profiles-collection-info-certificability-calculation": "Der Status Zertifizierbar wird automatisch auf der Registerkarte '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Schüler'</a>' aktualisiert."
+      },
+      "settings": {
+        "title": "Einstellungen"
       },
       "tags": {
         "BACK_TO_SCHOOL": "Parcours zum Schulanfang / 6. Klasse",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -751,6 +751,10 @@
       "copy-of": "Copy of",
       "course-label": "Select a course",
       "course-selection-label": "Select a course",
+      "course-title": {
+        "label": "Title of the customised test",
+        "sublabel": "This field will be displayed to campaign participants."
+      },
       "customization": {
         "title": "Customization"
       },
@@ -826,10 +830,6 @@
       "target-profiles-label": "Select a customised test",
       "target-profiles-list-label": "What would you like to test?",
       "target-profiles-search-placeholder": "Search by name",
-      "test-title": {
-        "label": "Title of the customised test",
-        "sublabel": "This field will be displayed to campaign participants."
-      },
       "title": "Create a campaign",
       "yes": "Yes"
     },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -751,6 +751,9 @@
       "copy-of": "Copy of",
       "course-label": "Select a course",
       "course-selection-label": "Select a course",
+      "customization": {
+        "title": "Customization"
+      },
       "exam-mode": {
         "label": "Do you want to enable exam mode?"
       },
@@ -802,6 +805,9 @@
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score.",
         "profiles-collection-info-certificability-calculation": "The “Eligible for certification” status is updated automatically in the '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Students'</a>' tab."
+      },
+      "settings": {
+        "title": "Settings"
       },
       "tags": {
         "BACK_TO_SCHOOL": "Back to school",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -751,6 +751,10 @@
       "copy-of": "Copia de",
       "course-label": "Seleccionar un curso",
       "course-selection-label": "Seleccionar un curso",
+      "course-title": {
+        "label": "Título del curso",
+        "sublabel": "Este campo se mostrará a los participantes de la campaña."
+      },
       "customization": {
         "title": "Personalización"
       },
@@ -826,10 +830,6 @@
       "target-profiles-label": "Seleccione una ruta",
       "target-profiles-list-label": "¿Qué le gustaría probar?",
       "target-profiles-search-placeholder": "Buscar por nombre",
-      "test-title": {
-        "label": "Título del curso",
-        "sublabel": "Este campo se mostrará a los participantes de la campaña."
-      },
       "title": "Crear una campaña",
       "yes": "Sí"
     },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -751,6 +751,9 @@
       "copy-of": "Copia de",
       "course-label": "Seleccionar un curso",
       "course-selection-label": "Seleccionar un curso",
+      "customization": {
+        "title": "Personalización"
+      },
       "exam-mode": {
         "label": "¿Desea activar el modo de consulta?"
       },
@@ -802,6 +805,9 @@
         "profiles-collection": "Recoger los perfiles Pix de los participantes",
         "profiles-collection-info": "Se utiliza una campaña de recogida de perfiles para recuperar el perfil de los participantes: niveles por habilidad y puntuación pix.",
         "profiles-collection-info-certificability-calculation": "El estado certificable se actualiza automáticamente en la pestaña <'a href=\"/eleves\" class=\"{linkClasses}\"'>'Alumnos'</a>'."
+      },
+      "settings": {
+        "title": "Configuración"
       },
       "tags": {
         "BACK_TO_SCHOOL": "Curso de vuelta al cole / 6e",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -751,6 +751,9 @@
       "copy-of": "Copie de",
       "course-label": "Sélectionnez un parcours",
       "course-selection-label": "Sélectionner un parcours",
+      "customization": {
+        "title": "Personnalisation"
+      },
       "exam-mode": {
         "label": "Souhaitez-vous activer le mode interro ?"
       },
@@ -802,6 +805,9 @@
         "profiles-collection": "Collecter les profils Pix des participants",
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix.",
         "profiles-collection-info-certificability-calculation": "Le statut Certifiable est mis à jour automatiquement dans l’onglet '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Élèves'</a>'."
+      },
+      "settings": {
+        "title": "Paramétrage"
       },
       "tags": {
         "BACK_TO_SCHOOL": "Parcours de rentrée / 6e",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -751,6 +751,10 @@
       "copy-of": "Copie de",
       "course-label": "Sélectionnez un parcours",
       "course-selection-label": "Sélectionner un parcours",
+      "course-title": {
+        "label": "Titre du parcours",
+        "sublabel": "Ce champ sera affiché aux participants de la campagne."
+      },
       "customization": {
         "title": "Personnalisation"
       },
@@ -826,10 +830,6 @@
       "target-profiles-label": "Sélectionner un parcours",
       "target-profiles-list-label": "Que souhaitez-vous tester ?",
       "target-profiles-search-placeholder": "Rechercher par nom",
-      "test-title": {
-        "label": "Titre du parcours",
-        "sublabel": "Ce champ sera affiché aux participants de la campagne."
-      },
       "title": "Création d'une campagne",
       "yes": "Oui"
     },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -751,6 +751,10 @@
       "copy-of": "Copia di",
       "course-label": "Seleziona un corso",
       "course-selection-label": "Selezionare un corso",
+      "course-title": {
+        "label": "Titolo del corso",
+        "sublabel": "Questo campo verrà visualizzato dai partecipanti alla campagna."
+      },
       "customization": {
         "title": "Personalizzazione"
       },
@@ -826,10 +830,6 @@
       "target-profiles-label": "Selezionare un percorso",
       "target-profiles-list-label": "Cosa vorresti testare?",
       "target-profiles-search-placeholder": "Ricerca per nome",
-      "test-title": {
-        "label": "Titolo del corso",
-        "sublabel": "Questo campo verrà visualizzato dai partecipanti alla campagna."
-      },
       "title": "Creare una campagna",
       "yes": "Sì"
     },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -751,6 +751,9 @@
       "copy-of": "Copia di",
       "course-label": "Seleziona un corso",
       "course-selection-label": "Selezionare un corso",
+      "customization": {
+        "title": "Personalizzazione"
+      },
       "exam-mode": {
         "label": "Desiderate attivare la modalità di interrogazione?"
       },
@@ -802,6 +805,9 @@
         "profiles-collection": "Raccogliere i profili Pix dei partecipanti",
         "profiles-collection-info": "Una campagna di raccolta di profili viene utilizzata per recuperare il profilo dei partecipanti: livelli per abilità e punteggio pix.",
         "profiles-collection-info-certificability-calculation": "Lo stato di certificabilità viene aggiornato automaticamente nella scheda '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Studenti'</a>'."
+      },
+      "settings": {
+        "title": "Impostazioni"
       },
       "tags": {
         "BACK_TO_SCHOOL": "Corso di ritorno a scuola / 6e",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -751,6 +751,10 @@
       "copy-of": "Kopie van",
       "course-label": "Selecteer een traject",
       "course-selection-label": "Selecteer een traject",
+      "course-title": {
+        "label": "Titel test",
+        "sublabel": "Dit veld wordt weergegeven voor deelnemers aan de campagne."
+      },
       "customization": {
         "title": "Personalisatie"
       },
@@ -826,10 +830,6 @@
       "target-profiles-label": "Selecteer een test",
       "target-profiles-list-label": "Wat wil je testen?",
       "target-profiles-search-placeholder": "Zoeken op naam",
-      "test-title": {
-        "label": "Titel test",
-        "sublabel": "Dit veld wordt weergegeven voor deelnemers aan de campagne."
-      },
       "title": "Een campagne maken",
       "yes": "Ja"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -751,6 +751,9 @@
       "copy-of": "Kopie van",
       "course-label": "Selecteer een traject",
       "course-selection-label": "Selecteer een traject",
+      "customization": {
+        "title": "Personalisatie"
+      },
       "exam-mode": {
         "label": "Wil je de vraagmodus activeren?"
       },
@@ -802,6 +805,9 @@
         "profiles-collection": "Pix-profielen van deelnemers verzamelen",
         "profiles-collection-info": "Een campagne voor het verzamelen van profielen wordt gebruikt om het profiel van de deelnemers te achterhalen: niveaus per vaardigheid en pix-score.",
         "profiles-collection-info-certificability-calculation": "De certificeerbare status wordt automatisch bijgewerkt in het tabblad '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Studenten'</a>'."
+      },
+      "settings": {
+        "title": "Instellingen"
       },
       "tags": {
         "BACK_TO_SCHOOL": "Terug naar school cursus / 6e",


### PR DESCRIPTION
## 🪧 Problème
Actuellement, le formulaire de création de campagne et un unique composant qui mêle tous les types de campagne possibles. Il devient difficile de le tester et le faire évoluer. 

## 🌈 Proposition
- Créer plusieurs petits composants pour les parties réutilisables.
- Avoir un composant par objectif de campagne.

## ✊ Remarques
Réalisé avec Claude.
Cette PR est basée sur la PR https://github.com/1024pix/pix/pull/16799. Cette dernière doit donc être mergée avant.

## 🎉 Pour tester
Faire une revue fonctionnelle complète (sorry).