### PR TITLE
[TECH] Divers nettoyage sur la configuration OpenTelemetry

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -40,7 +40,7 @@
         "@opentelemetry/sdk-logs": "^0.220.0",
         "@opentelemetry/sdk-metrics": "^2.9.0",
         "@opentelemetry/sdk-node": "^0.220.0",
-        "@opentelemetry/sdk-trace-base": "^2.7.0",
+        "@opentelemetry/sdk-trace": "^2.9.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@pdf-lib/fontkit": "^1.1.1",
         "@xmldom/xmldom": "^0.9.10",

--- a/api/package.json
+++ b/api/package.json
@@ -122,7 +122,7 @@
     "@opentelemetry/sdk-logs": "^0.220.0",
     "@opentelemetry/sdk-metrics": "^2.9.0",
     "@opentelemetry/sdk-node": "^0.220.0",
-    "@opentelemetry/sdk-trace-base": "^2.7.0",
+    "@opentelemetry/sdk-trace": "^2.9.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@pdf-lib/fontkit": "^1.1.1",
     "@xmldom/xmldom": "^0.9.10",

--- a/api/src/shared/infrastructure/metrics/datadog-metrics.js
+++ b/api/src/shared/infrastructure/metrics/datadog-metrics.js
@@ -10,12 +10,12 @@ export class DatadogMetrics {
 
   constructor({ config }) {
     if (!config.metrics.isDirectMetricsEnabled) {
-      logger.info('Metric initialisation : no reporter => no metrics sent');
+      logger.info('DatadogMetrics initialisation : no reporter => no metrics sent');
       metrics.init({ reporter: new metrics.reporters.NullReporter(), flushIntervalSeconds: 0 });
     }
 
     if (config.metrics.isDirectMetricsEnabled) {
-      logger.info('Metric initialisation : linked to Datadog');
+      logger.info('DatadogMetrics initialisation : linked to Datadog');
       metrics.init({
         host: config.infra.containerName,
         prefix: '',
@@ -65,7 +65,7 @@ export class DatadogMetrics {
   #registerMetric({ type, name, tags }) {
     const metricSignature = `${type}|${name}|${tags}`;
     if (!DatadogMetrics.metricDefinitions[metricSignature]) {
-      logger.info(`Metric registered with : ${type}, ${name}, ${tags}`);
+      logger.info(`DatadogMetrics metric registered with : ${type}, ${name}, ${tags}`);
       DatadogMetrics.metricDefinitions[metricSignature] = { type, name, tags };
     }
   }

--- a/api/src/shared/infrastructure/open-telemetry/hapi-tracing.js
+++ b/api/src/shared/infrastructure/open-telemetry/hapi-tracing.js
@@ -15,8 +15,7 @@
  *   Instead, `server.auth.scheme` is wrapped so that whatever `authenticate()` method a scheme
  *   returns is wrapped in its own span.
  */
-import { context, SpanStatusCode, trace } from '@opentelemetry/api';
-import { metrics } from '@opentelemetry/api';
+import { context, metrics, SpanStatusCode, trace } from '@opentelemetry/api';
 
 import { config } from '../../config.js';
 import { routeDomainToOwnerTeam } from '../utils/route-domain-to-owner-team.js';

--- a/api/src/shared/infrastructure/open-telemetry/inherited-span-attributes.js
+++ b/api/src/shared/infrastructure/open-telemetry/inherited-span-attributes.js
@@ -34,11 +34,11 @@ export function setInheritedAttributes(ctx, attributes) {
  * `NodeSDK`'s `spanProcessors` option) alongside the processor(s) actually responsible for
  * exporting spans - this one only annotates spans, it does not export them.
  *
- * @implements {import('@opentelemetry/sdk-trace-base').SpanProcessor}
+ * @implements {import('@opentelemetry/sdk-trace').SpanProcessor}
  */
 export class InheritedAttributesSpanProcessor {
   /**
-   * @param {import('@opentelemetry/sdk-trace-base').Span} span
+   * @param {import('@opentelemetry/sdk-trace').Span} span
    * @param {import('@opentelemetry/api').Context} parentContext
    */
   onStart(span, parentContext) {

--- a/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
+++ b/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
@@ -32,8 +32,9 @@ export function initializeOpenTelemetry(serviceName) {
   }
   diag.setLogger(
     {
-      ...logger,
-      verbose: logger.debug,
+      ...console,
+      // eslint-disable-next-line no-console
+      verbose: console.debug,
     },
     DiagLogLevel.WARN,
   );

--- a/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
+++ b/api/src/shared/infrastructure/open-telemetry/initialize-open-telemetry.js
@@ -18,7 +18,7 @@ import {
 import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 import { config } from '../../config.js';
@@ -55,7 +55,7 @@ export function initializeOpenTelemetry(serviceName) {
       [ATTR_SERVICE_NAME]: serviceName,
     }),
     resourceDetectors: [envDetector, hostDetector, osDetector, processDetector, containerDetector, scalingoDetector],
-    spanProcessors: [new InheritedAttributesSpanProcessor(), new BatchSpanProcessor(traceExporter)],
+    spanProcessors: [new InheritedAttributesSpanProcessor(), new BatchSpanProcessor({ exporter: traceExporter })],
     logRecordProcessors: [new BatchLogRecordProcessor({ exporter: logExporter })],
     metricReaders: [metricReader],
     instrumentations: [


### PR DESCRIPTION
## 🪧 Problème

1. La librairie `@opentelemetry/sdk-trace-base` est en cours de dépréciation.
1. Les logs de `DatadogMetrics` ne précisent pas qu'on parle des métriques **Datadog** (ambigu maintenant qu'il y a plusieurs types de métriques).
1. Le problème de [stack overflow dans le logger](https://github.com/1024pix/pix/pull/16869) n'a pas correctement été reglé.

## 🌈 Proposition

1. Remplacer la librairie par `@opentelemetry/sdk-trace`.
1. Ajouter le mot clé `DatadogMetrics` dans chacun des logs concernés.
1. Utiliser `console` au lieu de `logger` pour les diagnostics OpenTelemetry (pas super mais les alternatives sont peut-être pires).

## 🎉 Pour tester
- Constater que l'API se lance correctement (`OTEL_ENABLED=true npm start`).
- Constater que l'API se ferme correctement (<kbd>CTRL+C</kbd>).