### PR TITLE
[FEATURE] Ordonner les blueprints par id desc dans "Schémas de parcours" sur PixAdmin (PIX-21250)

### DIFF
--- a/admin/app/routes/authenticated/combined-course-blueprints/list.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/list.js
@@ -9,7 +9,8 @@ export default class ListRoute extends Route {
     this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier'], 'authenticated');
   }
 
-  model() {
-    return this.store.findAll('combined-course-blueprint');
+  async model() {
+    const blueprints = await this.store.findAll('combined-course-blueprint');
+    return blueprints.slice().sort((a, b) => Number(b.id) - Number(a.id));
   }
 }

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/list-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/list-test.js
@@ -17,7 +17,7 @@ module('Acceptance | Combined course blueprint | List', function (hooks) {
       id: 1,
       name: 'parcours IA',
       internalName: 'schéma de parcours IA',
-      illsutration: 'https://image.pix.fr/ia.svg',
+      illustration: 'https://image.pix.fr/ia.svg',
       description: "Un parcours sur l'IA pour le collège",
       content: [
         {
@@ -34,7 +34,7 @@ module('Acceptance | Combined course blueprint | List', function (hooks) {
       id: 2,
       name: 'parcours cyber',
       internalName: 'schéma de parcours cyber',
-      illsutration: 'https://image.pix.fr/cyber.svg',
+      illustration: 'https://image.pix.fr/cyber.svg',
       description: 'Un parcours sur la cybersécurité',
       content: [],
     });
@@ -42,7 +42,7 @@ module('Acceptance | Combined course blueprint | List', function (hooks) {
       id: 10,
       name: 'parcours numérique',
       internalName: 'schéma de parcours numérique',
-      illsutration: 'https://image.pix.fr/num.svg',
+      illustration: 'https://image.pix.fr/num.svg',
       description: 'Un parcours sur le numérique',
       content: [],
     });

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/list-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/list-test.js
@@ -1,5 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { click, currentURL } from '@ember/test-helpers';
+import { click, currentURL, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
@@ -30,6 +30,22 @@ module('Acceptance | Combined course blueprint | List', function (hooks) {
         },
       ],
     });
+    server.create('combined-course-blueprint', {
+      id: 2,
+      name: 'parcours cyber',
+      internalName: 'schéma de parcours cyber',
+      illsutration: 'https://image.pix.fr/cyber.svg',
+      description: 'Un parcours sur la cybersécurité',
+      content: [],
+    });
+    server.create('combined-course-blueprint', {
+      id: 10,
+      name: 'parcours numérique',
+      internalName: 'schéma de parcours numérique',
+      illsutration: 'https://image.pix.fr/num.svg',
+      description: 'Un parcours sur le numérique',
+      content: [],
+    });
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
@@ -42,5 +58,14 @@ module('Acceptance | Combined course blueprint | List', function (hooks) {
     await click(link);
     // then
     assert.strictEqual(currentURL(), '/combined-course-blueprints/1/organizations');
+  });
+
+  test('it should display blueprints ordered by id descending', async function (assert) {
+    // when
+    await visit('/combined-course-blueprints/list');
+
+    // then
+    const idCells = findAll('tbody tr td:first-child').map((cell) => cell.textContent.trim());
+    assert.deepEqual(idCells, ['10', '2', '1']);
   });
 });


### PR DESCRIPTION
## 🪧 Problème

Les blueprints ne sont pas ordonnés 

## 🌈 Proposition

Ajouter un tri par défaut décroissant, selon l'id 

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
- se connecter avec superadmin@example.net
- s'assurer que tous les blueprints sont triés 
- créer un blueprint 
- vérifier qu'il s'affiche bien en premier dans la liste 