### PR TITLE
[BUGFIX] Erreur 500 à l'appel Maddo `/api/campaigns/:id/participations`

### DIFF
--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -22,12 +22,14 @@ const register = async function (server) {
               number: Joi.number().integer().empty('').allow(null).optional(),
               size: Joi.number().integer().max(200).empty('').allow(null).optional(),
             }).default({}),
-            sort: Joi.array().items(
-              Joi.object({
-                value: Joi.string().empty('').allow(null).optional(),
-                type: Joi.string().valid('asc', 'desc').empty(['', null]).allow(null).optional(),
-              }),
-            ),
+            sort: Joi.array()
+              .items(
+                Joi.object({
+                  value: Joi.string().empty('').allow(null).optional(),
+                  type: Joi.string().valid('asc', 'desc').empty(['', null]).allow(null).optional(),
+                }),
+              )
+              .optional(),
             authenticationRequestedData: Joi.alternatives(Joi.array().items(Joi.string()), Joi.string()).optional(),
           }),
         },

--- a/api/src/maddo/domain/usecases/find-organization-ids-by-client-application.js
+++ b/api/src/maddo/domain/usecases/find-organization-ids-by-client-application.js
@@ -7,7 +7,7 @@ export async function findOrganizationIdsByClientApplication({
 }) {
   const jurisdiction = await clientApplicationRepository.getJurisdiction(clientId);
 
-  const tagsRules = jurisdiction.rules.filter((rule) => rule.name === 'tags');
+  const tagsRules = jurisdiction?.rules?.filter((rule) => rule.name === 'tags') ?? [];
 
   const rulesOrganizationIds = await PromiseUtils.mapSeries(tagsRules, (rule) =>
     organizationRepository.findIdsByTagNames(rule.value),

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -674,6 +674,84 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
       });
     });
 
+    context('when no juridictions are defined for client id', function () {
+      it('returns a 403 forbidden error', async function () {
+        // given
+        const orga = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
+        const client = databaseBuilder.factory.buildClientApplication({ clientId: 'client', jurisdiction: null });
+
+        const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+        const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+        const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+        const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+        const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+        const campaign = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.ASSESSMENT,
+          organizationId: orga.id,
+        });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/participations`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(
+              client.clientId,
+              'pix-client',
+              'campaigns meta',
+            ),
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    context('when the tag juridiction is not the same as the organization one', function () {
+      it('returns a 403 forbidden error', async function () {
+        // given
+        const tag1 = databaseBuilder.factory.buildTag({ name: 'tag1' });
+        const tag2 = databaseBuilder.factory.buildTag({ name: 'tag2' });
+        const orga = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: orga.id, tagId: tag1.id });
+        const client = databaseBuilder.factory.buildClientApplication({
+          clientId: 'client',
+          jurisdiction: { rules: [{ name: 'tags', value: [tag2.name] }] },
+        });
+
+        const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+        const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+        const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+        const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+        const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+        const campaign = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.ASSESSMENT,
+          organizationId: orga.id,
+        });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/participations`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(
+              client.clientId,
+              'pix-client',
+              'campaigns meta',
+            ),
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
     context('when authentication data are requested', function () {
       let campaign;
       let authorization;


### PR DESCRIPTION
## 🪧 Problème

Sur MADDO quand aucune juridiction n'est définie sur une application cliente et qu'on tente de faire un appel sur `/api/campaigns/:id/participations` on a une erreur `500` au lieu d'une erreur `403`.

```
TypeError: Cannot read properties of null (reading 'rules')
at findOrganizationIdsByClientApplication (usecases/find-organization-ids-by-client-application.js:10:34)
```

## 🌈 Proposition

Retourner une erreur `403`, quand aucune juridiction n'est définie sur une application cliente et qu'on tente de faire un appel sur `/api/campaigns/:id/participations`

## ✊ Remarques

On a rendu `sort` optionnel pour pouvoir faire des appels swagger sans `sort`.

## 🎉 Pour tester

Faire un appel sur `/api/campaigns/:id/participations` avec une application cliente définie sans juridiction : doit retourner une erreur `403`.
