### PR TITLE
[FEATURE] Réplication des tables du dashboard du MEN dans le Datamart (PIX-23444)

### DIFF
--- a/api/datamart/migrations/20260715085045_create-men_dashboard_participation_dataset.js
+++ b/api/datamart/migrations/20260715085045_create-men_dashboard_participation_dataset.js
@@ -1,0 +1,38 @@
+const TABLE_NAME = 'men_dashboard_participation_dataset';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('schoolUai');
+    table.index('schoolUai');
+    table.smallint('schoolYear');
+    table.string('academieName');
+    table.string('schoolName');
+    table.string('provinceCode');
+    table.string('schoolYearGroup');
+    table.string('competenceCode');
+    table.string('competenceName');
+    table.integer('participantCount');
+    table.float('standardDeviation');
+    table.float('firstDecileLevel');
+    table.float('firstQuartileLevel');
+    table.float('medianLevel');
+    table.float('thirdQuartileLevel');
+    table.float('ninthDecileLevel');
+    table.float('averageMaxLevelReached');
+    table.float('averageMaxLevelReachable');
+    table.float('coverage');
+    table.date('updatedAt');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/datamart/migrations/20260715085046_create-men_dashboard_certification_dataset.js
+++ b/api/datamart/migrations/20260715085046_create-men_dashboard_certification_dataset.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'men_dashboard_certification_dataset';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('schoolUai');
+    table.index('schoolUai');
+    table.smallint('schoolYear');
+    table.string('academieName');
+    table.string('schoolName');
+    table.string('provinceCode');
+    table.string('schoolYearGroup');
+    table.integer('validatedCertificationCount');
+    table.integer('certificationCount');
+    table.float('averagePixScore');
+    table.string('competenceCode');
+    table.float('avgCompetenceLevel');
+    table.date('updatedAt');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -53,6 +53,63 @@ export const replications = [
     },
   },
   {
+    name: 'men_dashboard_participation_dataset',
+    before: async ({ datamartKnex }) => {
+      await datamartKnex('men_dashboard_participation_dataset').truncate();
+    },
+    from: ({ datawarehouseKnex }) => {
+      return datawarehouseKnex('data_sco_edupilot').select({
+        schoolUai: 'uai',
+        schoolYear: 'annee_scolaire',
+        academieName: 'academie_nom',
+        schoolName: 'etablissement',
+        provinceCode: 'departement',
+        schoolYearGroup: 'niveau_scolaire',
+        competenceCode: 'code_competence',
+        competenceName: 'nom_competence',
+        participantCount: 'nombre_eleves_distinct',
+        standardDeviation: 'ecart_type',
+        firstDecileLevel: 'decile_10',
+        firstQuartileLevel: 'quartile_25',
+        medianLevel: 'quartile_50',
+        thirdQuartileLevel: 'quartile_75',
+        ninthDecileLevel: 'decile_90',
+        averageMaxLevelReached: 'niveau_maximum_moyen_atteint',
+        averageMaxLevelReachable: 'niveau_maximum_moyen_atteignable',
+        coverage: 'couverture',
+        updatedAt: 'date_derniere_mise_a_jour',
+      });
+    },
+    to: ({ datamartKnex }, chunk) => {
+      return datamartKnex('men_dashboard_participation_dataset').insert(chunk);
+    },
+  },
+  {
+    name: 'men_dashboard_certification_dataset',
+    before: async ({ datamartKnex }) => {
+      await datamartKnex('men_dashboard_certification_dataset').truncate();
+    },
+    from: ({ datawarehouseKnex }) => {
+      return datawarehouseKnex('data_sco_edupilot_lot_2').select({
+        schoolUai: 'uai',
+        schoolYear: 'annee_scolaire',
+        academieName: 'academie_nom',
+        schoolName: 'etablissement',
+        provinceCode: 'departement',
+        schoolYearGroup: 'niveau_scolaire',
+        validatedCertificationCount: 'total_certification_obtenues',
+        certificationCount: 'total_certifications',
+        averagePixScore: 'moyenne_score',
+        competenceCode: 'competence_code',
+        avgCompetenceLevel: 'avg_competence_level',
+        updatedAt: 'date_derniere_mise_a_jour',
+      });
+    },
+    to: ({ datamartKnex }, chunk) => {
+      return datamartKnex('men_dashboard_certification_dataset').insert(chunk);
+    },
+  },
+  {
     name: 'organizations_cover_rates',
     before: async ({ datamartKnex }) => {
       await datamartKnex('organizations_cover_rates').truncate();


### PR DESCRIPTION
## 🪧 Problème

Les tables du Datamart pour le tableau de bord du numérique du MEN ne sont pas alimentées.

## 🌈 Proposition

Répliquer les tables `data_sco_edupilot` vers `men_dashboard_participation_dataset` et `data_sco_edupilot_lot_2` vers `men_dashboard_certification_dataset`.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

Créer les tables `data_sco_edupilot` et `data_sco_edupilot_lot_2` dans le datawarehouse d'intégration (DDL à récupérer sur datawarehouse-data et donnée à positionner manuellement).

Créer un token avec le scope `replication` :

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr16898.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

Lancer les réplications :

```
curl -X POST "https://pix-api-maddo-review-pr16898.osc-fr1.scalingo.io/api/replications/men_dashboard_participation_dataset" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
curl -X POST "https://pix-api-maddo-review-pr16898.osc-fr1.scalingo.io/api/replications/men_dashboard_certification_dataset" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
```

Les tables `men_dashboard_participation_dataset` et `men_dashboard_certification_dataset` contiennent bien les données correspondant à celles des tables sources.
Modifier une information dans les tables sources.
Relancer les 2 réplications.
Les tables de dataset ont été mises à jour.