### PR TITLE
[TECH] Ajouter une colonne `prescriber_description` à la table `combined_course_blueprints` (PIX-23402)

### DIFF
--- a/api/db/migrations/20260724121045_add-column-preciber_description-in-table-combined_course_blueprints.js
+++ b/api/db/migrations/20260724121045_add-column-preciber_description-in-table-combined_course_blueprints.js
@@ -1,0 +1,36 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'combined_course_blueprints';
+const COLUMN_NAME = 'prescriber_description';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.text(COLUMN_NAME).comment('This description is displayed, for the prescriber, in the catalogue');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}


### PR DESCRIPTION
## 🪧 Problème
Le champ “description” affiché dans la modale de détail du blueprint pour le catalogue est destinée au participant. Cependant, nous avons aussi besoin d'une description à destinations des prescripteurs.

## 🌈 Proposition
Ajouter une colonne `prescriber_description` à la table  `combined_course_blueprints`

## 🎉 Pour tester
- Déployer l'API et vérifier que la colonne est bien présente dans la table `combined_course_blueprints` 
<img width="1851" height="539" alt="image" src="https://github.com/user-attachments/assets/17fbfdb3-7434-4a33-88d9-e4599fa8aa15" />
