### PR TITLE
[FEATURE] Ajouter des informations concernant l'identifiant externe lors de la création de campagnes (PIX-22693)

### DIFF
--- a/orga/app/components/campaign/create-form/external-id.gjs
+++ b/orga/app/components/campaign/create-form/external-id.gjs
@@ -80,7 +80,8 @@ export default class ExternalId extends Component {
 
     {{#if this.wantIdPix}}
       <FormField>
-        <PixFieldset @required={{true}} aria-labelledby="external-ids-types" role="radiogroup">
+        <:default>
+          <PixFieldset @required={{true}} aria-labelledby="external-ids-types" role="radiogroup">
           <:title>{{t "pages.campaign-creation.external-id-type.question-label"}}</:title>
           <:content>
             <PixRadioButton
@@ -107,6 +108,14 @@ export default class ExternalId extends Component {
             {{/if}}
           </:content>
         </PixFieldset>
+        </:default>
+        <:information>
+          <ExplanationCard id="external-ids-types-info">
+            <:title>{{t "pages.campaign-creation.external-id-type.information.label"}}</:title>
+
+            <:message>{{t "pages.campaign-creation.external-id-type.information.message" htmlSafe=true}}</:message>
+          </ExplanationCard>
+        </:information>
       </FormField>
       <FormField>
         <PixInput

--- a/orga/app/components/campaign/create-form/external-id.gjs
+++ b/orga/app/components/campaign/create-form/external-id.gjs
@@ -1,5 +1,6 @@
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
@@ -14,24 +15,17 @@ import FormField from '../../ui/form-field';
 import PixFieldset from '../../ui/pix-fieldset';
 
 export default class ExternalId extends Component {
-  @tracked wantIdPix = Boolean(this.args.campaign.externalIdLabel);
+  @tracked wantAdditionalIdentifier = Boolean(this.args.campaign.externalIdLabel);
 
-  get isExternalIdSelectedChecked() {
-    return this.wantIdPix === true;
+  get isAdditionalIdentifierChecked() {
+    return this.wantAdditionalIdentifier === true;
   }
 
   @action
-  askLabelIdPix() {
-    this.wantIdPix = true;
-    this.args.campaign.externalIdLabel = '';
-    this.args.campaign.externalIdType = '';
-  }
-
-  @action
-  doNotAskLabelIdPix() {
-    this.wantIdPix = false;
+  setAdditionalIdentifierSelected(value) {
+    this.wantAdditionalIdentifier = value;
     this.args.campaign.externalIdLabel = null;
-    this.args.campaign.externalIdType = '';
+    this.args.campaign.externalIdType = null;
   }
 
   @action
@@ -53,16 +47,16 @@ export default class ExternalId extends Component {
             <PixRadioButton
               name="external-id-label"
               @value="false"
-              {{on "change" this.doNotAskLabelIdPix}}
-              checked={{not this.isExternalIdSelectedChecked}}
+              {{on "change" (fn this.setAdditionalIdentifierSelected false)}}
+              checked={{not this.isAdditionalIdentifierChecked}}
             >
               <:label>{{t "pages.campaign-creation.no"}}</:label>
             </PixRadioButton>
             <PixRadioButton
               name="external-id-label"
               @value="true"
-              {{on "change" this.askLabelIdPix}}
-              checked={{this.isExternalIdSelectedChecked}}
+              {{on "change" (fn this.setAdditionalIdentifierSelected true)}}
+              checked={{this.isAdditionalIdentifierChecked}}
             >
               <:label>{{t "pages.campaign-creation.yes"}}</:label>
             </PixRadioButton>
@@ -78,36 +72,36 @@ export default class ExternalId extends Component {
       </:information>
     </FormField>
 
-    {{#if this.wantIdPix}}
+    {{#if this.isAdditionalIdentifierChecked}}
       <FormField>
         <:default>
           <PixFieldset @required={{true}} aria-labelledby="external-ids-types" role="radiogroup">
-          <:title>{{t "pages.campaign-creation.external-id-type.question-label"}}</:title>
-          <:content>
-            <PixRadioButton
-              name="external-id-types"
-              @value="EMAIL"
-              {{on "change" this.onChangeExternalIdType}}
-              checked={{eq @campaign.externalIdType "EMAIL"}}
-            >
-              <:label>{{t ID_PIX_TYPES.EMAIL}}</:label>
+            <:title>{{t "pages.campaign-creation.external-id-type.question-label"}}</:title>
+            <:content>
+              <PixRadioButton
+                name="external-id-types"
+                @value="EMAIL"
+                {{on "change" this.onChangeExternalIdType}}
+                checked={{eq @campaign.externalIdType "EMAIL"}}
+              >
+                <:label>{{t ID_PIX_TYPES.EMAIL}}</:label>
 
-            </PixRadioButton>
-            <PixRadioButton
-              name="external-id-types"
-              @value="STRING"
-              {{on "change" this.onChangeExternalIdType}}
-              checked={{eq @campaign.externalIdType "STRING"}}
-            >
-              <:label>{{t ID_PIX_TYPES.STRING}}</:label>
-            </PixRadioButton>
-            {{#if @errors.externalIdType}}
-              <div class="form__error error-message">
-                {{displayCampaignErrors @errors.externalIdType}}
-              </div>
-            {{/if}}
-          </:content>
-        </PixFieldset>
+              </PixRadioButton>
+              <PixRadioButton
+                name="external-id-types"
+                @value="STRING"
+                {{on "change" this.onChangeExternalIdType}}
+                checked={{eq @campaign.externalIdType "STRING"}}
+              >
+                <:label>{{t ID_PIX_TYPES.STRING}}</:label>
+              </PixRadioButton>
+              {{#if @errors.externalIdType}}
+                <div class="form__error error-message">
+                  {{displayCampaignErrors @errors.externalIdType}}
+                </div>
+              {{/if}}
+            </:content>
+          </PixFieldset>
         </:default>
         <:information>
           <ExplanationCard id="external-ids-types-info">

--- a/orga/app/components/campaign/create-form/external-id.gjs
+++ b/orga/app/components/campaign/create-form/external-id.gjs
@@ -9,6 +9,7 @@ import { eq, not } from 'ember-truth-helpers';
 import { ID_PIX_TYPES } from 'pix-orga/helpers/id-pix-types.js';
 
 import displayCampaignErrors from '../../../helpers/display-campaign-errors';
+import ExplanationCard from '../../ui/explanation-card';
 import FormField from '../../ui/form-field';
 import PixFieldset from '../../ui/pix-fieldset';
 
@@ -45,27 +46,36 @@ export default class ExternalId extends Component {
 
   <template>
     <FormField>
-      <PixFieldset aria-labelledby="external-ids-label" role="radiogroup">
-        <:title>{{t "pages.campaign-creation.external-id-label.question-label"}}</:title>
-        <:content>
-          <PixRadioButton
-            name="external-id-label"
-            @value="false"
-            {{on "change" this.doNotAskLabelIdPix}}
-            checked={{not this.isExternalIdSelectedChecked}}
-          >
-            <:label>{{t "pages.campaign-creation.no"}}</:label>
-          </PixRadioButton>
-          <PixRadioButton
-            name="external-id-label"
-            @value="true"
-            {{on "change" this.askLabelIdPix}}
-            checked={{this.isExternalIdSelectedChecked}}
-          >
-            <:label>{{t "pages.campaign-creation.yes"}}</:label>
-          </PixRadioButton>
-        </:content>
-      </PixFieldset>
+      <:default>
+        <PixFieldset aria-labelledby="external-ids-label" role="radiogroup">
+          <:title>{{t "pages.campaign-creation.external-id-label.question-label"}}</:title>
+          <:content>
+            <PixRadioButton
+              name="external-id-label"
+              @value="false"
+              {{on "change" this.doNotAskLabelIdPix}}
+              checked={{not this.isExternalIdSelectedChecked}}
+            >
+              <:label>{{t "pages.campaign-creation.no"}}</:label>
+            </PixRadioButton>
+            <PixRadioButton
+              name="external-id-label"
+              @value="true"
+              {{on "change" this.askLabelIdPix}}
+              checked={{this.isExternalIdSelectedChecked}}
+            >
+              <:label>{{t "pages.campaign-creation.yes"}}</:label>
+            </PixRadioButton>
+          </:content>
+        </PixFieldset>
+      </:default>
+      <:information>
+        <ExplanationCard id="external-ids-label-info">
+          <:title>{{t "pages.campaign-creation.external-id-label.information.label"}}</:title>
+
+          <:message>{{t "pages.campaign-creation.external-id-label.information.message" htmlSafe=true}}</:message>
+        </ExplanationCard>
+      </:information>
     </FormField>
 
     {{#if this.wantIdPix}}

--- a/orga/tests/acceptance/campaign-creation-catalogue-test.js
+++ b/orga/tests/acceptance/campaign-creation-catalogue-test.js
@@ -129,7 +129,7 @@ module('Acceptance | Campaign Creation (catalogue)', function (hooks) {
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
 
       const externalIdentifier = screen
-        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .getByText(t('pages.campaign-creation.external-id-label.question-label'))
         .closest('fieldset');
       const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
       await click(element);
@@ -150,7 +150,7 @@ module('Acceptance | Campaign Creation (catalogue)', function (hooks) {
       await clickByName('Collecter les profils Pix des participants');
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       const externalIdentifier = screen
-        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .getByText(t('pages.campaign-creation.external-id-label.question-label'))
         .closest('fieldset');
       const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
       await click(element);
@@ -256,7 +256,7 @@ module('Acceptance | Campaign Creation (catalogue)', function (hooks) {
 
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       const externalIdentifier = screen
-        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .getByText(t('pages.campaign-creation.external-id-label.question-label'))
         .closest('fieldset');
       const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
       await click(element);

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -86,7 +86,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
 
       const externalIdentifier = screen
-        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .getByText(t('pages.campaign-creation.external-id-label.question-label'))
         .closest('fieldset');
       const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
       await click(element);
@@ -107,7 +107,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       await clickByName('Collecter les profils Pix des participants');
       const externalIdentifier = screen
-        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .getByText(t('pages.campaign-creation.external-id-label.question-label'))
         .closest('fieldset');
       const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
       await click(element);
@@ -172,7 +172,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
       await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
       const externalIdentifier = screen
-        .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
+        .getByText(t('pages.campaign-creation.external-id-label.question-label'))
         .closest('fieldset');
       const element = within(externalIdentifier).getByRole('radio', { name: 'Non' });
       await click(element);

--- a/orga/tests/integration/components/campaign/create-form/external-id-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/external-id-test.gjs
@@ -111,7 +111,7 @@ module('Integration | Component | Campaign::CreateForm::ExternalId', function (h
 
     // then
     assert.strictEqual(data.campaign.externalIdLabel, null);
-    assert.strictEqual(data.campaign.externalIdType, '');
+    assert.strictEqual(data.campaign.externalIdType, null);
     assert.dom(screen.queryByText(t('pages.campaign-creation.legal-warning'))).doesNotExist();
   });
 

--- a/orga/tests/integration/components/campaign/create-form/external-id-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/external-id-test.gjs
@@ -62,7 +62,7 @@ module('Integration | Component | Campaign::CreateForm::ExternalId', function (h
     }
   });
 
-  test('it not displays external id type nor gdpr footnote by default', async function (assert) {
+  test('it not displays external id type, explanation nor gdpr footnote by default', async function (assert) {
     // when
     const screen = await render(
       <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
@@ -72,10 +72,11 @@ module('Integration | Component | Campaign::CreateForm::ExternalId', function (h
     assert
       .dom(screen.queryByRole('radiogroup', { name: t('pages.campaign-creation.external-id-type.question-label') }))
       .doesNotExist();
+    assert.dom(screen.queryByText(t('pages.campaign-creation.external-id-type.information.label'))).doesNotExist();
     assert.dom(screen.queryByText(t('pages.campaign-creation.legal-warning'))).doesNotExist();
   });
 
-  test('it displays external id type and gdpr footnote once the user asks for an external id', async function (assert) {
+  test('it displays external id type, explanation and gdpr footnote once the user asks for an external id', async function (assert) {
     // given
     const screen = await render(
       <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
@@ -88,6 +89,11 @@ module('Integration | Component | Campaign::CreateForm::ExternalId', function (h
     assert
       .dom(screen.getByRole('radiogroup', { name: t('pages.campaign-creation.external-id-type.question-label') }))
       .exists();
+    assert.dom(screen.queryByText(t('pages.campaign-creation.external-id-type.information.label'))).exists();
+    const informationMessageParts = t('pages.campaign-creation.external-id-type.information.message').split('<br>');
+    for (const part of informationMessageParts) {
+      assert.dom(screen.getByText(part, { exact: false })).exists();
+    }
     assert.dom(screen.getByText(t('pages.campaign-creation.legal-warning'))).exists();
   });
 

--- a/orga/tests/integration/components/campaign/create-form/external-id-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form/external-id-test.gjs
@@ -48,6 +48,20 @@ module('Integration | Component | Campaign::CreateForm::ExternalId', function (h
     assert.dom(element).isChecked();
   });
 
+  test('it display explanation information', async function (assert) {
+    // when
+    const screen = await render(
+      <template><ExternalId @campaign={{data.campaign}} @errors={{data.errors}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByText(t('pages.campaign-creation.external-id-label.information.label'))).exists();
+    const informationMessageParts = t('pages.campaign-creation.external-id-label.information.message').split('<br>');
+    for (const part of informationMessageParts) {
+      assert.dom(screen.getByText(part, { exact: false })).exists();
+    }
+  });
+
   test('it not displays external id type nor gdpr footnote by default', async function (assert) {
     // when
     const screen = await render(

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -768,7 +768,7 @@
         "suggestion": "Beispiel: \"Schülernummer\" oder \"Geschäftliche E-Mail-Adresse\" *."
       },
       "external-id-type": {
-        "question-label": "Wie lautet der Typ der externen Kennung?"
+        "question-label": "Welche Typ von zusätzlichem Kennung möchten Sie beantragen?"
       },
       "landing-page-text": {
         "label": "Text auf der Startseite",

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -949,9 +949,9 @@
         "title": "Sind Sie sicher, dass Sie die Kampagne löschen möchten?"
       },
       "direct-link": "Direkter Link",
-      "external-user-id-label": "Bezeichnung der Kennung",
+      "external-user-id-label": "Bezeichnung der zusätzlichen Kennung",
       "external-user-id-types": {
-        "email": "E-Mail",
+        "email": "E-Mail-Adresse",
         "string": "Andere"
       },
       "landing-page-text": "Text auf der Startseite",

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -772,6 +772,10 @@
         "suggestion": "Beispiel: \"Schülernummer\" oder \"Geschäftliche E-Mail-Adresse\" *."
       },
       "external-id-type": {
+        "information": {
+          "label": "Zusätzliche Kennung Typ",
+          "message": "Mit dem Typ „E-Mail-Adresse“ können Sie überprüfen, ob das Format der vom Teilnehmer eingegebenen Adresse korrekt ist. Verwenden Sie diesen Typ beispielsweise, um eine interne E-Mail-Adresse Ihrer Einrichtung abzufragen.'<br>'Der Typ „Sonstiges“ bietet ein Kurztextfeld. Verwenden Sie diesen Typ, um eine Matrikelnummer, eine interne Kennung oder einen Gruppen- bzw. Klassennamen abzufragen."
+        },
         "question-label": "Welche Typ von zusätzlichem Kennung möchten Sie beantragen?"
       },
       "landing-page-text": {

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -763,7 +763,7 @@
       },
       "external-id-label": {
         "label": "Bezeichnung der Kennung",
-        "question-label": "Möchten Sie eine externe Kennung beantragen?",
+        "question-label": "Möchten Sie zu Beginn Ihrer Teilnahme eine zusätzliche Kennung anfordern?",
         "required": "Die externe Id ist obligatorisch",
         "suggestion": "Beispiel: \"Schülernummer\" oder \"Geschäftliche E-Mail-Adresse\" *."
       },

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -762,9 +762,9 @@
         "label": "Möchten Sie den Testmodus aktivieren?"
       },
       "external-id-label": {
-        "label": "Bezeichnung der Kennung",
+        "label": "Bezeichnung der zusätzlichen Kennung",
         "question-label": "Möchten Sie zu Beginn Ihrer Teilnahme eine zusätzliche Kennung anfordern?",
-        "required": "Die externe Id ist obligatorisch",
+        "required": "Die zusätzlichen Kennung ist obligatorisch",
         "suggestion": "Beispiel: \"Schülernummer\" oder \"Geschäftliche E-Mail-Adresse\" *."
       },
       "external-id-type": {

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -762,6 +762,10 @@
         "label": "Möchten Sie den Testmodus aktivieren?"
       },
       "external-id-label": {
+        "information": {
+          "label": "Zusätzliche Kennung",
+          "message": "Mit dem zusätzlichen Kennung können Sie zu Beginn der Kampagne von jedem Teilnehmer die Identifikationsdaten Ihrer Wahl anfordern.'<br>'Wenn Sie „Ja“ auswählen, können Sie die Teilnehmer anhand dieser Daten filtern und sortieren.'<br>'Wenn Sie „Nein“ auswählen, stehen in der Kampagnenauswertung nur der Vorname und der Nachname des Teilnehmers zur Verfügung."
+        },
         "label": "Bezeichnung der zusätzlichen Kennung",
         "question-label": "Möchten Sie zu Beginn Ihrer Teilnahme eine zusätzliche Kennung anfordern?",
         "required": "Die zusätzlichen Kennung ist obligatorisch",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -768,7 +768,7 @@
         "suggestion": "Example : \"Student Number\" or \"Email address\" *"
       },
       "external-id-type": {
-        "question-label": "What is the type of the external ID ?"
+        "question-label": "What type of additional identifier would you like to request?"
       },
       "landing-page-text": {
         "label": "Text to display on the starting page",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -763,7 +763,7 @@
       },
       "external-id-label": {
         "label": "external user ID label",
-        "question-label": "Do you need an external user ID?",
+        "question-label": "Would you like to request an additional identifier at the start of the test ?",
         "required": "The external user ID label is mandatory.",
         "suggestion": "Example : \"Student Number\" or \"Email address\" *"
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -772,6 +772,10 @@
         "suggestion": "Example : \"Student Number\" or \"Email address\" *"
       },
       "external-id-type": {
+        "information": {
+          "label": "Additional identifier type",
+          "message": "The ‘email address’ field type allows you to check that the format of the address entered by the participant is correct. Use this to request an internal email address within your organisation, for example.'<br>'The ‘other’ field type provides a short text field. Use this to request a student number, a registration number or internal ID, or a group or class name."
+        },
         "question-label": "What type of additional identifier would you like to request?"
       },
       "landing-page-text": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -762,6 +762,10 @@
         "label": "Do you want to enable exam mode?"
       },
       "external-id-label": {
+        "information": {
+          "label": "Additional identifier",
+          "message": "The additional identifier allows you to request the identification details of your choice from each participant at the start of the campaign.'<br>'If you select ‘yes’, you will be able to filter and sort participants based on this data.'<br>'If you select ‘no’, only the participant’s first name and surname will be available in the campaign tracking."
+        },
         "label": "Additional identifier label",
         "question-label": "Would you like to request an additional identifier at the start of the test ?",
         "required": "The additional user ID label is mandatory.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -762,9 +762,9 @@
         "label": "Do you want to enable exam mode?"
       },
       "external-id-label": {
-        "label": "external user ID label",
+        "label": "Additional identifier label",
         "question-label": "Would you like to request an additional identifier at the start of the test ?",
-        "required": "The external user ID label is mandatory.",
+        "required": "The additional user ID label is mandatory.",
         "suggestion": "Example : \"Student Number\" or \"Email address\" *"
       },
       "external-id-type": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -949,9 +949,9 @@
         "title": "Are you sure you want to delete the campaign?"
       },
       "direct-link": "Direct link",
-      "external-user-id-label": "External user ID label",
+      "external-user-id-label": "Additional identifier label",
       "external-user-id-types": {
-        "email": "Email",
+        "email": "Email address",
         "string": "Other"
       },
       "landing-page-text": "Text to display on the starting page",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -763,7 +763,7 @@
       },
       "external-id-label": {
         "label": "Texto del identificador",
-        "question-label": "¿Desea solicitar un identificador externo?",
+        "question-label": "¿Desea solicitar un identificador adicional al inicio de su participación?",
         "required": "El identificador externo es obligatorio",
         "suggestion": "Ejemplo: \"Número de estudiante\" o \"Dirección de correo electrónico profesional\" *."
       },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -772,6 +772,10 @@
         "suggestion": "Ejemplo: \"Número de estudiante\" o \"Dirección de correo electrónico profesional\" *."
       },
       "external-id-type": {
+        "information": {
+          "label": "Tipo de identificador adicional",
+          "message": "El tipo «dirección de correo electrónico» permite comprobar que el formato de la dirección introducida por el participante es correcto. Úsalo, por ejemplo, para solicitar una dirección de correo electrónico interna de tu centro.'<br>'El tipo «otro» ofrece un campo de texto breve. Úsalo para solicitar un número de estudiante, un número de matrícula o un identificador interno, o el nombre de un grupo o una clase."
+        },
         "question-label": "¿Qué tipo de identificador adicional desea solicitar?"
       },
       "landing-page-text": {

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -762,9 +762,9 @@
         "label": "¿Desea activar el modo de consulta?"
       },
       "external-id-label": {
-        "label": "Texto del identificador",
+        "label": "Denominación del identificador adicional",
         "question-label": "¿Desea solicitar un identificador adicional al inicio de su participación?",
-        "required": "El identificador externo es obligatorio",
+        "required": "El identificador adicional es obligatorio",
         "suggestion": "Ejemplo: \"Número de estudiante\" o \"Dirección de correo electrónico profesional\" *."
       },
       "external-id-type": {

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -949,7 +949,7 @@
         "title": "¿Está seguro de que desea eliminar la campaña?"
       },
       "direct-link": "Enlace directo",
-      "external-user-id-label": "Texto del identificador",
+      "external-user-id-label": "Denominación del identificador adicional",
       "external-user-id-types": {
         "email": "Correo electrónico",
         "string": "Otros"

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -768,7 +768,7 @@
         "suggestion": "Ejemplo: \"Número de estudiante\" o \"Dirección de correo electrónico profesional\" *."
       },
       "external-id-type": {
-        "question-label": "¿Cuál es el tipo de identificador externo?"
+        "question-label": "¿Qué tipo de identificador adicional desea solicitar?"
       },
       "landing-page-text": {
         "label": "Texto de la página de inicio",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -762,6 +762,10 @@
         "label": "¿Desea activar el modo de consulta?"
       },
       "external-id-label": {
+        "information": {
+          "label": "Identificador adicional",
+          "message": "El identificador adicional te permite solicitar la información de identificación que desees al inicio de la campaña a cada participante.'<br>'Si seleccionas «sí», podrás filtrar y ordenar a los participantes según este dato.'<br>'Si seleccionas «no», solo estarán disponibles el nombre y los apellidos de la cuenta del participante en el seguimiento de la campaña."
+        },
         "label": "Denominación del identificador adicional",
         "question-label": "¿Desea solicitar un identificador adicional al inicio de su participación?",
         "required": "El identificador adicional es obligatorio",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -762,9 +762,9 @@
         "label": "Souhaitez-vous activer le mode interro ?"
       },
       "external-id-label": {
-        "label": "Libellé de l’identifiant",
+        "label": "Libellé de l’identifiant complémentaire",
         "question-label": "Souhaitez-vous demander un identifiant complémentaire en début de participation ?",
-        "required": "L'id externe est obligatoire",
+        "required": "L'identifiant complémentaire est obligatoire",
         "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
       },
       "external-id-type": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -772,6 +772,10 @@
         "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
       },
       "external-id-type": {
+        "information": {
+          "label": "Type d’identifiant complémentaire",
+          "message": "Le type \"adresse e-mail\" permet de vérifier que le format de l'adresse saisie par le participant est correct. Utilisez-le pour demander une adresse e-mail interne à votre structure par exemple.'<br>'Le type \"autre\" propose un champ texte court. Utilisez-le pour demander un numéro étudiant, un matricule ou un identifiant interne, un nom de groupe ou de classe."
+        },
         "question-label": "Quel type d’identifiant complémentaire souhaitez-vous demander ?"
       },
       "landing-page-text": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -768,7 +768,7 @@
         "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
       },
       "external-id-type": {
-        "question-label": "Quel est le type de l'identifiant externe ?"
+        "question-label": "Quel type d’identifiant complémentaire souhaitez-vous demander ?"
       },
       "landing-page-text": {
         "label": "Texte de la page d'accueil",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -762,6 +762,10 @@
         "label": "Souhaitez-vous activer le mode interro ?"
       },
       "external-id-label": {
+        "information": {
+          "label": "Identifiant complémentaire",
+          "message": "L'identifiant complémentaire vous permet de demander l'information identifiante de votre choix en début de campagne, à chaque participant.'<br>'En sélectionnant \"oui\", vous pourrez filtrer et trier les participants sur cette donnée.'<br>'En sélectionnant \"non\", seuls les prénom et nom du compte du participant seront disponibles dans le suivi de la campagne."
+        },
         "label": "Libellé de l’identifiant complémentaire",
         "question-label": "Souhaitez-vous demander un identifiant complémentaire en début de participation ?",
         "required": "L'identifiant complémentaire est obligatoire",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -763,7 +763,7 @@
       },
       "external-id-label": {
         "label": "Libellé de l’identifiant",
-        "question-label": "Souhaitez-vous demander un identifiant externe ?",
+        "question-label": "Souhaitez-vous demander un identifiant complémentaire en début de participation ?",
         "required": "L'id externe est obligatoire",
         "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -949,9 +949,9 @@
         "title": "Êtes-vous sûr(e) de vouloir supprimer la campagne ?"
       },
       "direct-link": "Lien direct",
-      "external-user-id-label": "Libellé de l'identifiant",
+      "external-user-id-label": "Libellé de l’identifiant complémentaire",
       "external-user-id-types": {
-        "email": "Email",
+        "email": "Adresse e-mail",
         "string": "Autre"
       },
       "landing-page-text": "Texte de la page d'accueil",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -763,7 +763,7 @@
       },
       "external-id-label": {
         "label": "Formulazione dell'identificatore",
-        "question-label": "Desiderate richiedere un identificatore esterno?",
+        "question-label": "Desidera richiedere un identificativo aggiuntivo all'inizio della partecipazione?",
         "required": "L'id esterno è obbligatorio",
         "suggestion": "Esempio: \"Numero dello studente\" o \"Indirizzo e-mail professionale\" *."
       },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -762,9 +762,9 @@
         "label": "Desiderate attivare la modalità di interrogazione?"
       },
       "external-id-label": {
-        "label": "Formulazione dell'identificatore",
+        "label": "Denominazione dell'identificativo aggiuntivo",
         "question-label": "Desidera richiedere un identificativo aggiuntivo all'inizio della partecipazione?",
-        "required": "L'id esterno è obbligatorio",
+        "required": "Il identificativo aggiuntivo è obbligatorio",
         "suggestion": "Esempio: \"Numero dello studente\" o \"Indirizzo e-mail professionale\" *."
       },
       "external-id-type": {

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -768,7 +768,7 @@
         "suggestion": "Esempio: \"Numero dello studente\" o \"Indirizzo e-mail professionale\" *."
       },
       "external-id-type": {
-        "question-label": "Qual è il tipo di identificatore esterno?"
+        "question-label": "Che tipo di identificativo aggiuntivo desidera richiedere?"
       },
       "landing-page-text": {
         "label": "Testo della pagina iniziale",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -772,6 +772,10 @@
         "suggestion": "Esempio: \"Numero dello studente\" o \"Indirizzo e-mail professionale\" *."
       },
       "external-id-type": {
+        "information": {
+          "label": "Tipo di identificativo aggiuntivo",
+          "message": "Il tipo “indirizzo e-mail” consente di verificare che il formato dell'indirizzo inserito dal partecipante sia corretto. Utilizzalo, ad esempio, per richiedere un indirizzo e-mail interno alla tua struttura.'<br>'Il tipo “altro” offre un campo di testo breve. Utilizzalo per richiedere un numero di matricola, un codice identificativo interno, il nome di un gruppo o di una classe."
+        },
         "question-label": "Che tipo di identificativo aggiuntivo desidera richiedere?"
       },
       "landing-page-text": {

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -762,6 +762,10 @@
         "label": "Desiderate attivare la modalità di interrogazione?"
       },
       "external-id-label": {
+        "information": {
+          "label": "Identificativo aggiuntivo",
+          "message": "L'identificativo aggiuntivo ti consente di richiedere, all'inizio della campagna, a ciascun partecipante le informazioni di identificazione che preferisci.'<br>'Selezionando “sì”, potrai filtrare e ordinare i partecipanti in base a questo dato.'<br>'Selezionando “no”, nel monitoraggio della campagna saranno disponibili solo il nome e il cognome dell'account del partecipante."
+        },
         "label": "Denominazione dell'identificativo aggiuntivo",
         "question-label": "Desidera richiedere un identificativo aggiuntivo all'inizio della partecipazione?",
         "required": "Il identificativo aggiuntivo è obbligatorio",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -949,9 +949,9 @@
         "title": "Sei sicuro di voler eliminare la campagna?"
       },
       "direct-link": "Collegamento diretto",
-      "external-user-id-label": "Formulazione dell'identificatore",
+      "external-user-id-label": "Denominazione dell'identificativo aggiuntivo",
       "external-user-id-types": {
-        "email": "Email",
+        "email": "Indirizzo e-mail",
         "string": "Altro"
       },
       "landing-page-text": "Testo della pagina iniziale",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -762,6 +762,10 @@
         "label": "Wil je de vraagmodus activeren?"
       },
       "external-id-label": {
+        "information": {
+          "label": "Aanvullende identificatie",
+          "message": "Met het aanvullende identificatie kunt u aan het begin van de campagne van elke deelnemer de identificatiegegevens opvragen die u wenst.'<br>'Als u “ja” selecteert, kunt u de deelnemers op basis van deze gegevens filteren en sorteren.'<br>'Als u “nee” selecteert, zijn alleen de voor- en achternaam van het account van de deelnemer beschikbaar in de campagne-analyse."
+        },
         "label": "Tekst van de aanvullende identificatie",
         "question-label": "Wilt u bij aanvang van uw deelname een extra identificatie aanvragen?",
         "required": "De aanvullende identificatie is verplicht",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -768,7 +768,7 @@
         "suggestion": "Voorbeeld: \"Studentnummer\" of \"Professioneel e-mailadres\" *."
       },
       "external-id-type": {
-        "question-label": "Wat is het type externe ID?"
+        "question-label": "Welk type aanvullende identificatie wilt u aanvragen?"
       },
       "landing-page-text": {
         "label": "Tekst op de startpagina",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -949,9 +949,9 @@
         "title": "Weet u zeker dat u de campagne wilt verwijderen?"
       },
       "direct-link": "Directe link",
-      "external-user-id-label": "Type externe user-ID",
+      "external-user-id-label": "Tekst van de aanvullende identificatie",
       "external-user-id-types": {
-        "email": "E-mail",
+        "email": "E-mailadres",
         "string": "Andere"
       },
       "landing-page-text": "Tekst op de startpagina",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -772,6 +772,10 @@
         "suggestion": "Voorbeeld: \"Studentnummer\" of \"Professioneel e-mailadres\" *."
       },
       "external-id-type": {
+        "information": {
+          "label": "Aanvullende identificatie type",
+          "message": "Met het type “e-mailadres” kunt u controleren of het door de deelnemer ingevoerde adres de juiste indeling heeft. Gebruik dit bijvoorbeeld om een intern e-mailadres binnen uw organisatie te vragen.'<br>'Het type “overig” biedt een kort tekstveld. Gebruik dit om een studentnummer, een personeelsnummer of een interne gebruikersnaam, of de naam van een groep of klas te vragen."
+        },
         "question-label": "Welk type aanvullende identificatie wilt u aanvragen?"
       },
       "landing-page-text": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -762,9 +762,9 @@
         "label": "Wil je de vraagmodus activeren?"
       },
       "external-id-label": {
-        "label": "Type externe user-ID",
+        "label": "Tekst van de aanvullende identificatie",
         "question-label": "Wilt u bij aanvang van uw deelname een extra identificatie aanvragen?",
-        "required": "De externe id is verplicht",
+        "required": "De aanvullende identificatie is verplicht",
         "suggestion": "Voorbeeld: \"Studentnummer\" of \"Professioneel e-mailadres\" *."
       },
       "external-id-type": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -763,7 +763,7 @@
       },
       "external-id-label": {
         "label": "Type externe user-ID",
-        "question-label": "Wil je een externe gebruikers-ID aanvragen?",
+        "question-label": "Wilt u bij aanvang van uw deelname een extra identificatie aanvragen?",
         "required": "De externe id is verplicht",
         "suggestion": "Voorbeeld: \"Studentnummer\" of \"Professioneel e-mailadres\" *."
       },


### PR DESCRIPTION
## 🪧 Problème
Le libellé “Identifiant externe” est source de confusion pour les prescripteurs. La notion d’externalité est ambiguë ce qui limite et dégrade l’usage de la feature. Aucune information n’est présente dans le produit pour expliciter le fonctionnement.

## 🌈 Proposition
Renommer identifiant externe POUR identifiant complémentaire + introduire des infobulles

## 🎉 Pour tester
- Se connecter à Pix Orga.
- Aller sur la page campagnes/creation-catalogue
- Créer une campagne d'évaluation
- Ajouter un identifiant complémentaire