### PR TITLE
[TECH] Corrige la configuration de l'instrumentation PG pour OpenTelemetry

### DIFF
--- a/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
+++ b/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
@@ -68,7 +68,7 @@ export function initializeOpenTelemetry(serviceName) {
       }),
       new PgInstrumentation({
         requireParentSpan: true,
-        enhancedDatabaseReporting: true,
+        enhancedDatabaseReporting: false, // prevent the instrumentation to add arguments of SQL in span attributes
         requestHook(span, pgRequest) {
           const statementWithoutComment = pgRequest.query.text.replace(/\/\* .* \*\/ /, '');
           span.setAttribute('db.statement', statementWithoutComment);


### PR DESCRIPTION
## 🪧 Problème

L'instrumentation de PG pour OpenTelemetry rajoute dans les attributs les valeurs de paramètres des requêtes SQL. Ces valeurs peuvent être sensibles.

## 🌈 Proposition

On change la valeur de la configuration de l'instrumentation PG pour prévenir l'envoie des paramètres.
