### PR TITLE
[FEATURE] Ajouter un bloc de commentaire dans le formulaire suivant le feedmoji (PIX-23571)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer.gjs
@@ -83,7 +83,7 @@ export default class Drawer extends Component {
   }
 
   @action
-  async submitContentRelevanceFormScores(scores) {
+  async submitContentRelevanceFormScores(results) {
     try {
       await this.requestManager.request({
         url: `${ENV.APP.API_HOST}/api/user-campaign-surveys`,
@@ -94,9 +94,10 @@ export default class Drawer extends Component {
             attributes: {
               'campaign-id': this.args.campaignId,
               'satisfaction-score': this.satisfactionScore,
-              'usefulness-score': scores.usefulness,
-              'personalization-score': scores.personalization,
-              'attractiveness-score': scores.attractiveness,
+              'usefulness-score': results.scores.usefulness,
+              'personalization-score': results.scores.personalization,
+              'attractiveness-score': results.scores.attractiveness,
+              comment: results.comment,
             },
           },
         }),

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { concat, fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -29,6 +30,7 @@ export default class ContentRelevanceForm extends Component {
   @tracked usefulness = null;
   @tracked personalization = null;
   @tracked attractiveness = null;
+  @tracked comment = null;
 
   get isSubmitDisabled() {
     return !SCALES.every((scale) => this[scale.key] !== null);
@@ -42,15 +44,23 @@ export default class ContentRelevanceForm extends Component {
   @action
   submit() {
     this.args.onSubmit({
-      usefulness: this.usefulness,
-      personalization: this.personalization,
-      attractiveness: this.attractiveness,
+      scores: {
+        usefulness: this.usefulness,
+        personalization: this.personalization,
+        attractiveness: this.attractiveness,
+      },
+      comment: this.comment,
     });
   }
 
   @action
   focusOnInsert(element) {
     element.focus();
+  }
+
+  @action
+  updateComment(event) {
+    this.comment = event.target.value;
   }
 
   <template>
@@ -100,6 +110,22 @@ export default class ContentRelevanceForm extends Component {
               </span>
             </fieldset>
           {{/each}}
+          <PixTextarea
+            @id="comment-content-relevance"
+            @maxlength="250"
+            placeholder={{t
+              "pages.skill-review.recommended-engine.drawer.content-relevance-form.comment-text.placeholder"
+            }}
+            @screenReaderOnly="true"
+            class="results-recommendation-engine-drawer__content-relevance-form-comment-text"
+            rows="5"
+            cols="50"
+            {{on "change" this.updateComment}}
+          >
+            <:label>{{t
+                "pages.skill-review.recommended-engine.drawer.content-relevance-form.comment-text.label"
+              }}</:label>
+          </PixTextarea>
           <div class="results-recommendation-engine-drawer__content-relevance-form-actions">
             <PixButton
               @variant="tertiary"

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
@@ -192,6 +192,15 @@
     text-align: center;
   }
 
+  &__content-relevance-form-actions {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    justify-content: center;
+    margin-top: var(--pix-spacing-6x);
+  }
+
   &__scale {
     display: flex;
     flex-direction: row;
@@ -228,14 +237,5 @@
     .pix-radio-button + .pix-radio-button {
       margin-top: 0;
     }
-  }
-
-  &__content-relevance-form-actions {
-    display: flex;
-    flex-direction: row;
-    gap: var(--pix-spacing-4x);
-    align-items: center;
-    justify-content: center;
-    margin-top: var(--pix-spacing-6x);
   }
 }

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
@@ -192,6 +192,11 @@
     text-align: center;
   }
 
+  &__content-relevance-form-comment-text {
+    margin-top: var(--pix-spacing-6x);
+    resize: none;
+  }
+
   &__content-relevance-form-actions {
     display: flex;
     flex-direction: row;

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -11,7 +11,7 @@
   }
 
   &--drawer-expanded {
-    padding-bottom: 323px;
+    padding-bottom: 425px;
   }
 }
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer-test.gjs
@@ -1,6 +1,6 @@
 import { render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click, triggerEvent } from '@ember/test-helpers';
+import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import Drawer from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/drawer';
 import { module, test } from 'qunit';
@@ -183,7 +183,7 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         assert.dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.thank-you.title'))).isVisible();
       });
 
-      test('it calls PUT /api/user-campaign-surveys with campaignId, satisfaction and content relevance scores', async function (assert) {
+      test('it calls PUT /api/user-campaign-surveys with campaignId, satisfaction and content relevance scores and comment', async function (assert) {
         // given
         const screen = await render(<template><Drawer @campaignId={{1}} /></template>);
         await click(
@@ -202,6 +202,12 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
           );
           await click(scale.getByRole('radio', { name: scoreLabel }));
         }
+        await fillIn(
+          screen.getByRole('textbox', {
+            name: t('pages.skill-review.recommended-engine.drawer.content-relevance-form.comment-text.label'),
+          }),
+          'youpi',
+        );
 
         // when
         await click(screen.getByRole('button', { name: t('common.actions.send') }));
@@ -216,6 +222,7 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         assert.strictEqual(body.data.attributes['personalization-score'], 5);
         assert.strictEqual(body.data.attributes['attractiveness-score'], 5);
         assert.strictEqual(body.data.attributes['satisfaction-score'], 5);
+        assert.strictEqual(body.data.attributes['comment'], 'youpi');
       });
 
       test('it displays an error notification when the request fails', async function (assert) {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form-test.gjs
@@ -17,7 +17,7 @@ module(
       await click(scale.getByRole('radio', { name: scoreLabel }));
     }
 
-    test('it displays the title, subtitle and the three rating scales', async function (assert) {
+    test('it displays the title, subtitle, the three rating scales and a comment text-area', async function (assert) {
       // when
       const onSubmit = sinon.stub();
       const onHide = sinon.stub();
@@ -47,6 +47,7 @@ module(
         )
         .isVisible();
       assert.strictEqual(screen.getAllByRole('radio').length, 15);
+      assert.dom(screen.getByRole('textbox', { name: 'Commentaire optionnel' })).exists();
     });
 
     test('the submit button is disabled until the three scales have a selected score', async function (assert) {
@@ -125,9 +126,12 @@ module(
       // then
       assert.true(
         onSubmit.calledOnceWithExactly({
-          usefulness: 4,
-          personalization: 5,
-          attractiveness: 5,
+          scores: {
+            usefulness: 4,
+            personalization: 5,
+            attractiveness: 5,
+          },
+          comment: null,
         }),
       );
     });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2260,6 +2260,10 @@
               "max-label": "Ansprechend",
               "min-label": "Nicht ansprechend"
             },
+            "comment-text": {
+              "label": "Optionaler Kommentar",
+              "placeholder": "Kommentar (optional)"
+            },
             "legend": "Die empfohlenen Inhalte sind…",
             "personalization": {
               "legend": "Bewerten Sie, wie personalisiert die Inhalte sind, von generisch 1 bis personalisiert 5",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2260,6 +2260,10 @@
               "max-label": "Appealing",
               "min-label": "Not appealing"
             },
+            "comment-text": {
+              "label": "Optional comment",
+              "placeholder": "Comment (optional)"
+            },
             "legend": "The recommended content is…",
             "personalization": {
               "legend": "Rate how personalized the content is, from generic 1 to personalized 5",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2260,6 +2260,10 @@
               "max-label": "Atractivos",
               "min-label": "Poco atractivos"
             },
+            "comment-text": {
+              "label": "Comentario opcional",
+              "placeholder": "Comentario (opcional)"
+            },
             "legend": "Los contenidos recomendados son…",
             "personalization": {
               "legend": "Evalúa la personalización de los contenidos, de genéricos 1 a personalizados 5",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2260,6 +2260,10 @@
               "max-label": "Attirantes",
               "min-label": "Pas attirantes"
             },
+            "comment-text": {
+              "label": "Commentaire optionnel",
+              "placeholder": "Commentaire (optionnel)"
+            },
             "legend": "Les offres de formation recommandées sont…",
             "personalization": {
               "legend": "Évaluez la personnalisation des offres de formation, de génériques 1 à personnalisées 5",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2260,6 +2260,10 @@
               "max-label": "Attraenti",
               "min-label": "Poco attraenti"
             },
+            "comment-text": {
+              "label": "Commento opzionale",
+              "placeholder": "Commento (opzionale)"
+            },
             "legend": "I contenuti consigliati sono…",
             "personalization": {
               "legend": "Valuta quanto sono personalizzati i contenuti, da generici 1 a personalizzati 5",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2260,6 +2260,10 @@
               "max-label": "Aantrekkelijk",
               "min-label": "Niet aantrekkelijk"
             },
+            "comment-text": {
+              "label": "Optionele opmerking",
+              "placeholder": "Opmerking (optioneel)"
+            },
             "legend": "De aanbevolen inhoud is…",
             "personalization": {
               "legend": "Beoordeel hoe gepersonaliseerd de inhoud is, van algemeen 1 tot gepersonaliseerd 5",


### PR DESCRIPTION
## 🌈 Proposition

- Sur la page de résultat d’une campagne tagguée moteur de reco, une fois que l’utilisateur a répondu au feedmoji lui demandant son avis sur les contenus qui lui ont été recommandés, au niveau du formulaire permettant de détailler l’avis rendu, ajouter un textArea permettant de saisir un commentaire pour détailler encore plus. 
- Sa saisie est facultative.

## ✊ Remarques

RAS

## 🎉 Pour tester

- Afficher la page de résultats avec le profil de Dave
- Répondre au Feedmoji
- Doit apparaître le formulaire avec un bloc commentaire
- Envoyer le formulaire sans saisir de commentaire => envoie possible et commentaire. à null
- Avec un autre utilisateur, tester l'envoi de formulaire en remplissant le commentaire => envoi possible et commentaire rempli

https://github.com/user-attachments/assets/d5e8dfc9-8355-4e62-a48a-0fb884577326

