### PR TITLE
[FEATURE] Filtrer la liste des sessions avec plusieurs IDs (PIX-23428).

### DIFF
--- a/admin/app/components/sessions/list-items.gjs
+++ b/admin/app/components/sessions/list-items.gjs
@@ -20,7 +20,7 @@ export default class ListItems extends Component {
   @tracked selectedSessionStatusOption = null;
   @tracked selectedSessionVersionOption = null;
 
-  searchedId = this.args.id;
+  searchedIds = this.args.ids;
   searchedCertificationCenterName = this.args.certificationCenterName;
   searchedCertificationCenterExternalId = this.args.certificationCenterExternalId;
 
@@ -97,12 +97,12 @@ export default class ListItems extends Component {
     <div class="session-list">
       <PixFilterBanner @title={{t "common.filters.title"}}>
         <PixInput
-          aria-label={{t "pages.sessions.list.filters.id.aria-label"}}
+          aria-label={{t "pages.sessions.list.filters.ids.aria-label"}}
           type="text"
-          value={{this.searchedId}}
-          oninput={{fn @triggerFiltering "id"}}
+          value={{this.searchedIds}}
+          oninput={{fn @triggerFiltering "ids"}}
         >
-          <:label>{{t "pages.sessions.list.filters.id.label"}}</:label>
+          <:label>{{t "pages.sessions.list.filters.ids.label"}}</:label>
         </PixInput>
         <PixInput
           aria-label={{t "pages.sessions.list.filters.certification-name.aria-label"}}

--- a/admin/app/controllers/authenticated/sessions/list/all.js
+++ b/admin/app/controllers/authenticated/sessions/list/all.js
@@ -10,7 +10,7 @@ export default class AuthenticatedSessionsListAllController extends Controller {
   queryParams = [
     'pageNumber',
     'pageSize',
-    'id',
+    'ids',
     'certificationCenterName',
     'certificationCenterExternalId',
     'status',
@@ -20,7 +20,7 @@ export default class AuthenticatedSessionsListAllController extends Controller {
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
-  @tracked id = null;
+  @tracked ids = null;
   @tracked certificationCenterName = null;
   @tracked certificationCenterExternalId = null;
   @tracked certificationCenterType = null;

--- a/admin/app/routes/authenticated/sessions/list/all.js
+++ b/admin/app/routes/authenticated/sessions/list/all.js
@@ -7,7 +7,7 @@ export default class AuthenticatedSessionsAllRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
-    id: { refreshModel: true },
+    ids: { refreshModel: true },
     certificationCenterName: { refreshModel: true },
     certificationCenterExternalId: { refreshModel: true },
     certificationCenterType: { refreshModel: true },
@@ -16,11 +16,16 @@ export default class AuthenticatedSessionsAllRoute extends Route {
   };
 
   async model(params) {
+    const ids = params.ids
+      ?.split(',')
+      .map((id) => id.trim())
+      .filter((id) => /^\d+$/.test(id));
+
     let sessions;
     try {
       sessions = await this.store.query('session', {
         filter: {
-          id: params.id?.trim() || undefined,
+          ids: ids?.length ? ids : undefined,
           certificationCenterName: params.certificationCenterName?.trim() || undefined,
           certificationCenterExternalId: params.certificationCenterExternalId?.trim() || undefined,
           certificationCenterType: params.certificationCenterType || undefined,
@@ -43,7 +48,7 @@ export default class AuthenticatedSessionsAllRoute extends Route {
     if (isExiting) {
       controller.pageNumber = 1;
       controller.pageSize = 10;
-      controller.id = null;
+      controller.ids = null;
       controller.certificationCenterName = null;
       controller.certificationCenterExternalId = null;
       controller.certificationCenterType = null;

--- a/admin/app/templates/authenticated/sessions/list/all.gjs
+++ b/admin/app/templates/authenticated/sessions/list/all.gjs
@@ -2,7 +2,7 @@ import ListItems from 'pix-admin/components/sessions/list-items';
 <template>
   <ListItems
     @sessions={{@controller.model}}
-    @id={{@controller.id}}
+    @ids={{@controller.ids}}
     @certificationCenterName={{@controller.certificationCenterName}}
     @certificationCenterExternalId={{@controller.certificationCenterExternalId}}
     @status={{@controller.status}}

--- a/admin/tests/acceptance/sessions-list-test.js
+++ b/admin/tests/acceptance/sessions-list-test.js
@@ -102,36 +102,66 @@ module('Acceptance | Session List', function (hooks) {
         });
       });
 
-      module('when invalid filter value are typed in', function () {
-        test('it should display an empty list', async function (assert) {
-          // given
-          const screen = await visit('/sessions/list');
-
+      module('when the ids filter contains no valid id', function () {
+        test('it should not filter the sessions', async function (assert) {
           // when
-          await fillByLabel('Filtrer les sessions avec un id', 'azere');
+          const screen = await visit('/sessions/list?ids=azere');
 
-          //then
-          assert.dom(screen.getByText('Aucun résultat')).exists();
+          // then
+          const table = screen.getByRole('table', {
+            name: t('pages.sessions.table.caption'),
+          });
+          const rows = within(table).getAllByRole('row');
+          assert.strictEqual(rows.length, 11);
         });
       });
     });
 
     module('#Filters', function () {
-      module('#id', function (hooks) {
-        let expectedSession;
+      module('#ids', function (hooks) {
+        let firstExpectedSession;
+        let secondExpectedSession;
 
         hooks.beforeEach(function () {
-          expectedSession = server.create('session', 'finalized');
+          firstExpectedSession = server.create('session', 'finalized');
+          secondExpectedSession = server.create('session', 'finalized');
           server.createList('session', 10, 'finalized');
         });
 
-        test('it should display the session with the ID specified in the input field', async function (assert) {
-          // when
-          const screen = await visit('/sessions/list');
-          await fillByLabel('Filtrer les sessions avec un id', expectedSession.id);
+        module('when only one ID is specified in the dedicated filter', function () {
+          test('it should display the expected session', async function (assert) {
+            // when
+            const screen = await visit('/sessions/list');
+            await fillByLabel(t('pages.sessions.list.filters.ids.aria-label'), firstExpectedSession.id);
 
-          // then
-          assert.dom(screen.getByRole('link', { name: '1' })).exists();
+            // then
+            const table = screen.getByRole('table', {
+              name: t('pages.sessions.table.caption'),
+            });
+            const rows = within(table).getAllByRole('row');
+            assert.strictEqual(rows.length, 2);
+            assert.dom(screen.getByRole('link', { name: firstExpectedSession.id })).exists();
+          });
+        });
+
+        module('when multiple IDs are specified in the dedicated filter', function () {
+          test('it should display the expected sessions', async function (assert) {
+            // when
+            const screen = await visit('/sessions/list');
+            await fillByLabel(
+              t('pages.sessions.list.filters.ids.aria-label'),
+              `${firstExpectedSession.id}, ${secondExpectedSession.id}`,
+            );
+
+            // then
+            const table = screen.getByRole('table', {
+              name: t('pages.sessions.table.caption'),
+            });
+            const rows = within(table).getAllByRole('row');
+            assert.strictEqual(rows.length, 3);
+            assert.dom(screen.getByRole('link', { name: firstExpectedSession.id })).exists();
+            assert.dom(screen.getByRole('link', { name: secondExpectedSession.id })).exists();
+          });
         });
       });
 

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.gjs
@@ -83,13 +83,13 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     assert.dom('table tbody tr:nth-child(2) td:nth-child(4)').hasText('-');
   });
 
-  module('Input field for id filtering', function () {
-    test('it should render a input field to filter on id', async function (assert) {
+  module('Input field for ids filtering', function () {
+    test('it should render a input field to filter on ids', async function (assert) {
       // when
       const screen = await render(<template><ListItems @triggerFiltering={{triggerFiltering}} /></template>);
 
       // then
-      assert.dom(screen.getByRole('textbox', { name: 'Filtrer les sessions avec un id' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: t('pages.sessions.list.filters.ids.aria-label') })).exists();
     });
   });
 

--- a/admin/tests/mirage/handlers/find-paginated-and-filtered-sessions.js
+++ b/admin/tests/mirage/handlers/find-paginated-and-filtered-sessions.js
@@ -19,7 +19,7 @@ export function findPaginatedAndFilteredSessions(schema, request) {
           {
             status: 422,
             title: 'Invalid filters',
-            description: 'Filter on id field must be a number.',
+            description: 'Filter on ids field must only contain numbers.',
           },
         ],
       },
@@ -39,7 +39,7 @@ export function findPaginatedAndFilteredSessions(schema, request) {
 }
 
 function _getFiltersFromQueryParams(queryParams) {
-  const idFilter = queryParams ? (queryParams['filter[id]'] ? queryParams['filter[id]'].trim() || null : null) : null;
+  const idsFilter = queryParams ? queryParams['filter[ids]'] || null : null;
   const certificationCenterNameFilter = queryParams
     ? queryParams['filter[certificationCenterName]']
       ? queryParams['filter[certificationCenterName]'].trim() || null
@@ -62,7 +62,7 @@ function _getFiltersFromQueryParams(queryParams) {
       : null
     : null;
   return {
-    idFilter,
+    idsFilter,
     certificationCenterNameFilter,
     certificationCenterExternalIdFilter,
     statusFilter,
@@ -70,10 +70,9 @@ function _getFiltersFromQueryParams(queryParams) {
   };
 }
 
-function _areFiltersValid({ idFilter }) {
-  if (idFilter !== null) {
-    const idAsNumber = parseInt(idFilter, 10);
-    return !isNaN(idAsNumber);
+function _areFiltersValid({ idsFilter }) {
+  if (idsFilter !== null) {
+    return idsFilter.every((id) => !isNaN(parseInt(id, 10)));
   }
 
   return true;
@@ -81,12 +80,12 @@ function _areFiltersValid({ idFilter }) {
 
 function _applyFilters(
   sessions,
-  { idFilter, certificationCenterNameFilter, certificationCenterExternalIdFilter, statusFilter, versionFilter },
+  { idsFilter, certificationCenterNameFilter, certificationCenterExternalIdFilter, statusFilter, versionFilter },
 ) {
   let filteredSessions = sessions;
-  if (idFilter) {
+  if (idsFilter) {
     filteredSessions = filter(filteredSessions, (session) => {
-      return session.id === idFilter;
+      return idsFilter.includes(session.id);
     });
   }
   if (certificationCenterNameFilter) {

--- a/admin/tests/unit/routes/authenticated/sessions/list/all-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/all-test.js
@@ -25,154 +25,156 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
       };
     });
 
-    module('when queryParams are undefined', function () {
-      test('it should call store.query with no filters', async function (assert) {
-        // when
-        await route.model(params);
-        expectedQueryArgs.filter = {
-          id: undefined,
-          certificationCenterName: undefined,
-          certificationCenterType: undefined,
-          certificationCenterExternalId: undefined,
-          status: undefined,
-          version: undefined,
-        };
+    module('queryParams', function () {
+      module('when queryParams are undefined', function () {
+        test('it should call store.query with no filters', async function (assert) {
+          // when
+          await route.model(params);
+          expectedQueryArgs.filter = {
+            ids: undefined,
+            certificationCenterName: undefined,
+            certificationCenterType: undefined,
+            certificationCenterExternalId: undefined,
+            status: undefined,
+            version: undefined,
+          };
 
-        // then
-        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
-        assert.ok(true);
+          // then
+          sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+          assert.ok(true);
+        });
       });
-    });
 
-    module('when queryParams id is truthy', function () {
-      test('it should call store.query with a filter with trimmed id', async function (assert) {
-        // given
-        params.id = ' someId';
-        expectedQueryArgs.filter = {
-          id: 'someId',
-          certificationCenterName: undefined,
-          certificationCenterType: undefined,
-          certificationCenterExternalId: undefined,
-          status: undefined,
-          version: undefined,
-        };
+      module('when queryParams ids exists', function () {
+        test('it should call store.query with a filter with trimmed integers ids', async function (assert) {
+          // given
+          params.ids = ' 122, unexpectedString, 33';
+          expectedQueryArgs.filter = {
+            ids: ['122', '33'],
+            certificationCenterName: undefined,
+            certificationCenterType: undefined,
+            certificationCenterExternalId: undefined,
+            status: undefined,
+            version: undefined,
+          };
 
-        // when
-        await route.model(params);
+          // when
+          await route.model(params);
 
-        // then
-        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
-        assert.ok(true);
+          // then
+          sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+          assert.ok(true);
+        });
       });
-    });
 
-    module('when queryParams certificationCenterName is truthy', function () {
-      test('it should call store.query with a filter with trimmed certificationCenterName', async function (assert) {
-        // given
-        params.certificationCenterName = ' someName';
-        expectedQueryArgs.filter = {
-          id: undefined,
-          certificationCenterName: 'someName',
-          certificationCenterType: undefined,
-          certificationCenterExternalId: undefined,
-          status: undefined,
-          version: undefined,
-        };
+      module('when queryParams certificationCenterName is truthy', function () {
+        test('it should call store.query with a filter with trimmed certificationCenterName', async function (assert) {
+          // given
+          params.certificationCenterName = ' someName';
+          expectedQueryArgs.filter = {
+            ids: undefined,
+            certificationCenterName: 'someName',
+            certificationCenterType: undefined,
+            certificationCenterExternalId: undefined,
+            status: undefined,
+            version: undefined,
+          };
 
-        // when
-        await route.model(params);
+          // when
+          await route.model(params);
 
-        // then
-        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
-        assert.ok(true);
+          // then
+          sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+          assert.ok(true);
+        });
       });
-    });
 
-    module('when queryParams certificationCenterType is truthy', function () {
-      test('it should call store.query with a filter with trimmed certificationCenterType', async function (assert) {
-        // given
-        params.certificationCenterType = 'SCO';
-        expectedQueryArgs.filter = {
-          id: undefined,
-          certificationCenterName: undefined,
-          certificationCenterType: 'SCO',
-          certificationCenterExternalId: undefined,
-          status: undefined,
-          version: undefined,
-        };
+      module('when queryParams certificationCenterType is truthy', function () {
+        test('it should call store.query with a filter with trimmed certificationCenterType', async function (assert) {
+          // given
+          params.certificationCenterType = 'SCO';
+          expectedQueryArgs.filter = {
+            ids: undefined,
+            certificationCenterName: undefined,
+            certificationCenterType: 'SCO',
+            certificationCenterExternalId: undefined,
+            status: undefined,
+            version: undefined,
+          };
 
-        // when
-        await route.model(params);
+          // when
+          await route.model(params);
 
-        // then
-        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
-        assert.ok(true);
+          // then
+          sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+          assert.ok(true);
+        });
       });
-    });
 
-    module('when queryParams certificationCenterExternalId is truthy', function () {
-      test('it should call store.query with a filter with trimmed certificationCenterExternalId', async function (assert) {
-        // given
-        params.certificationCenterExternalId = 'EXTID';
-        expectedQueryArgs.filter = {
-          id: undefined,
-          certificationCenterName: undefined,
-          certificationCenterType: undefined,
-          certificationCenterExternalId: 'EXTID',
-          status: undefined,
-          version: undefined,
-        };
+      module('when queryParams certificationCenterExternalId is truthy', function () {
+        test('it should call store.query with a filter with trimmed certificationCenterExternalId', async function (assert) {
+          // given
+          params.certificationCenterExternalId = 'EXTID';
+          expectedQueryArgs.filter = {
+            ids: undefined,
+            certificationCenterName: undefined,
+            certificationCenterType: undefined,
+            certificationCenterExternalId: 'EXTID',
+            status: undefined,
+            version: undefined,
+          };
 
-        // when
-        await route.model(params);
+          // when
+          await route.model(params);
 
-        // then
-        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
-        assert.ok(true);
+          // then
+          sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+          assert.ok(true);
+        });
       });
-    });
 
-    module('when queryParams status is truthy', function () {
-      test('it should call store.query with a filter with status', async function (assert) {
-        // given
-        params.status = 'someStatus';
-        expectedQueryArgs.filter = {
-          id: undefined,
-          certificationCenterName: undefined,
-          certificationCenterType: undefined,
-          certificationCenterExternalId: undefined,
-          status: 'someStatus',
-          version: undefined,
-        };
+      module('when queryParams status is truthy', function () {
+        test('it should call store.query with a filter with status', async function (assert) {
+          // given
+          params.status = 'someStatus';
+          expectedQueryArgs.filter = {
+            ids: undefined,
+            certificationCenterName: undefined,
+            certificationCenterType: undefined,
+            certificationCenterExternalId: undefined,
+            status: 'someStatus',
+            version: undefined,
+          };
 
-        // when
-        await route.model(params);
+          // when
+          await route.model(params);
 
-        // then
-        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
-        assert.ok(true);
+          // then
+          sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+          assert.ok(true);
+        });
       });
-    });
 
-    module('when queryParams version is 3', function () {
-      test('it should call store.query with a filter with version', async function (assert) {
-        // given
-        params.version = 3;
-        expectedQueryArgs.filter = {
-          id: undefined,
-          certificationCenterName: undefined,
-          certificationCenterType: undefined,
-          certificationCenterExternalId: undefined,
-          status: undefined,
-          version: 3,
-        };
+      module('when queryParams version is 3', function () {
+        test('it should call store.query with a filter with version', async function (assert) {
+          // given
+          params.version = 3;
+          expectedQueryArgs.filter = {
+            ids: undefined,
+            certificationCenterName: undefined,
+            certificationCenterType: undefined,
+            certificationCenterExternalId: undefined,
+            status: undefined,
+            version: 3,
+          };
 
-        // when
-        await route.model(params);
+          // when
+          await route.model(params);
 
-        // then
-        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
-        assert.ok(true);
+          // then
+          sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+          assert.ok(true);
+        });
       });
     });
 
@@ -210,7 +212,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
-        id: 'someId',
+        ids: '122',
         certificationCenterName: 'someName',
         certificationCenterType: 'someType',
         status: 'someStatus',
@@ -226,7 +228,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         // then
         assert.deepEqual(controller.pageNumber, 1);
         assert.deepEqual(controller.pageSize, 10);
-        assert.deepEqual(controller.id, null);
+        assert.deepEqual(controller.ids, null);
         assert.deepEqual(controller.certificationCenterName, null);
         assert.deepEqual(controller.certificationCenterType, null);
         assert.deepEqual(controller.status, null);
@@ -242,7 +244,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         // then
         assert.deepEqual(controller.pageNumber, 'somePageNumber');
         assert.deepEqual(controller.pageSize, 'somePageSize');
-        assert.deepEqual(controller.id, 'someId');
+        assert.deepEqual(controller.ids, '122');
         assert.deepEqual(controller.certificationCenterName, 'someName');
         assert.deepEqual(controller.status, 'someStatus');
         assert.deepEqual(controller.certificationCenterType, 'someType');

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1801,9 +1801,9 @@
           "external-id": {
             "aria-label": "Filtrer les sessions avec un identifiant externe"
           },
-          "id": {
-            "aria-label": "Filtrer les sessions avec un id",
-            "label": "Identifiant"
+          "ids": {
+            "aria-label": "Filtrer les sessions avec un ou plusieurs id séparés par des virgules",
+            "label": "Session(s) ID(s)"
           },
           "status": {
             "aria-label": "Filtrer les sessions en sélectionnant un statut"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1814,9 +1814,9 @@
           "external-id": {
             "aria-label": "Filtrer les sessions avec un identifiant externe"
           },
-          "id": {
-            "aria-label": "Filtrer les sessions avec un id",
-            "label": "Identifiant"
+          "ids": {
+            "aria-label": "Filtrer les sessions avec un ou plusieurs id séparés par des virgules",
+            "label": "ID(s) de session(s)"
           },
           "status": {
             "aria-label": "Filtrer les sessions en sélectionnant un statut"

--- a/api/src/certification/session-management/infrastructure/repositories/jury-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-session-repository.js
@@ -164,11 +164,11 @@ function _toDomain(jurySessionFromDB, counters) {
 }
 
 function _setupFilters(query, filters) {
-  const { id, certificationCenterName, status, certificationCenterExternalId, certificationCenterType, version } =
+  const { ids, certificationCenterName, status, certificationCenterExternalId, certificationCenterType, version } =
     filters;
 
-  if (id) {
-    query.where('sessions.id', id);
+  if (ids) {
+    query.whereIn('sessions.id', ids);
   }
 
   if (certificationCenterName) {

--- a/api/src/certification/shared/domain/validators/session-validator.js
+++ b/api/src/certification/shared/domain/validators/session-validator.js
@@ -75,7 +75,7 @@ const sessionValidationForMassImportJoiSchema = Joi.object({
 });
 
 const sessionFiltersValidationSchema = Joi.object({
-  id: identifiersType.sessionId.optional(),
+  ids: Joi.array().items(identifiersType.sessionId.optional()).single().optional(),
   status: Joi.string()
     .trim()
     .valid(

--- a/api/tests/certification/session-management/acceptance/application/session-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-route_test.js
@@ -42,20 +42,21 @@ describe('Certification | Session Management | Acceptance | Application | Route 
 
       it('should return a 200 status code with paginated and filtered data', async function () {
         // given
-        options.url = '/api/admin/sessions?filter[id]=121&page[number]=1&page[size]=2';
+        options.url = '/api/admin/sessions?filter[ids][]=121&filter[ids][]=333&page[number]=1&page[size]=2';
 
         // when
         const response = await server.inject(options);
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result.data).to.have.lengthOf(1);
+        expect(response.result.data).to.have.lengthOf(2);
         expect(response.result.data[0].type).to.equal('sessions');
+        expect(response.result.data[1].type).to.equal('sessions');
       });
 
       it('should return a 200 status code with empty result', async function () {
         // given
-        options.url = '/api/admin/sessions?filter[id]=4&page[number]=1&page[size]=1';
+        options.url = '/api/admin/sessions?filter[ids][]=4&filter[ids][]=22&page[number]=1&page[size]=1';
 
         // when
         const response = await server.inject(options);

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -255,28 +255,30 @@ describe('Integration | Repository | JurySession', function () {
         });
       });
 
-      context('when there is a filter on the ID', function () {
-        let expectedSession;
+      context('when there is a filter on the IDs', function () {
+        let firstExpectedSession;
+        let secondExpectedSession;
 
         beforeEach(function () {
-          expectedSession = databaseBuilder.factory.buildSession({ id: 121 });
-          databaseBuilder.factory.buildSession({ id: 333 });
+          firstExpectedSession = databaseBuilder.factory.buildSession({ id: 121 });
+          secondExpectedSession = databaseBuilder.factory.buildSession({ id: 333 });
+          databaseBuilder.factory.buildSession({ id: 555 });
 
           return databaseBuilder.commit();
         });
 
         it('should apply the strict filter and return the appropriate results', async function () {
           // given
-          const filters = { id: expectedSession.id };
+          const filters = { ids: [firstExpectedSession.id, secondExpectedSession.id] };
           const page = { number: 1, size: 10 };
-          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
+          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
 
           // when
           const { jurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
 
           // then
           expect(pagination).to.deep.equal(expectedPagination);
-          expect(jurySessions[0].id).to.equal(expectedSession.id);
+          expect(jurySessions.map(({ id }) => id)).to.have.members([firstExpectedSession.id, secondExpectedSession.id]);
         });
       });
 

--- a/api/tests/certification/shared/unit/domain/validators/session-validator_test.js
+++ b/api/tests/certification/shared/unit/domain/validators/session-validator_test.js
@@ -263,37 +263,44 @@ describe('Unit | Domain | Validators | session-validator', function () {
     context('return value', function () {
       it('should return the filters in a normalized form', function () {
         const value = sessionValidator.validateAndNormalizeFilters({
-          id: '123',
+          ids: ['123', 456],
           status: 'finalized',
         });
 
-        expect(typeof value.id).to.equal('number');
+        expect(value.ids).to.deep.equal([123, 456]);
         expect(value.status).to.equal('finalized');
       });
     });
 
-    context('when validating id', function () {
-      context('when id not in submitted filters', function () {
+    context('when validating ids', function () {
+      context('when ids not in submitted filters', function () {
         it('should not throw any error', function () {
           expect(() => sessionValidator.validateAndNormalizeFilters({})).to.not.throw();
         });
       });
 
-      context('when id is in submitted filters', function () {
-        context('when id is not an integer', function () {
+      context('when ids is in submitted filters', function () {
+        context('when ids contains a value which is not an integer', function () {
           it('should throw an error', async function () {
-            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ id: 'salut' });
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ ids: [123, 'salut'] });
             expect(error).to.be.instanceOf(EntityValidationError);
           });
         });
 
-        context('when id is an integer', function () {
-          it('accept a string containing an int', function () {
-            expect(() => sessionValidator.validateAndNormalizeFilters({ id: '123' })).to.not.throw();
+        context('when ids contains integers', function () {
+          it('accepts strings containing ints', function () {
+            expect(() => sessionValidator.validateAndNormalizeFilters({ ids: ['123', '456'] })).to.not.throw();
           });
 
           it('should not throw any error', function () {
-            expect(() => sessionValidator.validateAndNormalizeFilters({ id: 123 })).to.not.throw();
+            expect(() => sessionValidator.validateAndNormalizeFilters({ ids: [123, 456] })).to.not.throw();
+          });
+        });
+
+        context('when ids is a single value', function () {
+          it('should normalize it into an array', function () {
+            const value = sessionValidator.validateAndNormalizeFilters({ ids: '123' });
+            expect(value.ids).to.deep.equal([123]);
           });
         });
       });


### PR DESCRIPTION
## 🪧 Problème

Actuellement, la recherche par ID de session n’est possible qu’individuellement, session par session et cela leur fait perdre du temps lorsqu’elles doivent travailler sur plusieurs sessions.

## 🌈 Proposition

Modifier le champ de recherche par identifiant de l’onglet “Toutes les sessions” de la page “Sessions de certification” dans Pix Admin pour permettre aux utilisateurs Pix Admin de filtrer sur plusieurs ID de sessions à la fois séparés par des virgules.

## ✊ Remarques

A été prévu dans le code une partie défensive : éviter que des lettres cassent la recherche.

## 🎉 Pour tester

Tester la fonctionnalité en RA
