### PR TITLE
[TECH] Création d'un helper pour les primitives OpenTelemetry

### DIFF
--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -236,7 +236,6 @@ export class JobClient {
     };
 
     const stats = { global: { ...emptyStat } };
-
     for (const queue of queues) {
       stats[queue.name] = { ...emptyStat };
     }

--- a/api/src/shared/infrastructure/open-telemetry/helpers.js
+++ b/api/src/shared/infrastructure/open-telemetry/helpers.js
@@ -54,4 +54,14 @@ export const tracing = {
   spanify: function (name, resource, getSpanOptionsFn) {
     return otelProxy(resource, name, getSpanOptionsFn);
   },
+
+  /**
+   * Add an event to the currently active span.
+   *
+   * @param {string} name - Name of the event.
+   * @param {Record<string, string|number|boolean>} [attributes] - Key/value attributes attached to the event.
+   */
+  recordEvent: function (name, attributes) {
+    trace.getActiveSpan()?.addEvent(name, attributes);
+  },
 };

--- a/api/src/shared/infrastructure/open-telemetry/helpers.js
+++ b/api/src/shared/infrastructure/open-telemetry/helpers.js
@@ -1,0 +1,57 @@
+import { trace } from '@opentelemetry/api';
+
+import { otelProxy } from './otel_proxy.js';
+
+/**
+ * Helpers to interact with the currently active OpenTelemetry span, if any.
+ * All methods are no-ops when there is no active span.
+ */
+export const tracing = {
+  /**
+   * Add attributes to the currently active span, namespacing each key with a prefix.
+   *
+   * @param {Record<string, string|number|boolean>} attributes - Key/value attributes to set on the span.
+   * @param {string} [prefix="pix"] - Prefix prepended to each attribute key (as `${prefix}.${key}`). Falsy disables prefixing.
+   */
+  addAttributes: function (attributes, prefix = 'pix') {
+    if (!prefix) {
+      trace.getActiveSpan()?.setAttributes(attributes);
+    }
+    const prefixedAttributes = Object.fromEntries(
+      Object.entries(attributes).map(([key, value]) => [`${prefix}.${key}`, value]),
+    );
+    trace.getActiveSpan()?.setAttributes(prefixedAttributes);
+  },
+  /**
+   * Record an exception on the currently active span.
+   *
+   * @param {Error} exception - The exception to record.
+   */
+  recordException: function (exception) {
+    trace.getActiveSpan()?.recordException(exception);
+  },
+  /**
+   * Mark the currently active span as being in error.
+   *
+   * @param {string} [reason] - The reason to set on the span status.
+   */
+  markAsFailed: function (reason) {
+    trace.getActiveSpan()?.setStatus({
+      code: 2 /* SpanStatusCode.ERROR */,
+      message: reason,
+    });
+  },
+  /**
+   * Wraps an object or function with an OpenTelemetry proxy that automatically
+   * creates a span around each method call (or the call itself, if `resource`
+   * is a function).
+   *
+   * @param {string} name - Base name used to build span names (e.g. `${name}->${methodName}`).
+   * @param {object|Function} resource - The object whose methods should be traced, or a function to trace directly.
+   * @param {() => import('@opentelemetry/api').SpanOptions} [getSpanOptionsFn] - A function that returns SpanOptions to set on every span created by this proxy.
+   * @returns {object|Function} A proxy (or wrapped function) that behaves like `resource` but emits spans.
+   */
+  spanify: function (name, resource, getSpanOptionsFn) {
+    return otelProxy(resource, name, getSpanOptionsFn);
+  },
+};

--- a/api/src/shared/infrastructure/open-telemetry/job-tracing.js
+++ b/api/src/shared/infrastructure/open-telemetry/job-tracing.js
@@ -1,13 +1,13 @@
 import { getInContext } from '../execution-context-manager.js';
-import { otelProxy } from './otel_proxy.js';
+import { tracing } from './helpers.js';
 
 function instrumentJobHandle(jobName, jobControllerClass) {
   const originalHandle = jobControllerClass.prototype.handle;
-  jobControllerClass.prototype.handle = otelProxy(originalHandle, `job.${jobName}.handle`, () => {
+  jobControllerClass.prototype.handle = tracing.spanify(`job.${jobName}.handle`, originalHandle, () => {
     const producerContext = getInContext('openTelemetryContext');
     return {
       kind: 4 /* SpanKind.CONSUMER */,
-      links: producerContext ? [{ context: producerContext }] : [],
+      links: producerContext ? [{context: producerContext}] : [],
     };
   });
 }

--- a/api/src/shared/infrastructure/open-telemetry/job-tracing.js
+++ b/api/src/shared/infrastructure/open-telemetry/job-tracing.js
@@ -7,7 +7,7 @@ function instrumentJobHandle(jobName, jobControllerClass) {
     const producerContext = getInContext('openTelemetryContext');
     return {
       kind: 4 /* SpanKind.CONSUMER */,
-      links: producerContext ? [{context: producerContext}] : [],
+      links: producerContext ? [{ context: producerContext }] : [],
     };
   });
 }

--- a/api/src/shared/infrastructure/open-telemetry/otel_proxy.js
+++ b/api/src/shared/infrastructure/open-telemetry/otel_proxy.js
@@ -29,7 +29,7 @@ function wrapFunction(func, target, methodName, getSpanOptionsFn) {
               if (!(error instanceof DomainError)) {
                 span.setStatus({
                   code: 2 /* SpanStatusCode.ERROR */,
-                  message: error.message,
+                  message: 'A technical error has been thrown',
                 });
               }
               span.end();
@@ -43,7 +43,7 @@ function wrapFunction(func, target, methodName, getSpanOptionsFn) {
         if (!(error instanceof DomainError)) {
           span.setStatus({
             code: 2 /* SpanStatusCode.ERROR */,
-            message: error.message,
+            message: 'A technical error has been thrown',
           });
         }
         span.end();

--- a/api/src/shared/infrastructure/utils/dependency-injection.js
+++ b/api/src/shared/infrastructure/utils/dependency-injection.js
@@ -50,7 +50,7 @@ export function injectDependencies(toBeInjected, dependencies, boundedContext = 
   const wrappedDependencies = Object.fromEntries(
     Object.entries(dependencies).map(([name, value]) => [
       name,
-      value ? tracing.spanify(name, value, () => ({attributes: defaultAttributes})) : value,
+      value ? tracing.spanify(name, value, () => ({ attributes: defaultAttributes })) : value,
     ]),
   );
   const injected = Object.fromEntries(

--- a/api/src/shared/infrastructure/utils/dependency-injection.js
+++ b/api/src/shared/infrastructure/utils/dependency-injection.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { otelProxy } from '../open-telemetry/otel_proxy.js';
+import { tracing } from '../open-telemetry/helpers.js';
 
 function injectDefaults(defaults, targetFn) {
   return (args) => targetFn(Object.assign(Object.create(defaults), args));
@@ -50,13 +50,15 @@ export function injectDependencies(toBeInjected, dependencies, boundedContext = 
   const wrappedDependencies = Object.fromEntries(
     Object.entries(dependencies).map(([name, value]) => [
       name,
-      value ? otelProxy(value, name, () => ({ attributes: defaultAttributes })) : value,
+      value ? tracing.spanify(name, value, () => ({attributes: defaultAttributes})) : value,
     ]),
   );
   const injected = Object.fromEntries(
     Object.entries(toBeInjected).map(([name, value]) => {
       if (_.isFunction(value)) {
-        const wrapped = otelProxy(value, `${boundedContext.name}->${name}`, () => ({ attributes: defaultAttributes }));
+        const wrapped = tracing.spanify(`${boundedContext.name}->${name}`, value, () => ({
+          attributes: defaultAttributes,
+        }));
         return [name, _.partial(injectDefaults, wrappedDependencies, wrapped)()];
       } else {
         return [name, injectDependencies(value, dependencies)];


### PR DESCRIPTION
## 🪧 Problème

La librairie Open Telemetry est complexe et peut être difficile à prendre en main. 

## 🌈 Proposition

On ajoute un helper qui permet pour mettre à disposition des développeurs les primitives les plus courrantes de Open Telemetry.
