### PR TITLE
[TECH] Ajout d'une colonne `authorizedToStartAt` de type `timestampz` sur la table `certification-candidates` pour répondre à la nécessité de faire valoir l'autorisation d'entrée que sur une durée réduite (PIX-23661)

### DIFF
--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -31,6 +31,7 @@ const buildCertificationCandidate = function ({
   accessibilityAdjustmentNeeded = false,
   reconciledAt = null,
   subscription = Frameworks.CORE,
+  authorizedToStartAt = null,
 } = {}) {
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -62,6 +63,7 @@ const buildCertificationCandidate = function ({
     accessibilityAdjustmentNeeded,
     reconciledAt,
     subscription,
+    authorizedToStartAt,
   };
 
   databaseBuffer.pushInsertable({

--- a/api/db/migrations/20260723132147_add-authorized-to-start-at-column-in-certification-candidates-table.js
+++ b/api/db/migrations/20260723132147_add-authorized-to-start-at-column-in-certification-candidates-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-candidates';
+const COLUMN_NAME = 'authorizedToStartAt';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function (t) {
+    t.dateTime(COLUMN_NAME)
+      .nullable()
+      .comment('Timestamp at which the invigilator authorized the candidate to start the certification test');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}


### PR DESCRIPTION
## 🪧 Problème

Dans le cadre de l'EPIX du cadrage temporel, il est demandé que l'autorisation d'entrer en certification délivrée par le surveillant ne soit valable que 15 minutes.

## 🌈 Proposition

Aujourd'hui, l'info d'autorisation d'entrer est un booléen. On va d'abord ajouter une autre colonne du même style, mais en timestamp.

On verra à la fin du flux si c'est ok de supprimer la colonne avec le booléen.

Remplissage à null, colonne nullable

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
migrate / rollback (testé et OK)
