### PR TITLE
[FEATURE] Conditionner l'affichage des onglets du catalogue en fonction de la présence de schema dans l'organisation (PIX-23525)

### DIFF
--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -115,17 +115,29 @@ export default class List extends Component {
     );
   }
 
+  get displayAllTab() {
+    return this.args.hasBlueprints;
+  }
+
+  get displayBlueprintTab() {
+    return this.args.hasBlueprints;
+  }
+
   <template>
     <div class="catalogue">
       <PixTabs @variant="orga" class="catalogue__nav" @ariaLabel={{t "pages.catalogue.tab-filters.label"}}>
-        <LinkTo @route="authenticated.catalogue.list" @model="all">
-          {{t "pages.catalogue.tab-filters.all"}}</LinkTo>
+        {{#if this.displayAllTab}}
+          <LinkTo @route="authenticated.catalogue.list" @model="all">
+            {{t "pages.catalogue.tab-filters.all"}}</LinkTo>
+        {{/if}}
         <LinkTo @route="authenticated.catalogue.list" @model="targetProfile">{{t
             "pages.catalogue.tab-filters.target-profiles"
           }}</LinkTo>
-        <LinkTo @route="authenticated.catalogue.list" @model="blueprint">{{t
-            "pages.catalogue.tab-filters.blueprints"
-          }}</LinkTo>
+        {{#if this.displayBlueprintTab}}
+          <LinkTo @route="authenticated.catalogue.list" @model="blueprint">{{t
+              "pages.catalogue.tab-filters.blueprints"
+            }}</LinkTo>
+        {{/if}}
       </PixTabs>
       <PixFilterBanner
         class="catalogue__filters"

--- a/orga/app/routes/authenticated/catalogue/list.js
+++ b/orga/app/routes/authenticated/catalogue/list.js
@@ -44,7 +44,17 @@ export default class AuthenticatedCatalogueFilter extends Route {
       });
     }
 
-    return { courses, currentCourse, type };
+    const hasBlueprints = courses.some((course) => course.type === 'blueprint');
+
+    return { courses, currentCourse, type, hasBlueprints };
+  }
+
+  afterModel({ hasBlueprints }, transition) {
+    if (transition.to.params?.type === 'all') {
+      if (!hasBlueprints) {
+        return this.router.replaceWith('authenticated.catalogue.list', 'targetProfile');
+      }
+    }
   }
 
   handleCache() {

--- a/orga/app/templates/authenticated/catalogue/list.gjs
+++ b/orga/app/templates/authenticated/catalogue/list.gjs
@@ -11,5 +11,6 @@ import List from 'pix-orga/components/catalogue/list';
     @areas={{@controller.areas}}
     @competences={{@controller.competences}}
     @currentCourse={{@model.currentCourse}}
+    @hasBlueprints={{@model.hasBlueprints}}
   />
 </template>

--- a/orga/tests/integration/components/catalogue/list-test.gjs
+++ b/orga/tests/integration/components/catalogue/list-test.gjs
@@ -55,26 +55,55 @@ module('Integration | Component | Catalogue::List', function (hooks) {
     });
 
     module('type filters', function () {
-      test('it displays navigation links to filter by type', async function (assert) {
-        // given
-        const courses = [
-          { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
-          { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
-        ];
-        const updateFilter = sinon.stub();
+      module('when hasBlueprints is true', function () {
+        test('it displays all navigation links to filter by type', async function (assert) {
+          // given
+          const courses = [
+            { name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' },
+            { name: 'Mon parcours combiné', type: 'blueprint', nbModules: 2 },
+          ];
+          const updateFilter = sinon.stub();
 
-        // when
-        const screen = await render(
-          <template><List @courses={{courses}} @updateFilter={{updateFilter}} @type="blueprint" /></template>,
-        );
+          // when
+          const screen = await render(
+            <template>
+              <List @courses={{courses}} @updateFilter={{updateFilter}} @type="blueprint" @hasBlueprints={{true}} />
+            </template>,
+          );
 
-        // then
-        const allLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.all') });
-        assert.ok(allLink.href.endsWith('/catalogue/all'));
-        const targetProfilLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.target-profiles') });
-        assert.ok(targetProfilLink.href.endsWith('/catalogue/targetProfile'));
-        const blueprintLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.blueprints') });
-        assert.ok(blueprintLink.href.endsWith('/catalogue/blueprint'));
+          // then
+          const allLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.all') });
+          assert.ok(allLink.href.endsWith('/catalogue/all'));
+          const targetProfilLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.target-profiles') });
+          assert.ok(targetProfilLink.href.endsWith('/catalogue/targetProfile'));
+          const blueprintLink = screen.getByRole('link', { name: t('pages.catalogue.tab-filters.blueprints') });
+          assert.ok(blueprintLink.href.endsWith('/catalogue/blueprint'));
+        });
+      });
+
+      module('when hasBlueprints is false', function () {
+        test('it display only targetProfile navigation link', async function (assert) {
+          // given
+          const courses = [{ name: 'Ma super formation', type: 'targetProfile', nbTubes: 5, category: 'PREDEFINED' }];
+          const updateFilter = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template>
+              <List
+                @courses={{courses}}
+                @updateFilter={{updateFilter}}
+                @type="targetProfile"
+                @hasBlueprints={{false}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.dom(screen.queryByRole('link', { name: t('pages.catalogue.tab-filters.target-profiles') })).exists();
+          assert.dom(screen.queryByRole('link', { name: t('pages.catalogue.tab-filters.all') })).doesNotExist();
+          assert.dom(screen.queryByRole('link', { name: t('pages.catalogue.tab-filters.blueprints') })).doesNotExist();
+        });
       });
 
       test('it filters list by type', async function (assert) {

--- a/orga/tests/unit/routes/authenticated/catalogue/list-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue/list-test.js
@@ -49,7 +49,7 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
         const currentUser = this.owner.lookup('service:current-user');
         const organizationId = Symbol('organizationId');
         sinon.stub(currentUser, 'organization').value({ id: organizationId });
-        const courses = Symbol('Courses');
+        const courses = [Symbol('Course')];
 
         sinon.stub(store, 'peekAll').withArgs('course').returns([]);
         sinon
@@ -62,8 +62,14 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
 
         // then
         assert.ok(store.findAll.calledOnce);
-        assert.deepEqual(result, { courses, currentCourse: undefined, type: 'all' });
+        assert.deepEqual(result, {
+          courses,
+          currentCourse: undefined,
+          type: 'all',
+          hasBlueprints: false,
+        });
       });
+
       test('it returns cached courses without calling the API when the store is not empty', async function (assert) {
         // given
         const currentUser = this.owner.lookup('service:current-user');
@@ -80,8 +86,15 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
         const result = await route.model({ type: 'all' });
         // then
         assert.ok(store.findAll.notCalled);
-        assert.deepEqual(result, { courses, currentCourse: undefined, type: 'all' });
+        assert.deepEqual(result, {
+          courses,
+          currentCourse: undefined,
+          type: 'all',
+
+          hasBlueprints: false,
+        });
       });
+
       test('it unload cached courses when organization change', async function (assert) {
         // given
         const currentUser = this.owner.lookup('service:current-user');
@@ -98,7 +111,13 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
         const result = await route.model({ type: 'all' });
         // then
         assert.ok(store.findAll.notCalled);
-        assert.deepEqual(result, { courses, currentCourse: undefined, type: 'all' });
+        assert.deepEqual(result, {
+          courses,
+          currentCourse: undefined,
+          type: 'all',
+
+          hasBlueprints: false,
+        });
       });
     });
 
@@ -125,7 +144,53 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
 
         // then
         assert.ok(store.findRecord.calledOnce);
-        assert.deepEqual(result, { courses, currentCourse, type: 'all' });
+        assert.deepEqual(result, {
+          courses,
+          currentCourse,
+          type: 'all',
+
+          hasBlueprints: false,
+        });
+      });
+    });
+
+    module('hasBlueprints', function () {
+      test('it should return true if at least one of the courses is a blueprint', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/catalogue/list');
+        const store = this.owner.lookup('service:store');
+        const currentUser = this.owner.lookup('service:current-user');
+        const organizationId = Symbol('organizationId');
+        sinon.stub(currentUser, 'organization').value({ id: organizationId });
+        const courses = [{ type: 'blueprint' }, { type: 'targetProfile' }];
+
+        sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
+        sinon.stub(store, 'findAll');
+
+        // when
+        const result = await route.model({ type: 'all' });
+
+        // then
+        assert.true(result.hasBlueprints);
+      });
+
+      test('it should return false otherwise', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/catalogue/list');
+        const store = this.owner.lookup('service:store');
+        const currentUser = this.owner.lookup('service:current-user');
+        const organizationId = Symbol('organizationId');
+        sinon.stub(currentUser, 'organization').value({ id: organizationId });
+        const courses = [{ type: 'targetProfile' }, { type: 'targetProfile' }];
+
+        sinon.stub(store, 'peekAll').withArgs('course').returns(courses);
+        sinon.stub(store, 'findAll');
+
+        // when
+        const result = await route.model({ type: 'all' });
+
+        // then
+        assert.false(result.hasBlueprints);
       });
     });
   });
@@ -179,6 +244,33 @@ module('Unit | Route | authenticated/catalogue/list', function (hooks) {
       // then
       assert.true(controller.set.firstCall.calledWithExactly('targetProfileId', null));
       assert.true(controller.set.secondCall.calledWithExactly('blueprintId', null));
+    });
+  });
+
+  module('afterModel', function () {
+    module('when there is a transition to "all"', function () {
+      const transition = {
+        to: {
+          params: {
+            type: 'all',
+          },
+        },
+      };
+
+      test('it should redirect to "targetProfile" if there is no blueprint', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/catalogue/list');
+        const routerService = this.owner.lookup('service:router');
+        sinon.stub(routerService, 'replaceWith');
+
+        const hasBlueprints = false;
+
+        // when
+        route.afterModel({ hasBlueprints }, transition);
+
+        // then
+        assert.ok(routerService.replaceWith.calledWith('authenticated.catalogue.list', 'targetProfile'));
+      });
     });
   });
 });


### PR DESCRIPTION
## 🪧 Problème
Actuellement, les onglets “Évaluation” et “Apprentissage” sont visibles pour toutes les organisations, peu importe si elles disposent de PC ou schémas.

Un problème se pose pour l’international. Les parcours apprenants ne sont pas massivement diffusés à l'étranger. Les parcours d'évaluation sont le seul outil de développement de compétences. Le métier nous remonte que cet onglet “Apprentissage” vide risque de créer de la confusion, ou de susciter des demandes que Pix ne pourra pas adresser.

## 🌈 Proposition
Conditionner l’affichage des onglets aux objets disponibles dans l’organisation.

## 🎉 Pour tester
- Se connecter à Pix Orga.
- Aller sur le catalogue de l'organisation `SCO SIECLE` et constater que tous les onglets sont affichés.
- Aller sur le catalogue de l'organisation `Attestation` et constater qu'on est redirigé sur l'onglet Evaluation et que c'est le seul onglet visible.