### PR TITLE
[FEATURE] Stocker le hash du mot de passe d'un utilisateur révoqué par script (PIX-23481)

### DIFF
--- a/api/src/identity-access-management/domain/models/AuthenticationMethod.js
+++ b/api/src/identity-access-management/domain/models/AuthenticationMethod.js
@@ -23,6 +23,11 @@ class PixAuthenticationComplement {
       this,
     );
   }
+
+  revokePassword() {
+    this.revokedEncryptedPassword = this.password;
+    this.password = '[revoked]';
+  }
 }
 
 class OidcAuthenticationComplement {

--- a/api/src/identity-access-management/domain/models/AuthenticationMethod.js
+++ b/api/src/identity-access-management/domain/models/AuthenticationMethod.js
@@ -6,14 +6,19 @@ import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js'
 import { POLE_EMPLOI } from '../constants/oidc-identity-providers.js';
 
 class PixAuthenticationComplement {
-  constructor({ password, shouldChangePassword } = {}) {
+  constructor({ password, shouldChangePassword, revokedEncryptedPassword } = {}) {
     this.password = password;
     this.shouldChangePassword = shouldChangePassword;
+
+    if (revokedEncryptedPassword !== undefined) {
+      this.revokedEncryptedPassword = revokedEncryptedPassword;
+    }
 
     validateEntity(
       Joi.object({
         password: Joi.string().required(),
         shouldChangePassword: Joi.boolean().required(),
+        revokedEncryptedPassword: Joi.string().optional(),
       }),
       this,
     );

--- a/api/src/identity-access-management/domain/usecases/revoke-access-for-users.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/revoke-access-for-users.usecase.js
@@ -1,4 +1,5 @@
-import { AuthenticationMethodNotFoundError } from '../../../shared/domain/errors.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
 /**
  * Revokes access for a list of users.
@@ -21,9 +22,20 @@ export const revokeAccessForUsers = async function ({
 
     // Revoke current user password
     try {
-      await authenticationMethodRepository.updatePassword({ userId, hashedPassword: '[revoked]' });
+      const identityProvider = NON_OIDC_IDENTITY_PROVIDERS.PIX.code;
+      const authenticationComplement =
+        await authenticationMethodRepository.getAuthenticationComplementByUserIdAndIdentityProvider({
+          userId,
+          identityProvider,
+        });
+      authenticationComplement.revokePassword();
+      await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
+        authenticationComplement,
+        userId,
+        identityProvider,
+      });
     } catch (error) {
-      if (!(error instanceof AuthenticationMethodNotFoundError)) throw error;
+      if (!(error instanceof NotFoundError)) throw error;
     }
   }
 };

--- a/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
@@ -1,7 +1,11 @@
 import _ from 'lodash';
 
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { AlreadyExistingEntityError, AuthenticationMethodNotFoundError } from '../../../shared/domain/errors.js';
+import {
+  AlreadyExistingEntityError,
+  AuthenticationMethodNotFoundError,
+  NotFoundError,
+} from '../../../shared/domain/errors.js';
 import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
@@ -213,6 +217,21 @@ const updateExternalIdentifierByUserIdAndIdentityProvider = async function ({
   return _toDomain(authenticationMethodDTO);
 };
 
+const getAuthenticationComplementByUserIdAndIdentityProvider = async function ({ userId, identityProvider }) {
+  const knexConn = DomainTransaction.getConnection();
+  const authenticationMethodDTO = await knexConn(AUTHENTICATION_METHODS_TABLE)
+    .select('authenticationComplement')
+    .where({ userId, identityProvider })
+    .first();
+
+  if (!authenticationMethodDTO) {
+    throw new NotFoundError();
+  }
+
+  const authenticationComplement = authenticationMethodDTO.authenticationComplement;
+  return _toAuthenticationComplement(identityProvider, authenticationComplement);
+};
+
 const updateAuthenticationComplementByUserIdAndIdentityProvider = async function ({
   authenticationComplement,
   userId,
@@ -328,6 +347,7 @@ export {
   findByUserIdsAndIdentityProvider,
   findOneByExternalIdentifierAndIdentityProvider,
   findOneByUserIdAndIdentityProvider,
+  getAuthenticationComplementByUserIdAndIdentityProvider,
   getByIdAndUserId,
   hasIdentityProviderGar,
   hasIdentityProviderPIX,

--- a/api/tests/identity-access-management/integration/domain/usecases/revoke-access-for-users.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/revoke-access-for-users.usecase.test.js
@@ -10,7 +10,10 @@ describe('Integration | Identity Access Management | Domain | UseCase | revoke-a
     // given
     const userId = databaseBuilder.factory.buildUser().id;
     const authenticationMethod =
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+        userId,
+        hashedPassword: 'hashed-password',
+      });
     const refreshToken = RefreshToken.generate({
       userId,
       audience: 'https://app.dev.pix.fr',
@@ -34,6 +37,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | revoke-a
       .where({ id: authenticationMethod.id })
       .first();
     expect(updatedAuthenticationMethod.authenticationComplement.password).to.equal('[revoked]');
+    expect(updatedAuthenticationMethod.authenticationComplement.revokedEncryptedPassword).to.equal('hashed-password');
   });
 
   context('when a user does not have a Pix Authentication method and refresh token', function () {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
@@ -8,6 +8,7 @@ import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransa
 import {
   AlreadyExistingEntityError,
   AuthenticationMethodNotFoundError,
+  NotFoundError,
 } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
@@ -639,6 +640,53 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       const nonExistingAuthenticationMethod = await knex('authentication-methods').where({ userId }).first();
       expect(nonExistingAuthenticationMethod).to.not.exist;
     });
+  });
+
+  describe('#getAuthenticationComplementByUserIdAndIdentityProvider', function () {
+    context('when the user has an authentication method with complement for the given identity provider', function () {
+      it('returns the authentication complement', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const authenticationMethod =
+          databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+            userId,
+          });
+        await databaseBuilder.commit();
+
+        // when
+        const foundAuthenticationComplement =
+          await authenticationMethodRepository.getAuthenticationComplementByUserIdAndIdentityProvider({
+            userId,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+          });
+
+        // then
+        expect(foundAuthenticationComplement).to.be.an.instanceOf(AuthenticationMethod.PixAuthenticationComplement);
+        expect(foundAuthenticationComplement).to.deep.equal(authenticationMethod.authenticationComplement);
+      });
+    });
+
+    context(
+      'when the user does not have an authentication method with complement for the given identity provider',
+      function () {
+        it('throws a NotFoundError', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          await databaseBuilder.commit();
+
+          // when
+          const error = await catchErr(
+            authenticationMethodRepository.getAuthenticationComplementByUserIdAndIdentityProvider,
+          )({
+            userId,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+          });
+
+          // then
+          expect(error).to.be.an.instanceOf(NotFoundError);
+        });
+      },
+    );
   });
 
   describe('#updateAuthenticationComplementByUserIdAndIdentityProvider', function () {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
@@ -185,15 +185,13 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
     it('returns the updated AuthenticationMethod', async function () {
       // given
-      const originalAuthenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
-          id: 123,
+      const authenticationMethodId =
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           userId,
           hashedPassword,
-        });
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword(
-        originalAuthenticationMethod,
-      );
+          lastLoggedAt: new Date('2022-12-12'),
+        }).id;
+
       await databaseBuilder.commit();
 
       // when
@@ -205,9 +203,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       // then
       const expectedAuthenticationMethod =
         domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
-          id: 123,
+          id: authenticationMethodId,
           userId,
           hashedPassword: newHashedPassword,
+          lastLoggedAt: new Date('2022-12-12'),
           updatedAt: new Date(),
         });
       expect(updatedAuthenticationMethod).to.deepEqualInstance(expectedAuthenticationMethod);
@@ -1208,19 +1207,32 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   });
 
   describe('#batchUpsertPasswordThatShouldBeChanged', function () {
-    context('when user have an authentication method PIX', function () {
+    context('when users have an authentication method PIX', function () {
       it('updates password for provided users list', async function () {
         // given
-        const pierre = databaseBuilder.factory.buildUser.withRawPassword({ firstName: 'Pierre' });
-        const pierreNewHashedPassword = 'PierrePasswordHashed';
-        const paul = databaseBuilder.factory.buildUser.withRawPassword({ firstName: 'Paul' });
-        const paulNewHashedPassword = 'PaulPasswordHashed';
-        const usersToUpdateWithNewPassword = [
-          { userId: pierre.id, hashedPassword: pierreNewHashedPassword },
-          { userId: paul.id, hashedPassword: paulNewHashedPassword },
-        ];
+        const pierreId = databaseBuilder.factory.buildUser({ email: 'pierre.user@email.net' }).id;
+        const pierreHashedPassword = 'pierre-hashed-password';
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+          userId: pierreId,
+          hashedPassword: pierreHashedPassword,
+        });
+
+        const paulId = databaseBuilder.factory.buildUser({ email: 'paul.user@email.net' }).id;
+        const paulHashedPassword = 'paul-hashed-password';
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+          userId: paulId,
+          hashedPassword: paulHashedPassword,
+        });
 
         await databaseBuilder.commit();
+
+        const pierreNewHashedPassword = 'PierrePasswordHashed';
+        const paulNewHashedPassword = 'PaulPasswordHashed';
+
+        const usersToUpdateWithNewPassword = [
+          { userId: pierreId, hashedPassword: pierreNewHashedPassword },
+          { userId: paulId, hashedPassword: paulNewHashedPassword },
+        ];
 
         // when
         await authenticationMethodRepository.batchUpsertPasswordThatShouldBeChanged({ usersToUpdateWithNewPassword });
@@ -1228,18 +1240,24 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         // then
         const authenticationMethods = await knex('authentication-methods')
           .pluck('authenticationComplement')
-          .whereIn('userId', [pierre.id, paul.id]);
+          .whereIn('userId', [pierreId, paulId]);
         const expectedAuthenticationMethods = [
-          { password: pierreNewHashedPassword, shouldChangePassword: true },
-          { password: paulNewHashedPassword, shouldChangePassword: true },
+          {
+            password: pierreNewHashedPassword,
+            shouldChangePassword: true,
+          },
+          {
+            password: paulNewHashedPassword,
+            shouldChangePassword: true,
+          },
         ];
 
         expect(authenticationMethods).to.have.deep.members(expectedAuthenticationMethods);
       });
     });
 
-    context("when user doesn't have an authentication method PIX", function () {
-      it('create Pix authentication method with password for provided users list', async function () {
+    context("when users don't have an authentication method PIX", function () {
+      it('creates Pix authentication method with password for provided users list', async function () {
         // given
         const pierre = databaseBuilder.factory.buildUser({ firstName: 'Pierre' });
         const pierreNewHashedPassword = 'PierrePasswordHashed';

--- a/api/tests/identity-access-management/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/identity-access-management/unit/domain/models/AuthenticationMethod_test.js
@@ -271,6 +271,20 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
             }),
         ).to.throw(ObjectValidationError);
       });
+
+      context('revokePassword', function () {
+        it('stores previous password into revokedEncryptedPassword and sets password to the "[revoked]" unreachable value', function () {
+          // given
+          const pixAuthenticationComplement = new AuthenticationMethod.PixAuthenticationComplement(validArguments);
+
+          // when
+          pixAuthenticationComplement.revokePassword();
+
+          // then
+          expect(pixAuthenticationComplement.revokedEncryptedPassword).to.equal('Password123');
+          expect(pixAuthenticationComplement.password).to.equal('[revoked]');
+        });
+      });
     });
 
     context('OidcAuthenticationComplement', function () {

--- a/api/tests/identity-access-management/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/identity-access-management/unit/domain/models/AuthenticationMethod_test.js
@@ -225,6 +225,18 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
         };
       });
 
+      context('when there is the optional revokedEncryptedPassword', function () {
+        it('instantiates object', function () {
+          expect(
+            () =>
+              new AuthenticationMethod.PixAuthenticationComplement({
+                ...validArguments,
+                revokedEncryptedPassword: 'revoked-encrypted-password',
+              }),
+          ).not.to.throw(ObjectValidationError);
+        });
+      });
+
       it('should successfully instantiate object when passing all valid arguments', function () {
         // when
         expect(() => new AuthenticationMethod.PixAuthenticationComplement(validArguments)).not.to.throw(


### PR DESCRIPTION
## 🪧 Problème

Lorsque des mots de passe d’utilisateurs sont compromis en dehors de Pix, on exécute le script de révocation des accès utilisateurs. Les utilisateurs ont bien leur accès révoqués, mais rien n’empêche les utilisateurs de remettre les mêmes mots de passe ayant été compromis.

## 🌈 Proposition

Lorsque qu’on exécute le script de révocation des accès utilisateurs, on propose de stocker le hash du mot de passe révoqué afin d’empêcher (dans une autre PR) l’utilisateur de remettre le même mot de passe.

On propose de stocker la précédente valeur dans une propriété `revokedEncryptedPassword` dans la colonne `authentication-methods.authenticationComplement`. On choisit le stockage dans `authentication-methods.authenticationComplement` à la fois pour : 
* avoir `revokedEncryptedPassword` logiquement « à côté » de `password`
* pour bénéficier de tous les mécanismes de protection qui sont déjà présents autour de `authentication-methods.authenticationComplement`

## ✊ Remarques

RAS

## 🎉 Pour tester

### Test sur la RA

On pourra utiliser les 2 comptes suivants avec les `id` ci-dessous au moment de cette PR :
```
 112554 | justin.compte@example.net
 112556 | justin.instant@example.net
```

1. Noter les valeurs de la propriété `password` de la colonne `authentication-methods.authenticationComplement` pour 2 utilisateurs particuliers
2. Exécuter le script de révocation des accès utilisateurs sur ces 2 utilisateurs :
   ```.csv
   userId
   112554
   112556
   99999999
   ```
   ```shell
   scalingo -a pix-api-review-pr16910 run --file ~/tmp/users.csv "node src/identity-access-management/scripts/revoke-access-for-users.script.js --file /tmp/uploads/users.csv"
   ```
3. Constater que les utilisateurs spécifiés ont une nouvelle propriété `revokedEncryptedPassword` dans `authentication-methods.authenticationComplement` ayant pour valeur la valeur précédente de la propriété `password` précédemment notée
4. Vérifier que suite à l’exécution de ce script les accès de ces utilisateurs sont bien révoqués et que ces utilisateurs peuvent réinitialiser leur mot de passe via la page _« Mot de passe oublié »_ puis se connecter.

--- 

### Test en local

:warning: Pour tester en local notez bien l’utilisation de l’option `--env-file-if-exists=.env` : 
```shell
node --env-file-if-exists=.env src/identity-access-management/scripts/revoke-access-for-users.script.js --file ./test.csv
```
