### PR TITLE
[FEATURE] Ajout d'une API de mise à disposition des statistiques de certifications pour le TDB-NUM du MEN (PIX-23448)

### DIFF
--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -50,6 +50,7 @@ class DatamartBuilder {
       'data_active_calibrated_challenges',
       'data_calibrations',
       'target_profiles_course_duration',
+      'men_dashboard_certification_dataset',
     ].forEach((tableName) => {
       rawQuery += `DELETE FROM ${tableName};`;
     });

--- a/api/datamart/datamart-builder/factory/build-men-dashboard-certification-dataset.js
+++ b/api/datamart/datamart-builder/factory/build-men-dashboard-certification-dataset.js
@@ -1,0 +1,40 @@
+import { datamartBuffer } from '../datamart-buffer.js';
+
+const buildMenDashboardCertificationDataset = function ({
+  schoolUai = 'UAI001',
+  schoolYear = 2025,
+  academieName = 'Paris',
+  schoolName = 'Lycée Test',
+  provinceCode = '075',
+  schoolYearGroup = 'Terminale',
+  validatedCertificationCount = 10,
+  certificationCount = 15,
+  averagePixScore = 350.5,
+  competenceCode = '1.1',
+  avgCompetenceLevel = 3.2,
+  updatedAt = new Date('2026-07-01'),
+} = {}) {
+  const values = {
+    schoolUai,
+    schoolYear,
+    academieName,
+    schoolName,
+    provinceCode,
+    schoolYearGroup,
+    validatedCertificationCount,
+    certificationCount,
+    averagePixScore,
+    competenceCode,
+    avgCompetenceLevel,
+    updatedAt,
+  };
+
+  datamartBuffer.pushInsertable({
+    tableName: 'men_dashboard_certification_dataset',
+    values,
+  });
+
+  return values;
+};
+
+export { buildMenDashboardCertificationDataset };

--- a/api/datamart/migrations/20260715085045_create-men_dashboard_participation_dataset.js
+++ b/api/datamart/migrations/20260715085045_create-men_dashboard_participation_dataset.js
@@ -1,0 +1,38 @@
+const TABLE_NAME = 'men_dashboard_participation_dataset';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('schoolUai');
+    table.index('schoolUai');
+    table.smallint('schoolYear');
+    table.string('academieName');
+    table.string('schoolName');
+    table.string('provinceCode');
+    table.string('schoolYearGroup');
+    table.string('competenceCode');
+    table.string('competenceName');
+    table.integer('participantCount');
+    table.float('standardDeviation');
+    table.float('firstDecileLevel');
+    table.float('firstQuartileLevel');
+    table.float('medianLevel');
+    table.float('thirdQuartileLevel');
+    table.float('ninthDecileLevel');
+    table.float('averageMaxLevelReached');
+    table.float('averageMaxLevelReachable');
+    table.float('coverage');
+    table.date('updatedAt');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/datamart/migrations/20260715085046_create-men_dashboard_certification_dataset.js
+++ b/api/datamart/migrations/20260715085046_create-men_dashboard_certification_dataset.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'men_dashboard_certification_dataset';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('schoolUai');
+    table.index('schoolUai');
+    table.smallint('schoolYear');
+    table.string('academieName');
+    table.string('schoolName');
+    table.string('provinceCode');
+    table.string('schoolYearGroup');
+    table.integer('validatedCertificationCount');
+    table.integer('certificationCount');
+    table.float('averagePixScore');
+    table.string('competenceCode');
+    table.float('avgCompetenceLevel');
+    table.date('updatedAt');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/datamart/seeds/populate-tdb-num.js
+++ b/api/datamart/seeds/populate-tdb-num.js
@@ -1,0 +1,242 @@
+import { DatamartBuilder } from '../../datamart/datamart-builder/datamart-builder.js';
+
+const COMPETENCE_CODES = [
+  '1.1',
+  '1.2',
+  '1.3',
+  '2.1',
+  '2.2',
+  '2.3',
+  '2.4',
+  '3.1',
+  '3.2',
+  '3.3',
+  '3.4',
+  '4.1',
+  '4.2',
+  '4.3',
+  '5.1',
+  '5.2',
+];
+
+// Deterministic per-competence variation factors (index matches COMPETENCE_CODES)
+// Allows to have various avgPixScore
+const COMPETENCE_VARIATIONS = [
+  1.0, 0.92, 1.08, 0.88, 1.03, 0.97, 1.05, 0.93, 1.07, 0.99, 0.95, 1.04, 0.9, 1.02, 0.96, 1.01,
+];
+
+function scoreToLevel(pixScore) {
+  return Math.round((1 + ((pixScore - 1) / 895) * 6) * 10) / 10;
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function generateSchoolClassRecords({
+  schoolUai,
+  academieName,
+  schoolName,
+  provinceCode,
+  schoolYearGroup,
+  basePixScore,
+  certificationCount,
+  validatedCertificationCount,
+}) {
+  return COMPETENCE_CODES.map((competenceCode, index) => {
+    const averagePixScore = clamp(Math.round(basePixScore * COMPETENCE_VARIATIONS[index]), 1, 896);
+    const avgCompetenceLevel = clamp(scoreToLevel(averagePixScore), 1, 7);
+
+    return {
+      schoolUai,
+      schoolYear: 2025,
+      academieName,
+      schoolName,
+      provinceCode,
+      schoolYearGroup,
+      validatedCertificationCount,
+      certificationCount,
+      averagePixScore,
+      competenceCode,
+      avgCompetenceLevel,
+      updatedAt: new Date('2026-07-01'),
+    };
+  });
+}
+
+const SCHOOLS = [
+  {
+    schoolUai: '0311234A',
+    academieName: 'Toulouse',
+    schoolName: 'Collège Jean Jaurès',
+    provinceCode: '031',
+    classes: [
+      // 3ème obligatoire
+      {
+        schoolYearGroup: '3ème',
+        basePixScore: 250,
+        certificationCount: 45,
+        validatedCertificationCount: 32,
+      },
+    ],
+  },
+  {
+    schoolUai: '0319876B',
+    academieName: 'Toulouse',
+    schoolName: 'Lycée Pierre de Fermat',
+    provinceCode: '031',
+    classes: [
+      // Terminale obligatoire + 1ère optionnelle
+      {
+        schoolYearGroup: 'Terminale',
+        basePixScore: 620,
+        certificationCount: 180,
+        validatedCertificationCount: 158,
+      },
+      {
+        schoolYearGroup: '1ère',
+        basePixScore: 500,
+        certificationCount: 160,
+        validatedCertificationCount: 131,
+      },
+    ],
+  },
+  {
+    schoolUai: '0812345C',
+    academieName: 'Toulouse',
+    schoolName: 'Collège Jean Moulin',
+    provinceCode: '081',
+    classes: [
+      {
+        schoolYearGroup: '3ème',
+        basePixScore: 300,
+        certificationCount: 52,
+        validatedCertificationCount: 39,
+      },
+      {
+        schoolYearGroup: '4ème',
+        basePixScore: 190,
+        certificationCount: 48,
+        validatedCertificationCount: 30,
+      },
+    ],
+  },
+  {
+    schoolUai: '0351111D',
+    academieName: 'Rennes',
+    schoolName: 'Collège Anne de Bretagne',
+    provinceCode: '035',
+    classes: [
+      {
+        schoolYearGroup: '3ème',
+        basePixScore: 320,
+        certificationCount: 60,
+        validatedCertificationCount: 47,
+      },
+      {
+        schoolYearGroup: '5ème',
+        basePixScore: 115,
+        certificationCount: 58,
+        validatedCertificationCount: 31,
+      },
+    ],
+  },
+  {
+    schoolUai: '0352222E',
+    academieName: 'Rennes',
+    schoolName: 'Lycée Émile Zola',
+    provinceCode: '035',
+    classes: [
+      {
+        schoolYearGroup: 'Terminale',
+        basePixScore: 480,
+        certificationCount: 140,
+        validatedCertificationCount: 119,
+      },
+    ],
+  },
+  {
+    schoolUai: '0292222F',
+    academieName: 'Rennes',
+    schoolName: 'Collège La Recouvrance',
+    provinceCode: '029',
+    classes: [
+      {
+        schoolYearGroup: '3ème',
+        basePixScore: 175,
+        certificationCount: 35,
+        validatedCertificationCount: 21,
+      },
+    ],
+  },
+  {
+    schoolUai: '0871234G',
+    academieName: 'Limoges',
+    schoolName: 'Collège La Borie',
+    provinceCode: '087',
+    classes: [
+      {
+        schoolYearGroup: '3ème',
+        basePixScore: 390,
+        certificationCount: 50,
+        validatedCertificationCount: 40,
+      },
+    ],
+  },
+  {
+    schoolUai: '0879876H',
+    academieName: 'Limoges',
+    schoolName: 'Lycée Gay-Lussac',
+    provinceCode: '087',
+    classes: [
+      {
+        schoolYearGroup: 'Terminale',
+        basePixScore: 550,
+        certificationCount: 120,
+        validatedCertificationCount: 104,
+      },
+      {
+        schoolYearGroup: '1ère',
+        basePixScore: 430,
+        certificationCount: 110,
+        validatedCertificationCount: 87,
+      },
+    ],
+  },
+  {
+    schoolUai: '0231234I',
+    academieName: 'Limoges',
+    schoolName: 'Collège du Vallon',
+    provinceCode: '023',
+    classes: [
+      {
+        schoolYearGroup: '3ème',
+        basePixScore: 210,
+        certificationCount: 28,
+        validatedCertificationCount: 18,
+      },
+    ],
+  },
+];
+
+export async function seed(knex) {
+  const datamartBuilder = new DatamartBuilder({ knex });
+
+  for (const school of SCHOOLS) {
+    for (const cls of school.classes) {
+      const records = generateSchoolClassRecords({
+        schoolUai: school.schoolUai,
+        academieName: school.academieName,
+        schoolName: school.schoolName,
+        provinceCode: school.provinceCode,
+        schoolYearGroup: cls.schoolYearGroup,
+        basePixScore: cls.basePixScore,
+        certificationCount: cls.certificationCount,
+        validatedCertificationCount: cls.validatedCertificationCount,
+      });
+      records.forEach((record) => datamartBuilder.factory.buildMenDashboardCertificationDataset(record));
+    }
+  }
+
+  await datamartBuilder.commit();
+}

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -152,7 +152,10 @@ function _createSuperAdmin(databaseBuilder) {
     lastName: 'Admin',
     email: 'superadmin@example.net',
   });
-  databaseBuilder.factory.buildPixAdminRole({ userId: REAL_PIX_SUPER_ADMIN_ID, role: ROLES.SUPER_ADMIN });
+  databaseBuilder.factory.buildPixAdminRole({
+    userId: REAL_PIX_SUPER_ADMIN_ID,
+    role: ROLES.SUPER_ADMIN,
+  });
   acceptPixOrgaTermsOfService(databaseBuilder, REAL_PIX_SUPER_ADMIN_ID);
 }
 
@@ -223,6 +226,12 @@ function createClientApplications(databaseBuilder) {
     clientSecret: 'maddo-secret',
     scopes: ['meta', 'campaigns'],
     jurisdiction: { rules: [{ name: 'tags', value: [COLLEGE_TAG.name] }] },
+  });
+  databaseBuilder.factory.buildClientApplication({
+    name: 'men-dashboard-client-application',
+    clientId: 'men-dashboard',
+    clientSecret: 'men-dashboard-secret',
+    scopes: ['men-dashboard'],
   });
   databaseBuilder.factory.buildClientApplication({
     name: 'poc-llm',

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -10,6 +10,7 @@ import { parcoursupRoute } from './src/certification/results/application/parcour
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
 import * as serverAuthentication from './src/identity-access-management/infrastructure/server-authentication.js';
 import { campaignsRoute } from './src/maddo/application/campaigns-routes.js';
+import { menDashboardRoute } from './src/maddo/application/men-dashboard-routes.js';
 import { organizationsRoute } from './src/maddo/application/organizations-routes.js';
 import { replicationsRoute } from './src/maddo/application/replications-routes.js';
 import { poleEmploiRoute } from './src/prescription/campaign-participation/application/pole-emploi-route.js';
@@ -99,7 +100,11 @@ const enableOpsMetrics = async function (server, metrics) {
   metrics.addRecurrentMetrics(
     [
       { type: 'gauge', name: 'captain.api.memory.rss', value: 'rss' },
-      { type: 'gauge', name: 'captain.api.memory.heapTotal', value: 'heapTotal' },
+      {
+        type: 'gauge',
+        name: 'captain.api.memory.heapTotal',
+        value: 'heapTotal',
+      },
       { type: 'gauge', name: 'captain.api.memory.heapUsed', value: 'heapUsed' },
       { type: 'gauge', name: 'captain.api.conteneur', constValue: 1 },
     ],
@@ -110,8 +115,16 @@ const enableOpsMetrics = async function (server, metrics) {
   server.pixCustomIntervals = metrics.intervals;
 
   const gaugeConnections = (pool) => () => {
-    metrics.addMetricPoint({ type: 'gauge', name: 'captain.api.knex.db_connections_used', value: pool.numUsed() });
-    metrics.addMetricPoint({ type: 'gauge', name: 'captain.api.knex.db_connections_free', value: pool.numFree() });
+    metrics.addMetricPoint({
+      type: 'gauge',
+      name: 'captain.api.knex.db_connections_used',
+      value: pool.numUsed(),
+    });
+    metrics.addMetricPoint({
+      type: 'gauge',
+      name: 'captain.api.knex.db_connections_free',
+      value: pool.numFree(),
+    });
     metrics.addMetricPoint({
       type: 'gauge',
       name: 'captain.api.knex.db_connections_pending_creation',
@@ -188,6 +201,7 @@ const setupRoutesAndPlugins = async function (server) {
     healthcheckRoute,
     organizationsRoute,
     replicationsRoute,
+    menDashboardRoute,
     parcoursupRoute,
     poleEmploiRoute,
     livretScolaireRoute,

--- a/api/src/maddo/application/men-dashboard-controller.js
+++ b/api/src/maddo/application/men-dashboard-controller.js
@@ -1,0 +1,20 @@
+import { usecases } from '../domain/usecases/index.js';
+
+export async function getMenDashboardCertificationDataset(
+  request,
+  h,
+  dependencies = {
+    findCertificationDataset: usecases.findCertificationDataset,
+  },
+) {
+  const { page } = request.query;
+  const { models, meta } = await dependencies.findCertificationDataset({
+    page,
+  });
+  return h
+    .response({
+      dataset: models,
+      page: { number: meta.page, size: meta.pageSize, count: meta.pageCount },
+    })
+    .code(200);
+}

--- a/api/src/maddo/application/men-dashboard-routes.js
+++ b/api/src/maddo/application/men-dashboard-routes.js
@@ -1,0 +1,78 @@
+import Joi from 'joi';
+
+import { responseObjectErrorDoc } from '../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
+import { getMenDashboardCertificationDataset } from './men-dashboard-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/men/dashboard/certifications',
+      config: {
+        auth: { access: { scope: 'men-dashboard' } },
+        validate: {
+          query: Joi.object({
+            page: Joi.object({
+              number: Joi.number().integer().empty('').allow(null).optional(),
+              size: Joi.number().integer().max(200).empty('').allow(null).optional(),
+            }).default({}),
+          }),
+        },
+        handler: getMenDashboardCertificationDataset,
+        description:
+          'Dataset contenant les statistiques sur la certification des élèves des établissements français pour ' +
+          "l'année scolaire en cours par niveau scolaire et compétence.",
+        notes: [
+          'Retourne toutes les données triées par UAI sous format paginé.',
+          '**Cette route nécessite le scope men-dashboard.**',
+        ],
+        tags: ['api', 'men-dashboard', 'maddo'],
+        response: {
+          failAction: 'log',
+          status: {
+            200: Joi.object({
+              dataset: Joi.array().items(
+                Joi.object({
+                  schoolUai: Joi.string().description("UAI de l'établissement"),
+                  schoolYear: Joi.number().description('Année scolaire concernée par les données'),
+                  academieName: Joi.string().description("Nom de l'académie de l'établissement"),
+                  schoolName: Joi.string().description("Nom de l'établissement"),
+                  provinceCode: Joi.string().description("Nom du département de l'établissement"),
+                  schoolYearGroup: Joi.string().description('Niveau scolaire'),
+                  validatedCertificationCount: Joi.number().description(
+                    'Nombre de certification obtenues (i.e. réussies)',
+                  ),
+                  certificationCount: Joi.number().description(
+                    'Nombre total de certifications (réussies, échouées, abandonnées...)',
+                  ),
+                  averagePixScore: Joi.number().description(
+                    "Moyenne des scores en 'Pix' réalisés sur les certifications obtenues pour une compétence donnée",
+                  ),
+                  competenceCode: Joi.string().description('Code de la compétence'),
+                  avgCompetenceLevel: Joi.number().description(
+                    'Moyenne des niveaux atteints sur les certifications obtenues pour une compétence donnée',
+                  ),
+                  updatedAt: Joi.date().description('Date de dernière mise à jour des données.'),
+                }).label('MenDashboardCertificationRow'),
+              ),
+              page: Joi.object({
+                number: Joi.number().description('Numéro de la page courante'),
+                size: Joi.number().description('Taille de la page courante'),
+                count: Joi.number().description('Nombre total de pages'),
+              })
+                .description('Information de pagination')
+                .label('page'),
+            }).label('MenDashboardCertificationDataset'),
+            401: responseObjectErrorDoc,
+            403: responseObjectErrorDoc,
+          },
+        },
+      },
+    },
+  ]);
+};
+
+export const menDashboardRoute = {
+  name: 'maddo/maddo-men-dashboard-api',
+  register,
+};

--- a/api/src/maddo/domain/models/men/dashboard/CertificationDataset.js
+++ b/api/src/maddo/domain/models/men/dashboard/CertificationDataset.js
@@ -1,0 +1,29 @@
+export class CertificationDataset {
+  constructor({
+    schoolUai,
+    schoolYear,
+    academieName,
+    schoolName,
+    provinceCode,
+    schoolYearGroup,
+    validatedCertificationCount,
+    certificationCount,
+    averagePixScore,
+    competenceCode,
+    avgCompetenceLevel,
+    updatedAt,
+  }) {
+    this.schoolUai = schoolUai;
+    this.schoolYear = schoolYear;
+    this.academieName = academieName;
+    this.schoolName = schoolName;
+    this.provinceCode = provinceCode;
+    this.schoolYearGroup = schoolYearGroup;
+    this.validatedCertificationCount = validatedCertificationCount;
+    this.certificationCount = certificationCount;
+    this.averagePixScore = averagePixScore;
+    this.competenceCode = competenceCode;
+    this.avgCompetenceLevel = avgCompetenceLevel;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/api/src/maddo/domain/usecases/find-certification-dataset.js
+++ b/api/src/maddo/domain/usecases/find-certification-dataset.js
@@ -1,0 +1,3 @@
+export async function findCertificationDataset({ page, certificationDatasetRepository }) {
+  return certificationDatasetRepository.findAll({ page });
+}

--- a/api/src/maddo/domain/usecases/index.js
+++ b/api/src/maddo/domain/usecases/index.js
@@ -3,11 +3,13 @@ import * as campaignsAPI from '../../../prescription/campaign/application/api/ca
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';
+import * as certificationDatasetRepository from '../../infrastructure/repositories/certification-dataset-repository.js';
 import * as clientApplicationRepository from '../../infrastructure/repositories/client-application-repository.js';
 import * as oidcProviderRepository from '../../infrastructure/repositories/oidc-provider-repository.js';
 import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
 import { extractTransformAndLoadData } from './extract-transform-and-load-data.js';
 import { findCampaigns } from './find-campaigns.js';
+import { findCertificationDataset } from './find-certification-dataset.js';
 import { findOrganizationIdsByClientApplication } from './find-organization-ids-by-client-application.js';
 import { findOrganizations } from './find-organizations.js';
 import { getCampaignOrganizationId } from './get-campaign-organization-id.js';
@@ -16,6 +18,7 @@ import { getCampaignParticipations } from './get-campaign-participations.js';
 const dependencies = {
   campaignsAPI,
   authenticationMethodRepository,
+  certificationDatasetRepository,
   clientApplicationRepository,
   organizationRepository,
   campaignRepository,
@@ -25,6 +28,7 @@ const dependencies = {
 const usecasesWithoutInjectedDependencies = {
   extractTransformAndLoadData,
   findCampaigns,
+  findCertificationDataset,
   findOrganizationIdsByClientApplication,
   findOrganizations,
   getCampaignOrganizationId,

--- a/api/src/maddo/infrastructure/repositories/certification-dataset-repository.js
+++ b/api/src/maddo/infrastructure/repositories/certification-dataset-repository.js
@@ -1,0 +1,26 @@
+import { knex as datamartKnex } from '../../../../datamart/knex-database-connection.js';
+import { CertificationDataset } from '../../domain/models/men/dashboard/CertificationDataset.js';
+
+const TABLE_NAME = 'men_dashboard_certification_dataset';
+const DEFAULT_PAGE_NUMBER = 1;
+const DEFAULT_PAGE_SIZE = 10;
+
+export async function findAll({ page = {} } = {}) {
+  const number = page.number ?? DEFAULT_PAGE_NUMBER;
+  const size = page.size ?? DEFAULT_PAGE_SIZE;
+  const offset = (number - 1) * size;
+
+  const rows = await datamartKnex(TABLE_NAME).orderBy('schoolUai').limit(size).offset(offset);
+  const countResult = await datamartKnex(TABLE_NAME).count('* as rowCount').first();
+
+  const rowCount = parseInt(countResult.rowCount, 10);
+
+  return {
+    models: rows.map((row) => new CertificationDataset(row)),
+    meta: {
+      page: number,
+      pageSize: size,
+      pageCount: Math.ceil(rowCount / size),
+    },
+  };
+}

--- a/api/tests/maddo/application/acceptance/men-dashboard-routes_test.js
+++ b/api/tests/maddo/application/acceptance/men-dashboard-routes_test.js
@@ -1,0 +1,113 @@
+import { createMaddoServer } from '../../../../server.maddo.js';
+import { expect } from '../../../test-helper.js';
+import { datamartBuilder } from '../../../tooling/databases.js';
+import { generateValidRequestAuthorizationHeaderForApplication } from '../../../tooling/test-utils/http-server.js';
+
+describe('Acceptance | Maddo | Route | Men | Dashboard', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createMaddoServer();
+  });
+
+  describe('GET /api/men/dashboard/certifications', function () {
+    it('returns certification dataset with pagination and HTTP 200', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI001',
+        competenceCode: '1.1',
+      });
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/men/dashboard/certifications',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            'client-id',
+            'pix-client',
+            'men-dashboard',
+          ),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.dataset).to.have.length(1);
+      expect(response.result.dataset[0].schoolUai).to.equal('UAI001');
+      expect(response.result.dataset[0].competenceCode).to.equal('1.1');
+      expect(response.result.page).to.deep.equal({
+        number: 1,
+        size: 10,
+        count: 1,
+      });
+    });
+
+    it('paginates results when page params are provided', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI_A',
+      });
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI_B',
+      });
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI_C',
+      });
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/men/dashboard/certifications?page[number]=2&page[size]=2',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            'client-id',
+            'pix-client',
+            'men-dashboard',
+          ),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.dataset).to.have.length(1);
+      expect(response.result.dataset[0].schoolUai).to.equal('UAI_C');
+      expect(response.result.page).to.deep.equal({
+        number: 2,
+        size: 2,
+        count: 2,
+      });
+    });
+
+    it('returns HTTP 401 when no authorization header is provided', async function () {
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/men/dashboard/certifications',
+      });
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('returns HTTP 403 when the token does not have the men-dashboard scope', async function () {
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/men/dashboard/certifications',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication('client-id', 'pix-client', 'campaigns'),
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+});

--- a/api/tests/maddo/domain/unit/usecases/find-certification-dataset_test.js
+++ b/api/tests/maddo/domain/unit/usecases/find-certification-dataset_test.js
@@ -1,0 +1,30 @@
+import sinon from 'sinon';
+
+import { findCertificationDataset } from '../../../../../src/maddo/domain/usecases/find-certification-dataset.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Maddo | Domain | Usecase | Find certification dataset', function () {
+  it('delegates to the repository and returns its result', async function () {
+    // given
+    const page = { number: 1, size: 10 };
+    const expectedResult = {
+      models: [],
+      meta: { page: 1, pageSize: 10, pageCount: 0 },
+    };
+    const certificationDatasetRepository = {
+      findAll: sinon.stub().resolves(expectedResult),
+    };
+
+    // when
+    const result = await findCertificationDataset({
+      page,
+      certificationDatasetRepository,
+    });
+
+    // then
+    expect(certificationDatasetRepository.findAll).to.have.been.calledOnceWith({
+      page,
+    });
+    expect(result).to.deep.equal(expectedResult);
+  });
+});

--- a/api/tests/maddo/infrastructure/integration/repositories/certification-dataset-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/certification-dataset-repository_test.js
@@ -1,0 +1,87 @@
+import { CertificationDataset } from '../../../../../src/maddo/domain/models/men/dashboard/CertificationDataset.js';
+import { findAll } from '../../../../../src/maddo/infrastructure/repositories/certification-dataset-repository.js';
+import { expect } from '../../../../test-helper.js';
+import { datamartBuilder } from '../../../../tooling/databases.js';
+
+describe('Maddo | Infrastructure | Repositories | Integration | CertificationDataset', function () {
+  describe('#findAll', function () {
+    it('returns dataset sorted by schoolUai', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI_B',
+      });
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI_A',
+      });
+      await datamartBuilder.commit();
+
+      // when
+      const { models } = await findAll();
+
+      // then
+      expect(models[0].schoolUai).to.equal('UAI_A');
+      expect(models[1].schoolUai).to.equal('UAI_B');
+      expect(models[0]).to.be.instanceOf(CertificationDataset);
+    });
+
+    it('paginates results and returns correct meta', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI_A',
+      });
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI_B',
+      });
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI_C',
+      });
+      await datamartBuilder.commit();
+
+      // when
+      const { models, meta } = await findAll({ page: { number: 2, size: 2 } });
+
+      // then
+      expect(models).to.have.length(1);
+      expect(models[0].schoolUai).to.equal('UAI_C');
+      expect(models[0]).to.be.instanceOf(CertificationDataset);
+      expect(meta).to.deep.equal({ page: 2, pageSize: 2, pageCount: 2 });
+    });
+
+    it('maps all columns to the domain model', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        schoolUai: 'UAI001',
+        schoolYear: 2025,
+        academieName: 'Paris',
+        schoolName: 'Lycée Test',
+        provinceCode: '075',
+        schoolYearGroup: 'Terminale',
+        validatedCertificationCount: 12,
+        certificationCount: 20,
+        averagePixScore: 420.5,
+        competenceCode: '1.1',
+        avgCompetenceLevel: 3.5,
+        updatedAt: '2026-07-01',
+      });
+      await datamartBuilder.commit();
+
+      // when
+      const { models } = await findAll();
+
+      // then
+      const stat = models[0];
+      expect(stat.schoolUai).to.equal('UAI001');
+      expect(stat.schoolYear).to.equal(2025);
+      expect(stat.academieName).to.equal('Paris');
+      expect(stat.schoolName).to.equal('Lycée Test');
+      expect(stat.provinceCode).to.equal('075');
+      expect(stat.schoolYearGroup).to.equal('Terminale');
+      expect(stat.validatedCertificationCount).to.equal(12);
+      expect(stat.certificationCount).to.equal(20);
+      expect(stat.averagePixScore).to.equal(420.5);
+      expect(stat.competenceCode).to.equal('1.1');
+      expect(stat.avgCompetenceLevel).to.equal(3.5);
+      expect(stat.updatedAt).to.deep.equal('2026-07-01');
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

Les données statistiques concernant les certifications sont fournies par export au MEN pour le tableau de bord du numérique.

## 🌈 Proposition

Création d'une API pour mettre automatiquement à disposition ces données aux utilisateurs applicatifs ayant un scope `men-dashboard`. La juridiction n'est pas utilisée dans le cas de cette API non générique.

## 🎉 Pour tester

### Test fonctionnel d'accès aux données :

Obtenir un token applicatif avec les paramètres suivants : 
```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr16807.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=men-dashboard&client_secret=men-dashboard-secret&scope=men-dashboard' | jq -r .access_token)
```
puis appeler l'API `/api/men/dashboard/certifications` avec le token obtenu.

```
curl --get --data-urlencode "page[size]=2" --data-urlencode "page[number]=2" https://pix-api-maddo-review-pr16807.osc-fr1.scalingo.io/api/men/dashboard/certifications -H "Authorization: Bearer $ACCESS_TOKEN" | jq 
```

Les données sont les mêmes si l'on demande plusieurs fois la même page. 
Des données complémentaires sont obtenues si l'on demande les pages suivantes.
Le nombre de pages retourné est cohérent avec la taille des pages fournie.

Remarque : 208 enregistrements sont mis à disposition dans les seeds (soit 13 certifs de 16 compétences)

### Test de la documentation swagger
La documentation est disponible dans une section tdb-num : https://pix-api-maddo-review-pr16807.osc-fr1.scalingo.io/documentation/maddo#/