### PR TITLE
[FEATURE] Revoir les questions pour avoir "recommandations" + ajouter consigne fonctionnelle (PIX-23622)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form.gjs
@@ -78,8 +78,13 @@ export default class ContentRelevanceForm extends Component {
       </p>
       <form>
         <fieldset class="results-recommendation-engine-drawer__content-relevance-form-fieldset">
-          <legend class="results-recommendation-engine-drawer__content-relevance-form-statement">
-            {{t "pages.skill-review.recommended-engine.drawer.content-relevance-form.legend"}}
+          <legend class="results-recommendation-engine-drawer__content-relevance-form-legend">
+            <p class="results-recommendation-engine-drawer__content-relevance-form-legend__title">{{t
+                "pages.skill-review.recommended-engine.drawer.content-relevance-form.legend"
+              }}</p>
+            <p class="results-recommendation-engine-drawer__content-relevance-form-legend__instruction">
+              {{t "pages.skill-review.recommended-engine.drawer.content-relevance-form.instruction"}}
+            </p>
           </legend>
           {{#each SCALES as |scale|}}
             <fieldset class="results-recommendation-engine-drawer__scale">
@@ -95,6 +100,7 @@ export default class ContentRelevanceForm extends Component {
                     @screenReaderOnly={{true}}
                     checked={{eq (get this scale.key) score}}
                     {{on "click" (fn this.selectScore scale.key score)}}
+                    aria-required="true"
                   >
                     <:label>
                       {{t

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/drawer.scss
@@ -183,13 +183,21 @@
     flex-direction: column;
   }
 
-  &__content-relevance-form-statement {
-    @extend %pix-body-l;
-
+  &__content-relevance-form-legend {
     width: 100%;
-    padding-bottom: var(--pix-spacing-2x);
-    font-weight: 700;
+    padding-bottom: var(--pix-spacing-4x);
     text-align: center;
+
+    &__title {
+      @extend %pix-body-l;
+
+      font-weight: 700;
+    }
+
+    &__instruction {
+      @extend %pix-body-xs;
+
+    }
   }
 
   &__content-relevance-form-comment-text {

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -11,7 +11,7 @@
   }
 
   &--drawer-expanded {
-    padding-bottom: 425px;
+    padding-bottom: 465px;
   }
 }
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/drawer/content-relevance-form-test.gjs
@@ -33,6 +33,9 @@ module(
         .dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.content-relevance-form.subtitle')))
         .isVisible();
       assert
+        .dom(screen.getByText(t('pages.skill-review.recommended-engine.drawer.content-relevance-form.instruction')))
+        .isVisible();
+      assert
         .dom(
           screen.getByText(
             t('pages.skill-review.recommended-engine.drawer.content-relevance-form.usefulness.min-label'),
@@ -47,7 +50,7 @@ module(
         )
         .isVisible();
       assert.strictEqual(screen.getAllByRole('radio').length, 15);
-      assert.dom(screen.getByRole('textbox', { name: 'Commentaire optionnel' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Commentaire facultatif' })).exists();
     });
 
     test('the submit button is disabled until the three scales have a selected score', async function (assert) {

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2256,7 +2256,7 @@
         "drawer": {
           "content-relevance-form": {
             "attractiveness": {
-              "legend": "Bewerten Sie, wie ansprechend die Inhalte sind, von nicht ansprechend 1 bis ansprechend 5",
+              "legend": "Bewerten Sie, wie ansprechend die Empfehlungen sind, von nicht ansprechend 1 bis ansprechend 5",
               "max-label": "Ansprechend",
               "min-label": "Nicht ansprechend"
             },
@@ -2264,9 +2264,10 @@
               "label": "Optionaler Kommentar",
               "placeholder": "Kommentar (optional)"
             },
+            "instruction": "Alle Felder sind Pflichtfelder, außer denen, die als optional gekennzeichnet sind",
             "legend": "Die empfohlenen Inhalte sind…",
             "personalization": {
-              "legend": "Bewerten Sie, wie personalisiert die Inhalte sind, von generisch 1 bis personalisiert 5",
+              "legend": "Bewerten Sie, wie personalisiert die Empfehlungen sind, von generisch 1 bis personalisiert 5",
               "max-label": "Personalisiert",
               "min-label": "Generisch"
             },
@@ -2274,7 +2275,7 @@
             "subtitle": "Wie wäre es, noch weiterzugehen…",
             "title": "Danke für Ihr Feedback!",
             "usefulness": {
-              "legend": "Bewerten Sie, wie nützlich die Inhalte sind, von nicht nützlich 1 bis nützlich 5",
+              "legend": "Bewerten Sie, wie nützlich die Empfehlungen sind, von nicht nützlich 1 bis nützlich 5",
               "max-label": "Nützlich",
               "min-label": "Nicht nützlich"
             }
@@ -2288,14 +2289,14 @@
           },
           "error-message": "Beim Senden Ihrer Antwort ist ein Fehler aufgetreten.",
           "hide": "Ausblenden",
-          "hide-aria-label": "Feedbackbereich für Empfehlungen zu Lerninhalten ausblenden",
+          "hide-aria-label": "Feedbackbereich für Empfehlungen ausblenden",
           "instruction": "Klicken Sie auf ein Emoji, um Ihre Meinung zu geben.",
           "statement": "Erscheinen Ihnen diese Empfehlungen zur Vertiefung Ihres Wissens relevant?",
           "thank-you": {
             "subtitle": "Geschafft!",
             "title": "Danke für Ihr Feedback!"
           },
-          "title": "Feedback zur Empfehlung von Lerninhalten"
+          "title": "Feedback zu den Empfehlungen"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2290,7 +2290,7 @@
           "hide": "Ausblenden",
           "hide-aria-label": "Feedbackbereich für Empfehlungen zu Lerninhalten ausblenden",
           "instruction": "Klicken Sie auf ein Emoji, um Ihre Meinung zu geben.",
-          "statement": "Erscheinen Ihnen diese Lerninhalte zur Vertiefung Ihres Wissens relevant?",
+          "statement": "Erscheinen Ihnen diese Empfehlungen zur Vertiefung Ihres Wissens relevant?",
           "thank-you": {
             "subtitle": "Geschafft!",
             "title": "Danke für Ihr Feedback!"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2256,7 +2256,7 @@
         "drawer": {
           "content-relevance-form": {
             "attractiveness": {
-              "legend": "Rate how appealing the content is, from not appealing 1 to appealing 5",
+              "legend": "Rate how appealing the recommendations are, from not appealing 1 to appealing 5",
               "max-label": "Appealing",
               "min-label": "Not appealing"
             },
@@ -2264,9 +2264,10 @@
               "label": "Optional comment",
               "placeholder": "Comment (optional)"
             },
+            "instruction": "All fields are required except those marked as optional",
             "legend": "The recommended content is…",
             "personalization": {
-              "legend": "Rate how personalized the content is, from generic 1 to personalized 5",
+              "legend": "Rate how personalized the recommendations are, from generic 1 to personalized 5",
               "max-label": "Personalized",
               "min-label": "Generic"
             },
@@ -2274,7 +2275,7 @@
             "subtitle": "How about going further…",
             "title": "Thank you for your feedback!",
             "usefulness": {
-              "legend": "Rate how useful the content is, from not useful 1 to useful 5",
+              "legend": "Rate how useful the recommendations are, from not useful 1 to useful 5",
               "max-label": "Useful",
               "min-label": "Not useful"
             }
@@ -2288,14 +2289,14 @@
           },
           "error-message": "An error occurred while sending your response.",
           "hide": "Hide",
-          "hide-aria-label": "Hide the feedback panel for training content recommendations",
+          "hide-aria-label": "Hide the recommendations feedback panel",
           "instruction": "Click on an emoji to give your feedback.",
           "statement": "Do these recommendations to deepen your knowledge seem relevant to you?",
           "thank-you": {
             "subtitle": "It's in the bag",
             "title": "Thank you for your feedback!"
           },
-          "title": "Feedback on the training content recommendation"
+          "title": "Feedback on the recommendations"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2290,7 +2290,7 @@
           "hide": "Hide",
           "hide-aria-label": "Hide the feedback panel for training content recommendations",
           "instruction": "Click on an emoji to give your feedback.",
-          "statement": "Does this training content to deepen your knowledge seem relevant to you?",
+          "statement": "Do these recommendations to deepen your knowledge seem relevant to you?",
           "thank-you": {
             "subtitle": "It's in the bag",
             "title": "Thank you for your feedback!"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2290,7 +2290,7 @@
           "hide": "Ocultar",
           "hide-aria-label": "Ocultar el panel de comentarios de las recomendaciones de contenidos formativos",
           "instruction": "Haz clic en un emoji para dar tu opinión.",
-          "statement": "¿Te parecen pertinentes estos contenidos formativos para profundizar tus conocimientos?",
+          "statement": "¿Te parecen pertinentes estas recomendaciones para profundizar tus conocimientos?",
           "thank-you": {
             "subtitle": "¡Misión cumplida!",
             "title": "¡Gracias por tu opinión!"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2256,7 +2256,7 @@
         "drawer": {
           "content-relevance-form": {
             "attractiveness": {
-              "legend": "Evalúa el atractivo de los contenidos, de poco atractivos 1 a atractivos 5",
+              "legend": "Evalúa el atractivo de las recomendaciones, de poco atractivas 1 a atractivas 5",
               "max-label": "Atractivos",
               "min-label": "Poco atractivos"
             },
@@ -2264,9 +2264,10 @@
               "label": "Comentario opcional",
               "placeholder": "Comentario (opcional)"
             },
+            "instruction": "Todos los campos son obligatorios excepto los indicados como opcionales",
             "legend": "Los contenidos recomendados son…",
             "personalization": {
-              "legend": "Evalúa la personalización de los contenidos, de genéricos 1 a personalizados 5",
+              "legend": "Evalúa la personalización de las recomendaciones, de genéricas 1 a personalizadas 5",
               "max-label": "Personalizados",
               "min-label": "Genéricos"
             },
@@ -2274,7 +2275,7 @@
             "subtitle": "¿Y si vamos más allá…?",
             "title": "¡Gracias por tu opinión!",
             "usefulness": {
-              "legend": "Evalúa la utilidad de los contenidos, de poco útiles 1 a útiles 5",
+              "legend": "Evalúa la utilidad de las recomendaciones, de poco útiles 1 a útiles 5",
               "max-label": "Útiles",
               "min-label": "Poco útiles"
             }
@@ -2288,14 +2289,14 @@
           },
           "error-message": "Se produjo un error al enviar tu respuesta.",
           "hide": "Ocultar",
-          "hide-aria-label": "Ocultar el panel de comentarios de las recomendaciones de contenidos formativos",
+          "hide-aria-label": "Ocultar el panel de comentarios de las recomendaciones",
           "instruction": "Haz clic en un emoji para dar tu opinión.",
           "statement": "¿Te parecen pertinentes estas recomendaciones para profundizar tus conocimientos?",
           "thank-you": {
             "subtitle": "¡Misión cumplida!",
             "title": "¡Gracias por tu opinión!"
           },
-          "title": "Comentarios sobre la recomendación de contenido formativo"
+          "title": "Comentarios sobre las recomendaciones"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2280,17 +2280,17 @@
             }
           },
           "emojis": {
-            "dissatisfied": "Pas pertinent",
+            "dissatisfied": "Pas pertinentes",
             "neutral": "Je n’ai pas d’avis",
-            "satisfied": "Pertinent",
-            "very-dissatisfied": "Pas du tout pertinent",
-            "very-satisfied": "Très pertinent"
+            "satisfied": "Pertinentes",
+            "very-dissatisfied": "Pas du tout pertinentes",
+            "very-satisfied": "Très pertinentes"
           },
           "error-message": "Une erreur est survenue lors de l'envoi de votre réponse.",
           "hide": "Masquer",
           "hide-aria-label": "Fermer l'encart de retours sur la recommandation des offres de formation",
           "instruction": "Cliquez sur un emoji pour donner votre avis.",
-          "statement": "Ces offres de formation pour approfondir vos connaissances vous semblent-elles pertinentes ?",
+          "statement": "Ces recommandations pour approfondir vos connaissances vous semblent-elles pertinentes ?",
           "thank-you": {
             "subtitle": "C'est dans la boîte",
             "title": "Merci pour votre avis !"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2256,17 +2256,18 @@
         "drawer": {
           "content-relevance-form": {
             "attractiveness": {
-              "legend": "Évaluez l'attractivité des offres de formation, de pas attirantes 1 à attirantes 5",
+              "legend": "Évaluez l'attractivité des recommandations, de pas attirantes 1 à attirantes 5",
               "max-label": "Attirantes",
               "min-label": "Pas attirantes"
             },
             "comment-text": {
-              "label": "Commentaire optionnel",
-              "placeholder": "Commentaire (optionnel)"
+              "label": "Commentaire facultatif",
+              "placeholder": "Commentaire (facultatif)"
             },
-            "legend": "Les offres de formation recommandées sont…",
+            "instruction": "Tous les champs sont obligatoires sauf ceux indiqués comme étant facultatifs",
+            "legend": "Les recommandations sont…",
             "personalization": {
-              "legend": "Évaluez la personnalisation des offres de formation, de génériques 1 à personnalisées 5",
+              "legend": "Évaluez la personnalisation des recommandations, de génériques 1 à personnalisées 5",
               "max-label": "Personnalisées",
               "min-label": "Génériques"
             },
@@ -2274,7 +2275,7 @@
             "subtitle": "Et si on allait plus loin…",
             "title": "Merci pour votre avis !",
             "usefulness": {
-              "legend": "Évaluez l'utilité des offres de formation, de pas utiles 1 à utiles 5",
+              "legend": "Évaluez l'utilité des recommandations, de pas utiles 1 à utiles 5",
               "max-label": "Utiles",
               "min-label": "Pas utiles"
             }
@@ -2288,14 +2289,14 @@
           },
           "error-message": "Une erreur est survenue lors de l'envoi de votre réponse.",
           "hide": "Masquer",
-          "hide-aria-label": "Fermer l'encart de retours sur la recommandation des offres de formation",
+          "hide-aria-label": "Fermer l'encart de retours sur la recommandation",
           "instruction": "Cliquez sur un emoji pour donner votre avis.",
           "statement": "Ces recommandations pour approfondir vos connaissances vous semblent-elles pertinentes ?",
           "thank-you": {
             "subtitle": "C'est dans la boîte",
             "title": "Merci pour votre avis !"
           },
-          "title": "Encart de prise de retours sur la recommandation des offres de formation"
+          "title": "Encart de prise de retours sur les recommandations"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2256,7 +2256,7 @@
         "drawer": {
           "content-relevance-form": {
             "attractiveness": {
-              "legend": "Valuta quanto sono attraenti i contenuti, da poco attraenti 1 ad attraenti 5",
+              "legend": "Valuta quanto sono attraenti le raccomandazioni, da poco attraenti 1 ad attraenti 5",
               "max-label": "Attraenti",
               "min-label": "Poco attraenti"
             },
@@ -2264,9 +2264,10 @@
               "label": "Commento opzionale",
               "placeholder": "Commento (opzionale)"
             },
+            "instruction": "Tutti i campi sono obbligatori tranne quelli indicati come facoltativi",
             "legend": "I contenuti consigliati sono…",
             "personalization": {
-              "legend": "Valuta quanto sono personalizzati i contenuti, da generici 1 a personalizzati 5",
+              "legend": "Valuta quanto sono personalizzate le raccomandazioni, da generiche 1 a personalizzate 5",
               "max-label": "Personalizzati",
               "min-label": "Generici"
             },
@@ -2274,7 +2275,7 @@
             "subtitle": "E se andassimo oltre…",
             "title": "Grazie per il tuo feedback!",
             "usefulness": {
-              "legend": "Valuta quanto sono utili i contenuti, da poco utili 1 a utili 5",
+              "legend": "Valuta quanto sono utili le raccomandazioni, da poco utili 1 a utili 5",
               "max-label": "Utili",
               "min-label": "Poco utili"
             }
@@ -2288,14 +2289,14 @@
           },
           "error-message": "Si è verificato un errore durante l'invio della tua risposta.",
           "hide": "Nascondi",
-          "hide-aria-label": "Nascondi il pannello di feedback per le raccomandazioni sui contenuti formativi",
+          "hide-aria-label": "Nascondi il pannello di feedback per le raccomandazioni",
           "instruction": "Clicca su un emoji per dare il tuo parere.",
           "statement": "Queste raccomandazioni per approfondire le tue conoscenze ti sembrano pertinenti?",
           "thank-you": {
             "subtitle": "Missione compiuta!",
             "title": "Grazie per il tuo feedback!"
           },
-          "title": "Feedback sulla raccomandazione di contenuti formativi"
+          "title": "Feedback sulle raccomandazioni"
         },
         "modal": {
           "actions": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2290,7 +2290,7 @@
           "hide": "Nascondi",
           "hide-aria-label": "Nascondi il pannello di feedback per le raccomandazioni sui contenuti formativi",
           "instruction": "Clicca su un emoji per dare il tuo parere.",
-          "statement": "Questi contenuti formativi per approfondire le tue conoscenze ti sembrano pertinenti?",
+          "statement": "Queste raccomandazioni per approfondire le tue conoscenze ti sembrano pertinenti?",
           "thank-you": {
             "subtitle": "Missione compiuta!",
             "title": "Grazie per il tuo feedback!"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2290,7 +2290,7 @@
           "hide": "Verbergen",
           "hide-aria-label": "Het feedbackpaneel voor aanbevelingen voor trainingsinhoud verbergen",
           "instruction": "Klik op een emoji om uw mening te geven.",
-          "statement": "Lijkt de trainingsinhoud om uw kennis te verdiepen u relevant?",
+          "statement": "Lijken deze aanbevelingen om uw kennis te verdiepen u relevant?",
           "thank-you": {
             "subtitle": "Gelukt!",
             "title": "Bedankt voor uw feedback!"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2256,7 +2256,7 @@
         "drawer": {
           "content-relevance-form": {
             "attractiveness": {
-              "legend": "Beoordeel hoe aantrekkelijk de inhoud is, van niet aantrekkelijk 1 tot aantrekkelijk 5",
+              "legend": "Beoordeel hoe aantrekkelijk de aanbevelingen zijn, van niet aantrekkelijk 1 tot aantrekkelijk 5",
               "max-label": "Aantrekkelijk",
               "min-label": "Niet aantrekkelijk"
             },
@@ -2264,9 +2264,10 @@
               "label": "Optionele opmerking",
               "placeholder": "Opmerking (optioneel)"
             },
+            "instruction": "Alle velden zijn verplicht, behalve die welke als optioneel zijn aangeduid",
             "legend": "De aanbevolen inhoud is…",
             "personalization": {
-              "legend": "Beoordeel hoe gepersonaliseerd de inhoud is, van algemeen 1 tot gepersonaliseerd 5",
+              "legend": "Beoordeel hoe gepersonaliseerd de aanbevelingen zijn, van algemeen 1 tot gepersonaliseerd 5",
               "max-label": "Gepersonaliseerd",
               "min-label": "Algemeen"
             },
@@ -2274,7 +2275,7 @@
             "subtitle": "Zullen we verdergaan…",
             "title": "Bedankt voor uw feedback!",
             "usefulness": {
-              "legend": "Beoordeel hoe nuttig de inhoud is, van niet nuttig 1 tot nuttig 5",
+              "legend": "Beoordeel hoe nuttig de aanbevelingen zijn, van niet nuttig 1 tot nuttig 5",
               "max-label": "Nuttig",
               "min-label": "Niet nuttig"
             }
@@ -2288,14 +2289,14 @@
           },
           "error-message": "Er is een fout opgetreden bij het verzenden van uw antwoord.",
           "hide": "Verbergen",
-          "hide-aria-label": "Het feedbackpaneel voor aanbevelingen voor trainingsinhoud verbergen",
+          "hide-aria-label": "Het feedbackpaneel voor aanbevelingen verbergen",
           "instruction": "Klik op een emoji om uw mening te geven.",
           "statement": "Lijken deze aanbevelingen om uw kennis te verdiepen u relevant?",
           "thank-you": {
             "subtitle": "Gelukt!",
             "title": "Bedankt voor uw feedback!"
           },
-          "title": "Feedback over de aanbeveling voor trainingsinhoud"
+          "title": "Feedback over de aanbevelingen"
         },
         "modal": {
           "actions": {


### PR DESCRIPTION
## 🌈 Proposition

### Mise à jour du feedmojis
- proposer la question : "Ces recommandations pour approfondir vos connaissances vous semblent-elles pertinentes ?" 
- mettre les options au féminin : 
  - A l'écran : “Pas du tout pertinentes” et “Très pertinentes”
  - En tooltip : “Pas du tout pertinentes”, “Pas pertinentes”, “Pertinentes” et “Très pertinentes”


### Mise à jour du formulaire avec les radio-buttons
- Mettre la phrase : “Les recommandations sont..." 
- Ajouter la consigne fonctionnelle : “Tous les champs sont obligatoires sauf ceux indiqués comme facultatifs”
- Ajuster le placeholder dans le textArea commentaire pour avoir ““facultatif)” à la place de “(optionnel)”

## ✊ Remarques

Tester la vocalisation en général car pas certaine que tout soit OK.

## 🎉 Pour tester

- Se connecter avec Dave et accéder à la campagne EDUMULTIP
- Scroller et afficher le formulaire Feedmoji dans le drawer
- Vérifier que les wordings sont bien mis à jour par rapport à l'intégration
- Répondre au feedmojis pour afficher le deuxième formulaire
- Dans ce dernier, vérifier que les wordings sont bien à jour
- Vérifier que la mention de champs obligatoire apparaît
