### PR TITLE
[TECH] Augmenter la sécurité en rendant plus large le motif de nom de fichiers .env à ignorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,7 @@
 # system
 .DS_Store
 
-**/.env
-**/.env.*
+.env*
 
 # CircleCI
 *.circle-cache-key


### PR DESCRIPTION
## 🪧 Problème

Actuellement on peut commiter par erreur des fichiers `.env` comme `.env_old`.

## 🌈 Proposition

Rendre plus large les motifs de noms de fichiers `.env` à ignorer.

## ✊ Remarques

RAS

## 🎉 Pour tester

Vérifier que sont ignorés tous fichiers `.env`, `.env_old`, `.env.recette`, etc. situés à la racine du dépôt comme dans les sous-dossiers.