### PR TITLE
[FEATURE] Création d'une API interne pour récupérer des référentiels et toute leur arborescence à partir d'une liste d'id de sujets (PIX-23621)

### DIFF
--- a/api/jsconfig.json
+++ b/api/jsconfig.json
@@ -7,6 +7,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
+    "strictNullChecks": true,
     "resolveJsonModule": true,
     "disableSizeLimit": true,
     "maxNodeModuleJsDepth": 0

--- a/api/src/learning-content/application/api/learning-content-api.js
+++ b/api/src/learning-content/application/api/learning-content-api.js
@@ -1,0 +1,83 @@
+import { FRENCH_SPOKEN } from '../../../shared/domain/services/locale-service.js';
+import { NoTubesProvidedError, SomeTubesNotFoundError } from '../../domain/errors.js';
+import { findByTubeIds as findLearningContentViewByTubeIds } from '../../infrastructure/repositories/learning-content-view-repository.js';
+import { LearningContentDTO } from './models/LearningContentDTO.js';
+
+/**
+ * @typedef {object} NoTubesProvidedResult
+ * @property {NoTubesProvidedError} error
+ * @property {null} learningContentDTO
+ */
+
+/**
+ * @typedef {object} SomeTubesNotFoundResult
+ * @property {SomeTubesNotFoundError} error
+ * @property {LearningContentDTO} learningContentDTO
+ */
+
+/**
+ * @typedef {object} AllTubesFoundResult
+ * @property {null} error
+ * @property {LearningContentDTO} learningContentDTO
+ */
+
+class LearningContentResult {
+  constructor({ learningContentDTO, error }) {
+    this.learningContentDTO = learningContentDTO;
+    this.error = error;
+  }
+}
+
+/**
+ * @example
+ * const { learningContentDTO, error } = await learningContentAPI.findByTubeIds({ tubeIds });
+ * if (error instanceof learningContentAPI.NoTubesProvidedError) {
+ *   throw new MyDomainError(error.message);
+ * }
+ * if (error instanceof learningContentAPI.SomeTubesNotFoundError) {
+ *   logger.error({ missingTubeIds: error.missingTubeIds }, '...');
+ *   // handle the error report in your own way,
+ *   // learningContentDTO.frameworkDTOs will still contain some results
+ * }
+ * for (const frameworkDTO of learningContentDTO.frameworkDTOs) { ... }
+ *
+ *
+ * @param {Object} params
+ * @param {Array<string>} params.tubeIds
+ * @param {string} params.locale default to FRENCH_SPOKEN
+ * @returns {Promise<AllTubesFoundResult | SomeTubesNotFoundResult | NoTubesProvidedResult>}
+ */
+export async function findByTubeIds({ tubeIds = [], locale = FRENCH_SPOKEN }) {
+  if (!tubeIds?.length) {
+    return new LearningContentResult({
+      learningContentDTO: null,
+      error: new NoTubesProvidedError(),
+    });
+  }
+
+  const learningContentView = await findLearningContentViewByTubeIds(tubeIds);
+
+  const foundTubeIds = learningContentView.frameworkViews
+    .flatMap((framework) =>
+      framework.areaViews
+        .flatMap((area) => area.competenceViews)
+        .flatMap((competence) => competence.thematicViews)
+        .flatMap((thematic) => thematic.tubeViews),
+    )
+    .map((tube) => tube.id);
+
+  const missingTubeIdsSet = new Set(tubeIds).difference(new Set(foundTubeIds));
+  if (missingTubeIdsSet.size > 0 && missingTubeIdsSet.size !== tubeIds.length) {
+    return new LearningContentResult({
+      learningContentDTO: LearningContentDTO.buildFromView(learningContentView, locale),
+      error: new SomeTubesNotFoundError(Array.from(missingTubeIdsSet.values())),
+    });
+  }
+
+  return new LearningContentResult({
+    learningContentDTO: LearningContentDTO.buildFromView(learningContentView, locale),
+    error: null,
+  });
+}
+
+export { NoTubesProvidedError, SomeTubesNotFoundError };

--- a/api/src/learning-content/application/api/models/LearningContentDTO.js
+++ b/api/src/learning-content/application/api/models/LearningContentDTO.js
@@ -1,0 +1,143 @@
+import { FRENCH_SPOKEN } from '../../../../shared/domain/services/locale-service.js';
+
+export class LearningContentDTO {
+  /**
+   * @param {object} params
+   * @param {FrameworkDTO[]} params.frameworkDTOs
+   */
+  constructor({ frameworkDTOs }) {
+    this.frameworkDTOs = frameworkDTOs;
+  }
+
+  static buildFromView(learningContentView, locale) {
+    return new LearningContentDTO({
+      frameworkDTOs: learningContentView.frameworkViews.map((frameworkView) =>
+        FrameworkDTO.buildFromView(frameworkView, locale),
+      ),
+    });
+  }
+}
+
+class FrameworkDTO {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {string} params.name
+   * @param {AreaDTO[]} params.areaDTOs
+   */
+  constructor({ id, name, areaDTOs }) {
+    this.id = id;
+    this.name = name;
+    this.areaDTOs = areaDTOs;
+  }
+
+  static buildFromView(frameworkView, locale) {
+    return new FrameworkDTO({
+      id: frameworkView.id,
+      name: frameworkView.name,
+      areaDTOs: frameworkView.areaViews.map((areaView) => AreaDTO.buildFromView(areaView, locale)),
+    });
+  }
+}
+
+class AreaDTO {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {object} params.title
+   * @param {string} params.code
+   * @param {string} params.color
+   * @param {CompetenceDTO[]} params.competenceDTOs
+   */
+  constructor({ id, title, code, color, competenceDTOs }) {
+    this.id = id;
+    this.title = title;
+    this.code = code;
+    this.color = color;
+    this.competenceDTOs = competenceDTOs;
+  }
+
+  static buildFromView(areaView, locale) {
+    return new AreaDTO({
+      id: areaView.id,
+      title: areaView.title_i18n?.[locale] ?? areaView.title_i18n[FRENCH_SPOKEN] ?? null,
+      code: areaView.code,
+      color: areaView.color,
+      competenceDTOs: areaView.competenceViews.map((competenceView) =>
+        CompetenceDTO.buildFromView(competenceView, locale),
+      ),
+    });
+  }
+}
+
+class CompetenceDTO {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {object} params.name
+   * @param {string} params.index
+   * @param {ThematicDTO[]} params.thematicDTOs
+   */
+  constructor({ id, name, index, thematicDTOs }) {
+    this.id = id;
+    this.name = name;
+    this.index = index;
+    this.thematicDTOs = thematicDTOs;
+  }
+
+  static buildFromView(competenceView, locale) {
+    return new CompetenceDTO({
+      id: competenceView.id,
+      name: competenceView.name_i18n?.[locale] ?? competenceView.name_i18n[FRENCH_SPOKEN] ?? null,
+      index: competenceView.index,
+      thematicDTOs: competenceView.thematicViews.map((thematicView) => ThematicDTO.buildFromView(thematicView, locale)),
+    });
+  }
+}
+
+class ThematicDTO {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {object} params.name
+   * @param {string} params.index
+   * @param {TubeDTO[]} params.tubeDTOs
+   */
+  constructor({ id, name, index, tubeDTOs }) {
+    this.id = id;
+    this.name = name;
+    this.index = index;
+    this.tubeDTOs = tubeDTOs;
+  }
+
+  static buildFromView(thematicView, locale) {
+    return new ThematicDTO({
+      id: thematicView.id,
+      name: thematicView.name_i18n?.[locale] ?? thematicView.name_i18n[FRENCH_SPOKEN] ?? null,
+      index: thematicView.index,
+      tubeDTOs: thematicView.tubeViews.map((tubeView) => TubeDTO.buildFromView(tubeView, locale)),
+    });
+  }
+}
+
+class TubeDTO {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {string} params.name
+   * @param {object} params.practicalTitle
+   */
+  constructor({ id, name, practicalTitle }) {
+    this.id = id;
+    this.name = name;
+    this.practicalTitle = practicalTitle;
+  }
+
+  static buildFromView(tubeView, locale) {
+    return new TubeDTO({
+      id: tubeView.id,
+      name: tubeView.name,
+      practicalTitle: tubeView.practicalTitle_i18n?.[locale] ?? tubeView.practicalTitle_i18n[FRENCH_SPOKEN] ?? null,
+    });
+  }
+}

--- a/api/src/learning-content/domain/errors.js
+++ b/api/src/learning-content/domain/errors.js
@@ -1,0 +1,19 @@
+import { DomainError } from '../../shared/domain/errors.js';
+
+class SomeTubesNotFoundError extends DomainError {
+  /**
+   * @param {Array<string>} missingTubeIds
+   */
+  constructor(missingTubeIds) {
+    super(`Some tubes do not exist : ${missingTubeIds}`);
+    this.missingTubeIds = missingTubeIds;
+  }
+}
+
+class NoTubesProvidedError extends DomainError {
+  constructor() {
+    super('No tubes provided');
+  }
+}
+
+export { NoTubesProvidedError, SomeTubesNotFoundError };

--- a/api/src/learning-content/domain/models/AreaView.js
+++ b/api/src/learning-content/domain/models/AreaView.js
@@ -1,0 +1,21 @@
+/**
+ @typedef {import('./CompetenceView.js').CompetenceView} CompetenceView
+ */
+
+export class AreaView {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {object} params.title_i18n
+   * @param {string} params.code
+   * @param {string} params.color
+   * @param {CompetenceView[]} params.competenceViews
+   */
+  constructor({ id, title_i18n, code, color, competenceViews }) {
+    this.id = id;
+    this.title_i18n = title_i18n;
+    this.code = code;
+    this.color = color;
+    this.competenceViews = competenceViews;
+  }
+}

--- a/api/src/learning-content/domain/models/CompetenceView.js
+++ b/api/src/learning-content/domain/models/CompetenceView.js
@@ -1,0 +1,19 @@
+/**
+ @typedef {import('./ThematicView.js').ThematicView} ThematicView
+ */
+
+export class CompetenceView {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {object} params.name_i18n
+   * @param {string} params.index
+   * @param {ThematicView[]} params.thematicViews
+   */
+  constructor({ id, name_i18n, index, thematicViews }) {
+    this.id = id;
+    this.name_i18n = name_i18n;
+    this.index = index;
+    this.thematicViews = thematicViews;
+  }
+}

--- a/api/src/learning-content/domain/models/FrameworkView.js
+++ b/api/src/learning-content/domain/models/FrameworkView.js
@@ -1,0 +1,17 @@
+/**
+ @typedef {import('./AreaView.js').AreaView} AreaView
+ */
+
+export class FrameworkView {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {string} params.name
+   * @param {AreaView[]} params.areaViews
+   */
+  constructor({ id, name, areaViews }) {
+    this.id = id;
+    this.name = name;
+    this.areaViews = areaViews;
+  }
+}

--- a/api/src/learning-content/domain/models/LearningContentView.js
+++ b/api/src/learning-content/domain/models/LearningContentView.js
@@ -1,0 +1,13 @@
+/**
+  @typedef {import('./FrameworkView.js').FrameworkView} FrameworkView
+*/
+
+export class LearningContentView {
+  /**
+   * @param {object} params
+   * @param {FrameworkView[]} params.frameworkViews
+   */
+  constructor({ frameworkViews }) {
+    this.frameworkViews = frameworkViews;
+  }
+}

--- a/api/src/learning-content/domain/models/ThematicView.js
+++ b/api/src/learning-content/domain/models/ThematicView.js
@@ -1,0 +1,19 @@
+/**
+ @typedef {import('./TubeView.js').TubeView} TubeView
+ */
+
+export class ThematicView {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {object} params.name_i18n
+   * @param {string} params.index
+   * @param {TubeView[]} params.tubeViews
+   */
+  constructor({ id, name_i18n, index, tubeViews }) {
+    this.id = id;
+    this.name_i18n = name_i18n;
+    this.index = index;
+    this.tubeViews = tubeViews;
+  }
+}

--- a/api/src/learning-content/domain/models/TubeView.js
+++ b/api/src/learning-content/domain/models/TubeView.js
@@ -1,0 +1,13 @@
+export class TubeView {
+  /**
+   * @param {object} params
+   * @param {string} params.id
+   * @param {string} params.name
+   * @param {object} params.practicalTitle_i18n
+   */
+  constructor({ id, name, practicalTitle_i18n }) {
+    this.id = id;
+    this.name = name;
+    this.practicalTitle_i18n = practicalTitle_i18n;
+  }
+}

--- a/api/src/learning-content/infrastructure/repositories/learning-content-view-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/learning-content-view-repository.js
@@ -1,0 +1,116 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { AreaView } from '../../domain/models/AreaView.js';
+import { CompetenceView } from '../../domain/models/CompetenceView.js';
+import { FrameworkView } from '../../domain/models/FrameworkView.js';
+import { LearningContentView } from '../../domain/models/LearningContentView.js';
+import { ThematicView } from '../../domain/models/ThematicView.js';
+import { TubeView } from '../../domain/models/TubeView.js';
+
+/**
+ * Find the LearningContentView model represented by the provided tubeIds
+ *
+ * @param {string[]} tubeIds
+ * @returns {Promise<LearningContentView>}
+ */
+export async function findByTubeIds(tubeIds) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const thematicRows = await knexConn
+    .from({ frameworks: 'learningcontent.frameworks' })
+    .join({ areas: 'learningcontent.areas' }, 'frameworks.id', 'areas.frameworkId')
+    .join({ competences: 'learningcontent.competences' }, 'areas.id', 'competences.areaId')
+    .join({ thematics: 'learningcontent.thematics' }, 'competences.id', 'thematics.competenceId')
+    .join({ tubes: 'learningcontent.tubes' }, 'thematics.id', 'tubes.thematicId')
+    .whereIn('tubes.id', tubeIds)
+    .select({
+      frameworkId: 'frameworks.id',
+      frameworkName: 'frameworks.name',
+      areaId: 'areas.id',
+      areaCode: 'areas.code',
+      areaColor: 'areas.color',
+      areaTitle_i18n: 'areas.title_i18n',
+      competenceId: 'competences.id',
+      competenceIndex: 'competences.index',
+      competenceName_i18n: 'competences.name_i18n',
+      thematicId: 'thematics.id',
+      thematicIndex: 'thematics.index',
+      thematicName_i18n: 'thematics.name_i18n',
+      thematicTubes: knexConn.raw(`
+        json_agg(json_build_object(
+          'id', tubes.id,
+          'name', tubes.name,
+          'practicalTitle_i18n', tubes."practicalTitle_i18n"
+        ) order by tubes.id)
+    `),
+    })
+    .groupBy(
+      'frameworks.id',
+      'frameworks.name',
+      'areas.id',
+      'areas.code',
+      'areas.color',
+      'areas.title_i18n',
+      'competences.id',
+      'competences.index',
+      'competences.name_i18n',
+      'thematics.id',
+      'thematics.index',
+      'thematics.name_i18n',
+    )
+    .orderBy('frameworks.id')
+    .orderBy('areas.id')
+    .orderBy('competences.id')
+    .orderBy('thematics.id');
+
+  const mapFrameworks = new Map();
+  const mapAreas = new Map();
+  const mapCompetences = new Map();
+  for (const thematicRow of thematicRows) {
+    let frameworkView = mapFrameworks.get(thematicRow.frameworkId);
+    if (!frameworkView) {
+      frameworkView = new FrameworkView({
+        id: thematicRow.frameworkId,
+        name: thematicRow.frameworkName,
+        areaViews: [],
+      });
+      mapFrameworks.set(frameworkView.id, frameworkView);
+    }
+
+    let areaView = mapAreas.get(thematicRow.areaId);
+    if (!areaView) {
+      areaView = new AreaView({
+        id: thematicRow.areaId,
+        title_i18n: thematicRow.areaTitle_i18n,
+        code: thematicRow.areaCode,
+        color: thematicRow.areaColor,
+        competenceViews: [],
+      });
+      mapAreas.set(areaView.id, areaView);
+      frameworkView.areaViews.push(areaView);
+    }
+
+    let competenceView = mapCompetences.get(thematicRow.competenceId);
+    if (!competenceView) {
+      competenceView = new CompetenceView({
+        id: thematicRow.competenceId,
+        name_i18n: thematicRow.competenceName_i18n,
+        index: thematicRow.competenceIndex,
+        thematicViews: [],
+      });
+      mapCompetences.set(competenceView.id, competenceView);
+      areaView.competenceViews.push(competenceView);
+    }
+
+    const thematicView = new ThematicView({
+      id: thematicRow.thematicId,
+      name_i18n: thematicRow.thematicName_i18n,
+      index: thematicRow.thematicIndex,
+      tubeViews: thematicRow.thematicTubes.map((tubeRow) => new TubeView(tubeRow)),
+    });
+    competenceView.thematicViews.push(thematicView);
+  }
+
+  return new LearningContentView({
+    frameworkViews: [...mapFrameworks.values()],
+  });
+}

--- a/api/tests/learning-content/integration/application/api/learning-content-api_test.js
+++ b/api/tests/learning-content/integration/application/api/learning-content-api_test.js
@@ -1,0 +1,298 @@
+import {
+  findByTubeIds,
+  NoTubesProvidedError,
+  SomeTubesNotFoundError,
+} from '../../../../../src/learning-content/application/api/learning-content-api.js';
+import { LearningContentDTO } from '../../../../../src/learning-content/application/api/models/LearningContentDTO.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+
+describe('Learning Content | Integration | Application | API | LearningContent', function () {
+  describe('#findByTubeIds', function () {
+    beforeEach(function () {
+      const learningContent = {
+        frameworks: [
+          { id: 'framework1', name: 'FrameWork1' },
+          { id: 'framework2', name: 'FrameWork2' },
+        ],
+        areas: [
+          {
+            id: 'area1',
+            title_i18n: { fr: 'area1' },
+            code: '1',
+            color: 'red',
+            frameworkId: 'framework1',
+            competenceIds: ['comp1'],
+          },
+          {
+            id: 'area2',
+            title_i18n: { fr: 'area2', en: 'area2 EN' },
+            code: '18',
+            color: 'green',
+            frameworkId: 'framework2',
+            competenceIds: ['comp2'],
+          },
+        ],
+        competences: [
+          { id: 'comp1', areaId: 'area1', index: '1.1', name_i18n: { fr: 'comp1' } },
+          { id: 'comp2', areaId: 'area2', index: '18.1', name_i18n: { fr: 'comp2', en: 'comp2 EN' } },
+        ],
+        thematics: [
+          { id: 'them1', competenceId: 'comp1', index: 1, name_i18n: { fr: 'them1' } },
+          { id: 'them2', competenceId: 'comp2', index: 18, name_i18n: { fr: 'them2', en: 'them2 EN' } },
+        ],
+        tubes: [
+          {
+            id: 'tube1',
+            thematicId: 'them1',
+            name: '@tube_one',
+            competenceId: 'comp1',
+            practicalTitle_i18n: {
+              fr: 'tube1',
+            },
+          },
+          {
+            id: 'tube2',
+            thematicId: 'them2',
+            name: '@tube_two',
+            competenceId: 'comp2',
+            practicalTitle_i18n: {
+              fr: 'tube2',
+              en: 'tube2 EN',
+            },
+          },
+        ],
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+      return databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('learningcontent.frameworks').truncate();
+      await knex('learningcontent.areas').truncate();
+      await knex('learningcontent.competences').truncate();
+      await knex('learningcontent.thematics').truncate();
+      await knex('learningcontent.tubes').truncate();
+    });
+
+    context('success', function () {
+      it('returns a LearningContentResult with the expected info', async function () {
+        // when
+        const learningContentResult = await findByTubeIds({ tubeIds: ['tube1', 'tube2'], locale: 'en' });
+
+        // then
+        expect(learningContentResult.learningContentDTO).deepEqualInstance(
+          new LearningContentDTO({
+            frameworkDTOs: [
+              {
+                id: 'framework1',
+                name: 'FrameWork1',
+                areaDTOs: [
+                  {
+                    id: 'area1',
+                    title: 'area1',
+                    code: '1',
+                    color: 'red',
+                    competenceDTOs: [
+                      {
+                        id: 'comp1',
+                        name: 'comp1',
+                        index: '1.1',
+                        thematicDTOs: [
+                          {
+                            id: 'them1',
+                            index: 1,
+                            name: 'them1',
+                            tubeDTOs: [
+                              {
+                                id: 'tube1',
+                                name: '@tube_one',
+                                practicalTitle: 'tube1',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'framework2',
+                name: 'FrameWork2',
+                areaDTOs: [
+                  {
+                    id: 'area2',
+                    title: 'area2 EN',
+                    code: '18',
+                    color: 'green',
+                    competenceDTOs: [
+                      {
+                        id: 'comp2',
+                        name: 'comp2 EN',
+                        index: '18.1',
+                        thematicDTOs: [
+                          {
+                            id: 'them2',
+                            index: 18,
+                            name: 'them2 EN',
+                            tubeDTOs: [
+                              {
+                                id: 'tube2',
+                                name: '@tube_two',
+                                practicalTitle: 'tube2 EN',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+        );
+        expect(learningContentResult.error).to.be.null;
+      });
+
+      it('returns a LearningContentResult with the expected info with default FR when no locale provided', async function () {
+        // when
+        const learningContentResult = await findByTubeIds({ tubeIds: ['tube1', 'tube2'] });
+
+        // then
+        expect(learningContentResult.learningContentDTO).deepEqualInstance(
+          new LearningContentDTO({
+            frameworkDTOs: [
+              {
+                id: 'framework1',
+                name: 'FrameWork1',
+                areaDTOs: [
+                  {
+                    id: 'area1',
+                    title: 'area1',
+                    code: '1',
+                    color: 'red',
+                    competenceDTOs: [
+                      {
+                        id: 'comp1',
+                        name: 'comp1',
+                        index: '1.1',
+                        thematicDTOs: [
+                          {
+                            id: 'them1',
+                            index: 1,
+                            name: 'them1',
+                            tubeDTOs: [
+                              {
+                                id: 'tube1',
+                                name: '@tube_one',
+                                practicalTitle: 'tube1',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'framework2',
+                name: 'FrameWork2',
+                areaDTOs: [
+                  {
+                    id: 'area2',
+                    title: 'area2',
+                    code: '18',
+                    color: 'green',
+                    competenceDTOs: [
+                      {
+                        id: 'comp2',
+                        name: 'comp2',
+                        index: '18.1',
+                        thematicDTOs: [
+                          {
+                            id: 'them2',
+                            index: 18,
+                            name: 'them2',
+                            tubeDTOs: [
+                              {
+                                id: 'tube2',
+                                name: '@tube_two',
+                                practicalTitle: 'tube2',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+        );
+        expect(learningContentResult.error).to.be.null;
+      });
+    });
+
+    context('failure', function () {
+      it('returns an empty learning content along with error message when no tube IDS provided', async function () {
+        // when
+        const learningContentResult = await findByTubeIds({ tubeIds: null, locale: 'en' });
+
+        // then
+        expect(learningContentResult.learningContentDTO).to.be.null;
+        expect(learningContentResult.error).deepEqualInstance(new NoTubesProvidedError());
+      });
+
+      it('returns a partial learning content along with error message when some tube do not exist', async function () {
+        // when
+        const learningContentResult = await findByTubeIds({ tubeIds: ['tubeA', 'tube2'], locale: 'en' });
+
+        // then
+        expect(learningContentResult.learningContentDTO).deepEqualInstance(
+          new LearningContentDTO({
+            frameworkDTOs: [
+              {
+                id: 'framework2',
+                name: 'FrameWork2',
+                areaDTOs: [
+                  {
+                    id: 'area2',
+                    title: 'area2 EN',
+                    code: '18',
+                    color: 'green',
+                    competenceDTOs: [
+                      {
+                        id: 'comp2',
+                        name: 'comp2 EN',
+                        index: '18.1',
+                        thematicDTOs: [
+                          {
+                            id: 'them2',
+                            index: 18,
+                            name: 'them2 EN',
+                            tubeDTOs: [
+                              {
+                                id: 'tube2',
+                                name: '@tube_two',
+                                practicalTitle: 'tube2 EN',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+        );
+        expect(learningContentResult.error).deepEqualInstance(new SomeTubesNotFoundError(['tubeA']));
+      });
+    });
+  });
+});

--- a/api/tests/learning-content/integration/infrastructure/repositories/learning-content-view-repository_test.js
+++ b/api/tests/learning-content/integration/infrastructure/repositories/learning-content-view-repository_test.js
@@ -1,0 +1,168 @@
+import { AreaView } from '../../../../../src/learning-content/domain/models/AreaView.js';
+import { CompetenceView } from '../../../../../src/learning-content/domain/models/CompetenceView.js';
+import { FrameworkView } from '../../../../../src/learning-content/domain/models/FrameworkView.js';
+import { LearningContentView } from '../../../../../src/learning-content/domain/models/LearningContentView.js';
+import { ThematicView } from '../../../../../src/learning-content/domain/models/ThematicView.js';
+import { TubeView } from '../../../../../src/learning-content/domain/models/TubeView.js';
+import { findByTubeIds } from '../../../../../src/learning-content/infrastructure/repositories/learning-content-view-repository.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+
+describe('Learning Content | Integration | Repositories | Learning Content View', function () {
+  afterEach(async function () {
+    await knex('learningcontent.frameworks').truncate();
+    await knex('learningcontent.areas').truncate();
+    await knex('learningcontent.competences').truncate();
+    await knex('learningcontent.thematics').truncate();
+    await knex('learningcontent.tubes').truncate();
+  });
+
+  describe('#findByTubeIds', function () {
+    it('returns learningContentView with no frameworks', async function () {
+      // when
+      const result = await findByTubeIds(['tube1', 'tube2']);
+
+      // then
+      expect(result).deepEqualInstance(
+        new LearningContentView({
+          frameworkViews: [],
+        }),
+      );
+    });
+
+    it('returns learningContentView with frameworks', async function () {
+      // given
+      const learningContent = {
+        frameworks: [
+          { id: 'framework1', name: 'FrameWork1' },
+          { id: 'framework2', name: 'FrameWork2' },
+        ],
+        areas: [
+          {
+            id: 'area1',
+            title_i18n: { fr: 'area1' },
+            code: '1',
+            color: 'red',
+            frameworkId: 'framework1',
+            competenceIds: ['comp1'],
+          },
+          {
+            id: 'area2',
+            title_i18n: { fr: 'area2' },
+            code: '18',
+            color: 'green',
+            frameworkId: 'framework2',
+            competenceIds: ['comp2'],
+          },
+        ],
+        competences: [
+          { id: 'comp1', areaId: 'area1', index: '1.1', name_i18n: { fr: 'comp1' } },
+          { id: 'comp2', areaId: 'area2', index: '18.1', name_i18n: { fr: 'comp2' } },
+        ],
+        thematics: [
+          { id: 'them1', competenceId: 'comp1', index: 1, name_i18n: { fr: 'them1' } },
+          { id: 'them2', competenceId: 'comp2', index: 18, name_i18n: { fr: 'them2' } },
+        ],
+        tubes: [
+          {
+            id: 'tube1',
+            thematicId: 'them1',
+            name: '@tube_one',
+            competenceId: 'comp1',
+            practicalTitle_i18n: {
+              fr: 'tube1',
+            },
+          },
+          {
+            id: 'tube2',
+            thematicId: 'them2',
+            name: '@tube_two',
+            competenceId: 'comp2',
+            practicalTitle_i18n: {
+              fr: 'tube2',
+            },
+          },
+        ],
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
+
+      // when
+      const result = await findByTubeIds(['tube1', 'tube2']);
+
+      // then
+      expect(result).deepEqualInstance(
+        new LearningContentView({
+          frameworkViews: [
+            new FrameworkView({
+              id: 'framework1',
+              name: 'FrameWork1',
+              areaViews: [
+                new AreaView({
+                  id: 'area1',
+                  title_i18n: { fr: 'area1' },
+                  code: '1',
+                  color: 'red',
+                  competenceViews: [
+                    new CompetenceView({
+                      id: 'comp1',
+                      name_i18n: { fr: 'comp1' },
+                      index: '1.1',
+                      thematicViews: [
+                        new ThematicView({
+                          id: 'them1',
+                          index: 1,
+                          name_i18n: { fr: 'them1' },
+                          tubeViews: [
+                            new TubeView({
+                              id: 'tube1',
+                              name: '@tube_one',
+                              practicalTitle_i18n: { fr: 'tube1' },
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+            new FrameworkView({
+              id: 'framework2',
+              name: 'FrameWork2',
+              areaViews: [
+                new AreaView({
+                  id: 'area2',
+                  title_i18n: { fr: 'area2' },
+                  code: '18',
+                  color: 'green',
+                  competenceViews: [
+                    new CompetenceView({
+                      id: 'comp2',
+                      name_i18n: { fr: 'comp2' },
+                      index: '18.1',
+                      thematicViews: [
+                        new ThematicView({
+                          id: 'them2',
+                          index: 18,
+                          name_i18n: { fr: 'them2' },
+                          tubeViews: [
+                            new TubeView({
+                              id: 'tube2',
+                              name: '@tube_two',
+                              practicalTitle_i18n: { fr: 'tube2' },
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 🪧 Problème

> Reprise de https://github.com/1024pix/pix/pull/16847

On trouve dans plusieurs Bounded Context (`devcomp`, `prescription`, `shared`, ...) des instances de la méthode `_getLearningContent` (à partir d'une liste d'ids de sujets).
Cette fonction devrait être dans l'API interne du contexte `learning-content`.

## 🌈 Proposition

Création d'une API interne `learningContentAPI.findByTubeIds()`, qui permet de récuperer un ou plusieurs référentiels à partir d'une liste d'ids de sujets et d'une locale (`fr` par défaut).
Cette API ne devrait pas `throw` d'erreurs en temps normal, mais renvoie plutôt une propriété `error` dans son résultat. Il est à la personne qui utilise l'API de décider comment gérer cette erreur.


```js
const { learningContentDTO, error } = await learningContentAPI.findByTubeIds({ tubeIds, locale });
if (error instanceof learningContentAPI.NoTubesProvidedError) {
  throw new MyDomainError(error.message);
}
if (error instanceof learningContentAPI.SomeTubesNotFoundError) {
  logger.error({ missingTubeIds: error.missingTubeIds }, '...');
  // learningContentDTO.frameworkDTOs peut partiellement contenir des référentiels
}
for (const frameworkDTO of learningContentDTO.frameworkDTOs) { 
  // ... 
}
```

## ✊ Remarques

- Ajout de l'option `"strictNullChecks": true` dans le fichier `jsconfig.json`, afin d'avoir des types corrects lors de l'utilisation d'unions typescript (ex: `null | number` devenait `number` avant l'ajout de cette option).

## 🎉 Pour tester
// TODO: utiliser l'API dans un autre BC
