### PR TITLE
[FEATURE] Réparer l'affichage de la page Announcements (PIX-23583)

### DIFF
--- a/admin/app/adapters/announcement.js
+++ b/admin/app/adapters/announcement.js
@@ -1,6 +1,10 @@
 import ApplicationAdapter from './application';
 
 export default class AnnouncementAdapter extends ApplicationAdapter {
+  urlForFindRecord(id) {
+    return `${this.host}/api/announcements/${id}`;
+  }
+
   urlForUpdateRecord(id) {
     return `${this.host}/${this.namespace}/announcements/${id}`;
   }

--- a/admin/tests/unit/adapters/announcement-test.js
+++ b/admin/tests/unit/adapters/announcement-test.js
@@ -1,0 +1,32 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Adapters | announcement', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:announcement');
+  });
+
+  module('#urlForFindRecord', function () {
+    test('should build the find url on the public (non-admin) namespace', function (assert) {
+      // when
+      const url = adapter.urlForFindRecord('SCO', 'announcement');
+
+      // then
+      assert.strictEqual(url, 'http://localhost:3000/api/announcements/SCO');
+    });
+  });
+
+  module('#urlForUpdateRecord', function () {
+    test('should build the update url on the admin namespace', function (assert) {
+      // when
+      const url = adapter.urlForUpdateRecord('SCO', 'announcement');
+
+      // then
+      assert.strictEqual(url, 'http://localhost:3000/api/admin/announcements/SCO');
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème
La page /announcements de Pix Admin (bandeau d'annonce Orga) est inaccessible : elle affiche une erreur Ember, et la console remonte une 404 :

`{"statusCode":404,"error":"Not Found","message":"Not Found"}
`

Un récent changement a fait passer le namespace par défaut de api à api/admin. 
On passe donc de : 
GET /api/announcements/SCO 
à :
GET /api/admin/announcements/SCO (marche po))

## 🌈 Proposition

- Ajout d'un override urlForFindRecord dans l'adapter pour renvoyer le GET vers la route publique, tout en gardant le PATCH sur le namespace admin

- Ajout de tests 

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

- [ ] Se connecter à Pix Admin en Super Admin 
- [ ] Aller sur /announcements
- [ ] La page s'affiche bien 🎉 
