### PR TITLE
[TECH] Crée une API interne dans le BC Learning Content pour retrouver un référentiel et toute son arborescence à partir d'une liste d'ids de tubes

### DIFF
--- a/api/src/learning-content/application/api/learning-content-api.js
+++ b/api/src/learning-content/application/api/learning-content-api.js
@@ -1,0 +1,10 @@
+import { usecases } from '../../domain/usecases/index.js';
+import LearningContentDTO from './models/LearningContentDTO.js';
+
+/**
+ * @param {{ tubeIds: string[], locale: string }}
+ */
+export async function findByTubeIds({ tubeIds = [], locale }) {
+  const frameworks = await usecases.getLearningContentByTubeIds({ tubeIds, locale });
+  return frameworks.map((framework) => new LearningContentDTO(framework));
+}

--- a/api/src/learning-content/application/api/models/LearningContentDTO.js
+++ b/api/src/learning-content/application/api/models/LearningContentDTO.js
@@ -1,0 +1,8 @@
+import { FrameworkDTO } from './FrameworkDTO.js';
+
+export default class LearningContentDTO extends FrameworkDTO {
+  constructor({ id, name, areas }) {
+    super({ id, name });
+    this.areas = areas;
+  }
+}

--- a/api/src/learning-content/domain/models/FrameworkWithAreas.js
+++ b/api/src/learning-content/domain/models/FrameworkWithAreas.js
@@ -1,0 +1,15 @@
+import { Framework } from './Framework.js';
+
+export class FrameworkWithAreas extends Framework {
+  /**
+   * @param {{
+   *   id: string
+   *   name: string
+   *   areas: Area[]
+   * }}
+   */
+  constructor({ id, name, areas }) {
+    super({ id, name });
+    this.areas = areas;
+  }
+}

--- a/api/src/learning-content/domain/usecases/dependencies.js
+++ b/api/src/learning-content/domain/usecases/dependencies.js
@@ -1,5 +1,6 @@
 import { lcmsClient } from '../../../shared/infrastructure/lcms-client.js';
 import * as sharedAreaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
+import * as sharedCompetenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import * as sharedSkillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import * as sharedThematicRepository from '../../../shared/infrastructure/repositories/thematic-repository.js';
 import * as sharedTubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
@@ -32,6 +33,7 @@ export const dependencies = {
   sharedSkillRepository,
   sharedThematicRepository,
   sharedTubeRepository,
+  sharedCompetenceRepository,
   skillRepository,
   thematicRepository,
   tubeRepository,

--- a/api/src/learning-content/domain/usecases/get-learning-content-by-tube-ids.js
+++ b/api/src/learning-content/domain/usecases/get-learning-content-by-tube-ids.js
@@ -1,0 +1,53 @@
+import _ from 'lodash';
+
+import { FrameworkWithAreas } from '../models/FrameworkWithAreas.js';
+
+export async function getLearningContentByTubeIds({
+  tubeIds,
+  sharedThematicRepository,
+  sharedCompetenceRepository,
+  sharedAreaRepository,
+  sharedTubeRepository,
+  frameworkRepository,
+  locale,
+}) {
+  const tubes = await sharedTubeRepository.findByRecordIds(tubeIds, locale);
+  const thematicIds = _.uniq(tubes.map((tube) => tube.thematicId));
+  const thematics = await sharedThematicRepository.findByRecordIds(thematicIds, locale);
+  thematics.forEach((thematic) => {
+    thematic.tubes = tubes.filter((tube) => tube.thematicId === thematic.id);
+  });
+
+  const competenceIds = _.uniq(tubes.map((tube) => tube.competenceId));
+  const competences = await sharedCompetenceRepository.findByRecordIds({ competenceIds, locale });
+
+  competences.forEach((competence) => {
+    competence.tubes = tubes.filter((tube) => {
+      return tube.competenceId === competence.id;
+    });
+    competence.thematics = thematics.filter((thematic) => {
+      return thematic.competenceId === competence.id;
+    });
+  });
+
+  const allAreaIds = _.map(competences, (competence) => competence.areaId);
+  const uniqAreaIds = _.uniq(allAreaIds, 'id');
+  const areas = await sharedAreaRepository.findByRecordIds({ areaIds: uniqAreaIds, locale });
+  for (const area of areas) {
+    area.competences = competences.filter((competence) => {
+      return competence.areaId === area.id;
+    });
+  }
+
+  const frameworkIds = _.uniq(areas.map((area) => area.frameworkId));
+  const frameworkDtos = await frameworkRepository.findByIds(frameworkIds);
+
+  return frameworkDtos.map(
+    ({ id, name }) =>
+      new FrameworkWithAreas({
+        id,
+        name,
+        areas: areas.filter((area) => area.frameworkId === id),
+      }),
+  );
+}

--- a/api/src/learning-content/domain/usecases/index.js
+++ b/api/src/learning-content/domain/usecases/index.js
@@ -6,6 +6,7 @@ import { findFrameworksByIds } from './find-frameworks-by-ids.js';
 import { findSkillsByIds } from './find-skills-by-ids.js';
 import { getFrameworkAreas } from './get-framework-areas.js';
 import { getFrameworks } from './get-frameworks.js';
+import { getLearningContentByTubeIds } from './get-learning-content-by-tube-ids.js';
 import { patchLearningContentEntry } from './patch-learning-content-entry.js';
 import { refreshLearningContent } from './refresh-learning-content.js';
 import { scheduleCreateLearningContentReleaseJob } from './schedule-create-learning-content-release-job.js';
@@ -21,6 +22,7 @@ const usecasesWithoutInjectedDependencies = {
   refreshLearningContent,
   scheduleCreateLearningContentReleaseJob,
   scheduleRefreshLearningContentJob,
+  getLearningContentByTubeIds,
 };
 
 export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);

--- a/api/tests/learning-content/integration/domain/get-learning-content-by-tube-ids_test.js
+++ b/api/tests/learning-content/integration/domain/get-learning-content-by-tube-ids_test.js
@@ -1,0 +1,263 @@
+import { usecases } from '../../../../src/learning-content/domain/usecases/index.js';
+import { expect } from '../../../test-helper.js';
+import { databaseBuilder } from '../../../tooling/databases.js';
+import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
+
+describe('Learning Content | Integration | Domain | Usecase | get-learning-content-by-tube-ids', function () {
+  let framework1Fr, framework2Fr;
+  let area1Fr, area2Fr;
+  let competence1Fr, competence2Fr, competence3Fr;
+  let thematic1Fr, thematic2Fr, thematic3Fr;
+  let tube1Fr, tube2Fr, tube4Fr;
+
+  beforeEach(async function () {
+    const framework1DB = databaseBuilder.factory.learningContent.buildFramework({
+      id: 'recFramework1',
+      name: 'Framework 1',
+    });
+    const framework2DB = databaseBuilder.factory.learningContent.buildFramework({
+      id: 'recFramework2',
+      name: 'Framework 2',
+    });
+
+    const area1DB = databaseBuilder.factory.learningContent.buildArea({
+      id: 'recArea1',
+      name: 'area1_name',
+      title_i18n: { fr: 'domaine1_TitreFr', en: 'area1_TitleEn' },
+      color: 'area1_color',
+      code: 'area1_code',
+      frameworkId: 'recFramework1',
+      competenceIds: ['recCompetence1', 'recCompetence2'],
+    });
+    const area2DB = databaseBuilder.factory.learningContent.buildArea({
+      id: 'recArea2',
+      name: 'area2_name',
+      title_i18n: { fr: 'domaine2_TitreFr', en: 'area2_TitleEn' },
+      color: 'area2_color',
+      code: 'area2_code',
+      frameworkId: 'recFramework2',
+      competenceIds: ['recCompetence3'],
+    });
+
+    const competence1DB = databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'recCompetence1',
+      name_i18n: { fr: 'competence1_nomFr', en: 'competence1_nameEn' },
+      index: '1',
+      description_i18n: { fr: 'competence1_descriptionFr', en: 'competence1_descriptionEn' },
+      origin: 'Pix',
+      areaId: 'recArea1',
+    });
+    const competence2DB = databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'recCompetence2',
+      name_i18n: { fr: 'competence2_nomFr', en: 'competence2_nameEn' },
+      index: '2',
+      description_i18n: { fr: 'competence2_descriptionFr', en: 'competence2_descriptionEn' },
+      origin: 'Pix',
+      areaId: 'recArea1',
+    });
+    const competence3DB = databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'recCompetence3',
+      name_i18n: { fr: 'competence3_nomFr', en: 'competence3_nameEn' },
+      index: '1',
+      description_i18n: { fr: 'competence3_descriptionFr', en: 'competence3_descriptionEn' },
+      origin: 'Pix',
+      areaId: 'recArea2',
+    });
+
+    const thematic1DB = databaseBuilder.factory.learningContent.buildThematic({
+      id: 'recThematic1',
+      name_i18n: { fr: 'thematique1_nomFr', en: 'thematic1_nameEn' },
+      index: 10,
+      competenceId: 'recCompetence1',
+      tubeIds: ['recTube1'],
+    });
+    // recThematic2 has two tubes in the referential, but only one of them will be requested
+    // by the usecase (recTube3 is voluntarily left out of tubeIds below).
+    const thematic2DB = databaseBuilder.factory.learningContent.buildThematic({
+      id: 'recThematic2',
+      name_i18n: { fr: 'thematique2_nomFr', en: 'thematic2_nameEn' },
+      index: 20,
+      competenceId: 'recCompetence2',
+      tubeIds: ['recTube2', 'recTube3'],
+    });
+    const thematic3DB = databaseBuilder.factory.learningContent.buildThematic({
+      id: 'recThematic3',
+      name_i18n: { fr: 'thematique3_nomFr', en: 'thematic3_nameEn' },
+      index: 10,
+      competenceId: 'recCompetence3',
+      tubeIds: ['recTube4'],
+    });
+
+    const tube1DB = databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTube1',
+      name: '@tube1_name',
+      title: 'tube1_title',
+      description: 'tube1_description',
+      practicalTitle_i18n: { fr: 'tube1_practicalTitleFr', en: 'tube1_practicalTitleEn' },
+      practicalDescription_i18n: { fr: 'tube1_practicalDescriptionFr', en: 'tube1_practicalDescriptionEn' },
+      isMobileCompliant: true,
+      isTabletCompliant: false,
+      competenceId: 'recCompetence1',
+      thematicId: 'recThematic1',
+    });
+    const tube2DB = databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTube2',
+      name: '@tube2_name',
+      title: 'tube2_title',
+      description: 'tube2_description',
+      practicalTitle_i18n: { fr: 'tube2_practicalTitleFr', en: 'tube2_practicalTitleEn' },
+      practicalDescription_i18n: { fr: 'tube2_practicalDescriptionFr', en: 'tube2_practicalDescriptionEn' },
+      isMobileCompliant: false,
+      isTabletCompliant: true,
+      competenceId: 'recCompetence2',
+      thematicId: 'recThematic2',
+    });
+    // recTube3 exists in the referential (linked to recThematic2/recCompetence2) but is not
+    // part of the requested tubeIds: it must not appear anywhere in the result.
+    databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTube3',
+      name: '@tube3_name',
+      title: 'tube3_title',
+      description: 'tube3_description',
+      practicalTitle_i18n: { fr: 'tube3_practicalTitleFr', en: 'tube3_practicalTitleEn' },
+      practicalDescription_i18n: { fr: 'tube3_practicalDescriptionFr', en: 'tube3_practicalDescriptionEn' },
+      isMobileCompliant: true,
+      isTabletCompliant: true,
+      competenceId: 'recCompetence2',
+      thematicId: 'recThematic2',
+    });
+    const tube4DB = databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTube4',
+      name: '@tube4_name',
+      title: 'tube4_title',
+      description: 'tube4_description',
+      practicalTitle_i18n: { fr: 'tube4_practicalTitleFr', en: 'tube4_practicalTitleEn' },
+      practicalDescription_i18n: { fr: 'tube4_practicalDescriptionFr', en: 'tube4_practicalDescriptionEn' },
+      isMobileCompliant: false,
+      isTabletCompliant: false,
+      competenceId: 'recCompetence3',
+      thematicId: 'recThematic3',
+    });
+
+    await databaseBuilder.commit();
+
+    [framework1Fr, framework2Fr] = _buildDomainFrameworksFromDB([framework1DB, framework2DB]);
+    [area1Fr, area2Fr] = _buildDomainAreasFromDB([area1DB, area2DB], 'fr');
+    [competence1Fr, competence2Fr, competence3Fr] = _buildDomainCompetencesFromDB(
+      [competence1DB, competence2DB, competence3DB],
+      'fr',
+    );
+    [thematic1Fr, thematic2Fr, thematic3Fr] = _buildDomainThematicsFromDB(
+      [thematic1DB, thematic2DB, thematic3DB],
+      'fr',
+    );
+    [tube1Fr, tube2Fr, tube4Fr] = _buildDomainTubesFromDB([tube1DB, tube2DB, tube4DB], 'fr');
+
+    // Tubes returned by the repository are always hydrated with an empty skills collection.
+    tube1Fr.skills = [];
+    tube2Fr.skills = [];
+    tube4Fr.skills = [];
+
+    thematic1Fr.tubes = [tube1Fr];
+    // Only the requested tube (recTube2) is attached, recTube3 is left out.
+    thematic2Fr.tubes = [tube2Fr];
+    thematic3Fr.tubes = [tube4Fr];
+
+    competence1Fr.thematics = [thematic1Fr];
+    competence1Fr.tubes = [tube1Fr];
+    competence2Fr.thematics = [thematic2Fr];
+    competence2Fr.tubes = [tube2Fr];
+    competence3Fr.thematics = [thematic3Fr];
+    competence3Fr.tubes = [tube4Fr];
+
+    area1Fr.competences = [competence1Fr, competence2Fr];
+    area2Fr.competences = [competence3Fr];
+
+    framework1Fr.areas = [area1Fr];
+    framework2Fr.areas = [area2Fr];
+  });
+
+  it('should return the frameworks, hydrated down to the tubes matching the given tubeIds', async function () {
+    // when
+    const frameworks = await usecases.getLearningContentByTubeIds({
+      tubeIds: ['recTube1', 'recTube2', 'recTube4'],
+      locale: 'fr',
+    });
+
+    // then
+    expect(frameworks).to.lengthOf(2);
+    expect(frameworks).to.deep.equal([framework1Fr, framework2Fr]);
+  });
+
+  it('should not include tubes, thematics, competences, areas or frameworks that are not reachable from the given tubeIds', async function () {
+    // when
+    const frameworks = await usecases.getLearningContentByTubeIds({
+      tubeIds: ['recTube1', 'recTube2', 'recTube4'],
+      locale: 'fr',
+    });
+
+    // then
+    const [framework1, framework2] = frameworks;
+    expect(framework1.areas[0].competences[1].tubes).to.deep.equal([tube2Fr]);
+    expect(framework1.areas[0].competences[1].thematics[0].tubes).to.deep.equal([tube2Fr]);
+    expect(framework2.areas[0].competences[0].tubes.map(({ id }) => id)).to.not.include('recTube3');
+  });
+
+  context('when tubeIds is empty', function () {
+    it('should return an empty array', async function () {
+      // when
+      const frameworks = await usecases.getLearningContentByTubeIds({ tubeIds: [], locale: 'fr' });
+
+      // then
+      expect(frameworks).to.deep.equal([]);
+    });
+  });
+});
+
+function _buildDomainFrameworksFromDB(frameworksDB) {
+  return frameworksDB.map((frameworkDB) =>
+    domainBuilder.buildFramework({
+      id: frameworkDB.id,
+      name: frameworkDB.name,
+      areas: [],
+    }),
+  );
+}
+
+function _buildDomainAreasFromDB(areasDB, locale) {
+  return areasDB.map((areaDB) =>
+    domainBuilder.buildArea({
+      ...areaDB,
+      title: areaDB.title_i18n[locale],
+    }),
+  );
+}
+
+function _buildDomainCompetencesFromDB(competencesDB, locale) {
+  return competencesDB.map((competenceDB) =>
+    domainBuilder.buildCompetence({
+      ...competenceDB,
+      name: competenceDB.name_i18n[locale],
+      description: competenceDB.description_i18n[locale],
+    }),
+  );
+}
+
+function _buildDomainThematicsFromDB(thematicsDB, locale) {
+  return thematicsDB.map((thematicDB) =>
+    domainBuilder.buildThematic({
+      ...thematicDB,
+      name: thematicDB.name_i18n[locale],
+    }),
+  );
+}
+
+function _buildDomainTubesFromDB(tubesDB, locale) {
+  return tubesDB.map((tubeDB) =>
+    domainBuilder.buildTube({
+      ...tubeDB,
+      practicalTitle: tubeDB.practicalTitle_i18n[locale],
+      practicalDescription: tubeDB.practicalDescription_i18n[locale],
+    }),
+  );
+}

--- a/api/tests/learning-content/unit/application/api/learning-content-api_test.js
+++ b/api/tests/learning-content/unit/application/api/learning-content-api_test.js
@@ -1,0 +1,44 @@
+import sinon from 'sinon';
+
+import { findByTubeIds } from '../../../../../src/learning-content/application/api/learning-content-api.js';
+import LearningContentDTO from '../../../../../src/learning-content/application/api/models/LearningContentDTO.js';
+import { usecases } from '../../../../../src/learning-content/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+describe('LearningContent | Unit | Application | Api | learning-content', function () {
+  describe('#findByTubeIds', function () {
+    let getLearningContentByTubeIds;
+
+    beforeEach(function () {
+      getLearningContentByTubeIds = sinon.stub(usecases, 'getLearningContentByTubeIds');
+    });
+    it('returns a list of FrameworkWithAreasDTO', async function () {
+      // given
+      const area1 = domainBuilder.learningContent.buildArea();
+      const area2 = domainBuilder.learningContent.buildArea();
+      const area3 = domainBuilder.learningContent.buildArea();
+
+      getLearningContentByTubeIds.resolves([
+        domainBuilder.learningContent.buildFramework({
+          id: 'frameworkA',
+          name: 'Framework A',
+          areas: [area1, area2],
+        }),
+        domainBuilder.learningContent.buildFramework({
+          id: 'frameworkB',
+          name: 'Framework B',
+          areas: [area3],
+        }),
+      ]);
+
+      // when
+      const result = await findByTubeIds({ tubeIds: ['frameworkA', 'frameworkB'] });
+
+      // then
+      expect(result).to.deepEqualArray([
+        new LearningContentDTO({ id: 'frameworkA', name: 'Framework A', areas: [area1, area2] }),
+        new LearningContentDTO({ id: 'frameworkB', name: 'Framework B', areas: [area3] }),
+      ]);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/learning-content/build-framework-with-areas.js
+++ b/api/tests/tooling/domain-builder/factory/learning-content/build-framework-with-areas.js
@@ -1,0 +1,9 @@
+import { FrameworkWithAreas } from '../../../../../src/learning-content/domain/models/FrameworkWithAreas.js';
+
+export function buildFramework({ id = 'frameworkPix', name = 'Pix', areas = [] } = {}) {
+  return new FrameworkWithAreas({
+    id,
+    name,
+    areas,
+  });
+}


### PR DESCRIPTION
## 🪧 Problème
En développant une page pour retourner les cappedTubes d'une quête dans leur arborescence complète (référentiel / domaine / compétence / thématique), je me suis aperçue qu'on codait plusieurs fois la méthode _getLearningContent pour une liste d'ids de tubes. Et dans des BC différents : devcomp, prescription, shared...

## 🌈 Proposition
On crée une API interne dans le BC approprié.
On supprime le code dupliqués des différents repositories.

## ✊ Remarques
C'est pas un scope que je connais super bien. Il se peut que le nommage et les tests ne réflètent pas toutes les règles métiers, j'attends vos retours  

## 🎉 Pour tester
- Page de détail d'un badge dans PixAdmin
- Page de détail d'un contenu formatif dans PixAdmin