### PR TITLE
[TECH] :broom: Supprime les denières utilisations de la table `certification-subscriptions` (PIX-23543)

### DIFF
--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -46,8 +46,13 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     });
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
     userId = databaseBuilder.factory.buildUser().id;
-    databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-    const sessionData = databaseBuilder.factory.buildSession({ certificationCenterId });
+    databaseBuilder.factory.buildCertificationCenterMembership({
+      userId,
+      certificationCenterId,
+    });
+    const sessionData = databaseBuilder.factory.buildSession({
+      certificationCenterId,
+    });
     sessionId = sessionData.id;
     session = domainBuilder.certification.enrolment.buildSession(sessionData);
 
@@ -64,8 +69,16 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       matcher: 'AEEEGLNRRT',
     });
 
-    databaseBuilder.factory.buildCertificationCpfCity({ name: 'AJACCIO', INSEECode: '2A004', isActualName: true });
-    databaseBuilder.factory.buildCertificationCpfCity({ name: 'PARIS 18', postalCode: '75018', isActualName: true });
+    databaseBuilder.factory.buildCertificationCpfCity({
+      name: 'AJACCIO',
+      INSEECode: '2A004',
+      isActualName: true,
+    });
+    databaseBuilder.factory.buildCertificationCpfCity({
+      name: 'PARIS 18',
+      postalCode: '75018',
+      isActualName: true,
+    });
 
     await databaseBuilder.commit();
 
@@ -98,7 +111,10 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     // then
     expect(error).to.be.instanceOf(CertificationCandidatesError);
     expect(error.code).to.equal('CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID');
-    expect(error.meta).to.deep.equal({ line: 13, value: 'destinataire@gmail.com, destinataire@gmail.com' });
+    expect(error.meta).to.deep.equal({
+      line: 13,
+      value: 'destinataire@gmail.com, destinataire@gmail.com',
+    });
   });
 
   it('should throw a CertificationCandidatesError if there is an error in the birth information', async function () {
@@ -262,8 +278,13 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       });
 
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-      const sessionData = databaseBuilder.factory.buildSession({ certificationCenterId });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+      });
+      const sessionData = databaseBuilder.factory.buildSession({
+        certificationCenterId,
+      });
       const session = domainBuilder.certification.enrolment.buildSession(sessionData);
 
       await databaseBuilder.commit();
@@ -315,8 +336,13 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       });
 
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-      const sessionData = databaseBuilder.factory.buildSession({ certificationCenterId });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+      });
+      const sessionData = databaseBuilder.factory.buildSession({
+        certificationCenterId,
+      });
       const session = domainBuilder.certification.enrolment.buildSession(sessionData);
 
       await databaseBuilder.commit();
@@ -352,7 +378,10 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
     const odsFilePath = `${__dirname}/attendance_sheet_extract_with_billing_ok_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
-    candidateList = _buildCandidateList({ billingModes: [BILLING_MODES.PAID, BILLING_MODES.FREE], sessionId });
+    candidateList = _buildCandidateList({
+      billingModes: [BILLING_MODES.PAID, BILLING_MODES.FREE],
+      sessionId,
+    });
     const expectedCandidates = candidateList.map((candidate) => {
       return domainBuilder.certification.enrolment.buildCandidate({
         ...candidate,

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-import-sheet-data_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-import-sheet-data_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
 import { getCandidateImportSheetData } from '../../../../../../src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js';
-import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/constants.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -36,26 +36,12 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate-import-shee
     const michelCandidate = domainBuilder.certification.enrolment.buildCandidate({
       firstName: 'Michel',
       lastName: 'Jacques',
-      subscriptions: [
-        {
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-          complementaryCertificationLabel: null,
-          complementaryCertificationKey: null,
-        },
-      ],
+      subscription: Frameworks.CORE,
     });
     const jeannetteCandidate = domainBuilder.certification.enrolment.buildCandidate({
       firstName: 'Jeannette',
       lastName: 'Jacques',
-      subscriptions: [
-        {
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-          complementaryCertificationLabel: null,
-          complementaryCertificationKey: null,
-        },
-      ],
+      subscription: Frameworks.CORE,
     });
     const enrolledCandidates = [michelCandidate, jeannetteCandidate];
     candidateRepository.findBySessionId.withArgs({ sessionId }).resolves(enrolledCandidates);

--- a/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
@@ -133,7 +133,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         userId: null,
         reconciledAt: null,
         billingMode: BILLING_MODES.FREE,
-        subscriptions: [],
       });
       const session1 = { ...firstSession, candidates: [candidateData1] };
       const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
@@ -143,7 +142,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         userId: null,
         reconciledAt: null,
         billingMode: BILLING_MODES.FREE,
-        subscriptions: [],
       });
       const session2 = { ...secondSession, candidates: [candidateData2] };
 
@@ -237,7 +235,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           userId: null,
           reconciledAt: null,
           billingMode: BILLING_MODES.FREE,
-          subscriptions: [],
         });
         const session1 = { ...firstSession, candidates: [candidateData1] };
         const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
@@ -247,7 +244,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           userId: null,
           reconciledAt: null,
           billingMode: BILLING_MODES.FREE,
-          subscriptions: [],
         });
         const candidateData3 = { ...candidateData2, lastName: 'Brun', firstName: 'Petit Ours' };
         const candidate3 = domainBuilder.certification.enrolment.buildCandidate({
@@ -257,7 +253,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           userId: null,
           reconciledAt: null,
           billingMode: BILLING_MODES.FREE,
-          subscriptions: [],
         });
         const session2 = { sessionId: 2, candidates: [candidateData2, candidateData3] };
 
@@ -440,7 +435,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           createdAt: null,
           userId: null,
           billingMode: BILLING_MODES.FREE,
-          subscriptions: [],
         });
         const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
           ...candidateData2,
@@ -448,7 +442,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           createdAt: null,
           userId: null,
           billingMode: BILLING_MODES.FREE,
-          subscriptions: [],
         });
         const sessionsData = [
           {

--- a/api/tests/certification/shared/fixtures/certification-course.js
+++ b/api/tests/certification/shared/fixtures/certification-course.js
@@ -129,7 +129,7 @@ const buildKnowledgeElementsFromAnswers = ({ answers, challenges, userId }) => {
   });
 };
 
-export const createSuccessfulCertificationCourse = async ({ userId, certificationCourse }) => {
+export async function createSuccessfulCertificationCourse({ userId, certificationCourse }) {
   const { challenges } = createLearningContent();
 
   const assessment = databaseBuilder.factory.buildAssessment({
@@ -165,4 +165,4 @@ export const createSuccessfulCertificationCourse = async ({ userId, certificatio
     certificationCourse,
     certificationChallenges,
   };
-};
+}


### PR DESCRIPTION
## 🪧 Problème

Il reste quelques utilisations de cette table, mais qui ne sont pas vraiment utilisés (en dehors de remplir des modèles pour les remplir)

## 🌈 Proposition

Supprimer les utilisations de la table `certification-subscriptions` pour pouvoir la supprimer ensuite.

## ✊ Remarques

En attente du feu vert Data et de la PR #16698

## 🎉 Pour tester

Test et CI verte. Tout doit se dérouler comme d'habitude.