### PR TITLE
[TECH] Réduit le nombre d'appels SQL dans certains repositories

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -4,7 +4,7 @@ import {
   AlreadySharedCampaignParticipationError,
   AssessmentNotCompletedError,
   CampaignParticipationDeletedError,
-} from '../../../../../src/shared/domain/errors.js';
+} from '../../../../shared/domain/errors.js';
 import { CampaignParticipationLoggerContext, CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 import { ArchivedCampaignError } from '../../../shared/domain/errors.js';
 

--- a/api/src/prescription/campaign-participation/domain/usecases/get-user-campaign-assessment-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-user-campaign-assessment-result.js
@@ -30,17 +30,15 @@ const getUserCampaignAssessmentResult = async function ({
       campaignParticipationId: campaignParticipation.id,
     });
 
-    const stillValidBadgeIds = await checkStillValidBadges(
-      campaignId,
-      knowledgeElements,
-      badgeForCalculationRepository,
-    );
+    const badgesForCalculation = await badgeForCalculationRepository.findByCampaignId({ campaignId });
+    const stillValidBadgeIds = badgesForCalculation
+      .filter((badge) => badge.shouldBeObtained(knowledgeElements))
+      .map(({ id }) => id);
 
-    const badgeWithAcquisitionPercentage = await getBadgeAcquisitionPercentage(
-      campaignId,
-      knowledgeElements,
-      badgeForCalculationRepository,
-    );
+    const badgeWithAcquisitionPercentage = badgesForCalculation.map((badge) => ({
+      id: badge.id,
+      acquisitionPercentage: badge.getAcquisitionPercentage(knowledgeElements),
+    }));
 
     const badgesWithValidity = badges.map((badge) => ({
       ...badge,
@@ -74,18 +72,5 @@ const getUserCampaignAssessmentResult = async function ({
 };
 
 export { getUserCampaignAssessmentResult };
-
-async function checkStillValidBadges(campaignId, knowledgeElements, badgeForCalculationRepository) {
-  const badgesForCalculation = await badgeForCalculationRepository.findByCampaignId({ campaignId });
-  return badgesForCalculation.filter((badge) => badge.shouldBeObtained(knowledgeElements)).map(({ id }) => id);
-}
-
 // TODO PIX-21173 Create dedicated repository or service for badges to remove logic duplication for acquisition percentage
 // TODO PIX-21173 part2 We can use badgeAcquisitionRepository to avoid unnecessary calculation
-async function getBadgeAcquisitionPercentage(campaignId, knowledgeElements, badgeForCalculationRepository) {
-  const badgesForCalculation = await badgeForCalculationRepository.findByCampaignId({ campaignId });
-  return badgesForCalculation.map((badge) => ({
-    id: badge.id,
-    acquisitionPercentage: badge.getAcquisitionPercentage(knowledgeElements),
-  }));
-}

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -318,20 +318,20 @@ const getCodeOfLastParticipationToProfilesCollectionCampaignForUser = async func
 
 const isRetrying = async function ({ campaignParticipationId }) {
   const knexConn = DomainTransaction.getConnection();
-  const { id: campaignId, organizationLearnerId } = await knexConn('campaigns')
-    .select('campaigns.id', 'organizationLearnerId')
-    .join('campaign-participations', 'campaigns.id', 'campaignId')
-    .where({ 'campaign-participations.id': campaignParticipationId })
+  const { participationCountToCampaign, hasUnsharedRetry } = await knexConn('campaign-participations')
+    .whereIn(
+      ['campaignId', 'organizationLearnerId'],
+      knexConn('campaign-participations')
+        .select('campaignId', 'organizationLearnerId')
+        .where({ id: campaignParticipationId }),
+    )
+    .select(
+      knexConn.raw('COUNT(*) AS "participationCountToCampaign"'),
+      knexConn.raw('BOOL_OR(NOT "isImproved" AND "sharedAt" IS NULL) AS "hasUnsharedRetry"'),
+    )
     .first();
 
-  const campaignParticipations = await knexConn('campaign-participations')
-    .select('sharedAt', 'isImproved')
-    .where({ campaignId, organizationLearnerId });
-
-  return (
-    campaignParticipations.length > 1 &&
-    campaignParticipations.some((participation) => !participation.isImproved && !participation.sharedAt)
-  );
+  return participationCountToCampaign > 1 && hasUnsharedRetry;
 };
 
 function _rowToResult(row) {

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -41,29 +41,19 @@ const updateWithSnapshot = async function (campaignParticipation) {
 const getLocked = async function (id) {
   const knexConn = DomainTransaction.getConnection();
 
-  const campaignParticipationDTO = await knexConn.from('campaign-participations').forUpdate().where({ id }).first();
-  const campaignDTO = await knexConn.from('campaigns').where({ id: campaignParticipationDTO.campaignId }).first();
-  const assessmentDTOs = await knexConn.from('assessments').where({ campaignParticipationId: id });
-  const campaign = new Campaign(campaignDTO);
-  return new CampaignParticipation({
-    ...campaignParticipationDTO,
-    campaign,
-    assessments: assessmentDTOs.map((assessmentDTO) => new Assessment({ ...assessmentDTO, campaign })),
-  });
+  const participationData = await baseQuery(knexConn)
+    .where('campaign-participations.id', id)
+    .forUpdate('campaign-participations');
+
+  return toDomainCampaignParticipation(participationData);
 };
 
 const get = async function (id) {
   const knexConn = DomainTransaction.getConnection();
 
-  const campaignParticipationDTO = await knexConn.from('campaign-participations').where({ id }).first();
-  const campaignDTO = await knexConn.from('campaigns').where({ id: campaignParticipationDTO.campaignId }).first();
-  const assessmentDTOs = await knexConn.from('assessments').where({ campaignParticipationId: id });
-  const campaign = new Campaign(campaignDTO);
-  return new CampaignParticipation({
-    ...campaignParticipationDTO,
-    campaign,
-    assessments: assessmentDTOs.map((assessmentDTO) => new Assessment({ ...assessmentDTO, campaign })),
-  });
+  const participationData = await baseQuery(knexConn).where('campaign-participations.id', id);
+
+  return toDomainCampaignParticipation(participationData);
 };
 
 const getByCampaignIds = async function (campaignIds, { withDeletedParticipation = false } = {}) {
@@ -198,22 +188,17 @@ const findInfoByCampaignId = async function ({
 
 const findOneByCampaignIdAndUserId = async function ({ campaignId, userId }) {
   const knexConn = DomainTransaction.getConnection();
-  const campaignParticipation = await knexConn('campaign-participations')
-    .where({ userId, isImproved: false, campaignId })
-    .first();
-  if (!campaignParticipation) return null;
-  const assessments = await knexConn('assessments').where({ campaignParticipationId: campaignParticipation.id });
-  const campaign = await campaignRepository.get(campaignId);
-  return new CampaignParticipation({
-    ...campaignParticipation,
-    assessments: assessments.map(
-      (assessment) =>
-        new Assessment({
-          ...assessment,
-          campaign,
-        }),
-    ),
-  });
+
+  const participationData = await baseQuery(knexConn)
+    .where('campaign-participations.userId', userId)
+    .where('campaign-participations.isImproved', false)
+    .where('campaign-participations.campaignId', campaignId);
+
+  if (participationData.length === 0) {
+    return null;
+  }
+
+  return toDomainCampaignParticipation(participationData);
 };
 
 const findByOrganizationLearnerIds = async function ({ organizationLearnerIds }) {
@@ -372,11 +357,9 @@ function _rowToResult(row) {
 
 async function getSharedParticipationIds(campaignId) {
   const knexConn = DomainTransaction.getConnection();
-  const results = await knexConn('campaign-participations')
+  return knexConn('campaign-participations')
     .pluck('id')
     .where({ campaignId, status: SHARED, isImproved: false, deletedAt: null });
-
-  return results;
 }
 
 export {
@@ -397,3 +380,128 @@ export {
   updateInBatchByIds,
   updateWithSnapshot,
 };
+
+function baseQuery(knexConn) {
+  return knexConn
+    .select({
+      campaignId: 'campaigns.id',
+      campaignName: 'campaigns.name',
+      campaignCode: 'campaigns.code',
+      campaignOrganizationId: 'campaigns.organizationId',
+      campaignCreatorId: 'campaigns.creatorId',
+      campaignCreatedAt: 'campaigns.createdAt',
+      campaignTargetProfileId: 'campaigns.targetProfileId',
+      campaignIdPixLabel: 'campaigns.idPixLabel',
+      campaignTitle: 'campaigns.title',
+      campaignCustomLandingPageText: 'campaigns.customLandingPageText',
+      campaignArchivedAt: 'campaigns.archivedAt',
+      campaignType: 'campaigns.type',
+      campaignExternalIdHelpImageUrl: 'campaigns.externalIdHelpImageUrl',
+      campaignAlternativeTextToExternalIdHelpImage: 'campaigns.alternativeTextToExternalIdHelpImage',
+      campaignIsForAbsoluteNovice: 'campaigns.isForAbsoluteNovice',
+      campaignCustomResultPageText: 'campaigns.customResultPageText',
+      campaignCustomResultPageButtonText: 'campaigns.customResultPageButtonText',
+      campaignCustomResultPageButtonUrl: 'campaigns.customResultPageButtonUrl',
+      campaignMultipleSendings: 'campaigns.multipleSendings',
+      campaignAssessmentMethod: 'campaigns.assessmentMethod',
+      campaignOwnerId: 'campaigns.ownerId',
+      campaignArchivedBy: 'campaigns.archivedBy',
+      campaignDeletedAt: 'campaigns.deletedAt',
+      campaignDeletedBy: 'campaigns.deletedBy',
+      participationId: 'campaign-participations.id',
+      participationCreatedAt: 'campaign-participations.createdAt',
+      participationParticipantExternalId: 'campaign-participations.participantExternalId',
+      participationStatus: 'campaign-participations.status',
+      participationSharedAt: 'campaign-participations.sharedAt',
+      participationDeletedAt: 'campaign-participations.deletedAt',
+      participationDeletedBy: 'campaign-participations.deletedBy',
+      participationUserId: 'campaign-participations.userId',
+      participationValidatedSkillsCount: 'campaign-participations.validatedSkillsCount',
+      participationPixScore: 'campaign-participations.pixScore',
+      participationOrganizationLearnerId: 'campaign-participations.organizationLearnerId',
+      assessmentId: 'assessments.id',
+      assessmentCreatedAt: 'assessments.createdAt',
+      assessmentUpdatedAt: 'assessments.updatedAt',
+      assessmentState: 'assessments.state',
+      assessmentType: 'assessments.type',
+      assessmentIsImproving: 'assessments.isImproving',
+      assessmentLastChallengeId: 'assessments.lastChallengeId',
+      assessmentLastQuestionState: 'assessments.lastQuestionState',
+      assessmentLastQuestionDate: 'assessments.lastQuestionDate',
+      assessmentCourseId: 'assessments.courseId',
+      assessmentCertificationCourseId: 'assessments.certificationCourseId',
+      assessmentUserId: 'assessments.userId',
+      assessmentCompetenceId: 'assessments.competenceId',
+      assessmentCampaignParticipationId: 'assessments.campaignParticipationId',
+      assessmentMethod: 'assessments.method',
+    })
+    .from('campaign-participations')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .leftJoin('assessments', 'assessments.campaignParticipationId', 'campaign-participations.id');
+}
+
+function toDomainCampaignParticipation(participationData) {
+  const commonData = participationData[0];
+  const campaign = new Campaign({
+    id: commonData.campaignId,
+    name: commonData.campaignName,
+    code: commonData.campaignCode,
+    organizationId: commonData.campaignOrganizationId,
+    creatorId: commonData.campaignCreatorId,
+    createdAt: commonData.campaignCreatedAt,
+    targetProfileId: commonData.campaignTargetProfileId,
+    idPixLabel: commonData.campaignIdPixLabel,
+    title: commonData.campaignTitle,
+    customLandingPageText: commonData.campaignCustomLandingPageText,
+    archivedAt: commonData.campaignArchivedAt,
+    type: commonData.campaignType,
+    externalIdHelpImageUrl: commonData.campaignExternalIdHelpImageUrl,
+    alternativeTextToExternalIdHelpImage: commonData.campaignAlternativeTextToExternalIdHelpImage,
+    isForAbsoluteNovice: commonData.campaignIsForAbsoluteNovice,
+    customResultPageText: commonData.campaignCustomResultPageText,
+    customResultPageButtonText: commonData.campaignCustomResultPageButtonText,
+    customResultPageButtonUrl: commonData.campaignCustomResultPageButtonUrl,
+    multipleSendings: commonData.campaignMultipleSendings,
+    assessmentMethod: commonData.campaignAssessmentMethod,
+  });
+  let assessments = [];
+  if (commonData.assessmentId) {
+    assessments = participationData.map(
+      (assessmentData) =>
+        new Assessment({
+          id: assessmentData.assessmentId,
+          createdAt: assessmentData.assessmentCreatedAt,
+          updatedAt: assessmentData.assessmentUpdatedAt,
+          state: assessmentData.assessmentState,
+          type: assessmentData.assessmentType,
+          isImproving: assessmentData.assessmentIsImproving,
+          lastChallengeId: assessmentData.assessmentLastChallengeId,
+          lastQuestionState: assessmentData.assessmentLastQuestionState,
+          lastQuestionDate: assessmentData.assessmentLastQuestionDate,
+          courseId: assessmentData.assessmentCourseId,
+          certificationCourseId: assessmentData.assessmentCertificationCourseId,
+          userId: assessmentData.assessmentUserId,
+          competenceId: assessmentData.assessmentCompetenceId,
+          campaignParticipationId: assessmentData.assessmentCampaignParticipationId,
+          method: assessmentData.assessmentMethod,
+          campaign,
+        }),
+    );
+  }
+
+  return new CampaignParticipation({
+    id: commonData.participationId,
+    createdAt: commonData.participationCreatedAt,
+    participantExternalId: commonData.participationParticipantExternalId,
+    status: commonData.participationStatus,
+    sharedAt: commonData.participationSharedAt,
+    deletedAt: commonData.participationDeletedAt,
+    deletedBy: commonData.participationDeletedBy,
+    userId: commonData.participationUserId,
+    validatedSkillsCount: commonData.participationValidatedSkillsCount,
+    pixScore: commonData.participationPixScore,
+    organizationLearnerId: commonData.participationOrganizationLearnerId,
+    campaign,
+    assessments,
+  });
+}

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-repository.js
@@ -5,6 +5,54 @@ import * as skillRepository from '../../../../shared/infrastructure/repositories
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
+const getByCode = async function (code) {
+  const knexConn = DomainTransaction.getConnection();
+  const campaignData = await baseQuery(knexConn).where('campaigns.code', code).first();
+  if (!campaignData) {
+    return null;
+  }
+
+  return new Campaign({
+    ...campaignData,
+    ...{ externalIdLabel: campaignData?.params?.label, externalIdType: campaignData?.params?.type },
+  });
+};
+
+const get = async function (id) {
+  const knexConn = DomainTransaction.getConnection();
+  const campaignData = await baseQuery(knexConn).where('campaigns.id', id).first();
+  if (!campaignData) {
+    throw new NotFoundError(`Not found campaign for ID ${id}`);
+  }
+
+  return new Campaign({
+    ...campaignData,
+    ...{ externalIdLabel: campaignData?.params?.label, externalIdType: campaignData?.params?.type },
+  });
+};
+
+const getByCampaignParticipationId = async function (campaignParticipationId) {
+  const knexConn = DomainTransaction.getConnection();
+  const campaignData = await baseQuery(knexConn)
+    .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
+    .where({ 'campaign-participations.id': campaignParticipationId })
+    .first();
+  if (!campaignData) {
+    return null;
+  }
+
+  return new Campaign({
+    ...campaignData,
+    ...{ externalIdLabel: campaignData?.params?.label, externalIdType: campaignData?.params?.type },
+  });
+};
+
+const getCampaignIdByCampaignParticipationId = async function (campaignParticipationId) {
+  const campaign = await getByCampaignParticipationId(campaignParticipationId);
+  if (!campaign) return null;
+  return campaign.id;
+};
+
 const areKnowledgeElementsResettable = async function ({ id }) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn('campaigns')
@@ -19,34 +67,6 @@ const areKnowledgeElementsResettable = async function ({ id }) {
   return Boolean(result);
 };
 
-const getByCode = async function (code) {
-  const knexConn = DomainTransaction.getConnection();
-  const campaign = await knexConn('campaigns').first().where({ code });
-  if (!campaign) return null;
-  return new Campaign(campaign);
-};
-
-const get = async function (id) {
-  const knexConn = DomainTransaction.getConnection();
-
-  const campaign = await knexConn('campaigns').where({ id }).first();
-  if (!campaign) {
-    throw new NotFoundError(`Not found campaign for ID ${id}`);
-  }
-  const featureExternalId = await knexConn('campaign-features')
-    .join('features', 'features.id', 'featureId')
-    .where({
-      campaignId: id,
-      'features.key': CAMPAIGN_FEATURES.EXTERNAL_ID.key,
-    })
-    .first();
-
-  return new Campaign({
-    ...campaign,
-    ...{ externalIdLabel: featureExternalId?.params?.label, externalIdType: featureExternalId?.params?.type },
-  });
-};
-
 const checkIfUserOrganizationHasAccessToCampaign = async function (campaignId, userId) {
   const knexConn = DomainTransaction.getConnection();
 
@@ -56,24 +76,6 @@ const checkIfUserOrganizationHasAccessToCampaign = async function (campaignId, u
     .where({ 'campaigns.id': campaignId, 'memberships.userId': userId, 'memberships.disabledAt': null })
     .first('campaigns.id');
   return Boolean(campaign);
-};
-
-const getByCampaignParticipationId = async function (campaignParticipationId) {
-  const knexConn = DomainTransaction.getConnection();
-  const campaign = await knexConn('campaigns')
-    .select('campaigns.*')
-    .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
-    .where({ 'campaign-participations.id': campaignParticipationId })
-    .first();
-
-  if (!campaign) return null;
-  return new Campaign(campaign);
-};
-
-const getCampaignIdByCampaignParticipationId = async function (campaignParticipationId) {
-  const campaign = await getByCampaignParticipationId(campaignParticipationId);
-  if (!campaign) return null;
-  return campaign.id;
 };
 
 async function _findSkillIds(campaignIds) {
@@ -157,3 +159,19 @@ export {
   getByCode,
   getCampaignIdByCampaignParticipationId,
 };
+
+function baseQuery(knexConn) {
+  return knexConn
+    .select('campaigns.*', 'campaign-features.params')
+    .from('campaigns')
+    .leftJoin('features', function () {
+      this.onVal('features.key', CAMPAIGN_FEATURES.EXTERNAL_ID.key);
+    })
+    .leftJoin('campaign-features', function () {
+      this.on('campaign-features.campaignId', '=', 'campaigns.id').andOn(
+        'campaign-features.featureId',
+        '=',
+        'features.id',
+      );
+    });
+}


### PR DESCRIPTION
## 🪧 Problème

Certains repositories font plusieurs appels SQl individuels pour reconstituer un modèle ou un aggrégat. Or, il est parfois préférable de faire un seul appel SQL avec quelques jointures plutôt que de payer le coût de plusieurs allers-retours réseau.

## 🌈 Proposition

1er commit : `campaign-campaign-repository.js`
- Récupérer les infos de la campagne et de sa potentielle feature `CAMPAIGN_FEATURES.EXTERNAL_ID` en un seul appel au lieu de 2
- Utiliser la requête dans un maximum de méthodes pour s'assurer que les méthodes retournent bien un modèle complet à chaque fois

2ème commit : `prescription/campaign-participation/campaign-participation-repository.js`
- Récupérer les infos des tables `campaign-participations`, `campaigns` et `assessments` en un seul appel au lieu de 3

3ème commit : `prescription/campaign-participation/campaign-participation-repository.js`
- refacto de la méthode `isRetrying` pour ne faire qu'un appel au lieu de 2

4ème commit : le usecase `get-user-campaign-assessment-result`
- Éviter d'appeler deux fois `badgeForCalculationRepository.findByCampaignId()` avec les mêmes arguments (4 appels SQL de moins)

## ✊ Remarques

Pour info, le refacto du 3ème commit produit un SQL suivant :
```
SELECT
    COUNT(*) AS participationCountToCampaign,
    BOOL_OR(NOT "isImproved" AND "sharedAt" IS NULL) AS hasUnsharedRetry
FROM "campaign-participations"
WHERE ("campaignId", "organizationLearnerId") = (
  SELECT "campaignId", "organizationLearnerId"
  FROM "campaign-participations"
  WHERE id = ?
);
```
Donc d'abord PG va exécuter la sous-requête :
```
SELECT "campaignId", "organizationLearnerId"
  FROM "campaign-participations"
  WHERE id = ?
```
ce qui va retourner une seule paire de `campaignId`/`organizationLearnerId`
Cette paire va être utilisée pour exécuter la requête englobante, qui va donc rechercher toutes les participations avec la paire `campaignId`/`organizationLearnerId`.
Puis sur toutes les lignes trouvées, on va calculer deux éléments :
- `participationCountToCampaign` : le nombre de participations à cette campagne pour cet apprenant
- `hasUnsharedRetry` : flag qui se met à vrai si au moins une participation répond aux critères : `NOT "isImproved" AND "sharedAt" IS NULL` qui correspondent à ce que j'ai lu dans l'ancienne version du code à la définition d'une participation non partagée et pas en mode retenter ou je ne sais plus quoi

## 🎉 Pour tester
Non régression sur les features concernées
