### PR TITLE
[TECH] Ajout d'une fonction empêchant la proxification OpenTelemetry

### DIFF
--- a/api/src/shared/infrastructure/open-telemetry/helpers.js
+++ b/api/src/shared/infrastructure/open-telemetry/helpers.js
@@ -1,6 +1,6 @@
 import { trace } from '@opentelemetry/api';
 
-import { otelProxy } from './otel_proxy.js';
+import { otelProxy, preventTracingSymbol } from './otel_proxy.js';
 
 /**
  * Helpers to interact with the currently active OpenTelemetry span, if any.
@@ -63,5 +63,17 @@ export const tracing = {
    */
   recordEvent: function (name, attributes) {
     trace.getActiveSpan()?.addEvent(name, attributes);
+  },
+
+  /**
+   * Mark an object as excluded from tracing, so that {@link tracing.spanify}
+   * returns it as-is instead of wrapping it in an OpenTelemetry proxy.
+   *
+   * @param {object} resource - The object to exclude from tracing.
+   * @returns {object} The same `resource`, for chaining.
+   */
+  prevent: function (resource) {
+    resource[preventTracingSymbol] = true;
+    return resource;
   },
 };

--- a/api/src/shared/infrastructure/open-telemetry/otel_proxy.js
+++ b/api/src/shared/infrastructure/open-telemetry/otel_proxy.js
@@ -3,6 +3,7 @@ import { trace } from '@opentelemetry/api';
 import { config } from '../../config.js';
 import { DomainError } from '../../domain/errors.js';
 const otelProxySymbol = Symbol('otelProxy');
+export const preventTracingSymbol = Symbol('preventTracing');
 
 function isAlreadyProxied(resource) {
   return resource[otelProxySymbol] === true;
@@ -109,7 +110,7 @@ function wrapObject(resource, name, getSpanOptionsFn) {
  * @returns {object|Function} A proxy (or wrapped function) that behaves like `resource` but emits spans.
  */
 export function otelProxy(resource, name, getSpanOptionsFn) {
-  if (!config.logging.otelEnabled) {
+  if (!config.logging.otelEnabled || resource[preventTracingSymbol]) {
     return resource;
   }
   if (typeof resource === 'function') {

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -6,6 +6,7 @@ import pretty from 'pino-pretty';
 
 import { config } from '../../config.js';
 import { CORRELATION_METADATA, getCorrelationInfo } from '../execution-context-manager.js';
+import { tracing } from '../open-telemetry/helpers.js';
 
 const { logging } = config;
 
@@ -85,7 +86,7 @@ function buildLogWrapper(context, mergingObject, message, extraBindings = {}, ex
   emitOtelLogRecord(context, mergingObject, message, extraBindings);
 }
 
-export const logger = {
+export const logger = tracing.prevent({
   trace: (mergingObject, message) => {
     buildLogWrapper('trace', mergingObject, message);
   },
@@ -107,7 +108,7 @@ export const logger = {
   silent: (mergingObject, message) => {
     buildLogWrapper('silent', mergingObject, message);
   },
-};
+});
 
 /**
  * Creates a child logger for a section.
@@ -130,7 +131,7 @@ export function child(section, bindings, options) {
   }
 
   const extraOptions = { ...options, ...optionsOverride };
-  return {
+  return tracing.prevent({
     trace: (mergingObject, message) => {
       buildLogWrapper('trace', mergingObject, message, bindings, extraOptions);
     },
@@ -152,7 +153,7 @@ export function child(section, bindings, options) {
     silent: (mergingObject, message) => {
       buildLogWrapper('silent', mergingObject, message, bindings, extraOptions);
     },
-  };
+  });
 }
 
 export const SCOPES = {

--- a/api/tests/shared/unit/infrastructure/utils/otel_proxy_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/otel_proxy_test.js
@@ -2,6 +2,7 @@ import { trace } from '@opentelemetry/api';
 import sinon from 'sinon';
 
 import { config } from '../../../../../src/shared/config.js';
+import { tracing } from '../../../../../src/shared/infrastructure/open-telemetry/helpers.js';
 import { otelProxy } from '../../../../../src/shared/infrastructure/open-telemetry/otel_proxy.js';
 import { expect } from '../../../../test-helper.js';
 
@@ -154,6 +155,38 @@ describe('Unit | Infrastructure | Utils | otelProxy', function () {
 
       expect(getSpanOptionsFn).to.have.been.calledOnce;
       expect(tracerStub.startActiveSpan).to.have.been.calledWith('myObj->patate', getSpanOptionsFn());
+    });
+  });
+
+  describe('when resource is marked as prevented via tracing.prevent', function () {
+    it('should return the function as-is, without wrapping it', function () {
+      const fn = sinon.stub().returns(42);
+
+      const prevented = tracing.prevent(fn);
+      const result = otelProxy(prevented, 'myFunc');
+
+      expect(result).to.equal(fn);
+      result();
+      expect(tracerStub.startActiveSpan).to.not.have.been.called;
+    });
+
+    it('should return the object as-is, without wrapping it', function () {
+      const obj = { doSomething: sinon.stub().returns('done') };
+
+      const prevented = tracing.prevent(obj);
+      const proxied = otelProxy(prevented, 'myObj');
+
+      expect(proxied).to.equal(obj);
+      proxied.doSomething();
+      expect(tracerStub.startActiveSpan).to.not.have.been.called;
+    });
+
+    it('should return the same resource it was given, for chaining', function () {
+      const obj = {};
+
+      const result = tracing.prevent(obj);
+
+      expect(result).to.equal(obj);
     });
   });
 });


### PR DESCRIPTION
## 🪧 Problème

Il y a des utilitaires, comme le logger, qui sont parfois injectés via le `injectDependencies`. Créer des spans pour ce genre d'utilitaire rajoute du bruit et est peu pertinent.

## 🌈 Proposition

On ajoute une fonction au helper Open Telemetry qui permet de marquer un objet ou une fonction pour qu'il soit ignoré par le `otelProxy`.
