### PR TITLE
[A SUPPRIMER]

### DIFF
--- a/api/datamart/migrations/20260715085045_create-tdb_num_back_to_school_campaigns_statistics.js
+++ b/api/datamart/migrations/20260715085045_create-tdb_num_back_to_school_campaigns_statistics.js
@@ -1,0 +1,38 @@
+const TABLE_NAME = 'tdb_num_back_to_school_campaigns_statistics';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('schoolUai');
+    table.index('schoolUai');
+    table.string('schoolYear');
+    table.string('academieName');
+    table.string('schoolName');
+    table.string('provinceCode');
+    table.string('schoolYearGroup');
+    table.string('competenceCode');
+    table.string('competenceName');
+    table.integer('participantCount');
+    table.float('standardDeviation');
+    table.integer('firstDecileLevel');
+    table.integer('firstQuartileLevel');
+    table.integer('medianLevel');
+    table.integer('thirdQuartileLevel');
+    table.integer('ninthDecileLevel');
+    table.float('averageMaxLevelReached');
+    table.float('averageMaxLevelReachable');
+    table.float('coverage');
+    table.date('updatedAt');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/datamart/migrations/20260715085045_create-tdb_num_back_to_school_campaigns_statistics.js
+++ b/api/datamart/migrations/20260715085045_create-tdb_num_back_to_school_campaigns_statistics.js
@@ -8,7 +8,7 @@ export async function up(knex) {
   await knex.schema.createTable(TABLE_NAME, function (table) {
     table.string('schoolUai');
     table.index('schoolUai');
-    table.string('schoolYear');
+    table.integer('schoolYear');
     table.string('academieName');
     table.string('schoolName');
     table.string('provinceCode');
@@ -17,11 +17,11 @@ export async function up(knex) {
     table.string('competenceName');
     table.integer('participantCount');
     table.float('standardDeviation');
-    table.integer('firstDecileLevel');
-    table.integer('firstQuartileLevel');
-    table.integer('medianLevel');
-    table.integer('thirdQuartileLevel');
-    table.integer('ninthDecileLevel');
+    table.float('firstDecileLevel');
+    table.float('firstQuartileLevel');
+    table.float('medianLevel');
+    table.float('thirdQuartileLevel');
+    table.float('ninthDecileLevel');
     table.float('averageMaxLevelReached');
     table.float('averageMaxLevelReachable');
     table.float('coverage');

--- a/api/datamart/migrations/20260715085046_create-tdb_num_certification_statistics.js
+++ b/api/datamart/migrations/20260715085046_create-tdb_num_certification_statistics.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'tdb_num_certification_statistics';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('schoolUai');
+    table.index('schoolUai');
+    table.string('schoolYear');
+    table.string('academieName');
+    table.string('schoolName');
+    table.string('provinceCode');
+    table.string('schoolYearGroup');
+    table.integer('validatedCertificationCount');
+    table.integer('certificationCount');
+    table.float('averagePixScore');
+    table.string('competenceCode');
+    table.float('avgCompetenceLevel');
+    table.date('updatedAt');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/datamart/migrations/20260715085046_create-tdb_num_certification_statistics.js
+++ b/api/datamart/migrations/20260715085046_create-tdb_num_certification_statistics.js
@@ -8,7 +8,7 @@ export async function up(knex) {
   await knex.schema.createTable(TABLE_NAME, function (table) {
     table.string('schoolUai');
     table.index('schoolUai');
-    table.string('schoolYear');
+    table.integer('schoolYear');
     table.string('academieName');
     table.string('schoolName');
     table.string('provinceCode');

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -53,6 +53,101 @@ export const replications = [
     },
   },
   {
+    name: 'tdb_num_back_to_school_campaigns_statistics',
+    before: async ({ datamartKnex }) => {
+      await datamartKnex('tdb_num_back_to_school_campaigns_statistics').truncate();
+    },
+    from: ({ datawarehouseKnex }) => {
+      return datawarehouseKnex('data_sco_edupilot')
+        .select(
+          'uai',
+          'annee_scolaire',
+          'academie_nom',
+          'etablissement',
+          'departement',
+          'niveau_scolaire',
+          'code_competence',
+          'nom_competence',
+          'nombre_eleves_distinct',
+          'ecart_type',
+          'decile_10',
+          'quartile_25',
+          'quartile_50',
+          'quartile_75',
+          'decile_90',
+          'niveau_maximum_moyen_atteint',
+          'niveau_maximum_moyen_atteignable',
+          'couverture',
+          'date_derniere_mise_a_jour',
+        )
+        .as(
+          'schoolUai',
+          'schoolYear',
+          'academieName',
+          'schoolName',
+          'provinceCode',
+          'schoolYearGroup',
+          'competenceCode',
+          'competenceName',
+          'participantCount',
+          'standardDeviation',
+          'firstDecileLevel',
+          'firstQuartileLevel',
+          'medianLevel',
+          'thirdQuartileLevel',
+          'ninthDecileLevel',
+          'averageMaxLevelReached',
+          'averageMaxLevelReachable',
+          'coverage',
+          'updatedAt',
+        );
+    },
+    to: ({ datamartKnex }, chunk) => {
+      return datamartKnex('tdb_num_back_to_school_campaigns_statistics').insert(chunk);
+    },
+  },
+  {
+    name: 'tdb_num_certification_statistics',
+    before: async ({ datamartKnex }) => {
+      await datamartKnex('tdb_num_certification_statistics').truncate();
+    },
+    from: ({ datawarehouseKnex }) => {
+      return datawarehouseKnex('data_sco_edupilot_lot_2')
+        .select(
+          'uai',
+          'annee_scolaire',
+          'academie_nom',
+          'etablissement',
+          'departement',
+          'niveau_scolaire',
+          'total_certification_obtenues',
+          'total_certifications',
+          'moyenne_score',
+          'competence_code',
+          'avg_competence_level',
+          'date_derniere_mise_a_jour',
+        )
+        .as(
+          'schoolUai',
+          'schoolUai',
+          'schoolYear',
+          'academieName',
+          'schoolName',
+          'provinceCode',
+          'schoolYearGroup',
+          'validatedCertificationCount',
+          'certificationCount',
+          'averagePixScore',
+          'competenceCode',
+          'avgCompetenceLevel',
+          'updatedAt',
+        );
+    },
+    to: ({ datamartKnex }, chunk) => {
+      return datamartKnex('tdb_num_certification_statistics').insert(chunk);
+    },
+  },
+  {
     name: 'organizations_cover_rates',
     before: async ({ datamartKnex }) => {
       await datamartKnex('organizations_cover_rates').truncate();


### PR DESCRIPTION
## 🪧 Problème

Les tables du Datamart pour le tableau de bord du numérique du MEN ne sont pas alimentées.

## 🌈 Proposition

Répliquer les tables `data_sco_edupilot` vers `tdb_num_back_to_school_campaigns_statistics` et `data_sco_edupilot_lot2` vers `tdb_num_certification_statistics`.

## 🎉 Pour tester
A voir.