### PR TITLE
[TECH] Ajout du PolyfillUUID dans Junior

### DIFF
--- a/junior/ember-cli-build.mjs
+++ b/junior/ember-cli-build.mjs
@@ -27,6 +27,7 @@ export default async function (defaults) {
     deprecations: {
       DEPRECATE_TRACKING_PACKAGE: false,
     },
+    polyfillUUID: true,
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
## 🪧 Problème

Lors de la migration vers WarpDrive des applications Orga, Certif et Mon Pix, on a constaté dans le dans le fichier ember-cli-build.js la présence d’un  polyfillUUID: true

Ce polyfillUUID: true est nécessaire pour les vieux navigateurs.

## 🌈 Proposition

Ajouter ce polyfillUUID coté Junior, qui va être utilisé sur des postes institutionnels avec des navigateurs anciens ou verrouillés.

## ✊ Remarques

Il active un polyfill qui remplace crypto.randomUUID()

crypto.randomUUID() est une API qui n'existe que dans les navigateurs récents et uniquement en contexte sécurisé (HTTPS). Sur un vieux navigateur (ou un contexte non sécurisé), l'appel plante et casse la création d'enregistrement.

## 🎉 Pour tester
CI vert