### PR TITLE
[FEATURE] Notifier l'utilisateur de l'enregistrement de son avis sur la pertinence d'un seul CF (PIX-23594) 

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card-modal.gjs
@@ -4,6 +4,7 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -17,16 +18,29 @@ import Training from 'mon-pix/models/training';
 import RegistrationCardTag from './registration-card-tag';
 
 export default class CardModal extends Component {
+  @service intl;
   @service locale;
   @service store;
 
   @tracked isTrainingRecommendationRelevant = null;
+  @tracked shouldDisplayFeedbackNotification = false;
+  @tracked feedbackSubmittedSuccessfully = false;
 
   firedAccordions = new Set();
 
   constructor(...args) {
     super(...args);
     this.isTrainingRecommendationRelevant = this.args.training.isRelevant ?? null;
+  }
+
+  get feedbackNotificationMessage() {
+    return this.feedbackSubmittedSuccessfully
+      ? this.intl.t('pages.skill-review.recommended-engine.modal.feedback.success-message')
+      : this.intl.t('common.error');
+  }
+
+  get feedbackNotificationType() {
+    return this.feedbackSubmittedSuccessfully ? 'success' : 'error';
   }
 
   get formattedDuration() {
@@ -45,11 +59,18 @@ export default class CardModal extends Component {
     this.isTrainingRecommendationRelevant = feedbackResponse;
     const campaignParticipationId = this.args.training.belongsTo('campaignParticipation').id();
     const adapter = this.store.adapterFor('training');
-    await adapter.updateRelevance({
-      campaignParticipationId,
-      trainingId: this.args.training.id,
-      isRelevant: feedbackResponse,
-    });
+    try {
+      await adapter.updateRelevance({
+        campaignParticipationId,
+        trainingId: this.args.training.id,
+        isRelevant: feedbackResponse,
+      });
+      this.feedbackSubmittedSuccessfully = true;
+    } catch {
+      this.feedbackSubmittedSuccessfully = false;
+    } finally {
+      this.shouldDisplayFeedbackNotification = true;
+    }
   }
 
   @action onModalButtonClick() {
@@ -62,11 +83,16 @@ export default class CardModal extends Component {
     this.args.onModalAccordionClick({ trainingId: this.args.training.id, accordionName });
   }
 
+  @action onClose() {
+    this.shouldDisplayFeedbackNotification = false;
+    this.args.onClose();
+  }
+
   <template>
     <PixModal
       @title={{@training.title}}
       @showModal={{@isOpen}}
-      @onCloseButtonClick={{@onClose}}
+      @onCloseButtonClick={{this.onClose}}
       class="results-recommendation-engine-training-card-modal"
     >
       <:content>
@@ -131,6 +157,16 @@ export default class CardModal extends Component {
         {{/if}}
       </:content>
       <:footer>
+        {{#if this.shouldDisplayFeedbackNotification}}
+          <PixNotificationAlert
+            class="results-recommendation-engine-training-card-modal__notification"
+            @type={{this.feedbackNotificationType}}
+            @withIcon={{true}}
+            role="status"
+          >
+            {{this.feedbackNotificationMessage}}
+          </PixNotificationAlert>
+        {{/if}}
         <div class="results-recommendation-engine-training-card-modal-footer">
           <form>
             <fieldset class="results-recommendation-engine-training-card-modal-footer__feedback">
@@ -154,7 +190,7 @@ export default class CardModal extends Component {
           <ul class="results-recommendation-engine-training-card-modal-footer__action-buttons">
             <li>
               <PixButton
-                @triggerAction={{@onClose}}
+                @triggerAction={{this.onClose}}
                 @variant="secondary"
                 class="results-recommendation-engine-training-card-modal-footer-action-buttons__cancel"
               >

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -157,6 +157,10 @@
     }
   }
 
+  &__notification {
+    width: 100%;
+  }
+
   &__objectives {
     @extend %pix-body-m;
 

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -111,12 +111,25 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
         await click(thumbsDownButton);
         assert.dom(thumbsUpButton).doesNotHaveClass('selected');
         assert.dom(thumbsDownButton).hasClass('selected');
+        assert
+          .dom(await within(modal).findByRole('status'))
+          .hasText(t('pages.skill-review.recommended-engine.modal.feedback.success-message'));
 
         const actionButtons = within(modal).getByRole('list');
         await click(within(actionButtons).getByRole('button', { name: t('common.actions.close') }));
         await click(trainingCardButton);
 
         const reopenedModal = await screen.findByRole('dialog', { name: training.title });
+
+        assert.dom(within(reopenedModal).queryByRole('status')).doesNotExist();
+        assert
+          .dom(
+            within(reopenedModal).queryByText(
+              t('pages.skill-review.recommended-engine.modal.feedback.success-message'),
+            ),
+          )
+          .doesNotExist();
+
         assert.dom(within(reopenedModal).getByRole('button', { name: t('common.yes') })).doesNotHaveClass('selected');
         assert.dom(within(reopenedModal).getByRole('button', { name: t('common.no') })).hasClass('selected');
       });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2305,7 +2305,8 @@
           "duration": "Dauer",
           "editor-name": "Vorgeschlagen von : ",
           "feedback": {
-            "question": "Ist dieser Vorschlag relevant?"
+            "question": "Ist dieser Vorschlag relevant?",
+            "success-message": "Vielen Dank für Ihr Feedback!"
           },
           "localisation": "Standort",
           "objectives": "Ziele",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2305,7 +2305,8 @@
           "duration": "Duration",
           "editor-name": "Proposed by: ",
           "feedback": {
-            "question": "Is this proposal relevant?"
+            "question": "Is this proposal relevant?",
+            "success-message": "Thank you for your feedback!"
           },
           "localisation": "Location",
           "objectives": "Objectives",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2305,7 +2305,8 @@
           "duration": "Duración",
           "editor-name": "Propuesto por: ",
           "feedback": {
-            "question": "¿Es relevante esta propuesta?"
+            "question": "¿Es relevante esta propuesta?",
+            "success-message": "¡Gracias por su opinión!"
           },
           "localisation": "Localización",
           "objectives": "Objetivos",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2305,7 +2305,8 @@
           "duration": "Durée",
           "editor-name": "Proposé par : ",
           "feedback": {
-            "question": "Cette proposition est-elle pertinente ?"
+            "question": "Cette proposition est-elle pertinente ?",
+            "success-message": "Merci pour votre avis !"
           },
           "localisation": "Localisation",
           "objectives": "Objectifs",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2305,7 +2305,8 @@
           "duration": "Durata",
           "editor-name": "Proposto da : ",
           "feedback": {
-            "question": "Questa proposta è pertinente?"
+            "question": "Questa proposta è pertinente?",
+            "success-message": "Grazie per il tuo parere!"
           },
           "localisation": "Localizzazione",
           "objectives": "Obiettivi",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2305,7 +2305,8 @@
           "duration": "Duur",
           "editor-name": "Voorgesteld door : ",
           "feedback": {
-            "question": "Is dit voorstel relevant?"
+            "question": "Is dit voorstel relevant?",
+            "success-message": "Bedankt voor uw feedback!"
           },
           "localisation": "Locatie",
           "objectives": "Doelstellingen",


### PR DESCRIPTION
## 🪧 Problème

Lorsque l’utilisateur affiche l'un modale d'un seul CF et émet son avis sur sa pertinence (avec les pouces), il n’y a actuellement pas de feedback à l’utilisateur sur ce qui s’est passé (succès, erreur).

## 🌈 Proposition

- Si succès : on se contente d'afficher une notification succès "Merci pour votre avis"
- En cas d'erreur: on affiche une notification avec un message d'erreur

## ✊ Remarques

On affiche une erreur générique dans le cas où l'appel a échoué.

## 🎉 Pour tester
- Se connecter avec le compte `dave-comp@example.net` et passer la campagne `EDUMULTIP`
- Cliquer sur la carte d'un contenu formatif pour afficher la modale.

#### Affichage du message de succès.
- Donner un avis sur la pertinence du CF (avec les pouces). Constater qu'un message de succès s'affiche 😄 
- Fermer la modale et le réouvrir. Constater que le message ne s'affiche plus

#### Affichage du message d'erreur
- Ouvrir l'onglet Network et se mettre en mode hors connexion
- Donner un avis sur la pertinence du CF. Constater que le message d'erreur générique s'affiche bien.
- Enlever le mode hors connexion et redonner votre avis. Le message de succès devrait bien s'afficher 🚀 