### PR TITLE
[FEATURE] Déplacer la sélection d'objectif et la sélection de parcours en dehors du paramétrage (PIX-23634)

### DIFF
--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -1,29 +1,18 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-import displayCampaignErrors from '../../helpers/display-campaign-errors';
-import ExplanationCard from '../ui/explanation-card';
-import FormField from '../ui/form-field';
 import FormSection from '../ui/form-section';
-import PixFieldset from '../ui/pix-fieldset';
 import AssessmentGoalCustomization from './create-form/assessment-goal-customization';
 import AssessmentGoalSettings from './create-form/assessment-goal-settings';
+import CampaignGoals from './create-form/campaign-goals';
 import CombinedCourseGoalSettings from './create-form/combined-course-goal-settings';
 import ProfilesCollectionGoalCustomization from './create-form/profiles-collection-goal-customization';
 import ProfilesCollectionGoalSettings from './create-form/profiles-collection-goal-settings';
 
 export default class CreateForm extends Component {
-  @service currentUser;
-
-  get isComputeLearnerCertificabilityEnabled() {
-    return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
-  }
-
   get isSubmitDisabled() {
     return !(this.isCampaignGoalProfileCollection || this.args.campaign.course);
   }
@@ -48,21 +37,14 @@ export default class CreateForm extends Component {
     return this.isCampaignGoalAssessment || this.isCampaignGoalExam;
   }
 
+  get displaysSettingsSection() {
+    return this.isCampaignGoalProfileCollection || Boolean(this.args.campaign.course);
+  }
+
   get displaysCustomizationSection() {
     if (this.isCampaignGoalProfileCollection) return true;
     if (this.isAssessmentGoalSelected) return Boolean(this.args.campaign.course);
     return false;
-  }
-
-  @action
-  setCampaignGoal(event) {
-    if (event.target.value === 'collect-participants-profile') {
-      this.args.campaign.setType('PROFILES_COLLECTION');
-    } else if (event.target.value === 'assess-participants') {
-      this.args.campaign.setType('ASSESSMENT');
-    } else if (event.target.value === 'combined-course') {
-      this.args.campaign.setType('COMBINED_COURSE');
-    }
   }
 
   @action
@@ -78,98 +60,27 @@ export default class CreateForm extends Component {
         {{t "common.form.mandatory-fields"}}
       </p>
 
-      <FormSection @title={{t "pages.campaign-creation.settings.title"}}>
-        <FormField>
-          <:default>
-            <PixFieldset @required={{true}} aria-labelledby="campaign-goal" role="radiogroup">
-              <:title>{{t "pages.campaign-creation.purpose.label"}}</:title>
-              <:content>
-                <PixRadioButton
-                  name="campaign-goal"
-                  @value="assess-participants"
-                  {{on "change" this.setCampaignGoal}}
-                  aria-describedby="campaign-goal-assessment-info"
-                  checked={{this.isCampaignGoalAssessment}}
-                >
-                  <:label>{{t "pages.campaign-creation.purpose.assessment"}}</:label>
-                </PixRadioButton>
+      <CampaignGoals @campaign={{@campaign}} @errors={{@errors}} />
 
-                <PixRadioButton
-                  name="campaign-goal"
-                  @value="combined-course"
-                  {{on "change" this.setCampaignGoal}}
-                  aria-describedby="combined-course-info"
-                  checked={{this.isCombinedCourseGoal}}
-                >
-                  <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
-                </PixRadioButton>
-
-                <PixRadioButton
-                  name="campaign-goal"
-                  @value="collect-participants-profile"
-                  {{on "change" this.setCampaignGoal}}
-                  aria-describedby="campaign-goal-profiles-collection-info"
-                  checked={{this.isCampaignGoalProfileCollection}}
-                >
-                  <:label>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:label>
-                </PixRadioButton>
-
-                {{#if @errors.type}}
-                  <div class="form__error error-message">
-                    {{displayCampaignErrors @errors.type}}
-                  </div>
-                {{/if}}
-              </:content>
-            </PixFieldset>
-          </:default>
-          <:information>
-            {{#if this.isCampaignGoalAssessment}}
-              <ExplanationCard id="campaign-goal-assessment-info">
-                <:title>{{t "pages.campaign-creation.purpose.assessment"}}</:title>
-
-                <:message>{{t "pages.campaign-creation.purpose.assessment-info"}}</:message>
-              </ExplanationCard>
-            {{else if this.isCombinedCourseGoal}}
-              <ExplanationCard id="combined-course-info">
-                <:title>{{t "pages.campaign-creation.purpose.combined-course"}}</:title>
-
-                <:message>{{t "pages.campaign-creation.purpose.combined-course-info"}}</:message>
-              </ExplanationCard>
-            {{else if this.isCampaignGoalProfileCollection}}
-              <ExplanationCard id="campaign-goal-profiles-collection-info">
-                <:title>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:title>
-
-                <:message>
-                  {{t "pages.campaign-creation.purpose.profiles-collection-info"}}
-                  {{#if this.isComputeLearnerCertificabilityEnabled}}
-                    {{t
-                      "pages.campaign-creation.purpose.profiles-collection-info-certificability-calculation"
-                      linkClasses="link link--banner link--bold link--underlined"
-                      htmlSafe=true
-                    }}
-                  {{/if}}
-                </:message>
-              </ExplanationCard>
-            {{/if}}
-          </:information>
-        </FormField>
-
-        {{#if this.isAssessmentGoalSelected}}
-          <AssessmentGoalSettings
-            @campaign={{@campaign}}
-            @errors={{@errors}}
-            @membersSortedByFullName={{@membersSortedByFullName}}
-          />
-        {{else if this.isCombinedCourseGoal}}
-          <CombinedCourseGoalSettings @campaign={{@campaign}} @errors={{@errors}} />
-        {{else if this.isCampaignGoalProfileCollection}}
-          <ProfilesCollectionGoalSettings
-            @campaign={{@campaign}}
-            @errors={{@errors}}
-            @membersSortedByFullName={{@membersSortedByFullName}}
-          />
-        {{/if}}
-      </FormSection>
+      {{#if this.displaysSettingsSection}}
+        <FormSection @title={{t "pages.campaign-creation.settings.title"}}>
+          {{#if this.isAssessmentGoalSelected}}
+            <AssessmentGoalSettings
+              @campaign={{@campaign}}
+              @errors={{@errors}}
+              @membersSortedByFullName={{@membersSortedByFullName}}
+            />
+          {{else if this.isCombinedCourseGoal}}
+            <CombinedCourseGoalSettings @campaign={{@campaign}} @errors={{@errors}} />
+          {{else if this.isCampaignGoalProfileCollection}}
+            <ProfilesCollectionGoalSettings
+              @campaign={{@campaign}}
+              @errors={{@errors}}
+              @membersSortedByFullName={{@membersSortedByFullName}}
+            />
+          {{/if}}
+        </FormSection>
+      {{/if}}
 
       {{#if this.displaysCustomizationSection}}
         <FormSection @title={{t "pages.campaign-creation.customization.title"}}>

--- a/orga/app/components/campaign/create-form/assessment-goal-settings.gjs
+++ b/orga/app/components/campaign/create-form/assessment-goal-settings.gjs
@@ -12,7 +12,6 @@ import FormField from '../../ui/form-field';
 import PixFieldset from '../../ui/pix-fieldset';
 import CampaignName from './campaign-name';
 import CampaignOwner from './campaign-owner';
-import CourseSelection from './course-selection';
 import ExternalId from './external-id';
 import MultipleSendings from './multiple-sendings';
 
@@ -41,8 +40,6 @@ export default class AssessmentGoalSettings extends Component {
   }
 
   <template>
-    <CourseSelection @campaign={{@campaign}} @errors={{@errors}} @tab="targetProfile" />
-
     {{#if @campaign.course}}
       <CampaignName @campaign={{@campaign}} @errors={{@errors}} />
 

--- a/orga/app/components/campaign/create-form/campaign-goals.gjs
+++ b/orga/app/components/campaign/create-form/campaign-goals.gjs
@@ -1,0 +1,138 @@
+import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import displayCampaignErrors from '../../../helpers/display-campaign-errors';
+import ExplanationCard from '../../ui/explanation-card';
+import FormField from '../../ui/form-field';
+import PixFieldset from '../../ui/pix-fieldset';
+import CourseSelection from './course-selection';
+
+export default class CampaignGoals extends Component {
+  @service currentUser;
+
+  get displayCourseSelection() {
+    return this.isCampaignGoalAssessment || this.isCampaignGoalCombinedCourse;
+  }
+
+  get isCampaignGoalAssessment() {
+    return this.args.campaign.isTypeAssessment || this.args.campaign.isTypeExam;
+  }
+
+  get isCampaignGoalProfileCollection() {
+    return this.args.campaign.isProfilesCollection;
+  }
+
+  get isCampaignGoalCombinedCourse() {
+    return this.args.campaign.isTypeCombinedCourse;
+  }
+
+  get isComputeLearnerCertificabilityEnabled() {
+    return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
+  }
+
+  get courseSelectionTab() {
+    if (this.isCampaignGoalAssessment) {
+      return 'targetProfile';
+    }
+    if (this.isCampaignGoalCombinedCourse) {
+      return 'blueprint';
+    }
+    return 'all';
+  }
+
+  @action
+  setCampaignGoal(event) {
+    if (event.target.value === 'collect-participants-profile') {
+      this.args.campaign.setType('PROFILES_COLLECTION');
+    } else if (event.target.value === 'assess-participants') {
+      this.args.campaign.setType('ASSESSMENT');
+    } else if (event.target.value === 'combined-course') {
+      this.args.campaign.setType('COMBINED_COURSE');
+    }
+  }
+
+  <template>
+    <FormField>
+      <:default>
+        <PixFieldset @required={{true}} aria-labelledby="campaign-goal" role="radiogroup">
+          <:title>{{t "pages.campaign-creation.purpose.label"}}</:title>
+          <:content>
+            <PixRadioButton
+              name="campaign-goal"
+              @value="assess-participants"
+              {{on "change" this.setCampaignGoal}}
+              aria-describedby="campaign-goal-assessment-info"
+              checked={{this.isCampaignGoalAssessment}}
+            >
+              <:label>{{t "pages.campaign-creation.purpose.assessment"}}</:label>
+            </PixRadioButton>
+
+            <PixRadioButton
+              name="campaign-goal"
+              @value="combined-course"
+              {{on "change" this.setCampaignGoal}}
+              aria-describedby="combined-course-info"
+              checked={{this.isCampaignGoalCombinedCourse}}
+            >
+              <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
+            </PixRadioButton>
+
+            <PixRadioButton
+              name="campaign-goal"
+              @value="collect-participants-profile"
+              {{on "change" this.setCampaignGoal}}
+              aria-describedby="campaign-goal-profiles-collection-info"
+              checked={{this.isCampaignGoalProfileCollection}}
+            >
+              <:label>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:label>
+            </PixRadioButton>
+
+            {{#if @errors.type}}
+              <div class="form__error error-message">
+                {{displayCampaignErrors @errors.type}}
+              </div>
+            {{/if}}
+          </:content>
+        </PixFieldset>
+      </:default>
+      <:information>
+        {{#if this.isCampaignGoalAssessment}}
+          <ExplanationCard id="campaign-goal-assessment-info">
+            <:title>{{t "pages.campaign-creation.purpose.assessment"}}</:title>
+
+            <:message>{{t "pages.campaign-creation.purpose.assessment-info"}}</:message>
+          </ExplanationCard>
+        {{else if this.isCampaignGoalCombinedCourse}}
+          <ExplanationCard id="combined-course-info">
+            <:title>{{t "pages.campaign-creation.purpose.combined-course"}}</:title>
+
+            <:message>{{t "pages.campaign-creation.purpose.combined-course-info"}}</:message>
+          </ExplanationCard>
+        {{else if this.isCampaignGoalProfileCollection}}
+          <ExplanationCard id="campaign-goal-profiles-collection-info">
+            <:title>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:title>
+
+            <:message>
+              {{t "pages.campaign-creation.purpose.profiles-collection-info"}}
+              {{#if this.isComputeLearnerCertificabilityEnabled}}
+                {{t
+                  "pages.campaign-creation.purpose.profiles-collection-info-certificability-calculation"
+                  linkClasses="link link--banner link--bold link--underlined"
+                  htmlSafe=true
+                }}
+              {{/if}}
+            </:message>
+          </ExplanationCard>
+        {{/if}}
+      </:information>
+    </FormField>
+
+    {{#if this.displayCourseSelection}}
+      <CourseSelection @campaign={{@campaign}} @errors={{@errors}} @tab={{this.courseSelectionTab}} />
+    {{/if}}
+  </template>
+}

--- a/orga/app/components/campaign/create-form/combined-course-goal-settings.gjs
+++ b/orga/app/components/campaign/create-form/combined-course-goal-settings.gjs
@@ -1,9 +1,6 @@
 import CampaignName from './campaign-name';
-import CourseSelection from './course-selection';
 
 <template>
-  <CourseSelection @campaign={{@campaign}} @errors={{@errors}} @tab="blueprint" />
-
   {{#if @campaign.course}}
     <CampaignName @campaign={{@campaign}} @errors={{@errors}} />
   {{/if}}

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -72,6 +72,10 @@ export default class Campaign extends Model {
     return this.type === 'ASSESSMENT';
   }
 
+  get isTypeCombinedCourse() {
+    return this.type === 'COMBINED_COURSE';
+  }
+
   get isTypeExam() {
     return this.type === 'EXAM';
   }

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -41,7 +41,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when grouping fields into sections', function () {
-    test('it always displays a "Paramétrage" section containing the campaign goal field', async function (assert) {
+    test('it does not display a "Paramétrage" section until a goal is selected', async function (assert) {
       // when
       const screen = await render(
         <template>
@@ -56,12 +56,13 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       );
 
       // then
-      const settingsSection = screen.getByRole('heading', {
-        name: t('pages.campaign-creation.settings.title'),
-      }).parentElement;
       assert
-        .dom(within(settingsSection).getByRole('radiogroup', { name: t('pages.campaign-creation.purpose.label') }))
-        .exists();
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('pages.campaign-creation.settings.title'),
+          }),
+        )
+        .doesNotExist();
     });
 
     test('it does not display the "Personnalisation" section until a course is selected for an assessment goal', async function (assert) {
@@ -178,25 +179,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
     });
   });
 
-  test('it displays campaign goals', async function (assert) {
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    // then
-    const fieldset = screen.getByRole('radiogroup', { name: t('pages.campaign-creation.purpose.label') });
-    assert.strictEqual(within(fieldset).getAllByRole('radio').length, 3);
-  });
-
   module('when no campaign goal is selected', function () {
     test('it disables the submit button if no course (other than profile collection) is selected', async function (assert) {
       // when
@@ -281,130 +263,6 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
         }),
       )
       .exists();
-  });
-
-  test('it has ASSESSMENT checked and displays its purpose explanation', async function (assert) {
-    // given
-    data.campaign.type = 'ASSESSMENT';
-
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    // then
-    assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.assessment'))).isChecked();
-    assert.dom(screen.getByText(t('pages.campaign-creation.purpose.assessment-info'))).exists();
-  });
-
-  test('it has combined course goal checked and displays its purpose explanation', async function (assert) {
-    // given
-    data.campaign.type = 'COMBINED_COURSE';
-
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    // then
-    assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.combined-course'))).isChecked();
-    assert.dom(screen.getByText(t('pages.campaign-creation.purpose.combined-course-info'))).exists();
-  });
-
-  test('it has PROFILES_COLLECTION checked', async function (assert) {
-    // given
-    data.campaign.type = 'PROFILES_COLLECTION';
-
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-
-    assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.profiles-collection'))).isChecked();
-  });
-
-  test('it displays the purpose explanation of a profiles collection campaign', async function (assert) {
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-    await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
-
-    // then
-    assert.dom(screen.getByText(t('pages.campaign-creation.purpose.profiles-collection-info'))).exists();
-    assert.dom(screen.queryByText(t('pages.campaign-creation.purpose.assessment-info'))).doesNotExist();
-  });
-
-  test('it not displays the explanation of automatic compute certificability if the feature is not activated', async function (assert) {
-    // when
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-    await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
-
-    // then
-    assert.dom(screen.queryByRole('link', { name: 'Élèves' })).doesNotExist();
-  });
-
-  test('it displays the explanation of automatic compute certificability if the feature is activated', async function (assert) {
-    // when
-    data.prescriber.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY = { active: true, params: null };
-
-    const screen = await render(
-      <template>
-        <CreateForm
-          @campaign={{data.campaign}}
-          @onSubmit={{createCampaignSpy}}
-          @onCancel={{cancelSpy}}
-          @errors={{data.errors}}
-          @membersSortedByFullName={{data.defaultMembers}}
-        />
-      </template>,
-    );
-    await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
-
-    // then
-    assert.dom(screen.getByRole('link', { name: 'Élèves' })).exists();
   });
 
   test('it sends campaign creation action when submitted', async function (assert) {

--- a/orga/tests/integration/components/campaign/create-form/assessment-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/assessment-goal-settings-test.gjs
@@ -75,41 +75,6 @@ module('Integration | Component | Campaign::CreateForm::AssessmentGoalSettings',
       });
     });
 
-    test('it displays informations about the course', async function (assert) {
-      // when
-      const screen = await render(
-        <template>
-          <AssessmentGoalSettings
-            @campaign={{data.campaign}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.membersSortedByFullName}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.getByText(t('pages.catalogue.card.tag.target-profile'))).exists();
-      assert.dom(screen.getByRole('heading', { name: data.campaign.course.name })).exists();
-    });
-
-    test('it redirects to /catalogue/targetProfile', async function (assert) {
-      // when
-      const screen = await render(
-        <template>
-          <AssessmentGoalSettings
-            @campaign={{data.campaign}}
-            @errors={{data.errors}}
-            @membersSortedByFullName={{data.membersSortedByFullName}}
-          />
-        </template>,
-      );
-
-      // then
-      assert
-        .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
-        .hasAttribute('href', '/catalogue/targetProfile');
-    });
-
     test("it displays owner fields and auto complete owner field with owner's full name", async function (assert) {
       // when
       const screen = await render(

--- a/orga/tests/integration/components/campaign/create-form/campaign-goals-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/campaign-goals-test.gjs
@@ -1,0 +1,210 @@
+import { clickByName, clickByText, render, within } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
+import CampaignGoals from 'pix-orga/components/campaign/create-form/campaign-goals';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::CreateForm::CampaignGoals', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const data = {};
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+
+    const prescriber = store.createRecord('prescriber', {
+      firstName: 'Adam',
+      lastName: 'Troisjour',
+      id: '1',
+      features: {
+        COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: { active: false, params: null },
+      },
+    });
+
+    class CurrentUserStub extends Service {
+      prescriber = prescriber;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    data.prescriber = prescriber;
+    data.campaign = store.createRecord('campaign');
+    data.errors = {};
+  });
+
+  test('it displays campaign goals', async function (assert) {
+    // when
+    const screen = await render(
+      <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    const fieldset = screen.getByRole('radiogroup', { name: t('pages.campaign-creation.purpose.label') });
+    assert.dom(within(fieldset).getByRole('radio', { name: t('pages.campaign-creation.purpose.assessment') })).exists();
+    assert
+      .dom(within(fieldset).getByRole('radio', { name: t('pages.campaign-creation.purpose.combined-course') }))
+      .exists();
+    assert
+      .dom(within(fieldset).getByRole('radio', { name: t('pages.campaign-creation.purpose.profiles-collection') }))
+      .exists();
+  });
+
+  test('it should not display course selection when no campaign goal is selected', async function (assert) {
+    // when
+    const screen = await render(
+      <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert
+      .dom(screen.queryByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+      .doesNotExist();
+  });
+
+  module('when ASSESSMENT is selected', function () {
+    test('it displays ASSESSMENT purpose explanation', async function (assert) {
+      // given
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // when
+      await clickByText(t('pages.campaign-creation.purpose.assessment'));
+
+      // then
+      assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.assessment'))).isChecked();
+      assert.dom(screen.getByText(t('pages.campaign-creation.purpose.assessment-info'))).exists();
+    });
+
+    test('it redirects to /catalogue/targetProfile', async function (assert) {
+      // given
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // when
+      await clickByText(t('pages.campaign-creation.purpose.assessment'));
+
+      // then
+      assert
+        .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+        .hasAttribute('href', '/catalogue/targetProfile');
+    });
+  });
+
+  module('when COMBINED_COURSE is selected', function () {
+    test('it displays COMBINED_COURSE purpose explanation', async function (assert) {
+      // given
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // when
+      await clickByText(t('pages.campaign-creation.purpose.combined-course'));
+
+      // then
+      assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.combined-course'))).isChecked();
+      assert.dom(screen.getByText(t('pages.campaign-creation.purpose.combined-course-info'))).exists();
+    });
+
+    test('it redirects to /catalogue/blueprint for course selection', async function (assert) {
+      // given
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // when
+      await clickByText(t('pages.campaign-creation.purpose.combined-course'));
+
+      // then
+      assert
+        .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+        .hasAttribute('href', '/catalogue/blueprint');
+    });
+  });
+
+  module('when PROFILES_COLLECTION is selected', function () {
+    test('it displays PROFILES_COLLECTION purpose explanation', async function (assert) {
+      // given
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // when
+      await clickByText(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.profiles-collection'))).isChecked();
+      assert.dom(screen.getByText(t('pages.campaign-creation.purpose.profiles-collection-info'))).exists();
+    });
+
+    test('it does not display course selection', async function (assert) {
+      // given
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // when
+      await clickByText(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert
+        .dom(screen.queryByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
+        .doesNotExist();
+    });
+
+    test('it doest not display the explanation of automatic compute certificability if the feature is not activated', async function (assert) {
+      // given
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // when
+      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: 'Élèves' })).doesNotExist();
+    });
+
+    test('it displays the explanation of automatic compute certificability if the feature is activated', async function (assert) {
+      // given
+      data.prescriber.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY = { active: true, params: null };
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // when
+      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Élèves' })).exists();
+    });
+  });
+
+  module('when there are errors', function () {
+    test('it displays errors messages when the campaign purpose fields is empty', async function (assert) {
+      // given
+      const campaignWithErrors = EmberObject.create({
+        errors: {
+          type: [
+            {
+              message: 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+            },
+          ],
+        },
+      });
+
+      data.errors = campaignWithErrors.errors;
+
+      // when
+      const screen = await render(
+        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('api-error-messages.campaign-creation.purpose-required'))).exists();
+    });
+  });
+});

--- a/orga/tests/integration/components/campaign/create-form/combined-course-goal-settings-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/combined-course-goal-settings-test.gjs
@@ -16,18 +16,6 @@ module('Integration | Component | Campaign::CreateForm::CombinedCourseGoalSettin
     data.errors = {};
   });
 
-  test('it redirects to /catalogue/blueprint for course selection', async function (assert) {
-    // when
-    const screen = await render(
-      <template><CombinedCourseGoalSettings @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
-    );
-
-    // then
-    assert
-      .dom(screen.getByRole('link', { name: t('pages.campaign-creation.course-selection-label') }))
-      .hasAttribute('href', '/catalogue/blueprint');
-  });
-
   test('it does not display the campaign name field until a course is selected', async function (assert) {
     // when
     const screen = await render(


### PR DESCRIPTION
## 🪧 Problème
La sélection d'objectif de campagne et de parcours se trouve actuellement dans la section de paramétrage du formulaire de création de campagne. Nous souhaitons le déplacer en amont de cette section.

## 🌈 Proposition
Déplacer la sélection d'objectif et la sélection de parcours en dehors du paramétrage

## 🎉 Pour tester
- Se connecter à Pix Orga.
- Aller sur la page campagnes/creation-catalogue.
- Voir que la section paramétrage n'apparaît que quand on sélectionne un parcours ou que l'on sélectionne l'objectif collecte de profil 
