### PR TITLE
[FEATURE] Ne pas afficher l'objectif "Développer les compétences des apprenants" quand l'organisation n'a pas de parcours apprenant (PIX-23601)

### DIFF
--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -60,7 +60,7 @@ export default class CreateForm extends Component {
         {{t "common.form.mandatory-fields"}}
       </p>
 
-      <CampaignGoals @campaign={{@campaign}} @errors={{@errors}} />
+      <CampaignGoals @campaign={{@campaign}} @errors={{@errors}} @hasBlueprints={{@hasBlueprints}} />
 
       {{#if this.displaysSettingsSection}}
         <FormSection @title={{t "pages.campaign-creation.settings.title"}}>

--- a/orga/app/components/campaign/create-form/campaign-goals.gjs
+++ b/orga/app/components/campaign/create-form/campaign-goals.gjs
@@ -14,6 +14,10 @@ import CourseSelection from './course-selection';
 export default class CampaignGoals extends Component {
   @service currentUser;
 
+  get displayCampaignGoalCombinedCourse() {
+    return this.args.hasBlueprints;
+  }
+
   get displayCourseSelection() {
     return this.isCampaignGoalAssessment || this.isCampaignGoalCombinedCourse;
   }
@@ -71,15 +75,17 @@ export default class CampaignGoals extends Component {
               <:label>{{t "pages.campaign-creation.purpose.assessment"}}</:label>
             </PixRadioButton>
 
-            <PixRadioButton
-              name="campaign-goal"
-              @value="combined-course"
-              {{on "change" this.setCampaignGoal}}
-              aria-describedby="combined-course-info"
-              checked={{this.isCampaignGoalCombinedCourse}}
-            >
-              <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
-            </PixRadioButton>
+            {{#if this.displayCampaignGoalCombinedCourse}}
+              <PixRadioButton
+                name="campaign-goal"
+                @value="combined-course"
+                {{on "change" this.setCampaignGoal}}
+                aria-describedby="combined-course-info"
+                checked={{this.isCampaignGoalCombinedCourse}}
+              >
+                <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
+              </PixRadioButton>
+            {{/if}}
 
             <PixRadioButton
               name="campaign-goal"

--- a/orga/app/routes/authenticated/campaigns/new-catalogue.js
+++ b/orga/app/routes/authenticated/campaigns/new-catalogue.js
@@ -46,7 +46,7 @@ export default class NewRoute extends Route {
 
         campaignAttributes.name = `${this.intl.t('pages.campaign-creation.copy-of')} ${from.name}`;
         if (campaignAttributes.targetProfileId) {
-          campaignAttributes.targetProfile = this.store.peekRecord(
+          campaignAttributes.targetProfile = await this.store.findRecord(
             'target-profile',
             campaignAttributes.targetProfileId,
           );
@@ -62,29 +62,25 @@ export default class NewRoute extends Route {
       ...(campaignAttributes ?? campaignAttributes),
     });
 
+    const courses = await this.store.findAll('course', {
+      backgroundReload: false,
+      adapterOptions: { organizationId: organization.id },
+    });
+
     if (params?.courseId) {
-      let course = await this.store.peekRecord('course', params.courseId, {
-        adapterOptions: { organizationId: organization.id },
-      });
-
-      if (!course) {
-        const courses = await this.store.findAll('course', {
-          adapterOptions: { organizationId: organization.id },
-        });
-        course = courses.find(({ id }) => id === params.courseId);
-      }
-
-      campaign.course = course;
+      campaign.course = courses.find(({ id }) => id === params.courseId);
 
       if (campaign.course.type === 'targetProfile') {
-        campaign.type = 'ASSESSMENT';
+        campaign.setType('ASSESSMENT');
       }
       if (campaign.course.type === 'blueprint') {
-        campaign.type = 'COMBINED_COURSE';
+        campaign.setType('COMBINED_COURSE');
       }
     }
 
-    return { campaign, membersSortedByFullName };
+    const hasBlueprints = courses.some((course) => course.type === 'blueprint');
+
+    return { campaign, membersSortedByFullName, hasBlueprints };
   }
 
   resetController(controller, isExiting) {

--- a/orga/app/templates/authenticated/campaigns/new-catalogue.gjs
+++ b/orga/app/templates/authenticated/campaigns/new-catalogue.gjs
@@ -11,11 +11,10 @@ import PageTitle from 'pix-orga/components/ui/page-title';
 
   <CreateForm
     @campaign={{@model.campaign}}
-    @targetProfiles={{@model.targetProfiles}}
     @errors={{@controller.errors}}
     @onSubmit={{@controller.createCampaign}}
     @onCancel={{@controller.cancel}}
     @membersSortedByFullName={{@model.membersSortedByFullName}}
-    @combinedCourseBlueprints={{@model.combinedCourseBlueprints}}
+    @hasBlueprints={{@model.hasBlueprints}}
   />
 </template>

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -51,6 +51,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
           />
         </template>,
       );
@@ -78,6 +79,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
           />
         </template>,
       );
@@ -104,6 +106,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
           />
         </template>,
       );
@@ -135,6 +138,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
           />
         </template>,
       );
@@ -168,6 +172,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
           />
         </template>,
       );
@@ -190,6 +195,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
           />
         </template>,
       );
@@ -209,6 +215,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
           />
         </template>,
       );
@@ -232,6 +239,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
           @membersSortedByFullName={{data.defaultMembers}}
+          @hasBlueprints={{true}}
         />
       </template>,
     );
@@ -251,6 +259,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
           @membersSortedByFullName={{data.defaultMembers}}
+          @hasBlueprints={{true}}
         />
       </template>,
     );
@@ -280,6 +289,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
           @onCancel={{cancelSpy}}
           @errors={{data.errors}}
           @membersSortedByFullName={{data.defaultMembers}}
+          @hasBlueprints={{true}}
         />
       </template>,
     );
@@ -318,6 +328,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
             @onCancel={{cancelSpy}}
             @errors={{data.errors}}
             @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
           />
         </template>,
       );

--- a/orga/tests/integration/components/campaign/create-form/campaign-goals-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/campaign-goals-test.gjs
@@ -37,7 +37,9 @@ module('Integration | Component | Campaign::CreateForm::CampaignGoals', function
   test('it displays campaign goals', async function (assert) {
     // when
     const screen = await render(
-      <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      <template>
+        <CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} @hasBlueprints={{true}} />
+      </template>,
     );
 
     // then
@@ -51,10 +53,27 @@ module('Integration | Component | Campaign::CreateForm::CampaignGoals', function
       .exists();
   });
 
+  test('it does not display COMBINED_COURSE campaign goal when hasBlueprints is false', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} @hasBlueprints={{false}} />
+      </template>,
+    );
+
+    // then
+    const fieldset = screen.getByRole('radiogroup', { name: t('pages.campaign-creation.purpose.label') });
+    assert
+      .dom(within(fieldset).queryByRole('radio', { name: t('pages.campaign-creation.purpose.combined-course') }))
+      .doesNotExist();
+  });
+
   test('it should not display course selection when no campaign goal is selected', async function (assert) {
     // when
     const screen = await render(
-      <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+      <template>
+        <CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} @hasBlueprints={{true}} />
+      </template>,
     );
 
     // then
@@ -67,7 +86,9 @@ module('Integration | Component | Campaign::CreateForm::CampaignGoals', function
     test('it displays ASSESSMENT purpose explanation', async function (assert) {
       // given
       const screen = await render(
-        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+        <template>
+          <CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} @hasBlueprints={{true}} />
+        </template>,
       );
 
       // when
@@ -81,7 +102,9 @@ module('Integration | Component | Campaign::CreateForm::CampaignGoals', function
     test('it redirects to /catalogue/targetProfile', async function (assert) {
       // given
       const screen = await render(
-        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+        <template>
+          <CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} @hasBlueprints={{true}} />
+        </template>,
       );
 
       // when
@@ -98,7 +121,9 @@ module('Integration | Component | Campaign::CreateForm::CampaignGoals', function
     test('it displays COMBINED_COURSE purpose explanation', async function (assert) {
       // given
       const screen = await render(
-        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+        <template>
+          <CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} @hasBlueprints={{true}} />
+        </template>,
       );
 
       // when
@@ -112,7 +137,9 @@ module('Integration | Component | Campaign::CreateForm::CampaignGoals', function
     test('it redirects to /catalogue/blueprint for course selection', async function (assert) {
       // given
       const screen = await render(
-        <template><CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+        <template>
+          <CampaignGoals @campaign={{data.campaign}} @errors={{data.errors}} @hasBlueprints={{true}} />
+        </template>,
       );
 
       // when

--- a/orga/tests/unit/routes/authenticated/campaigns/new-catalogue-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new-catalogue-test.js
@@ -26,11 +26,13 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
     const members = Symbol('list of members sorted by firstnames and lastnames');
     const findAllStub = sinon.stub();
 
+    findAllStub.withArgs('member-identity', { adapterOptions: { organizationId: 12345 } }).resolves(members);
+    findAllStub.withArgs('course', { backgroundReload: false, adapterOptions: { organizationId: 12345 } }).resolves([]);
+
     class StoreStub extends Service {
-      findAll = findAllStub.resolves(members);
+      findAll = findAllStub;
       createRecord = sinon.stub();
     }
-
     this.owner.register('service:store', StoreStub);
 
     // when
@@ -69,8 +71,11 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
     const findAllStub = sinon.stub();
     const createRecordStub = sinon.stub();
 
+    findAllStub.withArgs('member-identity', { adapterOptions: { organizationId: 12345 } }).resolves(members);
+    findAllStub.withArgs('course', { backgroundReload: false, adapterOptions: { organizationId: 12345 } }).resolves([]);
+
     class StoreStub extends Service {
-      findAll = findAllStub.resolves(members);
+      findAll = findAllStub;
       createRecord = createRecordStub.resolves(createdCampaignRecord);
     }
 
@@ -85,13 +90,17 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
 
   module('when courseId param is defined', function (hooks) {
     const organizationId = 12345;
-    const createdCampaignRecord = {};
+    let campaign;
     let courseRecord;
-    let peekRecordStub;
 
     hooks.beforeEach(async function () {
       const organization = EmberObject.create({
         id: organizationId,
+      });
+      campaign = EmberObject.create({
+        setType(type) {
+          this.type = type;
+        },
       });
 
       const prescriber = { id: Symbol('prescriber id') };
@@ -107,16 +116,19 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
 
       const findAllStub = sinon.stub();
       const createRecordStub = sinon.stub();
-      peekRecordStub = sinon.stub();
 
       courseRecord = {
         id: Symbol('target profile overview id'),
       };
 
+      findAllStub.withArgs('member-identity', { adapterOptions: { organizationId: 12345 } }).resolves(members);
+      findAllStub
+        .withArgs('course', { backgroundReload: false, adapterOptions: { organizationId: 12345 } })
+        .resolves([courseRecord]);
+
       class StoreStub extends Service {
-        findAll = findAllStub.resolves(members);
-        createRecord = createRecordStub.resolves(createdCampaignRecord);
-        peekRecord = peekRecordStub.resolves(courseRecord);
+        findAll = findAllStub;
+        createRecord = createRecordStub.resolves(campaign);
       }
 
       this.owner.register('service:store', StoreStub);
@@ -132,9 +144,6 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
       const model = await route.model({ courseId: courseRecord.id });
 
       assert.strictEqual(model.campaign.course, courseRecord);
-      sinon.assert.calledWithExactly(peekRecordStub, 'course', courseRecord.id, {
-        adapterOptions: { organizationId },
-      });
     });
 
     module('when course is a target profile', function () {
@@ -163,6 +172,74 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
 
         assert.strictEqual(model.campaign.type, 'COMBINED_COURSE');
       });
+    });
+  });
+
+  module('when there is courses', function (hooks) {
+    let findAllStub;
+
+    hooks.beforeEach(async function () {
+      const organization = EmberObject.create({
+        id: 12345,
+      });
+      const campaign = EmberObject.create({
+        setType(type) {
+          this.type = type;
+        },
+      });
+
+      const prescriber = { id: Symbol('prescriber id') };
+
+      class CurrentUserStub extends Service {
+        organization = organization;
+        prescriber = prescriber;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const members = Symbol('list of members sorted by firstnames and lastnames');
+
+      findAllStub = sinon.stub();
+      const createRecordStub = sinon.stub();
+
+      findAllStub.withArgs('member-identity', { adapterOptions: { organizationId: 12345 } }).resolves(members);
+
+      class StoreStub extends Service {
+        findAll = findAllStub;
+        createRecord = createRecordStub.resolves(campaign);
+      }
+
+      this.owner.register('service:store', StoreStub);
+    });
+
+    test('should set hasBlueprints to false when there is no blueprint course', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+      findAllStub.withArgs('course', { backgroundReload: false, adapterOptions: { organizationId: 12345 } }).resolves([
+        { id: 1, type: 'targetProfile' },
+        { id: 2, type: 'targetProfile' },
+      ]);
+
+      // when
+      const model = await route.model();
+
+      assert.false(model.hasBlueprints);
+    });
+
+    test('should set hasBlueprints to true when there is at least one blueprint course', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/campaigns/new-catalogue');
+
+      findAllStub.withArgs('course', { backgroundReload: false, adapterOptions: { organizationId: 12345 } }).resolves([
+        { id: 1, type: 'blueprint' },
+        { id: 2, type: 'targetProfile' },
+      ]);
+
+      // when
+      const model = await route.model();
+
+      assert.true(model.hasBlueprints);
     });
   });
 
@@ -207,22 +284,30 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
 
         const duplicatedCampaignRecord = Symbol('duplicated campaign record');
 
+        const source = Symbol('source campaign id');
+
         const findAllStub = sinon.stub();
         const findRecordStub = sinon.stub();
-        const peekRecordStub = sinon.stub();
         const createRecordStub = sinon.stub();
 
+        findAllStub.withArgs('member-identity', { adapterOptions: { organizationId: 12345 } }).resolves(members);
+        findAllStub
+          .withArgs('course', { backgroundReload: false, adapterOptions: { organizationId: 12345 } })
+          .resolves([]);
+
+        findRecordStub.withArgs('campaign', source).resolves(sourceCampaign);
+        findRecordStub.withArgs('target-profile', sourceCampaign.targetProfileId).resolves(targetProfile);
+
         class StoreStub extends Service {
-          findAll = findAllStub.resolves(members);
+          findAll = findAllStub;
           createRecord = createRecordStub.resolves(duplicatedCampaignRecord);
-          findRecord = findRecordStub.resolves(sourceCampaign);
-          peekRecord = peekRecordStub.returns(targetProfile);
+          findRecord = findRecordStub;
         }
 
         this.owner.register('service:store', StoreStub);
 
         // when
-        const model = await route.model({ source: Symbol('source campaign id') });
+        const model = await route.model({ source });
 
         assert.strictEqual(await model.campaign, duplicatedCampaignRecord);
         sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
@@ -268,14 +353,17 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
 
         const findAllStub = sinon.stub();
         const findRecordStub = sinon.stub();
-        const peekRecordStub = sinon.stub();
         const createRecordStub = sinon.stub();
 
+        findAllStub.withArgs('member-identity', { adapterOptions: { organizationId: 12345 } }).resolves(members);
+        findAllStub
+          .withArgs('course', { backgroundReload: false, adapterOptions: { organizationId: 12345 } })
+          .resolves([]);
+
         class StoreStub extends Service {
-          findAll = findAllStub.resolves(members);
+          findAll = findAllStub;
           createRecord = createRecordStub.resolves(duplicatedCampaignRecord);
           findRecord = findRecordStub.resolves(sourceCampaign);
-          peekRecord = peekRecordStub;
         }
 
         this.owner.register('service:store', StoreStub);
@@ -285,7 +373,6 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
 
         assert.strictEqual(await model.campaign, duplicatedCampaignRecord);
         sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
-        sinon.assert.notCalled(peekRecordStub);
       });
     });
 
@@ -317,8 +404,13 @@ module('Unit | Route | authenticated/campaigns/new-catalogue', function (hooks) 
       const findRecordStub = sinon.stub();
       const createRecordStub = sinon.stub();
 
+      findAllStub.withArgs('member-identity', { adapterOptions: { organizationId: 12345 } }).resolves(members);
+      findAllStub
+        .withArgs('course', { backgroundReload: false, adapterOptions: { organizationId: 12345 } })
+        .resolves([]);
+
       class StoreStub extends Service {
-        findAll = findAllStub.resolves(members);
+        findAll = findAllStub;
         findRecord = findRecordStub.rejects(new Error());
         createRecord = createRecordStub.resolves(createdCampaignRecord);
       }


### PR DESCRIPTION
## 🪧 Problème
Actuellement, l'objectif de campagne "Développer les compétences des apprenants" est tout le temps affiché même si l'organisation de possède pas de parcours apprenant. C’est un problème car les parcours apprenants ne sont pas déployés dans plusieurs contextes, notamment l’international.

## 🌈 Proposition
Ne pas afficher l'objectif "Développer les compétences des apprenants" quand l'organisation n'a pas de parcours apprenant


## 🎉 Pour tester
- Se connecter à Pix Orga et sélectionner l'orga `Attestation`.
- Aller sur la page /campagnes/creation-catalogue et vérifier que l'objectif `Développer les compétences des apprenants` n'apparaît pas.
- Aller sur une orga avec parcours apprenants et vérifier que l'objectif apparaît bien.
