### PR TITLE
[TECH] Réécriture du domainBuilder Version (PIX-23580).

### DIFF
--- a/api/db/database-builder/factory/build-certification-version-tube.js
+++ b/api/db/database-builder/factory/build-certification-version-tube.js
@@ -1,7 +1,7 @@
 import { databaseBuffer } from '../database-buffer.js';
 import { buildCertificationVersion } from './build-certification-version.js';
 
-const buildCertificationVersionTube = function ({ versionId, tubeId = 'recTube123' } = {}) {
+export function buildCertificationVersionTube({ versionId, tubeId } = {}) {
   versionId = !versionId ? buildCertificationVersion().id : versionId;
 
   return databaseBuffer.pushInsertable({
@@ -11,6 +11,4 @@ const buildCertificationVersionTube = function ({ versionId, tubeId = 'recTube12
       tube_id: tubeId,
     },
   });
-};
-
-export { buildCertificationVersionTube };
+}

--- a/api/db/database-builder/factory/build-certification-version.js
+++ b/api/db/database-builder/factory/build-certification-version.js
@@ -1,19 +1,6 @@
-import { VERSION_STATUSES } from '../../../src/certification/configuration/domain/models/Version.js';
-import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../src/certification/shared/domain/constants.js';
-import { SCOPES } from '../../../src/certification/shared/domain/models/Scopes.js';
 import { databaseBuffer } from '../database-buffer.js';
 
-const defaultChallengesConfiguration = {
-  maximumAssessmentLength: 32,
-  challengesBetweenSameCompetence: 2,
-  limitToOneQuestionPerTube: true,
-  enablePassageByAllCompetences: true,
-  variationPercent: 0.5,
-  defaultCandidateCapacity: -3,
-  defaultProbabilityToPickChallenge: 51,
-};
-
-const defaultGlobalScoringConfiguration = [
+export const defaultGlobalScoringConfiguration = [
   {
     meshLevel: 0,
     bounds: {
@@ -72,7 +59,7 @@ const defaultGlobalScoringConfiguration = [
   },
 ];
 
-const defaultCompetencesScoringConfiguration = [
+export const defaultCompetencesScoringConfiguration = [
   {
     competence: '1.1',
     competenceId: 'competence1_1',
@@ -137,23 +124,19 @@ const defaultCompetencesScoringConfiguration = [
   },
 ];
 
-export const buildCertificationVersion = function ({
+export function buildCertificationVersion({
   id = databaseBuffer.getNextId(),
-  scope = SCOPES.CORE,
-  startDate = new Date('1977-10-19'),
-  expirationDate = null,
-  assessmentDuration = DEFAULT_SESSION_DURATION_MINUTES,
-  globalScoringConfiguration = defaultGlobalScoringConfiguration,
-  competencesScoringConfiguration = defaultCompetencesScoringConfiguration,
-  challengesConfiguration = defaultChallengesConfiguration,
-  minimumAnswersRequiredToValidateACertification = 20,
-  status = VERSION_STATUSES.DRAFT,
-  comments = 'Some comments',
+  scope,
+  startDate,
+  expirationDate,
+  assessmentDuration,
+  globalScoringConfiguration,
+  competencesScoringConfiguration,
+  challengesConfiguration,
+  minimumAnswersRequiredToValidateACertification,
+  status,
+  comments,
 } = {}) {
-  const finalChallengesConfiguration = {
-    ...defaultChallengesConfiguration,
-    ...challengesConfiguration,
-  };
   return databaseBuffer.pushInsertable({
     tableName: 'certification_versions',
     values: {
@@ -164,10 +147,10 @@ export const buildCertificationVersion = function ({
       assessmentDuration,
       globalScoringConfiguration: JSON.stringify(globalScoringConfiguration),
       competencesScoringConfiguration: JSON.stringify(competencesScoringConfiguration),
-      challengesConfiguration: JSON.stringify(finalChallengesConfiguration),
+      challengesConfiguration: JSON.stringify(challengesConfiguration),
       minimumAnswersRequiredToValidateACertification,
       status,
       comments,
     },
   });
-};
+}

--- a/api/db/seeds/data/team-certification/tools/certification-version.js
+++ b/api/db/seeds/data/team-certification/tools/certification-version.js
@@ -1,10 +1,14 @@
-import { Version, VERSION_STATUSES } from '../../../../../src/certification/configuration/domain/models/Version.js';
-import { DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION } from '../../../../../src/certification/shared/domain/constants.js';
-import { FlashAssessmentAlgorithmConfiguration } from '../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
+import { VERSION_STATUSES } from '../../../../../src/certification/configuration/domain/models/Version.js';
+import { versionBuilder } from '../../../../../tests/tooling/domain-builder/factory/certification/configuration/build-version.js';
 /**
  * @param {Object} params
  * @param {Object} params.databaseBuilder
- * @param {number} params.status - certification center member user id
+ * @param {string} [params.status] - one of VERSION_STATUSES, defaults to DRAFT
+ * @param {string} [params.scope]
+ * @param {number} [params.assessmentDuration]
+ * @param {Object} [params.challengesConfiguration]
+ * @param {Array<Object>} [params.globalScoringConfiguration]
+ * @param {Array<Object>} [params.competencesScoringConfiguration]
  * @returns {Promise<Version>}
  */
 export async function createVersion({
@@ -16,36 +20,24 @@ export async function createVersion({
   globalScoringConfiguration,
   competencesScoringConfiguration,
 }) {
-  const version = new Version({
+  const version = versionBuilder().withParameters({
     scope,
-    status,
-    challengesConfiguration: new FlashAssessmentAlgorithmConfiguration(challengesConfiguration),
+    tubeIds: [],
+    assessmentDuration,
+    challengesConfiguration,
     globalScoringConfiguration,
     competencesScoringConfiguration,
-    assessmentDuration,
-    minimumAnswersRequiredToValidateACertification: DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
   });
 
-  if (status === VERSION_STATUSES.DRAFT) {
-    version.startDate = null;
-    version.expirationDate = null;
-  }
-
   if (status === VERSION_STATUSES.ACTIVE) {
-    version.startDate = new Date();
-    version.expirationDate = null;
+    version.asActive({ startDate: new Date() });
   }
 
   if (status === VERSION_STATUSES.ARCHIVED) {
-    version.startDate = new Date('2018-01-01');
-    version.expirationDate = new Date('2019-01-01');
+    version.asArchived({ startDate: new Date('2018-01-01'), expirationDate: new Date('2019-01-01') });
   }
 
-  delete version.id;
-
-  const createdVersion = databaseBuilder.factory.buildCertificationVersion(version);
-
-  return createdVersion;
+  return version.insertToDB({ databaseBuilder });
 }
 
 export async function seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId }) {

--- a/api/src/certification/configuration/domain/read-models/CertificationInfo.js
+++ b/api/src/certification/configuration/domain/read-models/CertificationInfo.js
@@ -1,21 +1,15 @@
+import { VERSION_STATUSES } from '../models/Version.js';
+
 export class CertificationInfo {
-  constructor({
-    framework,
-    startDate,
-    expirationDate,
-    assessmentDuration,
-    minimumAssessmentLength,
-    maximumAssessmentLength,
-  }) {
+  constructor({ framework, status, assessmentDuration, minimumAssessmentLength, maximumAssessmentLength }) {
     this.framework = framework;
-    this.startDate = startDate;
-    this.expirationDate = expirationDate;
+    this.status = status;
     this.assessmentDuration = assessmentDuration;
     this.minimumAssessmentLength = minimumAssessmentLength;
     this.maximumAssessmentLength = maximumAssessmentLength;
   }
 
-  get isCertificationActive() {
-    return this.startDate !== null && this.expirationDate === null;
+  get isActive() {
+    return this.status === VERSION_STATUSES.ACTIVE;
   }
 }

--- a/api/src/certification/configuration/domain/usecases/get-info.js
+++ b/api/src/certification/configuration/domain/usecases/get-info.js
@@ -3,9 +3,7 @@ import { ActiveCertificationInfoNotFound } from '../errors.js';
 export async function getInfo({ framework, certificationInfoRepository }) {
   const certificationInfos = await certificationInfoRepository.findAllByFramework(framework);
 
-  const activeCertificationInfo = certificationInfos.find(
-    (certificationInfo) => certificationInfo.isCertificationActive,
-  );
+  const activeCertificationInfo = certificationInfos.find((certificationInfo) => certificationInfo.isActive);
   if (!activeCertificationInfo) {
     throw new ActiveCertificationInfoNotFound(framework);
   }

--- a/api/src/certification/configuration/infrastructure/repositories/certification-info-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/certification-info-repository.js
@@ -8,8 +8,7 @@ export async function findAllByFramework(framework) {
   const rawResults = await knexConn('certification_versions')
     .select([
       'challengesConfiguration',
-      'startDate',
-      'expirationDate',
+      'status',
       'assessmentDuration',
       'minimumAnswersRequiredToValidateACertification',
     ])
@@ -19,8 +18,7 @@ export async function findAllByFramework(framework) {
   return rawResults.map((rawResult) => {
     return new CertificationInfo({
       framework,
-      startDate: rawResult.startDate,
-      expirationDate: rawResult.expirationDate,
+      status: rawResult.status,
       assessmentDuration: rawResult.assessmentDuration,
       minimumAssessmentLength: rawResult.minimumAnswersRequiredToValidateACertification,
       maximumAssessmentLength: rawResult.challengesConfiguration.maximumAssessmentLength,

--- a/api/src/certification/configuration/infrastructure/repositories/version-details-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-details-repository.js
@@ -73,7 +73,6 @@ export async function getById(id) {
     tube.skills = skills.filter((skill) => {
       return skill.tubeId === tube.id;
     });
-    delete tube.skillIds;
   });
 
   const thematicIds = tubes.map((tube) => tube.thematicId);
@@ -122,6 +121,21 @@ export async function getById(id) {
     area.competences = competences.filter((competence) => {
       return competence.areaId === area.id;
     });
+  });
+
+  competences.forEach((competence) => {
+    delete competence.areaId;
+  });
+  thematics.forEach((thematic) => {
+    delete thematic.competenceId;
+  });
+  tubes.forEach((tube) => {
+    delete tube.thematicId;
+    delete tube.competenceId;
+    delete tube.skillIds;
+  });
+  skills.forEach((skill) => {
+    delete skill.tubeId;
   });
 
   return new VersionDetails({

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -85,21 +85,6 @@ export async function save(version) {
 
 /**
  * @param {object} params
- * @param {Version} params.version
- * @returns {Promise<void>}
- */
-export async function update({ version }) {
-  const knexConn = DomainTransaction.getConnection();
-
-  await knexConn('certification_versions').where({ id: version.id }).update({
-    comments: version.comments,
-    expirationDate: version.expirationDate,
-    challengesConfiguration: version.challengesConfiguration,
-  });
-}
-
-/**
- * @param {object} params
  * @param {SCOPES} params.scope
  * @returns {Promise<Array<FrameworkHistoryEntry>>}
  */

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -4,6 +4,7 @@ import { Frameworks } from '../../../../../src/certification/shared/domain/model
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Acceptance | Application | Certification | Configuration | certification-framework-route', function () {
@@ -27,16 +28,11 @@ describe('Acceptance | Application | Certification | Configuration | certificati
 
       const coreStartDate = new Date('2025-01-15');
 
-      databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        scope: SCOPES.CORE,
-        startDate: coreStartDate,
-        status: VERSION_STATUSES.ACTIVE,
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 123,
-      });
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: coreStartDate })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+        .insertToDB({ databaseBuilder });
 
       await databaseBuilder.commit();
 
@@ -109,19 +105,17 @@ describe('Acceptance | Application | Certification | Configuration | certificati
   describe('GET /api/admin/certification-frameworks/{scope}/framework-history', function () {
     it('should return the framework history for given scope ordered by start date descending', async function () {
       // given
-      const newerVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: SCOPES.CORE,
-        startDate: new Date('2025-01-11'),
-        expirationDate: null,
-        status: VERSION_STATUSES.ACTIVE,
-      });
+      const newerVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2025-01-11') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+        .insertToDB({ databaseBuilder });
 
-      const olderVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: SCOPES.CORE,
-        startDate: new Date('2024-01-11'),
-        expirationDate: newerVersion.startDate,
-        status: VERSION_STATUSES.ARCHIVED,
-      });
+      const olderVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({ startDate: new Date('2024-01-11'), expirationDate: newerVersion.startDate })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+        .insertToDB({ databaseBuilder });
 
       await databaseBuilder.commit();
 
@@ -147,7 +141,7 @@ describe('Acceptance | Application | Certification | Configuration | certificati
               startDate: newerVersion.startDate,
               expirationDate: newerVersion.expirationDate,
               assessmentDuration: newerVersion.assessmentDuration,
-              maximumAssessmentLength: JSON.parse(newerVersion.challengesConfiguration).maximumAssessmentLength,
+              maximumAssessmentLength: newerVersion.challengesConfiguration.maximumAssessmentLength,
               status: VERSION_STATUSES.ACTIVE,
             },
             {
@@ -155,7 +149,7 @@ describe('Acceptance | Application | Certification | Configuration | certificati
               startDate: olderVersion.startDate,
               expirationDate: olderVersion.expirationDate,
               assessmentDuration: olderVersion.assessmentDuration,
-              maximumAssessmentLength: JSON.parse(olderVersion.challengesConfiguration).maximumAssessmentLength,
+              maximumAssessmentLength: olderVersion.challengesConfiguration.maximumAssessmentLength,
               status: VERSION_STATUSES.ARCHIVED,
             },
           ],

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -6,6 +6,7 @@ import { Frameworks } from '../../../../../src/certification/shared/domain/model
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Acceptance | Certification | Configuration | API | certification-version-route', function () {
@@ -15,27 +16,31 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
   beforeEach(async function () {
     server = await createServer();
     superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
-    createLearningContent();
     await databaseBuilder.commit();
   });
 
   describe('GET /api/certifications/{framework}/info', function () {
     it('returns serialized info of the request framework', async function () {
-      databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        scope: SCOPES.CORE,
-        startDate: new Date('2025-01-11'),
-        expirationDate: null,
-        assessmentDuration: 100,
-        minimumAnswersRequiredToValidateACertification: 20,
-        challengesConfiguration: {
-          maximumAssessmentLength: 32,
-        },
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 123,
-      });
+      domainBuilder.certification.configuration
+        .certificationInfoBuilder()
+        .asDraft()
+        .withParameters({
+          framework: SCOPES.CORE,
+          assessmentDuration: 200,
+          minimumAssessmentLength: 200,
+          maximumAssessmentLength: 500,
+        })
+        .insertToDB({ databaseBuilder });
+      domainBuilder.certification.configuration
+        .certificationInfoBuilder()
+        .asActive()
+        .withParameters({
+          framework: SCOPES.CORE,
+          assessmentDuration: 100,
+          minimumAssessmentLength: 20,
+          maximumAssessmentLength: 50,
+        })
+        .insertToDB({ databaseBuilder });
       await databaseBuilder.commit();
 
       const options = {
@@ -53,7 +58,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
         attributes: {
           'assessment-duration': 100,
           'minimum-assessment-length': 20,
-          'maximum-assessment-length': 32,
+          'maximum-assessment-length': 50,
         },
       });
     });
@@ -62,16 +67,52 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
   describe('GET /api/admin/certification-versions/{certificationVersionId}', function () {
     it('should return the version details with areas for a given id', async function () {
       // given
-      const version = databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        scope: SCOPES.CORE,
-        startDate: new Date('2025-01-11'),
-        expirationDate: new Date('2026-01-01'),
-        status: VERSION_STATUSES.ARCHIVED,
-        assessmentDuration: 100,
-        minimumAnswersRequiredToValidateACertification: 20,
-        comments: 'Some awesome comments',
-        challengesConfiguration: {
+      const version = domainBuilder.certification.configuration
+        .versionDetailsBuilder()
+        .asArchived({ startDate: new Date('2025-01-11'), expirationDate: new Date('2026-01-01') })
+        .withLearningContent([
+          {
+            id: 'areaA',
+            code: 'code Domaine A',
+            color: 'color Domaine A',
+            frameworkId: 'frameworkA',
+            title: 'title FR Domaine A',
+            competences: [
+              {
+                id: 'competenceA',
+                index: 'index Competence A',
+                name: 'name FR Competence A',
+                thematics: [
+                  {
+                    id: 'thematicA',
+                    index: 1,
+                    name: 'name FR Thematic A',
+                    tubes: [
+                      {
+                        id: 'tubeA',
+                        mobile: true,
+                        name: 'Titre pratique Tube A',
+                        practicalTitle: 'practicalTitle FR Tube A',
+                        tablet: false,
+                        skills: [
+                          {
+                            id: 'skillA',
+                            difficulty: 2,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ])
+        .withParameters({
+          scope: SCOPES.CORE,
+          id: 123,
+          assessmentDuration: 100,
+          minimumAnswersRequiredForValidation: 20,
           maximumAssessmentLength: 32,
           challengesBetweenSameCompetence: 2,
           limitToOneQuestionPerTube: true,
@@ -79,12 +120,9 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
           variationPercent: 0.5,
           defaultCandidateCapacity: -3,
           defaultProbabilityToPickChallenge: 51,
-        },
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 123,
-      });
+          comments: 'Some awesome comments',
+        })
+        .insertToDB({ databaseBuilder });
 
       await databaseBuilder.commit();
 
@@ -220,29 +258,27 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
   describe('PATCH /api/admin/certification-versions/{certificationVersionId}', function () {
     it('updates the details of a version for a given id', async function () {
       // given
-      const version = databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        scope: SCOPES.CORE,
-        startDate: new Date('2025-01-11'),
-        expirationDate: new Date('2026-01-01'),
-        assessmentDuration: 100,
-        minimumAnswersRequiredToValidateACertification: 20,
-        challengesConfiguration: {
-          maximumAssessmentLength: 32,
-          challengesBetweenSameCompetence: 2,
-          limitToOneQuestionPerTube: true,
-          enablePassageByAllCompetences: true,
-          variationPercent: 0.5,
-          defaultCandidateCapacity: -3,
-          defaultProbabilityToPickChallenge: 51,
-        },
-        comments: 'Old comments',
-        status: VERSION_STATUSES.DRAFT,
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 123,
-      });
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-11') })
+        .withParameters({
+          scope: SCOPES.CORE,
+          tubeIds: ['tubeA'],
+          id: 123,
+          assessmentDuration: 100,
+          minimumAnswersRequiredToValidateACertification: 20,
+          challengesConfiguration: {
+            maximumAssessmentLength: 32,
+            challengesBetweenSameCompetence: 2,
+            limitToOneQuestionPerTube: true,
+            enablePassageByAllCompetences: true,
+            variationPercent: 0.5,
+            defaultCandidateCapacity: -3,
+            defaultProbabilityToPickChallenge: 51,
+          },
+          comments: 'Old comments',
+        })
+        .insertToDB({ databaseBuilder });
 
       await databaseBuilder.commit();
 
@@ -283,27 +319,24 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
   describe('PATCH /api/admin/certification-versions/{certificationVersionId}/comments', function () {
     it('updates only comment of a version for a given id', async function () {
       // given
-      const version = databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        status: VERSION_STATUSES.ACTIVE,
-        comments: 'Old comments',
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 123,
-      });
-
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({
+          id: 13,
+          comments: 'old comments',
+        })
+        .insertToDB({ databaseBuilder });
       await databaseBuilder.commit();
 
       const options = {
         method: 'PATCH',
-        url: `/api/admin/certification-versions/${version.id}/comments`,
+        url: `/api/admin/certification-versions/13/comments`,
         headers: generateAuthenticatedUserRequestHeaders({
           userId: superAdmin.id,
         }),
         payload: {
           data: {
-            id: version.id,
+            id: 13,
             attributes: {
               comments: 'COUCOU',
             },
@@ -315,7 +348,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       // when
       const response = await server.inject(options);
 
-      const updatedVersion = await knex('certification_versions').where({ id: version.id }).first();
+      const updatedVersion = await knex('certification_versions').where({ id: 13 }).first();
 
       // then
       expect(response.statusCode).to.equal(204);
@@ -326,29 +359,34 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
   describe('DELETE /api/admin/certification-versions/{id}', function () {
     it('should return 204 HTTP status code', async function () {
       // given
-      const versionId = databaseBuilder.factory.buildCertificationVersion({
-        scope: SCOPES.CORE,
-        startDate: null,
-        expirationDate: null,
-      }).id;
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: versionId,
-      });
-
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2021-01-01') })
+        .withParameters({
+          id: 13,
+        })
+        .insertToDB({ databaseBuilder });
       await databaseBuilder.commit();
 
       const options = {
         method: 'DELETE',
-        url: `/api/admin/certification-versions/${versionId}`,
+        url: `/api/admin/certification-versions/13`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       // when
+      const hasVersionBefore = !!(await knex('certification_versions').first());
+      const hasVersionTubeBefore = !!(await knex('certification_versions_tubes').first());
       const response = await server.inject(options);
 
       // then
+      const hasVersionAfter = !!(await knex('certification_versions').first());
+      const hasVersionTubeAfter = !!(await knex('certification_versions_tubes').first());
       expect(response.statusCode).to.equal(204);
+      expect(hasVersionBefore).to.be.true;
+      expect(hasVersionTubeBefore).to.be.true;
+      expect(hasVersionAfter).to.be.false;
+      expect(hasVersionTubeAfter).to.be.false;
     });
   });
 
@@ -367,6 +405,48 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
     it('should return 201 HTTP status code and a new version as a draft and link his challenges', async function () {
       // given
+      domainBuilder.certification.configuration.versionDetailsBuilder().insertLearningContentToDB({
+        databaseBuilder,
+        areas: [
+          {
+            id: 'areaA',
+            code: 'code Domaine A',
+            color: 'color Domaine A',
+            frameworkId: 'frameworkA',
+            title: 'title FR Domaine A',
+            competences: [
+              {
+                id: 'competenceA',
+                index: 'index Competence A',
+                name: 'name FR Competence A',
+                thematics: [
+                  {
+                    id: 'thematicA',
+                    index: 1,
+                    name: 'name FR Thematic A',
+                    tubes: [
+                      {
+                        id: 'tubeA',
+                        mobile: true,
+                        name: 'Titre pratique Tube A',
+                        practicalTitle: 'practicalTitle FR Tube A',
+                        tablet: false,
+                        skills: [
+                          {
+                            id: 'skillA',
+                            difficulty: 2,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      await databaseBuilder.commit();
       const options = {
         method: 'POST',
         url: `/api/admin/certification-versions`,
@@ -505,80 +585,3 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
     });
   });
 });
-
-function createLearningContent() {
-  databaseBuilder.factory.learningContent.buildFramework({
-    id: 'frameworkA',
-  });
-  databaseBuilder.factory.learningContent.buildFramework({
-    id: 'frameworkB',
-  });
-  databaseBuilder.factory.learningContent.buildArea({
-    id: 'areaA',
-    frameworkId: 'frameworkA',
-    code: 'code Domaine A',
-    title_i18n: { fr: 'title FR Domaine A' },
-    color: 'color Domaine A',
-  });
-  databaseBuilder.factory.learningContent.buildArea({
-    id: 'areaB',
-    frameworkId: 'frameworkB',
-    code: 'code Domaine B',
-    title_i18n: { fr: 'title FR Domaine B' },
-    color: 'color Domaine B',
-  });
-  databaseBuilder.factory.learningContent.buildCompetence({
-    id: 'competenceA',
-    areaId: 'areaA',
-    name_i18n: { fr: 'name FR Competence A' },
-    index: 'index Competence A',
-  });
-  databaseBuilder.factory.learningContent.buildCompetence({
-    id: 'competenceB',
-    areaId: 'areaB',
-    name_i18n: { fr: 'name FR Competence B' },
-    index: 'index Competence B',
-  });
-  databaseBuilder.factory.learningContent.buildThematic({
-    id: 'thematicA',
-    competenceId: 'competenceA',
-    name_i18n: { fr: 'name FR Thematic A' },
-    index: 1,
-  });
-  databaseBuilder.factory.learningContent.buildThematic({
-    id: 'thematicB',
-    competenceId: 'competenceB',
-    name_i18n: { fr: 'name FR Thematic B' },
-    index: 2,
-  });
-  databaseBuilder.factory.learningContent.buildTube({
-    id: 'tubeA',
-    thematicId: 'thematicA',
-    competenceId: 'competenceA',
-    name: 'Titre pratique Tube A',
-    practicalTitle_i18n: { fr: 'practicalTitle FR Tube A' },
-    isMobileCompliant: true,
-    isTabletCompliant: false,
-    skillIds: ['skillA'],
-  });
-  databaseBuilder.factory.learningContent.buildTube({
-    id: 'tubeB',
-    thematicId: 'thematicB',
-    competenceId: 'competenceB',
-    name: 'Titre pratique Tube B',
-    practicalTitle_i18n: { fr: 'practicalTitle FR Tube B' },
-    isMobileCompliant: false,
-    isTabletCompliant: true,
-    skillIds: ['skillB'],
-  });
-  databaseBuilder.factory.learningContent.buildSkill({
-    id: 'skillA',
-    tubeId: 'tubeA',
-    level: 2,
-  });
-  databaseBuilder.factory.learningContent.buildSkill({
-    id: 'skillB',
-    tubeId: 'tubeB',
-    level: 6,
-  });
-}

--- a/api/tests/certification/configuration/integration/domain/usecases/delete-certification-version_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/delete-certification-version_test.js
@@ -1,20 +1,19 @@
 import { CertificationVersionForbiddenDeletionError } from '../../../../../../src/certification/configuration/domain/errors.js';
-import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Integration | Domain | UseCase | delete-certification-version', function () {
   it('should throw CertificationVersionForbiddenDeletionError when version cannot be removed', async function () {
     // given
-    const certificationVersion = databaseBuilder.factory.buildCertificationVersion({
-      status: VERSION_STATUSES.ACTIVE,
-    });
-    databaseBuilder.factory.buildCertificationVersionTube({
-      tubeId: 'coucou',
-      versionId: certificationVersion.id,
-    });
+    const certificationVersion = domainBuilder.certification.configuration
+      .versionBuilder()
+      .asActive()
+      .withParameters({ scope: SCOPES.CORE, tubeIds: ['coucou'] })
+      .insertToDB({ databaseBuilder });
 
     await databaseBuilder.commit();
 
@@ -28,10 +27,10 @@ describe('Certification | Configuration | Integration | Domain | UseCase | delet
 
   it('should delete given certification version', async function () {
     // given
-    const certificationVersion = databaseBuilder.factory.buildCertificationVersion({
-      status: VERSION_STATUSES.DRAFT,
-    });
-    databaseBuilder.factory.buildCertificationVersionTube({ versionId: certificationVersion.id, tubeId: 'rec1' });
+    const certificationVersion = domainBuilder.certification.configuration
+      .versionBuilder()
+      .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'] })
+      .insertToDB({ databaseBuilder });
     await databaseBuilder.commit();
 
     // when

--- a/api/tests/certification/configuration/integration/domain/usecases/find-certification-frameworks_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/find-certification-frameworks_test.js
@@ -1,9 +1,9 @@
-import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Certification | Configuration | Integration | Domain | UseCase | find-certification-frameworks', function () {
   it('should return all frameworks with their active version start dates', async function () {
@@ -12,50 +12,29 @@ describe('Certification | Configuration | Integration | Domain | UseCase | find-
     const droitStartDate = new Date('2025-06-01');
     const edu1erDegreStartDate = new Date('2025-03-01');
 
-    databaseBuilder.factory.buildCertificationVersion({
-      id: 123,
-      scope: SCOPES.CORE,
-      startDate: coreStartDate,
-      status: VERSION_STATUSES.ACTIVE,
-    });
-    databaseBuilder.factory.buildCertificationVersionTube({
-      tubeId: 'tubeA',
-      versionId: 123,
-    });
+    domainBuilder.certification.configuration
+      .versionBuilder()
+      .asActive({ startDate: coreStartDate })
+      .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 123 })
+      .insertToDB({ databaseBuilder });
 
-    databaseBuilder.factory.buildCertificationVersion({
-      id: 456,
-      scope: SCOPES.PIX_PLUS_DROIT,
-      startDate: droitStartDate,
-      status: VERSION_STATUSES.ACTIVE,
-    });
-    databaseBuilder.factory.buildCertificationVersionTube({
-      tubeId: 'tubeA',
-      versionId: 456,
-    });
+    domainBuilder.certification.configuration
+      .versionBuilder()
+      .asActive({ startDate: droitStartDate })
+      .withParameters({ scope: SCOPES.PIX_PLUS_DROIT, tubeIds: ['tubeA'], id: 456 })
+      .insertToDB({ databaseBuilder });
 
-    databaseBuilder.factory.buildCertificationVersion({
-      id: 789,
-      scope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
-      startDate: new Date(2020, 12, 12),
-      expirationDate: new Date(2020, 12, 14),
-      status: VERSION_STATUSES.ARCHIVED,
-    });
-    databaseBuilder.factory.buildCertificationVersionTube({
-      tubeId: 'tubeA',
-      versionId: 789,
-    });
+    domainBuilder.certification.configuration
+      .versionBuilder()
+      .asArchived({ startDate: new Date(2020, 12, 12), expirationDate: new Date(2020, 12, 14) })
+      .withParameters({ scope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE, tubeIds: ['tubeA'], id: 789 })
+      .insertToDB({ databaseBuilder });
 
-    databaseBuilder.factory.buildCertificationVersion({
-      id: 159,
-      scope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
-      startDate: edu1erDegreStartDate,
-      status: VERSION_STATUSES.ACTIVE,
-    });
-    databaseBuilder.factory.buildCertificationVersionTube({
-      tubeId: 'tubeA',
-      versionId: 159,
-    });
+    domainBuilder.certification.configuration
+      .versionBuilder()
+      .asActive({ startDate: edu1erDegreStartDate })
+      .withParameters({ scope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE, tubeIds: ['tubeA'], id: 159 })
+      .insertToDB({ databaseBuilder });
 
     await databaseBuilder.commit();
 

--- a/api/tests/certification/configuration/integration/domain/usecases/update-version-comment_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/update-version-comment_test.js
@@ -1,22 +1,21 @@
-import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
 import * as versionRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/version-repository.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
-describe('Certification | Configuration | Integration | Domain | UseCase | update-version', function () {
+describe('Certification | Configuration | Integration | Domain | UseCase | update-version-comment', function () {
   describe('updateComments', function () {
     it('updates only the comment in the version', async function () {
       // given
-      databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        status: VERSION_STATUSES.ACTIVE,
-        comments: 'Super Comment',
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'coucou',
-        versionId: 123,
-      });
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive()
+        .withParameters({
+          id: 123,
+          comments: 'Super Comment',
+        })
+        .insertToDB({ databaseBuilder });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/certification/configuration/integration/domain/usecases/update-version_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/update-version_test.js
@@ -1,4 +1,3 @@
-import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
 import * as versionRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/version-repository.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
@@ -9,15 +8,14 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Integration | Domain | UseCase | update-version', function () {
-  describe('update', function () {
-    it('updates the version', async function () {
-      // given
-      databaseBuilder.factory.buildCertificationVersion({
+  it('updates the version', async function () {
+    // given
+    domainBuilder.certification.configuration
+      .versionBuilder()
+      .asDraft({ startDate: new Date('2025-01-01') })
+      .withParameters({
         id: 123,
         scope: SCOPES.PIX_PLUS_PRO_SANTE,
-        status: VERSION_STATUSES.DRAFT,
-        startDate: new Date('2025-01-01'),
-        expirationDate: null,
         assessmentDuration: 111,
         minimumAnswersRequiredToValidateACertification: 222,
         globalScoringConfiguration: [],
@@ -32,43 +30,40 @@ describe('Certification | Configuration | Integration | Domain | UseCase | updat
           limitToOneQuestionPerTube: false,
           enablePassageByAllCompetences: false,
         },
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'coucou',
-        versionId: 123,
-      });
-      await databaseBuilder.commit();
+        tubeIds: ['coucou'],
+      })
+      .insertToDB({ databaseBuilder });
+    await databaseBuilder.commit();
 
-      // when
-      await usecases.updateVersion({
-        id: 123,
-        startDate: new Date('2026-06-06'),
-        assessmentDuration: 100,
-        minimumAnswersRequiredForValidation: 200,
-        maximumAssessmentLength: 300,
-        challengesBetweenSameCompetence: 400,
-        defaultProbabilityToPickChallenge: 55,
-        variationPercent: 0.6,
-        defaultCandidateCapacity: 700,
-        limitToOneQuestionPerTube: true,
-        enablePassageByAllCompetences: true,
-        comments: 'COUCOU',
-      });
+    // when
+    await usecases.updateVersion({
+      id: 123,
+      startDate: new Date('2026-06-06'),
+      assessmentDuration: 100,
+      minimumAnswersRequiredForValidation: 200,
+      maximumAssessmentLength: 300,
+      challengesBetweenSameCompetence: 400,
+      defaultProbabilityToPickChallenge: 55,
+      variationPercent: 0.6,
+      defaultCandidateCapacity: 700,
+      limitToOneQuestionPerTube: true,
+      enablePassageByAllCompetences: true,
+    });
 
-      // then
-      const updatedVersion = await versionRepository.getById({ id: 123 });
-      expect(updatedVersion).to.deepEqualInstance(
-        domainBuilder.certification.configuration.buildVersion({
+    // then
+    const updatedVersion = await versionRepository.getById({ id: 123 });
+    expect(updatedVersion).to.deepEqualInstance(
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2026-06-06') })
+        .withParameters({
           id: 123,
           scope: SCOPES.PIX_PLUS_PRO_SANTE,
-          status: VERSION_STATUSES.DRAFT,
-          expirationDate: null,
-          startDate: new Date('2026-06-06'),
-          comments: 'Not Modified',
           assessmentDuration: 100,
           minimumAnswersRequiredToValidateACertification: 200,
           globalScoringConfiguration: [],
           competencesScoringConfiguration: [],
+          comments: 'Not Modified',
           challengesConfiguration: {
             maximumAssessmentLength: 300,
             challengesBetweenSameCompetence: 400,
@@ -79,24 +74,36 @@ describe('Certification | Configuration | Integration | Domain | UseCase | updat
             enablePassageByAllCompetences: true,
           },
           tubeIds: ['coucou'],
-        }),
-      );
+        })
+        .build(),
+    );
+  });
+
+  it('throws an error when no version is found', async function () {
+    // given
+    domainBuilder.certification.configuration
+      .versionBuilder()
+      .asDraft({ startDate: new Date('2025-01-01') })
+      .withParameters({ id: 456 })
+      .insertToDB({ databaseBuilder });
+    await databaseBuilder.commit();
+
+    // when
+    const error = await catchErr(usecases.updateVersion)({
+      id: 123,
+      startDate: new Date('2026-06-06'),
+      assessmentDuration: 100,
+      minimumAnswersRequiredForValidation: 200,
+      maximumAssessmentLength: 300,
+      challengesBetweenSameCompetence: 400,
+      defaultProbabilityToPickChallenge: 55,
+      variationPercent: 0.6,
+      defaultCandidateCapacity: 700,
+      limitToOneQuestionPerTube: true,
+      enablePassageByAllCompetences: true,
     });
 
-    it('throws an error when no version is found', async function () {
-      // given
-      databaseBuilder.factory.buildCertificationVersion({ id: 123 });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'coucou',
-        versionId: 123,
-      });
-      await databaseBuilder.commit();
-
-      // when
-      const error = await catchErr(usecases.updateVersion)({ id: 456, comments: 'new comments' });
-
-      // then
-      expect(error).to.be.instanceOf(NotFoundError);
-    });
+    // then
+    expect(error).to.be.instanceOf(NotFoundError);
   });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/certification-info-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/certification-info-repository_test.js
@@ -9,9 +9,10 @@ describe('Certification | Configuration | Integration | Repository | Certificati
   describe('#findAllByFramework', function () {
     context('when there are no versions for a framework', function () {
       it('returns an empty array', async function () {
-        databaseBuilder.factory.buildCertificationVersion({
-          scope: SCOPES.PIX_PLUS_DROIT,
-        });
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .withParameters({ framework: Frameworks.CORE })
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         const certificationInfos = await findAllByFramework(Frameworks.PRO_SANTE);
@@ -23,100 +24,113 @@ describe('Certification | Configuration | Integration | Repository | Certificati
 
     context('when there are some versions for a framework', function () {
       it('returns an array containing relevant certification info models', async function () {
-        databaseBuilder.factory.buildCertificationVersion({
-          id: 1,
-          scope: SCOPES.PIX_PLUS_DROIT,
-        });
-        databaseBuilder.factory.buildCertificationVersion({
-          id: 3,
-          scope: SCOPES.PIX_PLUS_PRO_SANTE,
-          startDate: new Date('1988-10-19'),
-          expirationDate: null,
-          assessmentDuration: 100,
-          challengesConfiguration: { maximumAssessmentLength: 2 },
-          minimumAnswersRequiredToValidateACertification: 1,
-        });
-        databaseBuilder.factory.buildCertificationVersion({
-          id: 2,
-          scope: SCOPES.PIX_PLUS_PRO_SANTE,
-          startDate: null,
-          expirationDate: null,
-          assessmentDuration: 200,
-          challengesConfiguration: { maximumAssessmentLength: 20 },
-          minimumAnswersRequiredToValidateACertification: 10,
-        });
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .withParameters({ framework: SCOPES.PIX_PLUS_DROIT, id: 1 })
+          .insertToDB({ databaseBuilder });
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .asDraft()
+          .withParameters({
+            framework: SCOPES.PIX_PLUS_PRO_SANTE,
+            assessmentDuration: 100,
+            minimumAssessmentLength: 1,
+            maximumAssessmentLength: 2,
+          })
+          .insertToDB({ databaseBuilder });
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .asActive()
+          .withParameters({
+            framework: SCOPES.PIX_PLUS_PRO_SANTE,
+            tubeIds: [],
+            assessmentDuration: 200,
+            minimumAssessmentLength: 10,
+            maximumAssessmentLength: 20,
+          })
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         const certificationInfos = await findAllByFramework(Frameworks.PRO_SANTE);
 
         // then
         expect(certificationInfos).to.deepEqualArray([
-          domainBuilder.certification.configuration.buildCertificationInfo({
-            framework: Frameworks.PRO_SANTE,
-            startDate: null,
-            expirationDate: null,
-            assessmentDuration: 200,
-            minimumAssessmentLength: 10,
-            maximumAssessmentLength: 20,
-          }),
-          domainBuilder.certification.configuration.buildCertificationInfo({
-            framework: Frameworks.PRO_SANTE,
-            startDate: new Date('1988-10-19'),
-            expirationDate: null,
-            assessmentDuration: 100,
-            minimumAssessmentLength: 1,
-            maximumAssessmentLength: 2,
-          }),
+          domainBuilder.certification.configuration
+            .certificationInfoBuilder()
+            .asDraft()
+            .withParameters({
+              framework: Frameworks.PRO_SANTE,
+              assessmentDuration: 100,
+              minimumAssessmentLength: 1,
+              maximumAssessmentLength: 2,
+            })
+            .build(),
+          domainBuilder.certification.configuration
+            .certificationInfoBuilder()
+            .asActive()
+            .withParameters({
+              framework: Frameworks.PRO_SANTE,
+              assessmentDuration: 200,
+              minimumAssessmentLength: 10,
+              maximumAssessmentLength: 20,
+            })
+            .build(),
         ]);
       });
     });
 
     context('when the required versions are for framework CLEA', function () {
       it('returns an array containing relevant certification info models as if it was for CORE framework', async function () {
-        databaseBuilder.factory.buildCertificationVersion({
-          id: 1,
-          scope: SCOPES.PIX_PLUS_DROIT,
-        });
-        databaseBuilder.factory.buildCertificationVersion({
-          id: 3,
-          scope: SCOPES.CORE,
-          startDate: new Date('1988-10-19'),
-          expirationDate: null,
-          assessmentDuration: 100,
-          challengesConfiguration: { maximumAssessmentLength: 2 },
-          minimumAnswersRequiredToValidateACertification: 1,
-        });
-        databaseBuilder.factory.buildCertificationVersion({
-          id: 2,
-          scope: SCOPES.CORE,
-          startDate: null,
-          expirationDate: null,
-          assessmentDuration: 200,
-          challengesConfiguration: { maximumAssessmentLength: 20 },
-          minimumAnswersRequiredToValidateACertification: 10,
-        });
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .withParameters({ framework: SCOPES.PIX_PLUS_DROIT, id: 1 })
+          .insertToDB({ databaseBuilder });
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .asActive()
+          .withParameters({
+            framework: SCOPES.CORE,
+            assessmentDuration: 100,
+            minimumAssessmentLength: 1,
+            maximumAssessmentLength: 2,
+          })
+          .insertToDB({ databaseBuilder });
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .asDraft()
+          .withParameters({
+            framework: SCOPES.CORE,
+            assessmentDuration: 200,
+            minimumAssessmentLength: 10,
+            maximumAssessmentLength: 20,
+          })
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         const certificationInfos = await findAllByFramework(Frameworks.CLEA);
 
         // then
         expect(certificationInfos).to.deepEqualArray([
-          domainBuilder.certification.configuration.buildCertificationInfo({
-            framework: Frameworks.CLEA,
-            startDate: null,
-            expirationDate: null,
-            assessmentDuration: 200,
-            minimumAssessmentLength: 10,
-            maximumAssessmentLength: 20,
-          }),
-          domainBuilder.certification.configuration.buildCertificationInfo({
-            framework: Frameworks.CLEA,
-            startDate: new Date('1988-10-19'),
-            expirationDate: null,
-            assessmentDuration: 100,
-            minimumAssessmentLength: 1,
-            maximumAssessmentLength: 2,
-          }),
+          domainBuilder.certification.configuration
+            .certificationInfoBuilder()
+            .asActive()
+            .withParameters({
+              framework: Frameworks.CLEA,
+              assessmentDuration: 100,
+              minimumAssessmentLength: 1,
+              maximumAssessmentLength: 2,
+            })
+            .build(),
+          domainBuilder.certification.configuration
+            .certificationInfoBuilder()
+            .asDraft()
+            .withParameters({
+              framework: Frameworks.CLEA,
+              assessmentDuration: 200,
+              minimumAssessmentLength: 10,
+              maximumAssessmentLength: 20,
+            })
+            .build(),
         ]);
       });
     });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-details-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-details-repository_test.js
@@ -1,4 +1,3 @@
-import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import * as versionDetailsRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/version-details-repository.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../../test-helper.js';
@@ -9,29 +8,13 @@ describe('Certification | Configuration | Integration | Repository | Version Det
   describe('#getById', function () {
     it('returns null when version is not found', async function () {
       // given
-      databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        scope: SCOPES.PIX_PLUS_PRO_SANTE,
-        startDate: new Date('2020-01-01'),
-        expirationDate: null,
-        status: VERSION_STATUSES.ACTIVE,
-        comments: 'Salut les zamis',
-        minimumAnswersRequiredToValidateACertification: 12,
-        assessmentDuration: 25,
-        challengesConfiguration: {
-          maximumAssessmentLength: 50,
-          challengesBetweenSameCompetence: 2,
-          defaultProbabilityToPickChallenge: 40,
-          defaultCandidateCapacity: -2,
-          variationPercent: 0.66,
-          limitToOneQuestionPerTube: true,
-          enablePassageByAllCompetences: true,
-        },
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 123,
-      });
+      domainBuilder.certification.configuration
+        .versionDetailsBuilder()
+        .asActive({ startDate: new Date('2020-01-01') })
+        .withParameters({
+          id: 123,
+        })
+        .insertToDB({ databaseBuilder });
       await databaseBuilder.commit();
 
       // when
@@ -43,46 +26,11 @@ describe('Certification | Configuration | Integration | Repository | Version Det
 
     it('returns a VersionDetails model when it exists', async function () {
       // given
-      databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        scope: SCOPES.PIX_PLUS_PRO_SANTE,
-        startDate: new Date('2020-01-01'),
-        expirationDate: null,
-        status: VERSION_STATUSES.ACTIVE,
-        comments: 'Salut les zamis',
-        minimumAnswersRequiredToValidateACertification: 12,
-        assessmentDuration: 25,
-        challengesConfiguration: {
-          maximumAssessmentLength: 50,
-          challengesBetweenSameCompetence: 2,
-          defaultProbabilityToPickChallenge: 40,
-          defaultCandidateCapacity: -2,
-          variationPercent: 0.66,
-          limitToOneQuestionPerTube: true,
-          enablePassageByAllCompetences: true,
-        },
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 123,
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeB',
-        versionId: 123,
-      });
-      createLearningContent();
-      await databaseBuilder.commit();
-
-      // when
-      const versionDetails = await versionDetailsRepository.getById(123);
-
-      // then
-      expect(versionDetails).to.deepEqualInstance(
-        domainBuilder.certification.configuration.buildVersionDetails({
+      const expectedVersionDetails = domainBuilder.certification.configuration
+        .versionDetailsBuilder()
+        .asActive({ startDate: new Date('2020-01-01') })
+        .withParameters({
           id: 123,
-          startDate: new Date('2020-01-01'),
-          expirationDate: null,
-          status: VERSION_STATUSES.ACTIVE,
           scope: SCOPES.PIX_PLUS_PRO_SANTE,
           comments: 'Salut les zamis',
           minimumAnswersRequiredForValidation: 12,
@@ -94,169 +42,89 @@ describe('Certification | Configuration | Integration | Repository | Version Det
           variationPercent: 0.66,
           limitToOneQuestionPerTube: true,
           enablePassageByAllCompetences: true,
-          areas: [
-            {
-              id: 'areaA',
-              frameworkId: 'frameworkA',
-              code: 'code Domaine A',
-              title: 'title FR Domaine A',
-              color: 'color Domaine A',
-              competences: [
-                {
-                  id: 'competenceA',
-                  areaId: 'areaA',
-                  name: 'name FR Competence A',
-                  index: 'index Competence A',
-                  thematics: [
-                    {
-                      id: 'thematicA',
-                      competenceId: 'competenceA',
-                      name: 'name FR Thematic A',
-                      index: 1,
-                      tubes: [
-                        {
-                          id: 'tubeA',
-                          thematicId: 'thematicA',
-                          competenceId: 'competenceA',
-                          name: 'Titre pratique Tube A',
-                          practicalTitle: 'practicalTitle FR Tube A',
-                          mobile: true,
-                          tablet: false,
-                          skills: [
-                            {
-                              id: 'skillA',
-                              tubeId: 'tubeA',
-                              difficulty: 2,
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              id: 'areaB',
-              frameworkId: 'frameworkB',
-              code: 'code Domaine B',
-              title: 'title FR Domaine B',
-              color: 'color Domaine B',
-              competences: [
-                {
-                  id: 'competenceB',
-                  areaId: 'areaB',
-                  name: 'name FR Competence B',
-                  index: 'index Competence B',
-                  thematics: [
-                    {
-                      id: 'thematicB',
-                      competenceId: 'competenceB',
-                      name: 'name FR Thematic B',
-                      index: 2,
-                      tubes: [
-                        {
-                          id: 'tubeB',
-                          thematicId: 'thematicB',
-                          competenceId: 'competenceB',
-                          name: 'Titre pratique Tube B',
-                          practicalTitle: 'practicalTitle FR Tube B',
-                          mobile: false,
-                          tablet: true,
-                          skills: [
-                            {
-                              id: 'skillB',
-                              tubeId: 'tubeB',
-                              difficulty: 6,
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        }),
-      );
+        })
+        .withLearningContent([
+          {
+            id: 'areaA',
+            frameworkId: 'frameworkA',
+            code: 'code Domaine A',
+            title: 'title FR Domaine A',
+            color: 'color Domaine A',
+            competences: [
+              {
+                id: 'competenceA',
+                name: 'name FR Competence A',
+                index: 'index Competence A',
+                thematics: [
+                  {
+                    id: 'thematicA',
+                    name: 'name FR Thematic A',
+                    index: 1,
+                    tubes: [
+                      {
+                        id: 'tubeA',
+                        name: 'Titre pratique Tube A',
+                        practicalTitle: 'practicalTitle FR Tube A',
+                        mobile: true,
+                        tablet: false,
+                        skills: [
+                          {
+                            id: 'skillA',
+                            difficulty: 2,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'areaB',
+            frameworkId: 'frameworkB',
+            code: 'code Domaine B',
+            title: 'title FR Domaine B',
+            color: 'color Domaine B',
+            competences: [
+              {
+                id: 'competenceB',
+                name: 'name FR Competence B',
+                index: 'index Competence B',
+                thematics: [
+                  {
+                    id: 'thematicB',
+                    name: 'name FR Thematic B',
+                    index: 2,
+                    tubes: [
+                      {
+                        id: 'tubeB',
+                        name: 'Titre pratique Tube B',
+                        practicalTitle: 'practicalTitle FR Tube B',
+                        mobile: false,
+                        tablet: true,
+                        skills: [
+                          {
+                            id: 'skillB',
+                            difficulty: 6,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ])
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
+
+      // when
+      const versionDetails = await versionDetailsRepository.getById(123);
+
+      // then
+      expect(versionDetails).to.deepEqualInstance(expectedVersionDetails);
     });
   });
 });
-
-function createLearningContent() {
-  databaseBuilder.factory.learningContent.buildFramework({
-    id: 'frameworkA',
-  });
-  databaseBuilder.factory.learningContent.buildFramework({
-    id: 'frameworkB',
-  });
-  databaseBuilder.factory.learningContent.buildArea({
-    id: 'areaA',
-    frameworkId: 'frameworkA',
-    code: 'code Domaine A',
-    title_i18n: { fr: 'title FR Domaine A' },
-    color: 'color Domaine A',
-  });
-  databaseBuilder.factory.learningContent.buildArea({
-    id: 'areaB',
-    frameworkId: 'frameworkB',
-    code: 'code Domaine B',
-    title_i18n: { fr: 'title FR Domaine B' },
-    color: 'color Domaine B',
-  });
-  databaseBuilder.factory.learningContent.buildCompetence({
-    id: 'competenceA',
-    areaId: 'areaA',
-    name_i18n: { fr: 'name FR Competence A' },
-    index: 'index Competence A',
-  });
-  databaseBuilder.factory.learningContent.buildCompetence({
-    id: 'competenceB',
-    areaId: 'areaB',
-    name_i18n: { fr: 'name FR Competence B' },
-    index: 'index Competence B',
-  });
-  databaseBuilder.factory.learningContent.buildThematic({
-    id: 'thematicA',
-    competenceId: 'competenceA',
-    name_i18n: { fr: 'name FR Thematic A' },
-    index: 1,
-  });
-  databaseBuilder.factory.learningContent.buildThematic({
-    id: 'thematicB',
-    competenceId: 'competenceB',
-    name_i18n: { fr: 'name FR Thematic B' },
-    index: 2,
-  });
-  databaseBuilder.factory.learningContent.buildTube({
-    id: 'tubeA',
-    thematicId: 'thematicA',
-    competenceId: 'competenceA',
-    name: 'Titre pratique Tube A',
-    practicalTitle_i18n: { fr: 'practicalTitle FR Tube A' },
-    isMobileCompliant: true,
-    isTabletCompliant: false,
-    skillIds: ['skillA'],
-  });
-  databaseBuilder.factory.learningContent.buildTube({
-    id: 'tubeB',
-    thematicId: 'thematicB',
-    competenceId: 'competenceB',
-    name: 'Titre pratique Tube B',
-    practicalTitle_i18n: { fr: 'practicalTitle FR Tube B' },
-    isMobileCompliant: false,
-    isTabletCompliant: true,
-    skillIds: ['skillB'],
-  });
-  databaseBuilder.factory.learningContent.buildSkill({
-    id: 'skillA',
-    tubeId: 'tubeA',
-    level: 2,
-  });
-  databaseBuilder.factory.learningContent.buildSkill({
-    id: 'skillB',
-    tubeId: 'tubeB',
-    level: 6,
-  });
-}

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -19,39 +19,11 @@ describe('Certification | Configuration | Integration | Repository | Version', f
           limitToOneQuestionPerTube: true,
           defaultCandidateCapacity: -8,
         };
-        const version = domainBuilder.certification.configuration.buildVersion({
-          scope: SCOPES.PIX_PLUS_DROIT,
-          startDate: new Date('2025-06-01'),
-          expirationDate: new Date('2025-12-31'),
-          assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
-          minimumAnswersRequiredToValidateACertification: 123,
-          comments: 'COUCOU',
-          status: VERSION_STATUSES.ACTIVE,
-          globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -1.4 } }],
-          competencesScoringConfiguration: [
-            {
-              competence: '1.1',
-              values: [{ bounds: { max: -2, min: -10 }, competenceLevel: 0 }],
-            },
-          ],
-          challengesConfiguration,
-          tubeIds: ['rec123', 'rec456', 'rec789'],
-        });
-        version.id = undefined;
-
-        await databaseBuilder.commit();
-
-        // when
-        const versionId = await versionRepository.save(version);
-
-        // then
-        const savedVersion = await versionRepository.getById({ id: versionId });
-        expect(savedVersion).to.deepEqualInstance(
-          domainBuilder.certification.configuration.buildVersion({
-            id: versionId,
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2025-06-01') })
+          .withParameters({
             scope: SCOPES.PIX_PLUS_DROIT,
-            startDate: new Date('2025-06-01'),
-            expirationDate: new Date('2025-12-31'),
             assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
             minimumAnswersRequiredToValidateACertification: 123,
             comments: 'COUCOU',
@@ -65,276 +37,185 @@ describe('Certification | Configuration | Integration | Repository | Version', f
             ],
             challengesConfiguration,
             tubeIds: ['rec123', 'rec456', 'rec789'],
-          }),
-        );
+          })
+          .insertToDB({ databaseBuilder });
+
+        await databaseBuilder.commit();
+
+        // when
+        const versionId = await versionRepository.save(version);
+
+        // then
+        const savedVersion = await versionRepository.getById({ id: versionId });
+        expect(savedVersion).to.deepEqualInstance(version);
       });
     });
+
     context('when the saved certification version already exists', function () {
       it('should update the certification version', async function () {
         // given
-        databaseBuilder.factory.buildCertificationVersion({
-          id: 123,
-          scope: SCOPES.PIX_PLUS_DROIT,
-          startDate: new Date('2025-06-01'),
-          expirationDate: new Date('2025-12-31'),
-          assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
-          minimumAnswersRequiredToValidateACertification: 123,
-          comments: 'COUCOU',
-          status: VERSION_STATUSES.ACTIVE,
-          globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -1.4 } }],
-          competencesScoringConfiguration: [
-            {
-              competence: '1.1',
-              values: [{ bounds: { max: -2, min: -10 }, competenceLevel: 0 }],
-            },
-          ],
-          challengesConfiguration: {
-            maximumAssessmentLength: 32,
-            limitToOneQuestionPerTube: true,
-            defaultCandidateCapacity: -8,
-          },
-        });
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId: 123,
-        });
-
-        const version = domainBuilder.certification.configuration.buildVersion({
-          id: 123,
-          scope: SCOPES.PIX_PLUS_PRO_SANTE,
-          startDate: new Date('2025-07-07'),
-          expirationDate: new Date('2025-11-12'),
-          assessmentDuration: 111,
-          minimumAnswersRequiredToValidateACertification: 222,
-          comments: 'COUCOUCAVA',
-          status: VERSION_STATUSES.ARCHIVED,
-          globalScoringConfiguration: [{ meshLevel: 1, bounds: { min: -1, max: -1 } }],
-          competencesScoringConfiguration: [
-            {
-              competence: '2.1',
-              values: [{ bounds: { max: -2, min: -2 }, competenceLevel: 2 }],
-            },
-          ],
-          challengesConfiguration: {
-            maximumAssessmentLength: 33,
-            limitToOneQuestionPerTube: false,
-            defaultCandidateCapacity: -4,
-          },
-          tubeIds: ['tubeB'],
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        await versionRepository.save(version);
-
-        // then
-        const savedVersion = await versionRepository.getById({ id: 123 });
-        expect(savedVersion).to.deepEqualInstance(
-          domainBuilder.certification.configuration.buildVersion({
-            id: 123,
-            scope: SCOPES.PIX_PLUS_PRO_SANTE,
-            startDate: new Date('2025-07-07'),
-            expirationDate: new Date('2025-11-12'),
-            assessmentDuration: 111,
-            minimumAnswersRequiredToValidateACertification: 222,
-            comments: 'COUCOUCAVA',
-            status: VERSION_STATUSES.ARCHIVED,
-            globalScoringConfiguration: [{ meshLevel: 1, bounds: { min: -1, max: -1 } }],
-            competencesScoringConfiguration: [
-              {
-                competence: '2.1',
-                values: [{ bounds: { max: -2, min: -2 }, competenceLevel: 2 }],
-              },
-            ],
-            challengesConfiguration: {
-              maximumAssessmentLength: 33,
-              limitToOneQuestionPerTube: false,
-              defaultCandidateCapacity: -4,
-            },
-            tubeIds: ['tubeB'],
-          }),
-        );
-      });
-    });
-
-    describe('#update', function () {
-      it('should update the expiration date, challenges configuration and comments of a certification version', async function () {
-        // given
-        const initialChallengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
-          maximumAssessmentLength: 20,
-          limitToOneQuestionPerTube: false,
-        });
-        const existingVersion = databaseBuilder.factory.buildCertificationVersion({
-          scope: SCOPES.PIX_PLUS_DROIT,
-          startDate: new Date('2024-01-01'),
-          expirationDate: null,
-          assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
-          challengesConfiguration: initialChallengesConfiguration,
-        });
-
-        await databaseBuilder.commit();
-
-        const newExpirationDate = new Date('2025-10-21T10:00:00Z');
-        const newComments = 'New comments';
-        const newChallengesConfiguration = {
+        const challengesConfiguration = {
           maximumAssessmentLength: 32,
           limitToOneQuestionPerTube: true,
-          defaultCandidateCapacity: 1,
+          defaultCandidateCapacity: -8,
         };
-        const versionToUpdate = domainBuilder.certification.configuration.buildVersion({
-          id: existingVersion.id,
-          scope: existingVersion.scope,
-          startDate: existingVersion.startDate,
-          expirationDate: newExpirationDate,
-          assessmentDuration: existingVersion.assessmentDuration,
-          challengesConfiguration: newChallengesConfiguration,
-          comments: newComments,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2025-06-01') })
+          .withParameters({
+            scope: SCOPES.PIX_PLUS_DROIT,
+            assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
+            minimumAnswersRequiredToValidateACertification: 123,
+            comments: 'COUCOU',
+            status: VERSION_STATUSES.ACTIVE,
+            globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -1.4 } }],
+            competencesScoringConfiguration: [
+              {
+                competence: '1.1',
+                values: [{ bounds: { max: -2, min: -10 }, competenceLevel: 0 }],
+              },
+            ],
+            challengesConfiguration,
+            tubeIds: ['rec123', 'rec456', 'rec789'],
+          })
+          .insertToDB({ databaseBuilder });
+        const alteredVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .copy(version)
+          .withParameters({
+            assessmentDuration: 11111,
+            minimumAnswersRequiredToValidateACertification: 22222,
+            comments: 'COUCOU',
+          })
+          .build();
 
         // when
-        await versionRepository.update({ version: versionToUpdate });
+        await versionRepository.save(alteredVersion);
 
         // then
-        const updatedVersion = await knex('certification_versions').where({ id: existingVersion.id }).first();
-
-        expect(updatedVersion.expirationDate).to.deep.equal(newExpirationDate);
-        expect(updatedVersion.challengesConfiguration).to.deep.equal(versionToUpdate.challengesConfiguration);
-        expect(updatedVersion.scope).to.equal(existingVersion.scope);
-        expect(updatedVersion.startDate).to.deep.equal(existingVersion.startDate);
-        expect(updatedVersion.comments).to.equal(newComments);
-      });
-
-      it('updates the comments to null if given an empty string', async function () {
-        // given
-        const initialChallengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
-          maximumAssessmentLength: 20,
-          limitToOneQuestionPerTube: false,
-        });
-        const existingVersion = databaseBuilder.factory.buildCertificationVersion({
-          scope: SCOPES.PIX_PLUS_DROIT,
-          startDate: new Date('2024-01-01'),
-          expirationDate: null,
-          assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
-          challengesConfiguration: initialChallengesConfiguration,
-        });
-
-        await databaseBuilder.commit();
-
-        const versionToUpdate = domainBuilder.certification.configuration.buildVersion({
-          id: existingVersion.id,
-          scope: existingVersion.scope,
-          startDate: existingVersion.startDate,
-          expirationDate: existingVersion.expirationDate,
-          assessmentDuration: existingVersion.assessmentDuration,
-          challengesConfiguration: existingVersion.challengesConfiguration,
-          comments: '',
-        });
-
-        // when
-        await versionRepository.update({ version: versionToUpdate });
-
-        // then
-        const updatedVersion = await knex('certification_versions').where({ id: existingVersion.id }).first();
-        expect(updatedVersion.comments).to.equal(null);
+        const savedVersion = await versionRepository.getById({ id: version.id });
+        expect(savedVersion).to.deepEqualInstance(alteredVersion);
       });
     });
+  });
 
-    describe('#findAllByScope', function () {
-      it('returns all the versions of a given scope', async function () {
-        // given
-        const scope = SCOPES.PIX_PLUS_DROIT;
+  describe('#findAllByScope', function () {
+    it('returns all the versions of a given scope', async function () {
+      // given
+      const scope = SCOPES.PIX_PLUS_DROIT;
 
-        const oldConfig = {
-          maximumAssessmentLength: 32,
-          challengesBetweenSameCompetence: 2,
-          limitToOneQuestionPerTube: false,
-          enablePassageByAllCompetences: false,
-          variationPercent: 0.25,
-          defaultCandidateCapacity: -1,
-          defaultProbabilityToPickChallenge: 10,
-        };
-        const archivedVersion = databaseBuilder.factory.buildCertificationVersion({
-          id: 1000,
+      const oldConfig = {
+        maximumAssessmentLength: 32,
+        challengesBetweenSameCompetence: 2,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: false,
+        variationPercent: 0.25,
+        defaultCandidateCapacity: -1,
+        defaultProbabilityToPickChallenge: 10,
+      };
+      const archivedVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({ startDate: new Date('2025-01-01'), expirationDate: new Date('2025-05-31') })
+        .withParameters({
           scope,
-          startDate: new Date('2025-01-01'),
-          expirationDate: new Date('2025-05-31'),
+          tubeIds: ['rec123', 'rec5678'],
+          id: 1000,
           assessmentDuration: 90,
           globalScoringConfiguration: [{ config: 'old' }],
           competencesScoringConfiguration: [{ config: 'old' }],
           challengesConfiguration: oldConfig,
-        });
+        })
+        .insertToDB({ databaseBuilder });
 
-        const middleConfig = {
-          maximumAssessmentLength: 31,
-          challengesBetweenSameCompetence: 2,
-          limitToOneQuestionPerTube: false,
-          enablePassageByAllCompetences: false,
-          variationPercent: 0.25,
-          defaultCandidateCapacity: -2,
-          defaultProbabilityToPickChallenge: 20,
-        };
-        const archivedVersion2 = databaseBuilder.factory.buildCertificationVersion({
-          id: 10000,
+      const middleConfig = {
+        maximumAssessmentLength: 31,
+        challengesBetweenSameCompetence: 2,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: false,
+        variationPercent: 0.25,
+        defaultCandidateCapacity: -2,
+        defaultProbabilityToPickChallenge: 20,
+      };
+      const archivedVersion2 = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({ startDate: new Date('2025-03-01'), expirationDate: new Date('2025-08-31') })
+        .withParameters({
           scope,
-          startDate: new Date('2025-03-01'),
-          expirationDate: new Date('2025-08-31'),
+          tubeIds: ['rec123', 'rec5678'],
+          id: 10000,
           assessmentDuration: 100,
           globalScoringConfiguration: [{ config: 'middle' }],
           competencesScoringConfiguration: [{ config: 'middle' }],
           challengesConfiguration: middleConfig,
-        });
+        })
+        .insertToDB({ databaseBuilder });
 
-        const activeConfig = {
-          maximumAssessmentLength: 30,
-          challengesBetweenSameCompetence: 2,
-          limitToOneQuestionPerTube: false,
-          enablePassageByAllCompetences: false,
-          variationPercent: 0.25,
-          defaultCandidateCapacity: -3,
-          defaultProbabilityToPickChallenge: 30,
-        };
+      const activeConfig = {
+        maximumAssessmentLength: 30,
+        challengesBetweenSameCompetence: 2,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: false,
+        variationPercent: 0.25,
+        defaultCandidateCapacity: -3,
+        defaultProbabilityToPickChallenge: 30,
+      };
 
-        const activeVersion = databaseBuilder.factory.buildCertificationVersion({
-          id: 100,
+      const activeVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2025-06-01') })
+        .withParameters({
           scope,
-          startDate: new Date('2025-06-01'),
-          expirationDate: null,
+          tubeIds: ['rec123', 'rec5678'],
+          id: 100,
           assessmentDuration: 120,
           globalScoringConfiguration: [{ config: 'latest' }],
           competencesScoringConfiguration: [{ config: 'latest' }],
           challengesConfiguration: activeConfig,
-        });
+        })
+        .insertToDB({ databaseBuilder });
 
-        const aWeDoNotCareConfig = {
-          maximumAssessmentLength: 29,
-          challengesBetweenSameCompetence: 2,
-          limitToOneQuestionPerTube: false,
-          enablePassageByAllCompetences: false,
-          variationPercent: 0.25,
-          defaultCandidateCapacity: -8,
-          defaultProbabilityToPickChallenge: 40,
-        };
-        const aScopeWeAreNotInterestedIn = SCOPES.CORE;
-        const activeVersion2 = databaseBuilder.factory.buildCertificationVersion({
-          id: 2,
+      const aWeDoNotCareConfig = {
+        maximumAssessmentLength: 29,
+        challengesBetweenSameCompetence: 2,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: false,
+        variationPercent: 0.25,
+        defaultCandidateCapacity: -8,
+        defaultProbabilityToPickChallenge: 40,
+      };
+      const aScopeWeAreNotInterestedIn = SCOPES.CORE;
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2025-10-01') })
+        .withParameters({
           scope: aScopeWeAreNotInterestedIn,
-          startDate: new Date('2025-10-01'),
-          expirationDate: null,
+          tubeIds: ['rec123', 'rec5678'],
+          id: 2,
           assessmentDuration: 150,
           globalScoringConfiguration: [{ other: 'scope' }],
-          competencesScoringConfiguration: null,
           challengesConfiguration: aWeDoNotCareConfig,
-        });
+        })
+        .insertToDB({ databaseBuilder });
 
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: archivedVersion.id, tubeId: 'rec123' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: archivedVersion.id, tubeId: 'rec5678' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: archivedVersion2.id, tubeId: 'rec123' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: archivedVersion2.id, tubeId: 'rec5678' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: activeVersion.id, tubeId: 'rec123' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: activeVersion.id, tubeId: 'rec5678' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: activeVersion2.id, tubeId: 'rec123' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: activeVersion2.id, tubeId: 'rec5678' });
+      await databaseBuilder.commit();
+
+      // when
+      const versions = await versionRepository.findAllByScope({ scope });
+
+      // then
+      expect(versions).to.deepEqualArray([activeVersion, archivedVersion, archivedVersion2]);
+    });
+
+    context('when no version exists for the scope', function () {
+      it('return an empty array', async function () {
+        // given
+        const scope = SCOPES.PIX_PLUS_EDU_CPE;
+
+        domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2025-01-01') })
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'], assessmentDuration: 90 })
+          .insertToDB({ databaseBuilder });
 
         await databaseBuilder.commit();
 
@@ -342,364 +223,258 @@ describe('Certification | Configuration | Integration | Repository | Version', f
         const versions = await versionRepository.findAllByScope({ scope });
 
         // then
-        expect(versions).to.deepEqualArray([
-          domainBuilder.certification.configuration.buildVersion({
-            id: 100,
-            scope,
-            startDate: new Date('2025-06-01'),
-            expirationDate: null,
-            assessmentDuration: 120,
-            globalScoringConfiguration: [{ config: 'latest' }],
-            competencesScoringConfiguration: [{ config: 'latest' }],
-            challengesConfiguration: activeConfig,
-            tubeIds: ['rec123', 'rec5678'],
-          }),
-          domainBuilder.certification.configuration.buildVersion({
-            id: 1000,
-            scope,
-            startDate: new Date('2025-01-01'),
-            expirationDate: new Date('2025-05-31'),
-            assessmentDuration: 90,
-            globalScoringConfiguration: [{ config: 'old' }],
-            competencesScoringConfiguration: [{ config: 'old' }],
-            challengesConfiguration: oldConfig,
-            tubeIds: ['rec123', 'rec5678'],
-          }),
-          domainBuilder.certification.configuration.buildVersion({
-            id: 10000,
-            scope,
-            startDate: new Date('2025-03-01'),
-            expirationDate: new Date('2025-08-31'),
-            assessmentDuration: 100,
-            globalScoringConfiguration: [{ config: 'middle' }],
-            competencesScoringConfiguration: [{ config: 'middle' }],
-            challengesConfiguration: middleConfig,
-            tubeIds: ['rec123', 'rec5678'],
-          }),
-        ]);
-      });
-
-      context('when no version exists for the scope', function () {
-        it('return an empty array', async function () {
-          // given
-          const scope = SCOPES.PIX_PLUS_EDU_CPE;
-
-          databaseBuilder.factory.buildCertificationVersion({
-            scope: SCOPES.CORE,
-            startDate: new Date('2025-01-01'),
-            expirationDate: null,
-            assessmentDuration: 90,
-            globalScoringConfiguration: null,
-            competencesScoringConfiguration: null,
-            challengesConfiguration: { config: 'test' },
-          });
-
-          await databaseBuilder.commit();
-
-          // when
-          const versions = await versionRepository.findAllByScope({ scope });
-
-          // then
-          expect(versions).to.deepEqualArray([]);
-        });
+        expect(versions).to.deepEqualArray([]);
       });
     });
+  });
 
-    describe('#getById', function () {
-      it('should return the version with the given id', async function () {
-        // given
-        const scope = SCOPES.PIX_PLUS_DROIT;
-        const expectedConfig = {
-          maximumAssessmentLength: 30,
-          challengesBetweenSameCompetence: 2,
-          limitToOneQuestionPerTube: false,
-          enablePassageByAllCompetences: false,
-          variationPercent: 0.25,
-          defaultCandidateCapacity: 1,
-          defaultProbabilityToPickChallenge: 51,
-        };
-        const versionId = databaseBuilder.factory.buildCertificationVersion({
+  describe('#getById', function () {
+    it('should return the version with the given id', async function () {
+      // given
+      const scope = SCOPES.PIX_PLUS_DROIT;
+      const expectedConfig = {
+        maximumAssessmentLength: 30,
+        challengesBetweenSameCompetence: 2,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: false,
+        variationPercent: 0.25,
+        defaultCandidateCapacity: 1,
+        defaultProbabilityToPickChallenge: 51,
+      };
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({ startDate: new Date('2025-06-01'), expirationDate: new Date('2025-12-31') })
+        .withParameters({
           scope,
-          startDate: new Date('2025-06-01'),
-          expirationDate: new Date('2025-12-31'),
+          tubeIds: ['rec123', 'rec5678'],
           assessmentDuration: 120,
           globalScoringConfiguration: [{ config: 'test' }],
           competencesScoringConfiguration: [{ config: 'test' }],
           challengesConfiguration: expectedConfig,
-        }).id;
+        })
+        .insertToDB({ databaseBuilder });
 
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId, tubeId: 'rec123' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId, tubeId: 'rec5678' });
+      await databaseBuilder.commit();
 
-        await databaseBuilder.commit();
+      // when
+      const result = await versionRepository.getById({ id: version.id });
 
-        // when
-        const result = await versionRepository.getById({ id: versionId });
-
-        // then
-        expect(result).to.be.instanceOf(Version);
-        expect(result.id).to.equal(versionId);
-        expect(result.scope).to.equal(scope);
-        expect(result.startDate).to.deep.equal(new Date('2025-06-01'));
-        expect(result.expirationDate).to.deep.equal(new Date('2025-12-31'));
-        expect(result.assessmentDuration).to.equal(120);
-        expect(result.globalScoringConfiguration).to.deep.equal([{ config: 'test' }]);
-        expect(result.competencesScoringConfiguration).to.deep.equal([{ config: 'test' }]);
-        expect(result.challengesConfiguration).to.deep.equal(expectedConfig);
-        expect(result.tubeIds).to.deep.equal(['rec123', 'rec5678']);
-      });
-
-      context('when the version does not exist', function () {
-        it('should throw a NotFoundError', async function () {
-          // given
-          const nonExistentVersionId = 99999;
-
-          // when
-          const error = await catchErr(versionRepository.getById)({ id: nonExistentVersionId });
-
-          // then
-          expect(error).to.deepEqualInstance(new NotFoundError(`Version with id ${nonExistentVersionId} not found`));
-        });
-      });
+      // then
+      expect(result).to.be.instanceOf(Version);
+      expect(result.id).to.equal(version.id);
+      expect(result.scope).to.equal(scope);
+      expect(result.startDate).to.deep.equal(new Date('2025-06-01'));
+      expect(result.expirationDate).to.deep.equal(new Date('2025-12-31'));
+      expect(result.assessmentDuration).to.equal(120);
+      expect(result.globalScoringConfiguration).to.deep.equal([{ config: 'test' }]);
+      expect(result.competencesScoringConfiguration).to.deep.equal([{ config: 'test' }]);
+      expect(result.challengesConfiguration).to.deep.equal(expectedConfig);
+      expect(result.tubeIds).to.deep.equal(['rec123', 'rec5678']);
     });
 
-    describe('#getFrameworkHistory', function () {
-      it('should return an empty array when there is no framework history', async function () {
+    context('when the version does not exist', function () {
+      it('should throw a NotFoundError', async function () {
         // given
-        const scope = SCOPES.PIX_PLUS_DROIT;
+        const nonExistentVersionId = 99999;
 
         // when
-        const frameworkHistory = await versionRepository.getFrameworkHistory({ scope });
+        const error = await catchErr(versionRepository.getById)({ id: nonExistentVersionId });
 
         // then
-        expect(frameworkHistory).to.deep.equal([]);
+        expect(error).to.deepEqualInstance(new NotFoundError(`Version with id ${nonExistentVersionId} not found`));
       });
+    });
+  });
 
-      it('should return the framework history ordered by start date descending', async function () {
-        // given
-        const scope = SCOPES.PIX_PLUS_DROIT;
-        const otherScope = SCOPES.CLEA;
+  describe('#getFrameworkHistory', function () {
+    it('should return an empty array when there is no framework history', async function () {
+      // given
+      const scope = SCOPES.PIX_PLUS_DROIT;
 
-        const version1Config = { maximumAssessmentLength: 1 };
-        const version1 = databaseBuilder.factory.buildCertificationVersion({
-          scope,
-          startDate: new Date('2024-03-15'),
-          assessmentDuration: 90,
-          challengesConfiguration: version1Config,
-          status: VERSION_STATUSES.ACTIVE,
-        });
-        const version2Config = { maximumAssessmentLength: 2 };
-        const version2 = databaseBuilder.factory.buildCertificationVersion({
-          scope,
-          startDate: null,
-          assessmentDuration: 80,
-          challengesConfiguration: version2Config,
-          status: VERSION_STATUSES.DRAFT,
-        });
-        const version3Config = { maximumAssessmentLength: 3 };
-        const version3 = databaseBuilder.factory.buildCertificationVersion({
-          scope,
-          startDate: new Date('2024-03-10'),
-          expirationDate: new Date('2024-03-14'),
-          assessmentDuration: 50,
-          challengesConfiguration: version3Config,
-          status: VERSION_STATUSES.ARCHIVED,
-        });
-        databaseBuilder.factory.buildCertificationVersion({
+      // when
+      const frameworkHistory = await versionRepository.getFrameworkHistory({ scope });
+
+      // then
+      expect(frameworkHistory).to.deep.equal([]);
+    });
+
+    it('should return the framework history ordered by start date descending', async function () {
+      // given
+      const scope = SCOPES.PIX_PLUS_DROIT;
+      const otherScope = SCOPES.CLEA;
+
+      const version1Config = { maximumAssessmentLength: 1 };
+      const version1 = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2024-03-15') })
+        .withParameters({ scope, tubeIds: ['rec123'], assessmentDuration: 90, challengesConfiguration: version1Config })
+        .insertToDB({ databaseBuilder });
+      const version2Config = { maximumAssessmentLength: 2 };
+      const version2 = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope, tubeIds: ['rec123'], assessmentDuration: 80, challengesConfiguration: version2Config })
+        .insertToDB({ databaseBuilder });
+      const version3Config = { maximumAssessmentLength: 3 };
+      const version3 = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({ startDate: new Date('2024-03-10'), expirationDate: new Date('2024-03-14') })
+        .withParameters({ scope, tubeIds: ['rec123'], assessmentDuration: 50, challengesConfiguration: version3Config })
+        .insertToDB({ databaseBuilder });
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2025-06-21') })
+        .withParameters({
           scope: otherScope,
-          startDate: new Date('2025-06-21'),
+          tubeIds: ['rec123'],
           assessmentDuration: 60,
           challengesConfiguration: { maximumAssessmentLength: 4 },
+        })
+        .insertToDB({ databaseBuilder });
+
+      await databaseBuilder.commit();
+
+      // when
+      const frameworkHistory = await versionRepository.getFrameworkHistory({ scope });
+
+      // then
+      expect(frameworkHistory).to.deep.equal([
+        domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
+          id: version2.id,
+          startDate: version2.startDate,
+          expirationDate: version2.expirationDate,
+          assessmentDuration: version2.assessmentDuration,
+          maximumAssessmentLength: version2Config.maximumAssessmentLength,
+          status: VERSION_STATUSES.DRAFT,
+        }),
+        domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
+          id: version1.id,
+          startDate: version1.startDate,
+          expirationDate: version1.expirationDate,
+          assessmentDuration: version1.assessmentDuration,
+          maximumAssessmentLength: version1Config.maximumAssessmentLength,
           status: VERSION_STATUSES.ACTIVE,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const frameworkHistory = await versionRepository.getFrameworkHistory({ scope });
-
-        // then
-        expect(frameworkHistory).to.deep.equal([
-          domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
-            id: version2.id,
-            startDate: version2.startDate,
-            expirationDate: version2.expirationDate,
-            assessmentDuration: version2.assessmentDuration,
-            maximumAssessmentLength: version2Config.maximumAssessmentLength,
-            status: VERSION_STATUSES.DRAFT,
-          }),
-          domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
-            id: version1.id,
-            startDate: version1.startDate,
-            expirationDate: version1.expirationDate,
-            assessmentDuration: version1.assessmentDuration,
-            maximumAssessmentLength: version1Config.maximumAssessmentLength,
-            status: VERSION_STATUSES.ACTIVE,
-          }),
-          domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
-            id: version3.id,
-            startDate: version3.startDate,
-            expirationDate: version3.expirationDate,
-            assessmentDuration: version3.assessmentDuration,
-            maximumAssessmentLength: version3Config.maximumAssessmentLength,
-            status: VERSION_STATUSES.ARCHIVED,
-          }),
-        ]);
-      });
+        }),
+        domainBuilder.certification.configuration.buildFrameworkHistoryEntry({
+          id: version3.id,
+          startDate: version3.startDate,
+          expirationDate: version3.expirationDate,
+          assessmentDuration: version3.assessmentDuration,
+          maximumAssessmentLength: version3Config.maximumAssessmentLength,
+          status: VERSION_STATUSES.ARCHIVED,
+        }),
+      ]);
     });
+  });
 
-    describe('#findAll', function () {
-      it('should return all the versions ordered by id', async function () {
-        // given
-        const scopeDroit = Frameworks.DROIT;
-        const expectedConfigDroit = {
-          maximumAssessmentLength: 30,
-          challengesBetweenSameCompetence: 2,
-          limitToOneQuestionPerTube: false,
-          enablePassageByAllCompetences: false,
-          variationPercent: 0.25,
-          defaultCandidateCapacity: 1,
-          defaultProbabilityToPickChallenge: 51,
-        };
-        const versionIdDroitId = databaseBuilder.factory.buildCertificationVersion({
-          id: 3,
+  describe('#findAll', function () {
+    it('should return all the versions ordered by id', async function () {
+      // given
+      const scopeDroit = Frameworks.DROIT;
+      const expectedConfigDroit = {
+        maximumAssessmentLength: 30,
+        challengesBetweenSameCompetence: 2,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: false,
+        variationPercent: 0.25,
+        defaultCandidateCapacity: 1,
+        defaultProbabilityToPickChallenge: 51,
+      };
+      const versionDroit = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({ startDate: new Date('2025-06-01'), expirationDate: new Date('2025-12-31') })
+        .withParameters({
           scope: scopeDroit,
-          startDate: new Date('2025-06-01'),
-          expirationDate: new Date('2025-12-31'),
+          tubeIds: ['rec1234', 'rec5678'],
+          id: 3,
           assessmentDuration: 120,
           minimumAnswersRequiredToValidateACertification: 1,
           globalScoringConfiguration: [{ config: 'testDroit' }],
           competencesScoringConfiguration: [{ config: 'testDroit' }],
           challengesConfiguration: expectedConfigDroit,
           comments: 'versionDroit',
-        }).id;
-        const scopeCoreOld = Frameworks.CORE;
-        const expectedConfigCoreOld = {
-          maximumAssessmentLength: 1,
-          challengesBetweenSameCompetence: 3,
-          limitToOneQuestionPerTube: true,
-          enablePassageByAllCompetences: true,
-          variationPercent: 0.5,
-          defaultCandidateCapacity: 4,
-          defaultProbabilityToPickChallenge: 5,
-        };
-        const versionIdCoreOldId = databaseBuilder.factory.buildCertificationVersion({
-          id: 2,
+        })
+        .insertToDB({ databaseBuilder });
+      const scopeCoreOld = Frameworks.CORE;
+      const expectedConfigCoreOld = {
+        maximumAssessmentLength: 1,
+        challengesBetweenSameCompetence: 3,
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: true,
+        variationPercent: 0.5,
+        defaultCandidateCapacity: 4,
+        defaultProbabilityToPickChallenge: 5,
+      };
+      const versionCoreOld = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({ startDate: new Date('2024-01-01'), expirationDate: new Date('2025-12-31') })
+        .withParameters({
           scope: scopeCoreOld,
-          startDate: new Date('2024-01-01'),
-          expirationDate: new Date('2025-12-31'),
+          tubeIds: ['rec1234', 'rec5678'],
+          id: 2,
           assessmentDuration: 66,
           minimumAnswersRequiredToValidateACertification: 2,
           globalScoringConfiguration: [{ config: 'testCoreOld' }],
           competencesScoringConfiguration: [{ config: 'testCoreOld' }],
           challengesConfiguration: expectedConfigCoreOld,
           comments: 'versionCoreOld',
-        }).id;
-        const scopeCoreNew = Frameworks.CORE;
-        const expectedConfigCoreNew = {
-          maximumAssessmentLength: 10,
-          challengesBetweenSameCompetence: 30,
-          limitToOneQuestionPerTube: false,
-          enablePassageByAllCompetences: false,
-          variationPercent: 0.75,
-          defaultCandidateCapacity: 40,
-          defaultProbabilityToPickChallenge: 50,
-        };
-        const versionIdCoreNewId = databaseBuilder.factory.buildCertificationVersion({
-          id: 1,
+        })
+        .insertToDB({ databaseBuilder });
+      const scopeCoreNew = Frameworks.CORE;
+      const expectedConfigCoreNew = {
+        maximumAssessmentLength: 10,
+        challengesBetweenSameCompetence: 30,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: false,
+        variationPercent: 0.75,
+        defaultCandidateCapacity: 40,
+        defaultProbabilityToPickChallenge: 50,
+      };
+      const versionCoreNew = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2026-01-01') })
+        .withParameters({
           scope: scopeCoreNew,
-          startDate: new Date('2026-01-01'),
-          expirationDate: null,
+          tubeIds: ['rec1234', 'rec5678'],
+          id: 1,
           assessmentDuration: 3,
           minimumAnswersRequiredToValidateACertification: 3,
           globalScoringConfiguration: [{ config: 'testCoreNew' }],
           competencesScoringConfiguration: [{ config: 'testCoreNew' }],
           challengesConfiguration: expectedConfigCoreNew,
           comments: 'versionCoreNew',
-        }).id;
+        })
+        .insertToDB({ databaseBuilder });
 
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: versionIdDroitId, tubeId: 'rec1234' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: versionIdDroitId, tubeId: 'rec5678' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: versionIdCoreOldId, tubeId: 'rec1234' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: versionIdCoreOldId, tubeId: 'rec5678' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: versionIdCoreNewId, tubeId: 'rec1234' });
-        databaseBuilder.factory.buildCertificationVersionTube({ versionId: versionIdCoreNewId, tubeId: 'rec5678' });
-        await databaseBuilder.commit();
+      await databaseBuilder.commit();
 
-        // when
-        const result = await versionRepository.findAll();
+      // when
+      const result = await versionRepository.findAll();
 
-        // then
-        expect(result).to.deepEqualArray([
-          domainBuilder.certification.configuration.buildVersion({
-            id: versionIdCoreNewId,
-            scope: scopeCoreNew,
-            startDate: new Date('2026-01-01'),
-            expirationDate: null,
-            assessmentDuration: 3,
-            minimumAnswersRequiredToValidateACertification: 3,
-            globalScoringConfiguration: [{ config: 'testCoreNew' }],
-            competencesScoringConfiguration: [{ config: 'testCoreNew' }],
-            challengesConfiguration: expectedConfigCoreNew,
-            comments: 'versionCoreNew',
-            tubeIds: ['rec1234', 'rec5678'],
-          }),
-          domainBuilder.certification.configuration.buildVersion({
-            id: versionIdCoreOldId,
-            scope: scopeCoreOld,
-            startDate: new Date('2024-01-01'),
-            expirationDate: new Date('2025-12-31'),
-            assessmentDuration: 66,
-            minimumAnswersRequiredToValidateACertification: 2,
-            globalScoringConfiguration: [{ config: 'testCoreOld' }],
-            competencesScoringConfiguration: [{ config: 'testCoreOld' }],
-            challengesConfiguration: expectedConfigCoreOld,
-            comments: 'versionCoreOld',
-            tubeIds: ['rec1234', 'rec5678'],
-          }),
-          domainBuilder.certification.configuration.buildVersion({
-            id: versionIdDroitId,
-            scope: scopeDroit,
-            startDate: new Date('2025-06-01'),
-            expirationDate: new Date('2025-12-31'),
-            assessmentDuration: 120,
-            minimumAnswersRequiredToValidateACertification: 1,
-            globalScoringConfiguration: [{ config: 'testDroit' }],
-            competencesScoringConfiguration: [{ config: 'testDroit' }],
-            challengesConfiguration: expectedConfigDroit,
-            comments: 'versionDroit',
-            tubeIds: ['rec1234', 'rec5678'],
-          }),
-        ]);
-      });
+      // then
+      expect(result).to.deepEqualArray([versionCoreNew, versionCoreOld, versionDroit]);
     });
+  });
 
-    describe('#remove', function () {
-      it('should delete a draft certification version ', async function () {
-        const certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
-          startDate: null,
-          expirationDate: null,
-        }).id;
+  describe('#remove', function () {
+    it('should delete a draft certification version ', async function () {
+      const certificationVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+        .insertToDB({ databaseBuilder });
 
-        databaseBuilder.factory.buildCertificationVersionTube({
-          versionId: certificationVersionId,
-          tubeId: 'rec123',
-        });
+      await databaseBuilder.commit();
 
-        await databaseBuilder.commit();
+      await versionRepository.remove(certificationVersion.id);
 
-        await versionRepository.remove(certificationVersionId);
+      const matchingCertificationVersions = await knex
+        .from('certification_versions')
+        .where({ id: certificationVersion.id });
+      expect(matchingCertificationVersions).to.be.empty;
 
-        const matchingCertificationVersions = await knex
-          .from('certification_versions')
-          .where({ id: certificationVersionId });
-        expect(matchingCertificationVersions).to.be.empty;
-
-        const certificationVersionTubeIds = await knex('certification_versions_tubes').where({
-          version_id: certificationVersionId,
-        });
-        expect(certificationVersionTubeIds).to.be.empty;
+      const certificationVersionTubeIds = await knex('certification_versions_tubes').where({
+        version_id: certificationVersion.id,
       });
+      expect(certificationVersionTubeIds).to.be.empty;
     });
   });
 });

--- a/api/tests/certification/configuration/unit/application/api/models/Version_test.js
+++ b/api/tests/certification/configuration/unit/application/api/models/Version_test.js
@@ -1,13 +1,5 @@
 import { VersionNotDraftError } from '../../../../../../../src/certification/configuration/domain/errors.js';
-import {
-  Version,
-  VERSION_STATUSES,
-} from '../../../../../../../src/certification/configuration/domain/models/Version.js';
-import {
-  DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
-  DEFAULT_PROBABILITY_TO_PICK_CHALLENGE,
-  DEFAULT_SESSION_DURATION_MINUTES,
-} from '../../../../../../../src/certification/shared/domain/constants.js';
+import { Version } from '../../../../../../../src/certification/configuration/domain/models/Version.js';
 import { SCOPES } from '../../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { EntityValidationError } from '../../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../../test-helper.js';
@@ -17,9 +9,11 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
   describe('#get isDraft', function () {
     context('when the version is archived', function () {
       it('return false', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.ARCHIVED,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asArchived()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.isDraft).to.be.false;
       });
@@ -27,9 +21,11 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
 
     context('when the version is active', function () {
       it('return false', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.ACTIVE,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.isDraft).to.be.false;
       });
@@ -37,9 +33,10 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
 
     context('when the version is draft', function () {
       it('return true', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.DRAFT,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.isDraft).to.be.true;
       });
@@ -49,9 +46,11 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
   describe('#canRemove', function () {
     context('when the version is archived', function () {
       it('return false', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.ARCHIVED,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asArchived()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.canRemove).to.be.false;
       });
@@ -59,9 +58,11 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
 
     context('when the version is active', function () {
       it('return false', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.ACTIVE,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.canRemove).to.be.false;
       });
@@ -69,9 +70,10 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
 
     context('when the version is draft', function () {
       it('return true', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.DRAFT,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.canRemove).to.be.true;
       });
@@ -81,9 +83,11 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
   describe('#get isActive', function () {
     context('when the version is archived', function () {
       it('return false', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.ARCHIVED,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asArchived()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.isActive).to.be.false;
       });
@@ -91,9 +95,11 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
 
     context('when the version is active', function () {
       it('return true', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.ACTIVE,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.isActive).to.be.true;
       });
@@ -101,9 +107,10 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
 
     context('when the version is draft', function () {
       it('return false', function () {
-        const version = domainBuilder.certification.configuration.buildVersion({
-          status: VERSION_STATUSES.DRAFT,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec123'] })
+          .build();
 
         expect(version.isActive).to.be.false;
       });
@@ -114,28 +121,29 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
     context('success cases', function () {
       context('when a base version is provided', function () {
         it('returns a newly created Version model based on attributes of the base version', function () {
-          const baseVersion = domainBuilder.certification.configuration.buildVersion({
-            id: 1,
-            scope: SCOPES.PIX_PLUS_DROIT,
-            startDate: new Date(),
-            expirationDate: new Date(),
-            assessmentDuration: 11,
-            minimumAnswersRequiredToValidateACertification: 11,
-            globalScoringConfiguration: ['some globalScoringConfiguration'],
-            competencesScoringConfiguration: ['some competencesScoringConfiguration'],
-            challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
-              maximumAssessmentLength: 11,
-              challengesBetweenSameCompetence: 11,
-              limitToOneQuestionPerTube: false,
-              enablePassageByAllCompetences: false,
-              variationPercent: 0.1,
-              defaultCandidateCapacity: 11,
-              defaultProbabilityToPickChallenge: 11,
-            }),
-            status: VERSION_STATUSES.ACTIVE,
-            comments: 'Some ignored value',
-            tubeIds: ['rec123'],
-          });
+          const baseVersion = domainBuilder.certification.configuration
+            .versionBuilder()
+            .asActive({ startDate: new Date() })
+            .withParameters({
+              scope: SCOPES.PIX_PLUS_DROIT,
+              tubeIds: ['rec123'],
+              id: 1,
+              assessmentDuration: 11,
+              minimumAnswersRequiredToValidateACertification: 11,
+              globalScoringConfiguration: ['some globalScoringConfiguration'],
+              competencesScoringConfiguration: ['some competencesScoringConfiguration'],
+              challengesConfiguration: {
+                maximumAssessmentLength: 11,
+                challengesBetweenSameCompetence: 11,
+                limitToOneQuestionPerTube: false,
+                enablePassageByAllCompetences: false,
+                variationPercent: 0.1,
+                defaultCandidateCapacity: 11,
+                defaultProbabilityToPickChallenge: 11,
+              },
+              comments: 'Some ignored value',
+            })
+            .build();
 
           const newVersion = Version.buildDraftFromActiveVersion({
             scope: SCOPES.PIX_PLUS_PRO_SANTE,
@@ -144,28 +152,26 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
           });
 
           expect(newVersion).to.deepEqualInstance(
-            domainBuilder.certification.configuration.buildVersion({
-              id: null,
-              scope: SCOPES.PIX_PLUS_DROIT,
-              startDate: null,
-              expirationDate: null,
-              assessmentDuration: 11,
-              minimumAnswersRequiredToValidateACertification: 11,
-              globalScoringConfiguration: ['some globalScoringConfiguration'],
-              competencesScoringConfiguration: ['some competencesScoringConfiguration'],
-              challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
-                maximumAssessmentLength: 11,
-                challengesBetweenSameCompetence: 11,
-                limitToOneQuestionPerTube: false,
-                enablePassageByAllCompetences: false,
-                variationPercent: 0.1,
-                defaultCandidateCapacity: 11,
-                defaultProbabilityToPickChallenge: 11,
-              }),
-              status: VERSION_STATUSES.DRAFT,
-              comments: null,
-              tubeIds: ['rec456'],
-            }),
+            domainBuilder.certification.configuration
+              .versionBuilder()
+              .withParameters({
+                scope: SCOPES.PIX_PLUS_DROIT,
+                tubeIds: ['rec456'],
+                assessmentDuration: 11,
+                minimumAnswersRequiredToValidateACertification: 11,
+                globalScoringConfiguration: ['some globalScoringConfiguration'],
+                competencesScoringConfiguration: ['some competencesScoringConfiguration'],
+                challengesConfiguration: {
+                  maximumAssessmentLength: 11,
+                  challengesBetweenSameCompetence: 11,
+                  limitToOneQuestionPerTube: false,
+                  enablePassageByAllCompetences: false,
+                  variationPercent: 0.1,
+                  defaultCandidateCapacity: 11,
+                  defaultProbabilityToPickChallenge: 11,
+                },
+              })
+              .build(),
           );
         });
       });
@@ -179,29 +185,10 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
           });
 
           expect(newVersion).to.deepEqualInstance(
-            domainBuilder.certification.configuration.buildVersion({
-              id: null,
-              scope: SCOPES.PIX_PLUS_PRO_SANTE,
-              startDate: null,
-              expirationDate: null,
-              assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
-              minimumAnswersRequiredToValidateACertification:
-                DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
-              globalScoringConfiguration: [],
-              competencesScoringConfiguration: [],
-              challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
-                maximumAssessmentLength: 32,
-                challengesBetweenSameCompetence: 0,
-                limitToOneQuestionPerTube: true,
-                enablePassageByAllCompetences: true,
-                variationPercent: 1,
-                defaultCandidateCapacity: 0,
-                defaultProbabilityToPickChallenge: DEFAULT_PROBABILITY_TO_PICK_CHALLENGE,
-              }),
-              status: VERSION_STATUSES.DRAFT,
-              comments: null,
-              tubeIds: ['rec456'],
-            }),
+            domainBuilder.certification.configuration
+              .versionBuilder()
+              .withParameters({ scope: SCOPES.PIX_PLUS_PRO_SANTE, tubeIds: ['rec456'] })
+              .build(),
           );
         });
       });
@@ -235,18 +222,15 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
   });
 
   describe('#update', function () {
-    let baseVersionData, version, validUpdateData;
+    let baseVersionData, validUpdateData;
 
     beforeEach(function () {
       baseVersionData = {
         id: 123,
         scope: SCOPES.PIX_PLUS_DROIT,
-        startDate: new Date('2025-01-01'),
-        expirationDate: new Date('2025-11-11'),
         assessmentDuration: 111,
         minimumAnswersRequiredToValidateACertification: 222,
         comments: '333',
-        status: VERSION_STATUSES.ACTIVE,
         globalScoringConfiguration: [],
         competencesScoringConfiguration: [],
         challengesConfiguration: {
@@ -270,24 +254,26 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
         defaultCandidateCapacity: 700,
         limitToOneQuestionPerTube: false,
         enablePassageByAllCompetences: false,
-        comments: 'COUCOU',
       };
-      version = domainBuilder.certification.configuration.buildVersion(baseVersionData);
     });
 
     context('when version is a draft', function () {
       it('updates the version', function () {
-        version.status = VERSION_STATUSES.DRAFT;
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2025-05-05') })
+          .withParameters(baseVersionData)
+          .build();
+
         version.update(validUpdateData);
 
-        expect(version).to.deepEqualInstance(
-          domainBuilder.certification.configuration.buildVersion({
-            ...baseVersionData,
-            status: VERSION_STATUSES.DRAFT,
-            startDate: validUpdateData.startDate,
+        const expectedVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: validUpdateData.startDate })
+          .withParameters(baseVersionData)
+          .withParameters({
             assessmentDuration: validUpdateData.assessmentDuration,
             minimumAnswersRequiredToValidateACertification: validUpdateData.minimumAnswersRequiredForValidation,
-            comments: '333',
             challengesConfiguration: {
               maximumAssessmentLength: validUpdateData.maximumAssessmentLength,
               challengesBetweenSameCompetence: validUpdateData.challengesBetweenSameCompetence,
@@ -297,16 +283,17 @@ describe('Certification | Configuration | Unit | Application | Api | Models | Ve
               limitToOneQuestionPerTube: validUpdateData.limitToOneQuestionPerTube,
               enablePassageByAllCompetences: validUpdateData.enablePassageByAllCompetences,
             },
-          }),
-        );
+          })
+          .build();
+        expect(version).to.deepEqualInstance(expectedVersion);
       });
     });
 
     context('when version is not a draft', function () {
       it('throws a VersionNotDraft error', function () {
-        version.status = VERSION_STATUSES.ARCHIVED;
+        let version = domainBuilder.certification.configuration.versionBuilder().asActive().build();
         expect(() => version.update(validUpdateData)).to.throw(VersionNotDraftError);
-        version.status = VERSION_STATUSES.ACTIVE;
+        version = domainBuilder.certification.configuration.versionBuilder().asArchived().build();
         expect(() => version.update(validUpdateData)).to.throw(VersionNotDraftError);
       });
     });

--- a/api/tests/certification/configuration/unit/domain/read-models/CertificationInfo_test.js
+++ b/api/tests/certification/configuration/unit/domain/read-models/CertificationInfo_test.js
@@ -3,32 +3,24 @@ import { expect } from 'chai';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Certification | Configuration Unit | Domain | ReadModels | CertificationInfo', function () {
-  describe('#get isCertificationActive', function () {
-    it('returns true when has a startDate but no expirationDate', function () {
-      const certificationInfo = domainBuilder.certification.configuration.buildCertificationInfo({
-        startDate: new Date(),
-        expirationDate: null,
-      });
+  describe('#get isActive', function () {
+    it('returns true only when certification info relates to an active version', function () {
+      const draftCertificationInfo = domainBuilder.certification.configuration
+        .certificationInfoBuilder()
+        .asDraft()
+        .build();
+      const activeCertificationInfo = domainBuilder.certification.configuration
+        .certificationInfoBuilder()
+        .asActive()
+        .build();
+      const archivedCertificationInfo = domainBuilder.certification.configuration
+        .certificationInfoBuilder()
+        .asArchived()
+        .build();
 
-      expect(certificationInfo.isCertificationActive).to.be.true;
-    });
-
-    it('returns false when has no startDate nor expirationDate', function () {
-      const certificationInfo = domainBuilder.certification.configuration.buildCertificationInfo({
-        startDate: null,
-        expirationDate: null,
-      });
-
-      expect(certificationInfo.isCertificationActive).to.be.false;
-    });
-
-    it('returns false when has both startDate and expirationDate', function () {
-      const certificationInfo = domainBuilder.certification.configuration.buildCertificationInfo({
-        startDate: new Date(),
-        expirationDate: new Date(),
-      });
-
-      expect(certificationInfo.isCertificationActive).to.be.false;
+      expect(draftCertificationInfo.isActive).to.be.false;
+      expect(activeCertificationInfo.isActive).to.be.true;
+      expect(archivedCertificationInfo.isActive).to.be.false;
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/create-draft_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-draft_test.js
@@ -1,13 +1,7 @@
 import sinon from 'sinon';
 
 import { CertificationVersionDraftAlreadyExistError } from '../../../../../../src/certification/configuration/domain/errors.js';
-import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { createDraft } from '../../../../../../src/certification/configuration/domain/usecases/create-draft.js';
-import {
-  DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
-  DEFAULT_PROBABILITY_TO_PICK_CHALLENGE,
-  DEFAULT_SESSION_DURATION_MINUTES,
-} from '../../../../../../src/certification/shared/domain/constants.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { expect } from '../../../../../test-helper.js';
@@ -31,16 +25,15 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
   context('when there is already a draft certification version in the same scope', function () {
     it('should throw an error', async function () {
       // given
-      const coreVersionActive = domainBuilder.certification.configuration.buildVersion({
-        scope: SCOPES.CORE,
-        startDate: new Date('2024-01-01'),
-        expirationDate: null,
-      });
-      const coreVersionDraft = domainBuilder.certification.configuration.buildVersion({
-        scope: SCOPES.CORE,
-        startDate: null,
-        expirationDate: null,
-      });
+      const coreVersionActive = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2024-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['someTubeId'] })
+        .build();
+      const coreVersionDraft = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['someTubeId'] })
+        .build();
       versionRepository.findAllByScope.withArgs({ scope: SCOPES.CORE }).resolves([coreVersionDraft, coreVersionActive]);
 
       // when
@@ -60,19 +53,21 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
     context('when there is an active version in the scope', function () {
       it('should create a new certification version based on the active one', async function () {
         // given
-        const activeVersion = domainBuilder.certification.configuration.buildVersion({
-          scope: SCOPES.CORE,
-          startDate: new Date('2024-01-01'),
-          expirationDate: null,
-          assessmentDuration: 111,
-          status: VERSION_STATUSES.ACTIVE,
-          minimumAnswersRequiredToValidateACertification: 222,
-          globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -1.4 } }],
-          competencesScoringConfiguration: [
-            { competence: '1.1', values: [{ bounds: { max: -2, min: -10 }, competenceLevel: 0 }] },
-          ],
-          comments: 'some comments',
-        });
+        const activeVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2024-01-01') })
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['recOldTube'],
+            assessmentDuration: 111,
+            minimumAnswersRequiredToValidateACertification: 222,
+            globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -1.4 } }],
+            competencesScoringConfiguration: [
+              { competence: '1.1', values: [{ bounds: { max: -2, min: -10 }, competenceLevel: 0 }] },
+            ],
+            comments: 'some comments',
+          })
+          .build();
         const tubeIds = ['recTube1', 'recTube2'];
 
         versionRepository.findAllByScope.withArgs({ scope: SCOPES.CORE }).resolves([activeVersion]);
@@ -88,21 +83,19 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
         // then
         expect(id).to.equal(66);
         expect(versionRepository.save).to.have.been.calledOnceWithExactly(
-          domainBuilder.certification.configuration.buildVersion({
-            id: null,
-            scope: SCOPES.CORE,
-            startDate: null,
-            expirationDate: null,
-            status: VERSION_STATUSES.DRAFT,
-            assessmentDuration: 111,
-            minimumAnswersRequiredToValidateACertification: 222,
-            globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -1.4 } }],
-            competencesScoringConfiguration: [
-              { competence: '1.1', values: [{ bounds: { max: -2, min: -10 }, competenceLevel: 0 }] },
-            ],
-            comments: null,
-            tubeIds,
-          }),
+          domainBuilder.certification.configuration
+            .versionBuilder()
+            .withParameters({
+              scope: SCOPES.CORE,
+              tubeIds,
+              assessmentDuration: 111,
+              minimumAnswersRequiredToValidateACertification: 222,
+              globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -1.4 } }],
+              competencesScoringConfiguration: [
+                { competence: '1.1', values: [{ bounds: { max: -2, min: -10 }, competenceLevel: 0 }] },
+              ],
+            })
+            .build(),
         );
       });
     });
@@ -124,28 +117,10 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
         // then
         expect(id).to.equal(66);
         expect(versionRepository.save).to.have.been.calledOnceWithExactly(
-          domainBuilder.certification.configuration.buildVersion({
-            id: null,
-            scope: SCOPES.CORE,
-            startDate: null,
-            expirationDate: null,
-            assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
-            minimumAnswersRequiredToValidateACertification:
-              DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
-            globalScoringConfiguration: [],
-            competencesScoringConfiguration: [],
-            challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
-              maximumAssessmentLength: 32,
-              challengesBetweenSameCompetence: 0,
-              limitToOneQuestionPerTube: true,
-              enablePassageByAllCompetences: true,
-              variationPercent: 1,
-              defaultCandidateCapacity: 0,
-              defaultProbabilityToPickChallenge: DEFAULT_PROBABILITY_TO_PICK_CHALLENGE,
-            }),
-            comments: null,
-            tubeIds,
-          }),
+          domainBuilder.certification.configuration
+            .versionBuilder()
+            .withParameters({ scope: SCOPES.CORE, tubeIds })
+            .build(),
         );
       });
     });

--- a/api/tests/certification/configuration/unit/domain/usecases/get-info_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-info_test.js
@@ -20,14 +20,26 @@ describe('Certification | Configuration | Unit | UseCase | get-info', function (
   context('when framework has no active version', function () {
     it('throws a ActiveCertificationInfoNotFound', async function () {
       certificationInfoRepository.findAllByFramework.withArgs(framework).resolves([
-        domainBuilder.certification.configuration.buildCertificationInfo({
-          framework: Frameworks.EDU_2ND_DEGRE,
-          startDate: null,
-          expirationDate: null,
-          assessmentDuration: 200,
-          minimumAssessmentLength: 10,
-          maximumAssessmentLength: 20,
-        }),
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .asDraft()
+          .withParameters({
+            framework: Frameworks.EDU_2ND_DEGRE,
+            assessmentDuration: 200,
+            minimumAssessmentLength: 10,
+            maximumAssessmentLength: 20,
+          })
+          .build(),
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .asArchived()
+          .withParameters({
+            framework: Frameworks.EDU_2ND_DEGRE,
+            assessmentDuration: 200,
+            minimumAssessmentLength: 10,
+            maximumAssessmentLength: 20,
+          })
+          .build(),
       ]);
 
       const err = await catchErr(getInfo)({ framework, certificationInfoRepository });
@@ -38,37 +50,37 @@ describe('Certification | Configuration | Unit | UseCase | get-info', function (
 
   context('when framework has an active version', function () {
     it('returns the certification info model for the active version', async function () {
-      certificationInfoRepository.findAllByFramework.withArgs(framework).resolves([
-        domainBuilder.certification.configuration.buildCertificationInfo({
+      const activeCertificationInfo = domainBuilder.certification.configuration
+        .certificationInfoBuilder()
+        .asActive()
+        .withParameters({
           framework: Frameworks.EDU_2ND_DEGRE,
           startDate: null,
           expirationDate: null,
           assessmentDuration: 200,
           minimumAssessmentLength: 10,
           maximumAssessmentLength: 20,
-        }),
-        domainBuilder.certification.configuration.buildCertificationInfo({
-          framework: Frameworks.EDU_2ND_DEGRE,
-          startDate: new Date('2021-01-01'),
-          expirationDate: null,
-          assessmentDuration: 33,
-          minimumAssessmentLength: 11,
-          maximumAssessmentLength: 22,
-        }),
+        })
+        .build();
+      certificationInfoRepository.findAllByFramework.withArgs(framework).resolves([
+        activeCertificationInfo,
+        domainBuilder.certification.configuration
+          .certificationInfoBuilder()
+          .asDraft()
+          .withParameters({
+            framework: Frameworks.EDU_2ND_DEGRE,
+            startDate: new Date('2021-01-01'),
+            expirationDate: null,
+            assessmentDuration: 33,
+            minimumAssessmentLength: 11,
+            maximumAssessmentLength: 22,
+          })
+          .build(),
       ]);
 
       const certificationInfo = await getInfo({ framework, certificationInfoRepository });
 
-      expect(certificationInfo).to.deepEqualInstance(
-        domainBuilder.certification.configuration.buildCertificationInfo({
-          framework: Frameworks.EDU_2ND_DEGRE,
-          startDate: new Date('2021-01-01'),
-          expirationDate: null,
-          assessmentDuration: 33,
-          minimumAssessmentLength: 11,
-          maximumAssessmentLength: 22,
-        }),
-      );
+      expect(certificationInfo).to.deepEqualInstance(activeCertificationInfo);
     });
   });
 });

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/certification-info-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/certification-info-serializer_test.js
@@ -8,14 +8,17 @@ describe('Unit | Certification | Configuration | Serializer | certification-info
   describe('#serialize', function () {
     it('should serialize certification info', function () {
       // given
-      const certificationInfo = domainBuilder.certification.configuration.buildCertificationInfo({
-        framework: Frameworks.EDU_2ND_DEGRE,
-        startDate: new Date('2021-01-01'),
-        expirationDate: null,
-        assessmentDuration: 33,
-        minimumAssessmentLength: 11,
-        maximumAssessmentLength: 22,
-      });
+      const certificationInfo = domainBuilder.certification.configuration
+        .certificationInfoBuilder()
+        .asActive()
+        .withParameters({
+          framework: Frameworks.EDU_2ND_DEGRE,
+          expirationDate: null,
+          assessmentDuration: 33,
+          minimumAssessmentLength: 11,
+          maximumAssessmentLength: 22,
+        })
+        .build();
 
       // when
       const serialized = certificationInfoSerializer.serialize(certificationInfo);

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/version-details-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/version-details-serializer_test.js
@@ -9,23 +9,26 @@ describe('Certification | Configuration | Unit | Serializer | version-details-se
   describe('#serialize', function () {
     it('should serialize a version with areas to JSONAPI format', function () {
       // given
-      const version = domainBuilder.certification.configuration.buildVersionDetails({
-        id: 42,
-        status: VERSION_STATUSES.ARCHIVED,
-        scope: SCOPES.PIX_PLUS_PRO_SANTE,
-        startDate: new Date('2024-01-01T00:00:00Z'),
-        expirationDate: new Date('2025-12-31T00:00:00Z'),
-        assessmentDuration: 105,
-        minimumAnswersRequiredForValidation: 20,
-        maximumAssessmentLength: 32,
-        challengesBetweenSameCompetence: 2,
-        defaultProbabilityToPickChallenge: 40,
-        defaultCandidateCapacity: -2,
-        variationPercent: 0.66,
-        limitToOneQuestionPerTube: true,
-        enablePassageByAllCompetences: true,
-        comments: 'some good comments',
-        areas: [
+      const versionDetails = domainBuilder.certification.configuration
+        .versionDetailsBuilder()
+        .asArchived({ startDate: new Date('2024-01-01T00:00:00Z'), expirationDate: new Date('2025-12-31T00:00:00Z') })
+        .withParameters({
+          id: 42,
+          scope: SCOPES.PIX_PLUS_PRO_SANTE,
+          startDate: new Date('2024-01-01T00:00:00Z'),
+          expirationDate: new Date('2025-12-31T00:00:00Z'),
+          assessmentDuration: 105,
+          minimumAnswersRequiredForValidation: 20,
+          maximumAssessmentLength: 32,
+          challengesBetweenSameCompetence: 2,
+          defaultProbabilityToPickChallenge: 40,
+          defaultCandidateCapacity: -2,
+          variationPercent: 0.66,
+          limitToOneQuestionPerTube: true,
+          enablePassageByAllCompetences: true,
+          comments: 'some good comments',
+        })
+        .withLearningContent([
           {
             id: 'areaA',
             frameworkId: 'frameworkA',
@@ -35,20 +38,16 @@ describe('Certification | Configuration | Unit | Serializer | version-details-se
             competences: [
               {
                 id: 'competenceA',
-                areaId: 'areaA',
                 name: 'name FR Competence A',
                 index: 'index Competence A',
                 thematics: [
                   {
                     id: 'thematicA',
-                    competenceId: 'competenceA',
                     name: 'name FR Thematic A',
                     index: 1,
                     tubes: [
                       {
                         id: 'tubeA',
-                        thematicId: 'thematicA',
-                        competenceId: 'competenceA',
                         name: 'Titre pratique Tube A',
                         practicalTitle: 'practicalTitle FR Tube A',
                         mobile: true,
@@ -56,7 +55,6 @@ describe('Certification | Configuration | Unit | Serializer | version-details-se
                         skills: [
                           {
                             id: 'skillA',
-                            tubeId: 'tubeA',
                             difficulty: 2,
                           },
                         ],
@@ -76,20 +74,16 @@ describe('Certification | Configuration | Unit | Serializer | version-details-se
             competences: [
               {
                 id: 'competenceB',
-                areaId: 'areaB',
                 name: 'name FR Competence B',
                 index: 'index Competence B',
                 thematics: [
                   {
                     id: 'thematicB',
-                    competenceId: 'competenceB',
                     name: 'name FR Thematic B',
                     index: 2,
                     tubes: [
                       {
                         id: 'tubeB',
-                        thematicId: 'thematicB',
-                        competenceId: 'competenceB',
                         name: 'Titre pratique Tube B',
                         practicalTitle: 'practicalTitle FR Tube B',
                         mobile: false,
@@ -97,7 +91,6 @@ describe('Certification | Configuration | Unit | Serializer | version-details-se
                         skills: [
                           {
                             id: 'skillB',
-                            tubeId: 'tubeB',
                             difficulty: 6,
                           },
                         ],
@@ -108,11 +101,11 @@ describe('Certification | Configuration | Unit | Serializer | version-details-se
               },
             ],
           },
-        ],
-      });
+        ])
+        .build();
 
       // when
-      const result = serializer.serialize(version);
+      const result = serializer.serialize(versionDetails);
 
       // then
       expect(result).to.deep.equal({

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -1,9 +1,11 @@
 import { createServer } from '../../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationIssueReportCategory } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../../tooling/learning-content-builder/index.js';
 import {
   generateAuthenticatedUserRequestHeaders,
@@ -38,14 +40,11 @@ describe('Acceptance | API | Certification Course', function () {
         reconciledAt,
       }).id;
 
-      const versionId = databaseBuilder.factory.buildCertificationVersion({
-        startDate: new Date('2024-01-01'),
-        expirationDate: null,
-      }).id;
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId,
-      });
+      const versionId = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2024-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+        .insertToDB({ databaseBuilder }).id;
 
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         sessionId: session.id,
@@ -403,15 +402,11 @@ function _createNonExistingCertifCourseSetup({ learningContent, sessionId, userI
     reconciledAt: new Date('2019-02-01'),
   });
 
-  databaseBuilder.factory.buildCertificationVersion({
-    id: 123,
-    startDate: new Date('2019-01-01'),
-    expirationDate: null,
-  });
-  databaseBuilder.factory.buildCertificationVersionTube({
-    tubeId: 'tubeA',
-    versionId: 123,
-  });
+  domainBuilder.certification.configuration
+    .versionBuilder()
+    .asDraft({ startDate: new Date('2019-01-01') })
+    .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 123 })
+    .insertToDB({ databaseBuilder });
 
   databaseBuilder.factory.buildCorrectAnswersAndKnowledgeElementsForLearningContent.fromAreas({
     learningContent,
@@ -445,12 +440,9 @@ function _createExistingCertifCourseSetup({ learningContent, userId, sessionId, 
 
   databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId, authorizedToStart: true });
 
-  const versionId = databaseBuilder.factory.buildCertificationVersion({
-    startDate: new Date('2020-01-01'),
-    expirationDate: null,
-  }).id;
-  databaseBuilder.factory.buildCertificationVersionTube({
-    tubeId: 'tubeA',
-    versionId,
-  });
+  domainBuilder.certification.configuration
+    .versionBuilder()
+    .asDraft({ startDate: new Date('2020-01-01') })
+    .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+    .insertToDB({ databaseBuilder });
 }

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
@@ -1,6 +1,8 @@
 import { createServer } from '../../../../../../server.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../../tooling/learning-content-builder/index.js';
 import {
   generateAuthenticatedUserRequestHeaders,
@@ -266,11 +268,11 @@ describe('Acceptance | Route | Certification Courses', function () {
       it('should return CREATED (201) and a certification course', async function () {
         // given
         databaseBuilder.factory.buildUser({ id: 1 });
-        databaseBuilder.factory.buildCertificationVersion({ id: 123 });
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId: 123,
-        });
+        domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('1977-10-19') })
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 123 })
+          .insertToDB({ databaseBuilder });
         databaseBuilder.factory.buildSession({ id: 2, accessCode: 'FMKP39' });
         databaseBuilder.factory.buildCertificationCandidate({
           sessionId: 2,

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -1,5 +1,6 @@
 import { createServer } from '../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../test-helper.js';
@@ -53,34 +54,50 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           skillId: 'recSkill0_0',
         });
 
-        databaseBuilder.factory.buildCertificationVersion({
-          startDate: new Date('2009-02-01'),
-          expirationDate: new Date('2010-02-01'),
-          challengesConfiguration: null,
-          globalScoringConfiguration: null,
-          competencesScoringConfiguration: null,
-          minimumAnswersRequiredToValidateACertification: 1,
-        });
-        const currentVersion = databaseBuilder.factory.buildCertificationVersion({
-          startDate: new Date('2010-02-01'),
-          expirationDate: null,
-          globalScoringConfiguration: [
-            { bounds: { max: -4, min: -8 }, meshLevel: 0 },
-            { bounds: { max: 8, min: -4 }, meshLevel: 1 },
-          ],
-          competencesScoringConfiguration: [
-            {
-              competence: '1.1',
-              competenceId: 'recCompetence0',
-              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+        domainBuilder.certification.configuration
+          .versionBuilder()
+          .asArchived({
+            startDate: new Date('2009-02-01'),
+            expirationDate: new Date('2010-02-01'),
+          })
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['tubeA'],
+            minimumAnswersRequiredToValidateACertification: 1,
+          })
+          .insertToDB({ databaseBuilder });
+
+        const currentVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2010-02-01') })
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['tubeA'],
+            minimumAnswersRequiredToValidateACertification: 1,
+            challengesConfiguration: {
+              maximumAssessmentLength: 32,
+              challengesBetweenSameCompetence: 2,
+              limitToOneQuestionPerTube: true,
+              enablePassageByAllCompetences: true,
+              variationPercent: 0.5,
+              defaultCandidateCapacity: -3,
+              defaultProbabilityToPickChallenge: 51,
             },
-          ],
-          minimumAnswersRequiredToValidateACertification: 1,
-        });
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId: currentVersion.id,
-        });
+            globalScoringConfiguration: [
+              { bounds: { max: -4, min: -8 }, meshLevel: 0 },
+              { bounds: { max: 8, min: -4 }, meshLevel: 1 },
+            ],
+            competencesScoringConfiguration: [
+              {
+                competence: '1.1',
+                competenceId: 'recCompetence0',
+                values: [
+                  { bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
+                ],
+              },
+            ],
+          })
+          .insertToDB({ databaseBuilder });
 
         const candidate = databaseBuilder.factory.buildUser();
         const sessionId = databaseBuilder.factory.buildSession({
@@ -207,38 +224,54 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           delta: 4.4,
         });
 
-        const archivedVersion = databaseBuilder.factory.buildCertificationVersion({
-          startDate: new Date('2010-02-01'),
-          expirationDate: new Date('2024-02-01'),
-          challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
-            maximumAssessmentLength: 1,
-            defaultCandidateCapacity: -3,
-          }),
-          globalScoringConfiguration: [
-            { bounds: { max: -4, min: -8 }, meshLevel: 0 },
-            { bounds: { max: 8, min: -4 }, meshLevel: 1 },
-          ],
-          competencesScoringConfiguration: [
-            {
-              competence: '1.1',
-              competenceId: 'recCompetence0',
-              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
-            },
-          ],
-          minimumAnswersRequiredToValidateACertification: 1,
-        });
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId: archivedVersion.id,
-        });
+        const archivedVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asArchived({ startDate: new Date('2010-02-01'), expirationDate: new Date('2024-02-01') })
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['tubeA'],
+            minimumAnswersRequiredToValidateACertification: 1,
+            challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
+              maximumAssessmentLength: 1,
+              defaultCandidateCapacity: -3,
+            }),
+            globalScoringConfiguration: [
+              { bounds: { max: -4, min: -8 }, meshLevel: 0 },
+              { bounds: { max: 8, min: -4 }, meshLevel: 1 },
+            ],
+            competencesScoringConfiguration: [
+              {
+                competence: '1.1',
+                competenceId: 'recCompetence0',
+                values: [
+                  { bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
+                ],
+              },
+            ],
+          })
+          .insertToDB({ databaseBuilder });
 
-        databaseBuilder.factory.buildCertificationVersion({
-          startDate: new Date('2024-02-01'),
-          expirationDate: null,
-          globalScoringConfiguration: null,
-          competencesScoringConfiguration: null,
-          minimumAnswersRequiredToValidateACertification: 1,
-        });
+        domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({
+            startDate: new Date('2024-02-01'),
+          })
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['tubeA'],
+            minimumAnswersRequiredToValidateACertification: 1,
+            challengesConfiguration: {
+              maximumAssessmentLength: 32,
+              challengesBetweenSameCompetence: 2,
+              limitToOneQuestionPerTube: true,
+              enablePassageByAllCompetences: true,
+              variationPercent: 0.5,
+              defaultCandidateCapacity: -3,
+              defaultProbabilityToPickChallenge: 51,
+            },
+          })
+          .withRealisticScoringConfigurations()
+          .insertToDB({ databaseBuilder });
 
         const candidate = databaseBuilder.factory.buildUser();
         const sessionId = databaseBuilder.factory.buildSession({

--- a/api/tests/certification/evaluation/acceptance/application/scenario-simulator-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/scenario-simulator-route_test.js
@@ -1,7 +1,9 @@
 import { createServer } from '../../../../../server.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { PIX_ADMIN } from '../../../../../src/shared/constants.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 import { parseNDJSON } from '../../../../tooling/test-utils/json.js';
 
@@ -19,21 +21,22 @@ describe('Acceptance | Controller | scenario-simulator-controller', function () 
       role: SUPER_ADMIN,
     });
 
-    const version = databaseBuilder.factory.buildCertificationVersion({
-      challengesConfiguration: {
-        maximumAssessmentLength: 2,
-        challengesBetweenSameCompetence: 2,
-        limitToOneQuestionPerTube: false,
-        enablePassageByAllCompetences: false,
-        variationPercent: 0.5,
-        defaultCandidateCapacity: -3,
-        defaultProbabilityToPickChallenge: 51,
-      },
-    });
-    databaseBuilder.factory.buildCertificationVersionTube({
-      tubeId: 'tubeA',
-      versionId: version.id,
-    });
+    const version = domainBuilder.certification.configuration
+      .versionBuilder()
+      .withParameters({
+        scope: SCOPES.CORE,
+        tubeIds: ['tubeA'],
+        challengesConfiguration: {
+          maximumAssessmentLength: 2,
+          challengesBetweenSameCompetence: 2,
+          limitToOneQuestionPerTube: false,
+          enablePassageByAllCompetences: false,
+          variationPercent: 0.5,
+          defaultCandidateCapacity: -3,
+          defaultProbabilityToPickChallenge: 51,
+        },
+      })
+      .insertToDB({ databaseBuilder });
 
     adminAuthorizationHeaders = generateAuthenticatedUserRequestHeaders({ userId: adminId });
 

--- a/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
@@ -1,7 +1,9 @@
 import { createServer } from '../../../../server.js';
+import { SCOPES } from '../../../../src/certification/shared/domain/models/Scopes.js';
 import { PIX_ADMIN } from '../../../../src/shared/constants.js';
 import { expect } from '../../../test-helper.js';
 import { databaseBuilder } from '../../../tooling/databases.js';
+import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
 import { buildLearningContent as learningContentBuilder } from '../../../tooling/learning-content-builder/index.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../tooling/test-utils/http-server.js';
 
@@ -454,29 +456,41 @@ describe('Certification | Evaluation | Acceptance | scoring-and-capacity-simulat
             role: PIX_ADMIN.ROLES.SUPER_ADMIN,
           });
 
-          databaseBuilder.factory.buildCertificationVersion({
-            id: 123,
-            competencesScoringConfiguration: [
-              {
-                competence: '1.1',
-                competenceId: 'recCompetence0',
-                values: [
-                  { bounds: { max: -2, min: -8 }, competenceLevel: 0 },
-                  { bounds: { max: -0.5, min: -2 }, competenceLevel: 1 },
-                  { bounds: { max: 0.6, min: -0.5 }, competenceLevel: 2 },
-                  { bounds: { max: 1.5, min: 0.6 }, competenceLevel: 3 },
-                  { bounds: { max: 2.25, min: 1.5 }, competenceLevel: 4 },
-                  { bounds: { max: 3.1, min: 2.25 }, competenceLevel: 5 },
-                  { bounds: { max: 4, min: 3.1 }, competenceLevel: 6 },
-                  { bounds: { max: 8, min: 4 }, competenceLevel: 7 },
-                ],
+          domainBuilder.certification.configuration
+            .versionBuilder()
+            .asActive({ startDate: new Date('1977-10-19') })
+            .withRealisticScoringConfigurations()
+            .withParameters({
+              scope: SCOPES.CORE,
+              tubeIds: ['tubeA'],
+              id: 123,
+              challengesConfiguration: {
+                maximumAssessmentLength: 32,
+                challengesBetweenSameCompetence: 2,
+                limitToOneQuestionPerTube: true,
+                enablePassageByAllCompetences: true,
+                variationPercent: 0.5,
+                defaultCandidateCapacity: -3,
+                defaultProbabilityToPickChallenge: 51,
               },
-            ],
-          });
-          databaseBuilder.factory.buildCertificationVersionTube({
-            tubeId: 'tubeA',
-            versionId: 123,
-          });
+              competencesScoringConfiguration: [
+                {
+                  competence: '1.1',
+                  competenceId: 'recCompetence0',
+                  values: [
+                    { bounds: { max: -2, min: -8 }, competenceLevel: 0 },
+                    { bounds: { max: -0.5, min: -2 }, competenceLevel: 1 },
+                    { bounds: { max: 0.6, min: -0.5 }, competenceLevel: 2 },
+                    { bounds: { max: 1.5, min: 0.6 }, competenceLevel: 3 },
+                    { bounds: { max: 2.25, min: 1.5 }, competenceLevel: 4 },
+                    { bounds: { max: 3.1, min: 2.25 }, competenceLevel: 5 },
+                    { bounds: { max: 4, min: 3.1 }, competenceLevel: 6 },
+                    { bounds: { max: 8, min: 4 }, competenceLevel: 7 },
+                  ],
+                },
+              ],
+            })
+            .insertToDB({ databaseBuilder });
           await databaseBuilder.commit();
 
           const options = {

--- a/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
@@ -2,11 +2,13 @@ import { CertificationCompletedJob } from '../../../../../../src/certification/e
 import { usecases } from '../../../../../../src/certification/evaluation/domain/usecases/index.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../../tooling/learning-content-builder/index.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
@@ -137,30 +139,41 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
     databaseBuilder.factory.learningContent.build(learningContentObjects);
 
-    certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
-      challengesConfiguration: { maximumAssessmentLength: 10 },
-      minimumAnswersRequiredToValidateACertification: 10,
-      competencesScoringConfiguration: [
-        {
-          competence: '1.1',
-          competenceId: 'recCompetence0',
-          values: [
-            { bounds: { max: -2, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
-            { bounds: { max: -1, min: -2 }, competenceLevel: 1 },
-            { bounds: { max: 0.5, min: -1 }, competenceLevel: 2 },
-            { bounds: { max: 1, min: 0.5 }, competenceLevel: 3 },
-            { bounds: { max: 2, min: 1 }, competenceLevel: 4 },
-            { bounds: { max: 3, min: 2 }, competenceLevel: 5 },
-            { bounds: { max: 4, min: 3 }, competenceLevel: 6 },
-            { bounds: { max: Number.MAX_SAFE_INTEGER, min: 4 }, competenceLevel: 7 },
-          ],
+    certificationVersionId = domainBuilder.certification.configuration
+      .versionBuilder()
+      .asActive({ startDate: new Date('1977-10-19') })
+      .withRealisticScoringConfigurations()
+      .withParameters({
+        scope: SCOPES.CORE,
+        tubeIds: ['tubeA'],
+        minimumAnswersRequiredToValidateACertification: 10,
+        challengesConfiguration: {
+          maximumAssessmentLength: 10,
+          challengesBetweenSameCompetence: 2,
+          limitToOneQuestionPerTube: true,
+          enablePassageByAllCompetences: true,
+          variationPercent: 0.5,
+          defaultCandidateCapacity: -3,
+          defaultProbabilityToPickChallenge: 51,
         },
-      ],
-    }).id;
-    databaseBuilder.factory.buildCertificationVersionTube({
-      tubeId: 'tubeA',
-      versionId: certificationVersionId,
-    });
+        competencesScoringConfiguration: [
+          {
+            competence: '1.1',
+            competenceId: 'recCompetence0',
+            values: [
+              { bounds: { max: -2, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
+              { bounds: { max: -1, min: -2 }, competenceLevel: 1 },
+              { bounds: { max: 0.5, min: -1 }, competenceLevel: 2 },
+              { bounds: { max: 1, min: 0.5 }, competenceLevel: 3 },
+              { bounds: { max: 2, min: 1 }, competenceLevel: 4 },
+              { bounds: { max: 3, min: 2 }, competenceLevel: 5 },
+              { bounds: { max: 4, min: 3 }, competenceLevel: 6 },
+              { bounds: { max: Number.MAX_SAFE_INTEGER, min: 4 }, competenceLevel: 7 },
+            ],
+          },
+        ],
+      })
+      .insertToDB({ databaseBuilder }).id;
 
     await databaseBuilder.commit();
   });
@@ -351,23 +364,28 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
       const limitDate = new Date('2025-01-01T00:00:00Z');
       certifiableUserId = databaseBuilder.factory.buildUser().id;
 
-      eduCertificationVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: Frameworks.EDU_1ER_DEGRE,
-        challengesConfiguration: { maximumAssessmentLength: 10 },
-        minimumAnswersRequiredToValidateACertification: 10,
-        globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: 10, max: 20 } }],
-        competencesScoringConfiguration: [
-          {
-            competence: '1.1',
-            competenceId: 'recCompetence0',
-            values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+      eduCertificationVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({
+          scope: Frameworks.EDU_1ER_DEGRE,
+          tubeIds: ['tubeA'],
+          minimumAnswersRequiredToValidateACertification: 10,
+          challengesConfiguration: {
+            maximumAssessmentLength: 10,
+            challengesBetweenSameCompetence: 2,
+            variationPercent: 0.5,
+            defaultCandidateCapacity: -3,
           },
-        ],
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: eduCertificationVersion.id,
-      });
+          globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: 10, max: 20 } }],
+          competencesScoringConfiguration: [
+            {
+              competence: '1.1',
+              competenceId: 'recCompetence0',
+              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+            },
+          ],
+        })
+        .insertToDB({ databaseBuilder });
 
       const session = databaseBuilder.factory.buildSession({
         version: AlgorithmEngineVersion.V3,
@@ -434,23 +452,30 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
         const limitDate = new Date('2025-01-01T00:00:00Z');
         certifiableUserId = databaseBuilder.factory.buildUser().id;
 
-        droitCertificationVersion = databaseBuilder.factory.buildCertificationVersion({
-          scope: Frameworks.DROIT,
-          challengesConfiguration: { maximumAssessmentLength: 10 },
-          minimumAnswersRequiredToValidateACertification: 10,
-          globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: 10, max: 20 } }],
-          competencesScoringConfiguration: [
-            {
-              competence: '1.1',
-              competenceId: 'recCompetence0',
-              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+        droitCertificationVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({
+            scope: Frameworks.DROIT,
+            tubeIds: ['tubeA'],
+            minimumAnswersRequiredToValidateACertification: 10,
+            challengesConfiguration: {
+              maximumAssessmentLength: 10,
+              challengesBetweenSameCompetence: 2,
+              variationPercent: 0.5,
+              defaultCandidateCapacity: -3,
             },
-          ],
-        });
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId: droitCertificationVersion.id,
-        });
+            globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: 10, max: 20 } }],
+            competencesScoringConfiguration: [
+              {
+                competence: '1.1',
+                competenceId: 'recCompetence0',
+                values: [
+                  { bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
+                ],
+              },
+            ],
+          })
+          .insertToDB({ databaseBuilder });
 
         const session = databaseBuilder.factory.buildSession({
           version: AlgorithmEngineVersion.V3,

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
@@ -12,7 +12,10 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
 
   beforeEach(async function () {
     userId = databaseBuilder.factory.buildUser().id;
-    versionId = databaseBuilder.factory.buildCertificationVersion().id;
+    versionId = domainBuilder.certification.configuration
+      .versionBuilder()
+      .withParameters({ scope: Frameworks.CORE, tubeIds: [] })
+      .insertToDB({ databaseBuilder }).id;
     const session = databaseBuilder.factory.buildSession();
     const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
       sessionId: session.id,

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
@@ -502,10 +502,14 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
 
     it('returns only valid calibrated flash compatible challenges', async function () {
       // given
-      const version = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.CORE });
-      const otherVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: SCOPES.CORE,
-      });
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+        .insertToDB({ databaseBuilder });
+      const otherVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+        .insertToDB({ databaseBuilder });
 
       challengesLC.push({
         id: 'challengeForComplementaryCertification',
@@ -570,7 +574,10 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
         it('should return an empty array', async function () {
           // given
           databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
-          const version = databaseBuilder.factory.buildCertificationVersion();
+          const version = domainBuilder.certification.configuration
+            .versionBuilder()
+            .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+            .insertToDB({ databaseBuilder });
           await databaseBuilder.commit();
 
           // when
@@ -593,7 +600,10 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
           challengesLC.push(challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson);
           challengesLC.push(challengeData09_skill03_qcu_archive_flashCompatible_fr_noEmbedJson);
           databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
-          const version = databaseBuilder.factory.buildCertificationVersion();
+          const version = domainBuilder.certification.configuration
+            .versionBuilder()
+            .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+            .insertToDB({ databaseBuilder });
 
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
             challengeId: challengesLC[3].id,
@@ -641,9 +651,10 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
     context('when at least one challenge is not found in cert referential amongst the provided ids', function () {
       it('should throw a NotFound error', async function () {
         // given
-        const versionWithoutChallenges = databaseBuilder.factory.buildCertificationVersion({
-          scope: SCOPES.CORE,
-        });
+        const versionWithoutChallenges = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         // when
@@ -661,9 +672,10 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
     context('when at least one challenge is not found in LCMS amongst the provided ids', function () {
       it('should throw a NotFound error', async function () {
         // given
-        const version = databaseBuilder.factory.buildCertificationVersion({
-          scope: SCOPES.CORE,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
         const challengeCalibrationNotInLCMS = databaseBuilder.factory.buildCertificationFrameworksChallenge({
           challengeId: 'challengeIdPipeauPipette',
           versionId: version.id,
@@ -700,10 +712,14 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       });
 
       it('should return only the challenges for given locale', async function () {
-        const versionActive = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.CORE });
-        const otherVersion = databaseBuilder.factory.buildCertificationVersion({
-          scope: SCOPES.CORE,
-        });
+        const versionActive = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
+        const otherVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
 
         challengesLC.push({
           id: 'challengeForComplementaryCertification',
@@ -807,13 +823,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
           // given
           databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
-          const { id } = databaseBuilder.factory.buildCertificationVersion({
-            startDate: new Date('1977-10-19'),
-            expirationDate: new Date('1977-10-20'),
-          });
-          const archivedVersionWithNonCompatibleChallenge = domainBuilder.certification.configuration.buildVersion({
-            id,
-          });
+          const archivedVersionWithNonCompatibleChallenge = domainBuilder.certification.configuration
+            .versionBuilder()
+            .asArchived({ startDate: new Date('1977-10-19'), expirationDate: new Date('1977-10-20') })
+            .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+            .insertToDB({ databaseBuilder });
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
             challengeId: challengesLC[0].id,
             versionId: archivedVersionWithNonCompatibleChallenge.id,
@@ -821,10 +835,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             difficulty: null,
           });
 
-          const activeVersionWithEligibleChallenge = databaseBuilder.factory.buildCertificationVersion({
-            startDate: new Date('1977-10-20'),
-            expirationDate: null,
-          });
+          const activeVersionWithEligibleChallenge = domainBuilder.certification.configuration
+            .versionBuilder()
+            .asActive({ startDate: new Date('1977-10-20') })
+            .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+            .insertToDB({ databaseBuilder });
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
             challengeId: challengesLC[0].id,
             versionId: activeVersionWithEligibleChallenge.id,
@@ -851,11 +866,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
           challengesLC.push(challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson);
           databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
-          const { id } = databaseBuilder.factory.buildCertificationVersion({
-            startDate: new Date('1977-10-19'),
-            expirationDate: new Date('1977-10-20'),
-          });
-          const archivedVersionWithEligibleChallenge = domainBuilder.certification.configuration.buildVersion({ id });
+          const archivedVersionWithEligibleChallenge = domainBuilder.certification.configuration
+            .versionBuilder()
+            .asArchived({ startDate: new Date('1977-10-19'), expirationDate: new Date('1977-10-20') })
+            .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+            .insertToDB({ databaseBuilder });
           const expectedDiscriminant = 2.221;
           const expectedDifficulty = 3.554;
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
@@ -879,10 +894,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             difficulty: notACompartibleDifficulty,
           });
 
-          const activeVersionWithNonCompatibleChallenge = databaseBuilder.factory.buildCertificationVersion({
-            startDate: new Date('1977-10-20'),
-            expirationDate: null,
-          });
+          const activeVersionWithNonCompatibleChallenge = domainBuilder.certification.configuration
+            .versionBuilder()
+            .asActive({ startDate: new Date('1977-10-20') })
+            .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+            .insertToDB({ databaseBuilder });
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
             challengeId: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
             versionId: activeVersionWithNonCompatibleChallenge.id,
@@ -925,10 +941,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             // given
             databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
-            const archivedVersionWithCompatibleChallenge = databaseBuilder.factory.buildCertificationVersion({
-              startDate: new Date('1977-10-19'),
-              expirationDate: new Date('1977-10-20'),
-            });
+            const archivedVersionWithCompatibleChallenge = domainBuilder.certification.configuration
+              .versionBuilder()
+              .asArchived({ startDate: new Date('1977-10-19'), expirationDate: new Date('1977-10-20') })
+              .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+              .insertToDB({ databaseBuilder });
 
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
               challengeId: challengesLC[0].id,
@@ -937,11 +954,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
               difficulty: 3.5,
             });
 
-            const { id } = databaseBuilder.factory.buildCertificationVersion({
-              startDate: new Date('1977-10-20'),
-              expirationDate: null,
-            });
-            const activeVersionWithNoEligibleChallenge = domainBuilder.certification.configuration.buildVersion({ id });
+            const activeVersionWithNoEligibleChallenge = domainBuilder.certification.configuration
+              .versionBuilder()
+              .asActive({ startDate: new Date('1977-10-20') })
+              .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+              .insertToDB({ databaseBuilder });
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
               challengeId: challengesLC[0].id,
               versionId: activeVersionWithNoEligibleChallenge.id,
@@ -968,10 +985,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             challengesLC.push(challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson);
             databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
-            const archivedVersionWithNonCompatibleChallenge = databaseBuilder.factory.buildCertificationVersion({
-              startDate: new Date('1977-10-19'),
-              expirationDate: new Date('1977-10-20'),
-            });
+            const archivedVersionWithNonCompatibleChallenge = domainBuilder.certification.configuration
+              .versionBuilder()
+              .asArchived({ startDate: new Date('1977-10-19'), expirationDate: new Date('1977-10-20') })
+              .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+              .insertToDB({ databaseBuilder });
 
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
               challengeId: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
@@ -992,11 +1010,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
               difficulty: null,
             });
 
-            const { id } = databaseBuilder.factory.buildCertificationVersion({
-              startDate: new Date('1977-10-20'),
-              expirationDate: null,
-            });
-            const activeVersionWithEligibleChallenge = domainBuilder.certification.configuration.buildVersion({ id });
+            const activeVersionWithEligibleChallenge = domainBuilder.certification.configuration
+              .versionBuilder()
+              .asActive({ startDate: new Date('1977-10-20') })
+              .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+              .insertToDB({ databaseBuilder });
             const expectedDiscriminant = 2.222;
             const expectedDifficulty = 3.555;
             databaseBuilder.factory.buildCertificationFrameworksChallenge({

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
@@ -40,37 +40,37 @@ describe('Certification | Evaluation | Integration | Repositories | scoring-conf
       buildFramework({ competenceIndex, origin: 'external' });
       buildFramework({ competenceIndex, origin: PIX_ORIGIN });
 
-      databaseBuilder.factory.buildCertificationVersion({
-        id: 123,
-        startDate: firstConfigurationDate,
-        expirationDate: secondConfigurationDate,
-        globalScoringConfiguration: null,
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 123,
-      });
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({
+          startDate: firstConfigurationDate,
+          expirationDate: secondConfigurationDate,
+        })
+        .withParameters({
+          id: 123,
+          scope: Frameworks.CORE,
+          tubeIds: ['tubeA'],
+          minimumAnswersRequiredToValidateACertification: 0,
+        })
+        .insertToDB({ databaseBuilder });
 
-      databaseBuilder.factory.buildCertificationVersion({
-        id: 456,
-        startDate: secondConfigurationDate,
-        expirationDate: thirdConfigurationDate,
-        competencesScoringConfiguration: secondCompetenceScoringConfiguration,
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 456,
-      });
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asArchived({ startDate: secondConfigurationDate, expirationDate: thirdConfigurationDate })
+        .withRealisticScoringConfigurations()
+        .withParameters({
+          scope: Frameworks.CORE,
+          tubeIds: ['tubeA'],
+          id: 456,
+          competencesScoringConfiguration: secondCompetenceScoringConfiguration,
+        })
+        .insertToDB({ databaseBuilder });
 
-      databaseBuilder.factory.buildCertificationVersion({
-        id: 789,
-        startDate: thirdConfigurationDate,
-        expirationDate: null,
-      });
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId: 789,
-      });
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: thirdConfigurationDate })
+        .withParameters({ scope: Frameworks.CORE, tubeIds: ['tubeA'], id: 789 })
+        .insertToDB({ databaseBuilder });
 
       await databaseBuilder.commit();
     });
@@ -127,17 +127,20 @@ describe('Certification | Evaluation | Integration | Repositories | scoring-conf
       buildFramework({ competenceIndex, origin: 'external' });
       buildFramework({ competenceIndex, origin: PIX_ORIGIN });
 
-      const version = domainBuilder.certification.configuration.buildVersion({
-        id: 1,
-        competencesScoringConfiguration: [
-          {
-            values: [{ bounds: { max: -1, min: -4 }, competenceLevel: 0 }],
-            competence: competenceIndex,
-            competenceId: `${PIX_ORIGIN}Competence`,
-          },
-        ],
-        scope: Frameworks.CORE,
-      });
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({
+          scope: Frameworks.CORE,
+          id: 1,
+          competencesScoringConfiguration: [
+            {
+              values: [{ bounds: { max: -1, min: -4 }, competenceLevel: 0 }],
+              competence: competenceIndex,
+              competenceId: `${PIX_ORIGIN}Competence`,
+            },
+          ],
+        })
+        .build();
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/calibrated-challenge-service_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/calibrated-challenge-service_test.js
@@ -40,9 +40,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | calibrated cha
         const certificationCourseId = 1234;
         const assessmentId = 5678;
 
-        const version = domainBuilder.certification.configuration.buildVersion({
-          startDate: new Date('2025-06-22'),
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2025-06-22') })
+          .withParameters({ id: 1 })
+          .build();
         calibratedChallengeRepository.getAllCalibratedChallenges.withArgs({ version }).resolves(challengeList);
 
         const expectedAskedChallenges = [...challengeList.slice(1)];
@@ -81,9 +83,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | calibrated cha
         // given
         const certificationCourseId = 1234;
         const assessmentId = 5678;
-        const version = domainBuilder.certification.configuration.buildVersion({
-          startDate: new Date('2025-06-22'),
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2025-06-22') })
+          .withParameters({ id: 1 })
+          .build();
         calibratedChallengeRepository.getAllCalibratedChallenges.withArgs({ version }).resolves(challengeList);
 
         const challengeWithValidatedLiveAlert = domainBuilder.buildChallenge({

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-certification-course_test.js
@@ -29,10 +29,10 @@ describe('Unit | UseCase | get-certification-course', function () {
       getById: sinon.stub(),
     };
 
-    version = domainBuilder.certification.configuration.buildVersion({
-      id: 123,
-      challengesConfiguration: { maximumAssessmentLength: 42 },
-    });
+    version = domainBuilder.certification.configuration
+      .versionBuilder()
+      .withParameters({ id: 123, challengesConfiguration: { maximumAssessmentLength: 42 } })
+      .build();
   });
 
   it('should get the certificationCourse with numberOfChallenges from version', async function () {

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -58,7 +58,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         getCapacityAndErrorRate: sinon.stub(),
       };
       assessmentId = 777;
-      version = domainBuilder.certification.configuration.buildVersion();
+      version = domainBuilder.certification.configuration.versionBuilder().withParameters({ id: 1 }).build();
 
       assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
         certificationCourseId: 123,
@@ -277,7 +277,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           id: 'nextCalibratedChallenge',
           blindnessCompatibility: 'KO',
           status: 'validé',
-          skill: domainBuilder.buildSkill({ id: 'nottAnsweredSkill' }),
+          skill: domainBuilder.buildSkill({ id: 'nottAnsweredSkill', tubeId: 'recTUBNotAnswered' }),
         });
         const alreadyAnsweredChallenge = domainBuilder.buildChallenge({
           id: 'alreadyAnsweredChallenge',
@@ -536,9 +536,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           getCapacityAndErrorRate: sinon.stub(),
         };
 
-        version = domainBuilder.certification.configuration.buildVersion({
-          challengesConfiguration: { maximumAssessmentLength: 1 },
-        });
+        version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ id: 1, challengesConfiguration: { maximumAssessmentLength: 1 } })
+          .build();
         versionApi.getById.withArgs({ id: version.id }).resolves(version);
 
         assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
@@ -602,9 +603,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             //given
             const nextCalibratedChallenge = domainBuilder.certification.evaluation.buildCalibratedChallenge();
 
-            version = domainBuilder.certification.configuration.buildVersion({
-              challengesConfiguration: flashConfiguration,
-            });
+            version = domainBuilder.certification.configuration
+              .versionBuilder()
+              .withParameters({ id: 1, challengesConfiguration: flashConfiguration })
+              .build();
             versionApi.getById.withArgs({ id: version.id }).resolves(version);
 
             assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
@@ -693,7 +695,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .withArgs(assessmentSheet.certificationCourseId, [])
           .resolves(null);
 
-        version = domainBuilder.certification.configuration.buildVersion({ scope: Frameworks.EDU_CPE });
+        version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: Frameworks.EDU_CPE, id: 1 })
+          .build();
         versionApi.getById.withArgs({ id: assessmentSheet.versionId }).resolves(version);
 
         calibratedChallengeRepository.findActiveFlashCompatible.resolves([]);

--- a/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -155,7 +155,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               .withArgs({ sessionId: 1, userId: 2 })
               .resolves(candidateNotAuthorizedToStart);
 
-            const version = domainBuilder.certification.configuration.buildVersion();
+            const version = domainBuilder.certification.configuration
+              .versionBuilder()
+              .withParameters({ id: 1 })
+              .build();
             versionApi.getByFrameworkAndDate.resolves(version);
 
             // when
@@ -200,7 +203,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               .withArgs({ userId: 2, sessionId: 1 })
               .resolves(existingCertificationCourse);
 
-            const version = domainBuilder.certification.configuration.buildVersion();
+            const version = domainBuilder.certification.configuration
+              .versionBuilder()
+              .withParameters({ id: 1 })
+              .build();
             versionApi.getByFrameworkAndDate.resolves(version);
 
             // when
@@ -287,9 +293,13 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               .withArgs({ userId: 2, sessionId: 1 })
               .resolves(existingCertificationCourse);
 
-            const version = domainBuilder.certification.configuration.buildVersion({
-              challengesConfiguration: { maximumAssessmentLength: 25, defaultCandidateCapacity: -3 },
-            });
+            const version = domainBuilder.certification.configuration
+              .versionBuilder()
+              .withParameters({
+                id: 1,
+                challengesConfiguration: { maximumAssessmentLength: 25, defaultCandidateCapacity: -3 },
+              })
+              .build();
             versionApi.getByFrameworkAndDate.resolves(version);
 
             // when
@@ -346,9 +356,13 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               .withArgs({ userId: 2, sessionId: 1 })
               .resolves(existingCertificationCourse);
 
-            const version = domainBuilder.certification.configuration.buildVersion({
-              challengesConfiguration: { maximumAssessmentLength: 25, defaultCandidateCapacity: -3 },
-            });
+            const version = domainBuilder.certification.configuration
+              .versionBuilder()
+              .withParameters({
+                id: 1,
+                challengesConfiguration: { maximumAssessmentLength: 25, defaultCandidateCapacity: -3 },
+              })
+              .build();
             versionApi.getByFrameworkAndDate.resolves(version);
 
             // when
@@ -408,7 +422,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               });
               assessmentSheetRepository.findByCertificationCourseId.withArgs(99).resolves(assessmentSheet);
 
-              const version = domainBuilder.certification.configuration.buildVersion();
+              const version = domainBuilder.certification.configuration
+                .versionBuilder()
+                .withParameters({ id: 1 })
+                .build();
               versionApi.getByFrameworkAndDate.resolves(version);
 
               // when
@@ -458,7 +475,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                 assessmentSheetRepository.findByCertificationCourseId.withArgs(99).resolves(null);
 
-                const version = domainBuilder.certification.configuration.buildVersion();
+                const version = domainBuilder.certification.configuration
+                  .versionBuilder()
+                  .withParameters({ id: 1 })
+                  .build();
                 versionApi.getByFrameworkAndDate.resolves(version);
 
                 // when
@@ -517,7 +537,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 .onCall(1)
                 .resolves(certificationCourseCreatedMeanwhile);
 
-              const version = domainBuilder.certification.configuration.buildVersion();
+              const version = domainBuilder.certification.configuration
+                .versionBuilder()
+                .withParameters({ id: 1 })
+                .build();
               versionApi.getByFrameworkAndDate.resolves(version);
 
               // when
@@ -546,9 +569,13 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
             beforeEach(function () {
               user = domainBuilder.buildUser({ id: 2, lang: FRENCH_SPOKEN });
 
-              version = domainBuilder.certification.configuration.buildVersion({
-                challengesConfiguration: { maximumAssessmentLength: 32, defaultCandidateCapacity: -3 },
-              });
+              version = domainBuilder.certification.configuration
+                .versionBuilder()
+                .withParameters({
+                  id: 1,
+                  challengesConfiguration: { maximumAssessmentLength: 32, defaultCandidateCapacity: -3 },
+                })
+                .build();
               versionApi.getByFrameworkAndDate.resolves(version);
             });
 
@@ -559,7 +586,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 accessCode: 'accessCode',
               });
               sessionRepository.get.withArgs({ id: foundSession.id }).resolves(foundSession);
-              const certificationVersion = domainBuilder.certification.configuration.buildVersion();
+              const certificationVersion = domainBuilder.certification.configuration
+                .versionBuilder()
+                .withParameters({ id: 1 })
+                .build();
 
               const foundCandidate = domainBuilder.certification.evaluation.buildCandidate({
                 userId: user.id,
@@ -638,7 +668,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 time: '12:00:00',
               });
               sessionRepository.get.withArgs({ id: foundSession.id }).resolves(foundSession);
-              const certificationVersion = domainBuilder.certification.configuration.buildVersion();
+              const certificationVersion = domainBuilder.certification.configuration
+                .versionBuilder()
+                .withParameters({ id: 1 })
+                .build();
 
               const foundCandidate = domainBuilder.certification.evaluation.buildCandidate({
                 userId: user.id,
@@ -821,7 +854,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   version: 3,
                 });
                 sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
-                const certificationVersion = domainBuilder.certification.configuration.buildVersion();
+                const certificationVersion = domainBuilder.certification.configuration
+                  .versionBuilder()
+                  .withParameters({ id: 1 })
+                  .build();
 
                 const foundCandidate = domainBuilder.certification.evaluation.buildCandidate({
                   userId,
@@ -910,7 +946,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   accessCode: 'accessCode',
                 });
                 sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
-                const certificationVersion = domainBuilder.certification.configuration.buildVersion();
+                const certificationVersion = domainBuilder.certification.configuration
+                  .versionBuilder()
+                  .withParameters({ id: 1 })
+                  .build();
 
                 const foundCandidate = domainBuilder.certification.evaluation.buildCandidate({
                   userId: 2,
@@ -988,7 +1027,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
                     },
                   );
-                  const certificationVersion = domainBuilder.certification.configuration.buildVersion();
+                  const certificationVersion = domainBuilder.certification.configuration
+                    .versionBuilder()
+                    .withParameters({ id: 1 })
+                    .build();
 
                   const foundSession = domainBuilder.certification.evaluation.buildSession.ongoing({
                     id: 1,
@@ -1119,7 +1161,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     const cleaCertification = domainBuilder.certification.shared.buildComplementaryCertification({
                       key: ComplementaryCertificationKeys.CLEA,
                     });
-                    const certificationVersion = domainBuilder.certification.configuration.buildVersion();
+                    const certificationVersion = domainBuilder.certification.configuration
+                      .versionBuilder()
+                      .withParameters({ id: 1 })
+                      .build();
 
                     const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
                       badgeKey: 'CLEA_BADGE_1',
@@ -1222,7 +1267,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       const cleaCertification = domainBuilder.certification.shared.buildComplementaryCertification({
                         key: ComplementaryCertificationKeys.CLEA,
                       });
-                      const certificationVersion = domainBuilder.certification.configuration.buildVersion();
+                      const certificationVersion = domainBuilder.certification.configuration
+                        .versionBuilder()
+                        .withParameters({ id: 1 })
+                        .build();
 
                       const foundSession = domainBuilder.certification.evaluation.buildSession.ongoing({
                         id: 1,

--- a/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
@@ -148,7 +148,7 @@ function stubVersionApi() {
   const versionApi = {
     getById: sinon.stub(),
   };
-  const version = domainBuilder.certification.configuration.buildVersion();
+  const version = domainBuilder.certification.configuration.versionBuilder().withParameters({ id: 1 }).build();
   versionApi.getById.resolves(version);
 
   return versionApi;

--- a/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -17,11 +17,10 @@ describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', functi
       const accessibilityAdjustmentNeeded = false;
       const versionId = 1;
       const challengesConfiguration = { minimumEstimatedSuccessRateRanges: [], defaultCandidateCapacity: -1 };
-      const version = domainBuilder.certification.configuration.buildVersion({
-        id: versionId,
-        scope: SCOPES.PIX_PLUS_DROIT,
-        challengesConfiguration,
-      });
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope: SCOPES.PIX_PLUS_DROIT, id: versionId, challengesConfiguration })
+        .build();
 
       const calibratedChallengeRepository = { findActiveFlashCompatible: sinon.stub() };
 

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -1,11 +1,13 @@
 import { createServer } from '../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { PIX_ADMIN } from '../../../../../src/shared/constants.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
@@ -154,35 +156,34 @@ describe('Certification | Session-management | Acceptance | Application | Routes
     context('when certification is v3', function () {
       it('should create a new cancelled assessment-result', async function () {
         // given
-        const versionId = databaseBuilder.factory.buildCertificationVersion({
-          startDate: new Date('2024-01-14'),
-          competencesScoringConfiguration: [
-            {
-              competence: 'index Compétence A',
-              competenceId: 'index Compétence A',
-              values: [
-                {
-                  bounds: {
-                    max: 0,
-                    min: -5,
-                  },
-                  competenceLevel: 0,
-                },
-                {
-                  bounds: {
-                    max: 5,
-                    min: 0,
-                  },
-                  competenceLevel: 1,
-                },
-              ],
+        const versionId = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2024-01-14') })
+          .withRealisticScoringConfigurations()
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['tubeA'],
+            challengesConfiguration: {
+              maximumAssessmentLength: 32,
+              challengesBetweenSameCompetence: 2,
+              limitToOneQuestionPerTube: true,
+              enablePassageByAllCompetences: true,
+              variationPercent: 0.5,
+              defaultCandidateCapacity: -3,
+              defaultProbabilityToPickChallenge: 51,
             },
-          ],
-        }).id;
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId,
-        });
+            competencesScoringConfiguration: [
+              {
+                competence: 'index Compétence A',
+                competenceId: 'index Compétence A',
+                values: [
+                  { bounds: { max: 0, min: -5 }, competenceLevel: 0 },
+                  { bounds: { max: 5, min: 0 }, competenceLevel: 1 },
+                ],
+              },
+            ],
+          })
+          .insertToDB({ databaseBuilder }).id;
         const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
         const session = databaseBuilder.factory.buildSession({
           version: AlgorithmEngineVersion.V3,
@@ -284,39 +285,35 @@ describe('Certification | Session-management | Acceptance | Application | Routes
   describe('PATCH /api/admin/certification-courses/{certificationCourseId}/uncancel', function () {
     it('should uncancel the certification with a new assessment-result', async function () {
       // given
-      const versionId = databaseBuilder.factory.buildCertificationVersion({
-        startDate: new Date('2024-01-14'),
-        challengesConfiguration: {
-          maximumAssessmentLength: 1,
-        },
-        competencesScoringConfiguration: [
-          {
-            competence: 'index Compétence A',
-            competenceId: 'index Compétence A',
-            values: [
-              {
-                bounds: {
-                  max: 0,
-                  min: -5,
-                },
-                competenceLevel: 0,
-              },
-              {
-                bounds: {
-                  max: 5,
-                  min: 0,
-                },
-                competenceLevel: 1,
-              },
-            ],
+      const versionId = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2024-01-14') })
+        .withRealisticScoringConfigurations()
+        .withParameters({
+          scope: SCOPES.CORE,
+          tubeIds: ['tubeA'],
+          minimumAnswersRequiredToValidateACertification: 1,
+          challengesConfiguration: {
+            maximumAssessmentLength: 1,
+            challengesBetweenSameCompetence: 2,
+            limitToOneQuestionPerTube: true,
+            enablePassageByAllCompetences: true,
+            variationPercent: 0.5,
+            defaultCandidateCapacity: -3,
+            defaultProbabilityToPickChallenge: 51,
           },
-        ],
-        minimumAnswersRequiredToValidateACertification: 1,
-      }).id;
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId,
-      });
+          competencesScoringConfiguration: [
+            {
+              competence: 'index Compétence A',
+              competenceId: 'index Compétence A',
+              values: [
+                { bounds: { max: 0, min: -5 }, competenceLevel: 0 },
+                { bounds: { max: 5, min: 0 }, competenceLevel: 1 },
+              ],
+            },
+          ],
+        })
+        .insertToDB({ databaseBuilder }).id;
       const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
       const session = databaseBuilder.factory.buildSession({
         version: AlgorithmEngineVersion.V3,

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -42,19 +42,23 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         server = await createServer();
         const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
 
-        const versionId = databaseBuilder.factory.buildCertificationVersion({
-          scope: 'CORE',
-          startDate: new Date('2019-01-01'),
-          expirationDate: null,
-          challengesConfiguration: {
-            maximumAssessmentLength: 10,
-            defaultCandidateCapacity: -3,
-          },
-        }).id;
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId,
-        });
+        const versionId = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2019-01-01') })
+          .withParameters({
+            scope: 'CORE',
+            tubeIds: ['tubeA'],
+            challengesConfiguration: {
+              maximumAssessmentLength: 10,
+              challengesBetweenSameCompetence: 2,
+              limitToOneQuestionPerTube: true,
+              enablePassageByAllCompetences: true,
+              variationPercent: 0.5,
+              defaultCandidateCapacity: -3,
+              defaultProbabilityToPickChallenge: 51,
+            },
+          })
+          .insertToDB({ databaseBuilder }).id;
 
         databaseBuilder.factory.buildCertificationCpfCountry({
           code: '99100',
@@ -209,20 +213,33 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           version: 3,
         });
 
-        const versionId = databaseBuilder.factory.buildCertificationVersion({
-          startDate: new Date('2018-12-01T01:02:03Z'),
-          competencesScoringConfiguration: [
-            {
-              competence: '1.1',
-              competenceId: 'competenceId',
-              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+        const versionId = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2018-12-01T01:02:03Z') })
+          .withRealisticScoringConfigurations()
+          .withParameters({
+            scope: 'CORE',
+            tubeIds: ['tubeA'],
+            challengesConfiguration: {
+              maximumAssessmentLength: 32,
+              challengesBetweenSameCompetence: 2,
+              limitToOneQuestionPerTube: true,
+              enablePassageByAllCompetences: true,
+              variationPercent: 0.5,
+              defaultCandidateCapacity: -3,
+              defaultProbabilityToPickChallenge: 51,
             },
-          ],
-        }).id;
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId,
-        });
+            competencesScoringConfiguration: [
+              {
+                competence: '1.1',
+                competenceId: 'competenceId',
+                values: [
+                  { bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
+                ],
+              },
+            ],
+          })
+          .insertToDB({ databaseBuilder }).id;
 
         const candidateId = databaseBuilder.factory.buildCertificationCandidate({
           sessionId: session.id,
@@ -279,20 +296,32 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     it('should create a new unrejected AssessmentResult', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
-      const versionId = databaseBuilder.factory.buildCertificationVersion({
-        minimumAnswersRequiredToValidateACertification: 1,
-        competencesScoringConfiguration: [
-          {
-            competence: '1.1',
-            competenceId: 'competenceId',
-            values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+      const versionId = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('1977-10-19') })
+        .withRealisticScoringConfigurations()
+        .withParameters({
+          scope: 'CORE',
+          tubeIds: ['tubeA'],
+          minimumAnswersRequiredToValidateACertification: 1,
+          challengesConfiguration: {
+            maximumAssessmentLength: 32,
+            challengesBetweenSameCompetence: 2,
+            limitToOneQuestionPerTube: true,
+            enablePassageByAllCompetences: true,
+            variationPercent: 0.5,
+            defaultCandidateCapacity: -3,
+            defaultProbabilityToPickChallenge: 51,
           },
-        ],
-      }).id;
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId,
-      });
+          competencesScoringConfiguration: [
+            {
+              competence: '1.1',
+              competenceId: 'competenceId',
+              values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+            },
+          ],
+        })
+        .insertToDB({ databaseBuilder }).id;
       const session = databaseBuilder.factory.buildSession({
         finalizedAt: new Date('2018-12-01T01:02:03Z'),
         version: AlgorithmEngineVersion.V3,
@@ -421,19 +450,18 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     let server;
 
     beforeEach(async function () {
-      const versionId = databaseBuilder.factory.buildCertificationVersion({
-        scope: 'CORE',
-        startDate: new Date('2020-01-01'),
-        expirationDate: null,
-        challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
-          maximumAssessmentLength: 10,
-          defaultCandidateCapacity: -3,
-        }),
-      }).id;
-      databaseBuilder.factory.buildCertificationVersionTube({
-        tubeId: 'tubeA',
-        versionId,
-      });
+      const versionId = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2020-01-01') })
+        .withParameters({
+          scope: 'CORE',
+          tubeIds: ['tubeA'],
+          challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
+            maximumAssessmentLength: 10,
+            defaultCandidateCapacity: -3,
+          }),
+        })
+        .insertToDB({ databaseBuilder }).id;
 
       const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const session = databaseBuilder.factory.buildSession();

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -5,11 +5,13 @@ import {
   CertificationIssueReportSubcategories,
 } from '../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
@@ -391,22 +393,34 @@ describe('Certification | Session Management | Acceptance | Application | Route 
 
         beforeEach(async function () {
           ({ options, session } = await _createSession({ version: 3 }));
-          certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
-            minimumAnswersRequiredToValidateACertification: 1,
-            competencesScoringConfiguration: [
-              {
-                competence: '1.1',
-                competenceId: 'recCompetence0',
-                values: [
-                  { bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
-                ],
+          certificationVersionId = domainBuilder.certification.configuration
+            .versionBuilder()
+            .asActive({ startDate: new Date('1977-10-19') })
+            .withRealisticScoringConfigurations()
+            .withParameters({
+              scope: SCOPES.CORE,
+              tubeIds: ['tubeA'],
+              minimumAnswersRequiredToValidateACertification: 1,
+              challengesConfiguration: {
+                maximumAssessmentLength: 32,
+                challengesBetweenSameCompetence: 2,
+                limitToOneQuestionPerTube: true,
+                enablePassageByAllCompetences: true,
+                variationPercent: 0.5,
+                defaultCandidateCapacity: -3,
+                defaultProbabilityToPickChallenge: 51,
               },
-            ],
-          }).id;
-          databaseBuilder.factory.buildCertificationVersionTube({
-            tubeId: 'tubeA',
-            versionId: certificationVersionId,
-          });
+              competencesScoringConfiguration: [
+                {
+                  competence: '1.1',
+                  competenceId: 'recCompetence0',
+                  values: [
+                    { bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 },
+                  ],
+                },
+              ],
+            })
+            .insertToDB({ databaseBuilder }).id;
           await databaseBuilder.commit();
         });
 
@@ -951,20 +965,31 @@ const _createSessionWithoutChallenge = async () => {
   const userId = databaseBuilder.factory.buildUser().id;
   const candidateUserId = databaseBuilder.factory.buildUser().id;
   const session = databaseBuilder.factory.buildSession({ version: 3 });
-  const version = databaseBuilder.factory.buildCertificationVersion({
-    startDate: new Date('2024-01-01'),
-    competencesScoringConfiguration: [
-      {
-        competence: '1.1',
-        competenceId: 'recCompetence0',
-        values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+  const version = domainBuilder.certification.configuration
+    .versionBuilder()
+    .asActive({ startDate: new Date('2024-01-01') })
+    .withRealisticScoringConfigurations()
+    .withParameters({
+      scope: SCOPES.CORE,
+      tubeIds: ['tubeA'],
+      challengesConfiguration: {
+        maximumAssessmentLength: 32,
+        challengesBetweenSameCompetence: 2,
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: true,
+        variationPercent: 0.5,
+        defaultCandidateCapacity: -3,
+        defaultProbabilityToPickChallenge: 51,
       },
-    ],
-  });
-  databaseBuilder.factory.buildCertificationVersionTube({
-    tubeId: 'tubeA',
-    versionId: version.id,
-  });
+      competencesScoringConfiguration: [
+        {
+          competence: '1.1',
+          competenceId: 'recCompetence0',
+          values: [{ bounds: { max: Number.MAX_SAFE_INTEGER, min: Number.MIN_SAFE_INTEGER }, competenceLevel: 0 }],
+        },
+      ],
+    })
+    .insertToDB({ databaseBuilder });
   databaseBuilder.factory.buildCertificationCenterMembership({
     userId,
     certificationCenterId: session.certificationCenterId,

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
@@ -1,5 +1,6 @@
 import * as certificationCandidateForSupervisingRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/certification-candidate-for-supervising-repository.js';
 import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
@@ -11,9 +12,10 @@ describe('Integration | Repository | certification candidate for supervising', f
     describe('when certification candidate is found', function () {
       it('should return the certification candidate', async function () {
         // given
-        const versionId = databaseBuilder.factory.buildCertificationVersion({
-          assessmentDuration: 100,
-        }).id;
+        const versionId = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'], assessmentDuration: 100 })
+          .insertToDB({ databaseBuilder }).id;
         const session = databaseBuilder.factory.buildSession();
         const user = databaseBuilder.factory.buildUser();
         const candidate = databaseBuilder.factory.buildCertificationCandidate({

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/course-assessment-result-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/course-assessment-result-repository_test.js
@@ -1,5 +1,6 @@
 import * as courseAssessmentResultRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/course-assessment-result-repository.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
@@ -10,7 +11,10 @@ describe('Certification | Course | Integration | Repository | course-assessment-
     context('when assessment result exists', function () {
       it('should return the assessment result', async function () {
         // given
-        const versionId = databaseBuilder.factory.buildCertificationVersion().id;
+        const versionId = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['recTube1'] })
+          .insertToDB({ databaseBuilder }).id;
         const juryId = databaseBuilder.factory.buildUser().id;
         const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ id: 1 }).id;
         databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -32,7 +32,10 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
 
       const userId = databaseBuilder.factory.buildUser().id;
       const sessionId = databaseBuilder.factory.buildSession().id;
-      const versionId = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.PIX_PLUS_DROIT }).id;
+      const versionId = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope: SCOPES.PIX_PLUS_DROIT, tubeIds: ['recTube1'] })
+        .insertToDB({ databaseBuilder }).id;
 
       databaseBuilder.factory.buildCertificationCourse({
         id: certificationCourseId,
@@ -130,7 +133,10 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       const thirdChallengeId = 'recCHAL123';
       const assessmentId = 78;
 
-      const versionId = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.PIX_PLUS_DROIT }).id;
+      const versionId = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope: SCOPES.PIX_PLUS_DROIT, tubeIds: ['recTube1'] })
+        .insertToDB({ databaseBuilder }).id;
       databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId, versionId });
       databaseBuilder.factory.buildCertificationChallenge({
         courseId: certificationCourseId,
@@ -274,7 +280,10 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         const certificationCourseId = 123;
         const assessmentId = 78;
 
-        const versionId = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.PIX_PLUS_DROIT }).id;
+        const versionId = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.PIX_PLUS_DROIT, tubeIds: ['recTube1'] })
+          .insertToDB({ databaseBuilder }).id;
         databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId, versionId });
         databaseBuilder.factory.buildAssessment({
           id: assessmentId,

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import * as certificationCourseRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
@@ -12,20 +13,23 @@ import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Shared | Integration | Repository | Certification Course', function () {
   describe('#save', function () {
-    let certificationCourseData, certificationCourse, userId, sessionId, candidateId, versionId;
+    let certificationCourseData, certificationCourse, userId, sessionId, candidateId;
 
     beforeEach(function () {
       userId = databaseBuilder.factory.buildUser().id;
       sessionId = databaseBuilder.factory.buildSession({ version: 3 }).id;
       candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
-      versionId = databaseBuilder.factory.buildCertificationVersion().id;
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+        .build();
       certificationCourseData = {
         userId,
         sessionId,
         version: 3,
         lang: 'fr',
         candidateId,
-        versionId,
+        versionId: version.id,
         firstName: 'JePasse',
         lastName: 'MaCertif',
         birthdate: '1990-04-01',

--- a/api/tests/scripts/integration/certification/add-competence-ids-to-scoring-configurations_test.js
+++ b/api/tests/scripts/integration/certification/add-competence-ids-to-scoring-configurations_test.js
@@ -1,9 +1,11 @@
 import sinon from 'sinon';
 
 import { AddCompetenceIdsToScoringConfigurations } from '../../../../scripts/certification/add-competence-ids-to-scoring-configurations.js';
+import { SCOPES } from '../../../../src/certification/shared/domain/models/Scopes.js';
 import { PIX_ORIGIN } from '../../../../src/shared/constants.js';
 import { expect } from '../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../tooling/databases.js';
+import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
 
 describe('Integration | Scripts | Certification | add-competence-ids-to-scoring-configurations', function () {
   let script;
@@ -54,13 +56,15 @@ describe('Integration | Scripts | Certification | add-competence-ids-to-scoring-
             values: [{ bounds: { min: 0, max: 10 }, competenceLevel: 1 }],
           },
         ];
-        const { id } = databaseBuilder.factory.buildCertificationVersion({
-          competencesScoringConfiguration: scoringConfig,
-        });
+        const { id } = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [], competencesScoringConfiguration: scoringConfig })
+          .insertToDB({ databaseBuilder });
 
-        const invalidVersion = databaseBuilder.factory.buildCertificationVersion({
-          competencesScoringConfiguration: [],
-        });
+        const invalidVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [], competencesScoringConfiguration: [] })
+          .insertToDB({ databaseBuilder });
         // competencesScoringConfiguration is overwritten as to simulate a null vale
         invalidVersion.competencesScoringConfiguration = null;
 
@@ -92,9 +96,10 @@ describe('Integration | Scripts | Certification | add-competence-ids-to-scoring-
         databaseBuilder.factory.learningContent.build({ competences: [competence11] });
 
         const scoringConfig = [{ competence: '1.1', values: [] }];
-        const { id } = databaseBuilder.factory.buildCertificationVersion({
-          competencesScoringConfiguration: scoringConfig,
-        });
+        const { id } = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [], competencesScoringConfiguration: scoringConfig })
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         // when
@@ -112,9 +117,10 @@ describe('Integration | Scripts | Certification | add-competence-ids-to-scoring-
         databaseBuilder.factory.learningContent.build({ competences: [competence11] });
 
         const scoringConfig = [{ competence: '9.9', values: [] }];
-        const { id } = databaseBuilder.factory.buildCertificationVersion({
-          competencesScoringConfiguration: scoringConfig,
-        });
+        const { id } = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [], competencesScoringConfiguration: scoringConfig })
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/scripts/integration/certification/duplicate-english-core-calibration-with-new-ids_test.js
+++ b/api/tests/scripts/integration/certification/duplicate-english-core-calibration-with-new-ids_test.js
@@ -1,8 +1,10 @@
 import sinon from 'sinon';
 
 import { DuplicateEnglishCoreCalibrationWithNewIds } from '../../../../scripts/certification/duplicate-english-core-calibration-with-new-ids.js';
+import { SCOPES } from '../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../tooling/databases.js';
+import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
 
 describe('Integration | Scripts | Certification | duplicate-english-core-calibration-with-new-ids', function () {
   let script;
@@ -17,10 +19,10 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
     context('when dryRun is false', function () {
       it('should insert duplicates with -EN suffix for challenges that have a -EN counterpart in LCMS', async function () {
         // given
-        const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
-          scope: 'CORE',
-          expirationDate: null,
-        });
+        const { id: versionId } = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
 
         const baseId = 'challengeEn1';
 
@@ -52,10 +54,10 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
 
       it('should not duplicate challenges that have no corresponding -EN entry in LCMS', async function () {
         // given
-        const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
-          scope: 'CORE',
-          expirationDate: null,
-        });
+        const { id: versionId } = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
 
         databaseBuilder.factory.learningContent.buildChallenge({
           id: 'challengeFr1',
@@ -81,10 +83,11 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
 
       it('should not duplicate challenges from an expired CORE version', async function () {
         // given
-        const { id: expiredVersionId } = databaseBuilder.factory.buildCertificationVersion({
-          scope: 'CORE',
-          expirationDate: new Date('2025-01-01'),
-        });
+        const { id: expiredVersionId } = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asArchived({ expirationDate: new Date('2025-01-01') })
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
 
         const baseId = 'challengeEnExpired';
 
@@ -114,10 +117,10 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
     context('when dryRun is true', function () {
       it('should not modify the database', async function () {
         // given
-        const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
-          scope: 'CORE',
-          expirationDate: null,
-        });
+        const { id: versionId } = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
 
         const baseId = 'challengeEn1';
 
@@ -150,10 +153,10 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
 
       it('should rollback the transaction and rethrow the error', async function () {
         // given
-        const { id: versionId } = databaseBuilder.factory.buildCertificationVersion({
-          scope: 'CORE',
-          expirationDate: null,
-        });
+        const { id: versionId } = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
 
         const baseId = 'challengeEnError';
 

--- a/api/tests/scripts/integration/certification/fill-tube-ids-for-existing-versions_test.js
+++ b/api/tests/scripts/integration/certification/fill-tube-ids-for-existing-versions_test.js
@@ -1,8 +1,10 @@
 import sinon from 'sinon';
 
 import { FillTubeIdsForExistingVersions } from '../../../../scripts/certification/fill-tube-ids-for-existing-versions.js';
+import { SCOPES } from '../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../tooling/databases.js';
+import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
 import { buildLearningContent as learningContentBuilder } from '../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | Scripts | Certification | fill-tube-ids-for-existing-versions', function () {
@@ -43,8 +45,15 @@ describe('Integration | Scripts | Certification | fill-tube-ids-for-existing-ver
     const learningContentObjects = learningContentBuilder.fromAreas(areas);
     databaseBuilder.factory.learningContent.build(learningContentObjects);
 
-    const version1 = databaseBuilder.factory.buildCertificationVersion();
-    const version2 = databaseBuilder.factory.buildCertificationVersion();
+    // the versions must be seeded WITHOUT tube rows: the script under test fills them
+    const version1 = domainBuilder.certification.configuration
+      .versionBuilder()
+      .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+      .insertToDB({ databaseBuilder });
+    const version2 = domainBuilder.certification.configuration
+      .versionBuilder()
+      .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+      .insertToDB({ databaseBuilder });
     for (const challengeId of ['recChallenge0_0', 'recChallenge0_1', 'recChallenge1_0']) {
       databaseBuilder.factory.buildCertificationFrameworksChallenge({ versionId: version1.id, challengeId });
     }
@@ -106,7 +115,10 @@ describe('Integration | Scripts | Certification | fill-tube-ids-for-existing-ver
     context('when an error occurs during insertion', function () {
       it('should rollback the transaction and rethrow the error', async function () {
         // given
-        databaseBuilder.factory.buildCertificationVersion();
+        domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         const dbError = new Error('DB insertion error');

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -8,6 +8,7 @@ import { SCOPES } from '../../../../../src/certification/shared/domain/models/Sc
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
@@ -124,14 +125,23 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           sessionId,
           reconciledAt: new Date('2020-01-15'),
         });
-        const version = databaseBuilder.factory.buildCertificationVersion({
-          scope: SCOPES.CORE,
-          startDate: new Date('2020-01-10'),
-        });
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId: version.id,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2020-01-10') })
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['tubeA'],
+            challengesConfiguration: {
+              maximumAssessmentLength: 32,
+              challengesBetweenSameCompetence: 2,
+              limitToOneQuestionPerTube: true,
+              enablePassageByAllCompetences: true,
+              variationPercent: 0.5,
+              defaultCandidateCapacity: -3,
+              defaultProbabilityToPickChallenge: 51,
+            },
+          })
+          .insertToDB({ databaseBuilder });
         const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
           isPublished: false,
           version: AlgorithmEngineVersion.V3,
@@ -280,14 +290,23 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           sessionId,
           reconciledAt: new Date('2020-01-01'),
         });
-        const version = databaseBuilder.factory.buildCertificationVersion({
-          scope: SCOPES.CORE,
-          startDate: new Date('2019-01-01'),
-        });
-        databaseBuilder.factory.buildCertificationVersionTube({
-          tubeId: 'tubeA',
-          versionId: version.id,
-        });
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2019-01-01') })
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['tubeA'],
+            challengesConfiguration: {
+              maximumAssessmentLength: 32,
+              challengesBetweenSameCompetence: 2,
+              limitToOneQuestionPerTube: true,
+              enablePassageByAllCompetences: true,
+              variationPercent: 0.5,
+              defaultCandidateCapacity: -3,
+              defaultProbabilityToPickChallenge: 51,
+            },
+          })
+          .insertToDB({ databaseBuilder });
 
         const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
           isPublished: false,

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -1,4 +1,5 @@
 import { AutoJuryCommentKeys } from '../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { MissingAssessmentId, NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
@@ -13,7 +14,10 @@ describe('Integration | Repository | AssessmentResult', function () {
     context('when save is successful', function () {
       it('should return the saved assessment result', async function () {
         // given
-        const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+        const certificationVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
         databaseBuilder.factory.buildUser({ id: 100 });
         const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
@@ -54,7 +58,10 @@ describe('Integration | Repository | AssessmentResult', function () {
 
       it('should persist the assessment result in DB', async function () {
         // given
-        const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+        const certificationVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({ id: 3 });
         databaseBuilder.factory.buildUser({ id: 100 });
         const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
@@ -99,7 +106,10 @@ describe('Integration | Repository | AssessmentResult', function () {
       context('when there is no assessment result for the certification course yet', function () {
         it('should persist the link between the assessment result and the certification course in DB', async function () {
           // given
-          const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+          const certificationVersion = domainBuilder.certification.configuration
+            .versionBuilder()
+            .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+            .insertToDB({ databaseBuilder });
           const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
           databaseBuilder.factory.buildUser({ id: 100 });
           const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
@@ -141,7 +151,10 @@ describe('Integration | Repository | AssessmentResult', function () {
       context('when there is already an assessment result for the certification course', function () {
         it('should update the link between the assessment result and the certification course in DB', async function () {
           // given
-          const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+          const certificationVersion = domainBuilder.certification.configuration
+            .versionBuilder()
+            .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+            .insertToDB({ databaseBuilder });
           const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
           databaseBuilder.factory.buildUser({ id: 100 });
           const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
@@ -340,7 +353,10 @@ describe('Integration | Repository | AssessmentResult', function () {
     context('when certification course has one assessment result', function () {
       it('should return the assessment result', async function () {
         // given
-        const version = databaseBuilder.factory.buildCertificationVersion();
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
         databaseBuilder.factory.buildCertificationCourse({ id: 1 });
         databaseBuilder.factory.buildUser({ id: 100 });
         databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
@@ -554,7 +570,10 @@ describe('Integration | Repository | AssessmentResult', function () {
     context('when the assessment result exists', function () {
       it('should update the assessment result', async function () {
         // given
-        const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+        const certificationVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
+          .insertToDB({ databaseBuilder });
         databaseBuilder.factory.buildCertificationCourse({ id: 1 });
         databaseBuilder.factory.buildUser({ id: 100 });
         const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: 1 });

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-certification-info.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-certification-info.js
@@ -1,20 +1,149 @@
+import {
+  defaultCompetencesScoringConfiguration,
+  defaultGlobalScoringConfiguration,
+} from '../../../../../../db/database-builder/factory/build-certification-version.js';
+import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { CertificationInfo } from '../../../../../../src/certification/configuration/domain/read-models/CertificationInfo.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 
-export const buildCertificationInfo = function ({
-  framework = Frameworks.CORE,
-  startDate = null,
-  expirationDate = null,
-  assessmentDuration = 10,
-  minimumAssessmentLength = 5,
-  maximumAssessmentLength = 10,
-}) {
-  return new CertificationInfo({
-    framework,
-    startDate,
-    expirationDate,
-    assessmentDuration,
-    minimumAssessmentLength,
-    maximumAssessmentLength,
-  });
-};
+/**
+ * @typedef {import('../../../../../../src/certification/shared/domain/models/Scopes.js').SCOPES} SCOPES
+ * @typedef {import('../../../../../../db/database-builder/database-builder.js').databaseBuilder} DatabaseBuilder
+ */
+
+/**
+ * Fluent builder for the {@link CertificationInfo} domain read-model.
+ *
+ * @example
+ * const certificationInfo = domainBuilder.certification.configuration
+ *   .certificationInfoBuilder()
+ *   .asActive()
+ *   .withParameters({ framework: SCOPES.PIX_PLUS_DROIT })
+ *   .insertToDB({ databaseBuilder });
+ */
+class CertificationInfoBuilder {
+  constructor() {
+    this.framework = Frameworks.CORE;
+    this.startDate = null;
+    this.expirationDate = null;
+    this.assessmentDuration = 60;
+    this.minimumAssessmentLength = 20;
+    this.maximumAssessmentLength = 50;
+    this.status = VERSION_STATUSES.DRAFT;
+  }
+
+  /**
+   * Marks as draft.
+   *
+   * @returns {CertificationInfoBuilder}
+   */
+  asDraft() {
+    this.status = VERSION_STATUSES.DRAFT;
+    this.startDate = null;
+    this.expirationDate = null;
+    return this;
+  }
+
+  /**
+   * Marks as active.
+   *
+   * @returns {CertificationInfoBuilder}
+   */
+  asActive() {
+    this.status = VERSION_STATUSES.ACTIVE;
+    this.startDate = new Date('2024-01-01');
+    this.expirationDate = null;
+    return this;
+  }
+
+  /**
+   * Marks the as archived.
+   *
+   * @returns {CertificationInfoBuilder}
+   */
+  asArchived() {
+    this.status = VERSION_STATUSES.ARCHIVED;
+    this.startDate = new Date('2024-01-01');
+    this.expirationDate = new Date('2024-12-31');
+    return this;
+  }
+
+  /**
+   * Overrides any subset of the CertificationInfo attributes carried by the builder.
+   * Omitted parameters keep their current value, so the method can be called
+   * several times in the same chain without resetting previous overrides.
+   *
+   * @param {object} [params]
+   * @param {SCOPES} [params.framework]
+   * @param {number} [params.assessmentDuration]
+   * @param {number} [params.minimumAssessmentLength]
+   * @param {number} [params.maximumAssessmentLength]
+   * @returns {CertificationInfoBuilder}
+   */
+  withParameters({ framework, assessmentDuration, minimumAssessmentLength, maximumAssessmentLength } = {}) {
+    this.framework = framework ?? this.framework;
+    this.assessmentDuration = assessmentDuration ?? this.assessmentDuration;
+    this.minimumAssessmentLength = minimumAssessmentLength ?? this.minimumAssessmentLength;
+    this.maximumAssessmentLength = maximumAssessmentLength ?? this.maximumAssessmentLength;
+    return this;
+  }
+
+  /**
+   * Inserts the necessary underlying data in the database
+   * then returns the built domain CertificationInfo
+   * Must be called before `await databaseBuilder.commit()`.
+   *
+   * @param {object} params
+   * @param {DatabaseBuilder} params.databaseBuilder
+   * @returns {CertificationInfo}
+   */
+  insertToDB({ databaseBuilder }) {
+    const certificationInfo = this.build();
+
+    const row = databaseBuilder.factory.buildCertificationVersion({
+      scope: certificationInfo.framework,
+      startDate: this.startDate,
+      expirationDate: this.expirationDate,
+      assessmentDuration: certificationInfo.assessmentDuration,
+      minimumAnswersRequiredToValidateACertification: certificationInfo.minimumAssessmentLength,
+      globalScoringConfiguration: defaultGlobalScoringConfiguration,
+      competencesScoringConfiguration: defaultCompetencesScoringConfiguration,
+      challengesConfiguration: {
+        maximumAssessmentLength: certificationInfo.maximumAssessmentLength,
+      },
+      status: certificationInfo.status,
+    });
+
+    databaseBuilder.factory.buildCertificationVersionTube({
+      versionId: row.id,
+      tubeId: 'fooTube',
+    });
+
+    return this.build();
+  }
+
+  /**
+   * Materializes the domain CertificationInfo without touching the database.
+   *
+   * @returns {CertificationInfo}
+   */
+  build() {
+    return new CertificationInfo({
+      framework: this.framework,
+      status: this.status,
+      assessmentDuration: this.assessmentDuration,
+      minimumAssessmentLength: this.minimumAssessmentLength,
+      maximumAssessmentLength: this.maximumAssessmentLength,
+    });
+  }
+}
+
+/**
+ * Entry point of the fluent CertificationInfo builder. Returns the builder, NOT a CertificationInfo:
+ * Note: end the chain with build() for in-memory storage or insertToDB() for DB storage.
+ *
+ * @returns {CertificationInfoBuilder}
+ */
+export function certificationInfoBuilder() {
+  return new CertificationInfoBuilder();
+}

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-version-details.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-version-details.js
@@ -1,27 +1,167 @@
+import {
+  defaultCompetencesScoringConfiguration,
+  defaultGlobalScoringConfiguration,
+} from '../../../../../../db/database-builder/factory/build-certification-version.js';
+import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { VersionDetails } from '../../../../../../src/certification/configuration/domain/read-models/VersionDetails.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 
-export function buildVersionDetails({
-  id,
-  startDate,
-  expirationDate,
-  assessmentDuration,
-  minimumAnswersRequiredForValidation,
-  maximumAssessmentLength,
-  challengesBetweenSameCompetence,
-  defaultProbabilityToPickChallenge,
-  defaultCandidateCapacity,
-  variationPercent,
-  limitToOneQuestionPerTube,
-  enablePassageByAllCompetences,
-  scope,
-  status,
-  comments,
-  areas,
-}) {
-  return new VersionDetails({
+/**
+ * @typedef {import('../../../../../../src/certification/shared/domain/models/Scopes.js').SCOPES} SCOPES
+ * @typedef {import('../../../../../../db/database-builder/database-builder.js').databaseBuilder} DatabaseBuilder
+ */
+/**
+ * @typedef {Object} Skill
+ * @property {string} id
+ * @property {number} difficulty
+ */
+
+/**
+ * @typedef {Object} Tube
+ * @property {string} id
+ * @property {string} name
+ * @property {string} practicalTitle
+ * @property {boolean} mobile
+ * @property {boolean} tablet
+ * @property {Skill[]} skills
+ */
+
+/**
+ * @typedef {Object} Thematic
+ * @property {string} id
+ * @property {string} name
+ * @property {number} index
+ * @property {Tube[]} tubes
+ */
+
+/**
+ * @typedef {Object} Competence
+ * @property {string} id
+ * @property {string} name
+ * @property {string} index
+ * @property {Thematic[]} thematics
+ */
+
+/**
+ * @typedef {Object} Area
+ * @property {string} id
+ * @property {string} frameworkId
+ * @property {string} code
+ * @property {string} title
+ * @property {string} color
+ * @property {Competence[]} competences
+ */
+
+/**
+ * Fluent builder for the {@link VersionDetails} domain read-model.
+ *
+ * @example
+ * const version = domainBuilder.certification.configuration
+ *   .versionDetailsBuilder()
+ *   .asActive({ startDate: new Date('2025-01-01') })
+ *   .withParameters({ scope: SCOPES.PIX_PLUS_DROIT, areas: ...someData })
+ *   .insertToDB({ databaseBuilder });
+ */
+class VersionDetailsBuilder {
+  constructor() {
+    this.id = null;
+    this.scope = Frameworks.CORE;
+    this.status = VERSION_STATUSES.DRAFT;
+    this.startDate = null;
+    this.expirationDate = null;
+    this.assessmentDuration = 60;
+    this.minimumAnswersRequiredForValidation = 20;
+    this.maximumAssessmentLength = 50;
+    this.challengesBetweenSameCompetence = 2;
+    this.defaultProbabilityToPickChallenge = 41;
+    this.defaultCandidateCapacity = 0;
+    this.variationPercent = 0.66;
+    this.limitToOneQuestionPerTube = true;
+    this.enablePassageByAllCompetences = false;
+    this.comments = null;
+    this.areas = [];
+  }
+
+  /**
+   * Marks as draft.
+   *
+   * @param {object} params
+   * @param {Date} [params.startDate] - defaults to null
+   * @returns {VersionDetailsBuilder}
+   */
+  asDraft({ startDate }) {
+    this.status = VERSION_STATUSES.DRAFT;
+    this.startDate = startDate ?? null;
+    this.expirationDate = null;
+    return this;
+  }
+
+  /**
+   * Marks version as active.
+   *
+   * @param {object} [params]
+   * @param {Date} [params.startDate]
+   * @returns {VersionDetailsBuilder}
+   */
+  asActive({ startDate = new Date('2024-01-01') } = {}) {
+    this.status = VERSION_STATUSES.ACTIVE;
+    this.startDate = startDate;
+    this.expirationDate = null;
+    return this;
+  }
+
+  /**
+   * Marks the version as archived.
+   *
+   * @param {object} [params]
+   * @param {Date} [params.startDate]
+   * @param {Date} [params.expirationDate]
+   * @returns {VersionDetailsBuilder}
+   */
+  asArchived({ startDate = new Date('2024-01-01'), expirationDate = new Date('2024-12-31') } = {}) {
+    this.status = VERSION_STATUSES.ARCHIVED;
+    this.startDate = startDate;
+    this.expirationDate = expirationDate;
+    return this;
+  }
+
+  /**
+   * Sets the learning content covered by the version.
+   *
+   * @param {Area[]} areas
+   * @returns {this}
+   */
+  withLearningContent(areas) {
+    this.areas = areas;
+    return this;
+  }
+
+  /**
+   * Overrides any subset of the VersionDetails attributes carried by the builder.
+   * Omitted parameters keep their current value, so the method can be called
+   * several times in the same chain without resetting previous overrides.
+   * Does not allow to set the areas view
+   *
+   * Note: status, startDate and expirationDate are driven by asDraft/asActive/asArchived.
+   *
+   * @param {object} [params]
+   * @param {number} [params.id] - explicit id; without it, insertToDB lets the database assign one and build() produces a non-persisted version (id null)
+   * @param {SCOPES} [params.scope] - certification scope, defaults to Frameworks.CORE
+   * @param {number} [params.assessmentDuration] - in minutes
+   * @param {number} [params.minimumAnswersRequiredForValidation]
+   * @param {number} [params.maximumAssessmentLength]
+   * @param {number} [params.challengesBetweenSameCompetence]
+   * @param {number} [params.defaultProbabilityToPickChallenge]
+   * @param {number} [params.defaultCandidateCapacity]
+   * @param {number} [params.variationPercent]
+   * @param {boolean} [params.limitToOneQuestionPerTube]
+   * @param {boolean} [params.enablePassageByAllCompetences]
+   * @param {string} [params.comments]
+   * @returns {VersionDetailsBuilder}
+   */
+  withParameters({
     id,
-    startDate,
-    expirationDate,
+    scope,
     assessmentDuration,
     minimumAnswersRequiredForValidation,
     maximumAssessmentLength,
@@ -31,9 +171,159 @@ export function buildVersionDetails({
     variationPercent,
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
-    scope,
-    status,
     comments,
-    areas,
-  });
+  } = {}) {
+    this.id = id ?? this.id;
+    this.scope = scope ?? this.scope;
+    this.assessmentDuration = assessmentDuration ?? this.assessmentDuration;
+    this.minimumAnswersRequiredForValidation =
+      minimumAnswersRequiredForValidation ?? this.minimumAnswersRequiredForValidation;
+    this.maximumAssessmentLength = maximumAssessmentLength ?? this.maximumAssessmentLength;
+    this.challengesBetweenSameCompetence = challengesBetweenSameCompetence ?? this.challengesBetweenSameCompetence;
+    this.defaultProbabilityToPickChallenge =
+      defaultProbabilityToPickChallenge ?? this.defaultProbabilityToPickChallenge;
+    this.defaultCandidateCapacity = defaultCandidateCapacity ?? this.defaultCandidateCapacity;
+    this.variationPercent = variationPercent ?? this.variationPercent;
+    this.limitToOneQuestionPerTube = limitToOneQuestionPerTube || this.limitToOneQuestionPerTube;
+    this.enablePassageByAllCompetences = enablePassageByAllCompetences || this.enablePassageByAllCompetences;
+    this.comments = comments ?? this.comments;
+    return this;
+  }
+
+  /**
+   * Inserts corresponding certification_version row, certification_versions_tubes rows and init corresponding learning content
+   * then returns the built domain VersionDetails carrying the persisted id.
+   * Must be called before `await databaseBuilder.commit()`.
+   *
+   * @param {object} params
+   * @param {DatabaseBuilder} params.databaseBuilder
+   * @returns {VersionDetails} the persisted version
+   */
+  insertToDB({ databaseBuilder }) {
+    const versionDetails = this.build();
+
+    const row = databaseBuilder.factory.buildCertificationVersion({
+      id: versionDetails.id ?? undefined,
+      scope: versionDetails.scope,
+      startDate: versionDetails.startDate,
+      expirationDate: versionDetails.expirationDate,
+      assessmentDuration: versionDetails.assessmentDuration,
+      minimumAnswersRequiredToValidateACertification: versionDetails.minimumAnswersRequiredForValidation,
+      globalScoringConfiguration: defaultGlobalScoringConfiguration,
+      competencesScoringConfiguration: defaultCompetencesScoringConfiguration,
+      challengesConfiguration: {
+        maximumAssessmentLength: versionDetails.maximumAssessmentLength,
+        challengesBetweenSameCompetence: versionDetails.challengesBetweenSameCompetence,
+        defaultProbabilityToPickChallenge: versionDetails.defaultProbabilityToPickChallenge,
+        defaultCandidateCapacity: versionDetails.defaultCandidateCapacity,
+        variationPercent: versionDetails.variationPercent,
+        limitToOneQuestionPerTube: versionDetails.limitToOneQuestionPerTube,
+        enablePassageByAllCompetences: versionDetails.enablePassageByAllCompetences,
+      },
+      status: versionDetails.status,
+      comments: versionDetails.comments,
+    });
+
+    const tubeIds = this.#insertLearningContentToDB({ databaseBuilder, areas: this.areas });
+
+    for (const tubeId of tubeIds) {
+      databaseBuilder.factory.buildCertificationVersionTube({
+        versionId: row.id,
+        tubeId,
+      });
+    }
+
+    this.id = row.id;
+    return this.build();
+  }
+
+  insertLearningContentToDB({ databaseBuilder, areas }) {
+    this.#insertLearningContentToDB({ databaseBuilder, areas });
+  }
+
+  #insertLearningContentToDB({ databaseBuilder, areas }) {
+    const tubeIds = [];
+    for (const area of areas) {
+      databaseBuilder.factory.learningContent.buildFramework({
+        id: area.frameworkId,
+      });
+      const competenceIds = area.competences.map((competence) => competence.id);
+      databaseBuilder.factory.learningContent.buildArea({
+        ...area,
+        competenceIds,
+        title_i18n: { fr: area.title },
+      });
+      for (const competence of area.competences) {
+        databaseBuilder.factory.learningContent.buildCompetence({
+          ...competence,
+          areaId: area.id,
+          name_i18n: { fr: competence.name },
+        });
+        for (const thematic of competence.thematics) {
+          databaseBuilder.factory.learningContent.buildThematic({
+            ...thematic,
+            competenceId: competence.id,
+            name_i18n: { fr: thematic.name },
+          });
+          for (const tube of thematic.tubes) {
+            const skillIds = tube.skills.map((skill) => skill.id);
+            databaseBuilder.factory.learningContent.buildTube({
+              ...tube,
+              thematicId: thematic.id,
+              competenceId: competence.id,
+              practicalTitle_i18n: { fr: tube.practicalTitle },
+              isMobileCompliant: tube.mobile,
+              isTabletCompliant: tube.tablet,
+              skillIds,
+            });
+            tubeIds.push(tube.id);
+            for (const skill of tube.skills) {
+              databaseBuilder.factory.learningContent.buildSkill({
+                ...skill,
+                tubeId: tube.id,
+                level: skill.difficulty,
+              });
+            }
+          }
+        }
+      }
+    }
+    return tubeIds;
+  }
+
+  /**
+   * Materializes the domain VersionDetails without touching the database.
+   *
+   * @returns {VersionDetails}
+   */
+  build() {
+    return new VersionDetails({
+      id: this.id,
+      scope: this.scope,
+      startDate: this.startDate,
+      expirationDate: this.expirationDate,
+      assessmentDuration: this.assessmentDuration,
+      minimumAnswersRequiredForValidation: this.minimumAnswersRequiredForValidation,
+      maximumAssessmentLength: this.maximumAssessmentLength,
+      challengesBetweenSameCompetence: this.challengesBetweenSameCompetence,
+      defaultProbabilityToPickChallenge: this.defaultProbabilityToPickChallenge,
+      defaultCandidateCapacity: this.defaultCandidateCapacity,
+      variationPercent: this.variationPercent,
+      limitToOneQuestionPerTube: this.limitToOneQuestionPerTube,
+      enablePassageByAllCompetences: this.enablePassageByAllCompetences,
+      comments: this.comments,
+      status: this.status,
+      areas: this.areas,
+    });
+  }
+}
+
+/**
+ * Entry point of the fluent VersionDetails builder. Returns the builder, NOT a VersionDetails:
+ * Note: end the chain with build() for in-memory storage or insertToDB() for DB storage.
+ *
+ * @returns {VersionDetailsBuilder}
+ */
+export function versionDetailsBuilder() {
+  return new VersionDetailsBuilder();
 }

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-version.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-version.js
@@ -1,63 +1,246 @@
-import { Version as VersionApi } from '../../../../../../src/certification/configuration/application/api/models/Version.js';
+import {
+  defaultCompetencesScoringConfiguration,
+  defaultGlobalScoringConfiguration,
+} from '../../../../../../db/database-builder/factory/build-certification-version.js';
 import { Version, VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
-import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
-import { buildFlashAlgorithmConfiguration } from '../../build-flash-algorithm-configuration.js';
+import {
+  DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
+  DEFAULT_PROBABILITY_TO_PICK_CHALLENGE,
+  DEFAULT_SESSION_DURATION_MINUTES,
+} from '../../../../../../src/certification/shared/domain/constants.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 
-export const buildVersion = ({
-  id = 1,
-  scope = SCOPES.CORE,
-  startDate = null,
-  expirationDate = null,
-  assessmentDuration = 105,
-  minimumAnswersRequiredToValidateACertification = 20,
-  globalScoringConfiguration = [],
-  competencesScoringConfiguration = [],
-  challengesConfiguration = {},
-  status = VERSION_STATUSES.DRAFT,
-  comments = 'Some comments',
-  tubeIds = ['rec123'],
-} = {}) => {
-  return new Version({
+/**
+ * @typedef {import('../../../../../../src/certification/shared/domain/models/Scopes.js').SCOPES} SCOPES
+ * @typedef {import('../../../../../../db/database-builder/database-builder.js').databaseBuilder} DatabaseBuilder
+ */
+
+/**
+ * Fluent builder for the {@link Version} domain model.
+ *
+ * @example
+ * const version = domainBuilder.certification.configuration
+ *   .versionBuilder()
+ *   .asActive({ startDate: new Date('2025-01-01') })
+ *   .withParameters({ scope: SCOPES.PIX_PLUS_DROIT, tubeIds: ['recTube1'] })
+ *   .insertToDB({ databaseBuilder });
+ */
+class VersionBuilder {
+  constructor() {
+    this.scope = Frameworks.CORE;
+    this.tubeIds = ['tubeA'];
+    this.id = null;
+    this.startDate = null;
+    this.expirationDate = null;
+    this.assessmentDuration = DEFAULT_SESSION_DURATION_MINUTES;
+    this.minimumAnswersRequiredToValidateACertification = DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION;
+    this.globalScoringConfiguration = [];
+    this.competencesScoringConfiguration = [];
+    this.challengesConfiguration = null;
+    this.comments = null;
+    this.status = VERSION_STATUSES.DRAFT;
+  }
+
+  /**
+   * Marks version as draft.
+   *
+   * @param {object} params
+   * @param {Date} [params.startDate] - defaults to null
+   * @returns {VersionBuilder}
+   */
+  asDraft({ startDate }) {
+    this.status = VERSION_STATUSES.DRAFT;
+    this.startDate = startDate ?? null;
+    this.expirationDate = null;
+    return this;
+  }
+
+  /**
+   * Marks version as active.
+   *
+   * @param {object} [params]
+   * @param {Date} [params.startDate]
+   * @returns {VersionBuilder}
+   */
+  asActive({ startDate = new Date('2024-01-01') } = {}) {
+    this.status = VERSION_STATUSES.ACTIVE;
+    this.startDate = startDate;
+    this.expirationDate = null;
+    return this;
+  }
+
+  /**
+   * Marks the version as archived.
+   *
+   * @param {object} [params]
+   * @param {Date} [params.startDate]
+   * @param {Date} [params.expirationDate]
+   * @returns {VersionBuilder}
+   */
+  asArchived({ startDate = new Date('2024-01-01'), expirationDate = new Date('2024-12-31') } = {}) {
+    this.status = VERSION_STATUSES.ARCHIVED;
+    this.startDate = startDate;
+    this.expirationDate = expirationDate;
+    return this;
+  }
+
+  /**
+   * Overrides any subset of the Version attributes carried by the builder.
+   * Omitted parameters keep their current value, so the method can be called
+   * several times in the same chain without resetting previous overrides.
+   *
+   * Note: status, startDate and expirationDate are driven by asDraft/asActive/asArchived.
+   *
+   * @param {object} [params]
+   * @param {number} [params.id] - explicit id; without it, insertToDB lets the database assign one and build() produces a non-persisted version (id null)
+   * @param {SCOPES} [params.scope] - certification scope, defaults to Frameworks.CORE
+   * @param {Array<string>} [params.tubeIds] - tube ids linked to the version, defaults to ['tubeA'] (use [] for a version without tubes)
+   * @param {number} [params.assessmentDuration] - in minutes
+   * @param {number} [params.minimumAnswersRequiredToValidateACertification]
+   * @param {Array<object>} [params.globalScoringConfiguration]
+   * @param {Array<object>} [params.competencesScoringConfiguration]
+   * @param {Partial<FlashAssessmentAlgorithmConfiguration>|FlashAssessmentAlgorithmConfiguration} [params.challengesConfiguration] - a partial object is merged over the build() defaults
+   * @param {string} [params.comments]
+   * @returns {VersionBuilder}
+   */
+  withParameters({
     id,
     scope,
-    startDate,
-    expirationDate,
-    assessmentDuration,
-    minimumAnswersRequiredToValidateACertification,
-    globalScoringConfiguration,
-    competencesScoringConfiguration,
-    challengesConfiguration: buildFlashAlgorithmConfiguration(challengesConfiguration),
-    status,
-    comments,
     tubeIds,
-  });
-};
-
-buildVersion.api = ({
-  id = 1,
-  scope = SCOPES.CORE,
-  startDate = new Date(),
-  expirationDate,
-  assessmentDuration = 105,
-  minimumAnswersRequiredToValidateACertification = 20,
-  globalScoringConfiguration,
-  competencesScoringConfiguration,
-  challengesConfiguration,
-  status = VERSION_STATUSES.DRAFT,
-  comments = 'Some comments',
-} = {}) => {
-  const baseVersion = new Version({
-    id,
-    scope,
-    startDate,
-    expirationDate,
     assessmentDuration,
     minimumAnswersRequiredToValidateACertification,
     globalScoringConfiguration,
     competencesScoringConfiguration,
-    status,
+    challengesConfiguration,
     comments,
-    challengesConfiguration: buildFlashAlgorithmConfiguration(challengesConfiguration),
-  });
-  return new VersionApi(baseVersion);
-};
+  } = {}) {
+    this.id = id ?? this.id;
+    this.scope = scope ?? this.scope;
+    this.tubeIds = tubeIds ?? this.tubeIds;
+    this.assessmentDuration = assessmentDuration ?? this.assessmentDuration;
+    this.minimumAnswersRequiredToValidateACertification =
+      minimumAnswersRequiredToValidateACertification ?? this.minimumAnswersRequiredToValidateACertification;
+    this.globalScoringConfiguration = globalScoringConfiguration ?? this.globalScoringConfiguration;
+    this.competencesScoringConfiguration = competencesScoringConfiguration ?? this.competencesScoringConfiguration;
+    this.challengesConfiguration = challengesConfiguration ?? this.challengesConfiguration;
+    this.comments = comments ?? this.comments;
+    return this;
+  }
+
+  /**
+   * Fills both scoring configurations with the realistic defaults of the DB factory
+   * (8 mesh levels, full competence levels) — required when the code under test
+   * computes actual scores.
+   * Values are deep-cloned so a test mutating its version cannot pollute other tests.
+   *
+   * @returns {VersionBuilder}
+   */
+  withRealisticScoringConfigurations() {
+    this.globalScoringConfiguration = structuredClone(defaultGlobalScoringConfiguration);
+    this.competencesScoringConfiguration = structuredClone(defaultCompetencesScoringConfiguration);
+    return this;
+  }
+
+  /**
+   * Inserts the version row and one certification_versions_tubes row per tubeId,
+   * then returns the built domain Version carrying the persisted id.
+   * Must be called before `await databaseBuilder.commit()`.
+   *
+   * @param {object} params
+   * @param {DatabaseBuilder} params.databaseBuilder
+   * @returns {Version} the persisted version
+   */
+  insertToDB({ databaseBuilder }) {
+    const version = this.build();
+
+    const row = databaseBuilder.factory.buildCertificationVersion({
+      id: version.id ?? undefined,
+      scope: version.scope,
+      startDate: version.startDate,
+      expirationDate: version.expirationDate,
+      assessmentDuration: version.assessmentDuration,
+      minimumAnswersRequiredToValidateACertification: version.minimumAnswersRequiredToValidateACertification,
+      globalScoringConfiguration: version.globalScoringConfiguration,
+      competencesScoringConfiguration: version.competencesScoringConfiguration,
+      challengesConfiguration: version.challengesConfiguration,
+      status: version.status,
+      comments: version.comments,
+    });
+
+    for (const tubeId of version.tubeIds) {
+      databaseBuilder.factory.buildCertificationVersionTube({
+        versionId: row.id,
+        tubeId,
+      });
+    }
+
+    this.id = row.id;
+    return this.build();
+  }
+
+  /**
+   * Materializes the domain Version without touching the database.
+   * The challenges configuration is merged over the builder defaults.
+   *
+   * @returns {Version}
+   */
+  build() {
+    const challengesConfiguration = new FlashAssessmentAlgorithmConfiguration({
+      challengesBetweenSameCompetence: 0,
+      maximumAssessmentLength: 32,
+      variationPercent: 1,
+      defaultCandidateCapacity: 0,
+      defaultProbabilityToPickChallenge: DEFAULT_PROBABILITY_TO_PICK_CHALLENGE,
+      limitToOneQuestionPerTube: true,
+      enablePassageByAllCompetences: true,
+      ...this.challengesConfiguration,
+    });
+
+    return new Version({
+      id: this.id,
+      scope: this.scope,
+      startDate: this.startDate,
+      expirationDate: this.expirationDate,
+      assessmentDuration: this.assessmentDuration,
+      minimumAnswersRequiredToValidateACertification: this.minimumAnswersRequiredToValidateACertification,
+      globalScoringConfiguration: this.globalScoringConfiguration,
+      competencesScoringConfiguration: this.competencesScoringConfiguration,
+      challengesConfiguration,
+      comments: this.comments,
+      status: this.status,
+      tubeIds: this.tubeIds,
+    });
+  }
+
+  /**
+   * Copy all the attributes from given Version in the builder
+   * @params {Version}
+   * @returns {VersionBuilder}
+   */
+  copy(version) {
+    this.id = version.id;
+    this.scope = version.scope;
+    this.tubeIds = version.tubeIds;
+    this.startDate = version.startDate;
+    this.expirationDate = version.expirationDate;
+    this.assessmentDuration = version.assessmentDuration;
+    this.minimumAnswersRequiredToValidateACertification = version.minimumAnswersRequiredToValidateACertification;
+    this.globalScoringConfiguration = version.globalScoringConfiguration;
+    this.competencesScoringConfiguration = version.competencesScoringConfiguration;
+    this.challengesConfiguration = version.challengesConfiguration;
+    this.comments = null;
+    this.status = VERSION_STATUSES.DRAFT;
+    return this;
+  }
+}
+
+/**
+ * Entry point of the fluent Version builder. Returns the builder, NOT a Version:
+ * Note: end the chain with build() for in-memory storage or insertToDB() for DB storage.
+ *
+ * @returns {VersionBuilder}
+ */
+export function versionBuilder() {
+  return new VersionBuilder();
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -165,14 +165,14 @@ import { buildValidator } from './build-validator.js';
 import { buildComplementaryCertification } from './certification/complementary-certification/build-complementary-certification.js';
 import { buildComplementaryCertificationBadge } from './certification/complementary-certification/build-complementary-certification-badge.js';
 import { buildCenter as buildConfigurationCenter } from './certification/configuration/build-center.js';
-import { buildCertificationInfo } from './certification/configuration/build-certification-info.js';
+import { certificationInfoBuilder } from './certification/configuration/build-certification-info.js';
 import { buildFrameworkHistoryEntry } from './certification/configuration/build-framework-history-entry.js';
 import {
   buildScoBlockedAccessDateCollege,
   buildScoBlockedAccessDateLycee,
 } from './certification/configuration/build-sco-blocked-access-date.js';
-import { buildVersion as buildConfigurationVersion } from './certification/configuration/build-version.js';
-import { buildVersionDetails } from './certification/configuration/build-version-details.js';
+import { versionBuilder } from './certification/configuration/build-version.js';
+import { versionDetailsBuilder } from './certification/configuration/build-version-details.js';
 import { buildCandidate } from './certification/enrolment/build-candidate.js';
 import { buildCertificationEligibility } from './certification/enrolment/build-certification-eligibility.js';
 import { buildComplementaryCertificationBadgeWithOffsetVersion as buildComplementaryCertificationBadgeForEnrolment } from './certification/enrolment/build-complementary-certification-badge.js';
@@ -250,11 +250,11 @@ const certification = {
   configuration: {
     buildCenter: buildConfigurationCenter,
     buildFrameworkHistoryEntry,
-    buildCertificationInfo,
-    buildVersion: buildConfigurationVersion,
+    certificationInfoBuilder,
+    versionBuilder,
     buildScoBlockedAccessDateCollege,
     buildScoBlockedAccessDateLycee,
-    buildVersionDetails,
+    versionDetailsBuilder,
   },
   complementaryCertification: {
     buildComplementaryCertificationBadge: buildComplementaryCertificationBadge,


### PR DESCRIPTION
## 🪧 Problème

Les domainBuilder tels que conçus actuellement posent plusieurs soucis: 
- Dans la grande majorité des cas, il s'agit simplement d'une méthode wrapper autour d'un `new <CLASSE_A_INSTANCIER>`, il n'y a donc pas de valeur ajoutée à leur utilisation
- Ils ne nous permettent pas de retranscrire les propriétés "métier" de l'instance construite car ils sont utilisés principalement via des valeurs primitives

## 🌈 Proposition

Nous ré-écrivons le domainBuilder `buildVersion` en appliquant le pattern builder qui nous permet de créer des objets complexes pas à pas via un language courant au travers des propriétés métier de la version

## ✊ Remarques

- Nous en profitons pour expérimenter la persistence de ces instances dans les tests d'intégration via l'ajout d'une méthode `insertToDB` pour ne plus avoir à appeler les `databaseBuilder.factory.buildCertificationVersion()` et `databaseBuilder.factory.buildCertificationVersionTube()` dans les tests d'intégration. Cette méthode gérant l'insertion de l'entièreté des données nécessaires à l'aggrégat Version
- Il subsiste toutefois quelques `databaseBuilder.factory.buildCertificationVersion()` pour tester des cas non valables d'un point de vue métier. (doivent-ils seulement être testés ? 🤷🏻)

## 🎉 Pour tester

Tests verts
