### PR TITLE
[BUGFIX] Correction des bugs liés au SDK OpenTelemetry

### DIFF
--- a/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
+++ b/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
@@ -56,7 +56,7 @@ export function initializeOpenTelemetry(serviceName) {
     }),
     resourceDetectors: [envDetector, hostDetector, osDetector, processDetector, containerDetector, scalingoDetector],
     spanProcessors: [new InheritedAttributesSpanProcessor(), new BatchSpanProcessor(traceExporter)],
-    logRecordProcessors: [new BatchLogRecordProcessor(logExporter)],
+    logRecordProcessors: [new BatchLogRecordProcessor({ exporter: logExporter })],
     metricReaders: [metricReader],
     instrumentations: [
       new HostMetricsInstrumentation(),

--- a/api/src/shared/infrastructure/open-telemetry/job-tracing.js
+++ b/api/src/shared/infrastructure/open-telemetry/job-tracing.js
@@ -5,6 +5,7 @@ import { tracing } from './helpers.js';
 
 function instrumentJobHandle(jobName, jobControllerClass) {
   const originalHandle = jobControllerClass.prototype.handle;
+  if (!originalHandle) return;
   jobControllerClass.prototype.handle = tracing.spanify(`job.${jobName}.handle`, originalHandle, () => {
     const producerContext = getInContext('openTelemetryContext');
     return {

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -66,6 +66,7 @@ function emitOtelLogRecord(context, mergingObject, message, extraBindings) {
 
   // No-op unless OpenTelemetry has been initialized (see initialize-open-telemetry.js), same as the tracing API.
   const otelLogger = logs.getLogger('pix-api-logger');
+  if (!otelLogger.enabled()) return;
 
   const isMergingObjectAMessage = typeof mergingObject === 'string';
   otelLogger.emit({

--- a/api/tests/shared/unit/infrastructure/utils/logger_otel_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/logger_otel_test.js
@@ -10,7 +10,7 @@ describe('Unit | Infrastructure | Utils | logger | OpenTelemetry', function () {
 
   beforeEach(function () {
     emitStub = sinon.stub();
-    sinon.stub(logs, 'getLogger').returns({ emit: emitStub });
+    sinon.stub(logs, 'getLogger').returns({ emit: emitStub, enabled: () => true });
   });
 
   it('emits an OpenTelemetry log record for each log level', function () {


### PR DESCRIPTION
## 🪧 Problème

Plusieurs erreurs ont été observées dans l'environnement d'intégration :
- L'export des logs ne fonctionne pas et lance une erreur au niveau du `BatchLogRecordProcessor`.
- `tracing.spanify` est appelé avec une variable `undefined`, ce qui crash le container.
- Lorsque que l'API s'éteint, une erreur de stack overflow est lancée au niveau du `logger`.

## 🌈 Proposition

- Mettre à jour la signature du constructeur de `BatchLogRecordProcessor`, qui a subit un **breaking change** dans la [version 0.220.0 ](https://github.com/1024pix/pix/pull/16842)du package `@opentelemetry/sdk-logs`.
- Vérifier que l'argument passé à `tracing.spanify` est *truthy* avant de l'appeler. Le problème vient d'un handler de `ImportFromSupJobController`, qui n'est pas correctement ajouté au prototype de la classe.
- Vérifier que le logger OpenTelemetry est activé avant d'émettre des logs.

## ✊ Remarques

Il y a un problème dans notre processus de mise à jour, étant donné qu'aucun breaking change n'avait été remonté par Renovate.

## 🎉 Pour tester
- Lancer l'API en local avec la variable d'environnement `OTEL_ENABLED=true`.
- Constater qu'il n'y a pas d'erreurs dans les logs.
- Fermer l'API (ctrl+c)
- Constater qu'il n'y a pas d'erreur de stack overflow.
