### PR TITLE
[FEATURE] Traiter les erreurs du NPS coté front (PIX-23541)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
@@ -35,8 +35,6 @@ export default class Drawer extends Component {
   @action
   async submitSatisfactionScore(score) {
     try {
-      this.step = 'content-relevance-form';
-
       this.satisfactionScore = score;
       await this.requestManager.request({
         url: `${ENV.APP.API_HOST}/api/user-campaign-surveys`,
@@ -51,6 +49,8 @@ export default class Drawer extends Component {
           },
         }),
       });
+
+      this.step = 'content-relevance-form';
     } catch {
       this.pixToast.sendErrorNotification({
         message: this.intl.t('pages.skill-review.recommended-engine.drawer.error-message'),

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
@@ -12,6 +12,8 @@ import ThankYou from './drawer/thank-you';
 
 export default class Drawer extends Component {
   @service requestManager;
+  @service intl;
+  @service pixToast;
 
   @tracked isHidden = false;
   @tracked isHiding = false;
@@ -50,7 +52,9 @@ export default class Drawer extends Component {
         }),
       });
     } catch {
-      // TODO Ajouter un PixToast d'erreur
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.skill-review.recommended-engine.drawer.error-message'),
+      });
     }
   }
 
@@ -99,7 +103,9 @@ export default class Drawer extends Component {
       });
       this.showThankYou();
     } catch {
-      // TODO Ajouter un PixToast d'erreur
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.skill-review.recommended-engine.drawer.error-message'),
+      });
     }
   }
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
@@ -1,4 +1,5 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click, triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import Drawer from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/drawer';
@@ -17,6 +18,13 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
     this.owner.register('service:current-user', { user: { id: 42 } });
 
     this.matchMediaStub = sinon.stub(window, 'matchMedia').returns({ matches: false });
+
+    const sendErrorNotificationStub = sinon.stub();
+    this.sendErrorNotificationStub = sendErrorNotificationStub;
+    class PixToastStub extends Service {
+      sendErrorNotification = sendErrorNotificationStub;
+    }
+    this.owner.register('service:pixToast', PixToastStub);
   });
 
   hooks.afterEach(function () {
@@ -69,6 +77,25 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         const body = JSON.parse(requestArgs.body);
         assert.strictEqual(body.data.attributes['campaign-id'], 99);
         assert.strictEqual(body.data.attributes['satisfaction-score'], 5);
+      });
+
+      test('it displays an error notification when the request fails', async function (assert) {
+        // given
+        this.requestManagerStub.request = sinon.stub().rejects();
+        const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
+
+        // when
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
+          }),
+        );
+
+        // then
+        sinon.assert.calledWith(this.sendErrorNotificationStub, {
+          message: t('pages.skill-review.recommended-engine.drawer.error-message'),
+        });
+        assert.ok(true);
       });
     });
 
@@ -189,6 +216,37 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         assert.strictEqual(body.data.attributes['personalization-score'], 5);
         assert.strictEqual(body.data.attributes['attractiveness-score'], 5);
         assert.strictEqual(body.data.attributes['satisfaction-score'], 5);
+      });
+
+      test('it displays an error notification when the request fails', async function (assert) {
+        // given
+        const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.drawer.emojis.very-satisfied'),
+          }),
+        );
+        const scoreLabel = t('pages.skill-review.recommended-engine.drawer.content-relevance-form.score-aria-label', {
+          score: 5,
+        });
+        for (const axisLegendKey of ['usefulness', 'personalization', 'attractiveness']) {
+          const scale = within(
+            screen.getByRole('group', {
+              name: t(`pages.skill-review.recommended-engine.drawer.content-relevance-form.${axisLegendKey}.legend`),
+            }),
+          );
+          await click(scale.getByRole('radio', { name: scoreLabel }));
+        }
+        this.requestManagerStub.request = sinon.stub().rejects();
+
+        // when
+        await click(screen.getByRole('button', { name: t('common.actions.send') }));
+
+        // then
+        sinon.assert.calledWith(this.sendErrorNotificationStub, {
+          message: t('pages.skill-review.recommended-engine.drawer.error-message'),
+        });
+        assert.ok(true);
       });
     });
 

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2282,6 +2282,7 @@
             "very-dissatisfied": "Überhaupt nicht relevant",
             "very-satisfied": "Sehr relevant"
           },
+          "error-message": "Beim Senden Ihrer Antwort ist ein Fehler aufgetreten.",
           "hide": "Ausblenden",
           "hide-aria-label": "Feedbackbereich für Empfehlungen zu Lerninhalten ausblenden",
           "instruction": "Klicken Sie auf ein Emoji, um Ihre Meinung zu geben.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2282,6 +2282,7 @@
             "very-dissatisfied": "Not relevant at all",
             "very-satisfied": "Very relevant"
           },
+          "error-message": "An error occurred while sending your response.",
           "hide": "Hide",
           "hide-aria-label": "Hide the feedback panel for training content recommendations",
           "instruction": "Click on an emoji to give your feedback.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2282,6 +2282,7 @@
             "very-dissatisfied": "Para nada pertinente",
             "very-satisfied": "Muy pertinente"
           },
+          "error-message": "Se produjo un error al enviar tu respuesta.",
           "hide": "Ocultar",
           "hide-aria-label": "Ocultar el panel de comentarios de las recomendaciones de contenidos formativos",
           "instruction": "Haz clic en un emoji para dar tu opinión.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2282,6 +2282,7 @@
             "very-dissatisfied": "Pas du tout pertinent",
             "very-satisfied": "Très pertinent"
           },
+          "error-message": "Une erreur est survenue lors de l'envoi de votre réponse.",
           "hide": "Masquer",
           "hide-aria-label": "Fermer l'encart de retours sur la recommandation des offres de formation",
           "instruction": "Cliquez sur un emoji pour donner votre avis.",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2282,6 +2282,7 @@
             "very-dissatisfied": "Per niente pertinente",
             "very-satisfied": "Molto pertinente"
           },
+          "error-message": "Si è verificato un errore durante l'invio della tua risposta.",
           "hide": "Nascondi",
           "hide-aria-label": "Nascondi il pannello di feedback per le raccomandazioni sui contenuti formativi",
           "instruction": "Clicca su un emoji per dare il tuo parere.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2282,6 +2282,7 @@
             "very-dissatisfied": "Helemaal niet relevant",
             "very-satisfied": "Zeer relevant"
           },
+          "error-message": "Er is een fout opgetreden bij het verzenden van uw antwoord.",
           "hide": "Verbergen",
           "hide-aria-label": "Het feedbackpaneel voor aanbevelingen voor trainingsinhoud verbergen",
           "instruction": "Klik op een emoji om uw mening te geven.",


### PR DESCRIPTION
## 🪧 Problème

Actuellement il n'y a pas de gestion d'erreurs lors de l'envoi des informations d'une enquête sur la page de résultat.

## 🌈 Proposition

Ajouter cela avec l'affichage de notification d'erreurs

## ✊ Remarques

- La séquence d'instruction a été modifié lors de l'envoi du score de satisfaction. En effet on change maintenant d'étape uniquement si le premier appel a fonctionné 🚀 

## 🎉 Pour tester
### En local
#### Test de la 1ère étape
- Aller sur la page de résultat de la campagne EDUMULTIP
- Ouvrir la console navigateur et passer en mode hors connexion dans l'onglet `Network`.
- Cliquer sur un émoji et constater que l'erreur s'affiche bien 😄 
#### Test de la 2ème étape
- Désactiver le mode hors connexion et refaire l'étape précédente. Vous devriez arriver sur le formulaire ⏭️ 
- Remettre le mode hors connexion et remplir le 2ème formulaire.
- Cliquer sur `envoyer`. Une erreur devrait aussi s'afficher 🚀 
