### PR TITLE
[FEATURE] Tri des endpoints du Tableau de bord du numérique MEN par critères métier

### DIFF
--- a/api/src/maddo/application/men-dashboard-routes.js
+++ b/api/src/maddo/application/men-dashboard-routes.js
@@ -24,7 +24,7 @@ const register = async function (server) {
           'Dataset contenant les statistiques sur la certification des élèves des établissements français pour ' +
           "l'année scolaire en cours par niveau scolaire et compétence.",
         notes: [
-          'Retourne toutes les données triées par UAI sous format paginé.',
+          "Retourne toutes les données triées par académie, département, UAI de l'établissement, niveau scolaire puis compétence, sous format paginé.",
           '**Cette route nécessite le scope men-dashboard.**',
         ],
         tags: ['api', 'men-dashboard', 'maddo'],
@@ -87,7 +87,7 @@ const register = async function (server) {
           'Dataset contenant les statistiques de participation aux campagnes de rentrée des élèves des établissements français pour ' +
           "l'année scolaire en cours par niveau scolaire et compétence.",
         notes: [
-          'Retourne toutes les données triées par UAI sous format paginé.',
+          "Retourne toutes les données triées par académie, département, UAI de l'établissement, niveau scolaire puis compétence, sous format paginé.",
           '**Cette route nécessite le scope men-dashboard.**',
         ],
         tags: ['api', 'men-dashboard', 'maddo'],

--- a/api/src/maddo/infrastructure/repositories/certification-dataset-repository.js
+++ b/api/src/maddo/infrastructure/repositories/certification-dataset-repository.js
@@ -10,7 +10,10 @@ export async function findAll({ page = {} } = {}) {
   const size = page.size ?? DEFAULT_PAGE_SIZE;
   const offset = (number - 1) * size;
 
-  const rows = await datamartKnex(TABLE_NAME).orderBy('schoolUai').limit(size).offset(offset);
+  const rows = await datamartKnex(TABLE_NAME)
+    .orderBy(['academieName', 'provinceCode', 'schoolUai', 'schoolYearGroup', 'competenceCode'])
+    .limit(size)
+    .offset(offset);
   const countResult = await datamartKnex(TABLE_NAME).count('* as rowCount').first();
 
   const rowCount = parseInt(countResult.rowCount, 10);

--- a/api/src/maddo/infrastructure/repositories/participation-dataset-repository.js
+++ b/api/src/maddo/infrastructure/repositories/participation-dataset-repository.js
@@ -11,7 +11,10 @@ export async function findAll({ page = {} } = {}) {
   const offset = (number - 1) * size;
 
   const [rows, countResult] = await Promise.all([
-    datamartKnex(TABLE_NAME).orderBy('schoolUai').limit(size).offset(offset),
+    datamartKnex(TABLE_NAME)
+      .orderBy(['academieName', 'provinceCode', 'schoolUai', 'schoolYearGroup', 'competenceCode'])
+      .limit(size)
+      .offset(offset),
     datamartKnex(TABLE_NAME).count('* as rowCount').first(),
   ]);
 

--- a/api/tests/maddo/infrastructure/integration/repositories/certification-dataset-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/certification-dataset-repository_test.js
@@ -5,13 +5,42 @@ import { datamartBuilder } from '../../../../tooling/databases.js';
 
 describe('Maddo | Infrastructure | Repositories | Integration | CertificationDataset', function () {
   describe('#findAll', function () {
-    it('returns dataset sorted by schoolUai', async function () {
+    it('returns dataset sorted by academieName, provinceCode, schoolUai, schoolYearGroup then competenceCode', async function () {
       // given
       datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        academieName: 'Amiens',
+        provinceCode: '080',
         schoolUai: 'UAI_B',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '2.1',
       });
       datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        academieName: 'Nantes',
+        provinceCode: '049',
+        schoolUai: 'UAI_B',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '2.1',
+      });
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        academieName: 'Nantes',
+        provinceCode: '085',
         schoolUai: 'UAI_A',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '2.1',
+      });
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        academieName: 'Nantes',
+        provinceCode: '085',
+        schoolUai: 'UAI_B',
+        schoolYearGroup: 'Sixième',
+        competenceCode: '2.1',
+      });
+      datamartBuilder.factory.buildMenDashboardCertificationDataset({
+        academieName: 'Nantes',
+        provinceCode: '085',
+        schoolUai: 'UAI_B',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '1.1',
       });
       await datamartBuilder.commit();
 
@@ -19,8 +48,51 @@ describe('Maddo | Infrastructure | Repositories | Integration | CertificationDat
       const { models } = await findAll();
 
       // then
-      expect(models[0].schoolUai).to.equal('UAI_A');
-      expect(models[1].schoolUai).to.equal('UAI_B');
+      expect(
+        models.map(({ academieName, provinceCode, schoolUai, schoolYearGroup, competenceCode }) => ({
+          academieName,
+          provinceCode,
+          schoolUai,
+          schoolYearGroup,
+          competenceCode,
+        })),
+      ).to.deep.equal([
+        {
+          academieName: 'Amiens',
+          provinceCode: '080',
+          schoolUai: 'UAI_B',
+          schoolYearGroup: 'Terminale',
+          competenceCode: '2.1',
+        },
+        {
+          academieName: 'Nantes',
+          provinceCode: '049',
+          schoolUai: 'UAI_B',
+          schoolYearGroup: 'Terminale',
+          competenceCode: '2.1',
+        },
+        {
+          academieName: 'Nantes',
+          provinceCode: '085',
+          schoolUai: 'UAI_A',
+          schoolYearGroup: 'Terminale',
+          competenceCode: '2.1',
+        },
+        {
+          academieName: 'Nantes',
+          provinceCode: '085',
+          schoolUai: 'UAI_B',
+          schoolYearGroup: 'Sixième',
+          competenceCode: '2.1',
+        },
+        {
+          academieName: 'Nantes',
+          provinceCode: '085',
+          schoolUai: 'UAI_B',
+          schoolYearGroup: 'Terminale',
+          competenceCode: '1.1',
+        },
+      ]);
       expect(models[0]).to.be.instanceOf(CertificationDataset);
     });
 
@@ -52,9 +124,9 @@ describe('Maddo | Infrastructure | Repositories | Integration | CertificationDat
       datamartBuilder.factory.buildMenDashboardCertificationDataset({
         schoolUai: 'UAI001',
         schoolYear: 2025,
-        academieName: 'Paris',
+        academieName: 'Nantes',
         schoolName: 'Lycée Test',
-        provinceCode: '075',
+        provinceCode: '085',
         schoolYearGroup: 'Terminale',
         validatedCertificationCount: 12,
         certificationCount: 20,
@@ -72,9 +144,9 @@ describe('Maddo | Infrastructure | Repositories | Integration | CertificationDat
       const stat = models[0];
       expect(stat.schoolUai).to.equal('UAI001');
       expect(stat.schoolYear).to.equal(2025);
-      expect(stat.academieName).to.equal('Paris');
+      expect(stat.academieName).to.equal('Nantes');
       expect(stat.schoolName).to.equal('Lycée Test');
-      expect(stat.provinceCode).to.equal('075');
+      expect(stat.provinceCode).to.equal('085');
       expect(stat.schoolYearGroup).to.equal('Terminale');
       expect(stat.validatedCertificationCount).to.equal(12);
       expect(stat.certificationCount).to.equal(20);

--- a/api/tests/maddo/infrastructure/integration/repositories/participation-dataset-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/participation-dataset-repository_test.js
@@ -5,13 +5,42 @@ import { datamartBuilder } from '../../../../tooling/databases.js';
 
 describe('Maddo | Infrastructure | Repositories | Integration | ParticipationDataset', function () {
   describe('#findAll', function () {
-    it('returns dataset sorted by schoolUai', async function () {
+    it('returns dataset sorted by academieName, provinceCode, schoolUai, schoolYearGroup then competenceCode', async function () {
       // given
       datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        academieName: 'Amiens',
+        provinceCode: '080',
         schoolUai: 'UAI_B',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '2.1',
       });
       datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        academieName: 'Nantes',
+        provinceCode: '049',
+        schoolUai: 'UAI_B',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '2.1',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        academieName: 'Nantes',
+        provinceCode: '085',
         schoolUai: 'UAI_A',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '2.1',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        academieName: 'Nantes',
+        provinceCode: '085',
+        schoolUai: 'UAI_B',
+        schoolYearGroup: 'Sixième',
+        competenceCode: '2.1',
+      });
+      datamartBuilder.factory.buildMenDashboardParticipationDataset({
+        academieName: 'Nantes',
+        provinceCode: '085',
+        schoolUai: 'UAI_B',
+        schoolYearGroup: 'Terminale',
+        competenceCode: '1.1',
       });
       await datamartBuilder.commit();
 
@@ -19,8 +48,51 @@ describe('Maddo | Infrastructure | Repositories | Integration | ParticipationDat
       const { models } = await findAll();
 
       // then
-      expect(models[0].schoolUai).to.equal('UAI_A');
-      expect(models[1].schoolUai).to.equal('UAI_B');
+      expect(
+        models.map(({ academieName, provinceCode, schoolUai, schoolYearGroup, competenceCode }) => ({
+          academieName,
+          provinceCode,
+          schoolUai,
+          schoolYearGroup,
+          competenceCode,
+        })),
+      ).to.deep.equal([
+        {
+          academieName: 'Amiens',
+          provinceCode: '080',
+          schoolUai: 'UAI_B',
+          schoolYearGroup: 'Terminale',
+          competenceCode: '2.1',
+        },
+        {
+          academieName: 'Nantes',
+          provinceCode: '049',
+          schoolUai: 'UAI_B',
+          schoolYearGroup: 'Terminale',
+          competenceCode: '2.1',
+        },
+        {
+          academieName: 'Nantes',
+          provinceCode: '085',
+          schoolUai: 'UAI_A',
+          schoolYearGroup: 'Terminale',
+          competenceCode: '2.1',
+        },
+        {
+          academieName: 'Nantes',
+          provinceCode: '085',
+          schoolUai: 'UAI_B',
+          schoolYearGroup: 'Sixième',
+          competenceCode: '2.1',
+        },
+        {
+          academieName: 'Nantes',
+          provinceCode: '085',
+          schoolUai: 'UAI_B',
+          schoolYearGroup: 'Terminale',
+          competenceCode: '1.1',
+        },
+      ]);
       expect(models[0]).to.be.instanceOf(ParticipationDataset);
     });
 
@@ -51,9 +123,9 @@ describe('Maddo | Infrastructure | Repositories | Integration | ParticipationDat
       datamartBuilder.factory.buildMenDashboardParticipationDataset({
         schoolUai: 'UAI001',
         schoolYear: 2025,
-        academieName: 'Paris',
+        academieName: 'Nantes',
         schoolName: 'Lycée Test',
-        provinceCode: '075',
+        provinceCode: '085',
         schoolYearGroup: 'Terminale',
         competenceCode: '1.1',
         competenceName: 'Mener une recherche et une veille d’information',
@@ -78,9 +150,9 @@ describe('Maddo | Infrastructure | Repositories | Integration | ParticipationDat
       const stat = models[0];
       expect(stat.schoolUai).to.equal('UAI001');
       expect(stat.schoolYear).to.equal(2025);
-      expect(stat.academieName).to.equal('Paris');
+      expect(stat.academieName).to.equal('Nantes');
       expect(stat.schoolName).to.equal('Lycée Test');
-      expect(stat.provinceCode).to.equal('075');
+      expect(stat.provinceCode).to.equal('085');
       expect(stat.schoolYearGroup).to.equal('Terminale');
       expect(stat.competenceCode).to.equal('1.1');
       expect(stat.competenceName).to.equal('Mener une recherche et une veille d’information');


### PR DESCRIPTION
## 🪧 Problème

Le tri par UAI des endpoints du Tableau de bord du numérique MEN n'est pas suffisant car il ne garantit pas l'ordre des enregistrements.

## 🌈 Proposition

Ajouter un tri métier complet des données : académie>département>uai>niveau>code compétence

## 🎉 Pour tester

Obtenir un token applicatif avec les paramètres suivants : 
```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr16934.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=men-dashboard&client_secret=men-dashboard-secret&scope=men-dashboard' | jq -r .access_token)
```
puis appeler l'API `/api/tdb-num/men/dashboard/participations` avec le token obtenu.

```
curl --get --data-urlencode "page[size]=200" --data-urlencode "page[number]=1" https://pix-api-maddo-review-pr16934.osc-fr1.scalingo.io/api/men/dashboard/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq 
```

Les données sont triées avec les critères académie>département>uai>niveau>code compétence croissants.

```
curl --get --data-urlencode "page[size]=200" --data-urlencode "page[number]=1" https://pix-api-maddo-review-pr16934.osc-fr1.scalingo.io/api/men/dashboard/certifications -H "Authorization: Bearer $ACCESS_TOKEN" | jq 
```

Les données sont triées avec les critères académie>département>uai>niveau>code compétence croissants.

**Remarque** : Le test peut être fait avec le swagger également.
