### PR TITLE
[FEATURE] Supprimer la limite de saisie d'heures (PIX-23623)

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -255,7 +255,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
             <PixInput
               @id="trainingHoursDuration"
               min="0"
-              max="23"
+              max="999"
               required={{true}}
               aria-required={{true}}
               type="number"

--- a/admin/app/styles/components/combined-course/form.scss
+++ b/admin/app/styles/components/combined-course/form.scss
@@ -73,7 +73,6 @@
 .card__content {
       display: flex;
       flex-direction: column;
-      gap: var(--pix-spacing-6x);
       margin-top: var(--pix-spacing-3x);
       margin-bottom: var(--pix-spacing-4x);
 }

--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -135,7 +135,7 @@ const register = async function (server) {
                 'internal-title': Joi.string().required(),
                 duration: Joi.object({
                   days: Joi.number().min(0).default(0),
-                  hours: Joi.number().min(0).max(23).default(0),
+                  hours: Joi.number().min(0).max(999).default(0),
                   minutes: Joi.number().min(0).max(59).default(0),
                 }).required(),
                 type: Joi.string()
@@ -223,7 +223,7 @@ const register = async function (server) {
                 'internal-title': Joi.string().allow(null),
                 duration: Joi.object({
                   days: Joi.number().min(0).required(),
-                  hours: Joi.number().min(0).max(23).required(),
+                  hours: Joi.number().min(0).max(999).required(),
                   minutes: Joi.number().min(0).max(59).required(),
                 }).allow(null),
                 type: Joi.string()

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -165,7 +165,7 @@ describe('Acceptance | Controller | training-controller', function () {
           type: 'webinaire',
           duration: {
             days: 0,
-            hours: 6,
+            hours: 40,
             minutes: 0,
           },
           locales: ['fr', 'fr-fr'],
@@ -192,7 +192,7 @@ describe('Acceptance | Controller | training-controller', function () {
               link: 'https://training-link.org',
               type: 'webinaire',
               duration: {
-                hours: 6,
+                hours: 40,
               },
               locales: ['fr', 'fr-fr'],
               'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/mon-logo.svg',
@@ -259,7 +259,7 @@ describe('Acceptance | Controller | training-controller', function () {
           editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/logo.svg',
           duration: {
             days: 2,
-            hours: 2,
+            hours: 40,
             minutes: 2,
           },
           locales,

--- a/api/tests/devcomp/integration/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/integration/application/trainings/training-route_test.js
@@ -510,7 +510,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
           expect(response.statusCode).to.equal(400);
         });
 
-        [{ days: -1 }, { hours: -1 }, { hours: 24 }, { minutes: -1 }, { minutes: 60 }].forEach((duration) => {
+        [{ days: -1 }, { hours: -1 }, { hours: 1000 }, { minutes: -1 }, { minutes: 60 }].forEach((duration) => {
           it(`should return 400 if the payload.duration is ${JSON.stringify(duration)}`, async function () {
             // given
             const invalidPayload = {


### PR DESCRIPTION
## 🪧 Problème

Lors de la saisie d’un Contenu formatif depuis pixAdmin, au niveau de la durée, on ne peut pas saisir plus de 23 heures. Il faudrait faire sauter cette limite car on souhaite proposer des contenus formatifs pouvant durer 40 heures et ces heures s'étalant sur un nombre de jours varié.

## 🌈 Proposition

Enlever la limite de max pour le nb d'heures pour la création et la mise à jour d'un CF

## ✊ Remarques

- Un maximum de 999 a été mis pour les heures afin d'éviter un impact sur l'affichage (dans le cas où le nombre serait très long)

## 🎉 Pour tester

- Se connecter à PixAdmin en tant que `superadmin@example.net`
- Créer un CF en mettant un nombre d'heures > 23, et vérifier que la création se passe bien
- Mettre à jour un CF en mettant un nombre d'heures > 23, et vérifier que la mise à jour se passe bien
