### PR TITLE
[FEATURE] Ajout d'une API de mise à disposition des statistiques de participations au parcours de rentrée pour le TDB-NUM du MEN (PIX-23449)

### DIFF
--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -51,6 +51,7 @@ class DatamartBuilder {
       'data_calibrations',
       'target_profiles_course_duration',
       'men_dashboard_certification_dataset',
+      'men_dashboard_participation_dataset',
     ].forEach((tableName) => {
       rawQuery += `DELETE FROM ${tableName};`;
     });

--- a/api/datamart/datamart-builder/factory/build-men-dashboard-participation-dataset.js
+++ b/api/datamart/datamart-builder/factory/build-men-dashboard-participation-dataset.js
@@ -1,0 +1,54 @@
+import { datamartBuffer } from '../datamart-buffer.js';
+
+const buildMenDashboardParticipationDataset = function ({
+  schoolUai = 'UAI001',
+  schoolYear = 2025,
+  academieName = 'Paris',
+  schoolName = 'Lycée Test',
+  provinceCode = '075',
+  schoolYearGroup = 'Terminale',
+  competenceCode = '1.1',
+  competenceName = 'Mener une recherche et une veille d’information',
+  participantCount = 30,
+  standardDeviation = 1.2,
+  firstDecileLevel = 1,
+  firstQuartileLevel = 2,
+  medianLevel = 4,
+  thirdQuartileLevel = 5,
+  ninthDecileLevel = 6,
+  averageMaxLevelReached = 4.2,
+  averageMaxLevelReachable = 5,
+  coverage = 0.85,
+  updatedAt = new Date('2026-07-01'),
+} = {}) {
+  const values = {
+    schoolUai,
+    schoolYear,
+    academieName,
+    schoolName,
+    provinceCode,
+    schoolYearGroup,
+    competenceCode,
+    competenceName,
+    participantCount,
+    standardDeviation,
+    firstDecileLevel,
+    firstQuartileLevel,
+    medianLevel,
+    thirdQuartileLevel,
+    ninthDecileLevel,
+    averageMaxLevelReached,
+    averageMaxLevelReachable,
+    coverage,
+    updatedAt,
+  };
+
+  datamartBuffer.pushInsertable({
+    tableName: 'men_dashboard_participation_dataset',
+    values,
+  });
+
+  return values;
+};
+
+export { buildMenDashboardParticipationDataset };

--- a/api/datamart/seeds/populate-tdb-num.js
+++ b/api/datamart/seeds/populate-tdb-num.js
@@ -1,36 +1,59 @@
 import { DatamartBuilder } from '../../datamart/datamart-builder/datamart-builder.js';
 
-const COMPETENCE_CODES = [
-  '1.1',
-  '1.2',
-  '1.3',
-  '2.1',
-  '2.2',
-  '2.3',
-  '2.4',
-  '3.1',
-  '3.2',
-  '3.3',
-  '3.4',
-  '4.1',
-  '4.2',
-  '4.3',
-  '5.1',
-  '5.2',
+// Deterministic per-competence variation factor allows to have various avgPixScore
+const COMPETENCES = [
+  { code: '1.1', name: 'Mener une recherche et une veille d’information', variation: 1.0 },
+  { code: '1.2', name: 'Gérer des données', variation: 0.92 },
+  { code: '1.3', name: 'Traiter des données', variation: 1.08 },
+  { code: '2.1', name: 'Interagir', variation: 0.88 },
+  { code: '2.2', name: 'Partager et publier', variation: 1.03 },
+  { code: '2.3', name: 'Collaborer', variation: 0.97 },
+  { code: '2.4', name: 'S’insérer dans le monde numérique', variation: 1.05 },
+  { code: '3.1', name: 'Développer des documents textuels', variation: 0.93 },
+  { code: '3.2', name: 'Développer des documents multimedia', variation: 1.07 },
+  { code: '3.3', name: 'Adapter les documents à leur finalité', variation: 0.99 },
+  { code: '3.4', name: 'Programmer', variation: 0.95 },
+  { code: '4.1', name: 'Sécuriser l’environnement numérique', variation: 1.04 },
+  { code: '4.2', name: 'Protéger les données personnelles et la vie privée', variation: 0.9 },
+  { code: '4.3', name: 'Protéger la santé, le bien-être et l’environnement', variation: 1.02 },
+  { code: '5.1', name: 'Résoudre des problèmes techniques', variation: 0.96 },
+  { code: '5.2', name: 'Construire un environnement numérique', variation: 1.01 },
 ];
 
-// Deterministic per-competence variation factors (index matches COMPETENCE_CODES)
-// Allows to have various avgPixScore
-const COMPETENCE_VARIATIONS = [
-  1.0, 0.92, 1.08, 0.88, 1.03, 0.97, 1.05, 0.93, 1.07, 0.99, 0.95, 1.04, 0.9, 1.02, 0.96, 1.01,
-];
-
-function scoreToLevel(pixScore) {
-  return Math.round((1 + ((pixScore - 1) / 895) * 6) * 10) / 10;
+function roundTo(value, precision) {
+  return Math.round(value * precision) / precision;
 }
 
 function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
+}
+
+function scoreToLevel(pixScore) {
+  return roundTo(1 + ((pixScore - 1) / 895) * 6, 10);
+}
+
+function computeCompetenceLevelStats({ basePixScore, variation }) {
+  const averagePixScore = clamp(roundTo(basePixScore * variation, 1), 1, 896);
+  const avgCompetenceLevel = clamp(scoreToLevel(averagePixScore), 1, 7);
+
+  return { averagePixScore, avgCompetenceLevel };
+}
+
+function computeParticipationLevelStats(avgCompetenceLevel) {
+  const medianLevel = clamp(roundTo(avgCompetenceLevel, 1), 1, 6);
+  const averageMaxLevelReached = clamp(roundTo(avgCompetenceLevel, 10), 1, 6);
+  const averageMaxLevelReachable = clamp(roundTo(averageMaxLevelReached + 0.5, 10), 1, 6);
+
+  return {
+    firstDecileLevel: clamp(medianLevel - 2, 1, 6),
+    firstQuartileLevel: clamp(medianLevel - 1, 1, 6),
+    medianLevel,
+    thirdQuartileLevel: clamp(medianLevel + 1, 1, 6),
+    ninthDecileLevel: clamp(medianLevel + 2, 1, 6),
+    averageMaxLevelReached,
+    averageMaxLevelReachable,
+    coverage: clamp(roundTo(averageMaxLevelReached / averageMaxLevelReachable, 100), 0, 1),
+  };
 }
 
 function generateSchoolClassRecords({
@@ -43,13 +66,18 @@ function generateSchoolClassRecords({
   certificationCount,
   validatedCertificationCount,
 }) {
-  return COMPETENCE_CODES.map((competenceCode, index) => {
-    const averagePixScore = clamp(Math.round(basePixScore * COMPETENCE_VARIATIONS[index]), 1, 896);
-    const avgCompetenceLevel = clamp(scoreToLevel(averagePixScore), 1, 7);
+  const schoolYear = 2025;
+  const updatedAt = new Date('2026-07-01');
 
-    return {
+  const certificationRecords = [];
+  const participationRecords = [];
+
+  COMPETENCES.forEach(({ code: competenceCode, name: competenceName, variation }) => {
+    const { averagePixScore, avgCompetenceLevel } = computeCompetenceLevelStats({ basePixScore, variation });
+
+    certificationRecords.push({
       schoolUai,
-      schoolYear: 2025,
+      schoolYear,
       academieName,
       schoolName,
       provinceCode,
@@ -59,9 +87,26 @@ function generateSchoolClassRecords({
       averagePixScore,
       competenceCode,
       avgCompetenceLevel,
-      updatedAt: new Date('2026-07-01'),
-    };
+      updatedAt,
+    });
+
+    participationRecords.push({
+      schoolUai,
+      schoolYear,
+      academieName,
+      schoolName,
+      provinceCode,
+      schoolYearGroup,
+      competenceCode,
+      competenceName,
+      participantCount: certificationCount,
+      standardDeviation: clamp(roundTo(2 - variation, 10), 0.5, 2),
+      ...computeParticipationLevelStats(avgCompetenceLevel),
+      updatedAt,
+    });
   });
+
+  return { certificationRecords, participationRecords };
 }
 
 const SCHOOLS = [
@@ -224,7 +269,7 @@ export async function seed(knex) {
 
   for (const school of SCHOOLS) {
     for (const cls of school.classes) {
-      const records = generateSchoolClassRecords({
+      const { certificationRecords, participationRecords } = generateSchoolClassRecords({
         schoolUai: school.schoolUai,
         academieName: school.academieName,
         schoolName: school.schoolName,
@@ -234,7 +279,8 @@ export async function seed(knex) {
         certificationCount: cls.certificationCount,
         validatedCertificationCount: cls.validatedCertificationCount,
       });
-      records.forEach((record) => datamartBuilder.factory.buildMenDashboardCertificationDataset(record));
+      certificationRecords.forEach((record) => datamartBuilder.factory.buildMenDashboardCertificationDataset(record));
+      participationRecords.forEach((record) => datamartBuilder.factory.buildMenDashboardParticipationDataset(record));
     }
   }
 

--- a/api/src/maddo/application/men-dashboard-controller.js
+++ b/api/src/maddo/application/men-dashboard-controller.js
@@ -18,3 +18,22 @@ export async function getMenDashboardCertificationDataset(
     })
     .code(200);
 }
+
+export async function getMenDashboardParticipationDataset(
+  request,
+  h,
+  dependencies = {
+    findParticipationDataset: usecases.findParticipationDataset,
+  },
+) {
+  const { page } = request.query;
+  const { models, meta } = await dependencies.findParticipationDataset({
+    page,
+  });
+  return h
+    .response({
+      dataset: models,
+      page: { number: meta.page, size: meta.pageSize, count: meta.pageCount },
+    })
+    .code(200);
+}

--- a/api/src/maddo/application/men-dashboard-routes.js
+++ b/api/src/maddo/application/men-dashboard-routes.js
@@ -1,7 +1,10 @@
 import Joi from 'joi';
 
 import { responseObjectErrorDoc } from '../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
-import { getMenDashboardCertificationDataset } from './men-dashboard-controller.js';
+import {
+  getMenDashboardCertificationDataset,
+  getMenDashboardParticipationDataset,
+} from './men-dashboard-controller.js';
 
 const register = async function (server) {
   server.route([
@@ -37,7 +40,7 @@ const register = async function (server) {
                   schoolYear: Joi.number().description('Année scolaire concernée par les données'),
                   academieName: Joi.string().description("Nom de l'académie de l'établissement"),
                   schoolName: Joi.string().description("Nom de l'établissement"),
-                  provinceCode: Joi.string().description("Nom du département de l'établissement"),
+                  provinceCode: Joi.string().description("Numéro du département de l'établissement sur 3 caractères"),
                   schoolYearGroup: Joi.string().description('Niveau scolaire'),
                   validatedCertificationCount: Joi.number().description(
                     'Nombre de certification obtenues (i.e. réussies)',
@@ -63,6 +66,67 @@ const register = async function (server) {
                 .description('Information de pagination')
                 .label('page'),
             }).label('MenDashboardCertificationDataset'),
+            401: responseObjectErrorDoc,
+            403: responseObjectErrorDoc,
+          },
+        },
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/men/dashboard/participations',
+      config: {
+        auth: { access: { scope: 'men-dashboard' } },
+        validate: {
+          query: Joi.object({
+            page: Joi.object({
+              number: Joi.number().integer().empty('').allow(null).optional(),
+              size: Joi.number().integer().max(200).empty('').allow(null).optional(),
+            }).default({}),
+          }),
+        },
+        handler: getMenDashboardParticipationDataset,
+        description:
+          'Dataset contenant les statistiques de participation aux campagnes de rentrée des élèves des établissements français pour ' +
+          "l'année scolaire en cours par niveau scolaire et compétence.",
+        notes: [
+          'Retourne toutes les données triées par UAI sous format paginé.',
+          '**Cette route nécessite le scope men-dashboard.**',
+        ],
+        tags: ['api', 'men-dashboard', 'maddo'],
+        response: {
+          failAction: 'log',
+          status: {
+            200: Joi.object({
+              dataset: Joi.array().items(
+                Joi.object({
+                  schoolUai: Joi.string().description("UAI de l'établissement"),
+                  schoolYear: Joi.number().description('Année scolaire concernée par les données'),
+                  academieName: Joi.string().description("Nom de l'académie de l'établissement"),
+                  schoolName: Joi.string().description("Nom de l'établissement"),
+                  provinceCode: Joi.string().description("Numéro du département de l'établissement sur 3 caractères"),
+                  schoolYearGroup: Joi.string().description('Niveau scolaire'),
+                  competenceCode: Joi.string().description('Code de la compétence'),
+                  competenceName: Joi.string().description('Nom de la compétence'),
+                  participantCount: Joi.number().description('Nombre de participants'),
+                  standardDeviation: Joi.number().description('Écart-type des niveaux atteints'),
+                  firstDecileLevel: Joi.number().description('Premier décile des niveaux atteints'),
+                  firstQuartileLevel: Joi.number().description('Premier quartile des niveaux atteints'),
+                  medianLevel: Joi.number().description('Niveau médian atteint'),
+                  thirdQuartileLevel: Joi.number().description('Troisième quartile des niveaux atteints'),
+                  ninthDecileLevel: Joi.number().description('Neuvième décile des niveaux atteints'),
+                  averageMaxLevelReached: Joi.number().description('Moyenne des niveaux maximum atteints'),
+                  averageMaxLevelReachable: Joi.number().description('Moyenne des niveaux maximum atteignables'),
+                  coverage: Joi.number().description('Taux de couverture'),
+                  updatedAt: Joi.date().description('Date de dernière mise à jour des données.'),
+                }),
+              ),
+              page: Joi.object({
+                number: Joi.number().description('Numéro de la page courante'),
+                size: Joi.number().description('Taille de la page courante'),
+                count: Joi.number().description('Nombre total de pages'),
+              }).description('Information de pagination'),
+            }).label('MENDashboardParticipationDataset'),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },

--- a/api/src/maddo/application/men-dashboard-routes.js
+++ b/api/src/maddo/application/men-dashboard-routes.js
@@ -32,30 +32,32 @@ const register = async function (server) {
           failAction: 'log',
           status: {
             200: Joi.object({
-              dataset: Joi.array().items(
-                Joi.object({
-                  schoolUai: Joi.string().description("UAI de l'établissement"),
-                  schoolYear: Joi.number().description('Année scolaire concernée par les données'),
-                  academieName: Joi.string().description("Nom de l'académie de l'établissement"),
-                  schoolName: Joi.string().description("Nom de l'établissement"),
-                  provinceCode: Joi.string().description("Numéro du département de l'établissement sur 3 caractères"),
-                  schoolYearGroup: Joi.string().description('Niveau scolaire'),
-                  validatedCertificationCount: Joi.number().description(
-                    'Nombre de certification obtenues (i.e. réussies)',
-                  ),
-                  certificationCount: Joi.number().description(
-                    'Nombre total de certifications (réussies, échouées, abandonnées...)',
-                  ),
-                  averagePixScore: Joi.number().description(
-                    "Moyenne des scores en 'Pix' réalisés sur les certifications obtenues pour une compétence donnée",
-                  ),
-                  competenceCode: Joi.string().description('Code de la compétence'),
-                  avgCompetenceLevel: Joi.number().description(
-                    'Moyenne des niveaux atteints sur les certifications obtenues pour une compétence donnée',
-                  ),
-                  updatedAt: Joi.date().description('Date de dernière mise à jour des données.'),
-                }).label('MenDashboardCertificationRow'),
-              ),
+              dataset: Joi.array()
+                .items(
+                  Joi.object({
+                    schoolUai: Joi.string().description("UAI de l'établissement"),
+                    schoolYear: Joi.number().description('Année scolaire concernée par les données'),
+                    academieName: Joi.string().description("Nom de l'académie de l'établissement"),
+                    schoolName: Joi.string().description("Nom de l'établissement"),
+                    provinceCode: Joi.string().description("Numéro du département de l'établissement sur 3 caractères"),
+                    schoolYearGroup: Joi.string().description('Niveau scolaire'),
+                    validatedCertificationCount: Joi.number().description(
+                      'Nombre de certification obtenues (i.e. réussies)',
+                    ),
+                    certificationCount: Joi.number().description(
+                      'Nombre total de certifications (réussies, échouées, abandonnées...)',
+                    ),
+                    averagePixScore: Joi.number().description(
+                      "Moyenne des scores en 'Pix' réalisés sur les certifications obtenues pour une compétence donnée",
+                    ),
+                    competenceCode: Joi.string().description('Code de la compétence'),
+                    avgCompetenceLevel: Joi.number().description(
+                      'Moyenne des niveaux atteints sur les certifications obtenues pour une compétence donnée',
+                    ),
+                    updatedAt: Joi.date().description('Date de dernière mise à jour des données.'),
+                  }).label('MENDashboardCertificationRow'),
+                )
+                .label('MENDashboardCertificationDataset'),
               page: Joi.object({
                 number: Joi.number().description('Numéro de la page courante'),
                 size: Joi.number().description('Taille de la page courante'),
@@ -63,7 +65,7 @@ const register = async function (server) {
               })
                 .description('Information de pagination')
                 .label('page'),
-            }).label('MenDashboardCertificationDataset'),
+            }).label('MENDashboardCertificationResponse'),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },
@@ -93,35 +95,39 @@ const register = async function (server) {
           failAction: 'log',
           status: {
             200: Joi.object({
-              dataset: Joi.array().items(
-                Joi.object({
-                  schoolUai: Joi.string().description("UAI de l'établissement"),
-                  schoolYear: Joi.number().description('Année scolaire concernée par les données'),
-                  academieName: Joi.string().description("Nom de l'académie de l'établissement"),
-                  schoolName: Joi.string().description("Nom de l'établissement"),
-                  provinceCode: Joi.string().description("Numéro du département de l'établissement sur 3 caractères"),
-                  schoolYearGroup: Joi.string().description('Niveau scolaire'),
-                  competenceCode: Joi.string().description('Code de la compétence'),
-                  competenceName: Joi.string().description('Nom de la compétence'),
-                  participantCount: Joi.number().description('Nombre de participants'),
-                  standardDeviation: Joi.number().description('Écart-type des niveaux atteints'),
-                  firstDecileLevel: Joi.number().description('Premier décile des niveaux atteints'),
-                  firstQuartileLevel: Joi.number().description('Premier quartile des niveaux atteints'),
-                  medianLevel: Joi.number().description('Niveau médian atteint'),
-                  thirdQuartileLevel: Joi.number().description('Troisième quartile des niveaux atteints'),
-                  ninthDecileLevel: Joi.number().description('Neuvième décile des niveaux atteints'),
-                  averageMaxLevelReached: Joi.number().description('Moyenne des niveaux maximum atteints'),
-                  averageMaxLevelReachable: Joi.number().description('Moyenne des niveaux maximum atteignables'),
-                  coverage: Joi.number().description('Taux de couverture'),
-                  updatedAt: Joi.date().description('Date de dernière mise à jour des données.'),
-                }),
-              ),
+              dataset: Joi.array()
+                .items(
+                  Joi.object({
+                    schoolUai: Joi.string().description("UAI de l'établissement"),
+                    schoolYear: Joi.number().description('Année scolaire concernée par les données'),
+                    academieName: Joi.string().description("Nom de l'académie de l'établissement"),
+                    schoolName: Joi.string().description("Nom de l'établissement"),
+                    provinceCode: Joi.string().description("Numéro du département de l'établissement sur 3 caractères"),
+                    schoolYearGroup: Joi.string().description('Niveau scolaire'),
+                    competenceCode: Joi.string().description('Code de la compétence'),
+                    competenceName: Joi.string().description('Nom de la compétence'),
+                    participantCount: Joi.number().description('Nombre de participants'),
+                    standardDeviation: Joi.number().description('Écart-type des niveaux atteints'),
+                    firstDecileLevel: Joi.number().description('Premier décile des niveaux atteints'),
+                    firstQuartileLevel: Joi.number().description('Premier quartile des niveaux atteints'),
+                    medianLevel: Joi.number().description('Niveau médian atteint'),
+                    thirdQuartileLevel: Joi.number().description('Troisième quartile des niveaux atteints'),
+                    ninthDecileLevel: Joi.number().description('Neuvième décile des niveaux atteints'),
+                    averageMaxLevelReached: Joi.number().description('Moyenne des niveaux maximum atteints'),
+                    averageMaxLevelReachable: Joi.number().description('Moyenne des niveaux maximum atteignables'),
+                    coverage: Joi.number().description('Taux de couverture'),
+                    updatedAt: Joi.date().description('Date de dernière mise à jour des données.'),
+                  }).label('MENDashboardParticipationRow'),
+                )
+                .label('MENDashboardParticipationDataset'),
               page: Joi.object({
                 number: Joi.number().description('Numéro de la page courante'),
                 size: Joi.number().description('Taille de la page courante'),
                 count: Joi.number().description('Nombre total de pages'),
-              }).description('Information de pagination'),
-            }).label('MENDashboardParticipationDataset'),
+              })
+                .description('Information de pagination')
+                .label('page'),
+            }).label('MENDashboardParticipationResponse'),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },

--- a/api/src/maddo/application/men-dashboard-routes.js
+++ b/api/src/maddo/application/men-dashboard-routes.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { pageQuerySchema } from '../../shared/application/pagination-query-schema.js';
 import { responseObjectErrorDoc } from '../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
 import {
   getMenDashboardCertificationDataset,
@@ -15,10 +16,7 @@ const register = async function (server) {
         auth: { access: { scope: 'men-dashboard' } },
         validate: {
           query: Joi.object({
-            page: Joi.object({
-              number: Joi.number().integer().empty('').allow(null).optional(),
-              size: Joi.number().integer().max(200).empty('').allow(null).optional(),
-            }).default({}),
+            page: pageQuerySchema,
           }),
         },
         handler: getMenDashboardCertificationDataset,
@@ -79,10 +77,7 @@ const register = async function (server) {
         auth: { access: { scope: 'men-dashboard' } },
         validate: {
           query: Joi.object({
-            page: Joi.object({
-              number: Joi.number().integer().empty('').allow(null).optional(),
-              size: Joi.number().integer().max(200).empty('').allow(null).optional(),
-            }).default({}),
+            page: pageQuerySchema,
           }),
         },
         handler: getMenDashboardParticipationDataset,

--- a/api/src/maddo/domain/models/men/dashboard/ParticipationDataset.js
+++ b/api/src/maddo/domain/models/men/dashboard/ParticipationDataset.js
@@ -1,0 +1,43 @@
+export class ParticipationDataset {
+  constructor({
+    schoolUai,
+    schoolYear,
+    academieName,
+    schoolName,
+    provinceCode,
+    schoolYearGroup,
+    competenceCode,
+    competenceName,
+    participantCount,
+    standardDeviation,
+    firstDecileLevel,
+    firstQuartileLevel,
+    medianLevel,
+    thirdQuartileLevel,
+    ninthDecileLevel,
+    averageMaxLevelReached,
+    averageMaxLevelReachable,
+    coverage,
+    updatedAt,
+  }) {
+    this.schoolUai = schoolUai;
+    this.schoolYear = schoolYear;
+    this.academieName = academieName;
+    this.schoolName = schoolName;
+    this.provinceCode = provinceCode;
+    this.schoolYearGroup = schoolYearGroup;
+    this.competenceCode = competenceCode;
+    this.competenceName = competenceName;
+    this.participantCount = participantCount;
+    this.standardDeviation = standardDeviation;
+    this.firstDecileLevel = firstDecileLevel;
+    this.firstQuartileLevel = firstQuartileLevel;
+    this.medianLevel = medianLevel;
+    this.thirdQuartileLevel = thirdQuartileLevel;
+    this.ninthDecileLevel = ninthDecileLevel;
+    this.averageMaxLevelReached = averageMaxLevelReached;
+    this.averageMaxLevelReachable = averageMaxLevelReachable;
+    this.coverage = coverage;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/api/src/maddo/domain/usecases/find-participation-dataset.js
+++ b/api/src/maddo/domain/usecases/find-participation-dataset.js
@@ -1,0 +1,3 @@
+export async function findParticipationDataset({ page, participationDatasetRepository }) {
+  return participationDatasetRepository.findAll({ page });
+}

--- a/api/src/maddo/domain/usecases/index.js
+++ b/api/src/maddo/domain/usecases/index.js
@@ -7,11 +7,13 @@ import * as certificationDatasetRepository from '../../infrastructure/repositori
 import * as clientApplicationRepository from '../../infrastructure/repositories/client-application-repository.js';
 import * as oidcProviderRepository from '../../infrastructure/repositories/oidc-provider-repository.js';
 import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
+import * as participationDatasetRepository from '../../infrastructure/repositories/participation-dataset-repository.js';
 import { extractTransformAndLoadData } from './extract-transform-and-load-data.js';
 import { findCampaigns } from './find-campaigns.js';
 import { findCertificationDataset } from './find-certification-dataset.js';
 import { findOrganizationIdsByClientApplication } from './find-organization-ids-by-client-application.js';
 import { findOrganizations } from './find-organizations.js';
+import { findParticipationDataset } from './find-participation-dataset.js';
 import { getCampaignOrganizationId } from './get-campaign-organization-id.js';
 import { getCampaignParticipations } from './get-campaign-participations.js';
 
@@ -21,6 +23,7 @@ const dependencies = {
   certificationDatasetRepository,
   clientApplicationRepository,
   organizationRepository,
+  participationDatasetRepository,
   campaignRepository,
   oidcProviderRepository,
 };
@@ -31,6 +34,7 @@ const usecasesWithoutInjectedDependencies = {
   findCertificationDataset,
   findOrganizationIdsByClientApplication,
   findOrganizations,
+  findParticipationDataset,
   getCampaignOrganizationId,
   getCampaignParticipations,
 };

--- a/api/src/maddo/infrastructure/repositories/participation-dataset-repository.js
+++ b/api/src/maddo/infrastructure/repositories/participation-dataset-repository.js
@@ -1,0 +1,28 @@
+import { knex as datamartKnex } from '../../../../datamart/knex-database-connection.js';
+import { ParticipationDataset } from '../../domain/models/men/dashboard/ParticipationDataset.js';
+
+const TABLE_NAME = 'men_dashboard_participation_dataset';
+const DEFAULT_PAGE_NUMBER = 1;
+const DEFAULT_PAGE_SIZE = 10;
+
+export async function findAll({ page = {} } = {}) {
+  const number = page.number ?? DEFAULT_PAGE_NUMBER;
+  const size = page.size ?? DEFAULT_PAGE_SIZE;
+  const offset = (number - 1) * size;
+
+  const [rows, countResult] = await Promise.all([
+    datamartKnex(TABLE_NAME).orderBy('schoolUai').limit(size).offset(offset),
+    datamartKnex(TABLE_NAME).count('* as rowCount').first(),
+  ]);
+
+  const rowCount = parseInt(countResult.rowCount, 10);
+
+  return {
+    models: rows.map((row) => new ParticipationDataset(row)),
+    meta: {
+      page: number,
+      pageSize: size,
+      pageCount: Math.ceil(rowCount / size),
+    },
+  };
+}

--- a/api/src/shared/application/pagination-query-schema.js
+++ b/api/src/shared/application/pagination-query-schema.js
@@ -1,0 +1,33 @@
+import Joi from 'joi';
+
+const pageObjectSchema = Joi.object({
+  number: Joi.number().integer().positive().empty('').allow(null).optional(),
+  size: Joi.number().integer().positive().max(200).empty('').allow(null).optional(),
+});
+
+const pageQuerySchema = Joi.alternatives()
+  .try(
+    pageObjectSchema,
+    Joi.string().custom((value, helpers) => {
+      let parsedValue;
+      try {
+        parsedValue = JSON.parse(value);
+      } catch {
+        return helpers.error('any.invalid');
+      }
+
+      const { error, value: validatedValue } = pageObjectSchema.validate(parsedValue);
+      if (error) {
+        return helpers.error('any.invalid');
+      }
+
+      return validatedValue;
+    }),
+  )
+  .default({})
+  .description(
+    'Paramètres de pagination, en bracket notation (page[number]=1&page[size]=10) ou en objet JSON encodé dans l’URL (page={"number":1,"size":10}).',
+  )
+  .example({ page: { number: 1, size: 10 } });
+
+export { pageQuerySchema };

--- a/api/tests/maddo/application/acceptance/men-dashboard-routes_test.js
+++ b/api/tests/maddo/application/acceptance/men-dashboard-routes_test.js
@@ -110,4 +110,105 @@ describe('Acceptance | Maddo | Route | Men | Dashboard', function () {
       expect(response.statusCode).to.equal(403);
     });
   });
+
+  describe('GET /api/men/dashboard/participations', function () {
+    it('returns participation dataset with pagination and HTTP 200', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI001',
+        competenceCode: '1.1',
+      });
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/men/dashboard/participations',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            'client-id',
+            'pix-client',
+            'men-dashboard',
+          ),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.dataset).to.have.length(1);
+      expect(response.result.dataset[0].schoolUai).to.equal('UAI001');
+      expect(response.result.dataset[0].competenceCode).to.equal('1.1');
+      expect(response.result.page).to.deep.equal({
+        number: 1,
+        size: 10,
+        count: 1,
+      });
+    });
+
+    it('paginates results when page params are provided', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_A',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_B',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_C',
+      });
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/men/dashboard/participations?page[number]=2&page[size]=2',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            'client-id',
+            'pix-client',
+            'men-dashboard',
+          ),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.dataset).to.have.length(1);
+      expect(response.result.dataset[0].schoolUai).to.equal('UAI_C');
+      expect(response.result.page).to.deep.equal({
+        number: 2,
+        size: 2,
+        count: 2,
+      });
+    });
+
+    it('returns HTTP 401 when no authorization header is provided', async function () {
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/men/dashboard/participations',
+      });
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('returns HTTP 403 when the token does not have the men-dashboard scope', async function () {
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/men/dashboard/participations',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication('client-id', 'pix-client', 'campaigns'),
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
 });

--- a/api/tests/maddo/application/acceptance/men-dashboard-routes_test.js
+++ b/api/tests/maddo/application/acceptance/men-dashboard-routes_test.js
@@ -62,6 +62,7 @@ describe('Acceptance | Maddo | Route | Men | Dashboard', function () {
       const options = {
         method: 'GET',
         url: '/api/men/dashboard/certifications?page[number]=2&page[size]=2',
+
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             'client-id',
@@ -163,6 +164,45 @@ describe('Acceptance | Maddo | Route | Men | Dashboard', function () {
       const options = {
         method: 'GET',
         url: '/api/men/dashboard/participations?page[number]=2&page[size]=2',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            'client-id',
+            'pix-client',
+            'men-dashboard',
+          ),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.dataset).to.have.length(1);
+      expect(response.result.dataset[0].schoolUai).to.equal('UAI_C');
+      expect(response.result.page).to.deep.equal({
+        number: 2,
+        size: 2,
+        count: 2,
+      });
+    });
+
+    it('paginates results when page param is a JSON-encoded object', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_A',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_B',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_C',
+      });
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/men/dashboard/participations?page=%7B%22number%22%3A2%2C%22size%22%3A2%7D',
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             'client-id',

--- a/api/tests/maddo/domain/unit/usecases/find-participation-dataset_test.js
+++ b/api/tests/maddo/domain/unit/usecases/find-participation-dataset_test.js
@@ -1,0 +1,30 @@
+import sinon from 'sinon';
+
+import { findParticipationDataset } from '../../../../../src/maddo/domain/usecases/find-participation-dataset.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Maddo | Domain | Usecase | Find participation dataset', function () {
+  it('delegates to the repository and returns its result', async function () {
+    // given
+    const page = { number: 1, size: 10 };
+    const expectedResult = {
+      models: [],
+      meta: { page: 1, pageSize: 10, pageCount: 0 },
+    };
+    const participationDatasetRepository = {
+      findAll: sinon.stub().resolves(expectedResult),
+    };
+
+    // when
+    const result = await findParticipationDataset({
+      page,
+      participationDatasetRepository,
+    });
+
+    // then
+    expect(participationDatasetRepository.findAll).to.have.been.calledOnceWith({
+      page,
+    });
+    expect(result).to.deep.equal(expectedResult);
+  });
+});

--- a/api/tests/maddo/infrastructure/integration/repositories/participation-dataset-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/participation-dataset-repository_test.js
@@ -1,0 +1,100 @@
+import { ParticipationDataset } from '../../../../../src/maddo/domain/models/men/dashboard/ParticipationDataset.js';
+import { findAll } from '../../../../../src/maddo/infrastructure/repositories/participation-dataset-repository.js';
+import { expect } from '../../../../test-helper.js';
+import { datamartBuilder } from '../../../../tooling/databases.js';
+
+describe('Maddo | Infrastructure | Repositories | Integration | ParticipationDataset', function () {
+  describe('#findAll', function () {
+    it('returns dataset sorted by schoolUai', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_B',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_A',
+      });
+      await datamartBuilder.commit();
+
+      // when
+      const { models } = await findAll();
+
+      // then
+      expect(models[0].schoolUai).to.equal('UAI_A');
+      expect(models[1].schoolUai).to.equal('UAI_B');
+      expect(models[0]).to.be.instanceOf(ParticipationDataset);
+    });
+
+    it('paginates results and returns correct meta', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_A',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_B',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI_C',
+      });
+      await datamartBuilder.commit();
+
+      // when
+      const { models, meta } = await findAll({ page: { number: 2, size: 2 } });
+
+      // then
+      expect(models).to.have.length(1);
+      expect(models[0].schoolUai).to.equal('UAI_C');
+      expect(meta).to.deep.equal({ page: 2, pageSize: 2, pageCount: 2 });
+    });
+
+    it('maps all columns to the domain model', async function () {
+      // given
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        schoolUai: 'UAI001',
+        schoolYear: 2025,
+        academieName: 'Paris',
+        schoolName: 'Lycée Test',
+        provinceCode: '075',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '1.1',
+        competenceName: 'Mener une recherche et une veille d’information',
+        participantCount: 30,
+        standardDeviation: 1.2,
+        firstDecileLevel: 1,
+        firstQuartileLevel: 2,
+        medianLevel: 4,
+        thirdQuartileLevel: 5,
+        ninthDecileLevel: 6,
+        averageMaxLevelReached: 4.2,
+        averageMaxLevelReachable: 5,
+        coverage: 0.85,
+        updatedAt: '2026-07-01',
+      });
+      await datamartBuilder.commit();
+
+      // when
+      const { models } = await findAll();
+
+      // then
+      const stat = models[0];
+      expect(stat.schoolUai).to.equal('UAI001');
+      expect(stat.schoolYear).to.equal(2025);
+      expect(stat.academieName).to.equal('Paris');
+      expect(stat.schoolName).to.equal('Lycée Test');
+      expect(stat.provinceCode).to.equal('075');
+      expect(stat.schoolYearGroup).to.equal('Terminale');
+      expect(stat.competenceCode).to.equal('1.1');
+      expect(stat.competenceName).to.equal('Mener une recherche et une veille d’information');
+      expect(stat.participantCount).to.equal(30);
+      expect(stat.standardDeviation).to.equal(1.2);
+      expect(stat.firstDecileLevel).to.equal(1);
+      expect(stat.firstQuartileLevel).to.equal(2);
+      expect(stat.medianLevel).to.equal(4);
+      expect(stat.thirdQuartileLevel).to.equal(5);
+      expect(stat.ninthDecileLevel).to.equal(6);
+      expect(stat.averageMaxLevelReached).to.equal(4.2);
+      expect(stat.averageMaxLevelReachable).to.equal(5);
+      expect(stat.coverage).to.equal(0.85);
+      expect(stat.updatedAt).to.deep.equal('2026-07-01');
+    });
+  });
+});

--- a/api/tests/shared/unit/application/pagination-query-schema_test.js
+++ b/api/tests/shared/unit/application/pagination-query-schema_test.js
@@ -1,0 +1,88 @@
+import { pageQuerySchema } from '../../../../src/shared/application/pagination-query-schema.js';
+import { expect } from '../../../test-helper.js';
+
+describe('Unit | Application | pagination-query-schema', function () {
+  it('defaults to an empty object when no value is provided', function () {
+    // when
+    const { error, value } = pageQuerySchema.validate(undefined);
+
+    // then
+    expect(error).to.not.exist;
+    expect(value).to.deep.equal({});
+  });
+
+  it('accepts an already parsed object (bracket notation)', function () {
+    // when
+    const { error, value } = pageQuerySchema.validate({ number: 2, size: 2 });
+
+    // then
+    expect(error).to.not.exist;
+    expect(value).to.deep.equal({ number: 2, size: 2 });
+  });
+
+  it('accepts a JSON-encoded string and parses it into an object', function () {
+    // when
+    const { error, value } = pageQuerySchema.validate('{"number":2,"size":2}');
+
+    // then
+    expect(error).to.not.exist;
+    expect(value).to.deep.equal({ number: 2, size: 2 });
+  });
+
+  it('rejects a string that is not valid JSON', function () {
+    // when
+    const { error } = pageQuerySchema.validate('not-json');
+
+    // then
+    expect(error).to.exist;
+  });
+
+  it('rejects a JSON-encoded string whose parsed object breaks the page schema', function () {
+    // when
+    const { error } = pageQuerySchema.validate('{"number":2,"size":500}');
+
+    // then
+    expect(error).to.exist;
+  });
+
+  it('rejects an object that breaks the page schema', function () {
+    // when
+    const { error } = pageQuerySchema.validate({ number: 2, size: 500 });
+
+    // then
+    expect(error).to.exist;
+  });
+
+  it('rejects a negative number', function () {
+    // when
+    const { error } = pageQuerySchema.validate({ number: -1, size: 2 });
+
+    // then
+    expect(error).to.exist;
+  });
+
+  it('rejects a size equal to zero', function () {
+    // when
+    const { error } = pageQuerySchema.validate({ number: 1, size: 0 });
+
+    // then
+    expect(error).to.exist;
+  });
+
+  it('rejects a JSON-encoded string with a negative size', function () {
+    // when
+    const { error } = pageQuerySchema.validate('{"number":1,"size":-2}');
+
+    // then
+    expect(error).to.exist;
+  });
+
+  it('accepts null values for number and size', function () {
+    // when
+    const { error, value } = pageQuerySchema.validate({ number: null, size: null });
+
+    // then
+    expect(error).to.not.exist;
+    expect(value).to.deep.equal({ number: null, size: null });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

Les données statistiques concernant les participations aux parcours de rentrée sont fournies par export au MEN pour le tableau de bord du numérique.

## 🌈 Proposition

Création d'une API pour mettre automatiquement à disposition ces données aux utilisateurs applicatifs ayant un scope `men-dashboard`. La juridiction n'est pas utilisée dans le cas de cette API non générique.

## 🎉 Pour tester

### Test fonctionnel d'accès aux données :

Obtenir un token applicatif avec les paramètres suivants : 
```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr16914.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=men-dashboard&client_secret=men-dashboard-secret&scope=men-dashboard' | jq -r .access_token)
```
puis appeler l'API `/api/tdb-num/men/dashboard/participations` avec le token obtenu.

```
curl --get --data-urlencode "page[size]=2" --data-urlencode "page[number]=2" https://pix-api-maddo-review-pr16914.osc-fr1.scalingo.io/api/men/dashboard/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq 
```

Les données sont les mêmes si l'on demande plusieurs fois la même page. 
Des données complémentaires sont obtenues si l'on demande les pages suivantes.
Le nombre de pages retourné est cohérent avec la taille des pages fournie.

### Test de la documentation swagger
La documentation est disponible dans une section tdb-num : https://pix-api-maddo-review-pr16914.osc-fr1.scalingo.io/documentation/maddo#/