### PR TITLE
[FEATURE] Ajouter un bloc graphique pour le titre de la page d'un centre de certification (PIX-22643)

### DIFF
--- a/admin/app/components/certification-centers/get.gjs
+++ b/admin/app/components/certification-centers/get.gjs
@@ -1,11 +1,36 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
+import CopyableId from 'pix-admin/components/ui/copyable-id';
+import HeadInformationBlock from 'pix-admin/components/ui/head-information-block';
+import ENV from 'pix-admin/config/environment';
+
+const getExternalURL = function (certificationCenterId) {
+  const urlDashboardPrefix = ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL;
+  return urlDashboardPrefix && urlDashboardPrefix + certificationCenterId;
+};
 
 <template>
   <section class="page-body certification-center-get-page">
-    <h1 class="pix-title-m">{{@certificationCenter.name}}</h1>
+    <HeadInformationBlock @title={{@certificationCenter.name}}>
+
+      <:subtitle>
+        <CopyableId @value={{@certificationCenter.id}} @copyButtonId="copy-certification-center-id" />
+      </:subtitle>
+      <:link>
+        <PixButtonLink
+          @variant="secondary"
+          @href={{getExternalURL @certificationCenter.id}}
+          @size="small"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Tableau de bord
+        </PixButtonLink>
+      </:link>
+    </HeadInformationBlock>
 
     {{#if @certificationCenter.isArchived}}
       <PixNotificationAlert class="certification-center-information-display__archived-warning" @type="warning">
@@ -17,7 +42,11 @@ import t from 'ember-intl/helpers/t';
       </PixNotificationAlert>
     {{/if}}
 
-    <PixTabs @variant="primary" @ariaLabel={{t "pages.certification-centers.get.navbar.aria-label"}} class="navigation">
+    <PixTabs
+      @variant="primary"
+      @ariaLabel={{t "pages.certification-centers.get.navbar.aria-label"}}
+      class="navigation"
+    >
       <LinkTo @route="authenticated.certification-centers.get.details" @model={{@certificationCenter.id}}>
         {{t "pages.certification-centers.get.navbar.details"}}
       </LinkTo>

--- a/admin/app/components/certification-centers/get.gjs
+++ b/admin/app/components/certification-centers/get.gjs
@@ -45,7 +45,7 @@ const getExternalURL = function (certificationCenterId) {
     <PixTabs
       @variant="primary"
       @ariaLabel={{t "pages.certification-centers.get.navbar.aria-label"}}
-      class="navigation"
+      class="navigation certification-center-get-page__navigation"
     >
       <LinkTo @route="authenticated.certification-centers.get.details" @model={{@certificationCenter.id}}>
         {{t "pages.certification-centers.get.navbar.details"}}

--- a/admin/app/components/certification-centers/get.scss
+++ b/admin/app/components/certification-centers/get.scss
@@ -1,4 +1,8 @@
 .certification-center-get-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-6x);
+
   .page-section__header {
     margin-top: var(--pix-spacing-6x);
     margin-bottom: 0;
@@ -22,5 +26,9 @@
     padding-top: 5px;
     color: var(--pix-error-700);
     font-size: 0.75rem;
+  }
+
+  &__navigation {
+    margin: 0
   }
 }

--- a/admin/app/components/certification-centers/information-view.gjs
+++ b/admin/app/components/certification-centers/information-view.gjs
@@ -1,5 +1,4 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -9,7 +8,6 @@ import { t } from 'ember-intl';
 import formatDate from 'ember-intl/helpers/format-date';
 import sortBy from 'lodash/sortBy';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
-import ENV from 'pix-admin/config/environment';
 
 import HabilitationTag from './habilitation-tag';
 
@@ -39,11 +37,6 @@ export default class InformationView extends Component {
       );
       return { isHabilitated, label, ariaLabel };
     });
-  }
-
-  get externalURL() {
-    const urlDashboardPrefix = ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL;
-    return urlDashboardPrefix && urlDashboardPrefix + this.args.certificationCenter.id;
   }
 
   @action
@@ -132,17 +125,6 @@ export default class InformationView extends Component {
           </PixButton>
         </li>
       {{/unless}}
-      <li>
-        <PixButtonLink
-          @variant="secondary"
-          @href={{this.externalURL}}
-          @size="small"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Tableau de bord
-        </PixButtonLink>
-      </li>
     </ul>
 
     {{#if this.isArchiveModalOpen}}

--- a/admin/app/components/networks/head-information.scss
+++ b/admin/app/components/networks/head-information.scss
@@ -15,24 +15,12 @@
 
     .network__name-row {
       display: flex;
-      align-items: center;
       gap: var(--pix-spacing-2x);
+      align-items: center;
     }
 
     .network__name {
       @extend %pix-title-s;
-    }
-
-    .network__id {
-      @extend %pix-title-xxs;
-
-      display: flex;
-      gap: var(--pix-spacing-2x);
-      align-items: center;
-
-      span {
-        font-weight: normal;
-      }
     }
   }
 }

--- a/admin/app/components/networks/title-view.gjs
+++ b/admin/app/components/networks/title-view.gjs
@@ -1,7 +1,7 @@
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import t from 'ember-intl/helpers/t';
-import CopyButton from 'pix-admin/components/ui/copy-button';
+import CopyableId from 'pix-admin/components/ui/copyable-id';
 
 <template>
   <div class="network__title-section">
@@ -22,14 +22,6 @@ import CopyButton from 'pix-admin/components/ui/copy-button';
         </PixTooltip>
       {{/if}}
     </div>
-    <div class="network__id">
-      <p>ID : <span>{{@network.id}}</span></p>
-      <CopyButton
-        @id="copy-network-id"
-        @value={{@network.id}}
-        @tooltip={{t "components.networks.copy-id"}}
-        @label={{t "components.networks.copy-id"}}
-      />
-    </div>
+    <CopyableId @value={{@network.id}} @copyButtonId="copy-network-id" />
   </div>
 </template>

--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -7,7 +7,8 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import get from 'lodash/get';
-import CopyButton from 'pix-admin/components/ui/copy-button';
+import CopyableId from 'pix-admin/components/ui/copyable-id';
+import HeadInformationBlock from 'pix-admin/components/ui/head-information-block';
 import ENV from 'pix-admin/config/environment';
 
 export default class HeadInformation extends Component {
@@ -71,48 +72,37 @@ export default class HeadInformation extends Component {
   }
 
   <template>
-    <div class="organization__head-information">
-      <div class="organization__logo">
-        <figure class="organization__logo-figure">
-          {{#if @organization.logoUrl}}
-            {{! template-lint-disable no-redundant-role }}
-            <img src={{@organization.logoUrl}} alt="" role="presentation" />
-          {{else}}
-            {{! template-lint-disable no-redundant-role }}
-            <img src="{{this.rootURL}}/logo-placeholder.png" alt="" role="presentation" />
-          {{/if}}
+    <HeadInformationBlock @title={{@organization.name}}>
+      <:logo>
+        {{#if @organization.logoUrl}}
+          <img src={{@organization.logoUrl}} alt="" />
+        {{else}}
+          <img src="{{ENV.rootURL}}logo-placeholder.png" alt="" />
+        {{/if}}
 
-          <label class="file-upload">
-            <input type="file" accept="image/*" hidden {{on "change" this.onLogoUpload}} />
-          </label>
-        </figure>
-      </div>
+        <label class="organization-head-information__file-upload">
+          <span class="sr-only">{{t "components.organizations.head-information.change-logo"}}</span>
+          <input class="sr-only" type="file" accept="image/*" {{on "change" this.onLogoUpload}} />
+        </label>
+      </:logo>
 
-      <div class="organization__title">
-        <div>
-          <h1 class="organization__name">{{@organization.name}}</h1>
-          <div class="organization__id">
-            <p>ID : <span>{{@organization.id}}</span></p>
-            <CopyButton
-              @id="copy-organization-id"
-              @value={{@organization.id}}
-              @tooltip={{t "components.organizations.head-information.copy-id"}}
-              @label={{t "components.organizations.head-information.copy-id"}}
-            />
-          </div>
-        </div>
-
-        <ul class="organization-tags-list">
+      <:subtitle>
+        <CopyableId @value={{@organization.id}} @copyButtonId="copy-organization-id" />
+      </:subtitle>
+      <:tagsSection>
+        <ul class="organization-head-information__tags-list">
           {{#if this.belongsToNetwork}}
-            <PixTag class="organization__child-tag" @color="success">
-              {{t "components.organizations.head-information.network"}}
-              <LinkTo @route="authenticated.networks.get" @model={{@organization.network.id}}>
-                {{@organization.network.name}}
-              </LinkTo>
-            </PixTag>
+            <li>
+              <PixTag class="organization-head-information__child-tag" @color="success">
+                {{t "components.organizations.head-information.network"}}
+                <LinkTo @route="authenticated.networks.get" @model={{@organization.network.id}}>
+                  {{@organization.network.name}}
+                </LinkTo>
+              </PixTag>
+            </li>
             {{#if @organization.parentOrganizationId}}
               <li>
-                <PixTag class="organization__child-tag" @color="success">
+                <PixTag class="organization-head-information__child-tag" @color="success">
                   {{t "components.organizations.head-information.parent-organization-tag"}}
                   <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
                     {{@organization.parentOrganizationName}}
@@ -121,7 +111,7 @@ export default class HeadInformation extends Component {
               </li>
             {{else}}
               <li>
-                <PixTag class="organization__child-tag" @color="success">
+                <PixTag class="organization-head-information__child-tag" @color="success">
                   {{t "components.organizations.head-information.head-organization-tag"}}
 
                 </PixTag>
@@ -137,18 +127,20 @@ export default class HeadInformation extends Component {
             {{/each}}
           {{/if}}
         </ul>
-      </div>
+      </:tagsSection>
 
-      <PixButtonLink
-        class="organization__dashboard-button"
-        @variant="secondary"
-        @href={{this.externalURL}}
-        @size="small"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Tableau de bord
-      </PixButtonLink>
-    </div>
+      <:link>
+        <PixButtonLink
+          @variant="secondary"
+          @href={{this.externalURL}}
+          @size="small"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Tableau de bord
+        </PixButtonLink>
+
+      </:link>
+    </HeadInformationBlock>
   </template>
 }

--- a/admin/app/components/organizations/head-information.scss
+++ b/admin/app/components/organizations/head-information.scss
@@ -1,89 +1,37 @@
 @use 'pix-design-tokens/typography';
 @use 'pix-design-tokens/shadows';
 
-.organization__head-information {
-  @extend %pix-shadow-default;
+.organization-head-information {
 
-  display: flex;
-  gap: var(--pix-spacing-4x);
-  align-items: center;
-  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
-  color: var(--pix-neutral-900);
-  background-color: var(--pix-neutral-0);
-  border-radius: var(--pix-spacing-4x);
 
-  .organization__logo {
-    width: 83px;
-    height: 83px;
+  &__file-upload {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    cursor: pointer;
 
-    .organization__logo-figure {
-      position: relative;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      width: 75px;
-      height: 75px;
-      margin: 0;
-      border: 2px solid var(--pix-neutral-100);
-      border-radius: 3px;
-
-      > img {
-        max-width: 100%;
-        max-height: 100%;
-      }
-
-      > .file-upload {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: transparent;
-        cursor: pointer;
-      }
+    &:focus-within {
+      outline: 1.5px solid var(--pix-primary-700);
+      outline-offset: 1px;
     }
   }
 
-  .organization__title {
+  &__tags-list {
     display: flex;
-    flex-direction: column;
-    flex-grow: 1;
+    flex-wrap: wrap;
     gap: var(--pix-spacing-2x);
+    padding: 0;
+    list-style: none;
+  }
 
-    .organization__name {
-      @extend %pix-title-s;
-    }
-
-    .organization__id {
-      @extend %pix-title-xxs;
-
-      display: flex;
-      gap: var(--pix-spacing-2x);
-      align-items: center;
-
-      span {
-        font-weight: normal;
-      }
-    }
-
-    .organization-tags-list {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--pix-spacing-2x);
-      padding: 0;
-      list-style: none;
-    }
-
-    .organization__child-tag {
-      a {
-        color: var(--pix-success-700);
-        text-decoration: underline;
-      }
+  &__child-tag {
+    a {
+      color: var(--pix-success-700);
+      text-decoration: underline;
     }
   }
 
-  .organization__dashboard-button {
-    align-self: center;
-  }
 }

--- a/admin/app/components/ui/copyable-id.gjs
+++ b/admin/app/components/ui/copyable-id.gjs
@@ -1,0 +1,14 @@
+import t from 'ember-intl/helpers/t';
+import CopyButton from 'pix-admin/components/ui/copy-button';
+
+<template>
+  <div class="copyable-id">
+    <p>ID : <span>{{@value}}</span></p>
+    <CopyButton
+      @id={{@copyButtonId}}
+      @value={{@value}}
+      @tooltip={{t "common.actions.copy-id"}}
+      @label={{t "common.actions.copy-id"}}
+    />
+  </div>
+</template>

--- a/admin/app/components/ui/copyable-id.scss
+++ b/admin/app/components/ui/copyable-id.scss
@@ -1,0 +1,9 @@
+.copyable-id {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
+
+  span {
+    font-weight: normal;
+  }
+}

--- a/admin/app/components/ui/head-information-block.gjs
+++ b/admin/app/components/ui/head-information-block.gjs
@@ -1,0 +1,31 @@
+<template>
+  <div class="head-information-block">
+    {{#if (has-block "logo")}}
+      <div class="head-information-block__logo-container">
+        <div class="head-information-block__logo">
+          {{yield to="logo"}}
+        </div>
+      </div>
+    {{/if}}
+
+    <div class="head-information-block__main-section">
+      <div>
+        <h1 class="head-information-block__title">{{@title}}</h1>
+        {{#if (has-block "subtitle")}}
+          <div class="head-information-block__subtitle">
+            {{yield to="subtitle"}}
+          </div>
+        {{/if}}
+      </div>
+      {{#if (has-block "tagsSection")}}
+        {{yield to="tagsSection"}}
+      {{/if}}
+    </div>
+
+    {{#if (has-block "link")}}
+      <div class="head-information-block__link">
+        {{yield to="link"}}
+      </div>
+    {{/if}}
+  </div>
+</template>

--- a/admin/app/components/ui/head-information-block.scss
+++ b/admin/app/components/ui/head-information-block.scss
@@ -1,0 +1,56 @@
+@use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/shadows';
+
+.head-information-block {
+  @extend %pix-shadow-default;
+
+  display: flex;
+  gap: var(--pix-spacing-4x);
+  align-items: center;
+  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+  color: var(--pix-neutral-900);
+  background-color: var(--pix-neutral-0);
+  border-radius: var(--pix-spacing-4x);
+
+  &__logo-container {
+    width: 83px;
+    height: 83px;
+  }
+
+  &__logo {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 75px;
+    height: 75px;
+    margin: 0;
+    border: 2px solid var(--pix-neutral-100);
+    border-radius: 3px;
+
+    > img {
+      max-width: 100%;
+      max-height: 100%;
+    }
+  }
+
+  &__main-section {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: var(--pix-spacing-2x);
+  }
+
+  &__title {
+    @extend %pix-title-s;
+  }
+
+  &__subtitle {
+    @extend %pix-title-xxs
+  }
+
+  &__link {
+    align-self: center;
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -109,6 +109,7 @@
 /* App/Components */
 @use 'ui/copyable-id' as *;
 @use 'ui/deletion-modal' as *;
+@use 'ui/head-information-block' as *;
 @use 'ui/pix-loader' as *;
 @use 'certifications/certification/details-v3' as *;
 @use 'certification-centers/creation-form' as *;

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -1,4 +1,5 @@
 /* global */
+@use 'globals/a11y' as *;
 @use 'globals/global' as *;
 @use 'globals/form' as *;
 @use 'globals/page' as *;

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -107,6 +107,7 @@
 @use 'display/footer-modal' as *;
 
 /* App/Components */
+@use 'ui/copyable-id' as *;
 @use 'ui/deletion-modal' as *;
 @use 'ui/pix-loader' as *;
 @use 'certifications/certification/details-v3' as *;

--- a/admin/app/styles/globals/a11y.scss
+++ b/admin/app/styles/globals/a11y.scss
@@ -1,0 +1,11 @@
+.sr-only {
+  position: absolute;
+  display: block;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  clip-path: rect(0, 0, 0, 0);
+}

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -121,6 +121,8 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.APP.TARGET_PROFILE_DASHBOARD_URL = 'https://exemple.net';
+    ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL = 'https://example.net/id=';
+    ENV.APP.ORGANIZATION_DASHBOARD_URL = 'https://example.net/id=';
   }
 
   if (environment === 'test') {
@@ -134,6 +136,8 @@ module.exports = function (environment) {
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
     ENV.APP.TARGET_PROFILE_DASHBOARD_URL = 'https://example.net';
+    ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL = 'https://example.net/id=';
+    ENV.APP.ORGANIZATION_DASHBOARD_URL = 'https://example.net/id=';
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
@@ -145,6 +149,5 @@ module.exports = function (environment) {
     ENV.pagination.debounce = 0;
     ENV.searchTargetProfiles.debounce = 0;
   }
-
   return ENV;
 };

--- a/admin/tests/integration/components/certification-centers/get-test.gjs
+++ b/admin/tests/integration/components/certification-centers/get-test.gjs
@@ -3,6 +3,7 @@ import { t } from 'ember-intl/test-support';
 import Get from 'pix-admin/components/certification-centers/get';
 import { module, test } from 'qunit';
 
+import ENV from '../../../../config/environment';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | certification-centers/get', function (hooks) {
@@ -13,9 +14,10 @@ module('Integration | Component | certification-centers/get', function (hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  test('it should display certification center name as title', async function (assert) {
+  test('it should display certification center name and id', async function (assert) {
     // given
     const certificationCenter = store.createRecord('certification-center', {
+      id: 42,
       name: 'Centre SCO',
       type: 'SCO',
       habilitations: [],
@@ -27,6 +29,25 @@ module('Integration | Component | certification-centers/get', function (hooks) {
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Centre SCO' })).exists();
+    assert.dom(screen.getByText((_, element) => element.textContent === 'ID : 42')).exists();
+  });
+
+  test('it should show button to direct user to metabase dashboard', async function (assert) {
+    // given
+    const certificationCenter = store.createRecord('certification-center', {
+      id: 1,
+      name: 'Centre SCO',
+      type: 'SCO',
+      externalId: 'AX129',
+    });
+    const expectedLink = ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL + certificationCenter.id;
+
+    // when
+    const screen = await render(<template><Get @certificationCenter={{certificationCenter}} /></template>);
+
+    // then
+    const dashboardLink = screen.getByRole('link', { name: 'Tableau de bord' });
+    assert.dom(dashboardLink).hasAttribute('href', expectedLink);
   });
 
   test('it should display navigation bar with links to navigate', async function (assert) {

--- a/admin/tests/integration/components/certification-centers/information-view-test.gjs
+++ b/admin/tests/integration/components/certification-centers/information-view-test.gjs
@@ -57,28 +57,4 @@ module('Integration | Component | certification-centers/information-view', funct
     assert.dom(screen.getByLabelText('Non habilité pour Cléa')).exists();
     assert.dom(screen.getByText('27/07/2023')).exists();
   });
-
-  test('it should show button to direct user to metabase dashboard', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationCenter = store.createRecord('certification-center', {
-      name: 'Centre SCO',
-      type: 'SCO',
-      externalId: 'AX129',
-    });
-
-    // when
-    const screen = await render(
-      <template>
-        <InformationView
-          @certificationCenter={{certificationCenter}}
-          @toggleEditMode={{toggleEditMode}}
-          @toggleShowArchiveModal={{toggleShowArchiveModal}}
-        />
-      </template>,
-    );
-
-    // then
-    assert.dom(screen.getByText('Tableau de bord')).exists();
-  });
 });

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -35,20 +35,30 @@ module('Integration | Component | organizations/header-information', function (h
       // then
       assert.dom(screen.getByRole('heading', { name: 'Organization SCO' })).exists();
       assert.dom(screen.getByText((_, element) => element.textContent === 'ID : 1')).exists();
-      assert.dom(screen.getByRole('button', { name: t('components.organizations.head-information.copy-id') })).exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.copy-id') })).exists();
     });
 
-    test('it generates correct external dashboard URL', async function (assert) {
+    test('it displays an accessible control to change the logo', async function (assert) {
       // given
-      ENV.APP.ORGANIZATION_DASHBOARD_URL = 'https://metabase.pix.fr/dashboard/137/?id=';
-      const organization = EmberObject.create({ id: 1, name: 'Test Organization' });
+      const organization = EmberObject.create({ id: 1, name: 'Organization SCO' });
 
       // when
       const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
 
       // then
+      assert.dom(screen.getByLabelText(t('components.organizations.head-information.change-logo'))).exists();
+    });
+
+    test('it generates correct external dashboard URL', async function (assert) {
+      // given
+      const organization = EmberObject.create({ id: 1, name: 'Test Organization' });
+      const expectedLink = ENV.APP.ORGANIZATION_DASHBOARD_URL + organization.id;
+      // when
+      const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+      // then
       const dashboardLink = screen.getByRole('link', { name: 'Tableau de bord' });
-      assert.dom(dashboardLink).hasAttribute('href', 'https://metabase.pix.fr/dashboard/137/?id=1');
+      assert.dom(dashboardLink).hasAttribute('href', expectedLink);
     });
 
     module('when organization has tags', function () {
@@ -164,9 +174,13 @@ module('Integration | Component | organizations/header-information', function (h
         // when
         const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
 
-        await triggerEvent('input[type="file"]', 'change', {
-          files: [file],
-        });
+        await triggerEvent(
+          screen.getByLabelText(t('components.organizations.head-information.change-logo')),
+          'change',
+          {
+            files: [file],
+          },
+        );
 
         // then
         assert.true(organization.save.calledOnce);
@@ -194,11 +208,15 @@ module('Integration | Component | organizations/header-information', function (h
         const file = new Blob([''], { type: `new-logo-file` });
 
         // when
-        await render(<template><HeadInformation @organization={{organization}} /></template>);
+        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
 
-        await triggerEvent('input[type="file"]', 'change', {
-          files: [file],
-        });
+        await triggerEvent(
+          screen.getByLabelText(t('components.organizations.head-information.change-logo')),
+          'change',
+          {
+            files: [file],
+          },
+        );
 
         // then
         assert.true(organization.rollbackAttributes.calledOnce);
@@ -224,11 +242,15 @@ module('Integration | Component | organizations/header-information', function (h
         const file = new Blob([''], { type: `new-logo-file` });
 
         // when
-        await render(<template><HeadInformation @organization={{organization}} /></template>);
+        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
 
-        await triggerEvent('input[type="file"]', 'change', {
-          files: [file],
-        });
+        await triggerEvent(
+          screen.getByLabelText(t('components.organizations.head-information.change-logo')),
+          'change',
+          {
+            files: [file],
+          },
+        );
 
         // then
         assert.true(organization.rollbackAttributes.calledOnce);

--- a/admin/tests/integration/components/ui/copyable-id-test.gjs
+++ b/admin/tests/integration/components/ui/copyable-id-test.gjs
@@ -1,0 +1,25 @@
+import { render } from '@1024pix/ember-testing-library';
+import CopyableId from 'pix-admin/components/ui/copyable-id';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | ui/copyable-id', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays the given value', async function (assert) {
+    // when
+    const screen = await render(<template><CopyableId @value="123" @copyButtonId="copy-test-id" /></template>);
+
+    // then
+    assert.dom(screen.getByText((_, element) => element.textContent === 'ID : 123')).exists();
+  });
+
+  test('it renders a copy button for the given value', async function (assert) {
+    // when
+    const screen = await render(<template><CopyableId @value="123" @copyButtonId="copy-test-id" /></template>);
+
+    // then
+    assert.dom(screen.getByRole('button')).exists();
+  });
+});

--- a/admin/tests/integration/components/ui/head-information-block-test.gjs
+++ b/admin/tests/integration/components/ui/head-information-block-test.gjs
@@ -1,0 +1,46 @@
+import { render } from '@1024pix/ember-testing-library';
+import HeadInformationBlock from 'pix-admin/components/ui/head-information-block';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | ui/head-information-block', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays the title', async function (assert) {
+    // when
+    const screen = await render(<template><HeadInformationBlock @title="Mon titre" /></template>);
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Mon titre' })).exists();
+  });
+
+  test('it displays each optional block when provided', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <HeadInformationBlock @title="Mon titre">
+          <:logo>Logo content</:logo>
+          <:subtitle>Subtitle content</:subtitle>
+          <:tagsSection>Tags content</:tagsSection>
+          <:link>Link content</:link>
+        </HeadInformationBlock>
+      </template>,
+    );
+
+    //then
+    assert.dom(screen.getByText('Logo content')).exists();
+    assert.dom(screen.getByText('Subtitle content')).exists();
+    assert.dom(screen.getByText('Tags content')).exists();
+    assert.dom(screen.getByText('Link content')).exists();
+  });
+
+  test('it does not render optional block containers when not provided', async function (assert) {
+    // when
+    await render(<template><HeadInformationBlock @title="Mon titre" /></template>);
+
+    // then
+    assert.dom('.head-information-block__logo-container').doesNotExist();
+    assert.dom('.head-information-block__link').doesNotExist();
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -10,6 +10,7 @@
       "confirm-deletion": "Yes, delete",
       "confirm-title": "Please confirm",
       "copied": "Copied!",
+      "copy-id": "Copy ID",
       "deactivate": "Deactivate",
       "download-template": "Download template",
       "edit": "Edit",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1098,7 +1098,7 @@
         "required-fields-error": "Please fill in all required fields."
       },
       "head-information": {
-        "copy-id": "Copy ID",
+        "change-logo": "Change logo",
         "head-organization-tag": "Head of network",
         "network": "Network:",
         "notifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -10,6 +10,7 @@
       "confirm-deletion": "Oui, je supprime",
       "confirm-title": "Merci de confirmer",
       "copied": "Copié !",
+      "copy-id": "Copier l'ID",
       "deactivate": "Désactiver",
       "download-template": "Télécharger le template",
       "edit": "Modifier",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1106,7 +1106,7 @@
         "required-fields-error": "Veuillez remplir tous les champs obligatoires."
       },
       "head-information": {
-        "copy-id": "Copier l'ID",
+        "change-logo": "Changer le logo",
         "head-organization-tag": "Tête de réseau",
         "network": "Réseau :",
         "notifications": {


### PR DESCRIPTION
## 🪧 Problème

Toujours dans l'objectif d'aligner la page d'un centre de certification avec celle d'une organisation, il faut maintenant revoir la partie du titre.

## 🌈 Proposition

Utiliser le même élément bloc de la page d'une organisation. Il n'y a en revanche pas de logo ni de tags sur un centre de certification.

## ✊ Remarques
- un nouveau composant réutilisable `HeadInformationBlock` a été créé pour mutualiser les styles. Ce composant prend un titre en attribut et plusieurs yields optionnels: `subtitle`, `logo`, `link` et `tagsSection`. Dans un commit à part, ce composant a été implémenté également sur la page d'une organisation
- un sous-composant `CopyableId` a aussi été créé pour la partie de l'iD et de son bouton de copie (mutualisé pour les centres de certif, orgas et réseaux)
- un correctif sur le logo d'une orga a aussi été effectué (avec l'aide de Claude) afin de faciliter la factorisation et améliorer son accessibilité (l'élément n'était pas focusable par tabulation)
- un soucis a été détecté sur le lien vers le Tableau de bord Metabase en environnement de dev local: le `.env` de Pix Admin n'est jamais chargé donc le lien n'est pas généré. À priori pas de soucis sur la RA. Aucun correctif n'a été appliqué.

## 🎉 Pour tester
Sur Pix Admin:
- sur la page de détail d'un centre de certif, constater le nouveau header
- tester différentes actions pour vérifier la non-régression (modification, archivage)
- constater que rien n'a changé visuellement sur les pages d'une organisation et d'un réseau