### PR TITLE
[FEATURE] Amélioration du wording de la page de résultat du moteur de recommandations (PIX-23584)

### DIFF
--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2325,7 +2325,7 @@
           }
         },
         "trainings": {
-          "description": "Es wird entsprechend deinen Fortschritten empfohlen, um dir dabei zu helfen, deine Fähigkeiten zu festigen und zum richtigen Zeitpunkt einen Schritt weiter zu gehen.",
+          "description": "Die unten aufgeführten Lösungen werden dir basierend auf deinem Niveau empfohlen.",
           "title": "Gehen Sie noch einen Schritt weiter – ganz in Ihrem eigenen Tempo."
         }
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2325,7 +2325,7 @@
           }
         },
         "trainings": {
-          "description": "It is recommended based on your progress to help you build your skills and take them to the next level at just the right time.",
+          "description": "The solutions listed below are recommended to you based on your level.",
           "title": "Go further, at your own pace."
         }
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2325,7 +2325,7 @@
           }
         },
         "trainings": {
-          "description": "Se recomienda en función de tu progreso para ayudarte a reforzar tus habilidades y avanzar más, en el momento adecuado.",
+          "description": "Las soluciones que se muestran a continuación se te recomiendan en función de tu nivel.",
           "title": "Ve más allá, a tu propio ritmo."
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2325,7 +2325,7 @@
           }
         },
         "trainings": {
-          "description": "Il est recommandé en fonction de votre progression pour vous aider à renforcer vos compétences et aller plus loin, au bon moment.",
+          "description": "Les solutions listées ci-dessous vous sont recommandées en fonction de votre niveau.",
           "title": "Allez plus loin, à votre rythme."
         }
       },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2325,7 +2325,7 @@
           }
         },
         "trainings": {
-          "description": "Viene consigliato in base ai tuoi progressi per aiutarti a consolidare le tue competenze e ad andare oltre, al momento giusto.",
+          "description": "Le soluzioni elencate qui sotto ti vengono consigliate in base al tuo livello.",
           "title": "Andate oltre, al vostro ritmo."
         }
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2325,7 +2325,7 @@
           }
         },
         "trainings": {
-          "description": "Deze aanbeveling wordt gedaan op basis van je voortgang, om je te helpen je vaardigheden te versterken en op het juiste moment een stap verder te gaan.",
+          "description": "De onderstaande oplossingen worden je aanbevolen op basis van je niveau.",
           "title": "Ga verder, op je eigen tempo."
         }
       },


### PR DESCRIPTION
## 🪧 Problème
Le wording qui précède les contenus formatif ne convient pas :
<img width="917" height="676" alt="wording" src="https://github.com/user-attachments/assets/32883fde-ce58-464c-b2f3-c4824388c82e" />


## 🌈 Proposition
L'améliorer

## ✊ Remarques
Claudio s'est occupé de faire les traductions dans les autres langues.

## 🎉 Pour tester
- Aller sur la [RA](https://app-pr16822.review.pix.fr/campaigns/EDUMULTIP) avec dave-comp@example.net
- constater que le wording est le bon