### PR TITLE
[TECH] :recycle: Utilise un vrai `builder` pour le candidat dans le contexte `enrolment` (PIX-23680)

### DIFF
--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -1,11 +1,9 @@
-import _ from 'lodash';
-
 import { Frameworks } from '../../../src/certification/shared/domain/models/Frameworks.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildSession } from './build-session.js';
 import { buildUser } from './build-user.js';
 
-const buildCertificationCandidate = function ({
+export function buildCertificationCandidate({
   id = databaseBuffer.getNextId(),
   firstName = 'first-name',
   lastName = 'last-name',
@@ -32,8 +30,13 @@ const buildCertificationCandidate = function ({
   subscription = Frameworks.CORE,
   authorizedToStartAt = null,
 } = {}) {
-  sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
-  userId = _.isUndefined(userId) ? buildUser().id : userId;
+  if (!sessionId) {
+    sessionId = buildSession().id;
+  }
+
+  if (!userId && reconciledAt) {
+    userId = buildUser().id;
+  }
   reconciledAt = userId && !reconciledAt ? new Date('2020-01-02') : reconciledAt;
 
   const values = {
@@ -95,6 +98,4 @@ const buildCertificationCandidate = function ({
     reconciledAt,
     subscription,
   };
-};
-
-export { buildCertificationCandidate };
+}

--- a/api/db/database-builder/factory/build-session.js
+++ b/api/db/database-builder/factory/build-session.js
@@ -4,7 +4,7 @@ import { databaseBuffer } from '../database-buffer.js';
 import { buildCertificationCenter } from './build-certification-center.js';
 import { buildUser } from './build-user.js';
 
-const buildSession = function ({
+export function buildSession({
   id = databaseBuffer.getNextId(),
   accessCode = 'FMKP39',
   address = '3 rue des églantines',
@@ -68,6 +68,4 @@ const buildSession = function ({
     tableName: 'sessions',
     values,
   });
-};
-
-export { buildSession };
+}

--- a/api/src/certification/enrolment/application/usecases/check-user-is-candidate.js
+++ b/api/src/certification/enrolment/application/usecases/check-user-is-candidate.js
@@ -1,8 +1,6 @@
 import * as candidateRepository from '../../infrastructure/repositories/candidate-repository.js';
 
-const execute = async ({ userId, certificationCandidateId, dependencies = { candidateRepository } }) => {
+export async function execute({ userId, certificationCandidateId, dependencies = { candidateRepository } }) {
   const candidate = await dependencies.candidateRepository.get({ certificationCandidateId });
   return candidate?.isReconciledTo(userId);
-};
-
-export { execute };
+}

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -31,7 +31,7 @@ export class Candidate {
     prepaymentCode,
     hasSeenCertificationInstructions = false,
     subscription,
-    accessibilityAdjustmentNeeded,
+    accessibilityAdjustmentNeeded = false,
     hasStartedTest = false,
     doubleCertificationEligibility = false,
   }) {

--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -124,6 +124,7 @@ export async function extractCertificationCandidatesFromCandidatesImportSheet({
       createdAt: null,
       organizationLearnerId: null,
       userId: null,
+      reconciledAt: null,
     });
 
     try {

--- a/api/src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js
+++ b/api/src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js
@@ -10,16 +10,13 @@ import { CertificationCandidateNotFoundError } from '../../../shared/domain/erro
  * @param {CandidateRepository} params.candidateRepository
  * @returns {Candidate}
  */
-const candidateHasSeenCertificationInstructions = async function ({ certificationCandidateId, candidateRepository }) {
+export async function candidateHasSeenCertificationInstructions({ certificationCandidateId, candidateRepository }) {
   const candidate = await candidateRepository.get({ certificationCandidateId });
 
   if (!candidate) {
     throw new CertificationCandidateNotFoundError();
   }
-
   candidate.validateCertificationInstructions();
   await candidateRepository.update(candidate);
   return candidate;
-};
-
-export { candidateHasSeenCertificationInstructions };
+}

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -19,7 +19,7 @@ import { SessionMassImportReport } from '../models/SessionMassImportReport.js';
  * @param {deps["temporarySessionsStorageForMassImportService"]} params.temporarySessionsStorageForMassImportService
  */
 
-const validateSessions = async function ({
+export async function validateSessions({
   sessionsData,
   userId,
   certificationCenterId,
@@ -94,9 +94,7 @@ const validateSessions = async function ({
   sessionsMassImportReport.updateSessionsCounters(validatedSessions);
 
   return sessionsMassImportReport;
-};
-
-export { validateSessions };
+}
 
 async function _createValidCertificationCandidates({
   candidatesDTO,

--- a/api/src/certification/enrolment/domain/validators/candidate-validator.js
+++ b/api/src/certification/enrolment/domain/validators/candidate-validator.js
@@ -71,8 +71,6 @@ const schema = Joi.object({
   }),
 });
 
-function validate(certificationCandidate, options = { allowUnknown: true }) {
+export function validate(certificationCandidate, options = { allowUnknown: true }) {
   return schema.validate(certificationCandidate, options);
 }
-
-export { validate };

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
@@ -20,14 +20,17 @@ describe('Acceptance | Controller | Certification | Enrolment | session-controll
     let candidate;
 
     beforeEach(function () {
-      candidate = domainBuilder.certification.enrolment.buildCandidate({
-        birthCountry: 'FRANCE',
-        birthINSEECode: '75115',
-        birthPostalCode: null,
-        birthCity: null,
-        billingMode: BILLING_MODES.FREE,
-        subscription: Frameworks.CLEA,
-      });
+      candidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withSubscription(Frameworks.CLEA)
+        .withParameters({
+          birthCountry: 'FRANCE',
+          birthINSEECode: '75115',
+          birthPostalCode: null,
+          birthCity: null,
+          billingMode: BILLING_MODES.FREE,
+        })
+        .build();
       userId = databaseBuilder.factory.buildUser().id;
 
       databaseBuilder.factory.buildOrganization({

--- a/api/tests/certification/enrolment/acceptance/application/session-controller-delete-certification-candidate_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-controller-delete-certification-candidate_test.js
@@ -1,6 +1,7 @@
 import { createServer } from '../../../../../server.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Acceptance | Controller | session-controller-delete-certification-candidate', function () {
@@ -31,7 +32,11 @@ describe('Acceptance | Controller | session-controller-delete-certification-cand
 
     context('when the candidate is linked', function () {
       beforeEach(function () {
-        certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
+        certificationCandidateId = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({ userId })
+          .withParameters({ sessionId })
+          .insertToDB({ databaseBuilder }).id;
         options.url = `/api/sessions/${sessionId}/certification-candidates/${certificationCandidateId}`;
         return databaseBuilder.commit();
       });
@@ -47,7 +52,10 @@ describe('Acceptance | Controller | session-controller-delete-certification-cand
 
     context('when the candidate is not linked', function () {
       beforeEach(function () {
-        certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId: null }).id;
+        certificationCandidateId = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({ sessionId })
+          .insertToDB({ databaseBuilder }).id;
         options.url = `/api/sessions/${sessionId}/certification-candidates/${certificationCandidateId}`;
         return databaseBuilder.commit();
       });

--- a/api/tests/certification/enrolment/acceptance/application/session-controller_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-controller_test.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { createServer } from '../../../../../server.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Acceptance | Controller | session-controller', function () {
@@ -48,15 +49,27 @@ describe('Acceptance | Controller | session-controller', function () {
       let expectedCertificationCandidateBAttributes;
 
       beforeEach(function () {
-        const certificationCandidateA = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'A',
-          sessionId,
-        });
+        const certificationCandidateA = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'A',
+          })
+          .asReconciled()
+          .withParameters({
+            sessionId,
+          })
+          .insertToDB({ databaseBuilder });
 
-        const certificationCandidateB = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'B',
-          sessionId,
-        });
+        const certificationCandidateB = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'B',
+          })
+          .asReconciled()
+          .withParameters({
+            sessionId,
+          })
+          .insertToDB({ databaseBuilder });
 
         _.times(5, () => {
           databaseBuilder.factory.buildCertificationCandidate();

--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -31,7 +31,6 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
   let userId;
   let sessionId, session;
   let mailCheck;
-  let candidateList;
   let cleaComplementaryCertification;
   let eduComplementaryCertification;
 
@@ -83,8 +82,6 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     await databaseBuilder.commit();
 
     mailCheck = { assertEmailDomainHasMx: sinon.stub() };
-
-    candidateList = _buildCandidateList({ sessionId });
   });
 
   it('should throw a CertificationCandidatesError if there is an error in the file', async function () {
@@ -252,13 +249,51 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       });
 
     // then
-    candidateList = _buildCandidateList({ sessionId });
-    const expectedCandidates = candidateList.map((candidate) => {
-      return domainBuilder.certification.enrolment.buildCandidate({
-        ...candidate,
-        subscription: Frameworks.CORE,
-      });
-    });
+    const expectedCandidates = [
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Gallagher',
+          firstName: 'Jack',
+          birthdate: '1980-08-10',
+        })
+        .withSubscription(Frameworks.CORE)
+        .withParameters({
+          birthCity: 'Londres',
+          birthCountry: 'ANGLETERRE',
+          birthINSEECode: '99132',
+          sex: 'M',
+          sessionId,
+          resultRecipientEmail: 'destinataire@gmail.com',
+          email: 'jack@d.it',
+          extraTimePercentage: '0.15',
+          createdAt: null,
+        })
+        .build(),
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Jackson',
+          firstName: 'Janet',
+          birthdate: '2005-12-05',
+        })
+        .withSubscription(Frameworks.CORE)
+        .withParameters({
+          createdAt: null,
+          birthCity: 'AJACCIO',
+          birthCountry: 'FRANCE',
+          birthINSEECode: '2A004',
+          sex: 'F',
+          sessionId,
+          resultRecipientEmail: 'destinataire@gmail.com',
+          email: 'jaja@hotmail.fr',
+          externalId: 'DEF456',
+        })
+        .build(),
+    ];
+
+    expectedCandidates.forEach((c) => delete c.id);
+    actualCandidates.forEach((c) => delete c.id);
     expect(actualCandidates).to.deep.equal(expectedCandidates);
   });
 
@@ -292,19 +327,50 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
       const odsFilePath = `${__dirname}/attendance_sheet_extract_with_complementary_certifications_ok_test.ods`;
       const odsBuffer = await readFile(odsFilePath);
-      candidateList = _buildCandidateList({
-        sessionId: sessionData.id,
-        billingModes: [BILLING_MODES.FREE, BILLING_MODES.FREE],
-      });
+      const sessionId = sessionData.id;
       const expectedCandidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateList[0],
-          subscription: Frameworks.EDU_1ER_DEGRE,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateList[1],
-          subscription: Frameworks.CLEA,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'Gallagher',
+            firstName: 'Jack',
+            birthdate: '1980-08-10',
+          })
+          .withSubscription(Frameworks.EDU_1ER_DEGRE)
+          .withParameters({
+            birthCity: 'Londres',
+            birthCountry: 'ANGLETERRE',
+            birthINSEECode: '99132',
+            sex: 'M',
+            sessionId,
+            resultRecipientEmail: 'destinataire@gmail.com',
+            email: 'jack@d.it',
+            extraTimePercentage: '0.15',
+            billingMode: BILLING_MODES.FREE,
+            createdAt: null,
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'Jackson',
+            firstName: 'Janet',
+            birthdate: '2005-12-05',
+          })
+          .withSubscription(Frameworks.CLEA)
+          .withParameters({
+            birthCity: 'AJACCIO',
+            birthCountry: 'FRANCE',
+            birthINSEECode: '2A004',
+            sex: 'F',
+            sessionId,
+            resultRecipientEmail: 'destinataire@gmail.com',
+            email: 'jaja@hotmail.fr',
+            externalId: 'DEF456',
+            billingMode: BILLING_MODES.FREE,
+            createdAt: null,
+          })
+          .build(),
       ];
 
       // when
@@ -322,6 +388,8 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
         });
 
       // then
+      expectedCandidates.forEach((c) => delete c.id);
+      actualCandidates.forEach((c) => delete c.id);
       expect(actualCandidates).to.deep.equal(expectedCandidates);
     });
 
@@ -383,16 +451,50 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
     const odsFilePath = `${__dirname}/attendance_sheet_extract_with_billing_ok_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
-    candidateList = _buildCandidateList({
-      billingModes: [BILLING_MODES.PAID, BILLING_MODES.FREE],
-      sessionId,
-    });
-    const expectedCandidates = candidateList.map((candidate) => {
-      return domainBuilder.certification.enrolment.buildCandidate({
-        ...candidate,
-        subscription: Frameworks.CORE,
-      });
-    });
+    const expectedCandidates = [
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Gallagher',
+          firstName: 'Jack',
+          birthdate: '1980-08-10',
+        })
+        .withSubscription(Frameworks.CORE)
+        .withParameters({
+          birthCity: 'Londres',
+          birthCountry: 'ANGLETERRE',
+          birthINSEECode: '99132',
+          sex: 'M',
+          sessionId,
+          resultRecipientEmail: 'destinataire@gmail.com',
+          email: 'jack@d.it',
+          extraTimePercentage: '0.15',
+          createdAt: null,
+          billingMode: BILLING_MODES.PAID,
+        })
+        .build(),
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Jackson',
+          firstName: 'Janet',
+          birthdate: '2005-12-05',
+        })
+        .withSubscription(Frameworks.CORE)
+        .withParameters({
+          birthCity: 'AJACCIO',
+          birthCountry: 'FRANCE',
+          birthINSEECode: '2A004',
+          sex: 'F',
+          sessionId,
+          resultRecipientEmail: 'destinataire@gmail.com',
+          email: 'jaja@hotmail.fr',
+          externalId: 'DEF456',
+          billingMode: BILLING_MODES.FREE,
+          createdAt: null,
+        })
+        .build(),
+    ];
 
     // when
     const actualCandidates =
@@ -408,6 +510,8 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
         mailCheck,
       });
 
+    expectedCandidates.forEach((c) => delete c.id);
+    actualCandidates.forEach((c) => delete c.id);
     // then
     expect(actualCandidates).to.deep.equal(expectedCandidates);
   });
@@ -434,64 +538,52 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       });
 
     // then
-    const expectedCandidates = candidateList.map((candidate) => {
-      return domainBuilder.certification.enrolment.buildCandidate({
-        ...candidate,
-        subscription: Frameworks.CORE,
-      });
-    });
+
+    const expectedCandidates = [
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Gallagher',
+          firstName: 'Jack',
+          birthdate: '1980-08-10',
+        })
+        .withSubscription(Frameworks.CORE)
+        .withParameters({
+          birthCity: 'Londres',
+          birthCountry: 'ANGLETERRE',
+          birthINSEECode: '99132',
+          sex: 'M',
+          sessionId,
+          resultRecipientEmail: 'destinataire@gmail.com',
+          email: 'jack@d.it',
+          extraTimePercentage: '0.15',
+          createdAt: null,
+        })
+        .build(),
+
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Jackson',
+          firstName: 'Janet',
+          birthdate: '2005-12-05',
+        })
+        .withSubscription(Frameworks.CORE)
+        .withParameters({
+          birthCity: 'AJACCIO',
+          birthCountry: 'FRANCE',
+          birthINSEECode: '2A004',
+          sex: 'F',
+          sessionId,
+          resultRecipientEmail: 'destinataire@gmail.com',
+          email: 'jaja@hotmail.fr',
+          externalId: 'DEF456',
+          createdAt: null,
+        })
+        .build(),
+    ];
+    expectedCandidates.forEach((c) => delete c.id);
+    actualCandidates.forEach((c) => delete c.id);
     expect(actualCandidates).to.deep.equal(expectedCandidates);
   });
 });
-
-function _buildCandidateList({ billingModes = [], sessionId }) {
-  const candidates = [];
-  candidates.push({
-    id: null,
-    sessionId,
-    createdAt: null,
-    lastName: 'Gallagher',
-    firstName: 'Jack',
-    birthdate: '1980-08-10',
-    sex: 'M',
-    birthCity: 'Londres',
-    birthCountry: 'ANGLETERRE',
-    birthINSEECode: '99132',
-    birthPostalCode: null,
-    birthProvinceCode: null,
-    resultRecipientEmail: 'destinataire@gmail.com',
-    email: 'jack@d.it',
-    externalId: null,
-    extraTimePercentage: 0.15,
-    billingMode: billingModes[0] ? billingModes[0] : null,
-    prepaymentCode: null,
-    subscription: Frameworks.CORE,
-    organizationLearnerId: null,
-    userId: null,
-  });
-  candidates.push({
-    id: null,
-    sessionId,
-    createdAt: null,
-    lastName: 'Jackson',
-    firstName: 'Janet',
-    birthdate: '2005-12-05',
-    sex: 'F',
-    birthCity: 'AJACCIO',
-    birthCountry: 'FRANCE',
-    birthINSEECode: '2A004',
-    birthPostalCode: null,
-    birthProvinceCode: null,
-    resultRecipientEmail: 'destinataire@gmail.com',
-    email: 'jaja@hotmail.fr',
-    externalId: 'DEF456',
-    extraTimePercentage: null,
-    billingMode: billingModes[1] ? billingModes[1] : null,
-    prepaymentCode: null,
-    subscription: Frameworks.CORE,
-    organizationLearnerId: null,
-    userId: null,
-  });
-
-  return candidates;
-}

--- a/api/tests/certification/enrolment/integration/infrastructure/candidates-import/fill-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/candidates-import/fill-candidates-import-sheet_test.js
@@ -1,8 +1,6 @@
 import fs from 'node:fs';
 import * as url from 'node:url';
 
-import _ from 'lodash';
-
 import { usecases } from '../../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { fillCandidatesImportSheet } from '../../../../../../src/certification/enrolment/infrastructure/candidates-import/fill-candidates-import-sheet.js';
 import * as readOdsUtils from '../../../../../../src/certification/enrolment/infrastructure/utils/ods/read-ods-utils.js';
@@ -11,6 +9,7 @@ import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/constan
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 const { promises } = fs;
 
@@ -65,73 +64,89 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
         description: 'La super description',
       }).id;
 
-      _.each(
-        [
-          {
-            lastName: 'Jackson',
-            firstName: 'Michael',
-            sex: 'M',
-            birthPostalCode: '75018',
-            birthINSEECode: null,
-            birthCity: 'Paris',
-            birthCountry: 'France',
-            email: 'jackson@gmail.com',
-            resultRecipientEmail: 'destinataire@gmail.com',
-            birthdate: '2004-04-04',
-            sessionId,
-            externalId: 'ABC123',
-            extraTimePercentage: 0.6,
-          },
-          {
-            lastName: 'Jackson',
-            firstName: 'Janet',
-            sex: 'F',
-            birthPostalCode: null,
-            birthINSEECode: '2A004',
-            birthCity: 'Ajaccio',
-            birthCountry: 'France',
-            email: 'jaja@hotmail.fr',
-            resultRecipientEmail: 'destinataire@gmail.com',
-            birthdate: '2005-12-05',
-            sessionId,
-            externalId: 'DEF456',
-            extraTimePercentage: null,
-          },
-          {
-            lastName: 'Mercury',
-            firstName: 'Freddy',
-            sex: 'M',
-            birthPostalCode: '97180',
-            birthINSEECode: null,
-            birthCity: 'Sainte-Anne',
-            birthCountry: 'France',
-            email: null,
-            resultRecipientEmail: null,
-            birthdate: '1925-06-28',
-            sessionId,
-            externalId: 'GHI789',
-            extraTimePercentage: 1.5,
-          },
-          {
-            lastName: 'Gallagher',
-            firstName: 'Jack',
-            sex: 'M',
-            birthPostalCode: null,
-            birthINSEECode: '99132',
-            birthCity: 'Londres',
-            birthCountry: 'Angleterre',
-            email: 'jack@d.it',
-            resultRecipientEmail: 'destinataire@gmail.com',
-            birthdate: '1980-08-10',
-            sessionId,
-            externalId: null,
-            extraTimePercentage: 0.15,
-          },
-        ],
-        (candidate) => {
-          databaseBuilder.factory.buildCertificationCandidate(candidate);
-        },
-      );
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Jackson',
+          firstName: 'Michael',
+          birthdate: '2004-04-04',
+        })
+        .withParameters({
+          sex: 'M',
+          birthPostalCode: '75018',
+          birthINSEECode: null,
+          birthCity: 'Paris',
+          birthCountry: 'France',
+          email: 'jackson@gmail.com',
+          resultRecipientEmail: 'destinataire@gmail.com',
+          sessionId,
+          externalId: 'ABC123',
+          extraTimePercentage: 0.6,
+        })
+        .insertToDB({ databaseBuilder });
+
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Jackson',
+          firstName: 'Janet',
+          birthdate: '2005-12-05',
+        })
+        .withParameters({
+          sex: 'F',
+          birthPostalCode: null,
+          birthINSEECode: '2A004',
+          birthCity: 'Ajaccio',
+          birthCountry: 'France',
+          email: 'jaja@hotmail.fr',
+          resultRecipientEmail: 'destinataire@gmail.com',
+          sessionId,
+          externalId: 'DEF456',
+          extraTimePercentage: null,
+        })
+        .insertToDB({ databaseBuilder });
+
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Mercury',
+          firstName: 'Freddy',
+          birthdate: '1925-06-28',
+        })
+        .withParameters({
+          sex: 'M',
+          birthPostalCode: '97180',
+          birthINSEECode: null,
+          birthCity: 'Sainte-Anne',
+          birthCountry: 'France',
+          email: null,
+          resultRecipientEmail: null,
+          sessionId,
+          externalId: 'GHI789',
+          extraTimePercentage: 1.5,
+        })
+        .insertToDB({ databaseBuilder });
+
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          lastName: 'Gallagher',
+          firstName: 'Jack',
+          birthdate: '1980-08-10',
+        })
+        .withParameters({
+          sex: 'M',
+          birthPostalCode: null,
+          birthINSEECode: '99132',
+          birthCity: 'Londres',
+          birthCountry: 'Angleterre',
+          email: 'jack@d.it',
+          resultRecipientEmail: 'destinataire@gmail.com',
+          sessionId,
+          externalId: null,
+          extraTimePercentage: 0.15,
+        })
+        .insertToDB({ databaseBuilder });
 
       await databaseBuilder.commit();
       // when
@@ -444,37 +459,87 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
         description: 'La super description',
       }).id;
 
-      databaseBuilder.factory.buildCertificationCandidate({
-        firstName: 'Certif',
-        lastName: 'Gratos',
-        billingMode: 'FREE',
-        prepaymentCode: null,
-        sessionId,
-      });
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          firstName: 'Certif',
+          lastName: 'Gratos',
+          birthdate: '2000-01-04',
+        })
+        .withParameters({
+          billingMode: 'FREE',
+          prepaymentCode: null,
+          sessionId,
+          resultRecipientEmail: 'somerecipientmail@example.net',
+          externalId: 'externalId',
+          email: 'somemail@example.net',
+          extraTimePercentage: 0.3,
+          birthCountry: 'France',
+          birthINSEECode: 75101,
+          sex: 'M',
+        })
+        .insertToDB({ databaseBuilder });
 
-      databaseBuilder.factory.buildCertificationCandidate({
-        firstName: 'Candidat',
-        lastName: 'Qui Raque',
-        billingMode: 'PAID',
-        prepaymentCode: null,
-        sessionId,
-      });
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          firstName: 'Candidat',
+          lastName: 'Qui Raque',
+          birthdate: '2000-01-04',
+        })
+        .withParameters({
+          billingMode: 'PAID',
+          prepaymentCode: null,
+          sessionId,
+          resultRecipientEmail: 'somerecipientmail@example.net',
+          externalId: 'externalId',
+          email: 'somemail@example.net',
+          extraTimePercentage: 0.3,
+          birthCountry: 'France',
+          birthINSEECode: 75101,
+          sex: 'M',
+        })
+        .insertToDB({ databaseBuilder });
 
-      databaseBuilder.factory.buildCertificationCandidate({
-        firstName: 'A Man',
-        lastName: 'With A Code',
-        billingMode: 'PREPAID',
-        prepaymentCode: 'CODECODECODEC',
-        sessionId,
-      });
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          firstName: 'A Man',
+          lastName: 'With A Code',
+          birthdate: '2000-01-04',
+        })
+        .withParameters({
+          billingMode: 'PREPAID',
+          prepaymentCode: 'CODECODECODEC',
+          sessionId,
+          resultRecipientEmail: 'somerecipientmail@example.net',
+          externalId: 'externalId',
+          email: 'somemail@example.net',
+          extraTimePercentage: 0.3,
+          birthCountry: 'France',
+          birthINSEECode: 75101,
+          sex: 'M',
+        })
+        .insertToDB({ databaseBuilder });
 
-      databaseBuilder.factory.buildCertificationCandidate({
-        firstName: 'Yo',
-        lastName: 'Lo',
-        billingMode: null,
-        prepaymentCode: null,
-        sessionId,
-      });
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          firstName: 'Yo',
+          lastName: 'Lo',
+          birthdate: '01/04/2000',
+        })
+        .withParameters({
+          sessionId,
+          resultRecipientEmail: 'somerecipientmail@example.net',
+          externalId: 'externalId',
+          email: 'somemail@example.net',
+          extraTimePercentage: 0.3,
+          birthCountry: 'France',
+          birthINSEECode: 75101,
+          sex: 'M',
+        })
+        .insertToDB({ databaseBuilder });
 
       await databaseBuilder.commit();
       const { session, enrolledCandidates } = await usecases.getCandidateImportSheetData({ sessionId, userId });
@@ -538,14 +603,27 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
           description: 'La super description',
         }).id;
 
-        databaseBuilder.factory.buildCertificationCandidate({
-          firstName: 'Yo',
-          lastName: 'Lo',
-          billingMode: null,
-          prepaymentCode: null,
-          sessionId,
-          subscription: Frameworks.CLEA,
-        });
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Yo',
+            lastName: 'Lo',
+            birthdate: '01/04/2000',
+          })
+          .withSubscription(Frameworks.CLEA)
+          .withParameters({
+            billingMode: null,
+            prepaymentCode: null,
+            sessionId,
+            sex: 'M',
+            birthINSEECode: '75101',
+            birthCountry: 'France',
+            email: 'somemail@example.net',
+            resultRecipientEmail: 'somerecipientmail@example.net',
+            externalId: 'externalId',
+            extraTimePercentage: 0.3,
+          })
+          .insertToDB({ databaseBuilder });
 
         await databaseBuilder.commit();
         const { session, enrolledCandidates, certificationCenterHabilitations } =

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -12,34 +12,39 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
     context('when the candidate exists', function () {
       it('should return the candidate', async function () {
         // given
-        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-          subscription: Frameworks.CLEA,
-        });
+        const certificationCandidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         // when
         const result = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
 
         // then
-        expect(result).to.deepEqualInstance(new Candidate({ ...certificationCandidate, hasStartedTest: false }));
+        expect(result).to.deepEqualInstance(certificationCandidate);
       });
     });
 
     context('when the candidate has an associated certification course', function () {
       it('should return the candidate with information on whether he/she started the test', async function () {
         // given
-        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
+        const certificationCandidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled()
+          .insertToDB({ databaseBuilder });
         databaseBuilder.factory.buildCertificationCourse({
           userId: certificationCandidate.userId,
           candidateId: certificationCandidate.id,
         });
+        // when certificationCourse is linked to CandidateId, hasStartedTest is true
+        certificationCandidate.hasStartedTest = true;
         await databaseBuilder.commit();
 
         // when
         const result = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
 
         // then
-        expect(result).to.deepEqualInstance(new Candidate({ ...certificationCandidate, hasStartedTest: true }));
+        expect(result).to.deepEqualInstance(certificationCandidate);
       });
     });
 
@@ -62,25 +67,26 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       it('should return the candidates', async function () {
         // given
         const sessionId = databaseBuilder.factory.buildSession().id;
-        const certificationCandidate1 = databaseBuilder.factory.buildCertificationCandidate({
-          sessionId,
-          subscription: Frameworks.CLEA,
-        });
-        const certificationCandidate2 = databaseBuilder.factory.buildCertificationCandidate({
-          firstName: 'FiFouLaPraline',
-          sessionId,
-        });
-        databaseBuilder.factory.buildCertificationCandidate();
+
+        const certificationCandidate1 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withSubscription(Frameworks.CLEA)
+          .withParameters({ sessionId })
+          .insertToDB({ databaseBuilder });
+
+        const certificationCandidate2 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({ sessionId })
+          .insertToDB({ databaseBuilder });
+
+        domainBuilder.certification.enrolment.candidateBuilder().insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         // when
         const result = await candidateRepository.findBySessionId({ sessionId });
 
         // then
-        expect(result).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildCandidate({ ...certificationCandidate1 }),
-          domainBuilder.certification.enrolment.buildCandidate({ ...certificationCandidate2 }),
-        ]);
+        expect(result).to.deepEqualArray([certificationCandidate1, certificationCandidate2]);
       });
     });
 
@@ -89,7 +95,10 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         // given
         const sessionId = databaseBuilder.factory.buildSession().id;
         const otherSessionId = databaseBuilder.factory.buildSession().id;
-        databaseBuilder.factory.buildCertificationCandidate({ sessionId });
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({ sessionId })
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         //when
@@ -105,20 +114,24 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
     context('when there are candidates', function () {
       it('should return the candidates', async function () {
         // given
-        const candidate1 = databaseBuilder.factory.buildCertificationCandidate();
-        const userId = candidate1.userId;
-        const candidate2 = databaseBuilder.factory.buildCertificationCandidate({ userId });
-        databaseBuilder.factory.buildCertificationCandidate();
+        const userId = databaseBuilder.factory.buildUser().id;
+        const candidate1 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({ userId })
+          .insertToDB({ databaseBuilder });
+        const candidate2 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({ userId })
+          .insertToDB({ databaseBuilder });
+
+        domainBuilder.certification.enrolment.candidateBuilder().withParameters().insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
         // when
         const result = await candidateRepository.findByUserId({ userId });
 
         // then
-        expect(result).to.deepEqualArray([
-          domainBuilder.certification.enrolment.buildCandidate({ ...candidate1 }),
-          domainBuilder.certification.enrolment.buildCandidate({ ...candidate2 }),
-        ]);
+        expect(result).to.deepEqualArray([candidate1, candidate2]);
       });
     });
 
@@ -137,17 +150,16 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
     context('when the candidate exists', function () {
       it('should update the candidate', async function () {
         // when
-        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-          firstName: 'toto',
-        });
+        const certificationCandidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({ firstName: 'toto' })
+          .insertToDB({ databaseBuilder });
+
         await databaseBuilder.commit();
-        const certificationCandidateToUpdate = domainBuilder.certification.enrolment.buildCandidate({
-          ...certificationCandidate,
-        });
-        certificationCandidateToUpdate.firstName = 'tutu';
 
         // when
-        await candidateRepository.update(certificationCandidateToUpdate);
+        await candidateRepository.update({ ...certificationCandidate, firstName: 'tutu' });
+
         const candidate = await candidateRepository.get({
           certificationCandidateId: certificationCandidate.id,
         });
@@ -159,19 +171,14 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
 
       it('should update its subscription', async function () {
         // given
-        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-          subscription: Frameworks.DROIT,
-        });
-
+        const certificationCandidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withSubscription(Frameworks.DROIT)
+          .insertToDB({ databaseBuilder });
         await databaseBuilder.commit();
 
-        const candidateToUpdate = domainBuilder.certification.enrolment.buildCandidate({
-          ...certificationCandidate,
-          subscription: Frameworks.EDU_1ER_DEGRE,
-        });
-
         // when
-        await candidateRepository.update(candidateToUpdate);
+        await candidateRepository.update({ ...certificationCandidate, subscription: Frameworks.EDU_1ER_DEGRE });
 
         // then
         const updated = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
@@ -201,26 +208,41 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       // given
       const sessionId = databaseBuilder.factory.buildSession({}).id;
       await databaseBuilder.commit();
-      const candidateA = domainBuilder.certification.enrolment.buildCandidate({
-        firstName: 'Lolo',
-        lastName: 'Lapraline',
-        accessibilityAdjustmentNeeded: true,
-        sessionId,
-        subscription: Frameworks.CLEA,
-      });
-      const candidateB = domainBuilder.certification.enrolment.buildCandidate({
-        firstName: 'Geogeo',
-        lastName: 'Lenougat',
-        accessibilityAdjustmentNeeded: true,
-        sessionId,
-      });
-      const candidateC = domainBuilder.certification.enrolment.buildCandidate({
-        firstName: 'Loulou',
-        lastName: 'Lapistache',
-        sessionId,
-        accessibilityAdjustmentNeeded: false,
-        subscription: Frameworks.DROIT,
-      });
+      const candidateA = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withSubscription(Frameworks.CLEA)
+        .withIdentity({
+          firstName: 'Lolo',
+          lastName: 'Lapraline',
+        })
+        .withParameters({
+          accessibilityAdjustmentNeeded: true,
+          sessionId,
+        })
+        .build();
+      const candidateB = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          firstName: 'Geogeo',
+          lastName: 'Lenougat',
+        })
+        .withParameters({
+          accessibilityAdjustmentNeeded: true,
+          sessionId,
+        })
+        .build();
+      const candidateC = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          firstName: 'Loulou',
+          lastName: 'Lapistache',
+        })
+        .withSubscription(Frameworks.DROIT)
+        .withParameters({
+          sessionId,
+          accessibilityAdjustmentNeeded: false,
+        })
+        .build();
 
       // when
       const savedCandidates = await candidateRepository.save({ candidates: [candidateA, candidateB, candidateC] });
@@ -228,98 +250,6 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       // then
       const candidatesInSession = await candidateRepository.findBySessionId({ sessionId });
       expect(savedCandidates).to.deepEqualArray(candidatesInSession);
-      const { id: idCandidateA, createdAt: createdAtA } = savedCandidates.find(
-        (savedCandidate) => savedCandidate.firstName === candidateA.firstName,
-      );
-      const { id: idCandidateB, createdAt: createdAtB } = savedCandidates.find(
-        (savedCandidate) => savedCandidate.firstName === candidateB.firstName,
-      );
-      const { id: idCandidateC, createdAt: createdAtC } = savedCandidates.find(
-        (savedCandidate) => savedCandidate.firstName === candidateC.firstName,
-      );
-      expect(savedCandidates).to.deepEqualArray([
-        domainBuilder.certification.enrolment.buildCandidate({
-          id: idCandidateA,
-          createdAt: createdAtA,
-          firstName: candidateA.firstName,
-          reconciledAt: null,
-          lastName: candidateA.lastName,
-          birthCity: candidateA.birthCity,
-          externalId: candidateA.externalId,
-          extraTimePercentage: candidateB.extraTimePercentage,
-          birthdate: candidateA.birthdate,
-          sessionId: sessionId,
-          birthProvinceCode: candidateA.birthProvinceCode,
-          birthCountry: candidateA.birthCountry,
-          userId: null,
-          email: candidateA.email,
-          resultRecipientEmail: candidateA.resultRecipientEmail,
-          organizationLearnerId: candidateA.organizationLearnerId,
-          birthPostalCode: candidateA.birthPostalCode,
-          birthINSEECode: candidateA.birthINSEECode,
-          sex: candidateA.sex,
-          billingMode: candidateA.billingMode,
-          prepaymentCode: candidateA.prepaymentCode,
-          hasSeenCertificationInstructions: false,
-          accessibilityAdjustmentNeeded: candidateA.accessibilityAdjustmentNeeded,
-          subscription: Frameworks.CLEA,
-          hasStartedTest: false,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          id: idCandidateB,
-          createdAt: createdAtB,
-          firstName: candidateB.firstName,
-          reconciledAt: null,
-          lastName: candidateB.lastName,
-          birthCity: candidateB.birthCity,
-          externalId: candidateB.externalId,
-          extraTimePercentage: candidateB.extraTimePercentage,
-          birthdate: candidateB.birthdate,
-          sessionId: sessionId,
-          birthProvinceCode: candidateB.birthProvinceCode,
-          birthCountry: candidateB.birthCountry,
-          userId: null,
-          email: candidateB.email,
-          resultRecipientEmail: candidateB.resultRecipientEmail,
-          organizationLearnerId: candidateB.organizationLearnerId,
-          birthPostalCode: candidateB.birthPostalCode,
-          birthINSEECode: candidateB.birthINSEECode,
-          sex: candidateB.sex,
-          billingMode: candidateB.billingMode,
-          prepaymentCode: candidateB.prepaymentCode,
-          hasSeenCertificationInstructions: false,
-          accessibilityAdjustmentNeeded: candidateB.accessibilityAdjustmentNeeded,
-          subscription: Frameworks.CORE,
-          hasStartedTest: false,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          id: idCandidateC,
-          createdAt: createdAtC,
-          firstName: candidateC.firstName,
-          reconciledAt: null,
-          lastName: candidateC.lastName,
-          birthCity: candidateC.birthCity,
-          externalId: candidateC.externalId,
-          extraTimePercentage: candidateC.extraTimePercentage,
-          birthdate: candidateC.birthdate,
-          sessionId: sessionId,
-          birthProvinceCode: candidateC.birthProvinceCode,
-          birthCountry: candidateC.birthCountry,
-          userId: null,
-          email: candidateC.email,
-          resultRecipientEmail: candidateC.resultRecipientEmail,
-          organizationLearnerId: candidateC.organizationLearnerId,
-          birthPostalCode: candidateC.birthPostalCode,
-          birthINSEECode: candidateC.birthINSEECode,
-          sex: candidateC.sex,
-          billingMode: candidateC.billingMode,
-          prepaymentCode: candidateC.prepaymentCode,
-          hasSeenCertificationInstructions: false,
-          accessibilityAdjustmentNeeded: candidateC.accessibilityAdjustmentNeeded,
-          subscription: Frameworks.DROIT,
-          hasStartedTest: false,
-        }),
-      ]);
     });
   });
 });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-for-attendance-sheet-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-for-attendance-sheet-repository_test.js
@@ -4,6 +4,7 @@ import * as sessionForAttendanceSheetRepository from '../../../../../../src/cert
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Repository | Session-for-attendance-sheet', function () {
@@ -30,21 +31,38 @@ describe('Integration | Repository | Session-for-attendance-sheet', function () 
           time: '12:00:00',
         });
 
-        const candidate1 = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'Jackson',
-          firstName: 'Michael',
-          sessionId: session.id,
-        });
-        const candidate2 = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'Stardust',
-          firstName: 'Ziggy',
-          sessionId: session.id,
-        });
-        const candidate3 = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'Jackson',
-          firstName: 'Janet',
-          sessionId: session.id,
-        });
+        const candidate1 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'Jackson',
+            firstName: 'Michael',
+          })
+          .withParameters({
+            sessionId: session.id,
+          })
+          .insertToDB({ databaseBuilder });
+
+        const candidate2 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'Stardust',
+            firstName: 'Ziggy',
+          })
+          .withParameters({
+            sessionId: session.id,
+          })
+          .insertToDB({ databaseBuilder });
+
+        const candidate3 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'Jackson',
+            firstName: 'Janet',
+          })
+          .withParameters({
+            sessionId: session.id,
+          })
+          .insertToDB({ databaseBuilder });
 
         await databaseBuilder.commit();
 
@@ -99,24 +117,49 @@ describe('Integration | Repository | Session-for-attendance-sheet', function () 
         const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({ division: '3b' });
         const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({ division: '3a' });
         const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({ division: '2c' });
-        const candidate1 = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'Jackson',
-          firstName: 'Michael',
-          sessionId: session.id,
-          organizationLearnerId: organizationLearner1.id,
-        });
-        const candidate2 = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'Stardust',
-          firstName: 'Ziggy',
-          sessionId: session.id,
-          organizationLearnerId: organizationLearner2.id,
-        });
-        const candidate3 = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'Jackson',
-          firstName: 'Janet',
-          sessionId: session.id,
-          organizationLearnerId: organizationLearner3.id,
-        });
+
+        const candidate1 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'Jackson',
+            firstName: 'Michael',
+          })
+          .withParameters({
+            sessionId: session.id,
+          })
+          .asScoCandidate({
+            organizationLearnerId: organizationLearner1.id,
+          })
+          .insertToDB({ databaseBuilder });
+
+        const candidate2 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'Stardust',
+            firstName: 'Ziggy',
+          })
+          .withParameters({
+            sessionId: session.id,
+          })
+          .asScoCandidate({
+            organizationLearnerId: organizationLearner2.id,
+          })
+          .insertToDB({ databaseBuilder });
+
+        const candidate3 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            lastName: 'Jackson',
+            firstName: 'Janet',
+          })
+          .withParameters({
+            sessionId: session.id,
+          })
+          .asScoCandidate({
+            organizationLearnerId: organizationLearner3.id,
+          })
+          .insertToDB({ databaseBuilder });
+
         await databaseBuilder.commit();
 
         const expectedSessionValues = new SessionForAttendanceSheet({

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -147,8 +147,14 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
         it('should remove candidates and delete the session', async function () {
           // given
           const sessionId = databaseBuilder.factory.buildSession().id;
-          databaseBuilder.factory.buildCertificationCandidate({ sessionId });
-          databaseBuilder.factory.buildCertificationCandidate({ sessionId });
+          domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withParameters({ sessionId })
+            .insertToDB({ databaseBuilder });
+          domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withParameters({ sessionId })
+            .insertToDB({ databaseBuilder });
 
           await databaseBuilder.commit();
 

--- a/api/tests/certification/enrolment/unit/application/validator/checkUserIsCandidate_test.js
+++ b/api/tests/certification/enrolment/unit/application/validator/checkUserIsCandidate_test.js
@@ -15,10 +15,13 @@ describe('Unit | Application | Validator | checkUserIsCandidateUseCase', functio
       };
 
       candidateRepositoryStub.get.withArgs({ certificationCandidateId }).resolves(
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId,
-          reconciledAt: new Date('2024-09-25'),
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId,
+            reconciledAt: new Date('2024-09-25'),
+          })
+          .build(),
       );
 
       // when
@@ -42,11 +45,9 @@ describe('Unit | Application | Validator | checkUserIsCandidateUseCase', functio
         get: sinon.stub(),
       };
 
-      candidateRepositoryStub.get.withArgs({ certificationCandidateId }).resolves(
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: null,
-        }),
-      );
+      candidateRepositoryStub.get
+        .withArgs({ certificationCandidateId })
+        .resolves(domainBuilder.certification.enrolment.candidateBuilder().build());
 
       // when
       const response = await checkUserIsCandidateUseCase.execute({

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -5,7 +5,6 @@ import { Frameworks } from '../../../../../../src/certification/shared/domain/mo
 import { CertificationCandidatesError } from '../../../../../../src/shared/domain/errors.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { expect } from '../../../../../test-helper.js';
-import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr, catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 const FIRST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code;
@@ -53,13 +52,13 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       const birthPostalCode = 'updatedBirthPostalCode';
       const birthCity = 'updatedBirthCity';
 
-      const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
+      const candidate = new Candidate(candidateData);
 
       // when
       candidate.updateBirthInformation({ birthCountry, birthINSEECode, birthPostalCode, birthCity });
 
       // then
-      const expectedCandidate = domainBuilder.certification.enrolment.buildCandidate({
+      const expectedCandidate = new Candidate({
         ...candidateData,
         birthCountry: 'updatedBirthCountry',
         birthINSEECode: 'updatedBirthINSEECode',
@@ -74,7 +73,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     it('should link candidate to a user', function () {
       // given
       const userId = 123;
-      const candidate = domainBuilder.certification.enrolment.buildCandidate();
+      const candidate = new Candidate({ ...candidateData, userId: undefined });
 
       // when
       candidate.reconcile(userId);
@@ -89,7 +88,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     context('when all required fields are presents', function () {
       it('should not throw when object is valid', function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
+        const candidate = new Candidate(candidateData);
 
         // when, then
         candidate.validate();
@@ -110,7 +109,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
         });
 
         // when
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate = new Candidate({
           ...candidateData,
           [field.name]: 123,
         });
@@ -126,8 +125,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       ].forEach((field) => {
         it(`should throw an error when field ${field.name} is not present`, async function () {
           //given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
-          candidate[field.name] = undefined;
+          const candidate = new Candidate({ ...candidateData, [field.name]: undefined });
           const certificationCandidatesError = new CertificationCandidatesError({
             code: field.code,
           });
@@ -141,10 +139,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
         it(`should throw an error when field ${field.name} contains only spaces`, async function () {
           //given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateData,
-            [field.name]: ' ',
-          });
+          const candidate = new Candidate({ ...candidateData, [field.name]: ' ' });
           const certificationCandidatesError = new CertificationCandidatesError({
             code: field.code,
           });
@@ -157,8 +152,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
         });
 
         it(`should throw an error when field ${field.name} is not present because null`, async function () {
-          // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
+          const candidate = new Candidate({
             ...candidateData,
             [field.name]: null,
           });
@@ -177,7 +171,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when field sessionId is not a number', async function () {
       //given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         sessionId: 'salut',
       });
@@ -195,8 +189,10 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when field sessionId is not present', async function () {
       //given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
-      candidate.sessionId = undefined;
+      const candidate = new Candidate({
+        ...candidateData,
+        sessionId: undefined,
+      });
       const certificationCandidatesError = new CertificationCandidatesError({
         code: 'CANDIDATE_SESSION_ID_REQUIRED',
       });
@@ -210,7 +206,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when field sessionId is not present because null', async function () {
       //given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         sessionId: null,
       });
@@ -227,7 +223,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when field externalId is not a string', async function () {
       //given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         externalId: 1235,
       });
@@ -245,7 +241,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when birthdate is not a date', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         birthdate: 'je mange des légumes',
       });
@@ -263,7 +259,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when birthdate is not a valid format', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         birthdate: '2020/02/01',
       });
@@ -281,7 +277,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when birthdate is null', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         birthdate: null,
       });
@@ -298,8 +294,11 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when birthdate is not present', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
-      candidate.birthdate = undefined;
+      const candidate = new Candidate({
+        ...candidateData,
+        birthdate: undefined,
+      });
+
       const certificationCandidatesError = new CertificationCandidatesError({
         code: 'CANDIDATE_BIRTHDATE_REQUIRED',
       });
@@ -312,7 +311,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     });
 
     it('should throw an error when field extraTimePercentage is not a number', async function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         extraTimePercentage: 'salut',
       });
@@ -330,7 +329,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should throw an error when sex is neither M nor F', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         sex: 'salut',
       });
@@ -348,7 +347,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should return a report when email is not a valid format', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         email: 'email@example.net, anotheremail@example.net',
       });
@@ -366,7 +365,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should return a report when resultRecipientEmail is not a valid format', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         resultRecipientEmail: 'email@example.net, anotheremail@example.net',
       });
@@ -386,7 +385,10 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       context('success cases', function () {
         Object.values(Frameworks).forEach((subscription) => {
           it(`should validate when subscription is ${subscription}`, function () {
-            const candidate = domainBuilder.certification.enrolment.buildCandidate({ ...candidateData, subscription });
+            const candidate = new Candidate({
+              ...candidateData,
+              subscription,
+            });
             candidate.validate();
           });
         });
@@ -394,8 +396,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
       context('ko cases', function () {
         it('should not validate when subscription is an unknown value', async function () {
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({ ...candidateData });
-          candidate.subscription = 'UNKNOWN_FRAMEWORK';
+          const candidate = new Candidate({ ...candidateData, subscription: 'UNKNOWN_FRAMEWORK' });
           const error = await catchErr(candidate.validate, candidate)();
           expect(error).to.be.instanceOf(CertificationCandidatesError);
         });
@@ -406,7 +407,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       context('when the billing mode is null', function () {
         it('should not throw an error', async function () {
           // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
+          const candidate = new Candidate({
             ...candidateData,
             billingMode: null,
           });
@@ -425,7 +426,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     context('when the certification center is not SCO', function () {
       it('should throw an error if billingMode is null', async function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate = new Candidate({
           ...candidateData,
           billingMode: null,
         });
@@ -444,7 +445,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
       it('should throw an error if billingMode is not an expected value', async function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate = new Candidate({
           ...candidateData,
           billingMode: 'NOT_ALLOWED_VALUE',
         });
@@ -465,7 +466,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
         it(`should not throw if billing mode is an expected value ${billingMode}`, async function () {
           // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
+          const candidate = new Candidate({
             ...candidateData,
             billingMode,
             prepaymentCode: billingMode === BILLING_MODES.PREPAID ? '12345' : undefined,
@@ -484,7 +485,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       context('when billingMode is not PREPAID', function () {
         it('should throw an error if prepaymentCode is not null', async function () {
           // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
+          const candidate = new Candidate({
             ...candidateData,
             billingMode: 'PAID',
             prepaymentCode: 'NOT_NULL',
@@ -506,7 +507,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       context('when billingMode is PREPAID', function () {
         it('should not throw an error if prepaymentCode is not null', function () {
           // given
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
+          const candidate = new Candidate({
             ...candidateData,
             billingMode: 'PREPAID',
             prepaymentCode: 'NOT_NULL',
@@ -528,7 +529,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     context('when all required fields are presents', function () {
       it('should return nothing', function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
+        const candidate = new Candidate(candidateData);
 
         // when
         const report = candidate.validateForMassSessionImport();
@@ -549,7 +550,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     ].forEach(({ field, expectedCode }) => {
       it(`should return a report when field ${field} is not present`, async function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
+        const candidate = new Candidate(candidateData);
         delete candidate[field];
 
         // when
@@ -561,7 +562,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
       it(`should return a report when field ${field} is null`, async function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate = new Candidate({
           ...candidateData,
           [field]: null,
         });
@@ -576,7 +577,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should return a report when birthdate is not a valid format', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         birthdate: '2020/02/01',
       });
@@ -590,7 +591,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should return a report when birthdate is null', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         birthdate: null,
       });
@@ -605,7 +606,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     context('when extraTimePercentage field is presents', function () {
       it('should return a report when field extraTimePercentage is not a number', async function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate = new Candidate({
           ...candidateData,
           extraTimePercentage: 'salut',
         });
@@ -619,7 +620,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
       it('should throw an error when field extraTimePercentage is greater than 10', async function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate = new Candidate({
           ...candidateData,
           extraTimePercentage: 11,
         });
@@ -634,7 +635,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should return a report when sex is neither M nor F', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         sex: 'something_else',
       });
@@ -648,7 +649,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should return a report when sex is null', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         sex: null,
       });
@@ -665,7 +666,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
         context('when the billing mode is null', function () {
           it('should return nothing', async function () {
             // given
-            const candidate = domainBuilder.certification.enrolment.buildCandidate({
+            const candidate = new Candidate({
               ...candidateData,
               billingMode: null,
             });
@@ -682,7 +683,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
         context('when the billing mode is not null', function () {
           it('should return a report', async function () {
             // given
-            const candidate = domainBuilder.certification.enrolment.buildCandidate({
+            const candidate = new Candidate({
               ...candidateData,
               billingMode: 'FREE',
             });
@@ -702,7 +703,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
           it('should return a report', async function () {
             // given
             const isSco = false;
-            const candidate = domainBuilder.certification.enrolment.buildCandidate({
+            const candidate = new Candidate({
               ...candidateData,
               billingMode: null,
             });
@@ -718,7 +719,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
         context('when the billing mode is not an expected value', function () {
           it('should return a report', async function () {
             // given
-            const candidate = domainBuilder.certification.enrolment.buildCandidate({
+            const candidate = new Candidate({
               ...candidateData,
               billingMode: 'NOT_ALLOWED_VALUE',
             });
@@ -736,7 +737,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
           ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
             it(`should return nothing for ${billingMode}`, async function () {
               // given
-              const candidate = domainBuilder.certification.enrolment.buildCandidate({
+              const candidate = new Candidate({
                 ...candidateData,
                 billingMode,
               });
@@ -755,7 +756,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
           context('when prepaymentCode is not null', function () {
             it('should return a report', async function () {
               // given
-              const candidate = domainBuilder.certification.enrolment.buildCandidate({
+              const candidate = new Candidate({
                 ...candidateData,
                 billingMode: 'PAID',
                 prepaymentCode: 'NOT_NULL',
@@ -775,7 +776,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
         context('when billingMode is PREPAID', function () {
           it('should return nothing if prepaymentCode is not null', function () {
             // given
-            const candidate = domainBuilder.certification.enrolment.buildCandidate({
+            const candidate = new Candidate({
               ...candidateData,
               billingMode: 'PREPAID',
               prepaymentCode: 'NOT_NULL',
@@ -790,7 +791,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
           it('should return report if prepaymentCode is null', function () {
             // given
-            const candidate = domainBuilder.certification.enrolment.buildCandidate({
+            const candidate = new Candidate({
               ...candidateData,
               billingMode: 'PREPAID',
               prepaymentCode: '',
@@ -809,7 +810,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     context('when there are multiple errors', function () {
       it('should return multiple message', function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate = new Candidate({
           ...candidateData,
           billingMode: 'FREE',
         });
@@ -841,15 +842,15 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     it('should return false when candidate is not reconciled', function () {
       // given
       const notReconciledCandidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
+        new Candidate({
           userId: null,
           reconciledAt: null,
         }),
-        domainBuilder.certification.enrolment.buildCandidate({
+        new Candidate({
           userId: 123,
           reconciledAt: null,
         }),
-        domainBuilder.certification.enrolment.buildCandidate({
+        new Candidate({
           userId: null,
           reconciledAt: new Date(),
         }),
@@ -865,7 +866,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
     it('should return true when candidate is reconciled', function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         userId: 123,
         reconciledAt: new Date(),
       });
@@ -882,7 +883,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     it('should return true when candidate is reconciled to given userId', function () {
       // given
       const userId = 123;
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         userId,
         reconciledAt: new Date(),
       });
@@ -898,15 +899,15 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       // given
       const userId = 123;
       const notReconciledToUser123 = [
-        domainBuilder.certification.enrolment.buildCandidate({
+        new Candidate({
           userId: 456,
           reconciledAt: new Date(),
         }),
-        domainBuilder.certification.enrolment.buildCandidate({
+        new Candidate({
           userId,
           reconciledAt: null,
         }),
-        domainBuilder.certification.enrolment.buildCandidate({
+        new Candidate({
           userId: null,
           reconciledAt: new Date(),
         }),
@@ -923,7 +924,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     it('should return false when candidate is not reconciled to anyone', function () {
       // given
       const userId = 123;
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         userId: null,
       });
 
@@ -938,7 +939,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
   describe('convertExtraTimePercentageToDecimal', function () {
     it('should convert extraTimePercentageToDecimal integer to decimal', function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         ...candidateData,
         extraTimePercentage: 20,
       });
@@ -953,63 +954,63 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
   describe('hasCoreFrameworkSubscription', function () {
     it('should return false when subscription is not CORE', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
+      const candidate = new Candidate({ subscription: Frameworks.CLEA });
       expect(candidate.hasCoreFrameworkSubscription()).to.be.false;
     });
 
     it('should return true when subscription is CORE', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CORE });
+      const candidate = new Candidate({ subscription: Frameworks.CORE });
       expect(candidate.hasCoreFrameworkSubscription()).to.be.true;
     });
   });
 
   describe('hasCoreScopeSubscription', function () {
     it('should return false when subscription is not CORE or CLEA', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.DROIT });
+      const candidate = new Candidate({ subscription: Frameworks.DROIT });
       expect(candidate.hasCoreScopeSubscription()).to.be.false;
     });
 
     it('should return true when subscription is CORE', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CORE });
+      const candidate = new Candidate({ subscription: Frameworks.CORE });
       expect(candidate.hasCoreScopeSubscription()).to.be.true;
     });
     it('should return true when subscription is CLEA', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
+      const candidate = new Candidate({ subscription: Frameworks.CLEA });
       expect(candidate.hasCoreScopeSubscription()).to.be.true;
     });
   });
 
   describe('#isRegisteredToDoubleCertification', function () {
     it('returns true when candidate subscription is CLEA', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CLEA });
+      const candidate = new Candidate({ subscription: Frameworks.CLEA });
       expect(candidate.isRegisteredToDoubleCertification()).to.be.true;
     });
 
     it('returns false when candidate subscription is not CLEA', function () {
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.DROIT });
+      const candidate = new Candidate({ subscription: Frameworks.DROIT });
       expect(candidate.isRegisteredToDoubleCertification()).to.be.false;
     });
   });
 
   describe('#static sortByLastNameAndFirstName', function () {
     it('sorts candidates alphabetically by last name then first name', function () {
-      const michelJacques = domainBuilder.certification.enrolment.buildCandidate({
+      const michelJacques = new Candidate({
         firstName: 'Michel',
         lastName: 'Jacques',
       });
-      const jeannetteJacques = domainBuilder.certification.enrolment.buildCandidate({
+      const jeannetteJacques = new Candidate({
         firstName: 'Jeanette',
         lastName: 'Jacques',
       });
-      const fredericMercure = domainBuilder.certification.enrolment.buildCandidate({
+      const fredericMercure = new Candidate({
         firstName: 'Frédéric',
         lastName: 'Mercure',
       });
-      const francoisMercure = domainBuilder.certification.enrolment.buildCandidate({
+      const francoisMercure = new Candidate({
         firstName: 'François',
         lastName: 'Mercure',
       });
-      const fridaMercure = domainBuilder.certification.enrolment.buildCandidate({
+      const fridaMercure = new Candidate({
         firstName: 'Frida',
         lastName: 'Mercure',
       });

--- a/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
@@ -191,16 +191,22 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Un',
-          lastName: 'Related',
-          birthdate: '1995-04-04',
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'un prénom très proche de frederic',
-          lastName: `un nom tres proche de debussy`,
-          birthdate: '1990-01-04',
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Un',
+            lastName: 'Related',
+            birthdate: '1995-04-04',
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'un prénom très proche de frederic',
+            lastName: `un nom tres proche de debussy`,
+            birthdate: '1990-01-04',
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub();
       normalizeStringFnc.withArgs(candidatePersonalInfo.lastName).returns(candidatePersonalInfo.lastName);
@@ -230,16 +236,22 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Un',
-          lastName: 'Related',
-          birthdate: '1995-04-04',
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Richard',
-          lastName: candidatePersonalInfo.lastName,
-          birthdate: candidatePersonalInfo.birthdate,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Un',
+            lastName: 'Related',
+            birthdate: '1995-04-04',
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Richard',
+            lastName: candidatePersonalInfo.lastName,
+            birthdate: candidatePersonalInfo.birthdate,
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub((str) => str);
 
@@ -263,16 +275,22 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Un',
-          lastName: 'Related',
-          birthdate: '1995-04-04',
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: candidatePersonalInfo.firstName,
-          lastName: 'Chopin',
-          birthdate: candidatePersonalInfo.birthdate,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Un',
+            lastName: 'Related',
+            birthdate: '1995-04-04',
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: candidatePersonalInfo.firstName,
+            lastName: 'Chopin',
+            birthdate: candidatePersonalInfo.birthdate,
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub((str) => str);
 
@@ -296,16 +314,22 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Un',
-          lastName: 'Related',
-          birthdate: '1995-04-04',
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: candidatePersonalInfo.firstName,
-          lastName: candidatePersonalInfo.lastName,
-          birthdate: '1990-01-05',
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Un',
+            lastName: 'Related',
+            birthdate: '1995-04-04',
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: candidatePersonalInfo.firstName,
+            lastName: candidatePersonalInfo.lastName,
+            birthdate: '1990-01-05',
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub((str) => str);
 
@@ -326,13 +350,14 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       // given
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: null,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: 123,
-          reconciledAt: new Date('2024-09-25'),
-        }),
+        domainBuilder.certification.enrolment.candidateBuilder().build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId: 123,
+            reconciledAt: new Date('2024-09-25'),
+          })
+          .build(),
       ];
 
       // when
@@ -348,12 +373,8 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       // given
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: null,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: null,
-        }),
+        domainBuilder.certification.enrolment.candidateBuilder().build(),
+        domainBuilder.certification.enrolment.candidateBuilder().build(),
       ];
 
       // when
@@ -372,17 +393,21 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       const userId = 123;
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: null,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: 123,
-          reconciledAt: new Date('2024-09-25'),
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: 456,
-          reconciledAt: new Date('2024-09-25'),
-        }),
+        domainBuilder.certification.enrolment.candidateBuilder().build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId: 123,
+            reconciledAt: new Date('2024-09-25'),
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId: 456,
+            reconciledAt: new Date('2024-09-25'),
+          })
+          .build(),
       ];
 
       // when
@@ -400,12 +425,13 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       const userId = 123;
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: null,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          userId: 456,
-        }),
+        domainBuilder.certification.enrolment.candidateBuilder().build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId: 456,
+          })
+          .build(),
       ];
 
       // when
@@ -479,18 +505,28 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          id: 123,
-          firstName: 'Un',
-          lastName: 'Related',
-          birthdate: '1995-04-04',
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          id: 456,
-          firstName: 'un prénom très proche de frederic',
-          lastName: `un nom tres proche de debussy`,
-          birthdate: '1990-01-04',
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Un',
+            lastName: 'Related',
+            birthdate: '1995-04-04',
+          })
+          .withParameters({
+            id: 123,
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'un prénom très proche de frederic',
+            lastName: `un nom tres proche de debussy`,
+            birthdate: '1990-01-04',
+          })
+          .withParameters({
+            id: 456,
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub();
       normalizeStringFnc.withArgs(candidatePersonalInfo.lastName).returns(candidatePersonalInfo.lastName);
@@ -520,16 +556,22 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Un',
-          lastName: 'Related',
-          birthdate: '1995-04-04',
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Richard',
-          lastName: candidatePersonalInfo.lastName,
-          birthdate: candidatePersonalInfo.birthdate,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Un',
+            lastName: 'Related',
+            birthdate: '1995-04-04',
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Richard',
+            lastName: candidatePersonalInfo.lastName,
+            birthdate: candidatePersonalInfo.birthdate,
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub((str) => str);
 
@@ -553,16 +595,22 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Un',
-          lastName: 'Related',
-          birthdate: '1995-04-04',
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: candidatePersonalInfo.firstName,
-          lastName: 'Chopin',
-          birthdate: candidatePersonalInfo.birthdate,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Un',
+            lastName: 'Related',
+            birthdate: '1995-04-04',
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: candidatePersonalInfo.firstName,
+            lastName: 'Chopin',
+            birthdate: candidatePersonalInfo.birthdate,
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub((str) => str);
 
@@ -586,16 +634,22 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Un',
-          lastName: 'Related',
-          birthdate: '1995-04-04',
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: candidatePersonalInfo.firstName,
-          lastName: candidatePersonalInfo.lastName,
-          birthdate: '1990-01-05',
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Un',
+            lastName: 'Related',
+            birthdate: '1995-04-04',
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: candidatePersonalInfo.firstName,
+            lastName: candidatePersonalInfo.lastName,
+            birthdate: '1990-01-05',
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub((str) => str);
 
@@ -619,18 +673,28 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       };
       const session = domainBuilder.certification.enrolment.buildSession();
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          id: 123,
-          firstName: candidatePersonalInfo.firstName,
-          lastName: candidatePersonalInfo.lastName,
-          birthdate: candidatePersonalInfo.birthdate,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          id: 456,
-          firstName: candidatePersonalInfo.firstName,
-          lastName: candidatePersonalInfo.lastName,
-          birthdate: candidatePersonalInfo.birthdate,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: candidatePersonalInfo.firstName,
+            lastName: candidatePersonalInfo.lastName,
+            birthdate: candidatePersonalInfo.birthdate,
+          })
+          .withParameters({
+            id: 123,
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: candidatePersonalInfo.firstName,
+            lastName: candidatePersonalInfo.lastName,
+            birthdate: candidatePersonalInfo.birthdate,
+          })
+          .withParameters({
+            id: 456,
+          })
+          .build(),
       ];
       const normalizeStringFnc = sinon.stub((str) => str);
 

--- a/api/tests/certification/enrolment/unit/domain/services/reconcile-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/reconcile-candidate_test.js
@@ -37,10 +37,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | reconcile-candid
 
   it('should link user', async function () {
     // given
-    const candidate = domainBuilder.certification.enrolment.buildCandidate({
-      userId: null,
-      reconciledAt: null,
-    });
+    const candidate = domainBuilder.certification.enrolment.candidateBuilder().build();
 
     candidateRepository.update.withArgs(candidate).resolves();
 

--- a/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
@@ -973,21 +973,26 @@ function _buildValidCandidateData({ lineNumber = 0, candidateNumber = 2 } = { ca
 }
 
 function _buildValidCandidateModel({ lineNumber = 0, candidateNumber = 2 } = { candidateNumber: 0, lineNumber: 0 }) {
-  return domainBuilder.certification.enrolment.buildCandidate({
-    lastName: `Candidat ${candidateNumber}`,
-    firstName: `Candidat ${candidateNumber}`,
-    birthdate: '1981-03-12',
-    sex: 'M',
-    birthINSEECode: '134',
-    birthPostalCode: null, //'3456',
-    birthCity: '',
-    birthCountry: 'France',
-    resultRecipientEmail: 'robindahood@email.fr',
-    email: 'robindahood2@email.fr',
-    externalId: 'htehte',
-    extraTimePercentage: 20,
-    billingMode: 'PAID',
-    line: lineNumber,
-    subscription: Frameworks.CORE,
-  });
+  return domainBuilder.certification.enrolment
+    .candidateBuilder()
+    .withIdentity({
+      lastName: `Candidat ${candidateNumber}`,
+      firstName: `Candidat ${candidateNumber}`,
+      birthdate: '1981-03-12',
+    })
+    .withParameters({
+      sex: 'M',
+      birthINSEECode: '134',
+      birthPostalCode: null, //'3456',
+      birthCity: '',
+      birthCountry: 'France',
+      resultRecipientEmail: 'robindahood@email.fr',
+      email: 'robindahood2@email.fr',
+      externalId: 'htehte',
+      extraTimePercentage: 20,
+      billingMode: 'PAID',
+      line: lineNumber,
+      subscription: Frameworks.CORE,
+    })
+    .build();
 }

--- a/api/tests/certification/enrolment/unit/domain/services/verify-candidate-identity_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/verify-candidate-identity_test.js
@@ -62,12 +62,15 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
       id: sessionId,
       certificationCenterId,
     });
-    const matchingCandidate = domainBuilder.certification.enrolment.buildCandidate({
-      firstName,
-      lastName,
-      userId: null,
-      birthdate,
-    });
+    const matchingCandidate = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .withIdentity({
+        firstName,
+        lastName,
+        birthdate,
+      })
+      .withSubscription(Frameworks.CORE)
+      .build();
 
     userRepository.get.withArgs({ id: userId }).resolves(
       domainBuilder.certification.enrolment.buildUser({
@@ -85,11 +88,15 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
 
     candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
       matchingCandidate,
-      domainBuilder.certification.enrolment.buildCandidate({
-        firstName: 'Henri',
-        lastName: 'Quatre',
-        birthdate: '2005-05-01',
-      }),
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          firstName: 'Henri',
+          lastName: 'Quatre',
+          birthdate: '2005-05-01',
+        })
+        .withSubscription(Frameworks.CORE)
+        .build(),
     ]);
 
     // when
@@ -144,11 +151,14 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
         }),
       );
       candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Henri',
-          lastName: 'Quatre',
-          birthdate: '2005-05-01',
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Henri',
+            lastName: 'Quatre',
+            birthdate: '2005-05-01',
+          })
+          .build(),
       ]);
 
       // when
@@ -178,18 +188,22 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
         }),
       );
       candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName,
-          lastName,
-          userId: null,
-          birthdate,
-        }),
-        domainBuilder.certification.enrolment.buildCandidate({
-          firstName,
-          lastName,
-          userId: null,
-          birthdate,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName,
+            lastName,
+            birthdate,
+          })
+          .build(),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName,
+            lastName,
+            birthdate,
+          })
+          .build(),
       ]);
 
       // when
@@ -226,21 +240,29 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
           }),
         );
 
-        const matchingCandidateAlreadyLinkedToAnotherUserId = domainBuilder.certification.enrolment.buildCandidate({
-          firstName,
-          lastName,
-          userId: userId + 10,
-          reconciledAt: new Date('2024-09-25'),
-          birthdate,
-        });
+        const matchingCandidateAlreadyLinkedToAnotherUserId = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId: userId + 10,
+            reconciledAt: new Date('2024-09-25'),
+          })
+          .withIdentity({
+            firstName,
+            lastName,
+            birthdate,
+          })
+          .build();
 
         candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
           matchingCandidateAlreadyLinkedToAnotherUserId,
-          domainBuilder.certification.enrolment.buildCandidate({
-            firstName: 'Henri',
-            lastName: 'Quatre',
-            birthdate: '2005-05-01',
-          }),
+          domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withIdentity({
+              firstName: 'Henri',
+              lastName: 'Quatre',
+              birthdate: '2005-05-01',
+            })
+            .build(),
         ]);
 
         // when
@@ -275,21 +297,29 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
           }),
         );
 
-        const matchingCandidateAlreadyLinked = domainBuilder.certification.enrolment.buildCandidate({
-          firstName,
-          lastName,
-          userId,
-          reconciledAt: new Date('2024-09-25'),
-          birthdate,
-        });
+        const matchingCandidateAlreadyLinked = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId,
+            reconciledAt: new Date('2024-09-25'),
+          })
+          .withIdentity({
+            firstName,
+            lastName,
+            birthdate,
+          })
+          .build();
 
         candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
           matchingCandidateAlreadyLinked,
-          domainBuilder.certification.enrolment.buildCandidate({
-            firstName: 'Henri',
-            lastName: 'Quatre',
-            birthdate: '2005-05-01',
-          }),
+          domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withIdentity({
+              firstName: 'Henri',
+              lastName: 'Quatre',
+              birthdate: '2005-05-01',
+            })
+            .build(),
         ]);
 
         // when
@@ -324,21 +354,28 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
           }),
         );
 
-        const anotherCandidateWithGivenUserId = domainBuilder.certification.enrolment.buildCandidate({
-          firstName: 'Louis',
-          lastName: 'Michel',
-          userId,
-          reconciledAt: new Date('2024-09-25'),
-          birthdate: '2005-05-01',
-        });
+        const anotherCandidateWithGivenUserId = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId,
+            reconciledAt: new Date('2024-09-25'),
+          })
+          .withIdentity({
+            firstName: 'Louis',
+            lastName: 'Michel',
+            birthdate: '2005-05-01',
+          })
+          .build();
 
         candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
-          domainBuilder.certification.enrolment.buildCandidate({
-            firstName,
-            lastName,
-            userId: null,
-            birthdate,
-          }),
+          domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withIdentity({
+              firstName,
+              lastName,
+              birthdate,
+            })
+            .build(),
           anotherCandidateWithGivenUserId,
         ]);
 
@@ -380,13 +417,15 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
               }),
             );
             candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
-              domainBuilder.certification.enrolment.buildCandidate({
-                firstName,
-                lastName,
-                userId: null,
-                birthdate,
-                subscription: Frameworks.DROIT,
-              }),
+              domainBuilder.certification.enrolment
+                .candidateBuilder()
+                .withSubscription(Frameworks.DROIT)
+                .withIdentity({
+                  firstName,
+                  lastName,
+                  birthdate,
+                })
+                .build(),
             ]);
 
             // when
@@ -403,13 +442,15 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
         context('when the certification center is habilitated for the subscription', function () {
           it('should return the candidate', async function () {
             // given
-            const matchingCandidate = domainBuilder.certification.enrolment.buildCandidate({
-              firstName,
-              lastName,
-              userId: null,
-              birthdate,
-              subscription: Frameworks.DROIT,
-            });
+            const matchingCandidate = domainBuilder.certification.enrolment
+              .candidateBuilder()
+              .withSubscription(Frameworks.DROIT)
+              .withIdentity({
+                firstName,
+                lastName,
+                birthdate,
+              })
+              .build();
             userRepository.get.withArgs({ id: userId }).resolves(
               domainBuilder.certification.enrolment.buildUser({
                 id: userId,
@@ -475,18 +516,26 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
             );
 
             candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
-              domainBuilder.certification.enrolment.buildCandidate({
-                firstName,
-                lastName,
-                userId: null,
-                birthdate,
-                organizationLearnerId: 789,
-              }),
-              domainBuilder.certification.enrolment.buildCandidate({
-                firstName: 'Henri',
-                lastName: 'Quatre',
-                birthdate: '2005-05-01',
-              }),
+              domainBuilder.certification.enrolment
+                .candidateBuilder()
+                .withIdentity({
+                  firstName,
+                  lastName,
+                  birthdate,
+                })
+                .asScoCandidate({ organizationLearnerId: 789 })
+                .withSubscription(Frameworks.CORE)
+                .build(),
+              domainBuilder.certification.enrolment
+                .candidateBuilder()
+                .withIdentity({
+                  firstName: 'Henri',
+                  lastName: 'Quatre',
+                  birthdate: '2005-05-01',
+                })
+                .withSubscription(Frameworks.CORE)
+                .asScoCandidate({ organizationLearnerId: 123 })
+                .build(),
             ]);
 
             // when

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { addCandidateToSession } from '../../../../../../src/certification/enrolment/domain/usecases/add-candidate-to-session.js';
 import { BILLING_MODES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
@@ -82,7 +83,10 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
   context('when session cannot accept any candidate', function () {
     it('should throw a CertificationCandidateOnFinalizedSessionError', async function () {
       // given
-      candidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({ sessionId });
+      candidateToEnroll = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({ sessionId })
+        .build();
       sessionRepository.get.withArgs({ id: sessionId }).resolves(
         domainBuilder.certification.enrolment.buildSession({
           finalizedAt: new Date(),
@@ -119,9 +123,12 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
     context('when candidate is not valid', function () {
       it('should throw a CertificationCandidatesError', async function () {
         // given
-        candidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
-          email: 'toto@toto.fr;tutu@tutu.fr',
-        });
+        candidateToEnroll = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({
+            email: 'toto@toto.fr;tutu@tutu.fr',
+          })
+          .build();
 
         // when
         const error = await catchErr(addCandidateToSession)({
@@ -146,28 +153,38 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
 
     context('when candidate is valid', function () {
       beforeEach(function () {
-        candidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
-          billingMode: BILLING_MODES.FREE,
-        });
+        candidateToEnroll = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({
+            billingMode: BILLING_MODES.FREE,
+          })
+          .build();
       });
 
       context('when a candidate with the same personal info already enrolled in session', function () {
-        const personalInfo = {
-          firstName: 'Les',
-          lastName: 'Fruits',
-          birthdate: '1990-01-04',
-        };
-
         it('should throw an CertificationCandidateByPersonalInfoTooManyMatchesError', async function () {
           // given
-          candidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidateToEnroll,
-            ...personalInfo,
-          });
-          candidateRepository.findBySessionId
-            .withArgs({ sessionId })
-            .resolves([domainBuilder.certification.enrolment.buildCandidate({ ...personalInfo })]);
-
+          candidateToEnroll = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withIdentity({
+              firstName: 'Les',
+              lastName: 'Fruits',
+              birthdate: '1990-01-04',
+            })
+            .withParameters({
+              ...candidateToEnroll,
+            })
+            .build();
+          candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
+            domainBuilder.certification.enrolment
+              .candidateBuilder()
+              .withIdentity({
+                firstName: 'Les',
+                lastName: 'Fruits',
+                birthdate: '1990-01-04',
+              })
+              .build(),
+          ]);
           // when
           const error = await catchErr(addCandidateToSession)({
             sessionId,
@@ -186,7 +203,12 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
         beforeEach(function () {
           candidateRepository.findBySessionId
             .withArgs({ sessionId })
-            .resolves([domainBuilder.certification.enrolment.buildCandidate({ firstName: 'Tout autre chose' })]);
+            .resolves([
+              domainBuilder.certification.enrolment
+                .candidateBuilder()
+                .withIdentity({ firstName: 'Tout autre chose' })
+                .build(),
+            ]);
         });
 
         context('when birth information validation fails', function () {
@@ -233,11 +255,14 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
             context('when candidate convocation email is not valid', function () {
               it('should throw a CertificationCandidatesError', async function () {
                 // given
-                candidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
-                  ...candidateToEnroll,
-                  email: 'jesuisunemail@incorrect.fr',
-                  resultRecipientEmail: 'jesuisunemail@correct.fr',
-                });
+                candidateToEnroll = domainBuilder.certification.enrolment
+                  .candidateBuilder()
+                  .withParameters({
+                    ...candidateToEnroll,
+                    email: 'jesuisunemail@incorrect.fr',
+                    resultRecipientEmail: 'jesuisunemail@correct.fr',
+                  })
+                  .build();
                 mailCheck.assertEmailDomainHasMx.withArgs('jesuisunemail@incorrect.fr').throws();
                 mailCheck.assertEmailDomainHasMx.withArgs('jesuisunemail@correct.fr').resolves();
 
@@ -262,11 +287,14 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
             context('when candidate recipient email is not valid', function () {
               it('should throw a CertificationCandidatesError', async function () {
                 // given
-                candidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
-                  ...candidateToEnroll,
-                  email: 'jesuisunemail@correct.fr',
-                  resultRecipientEmail: 'jesuisunemail@incorrect.fr',
-                });
+                candidateToEnroll = domainBuilder.certification.enrolment
+                  .candidateBuilder()
+                  .withParameters({
+                    ...candidateToEnroll,
+                    email: 'jesuisunemail@correct.fr',
+                    resultRecipientEmail: 'jesuisunemail@incorrect.fr',
+                  })
+                  .build();
                 mailCheck.assertEmailDomainHasMx.withArgs('jesuisunemail@incorrect.fr').throws();
                 mailCheck.assertEmailDomainHasMx.withArgs('jesuisunemail@correct.fr').resolves();
 
@@ -297,7 +325,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
 
             it('should insert the candidate and return the ID', async function () {
               // given
-              const correctedCandidateToEnroll = domainBuilder.certification.enrolment.buildCandidate({
+              const correctedCandidateToEnroll = new Candidate({
                 ...candidateToEnroll,
                 sessionId,
                 birthCountry: 'COUNTRY',

--- a/api/tests/certification/enrolment/unit/domain/usecases/candidate-has-seen-certification-instructions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/candidate-has-seen-certification-instructions_test.js
@@ -19,13 +19,25 @@ describe('Unit | UseCase | candidate-has-seen-certification-instructions', funct
   context('when the candidate is found', function () {
     it('should proceed to update candidate', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        id: 187,
-        createdAt: new Date('2020-01-01T00:00:00Z'),
-        hasSeenCertificationInstructions: false,
-      });
+      const candidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({
+          id: 187,
+          createdAt: new Date('2020-01-01T00:00:00Z'),
+          hasSeenCertificationInstructions: false,
+        })
+        .build();
+
+      const expectedCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({
+          id: 187,
+          createdAt: new Date('2020-01-01T00:00:00Z'),
+          hasSeenCertificationInstructions: true,
+        })
+        .build();
       candidateRepository.get.withArgs({ certificationCandidateId: 187 }).resolves(candidate);
-      candidateRepository.update.resolves();
+      candidateRepository.update.withArgs(expectedCandidate).resolves();
 
       // when
       const result = await candidateHasSeenCertificationInstructions({
@@ -34,12 +46,6 @@ describe('Unit | UseCase | candidate-has-seen-certification-instructions', funct
       });
 
       // then
-      const expectedCandidateUpdated = domainBuilder.certification.enrolment.buildCandidate({
-        id: 187,
-        createdAt: new Date('2020-01-01T00:00:00Z'),
-        hasSeenCertificationInstructions: true,
-      });
-      expect(candidateRepository.update).to.have.been.calledOnceWithExactly(expectedCandidateUpdated);
       expect(result.hasSeenCertificationInstructions).to.be.true;
     });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -16,7 +16,6 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
   let eventAdapter;
   let dependencies;
   let temporarySessionsStorageForMassImportService;
-  let candidateData;
 
   beforeEach(function () {
     centerRepository = { getById: sinon.stub() };
@@ -34,11 +33,6 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       sessionRepository,
       eventAdapter,
       temporarySessionsStorageForMassImportService,
-    };
-
-    candidateData = {
-      sessionId: undefined,
-      subscription: Frameworks.DROIT,
     };
   });
 
@@ -113,7 +107,10 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           // given
           const center = domainBuilder.certification.enrolment.buildCenter({ id: 567 });
           centerRepository.getById.withArgs({ id: center.id }).resolves(center);
-          const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
+          const candidate = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withSubscription(Frameworks.DROIT)
+            .build();
           const sessionCreatorId = 1234;
           const temporaryCachedSessions = [
             {
@@ -136,11 +133,14 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           const cachedValidatedSessionsKey = 'uuid';
           sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
           sessionRepository.save.resolves({ id: 1234 });
-          const savedCandidate = domainBuilder.certification.enrolment.buildCandidate({
-            ...candidate,
-            sessionId: 1234,
-            subscription: Frameworks.DROIT,
-          });
+          const savedCandidate = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withSubscription(Frameworks.DROIT)
+            .withParameters({
+              ...candidate,
+              sessionId: 1234,
+            })
+            .build();
           candidateRepository.save.resolves([savedCandidate]);
 
           // when
@@ -169,7 +169,10 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         // given
         const center = domainBuilder.certification.enrolment.buildCenter();
         centerRepository.getById.withArgs({ id: center.id }).resolves(center);
-        const candidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
+        const candidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withSubscription(Frameworks.DROIT)
+          .build();
         const temporaryCachedSessions = [
           {
             id: 1234,
@@ -180,11 +183,14 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         const sessionCreatorId = 1234;
         const cachedValidatedSessionsKey = 'uuid';
         sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
-        const savedCandidate = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidate,
-          sessionId: 1234,
-          subscription: Frameworks.DROIT,
-        });
+        const savedCandidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withSubscription(Frameworks.DROIT)
+          .withParameters({
+            ...candidate,
+            sessionId: 1234,
+          })
+          .build();
         candidateRepository.save.resolves([savedCandidate]);
 
         // when
@@ -212,7 +218,10 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       // given
       const center = domainBuilder.certification.enrolment.buildCenter();
       centerRepository.getById.withArgs({ id: center.id }).resolves(center);
-      const certificationCandidate = domainBuilder.certification.enrolment.buildCandidate(candidateData);
+      const certificationCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withSubscription(Frameworks.DROIT)
+        .build();
       const temporaryCachedSessions = [
         {
           id: 1234,

--- a/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
@@ -194,9 +194,12 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
       // given
       const studentIds = [michelStudentData.id, jeannetteStudentData.id];
       candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
-        domainBuilder.certification.enrolment.buildCandidate({
-          organizationLearnerId: 1,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asScoCandidate({
+            organizationLearnerId: 1,
+          })
+          .build(),
       ]);
       const jeanetteLearner = domainBuilder.buildOrganizationLearner({
         ...jeannetteStudentData,

--- a/api/tests/certification/enrolment/unit/domain/usecases/find-students-for-enrolment_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/find-students-for-enrolment_test.js
@@ -63,10 +63,15 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
         domainBuilder.buildOrganizationLearner({ id: iteration, organization }),
       );
       const candidates = [
-        domainBuilder.certification.enrolment.buildCandidate({
-          sessionId,
-          organizationLearnerId: enrolledStudent.id,
-        }),
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asScoCandidate({
+            organizationLearnerId: enrolledStudent.id,
+          })
+          .withParameters({
+            sessionId,
+          })
+          .build(),
       ];
       organizationLearnerRepository.findByOrganizationIdAndUpdatedAtOrderByDivision
         .withArgs({ page: { number: 1, size: 10 }, filter: { divisions: ['3A'] }, organizationId: organization.id })

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-import-sheet-data_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-import-sheet-data_test.js
@@ -33,16 +33,22 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate-import-shee
       certificationCandidates: [],
     });
     sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
-    const michelCandidate = domainBuilder.certification.enrolment.buildCandidate({
-      firstName: 'Michel',
-      lastName: 'Jacques',
-      subscription: Frameworks.CORE,
-    });
-    const jeannetteCandidate = domainBuilder.certification.enrolment.buildCandidate({
-      firstName: 'Jeannette',
-      lastName: 'Jacques',
-      subscription: Frameworks.CORE,
-    });
+    const michelCandidate = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .withSubscription(Frameworks.CORE)
+      .withIdentity({
+        firstName: 'Michel',
+        lastName: 'Jacques',
+      })
+      .build();
+    const jeannetteCandidate = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .withSubscription(Frameworks.CORE)
+      .withIdentity({
+        firstName: 'Jeannette',
+        lastName: 'Jacques',
+      })
+      .build();
     const enrolledCandidates = [michelCandidate, jeannetteCandidate];
     candidateRepository.findBySessionId.withArgs({ sessionId }).resolves(enrolledCandidates);
     const habilitation1 = domainBuilder.certification.enrolment.buildHabilitation({ label: 'Pix+Droit' });

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
@@ -63,7 +63,10 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
       // given
       const sessionId = 1234;
       const certificationCandidateId = 4567;
-      const candidate = domainBuilder.certification.enrolment.buildCandidate();
+      const candidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({ createdAt: new Date() })
+        .build();
       candidateRepository.get.resolves(candidate);
 
       // when
@@ -83,10 +86,11 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
       // given
       const sessionId = 1234;
       const certificationCandidateId = 4567;
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        userId: 222,
-        reconciledAt: new Date(),
-      });
+      const candidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled({ userId: 123 })
+        .withParameters({ createdAt: new Date() })
+        .build();
       candidateRepository.get.resolves(candidate);
       placementProfileService.getPlacementProfile.resolves(domainBuilder.buildPlacementProfile());
       eligibilityService.getUserCertificationEligibility.resolves(
@@ -109,10 +113,11 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
         // given
         const sessionId = 1234;
         const certificationCandidateId = 4567;
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
-          userId: 222,
-          reconciledAt: new Date(),
-        });
+        const candidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({ userId: 123 })
+          .withParameters({ createdAt: new Date() })
+          .build();
         candidateRepository.get.resolves(candidate);
         certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.resolves(null);
         const placementProfile = domainBuilder.buildPlacementProfile();
@@ -145,10 +150,11 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
         const sessionId = 1234;
         const certificationCandidateId = 4567;
         candidateRepository.get.resolves(
-          domainBuilder.certification.enrolment.buildCandidate({
-            userId: 222,
-            reconciledAt: new Date(),
-          }),
+          domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .asReconciled({ userId: 123 })
+            .withParameters({ createdAt: new Date() })
+            .build(),
         );
         const certifCourse = domainBuilder.buildCertificationCourse();
         const placementProfile = domainBuilder.buildPlacementProfile();
@@ -184,11 +190,12 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           // given
           const sessionId = 1234;
           const certificationCandidateId = 4567;
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            userId: 222,
-            reconciledAt: new Date(),
-            subscription: Frameworks.CLEA,
-          });
+          const candidate = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .asReconciled({ userId: 123 })
+            .withSubscription(Frameworks.CLEA)
+            .withParameters({ createdAt: new Date() })
+            .build();
           candidateRepository.get.resolves(candidate);
           const placementProfile = domainBuilder.buildPlacementProfile();
           placementProfileService.getPlacementProfile.resolves(placementProfile);
@@ -221,11 +228,12 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           // given
           const sessionId = 1234;
           const certificationCandidateId = 4567;
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            userId: 222,
-            reconciledAt: new Date(),
-            subscription: Frameworks.CLEA,
-          });
+          const candidate = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .asReconciled({ userId: 123 })
+            .withSubscription(Frameworks.CLEA)
+            .withParameters({ createdAt: new Date() })
+            .build();
           candidateRepository.get.resolves(candidate);
           const placementProfile = domainBuilder.buildPlacementProfile();
           placementProfileService.getPlacementProfile.resolves(placementProfile);
@@ -262,10 +270,11 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           // given
           const sessionId = 1234;
           const certificationCandidateId = 4567;
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            userId: 222,
-            reconciledAt: new Date(),
-          });
+          const candidate = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .asReconciled({ userId: 123 })
+            .withParameters({ createdAt: new Date() })
+            .build();
           candidateRepository.get.resolves(candidate);
           const placementProfile = domainBuilder.buildPlacementProfile();
           placementProfileService.getPlacementProfile.resolves(placementProfile);
@@ -301,10 +310,11 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           const sessionId = 1234;
           const certificationCandidateId = 4567;
           candidateRepository.get.resolves(
-            domainBuilder.certification.enrolment.buildCandidate({
-              userId: 222,
-              reconciledAt: new Date(),
-            }),
+            domainBuilder.certification.enrolment
+              .candidateBuilder()
+              .asReconciled({ userId: 123 })
+              .withParameters({ createdAt: new Date() })
+              .build(),
           );
           const certificationCourse = domainBuilder.buildCertificationCourse({
             lastAnswerAt: new Date('2024-04-21T13:56:00Z'),

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate_test.js
@@ -19,7 +19,11 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate', function 
 
   it('should return the candidate by id', async function () {
     // given
-    const candidate = domainBuilder.certification.enrolment.buildCandidate({ id: 1234, subscription: Frameworks.CORE });
+    const candidate = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .withSubscription(Frameworks.CORE)
+      .withParameters({ id: 1234 })
+      .build();
     candidateRepository.get.withArgs({ certificationCandidateId: 1234 }).resolves(candidate);
 
     // when
@@ -38,7 +42,10 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate', function 
   context('when the candidate is not registered to double certification', function () {
     it('should set doubleCertificationEligibility to false', async function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({ subscription: Frameworks.CORE });
+      const candidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withSubscription(Frameworks.CORE)
+        .build();
       candidateRepository.get.resolves(candidate);
 
       // when
@@ -59,12 +66,17 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate', function 
     context('when the center is not habilitated', function () {
       it('should set doubleCertificationEligibility to false', async function () {
         // given
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
-          subscription: Frameworks.CLEA,
-          userId: 456,
-          sessionId: 789,
-          reconciledAt: new Date(),
-        });
+        const candidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId: 456,
+            reconciledAt: new Date(),
+          })
+          .withSubscription(Frameworks.CLEA)
+          .withParameters({
+            sessionId: 789,
+          })
+          .build();
         const center = domainBuilder.certification.enrolment.buildCenter({ habilitations: [] });
         candidateRepository.get.resolves(candidate);
         certificationCenterRepository.getBySessionId.withArgs({ sessionId: 789 }).resolves(center);
@@ -88,12 +100,17 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate', function 
         it('should set doubleCertificationEligibility to false', async function () {
           // given
           const reconciledAt = new Date();
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            subscription: Frameworks.CLEA,
-            userId: 456,
-            sessionId: 789,
-            reconciledAt,
-          });
+          const candidate = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .asReconciled({
+              userId: 456,
+              reconciledAt,
+            })
+            .withSubscription(Frameworks.CLEA)
+            .withParameters({
+              sessionId: 789,
+            })
+            .build();
           const habilitation = domainBuilder.certification.shared.buildComplementaryCertification({
             key: Frameworks.CLEA,
           });
@@ -121,12 +138,17 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate', function 
         it('should set doubleCertificationEligibility to true', async function () {
           // given
           const reconciledAt = new Date();
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            subscription: Frameworks.CLEA,
-            userId: 456,
-            sessionId: 789,
-            reconciledAt,
-          });
+          const candidate = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .asReconciled({
+              userId: 456,
+              reconciledAt,
+            })
+            .withSubscription(Frameworks.CLEA)
+            .withParameters({
+              sessionId: 789,
+            })
+            .build();
           const habilitation = domainBuilder.certification.shared.buildComplementaryCertification({
             key: Frameworks.CLEA,
           });

--- a/api/tests/certification/enrolment/unit/domain/usecases/has-been-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/has-been-candidate_test.js
@@ -14,11 +14,16 @@ describe('Certification | Enrolment | Unit | UseCase | has-been-candidate', func
   context('when at least one candidate is reconciled', function () {
     it('should return true', async function () {
       // given
-      const candidate1 = domainBuilder.certification.enrolment.buildCandidate({
-        userId: 4321,
-        reconciledAt: new Date(),
-      });
-      const candidate2 = domainBuilder.certification.enrolment.buildCandidate({ userId: 4321 });
+      const candidate1 = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled({
+          userId: 4321,
+        })
+        .build();
+      const candidate2 = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled({ userId: 4321 })
+        .build();
 
       candidateRepository.findByUserId.withArgs({ userId: 4321 }).resolves([candidate1, candidate2]);
 
@@ -27,22 +32,6 @@ describe('Certification | Enrolment | Unit | UseCase | has-been-candidate', func
 
       // then
       expect(result).to.be.true;
-    });
-  });
-
-  context('when no candidates are reconciled', function () {
-    it('should return false', async function () {
-      // given
-      const candidate1 = domainBuilder.certification.enrolment.buildCandidate({ userId: 4321 });
-      const candidate2 = domainBuilder.certification.enrolment.buildCandidate({ userId: 4321 });
-
-      candidateRepository.findByUserId.withArgs({ userId: 4321 }).resolves([candidate1, candidate2]);
-
-      // when
-      const result = await hasBeenCandidate({ userId: 4321, candidateRepository });
-
-      // then
-      expect(result).to.be.false;
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -68,11 +68,12 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
         const session = domainBuilder.certification.enrolment.buildSession({ sessionId });
         const odsBuffer = 'buffer';
 
-        candidateRepository.findBySessionId
-          .withArgs({ sessionId })
-          .resolves([
-            domainBuilder.certification.enrolment.buildCandidate({ userId: 123, reconciledAt: new Date('2024-09-25') }),
-          ]);
+        candidateRepository.findBySessionId.withArgs({ sessionId }).resolves([
+          domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .asReconciled({ userId: 123, reconciledAt: new Date('2024-09-25') })
+            .build(),
+        ]);
         sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
 
         // when
@@ -101,7 +102,7 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
         });
         candidateRepository.findBySessionId
           .withArgs({ sessionId })
-          .resolves([domainBuilder.certification.enrolment.buildCandidate({ userId: null })]);
+          .resolves([domainBuilder.certification.enrolment.candidateBuilder().build()]);
         sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
       });
 
@@ -109,9 +110,10 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
         it('should add the certification candidates', async function () {
           // given
           const odsBuffer = 'buffer';
-          const candidate = domainBuilder.certification.enrolment.buildCandidate({
-            subscription: Frameworks.DROIT,
-          });
+          const candidate = domainBuilder.certification.enrolment
+            .candidateBuilder()
+            .withSubscription(Frameworks.DROIT)
+            .build();
           const candidates = [candidate];
 
           certificationCandidatesOdsService.extractCertificationCandidatesFromCandidatesImportSheet

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -20,11 +20,6 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
     eventAdapter,
     dependencies;
 
-  const candidateData = {
-    firstName: 'Brice',
-    lastName: 'Wine',
-    birthdate: new Date(),
-  };
   const sessionId = 456;
 
   beforeEach(function () {
@@ -65,19 +60,32 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
   context('when reconciliation is ok', function () {
     context('when the candidate is already link to a user', function () {
       it('should not link the candidate to the given user', async function () {
+        const birthdate = '2000-03-23';
         // given
         const userId = domainBuilder.buildUser().id;
-        const alreadyLinkedCandidate = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-          sessionId,
-          userId,
-          reconciledAt: new Date('2024-09-25'),
-        });
+        const alreadyLinkedCandidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId,
+            reconciledAt: new Date('2024-09-25'),
+          })
+          .withIdentity({
+            firstName: 'Brice',
+            lastName: 'Wine',
+            birthdate,
+          })
+          .withParameters({
+            sessionId,
+          })
+          .build();
+
         verifyCandidateIdentityService.verifyCandidateIdentity.resolves(alreadyLinkedCandidate);
 
         // when
         await registerCandidateParticipation({
-          ...candidateData,
+          firstName: 'Brice',
+          lastName: 'Wine',
+          birthdate,
           userId,
           sessionId,
           isFrenchDomainExtension: true,
@@ -86,9 +94,11 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
 
         // then
         sinon.assert.calledOnceWithExactly(verifyCandidateIdentityService.verifyCandidateIdentity, {
-          ...candidateData,
-          sessionId,
+          firstName: 'Brice',
+          lastName: 'Wine',
+          birthdate,
           userId,
+          sessionId,
           normalizeStringFnc,
           candidateRepository,
           centerRepository,
@@ -102,16 +112,26 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
       it('should throw WrongDomainExtensionForPixPlusError', async function () {
         // given
         const userId = domainBuilder.buildUser().id;
-        const candidateWithComplementary = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-          sessionId,
-          subscription: Frameworks.DROIT,
-        });
+        const candidateWithComplementary = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withSubscription(Frameworks.DROIT)
+          .withIdentity({
+            firstName: 'Brice',
+            lastName: 'Wine',
+            birthdate: new Date(),
+          })
+          .withParameters({
+            sessionId,
+          })
+          .build();
+
         verifyCandidateIdentityService.verifyCandidateIdentity.resolves(candidateWithComplementary);
 
         // when
         const error = await catchErr(registerCandidateParticipation)({
-          ...candidateData,
+          firstName: 'Brice',
+          lastName: 'Wine',
+          birthdate: new Date(),
           userId,
           sessionId,
           isFrenchDomainExtension: false,
@@ -132,9 +152,13 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
       beforeEach(function () {
         clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
         userId = domainBuilder.buildUser().id;
-        unlinkedCandidate = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData,
-        });
+        unlinkedCandidate = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Brice',
+            lastName: 'Wine',
+          })
+          .build();
       });
 
       afterEach(function () {
@@ -152,7 +176,9 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
 
           // when
           const err = await catchErr(registerCandidateParticipation)({
-            ...candidateData,
+            firstName: 'Brice',
+            lastName: 'Wine',
+            birthdate: new Date(),
             sessionId,
             userId,
             isFrenchDomainExtension: true,
@@ -162,7 +188,9 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
           // then
           expect(err).to.be.instanceOf(UserNotAuthorizedToCertifyError);
           sinon.assert.calledOnceWith(verifyCandidateIdentityService.verifyCandidateIdentity, {
-            ...candidateData,
+            firstName: 'Brice',
+            lastName: 'Wine',
+            birthdate: new Date(),
             userId,
             sessionId,
             normalizeStringFnc,
@@ -185,16 +213,20 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
 
         // when
         await registerCandidateParticipation({
-          ...candidateData,
-          sessionId,
+          firstName: 'Brice',
+          lastName: 'Wine',
+          birthdate: new Date(),
           userId,
+          sessionId,
           isFrenchDomainExtension: true,
           ...dependencies,
         });
 
         // then
         sinon.assert.calledOnceWith(verifyCandidateIdentityService.verifyCandidateIdentity, {
-          ...candidateData,
+          firstName: 'Brice',
+          lastName: 'Wine',
+          birthdate: new Date(),
           userId,
           sessionId,
           normalizeStringFnc,

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
@@ -32,11 +32,13 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
   context('when the  candidate is found and not linked to a user', function () {
     it('should call update method with correct data', async function () {
       // given
-      const foundCandidate = domainBuilder.certification.enrolment.buildCandidate({
-        userId: null,
-        accessibilityAdjustmentNeeded: false,
-        createdAt,
-      });
+      const foundCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({
+          accessibilityAdjustmentNeeded: false,
+          createdAt,
+        })
+        .build();
       candidateRepository.get.withArgs({ certificationCandidateId: editedCandidate.id }).resolves(foundCandidate);
       candidateRepository.update.resolves();
 
@@ -47,10 +49,13 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
       });
 
       // then
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...foundCandidate,
-        accessibilityAdjustmentNeeded: editedCandidate.accessibilityAdjustmentNeeded,
-      });
+      const candidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({
+          ...foundCandidate,
+          accessibilityAdjustmentNeeded: editedCandidate.accessibilityAdjustmentNeeded,
+        })
+        .build();
 
       expect(candidateRepository.update).to.have.been.calledOnceWithExactly(candidate);
     });
@@ -75,12 +80,17 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
   context('when the candidate is reconciled', function () {
     it('should call update method with correct data', async function () {
       // given
-      const foundCandidate = domainBuilder.certification.enrolment.buildCandidate({
-        id: editedCandidate.id,
-        accessibilityAdjustmentNeeded: false,
-        userId: 123,
-        reconciledAt: new Date('2024-09-25'),
-      });
+      const foundCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled({
+          userId: 123,
+          reconciledAt: new Date('2024-09-25'),
+        })
+        .withParameters({
+          id: editedCandidate.id,
+          accessibilityAdjustmentNeeded: false,
+        })
+        .build();
       candidateRepository.get.withArgs({ certificationCandidateId: editedCandidate.id }).resolves(foundCandidate);
 
       // when

--- a/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
 import { SessionMassImportReport } from '../../../../../../src/certification/enrolment/domain/models/SessionMassImportReport.js';
 import { validateSessions } from '../../../../../../src/certification/enrolment/domain/usecases/validate-sessions.js';
 import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
@@ -126,23 +125,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
   context('when sessions and candidates are valid', function () {
     it('return a sessions report', async function () {
       // given
-      const candidate1 = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData1,
-        id: null,
-        createdAt: null,
-        userId: null,
-        reconciledAt: null,
-        billingMode: BILLING_MODES.FREE,
-      });
       const session1 = { ...firstSession, candidates: [candidateData1] };
-      const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
-        ...candidateData2,
-        id: null,
-        createdAt: null,
-        userId: null,
-        reconciledAt: null,
-        billingMode: BILLING_MODES.FREE,
-      });
       const session2 = { ...secondSession, candidates: [candidateData2] };
 
       sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
@@ -155,7 +138,14 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         cpfBirthInformation,
       });
 
-      temporarySessionsStorageForMassImportService.save.resolves(cachedValidatedSessionsKey);
+      temporarySessionsStorageForMassImportService = {
+        save: () => '',
+      };
+      sinon.replace(
+        temporarySessionsStorageForMassImportService,
+        'save',
+        sinon.fake.returns(cachedValidatedSessionsKey),
+      );
 
       sessionsImportValidationService.getUniqueCandidates.withArgs([candidateData1]).returns({
         uniqueCandidates: [candidateData1],
@@ -165,25 +155,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         uniqueCandidates: [candidateData2],
         duplicateCandidateErrors: [],
       });
-
-      const [expectedSession1, expectedSession2] = [
-        domainBuilder.certification.enrolment.buildSession({
-          ...firstSession,
-          certificationCenterId,
-          certificationCenter: certificationCenterName,
-          certificationCenterType: certificationCenterType,
-          accessCode,
-          certificationCandidates: [candidate1],
-        }),
-        domainBuilder.certification.enrolment.buildSession({
-          ...secondSession,
-          certificationCenterId,
-          certificationCenter: certificationCenterName,
-          certificationCenterType: certificationCenterType,
-          accessCode,
-          certificationCandidates: [candidate2],
-        }),
-      ];
 
       // when
       const sessionsMassImportReport = await validateSessions({
@@ -198,24 +169,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       });
 
       // then
-      expect(temporarySessionsStorageForMassImportService.save).to.have.been.calledWith({
-        sessions: [
-          sinon.match({
-            ...expectedSession1,
-            certificationCandidates: [candidate1],
-            createdBy: undefined,
-            invigilatorPassword: sinon.match.string,
-          }),
-          sinon.match({
-            ...expectedSession2,
-            certificationCandidates: [candidate2],
-            createdBy: undefined,
-            invigilatorPassword: sinon.match.string,
-          }),
-        ],
-        userId,
-      });
-
       expect(sessionsMassImportReport).to.deep.equal({
         cachedValidatedSessionsKey,
         sessionsCount: 2,
@@ -228,32 +181,35 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when there is only sessionId and candidate information', function () {
       it('should validate the candidates in the session', async function () {
         // given
-        const candidate1 = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData1,
-          id: null,
-          createdAt: null,
-          userId: null,
-          reconciledAt: null,
-          billingMode: BILLING_MODES.FREE,
-        });
+        const candidate1 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({
+            ...candidateData1,
+            id: null,
+            createdAt: null,
+            billingMode: BILLING_MODES.FREE,
+          })
+          .build();
         const session1 = { ...firstSession, candidates: [candidateData1] };
-        const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData2,
-          id: null,
-          createdAt: null,
-          userId: null,
-          reconciledAt: null,
-          billingMode: BILLING_MODES.FREE,
-        });
+        const candidate2 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({
+            ...candidateData2,
+            id: null,
+            createdAt: null,
+            billingMode: BILLING_MODES.FREE,
+          })
+          .build();
         const candidateData3 = { ...candidateData2, lastName: 'Brun', firstName: 'Petit Ours' };
-        const candidate3 = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData3,
-          id: null,
-          createdAt: null,
-          userId: null,
-          reconciledAt: null,
-          billingMode: BILLING_MODES.FREE,
-        });
+        const candidate3 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({
+            ...candidateData3,
+            id: null,
+            createdAt: null,
+            billingMode: BILLING_MODES.FREE,
+          })
+          .build();
         const session2 = { sessionId: 2, candidates: [candidateData2, candidateData3] };
 
         sessionsImportValidationService.getUniqueCandidates.withArgs([candidateData1]).returns({
@@ -284,7 +240,14 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           subscription: Frameworks.CORE,
         });
 
-        temporarySessionsStorageForMassImportService.save.resolves(cachedValidatedSessionsKey);
+        temporarySessionsStorageForMassImportService = {
+          save: () => '',
+        };
+        sinon.replace(
+          temporarySessionsStorageForMassImportService,
+          'save',
+          sinon.fake.returns(cachedValidatedSessionsKey),
+        );
 
         // when
         const sessionsMassImportReport = await validateSessions({
@@ -300,44 +263,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         });
 
         // then
-        const [expectedSession1, expectedSession2] = [
-          new SessionEnrolment({
-            ...session1,
-            id: 1,
-            certificationCenterId,
-            certificationCenter: certificationCenterName,
-            certificationCenterType: certificationCenterType,
-            accessCode,
-            certificationCandidates: [candidate1],
-          }),
-          new SessionEnrolment({
-            ...session2,
-            id: 2,
-            certificationCenterId,
-            certificationCenter: certificationCenterName,
-            certificationCenterType: certificationCenterType,
-            accessCode,
-            certificationCandidates: [candidate2, candidate3],
-          }),
-        ];
-
-        expect(temporarySessionsStorageForMassImportService.save).to.have.been.calledWith({
-          sessions: [
-            sinon.match({
-              ...expectedSession1,
-              certificationCandidates: [candidate1],
-              createdBy: undefined,
-              invigilatorPassword: sinon.match.string,
-            }),
-            sinon.match({
-              ...expectedSession2,
-              certificationCandidates: [candidate2, candidate3],
-              createdBy: undefined,
-              invigilatorPassword: sinon.match.string,
-            }),
-          ],
-          userId,
-        });
 
         expect(sessionsMassImportReport).to.deep.equal({
           cachedValidatedSessionsKey,
@@ -429,20 +354,24 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when there is at least one duplicate candidate in a session', function () {
       it('should remove duplicate certification candidates from the session', async function () {
         // given
-        const candidate1 = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData1,
-          id: null,
-          createdAt: null,
-          userId: null,
-          billingMode: BILLING_MODES.FREE,
-        });
-        const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
-          ...candidateData2,
-          id: null,
-          createdAt: null,
-          userId: null,
-          billingMode: BILLING_MODES.FREE,
-        });
+        const candidate1 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({
+            ...candidateData1,
+            id: null,
+            createdAt: null,
+            billingMode: BILLING_MODES.FREE,
+          })
+          .build();
+        const candidate2 = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withParameters({
+            ...candidateData2,
+            id: null,
+            createdAt: null,
+            billingMode: BILLING_MODES.FREE,
+          })
+          .build();
         const sessionsData = [
           {
             ...firstSession,

--- a/api/tests/certification/enrolment/unit/infrastructure/adapters/event-adapter_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/adapters/event-adapter_test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import * as eventAdapter from '../../../../../../src/certification/enrolment/infrastructure/adapters/event-adapter.js';
 import { EVENT_NAMES } from '../../../../../../src/certification/shared/domain/constants/event-names.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -13,56 +14,76 @@ describe('Certification | Enrolment | Unit | Adapter | event', function () {
       pushEvents: sinon.stub(),
     };
     eventApi.pushEvents.resolves();
-    candidateA = domainBuilder.certification.enrolment.buildCandidate({
-      id: 123,
-      firstName: 'firstName A',
-      lastName: 'lastName A',
-      birthCity: 'birthCity A',
-      birthProvinceCode: 'birthProvinceCode A',
-      birthCountry: 'birthCountry A',
-      birthPostalCode: 'birthPostalCode A',
-      birthINSEECode: 'birthINSEECode A',
-      sex: 'sex A',
-      email: 'email A',
-      resultRecipientEmail: 'resultRecipientEmail A',
-      externalId: 'externalId A',
-      birthdate: 'birthdate A',
-      extraTimePercentage: 1,
-      createdAt: 'createdAt A',
-      sessionId: 'sessionId A',
-      userId: 'userId A',
-      organizationLearnerId: 'organizationLearnerId A',
-      billingMode: 'billingMode A',
-      prepaymentCode: 'prepaymentCode A',
-      subscription: 'subscription A',
-      accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded A',
-      reconciledAt: 'reconciledAt A',
-    });
-    candidateB = domainBuilder.certification.enrolment.buildCandidate({
-      id: 456,
-      firstName: 'firstName B',
-      lastName: 'lastName B',
-      birthCity: 'birthCity B',
-      birthProvinceCode: 'birthProvinceCode B',
-      birthCountry: 'birthCountry B',
-      birthPostalCode: 'birthPostalCode B',
-      birthINSEECode: 'birthINSEECode B',
-      sex: 'sex B',
-      email: 'email B',
-      resultRecipientEmail: 'resultRecipientEmail B',
-      externalId: 'externalId B',
-      birthdate: 'birthdate B',
-      extraTimePercentage: 2,
-      createdAt: 'createdAt B',
-      sessionId: 'sessionId B',
-      userId: 'userId B',
-      organizationLearnerId: 'organizationLearnerId B',
-      billingMode: 'billingMode B',
-      prepaymentCode: 'prepaymentCode B',
-      subscription: 'subscription B',
-      accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded B',
-      reconciledAt: 'reconciledAt B',
-    });
+    candidateA = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .asReconciled({
+        userId: 'userId A',
+        reconciledAt: 'reconciledAt A',
+      })
+      .asScoCandidate({
+        organizationLearnerId: 'organizationLearnerId A',
+      })
+      .withSubscription(Frameworks.CORE)
+      .withIdentity({
+        firstName: 'firstName A',
+        lastName: 'lastName A',
+        birthdate: 'birthdate A',
+      })
+      .withParameters({
+        id: 123,
+        birthCity: 'birthCity A',
+        birthProvinceCode: 'birthProvinceCode A',
+        birthCountry: 'birthCountry A',
+        birthPostalCode: 'birthPostalCode A',
+        birthINSEECode: 'birthINSEECode A',
+        sex: 'sex A',
+        email: 'email A',
+        resultRecipientEmail: 'resultRecipientEmail A',
+        externalId: 'externalId A',
+        extraTimePercentage: 1,
+        createdAt: 'createdAt A',
+        authorizedToStart: 'authorizedToStart A',
+        sessionId: 'sessionId A',
+        billingMode: 'billingMode A',
+        prepaymentCode: 'prepaymentCode A',
+        accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded A',
+      })
+      .build();
+    candidateB = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .asReconciled({
+        userId: 'userId B',
+        reconciledAt: 'reconciledAt B',
+      })
+      .asScoCandidate({
+        organizationLearnerId: 'organizationLearnerId B',
+      })
+      .withSubscription(Frameworks.CORE)
+      .withIdentity({
+        firstName: 'firstName B',
+        lastName: 'lastName B',
+        birthdate: 'birthdate B',
+      })
+      .withParameters({
+        id: 456,
+        birthCity: 'birthCity B',
+        birthProvinceCode: 'birthProvinceCode B',
+        birthCountry: 'birthCountry B',
+        birthPostalCode: 'birthPostalCode B',
+        birthINSEECode: 'birthINSEECode B',
+        sex: 'sex B',
+        email: 'email B',
+        resultRecipientEmail: 'resultRecipientEmail B',
+        externalId: 'externalId B',
+        extraTimePercentage: 2,
+        createdAt: 'createdAt B',
+        authorizedToStart: 'authorizedToStart B',
+        sessionId: 'sessionId B',
+        billingMode: 'billingMode B',
+        prepaymentCode: 'prepaymentCode B',
+        accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded B',
+      })
+      .build();
     dependencies = {
       eventApi,
     };
@@ -94,12 +115,12 @@ describe('Certification | Enrolment | Unit | Adapter | event', function () {
             extraTimePercentage: 1,
             createdAt: 'createdAt A',
             sessionId: 'sessionId A',
-            userId: 'userId A',
             organizationLearnerId: 'organizationLearnerId A',
             billingMode: 'billingMode A',
             prepaymentCode: 'prepaymentCode A',
-            subscription: 'subscription A',
+            subscription: 'CORE',
             accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded A',
+            userId: 'userId A',
             reconciledAt: 'reconciledAt A',
           },
         },
@@ -137,7 +158,7 @@ describe('Certification | Enrolment | Unit | Adapter | event', function () {
             organizationLearnerId: 'organizationLearnerId A',
             billingMode: 'billingMode A',
             prepaymentCode: 'prepaymentCode A',
-            subscription: 'subscription A',
+            subscription: 'CORE',
             accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded A',
             reconciledAt: 'reconciledAt A',
           },
@@ -167,7 +188,7 @@ describe('Certification | Enrolment | Unit | Adapter | event', function () {
             organizationLearnerId: 'organizationLearnerId B',
             billingMode: 'billingMode B',
             prepaymentCode: 'prepaymentCode B',
-            subscription: 'subscription B',
+            subscription: 'CORE',
             accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded B',
             reconciledAt: 'reconciledAt B',
           },
@@ -209,7 +230,7 @@ describe('Certification | Enrolment | Unit | Adapter | event', function () {
             organizationLearnerId: 'organizationLearnerId A',
             billingMode: 'billingMode A',
             prepaymentCode: 'prepaymentCode A',
-            subscription: 'subscription A',
+            subscription: 'CORE',
             accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded A',
             reconciledAt: 'reconciledAt A',
           },
@@ -239,7 +260,7 @@ describe('Certification | Enrolment | Unit | Adapter | event', function () {
             organizationLearnerId: 'organizationLearnerId B',
             billingMode: 'billingMode B',
             prepaymentCode: 'prepaymentCode B',
-            subscription: 'subscription B',
+            subscription: 'CORE',
             accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded B',
             reconciledAt: 'reconciledAt B',
           },
@@ -278,7 +299,7 @@ describe('Certification | Enrolment | Unit | Adapter | event', function () {
             organizationLearnerId: 'organizationLearnerId A',
             billingMode: 'billingMode A',
             prepaymentCode: 'prepaymentCode A',
-            subscription: 'subscription A',
+            subscription: 'CORE',
             accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded A',
             reconciledAt: 'reconciledAt A',
           },
@@ -308,7 +329,7 @@ describe('Certification | Enrolment | Unit | Adapter | event', function () {
             organizationLearnerId: 'organizationLearnerId B',
             billingMode: 'billingMode B',
             prepaymentCode: 'prepaymentCode B',
-            subscription: 'subscription B',
+            subscription: 'CORE',
             accessibilityAdjustmentNeeded: 'accessibilityAdjustmentNeeded B',
             reconciledAt: 'reconciledAt B',
           },

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
@@ -1,3 +1,4 @@
+import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { candidateSerializer } from '../../../../../../src/certification/enrolment/infrastructure/serializers/candidate-serializer.js';
 import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
@@ -91,9 +92,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
       const deserializedCandidate = await candidateSerializer.deserialize(candidateJsonApiData);
 
       // then
-      expect(deserializedCandidate).to.deepEqualInstance(
-        domainBuilder.certification.enrolment.buildCandidate({ ...candidateData }),
-      );
+      expect(deserializedCandidate).to.deepEqualInstance(new Candidate({ ...candidateData }));
     });
 
     it('should deserialize correctly candidate with legacy subscriptions array format', async function () {
@@ -129,7 +128,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
   describe('#serializeForParticipation()', function () {
     it('should convert a EnrolledCandidate model object into JSON API data', function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         id: 123,
         firstName: 'Michel',
         lastName: 'Jacques',
@@ -180,7 +179,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
   describe('#serialize()', function () {
     it('should convert a Candidate model object without subscriptions into JSON API data', function () {
       // given
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate = new Candidate({
         id: 123,
         firstName: 'Michel',
         lastName: 'Jacques',
@@ -243,29 +242,34 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
   describe('#serializeForSession()', function () {
     it('should convert a Candidate model object with subscriptions into JSON API data', function () {
       // given
-      const sessionCandidate = domainBuilder.certification.enrolment.buildCandidate({
-        id: 123,
-        firstName: 'Michel',
-        lastName: 'Jacques',
-        sex: 'M',
-        birthPostalCode: 'somePostalCode1',
-        birthINSEECode: 'someInseeCode1',
-        birthCity: 'someBirthCity1',
-        birthProvinceCode: 'someProvinceCode1',
-        birthCountry: 'someBirthCountry1',
-        email: 'michel.jacques@example.net',
-        resultRecipientEmail: 'jeanette.jacques@example.net',
-        externalId: 'MICHELJACQUES',
-        birthdate: '1990-01-01',
-        extraTimePercentage: null,
-        userId: 159,
-        organizationLearnerId: null,
-        billingMode: BILLING_MODES.PAID,
-        prepaymentCode: 'somePrepaymentCode1',
-        hasSeenCertificationInstructions: true,
-        subscription: Frameworks.DROIT,
-        accessibilityAdjustmentNeeded: true,
-      });
+      const sessionCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({
+          firstName: 'Michel',
+          lastName: 'Jacques',
+          birthdate: '1990-01-01',
+        })
+        .asReconciled({
+          userId: 159,
+        })
+        .withSubscription(Frameworks.DROIT)
+        .withParameters({
+          id: 123,
+          sex: 'M',
+          birthPostalCode: 'somePostalCode1',
+          birthINSEECode: 'someInseeCode1',
+          birthCity: 'someBirthCity1',
+          birthProvinceCode: 'someProvinceCode1',
+          birthCountry: 'someBirthCountry1',
+          email: 'michel.jacques@example.net',
+          resultRecipientEmail: 'jeanette.jacques@example.net',
+          externalId: 'MICHELJACQUES',
+          billingMode: BILLING_MODES.PAID,
+          prepaymentCode: 'somePrepaymentCode1',
+          hasSeenCertificationInstructions: true,
+          accessibilityAdjustmentNeeded: true,
+        })
+        .build();
       const expectedJsonApiData = {
         data: {
           type: 'certification-candidates',

--- a/api/tests/certification/evaluation/integration/domain/services/scoring/score-complementary-certification-v2_test.js
+++ b/api/tests/certification/evaluation/integration/domain/services/scoring/score-complementary-certification-v2_test.js
@@ -14,6 +14,7 @@ import { AnswerStatus } from '../../../../../../../src/shared/domain/models/Answ
 import * as assessmentResultRepository from '../../../../../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Certification | Evaluation | Integration | Domain | Services | Score Complementary Certification', function () {
   afterEach(async function () {
@@ -327,11 +328,12 @@ function _buildComplementaryCertificationCourse({
 }) {
   databaseBuilder.factory.buildUser({ id: userId });
   const sessionId = databaseBuilder.factory.buildSession().id;
-  const { id: certificationCandidateId } = databaseBuilder.factory.buildCertificationCandidate({
-    userId,
-    sessionId,
-    subscription: complementaryCertificationKey,
-  });
+  const { id: certificationCandidateId } = domainBuilder.certification.enrolment
+    .candidateBuilder()
+    .asReconciled({ userId })
+    .withSubscription(complementaryCertificationKey)
+    .withParameters({ sessionId })
+    .insertToDB({ databaseBuilder });
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationCourseId,
     userId,

--- a/api/tests/certification/evaluation/integration/domain/usecases/complete-certification-assessment_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/complete-certification-assessment_test.js
@@ -17,7 +17,12 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | complete
 
   beforeEach(async function () {
     clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
+    const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'A',
+      lastName: 'B',
+      birthdate: '01/01/1999',
+    });
+
     certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
       abortReason: 'candidate',
       maxReachableLevelOnCertificationDate: 6,

--- a/api/tests/certification/evaluation/integration/domain/usecases/evaluate-and-save-answer_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/evaluate-and-save-answer_test.js
@@ -51,7 +51,12 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
     context('when user submitting the answer is not the owner of the certification test', function () {
       it('throws a ForbiddenAccess error', async function () {
         userId = databaseBuilder.factory.buildUser().id;
-        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({ userId });
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+          firstName: 'A',
+          lastName: 'B',
+          birthdate: '01/01/1999',
+          userId,
+        });
         certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
           userId,
           candidateId: certificationCandidate.id,
@@ -79,7 +84,12 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
 
       context('when certification test has been ended by the invigilator', function () {
         it('throws a CertificationEndedByInvigilatorError error', async function () {
-          const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({ userId });
+          const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+            firstName: 'a',
+            lastName: 'b',
+            birthdate: '01/01/1998',
+            userId,
+          });
           certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
             userId,
             candidateId: certificationCandidate.id,
@@ -103,7 +113,12 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
 
       context('when certification test has been ended by session finalization', function () {
         it('throws a CertificationEndedByFinalizationError error', async function () {
-          const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({ userId });
+          const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+            firstName: 'a',
+            lastName: 'b',
+            birthdate: '01/01/1996',
+            userId,
+          });
           certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
             userId,
             candidateId: certificationCandidate.id,
@@ -128,7 +143,13 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
       context('when certification test has been started for more than 24 hours', function () {
         it('ends the assessment due to duration exceeded and throws a CertificationDurationExceededError error', async function () {
           const sessionId = databaseBuilder.factory.buildSession().id;
-          const candidateId = databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId }).id;
+          const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+            firstName: 'a',
+            lastName: 't',
+            birthdate: '01/01/2000',
+            userId,
+            sessionId,
+          }).id;
           certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
             userId,
             candidateId,
@@ -162,10 +183,16 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
         beforeEach(function () {
           const sessionId = databaseBuilder.factory.buildSession().id;
           const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+            firstName: 'a',
+            lastName: 'b',
+            birthdate: '01/01/1999',
             userId,
             sessionId,
           }).id;
           certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            firstName: 'a',
+            lastName: 'b',
+            birthdate: '01/01/1999',
             userId,
             candidateId,
             sessionId,

--- a/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
@@ -190,6 +190,9 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
       });
 
       const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Jean',
+        lastName: 'Peuplus',
+        birthdate: '04/23/2000',
         sessionId: session.id,
         userId: certifiableUserId,
       }).id;
@@ -392,6 +395,9 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
       });
 
       const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Jean',
+        lastName: 'Peuplus',
+        birthdate: '04/23/2000',
         sessionId: session.id,
         userId: certifiableUserId,
         subscription: eduCertificationVersion.scope,
@@ -482,6 +488,9 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
         });
 
         const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+          firstName: 'Jean',
+          lastName: 'Peuplus',
+          birthdate: '04/23/2000',
           sessionId: session.id,
           userId: certifiableUserId,
           subscription: droitCertificationVersion.scope,
@@ -564,6 +573,9 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
       });
 
       const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Jean',
+        lastName: 'Peuplus',
+        birthdate: '04/23/2000',
         sessionId: session.id,
         userId: certifiableUserId,
       }).id;

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
@@ -18,6 +18,9 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
       .insertToDB({ databaseBuilder }).id;
     const session = databaseBuilder.factory.buildSession();
     const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+      firstName: 'a',
+      lastName: 'b',
+      birthdate: '01/01/2000',
       sessionId: session.id,
       userId,
       accessibilityAdjustmentNeeded: true,

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/candidate-repository_test.js
@@ -18,6 +18,13 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
           const candidate = databaseBuilder.factory.buildCertificationCandidate({
             lastName: 'Joplin',
             firstName: 'Janis',
+            birthdate: '2000-01-01',
+            externalId: 'foo externalId',
+            sex: 'F',
+            subscription: Frameworks.CORE,
+            birthCity: 'Perpignan',
+            birthCountry: 'France',
+            birthPostalCode: '66000',
             sessionId: session.id,
             userId: user.id,
             reconciledAt: new Date('2024-10-17'),
@@ -58,6 +65,12 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
           const candidate = databaseBuilder.factory.buildCertificationCandidate({
             lastName: 'Hendrix',
             firstName: 'Jimi',
+            birthCity: 'Perpignan',
+            birthCountry: 'France',
+            birthPostalCode: '66000',
+            birthdate: '2000-01-01',
+            externalId: 'foo externalId',
+            sex: 'F',
             sessionId: session.id,
             userId: user.id,
             reconciledAt: new Date('2024-10-17'),
@@ -100,6 +113,13 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
             lastName: 'Hendrix',
             firstName: 'Jimi',
             sessionId: session.id,
+            birthCity: 'Perpignan',
+            birthCountry: 'France',
+            birthPostalCode: '66000',
+            birthdate: '1995-01-01',
+            externalId: 'foo externalId',
+            sex: 'F',
+
             userId: user.id,
             reconciledAt: new Date('2024-10-17'),
             subscription: Frameworks.DROIT,
@@ -141,6 +161,7 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
         databaseBuilder.factory.buildCertificationCandidate({
           lastName: 'Joplin',
           firstName: 'Janis',
+          birthdate: '04/02/2000',
           sessionId: session.id,
           userId: user.id,
           reconciledAt: new Date('2024-10-10'),
@@ -176,6 +197,7 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
           databaseBuilder.factory.buildCertificationCandidate({
             lastName: 'Joplin',
             firstName: 'Janis',
+            birthdate: '01/02/1996',
             sessionId: otherSession.id,
             userId: user.id,
             reconciledAt: new Date('2024-10-01'),
@@ -190,6 +212,13 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
           const candidate = databaseBuilder.factory.buildCertificationCandidate({
             lastName: 'Joplin',
             firstName: 'Janis',
+            birthdate: '1996-01-02',
+            birthCity: 'Perpignan',
+            birthCountry: 'France',
+            birthPostalCode: '66000',
+            externalId: 'foo externalId',
+            sex: 'F',
+            subscription: 'CORE',
             sessionId: session.id,
             userId: user.id,
             reconciledAt: new Date('2024-10-18'),
@@ -231,6 +260,14 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
         const session = databaseBuilder.factory.buildSession();
         const user = databaseBuilder.factory.buildUser();
         const candidate = databaseBuilder.factory.buildCertificationCandidate({
+          birthdate: '1996-01-02',
+          firstName: 'a',
+          lastName: 'b',
+          birthCity: 'Perpignan',
+          birthCountry: 'France',
+          birthPostalCode: '66000',
+          externalId: 'foo externalId',
+          sex: 'F',
           sessionId: session.id,
           userId: user.id,
           reconciledAt: new Date('2024-10-17'),
@@ -261,6 +298,9 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
         const session = databaseBuilder.factory.buildSession();
         const user = databaseBuilder.factory.buildUser();
         databaseBuilder.factory.buildCertificationCandidate({
+          birthdate: '01/02/1996',
+          firstName: 'a',
+          lastName: 'b',
           sessionId: session.id,
           userId: user.id,
           reconciledAt: new Date('2024-10-17'),

--- a/api/tests/certification/results/acceptance/application/organization-route_test.js
+++ b/api/tests/certification/results/acceptance/application/organization-route_test.js
@@ -4,6 +4,7 @@ import { AssessmentResult } from '../../../../../src/shared/domain/models/Assess
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Certification | Results | Acceptance | Application | Routes | organization', function () {
@@ -32,10 +33,16 @@ describe('Certification | Results | Acceptance | Application | Routes | organiza
         organizationId: organization.id,
         division: 'aDivision',
       });
-      const candidate = databaseBuilder.factory.buildCertificationCandidate({
-        organizationLearnerId: organizationLearner.id,
-        sessionId,
-      });
+      const candidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled({ userId: user.id })
+        .asScoCandidate({
+          organizationLearnerId: organizationLearner.id,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         id: 20484096,
         userId: candidate.userId,
@@ -54,10 +61,15 @@ describe('Certification | Results | Acceptance | Application | Routes | organiza
         organizationId: organization.id,
         division: 'aDivision',
       });
-      const candidateDidNotComeToTheSession = databaseBuilder.factory.buildCertificationCandidate({
-        organizationLearnerId: organizationLearnerDidNotComeToTheSession.id,
-        sessionId,
-      });
+      const candidateDidNotComeToTheSession = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asScoCandidate({
+          organizationLearnerId: organizationLearnerDidNotComeToTheSession.id,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
       databaseBuilder.factory.buildCertificationCourse({
         sessionId: candidateDidNotComeToTheSession.sessionId,
         isPublished: true,

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -1376,11 +1376,18 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           certificationAttestationDataRejected,
           AssessmentResult.status.REJECTED,
         );
-        databaseBuilder.factory.buildCertificationCandidate({
-          userId: 456,
-          sessionId: certificationAttestationDataRejected.sessionId,
-          organizationLearnerId: 55,
-        });
+        domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled({
+            userId: 456,
+          })
+          .asScoCandidate({
+            organizationLearnerId: 55,
+          })
+          .withParameters({
+            sessionId: certificationAttestationDataRejected.sessionId,
+          })
+          .insertToDB({ databaseBuilder });
 
         await databaseBuilder.commit();
 
@@ -2864,11 +2871,20 @@ function _linkCertificationAttestationToOrganization({
       division,
       isDisabled,
     }).id;
-  databaseBuilder.factory.buildCertificationCandidate({
-    userId: certificationAttestationData.userId,
-    sessionId: certificationAttestationData.sessionId,
-    organizationLearnerId: srId,
-  });
+  domainBuilder.certification.enrolment
+    .candidateBuilder()
+    .asReconciled({
+      userId: certificationAttestationData.userId,
+    })
+    .asScoCandidate({
+      organizationLearnerId: srId,
+    })
+    .withParameters({
+      sessionId: certificationAttestationData.sessionId,
+    })
+    .insertToDB({
+      databaseBuilder,
+    });
 }
 
 async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({

--- a/api/tests/certification/results/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -2,6 +2,7 @@ import { status } from '../../../../../../src/certification/results/domain/read-
 import * as certificationLsRepository from '../../../../../../src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import {
   buildCancelledCertificationData,
   buildCertificationDataWithNoCompetenceMarks,
@@ -126,11 +127,18 @@ describe('Integration | Repository | Certification-livret-scolaire ', function (
         certificationCenter,
       });
 
-      databaseBuilder.factory.buildCertificationCandidate({
-        sessionId: session.id,
-        organizationLearnerId: organizationLearner.id,
-        userId: user.id,
-      });
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asScoCandidate({
+          organizationLearnerId: organizationLearner.id,
+        })
+        .asReconciled({
+          userId: user.id,
+        })
+        .withParameters({
+          sessionId: session.id,
+        })
+        .insertToDB({ databaseBuilder });
 
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         userId: user.id,

--- a/api/tests/certification/results/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -607,25 +607,42 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
         assessmentResultId: assessmentResultId1,
       });
       const certificationCandidateId1 = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Paul',
+        lastName: 'Truc',
+        birthdate: '01/01/2000',
         userId: userId1,
         sessionId,
       }).id;
 
       const certificationCandidateId2 = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Solène',
+        lastName: 'Truc',
+        birthdate: '01/01/2000',
         userId: userId2,
         sessionId,
       }).id;
 
       const certificationCandidateId3 = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Marion',
+        lastName: 'Truc',
+        birthdate: '01/01/2000',
         userId: userId3,
         sessionId,
       }).id;
 
       const certificationCandidateIdNotInSession = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Anouk',
+        lastName: 'Truc',
+        birthdate: '01/01/2000',
         userId: userId3,
       }).id;
 
-      const certificationCandidateIdNoResult = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
+      const certificationCandidateIdNoResult = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Anaïs',
+        lastName: 'Truc',
+        birthdate: '01/01/2000',
+        sessionId,
+      }).id;
 
       await databaseBuilder.commit();
 
@@ -749,7 +766,13 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
         competenceId: 'recComp23',
         assessmentResultId,
       });
-      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId }).id;
+      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Marjolaine',
+        lastName: 'Feu',
+        birthdate: '03/04/2000',
+        userId,
+        sessionId,
+      }).id;
       await databaseBuilder.commit();
 
       // when
@@ -795,7 +818,13 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
         acquired: true,
         source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
       });
-      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId }).id;
+      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Charlotte',
+        lastName: 'Bal',
+        birthdate: '01/02/2000',
+        userId,
+        sessionId,
+      }).id;
       await databaseBuilder.commit();
 
       // when
@@ -835,6 +864,9 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
         assessmentResultId,
       }).id;
       const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({
+        firstName: 'Luc',
+        lastName: 'Pou',
+        birthdate: '06/05/1997',
         sessionId,
         userId,
       }).id;

--- a/api/tests/certification/results/integration/infrastructure/repositories/clea-certified-candidate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/clea-certified-candidate-repository_test.js
@@ -11,6 +11,9 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
         const sessionId = databaseBuilder.factory.buildSession().id;
         const userId = databaseBuilder.factory.buildUser({}).id;
         databaseBuilder.factory.buildCertificationCandidate({
+          firstName: 'Odile',
+          lastName: 'Cerise',
+          birthdate: '10/08/1998',
           userId,
           sessionId,
           resultRecipientEmail: 'jean-mi@coco.fr',
@@ -18,6 +21,9 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
 
         const userId2 = databaseBuilder.factory.buildUser({}).id;
         databaseBuilder.factory.buildCertificationCandidate({
+          firstName: 'Caroline',
+          lastName: 'Solar',
+          birthdate: '05/08/1993',
           userId: userId2,
           sessionId,
           resultRecipientEmail: 'marie-mi@coco.fr',
@@ -123,6 +129,9 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
           const sessionId = databaseBuilder.factory.buildSession().id;
           const userId = databaseBuilder.factory.buildUser().id;
           databaseBuilder.factory.buildCertificationCandidate({
+            firstName: 'Jean-Mi',
+            lastName: 'Coco',
+            birthdate: '2001-02-07',
             userId,
             sessionId,
             resultRecipientEmail: 'jean-mi@coco.fr',

--- a/api/tests/certification/results/integration/infrastructure/repositories/result-recipient-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/result-recipient-repository_test.js
@@ -8,18 +8,30 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
     it('should return candidate ids matching sessionId and resultRecipientEmail (case insensitive)', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
-      const candidate1 = databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        resultRecipientEmail: 'recipient@example.net',
-      });
-      const candidate2 = databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        resultRecipientEmail: 'RECIPIENT@example.net',
-      });
-      databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        resultRecipientEmail: 'other@example.net',
-      });
+      const candidate1 = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({
+          sessionId,
+          resultRecipientEmail: 'recipient@example.net',
+        })
+        .insertToDB({ databaseBuilder });
+
+      const candidate2 = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({
+          sessionId,
+          resultRecipientEmail: 'RECIPIENT@example.net',
+        })
+        .insertToDB({ databaseBuilder });
+
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({
+          sessionId,
+          resultRecipientEmail: 'other@example.net',
+        })
+        .insertToDB({ databaseBuilder });
+
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/certification/results/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -1,6 +1,7 @@
 import * as scoCertificationCandidateRepository from '../../../../../../src/certification/results/infrastructure/repositories/sco-certification-candidate-repository.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Certification | Course | Integration | Repository | SCOCertificationCandidate', function () {
   describe('#findIdsByOrganizationIdAndDivision', function () {
@@ -14,11 +15,20 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
         organizationId: anOrganizationId,
         division: '3ème A',
       }).id;
-      const candidate = databaseBuilder.factory.buildCertificationCandidate({
-        userId,
-        sessionId,
-        organizationLearnerId,
-      });
+      const candidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled({
+          userId,
+        })
+        .asScoCandidate({
+          organizationLearnerId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({
+          databaseBuilder,
+        });
       databaseBuilder.factory.buildCertificationCourse({
         sessionId,
         lastName: candidate.lastName,
@@ -48,10 +58,17 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
         division: '3ème A',
         isDisabled: false,
       }).id;
-      const nonDisabledCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        organizationLearnerId: nonDisabledOrganizationLearnerId,
-      });
+      const nonDisabledCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .asScoCandidate({
+          organizationLearnerId: nonDisabledOrganizationLearnerId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
+
       databaseBuilder.factory.buildCertificationCourse({
         sessionId,
         lastName: nonDisabledCandidate.lastName,
@@ -66,10 +83,17 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
         division: '3ème A',
         isDisabled: true,
       }).id;
-      const disabledCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        organizationLearnerId: disabledOrganizationLearnerId,
-      });
+
+      const disabledCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asScoCandidate({
+          organizationLearnerId: disabledOrganizationLearnerId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
+
       databaseBuilder.factory.buildCertificationCourse({
         sessionId,
         lastName: disabledCandidate.lastName,
@@ -102,10 +126,17 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
         organizationId: anOrganizationId,
         division: '3ème B',
       }).id;
-      const candidateFromTheGivenDivision = databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        organizationLearnerId: aOrganizationLearnerId,
-      });
+      const candidateFromTheGivenDivision = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .asScoCandidate({
+          organizationLearnerId: aOrganizationLearnerId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
+
       databaseBuilder.factory.buildCertificationCourse({
         sessionId,
         lastName: candidateFromTheGivenDivision.lastName,
@@ -115,10 +146,16 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
         pixCertificationStatus: 'validated',
       });
 
-      const candidateFromAnotherDivision = databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        organizationLearnerId: anotherOrganizationLearnerId,
-      });
+      const candidateFromAnotherDivision = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .asScoCandidate({
+          organizationLearnerId: anotherOrganizationLearnerId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
       databaseBuilder.factory.buildCertificationCourse({
         sessionId,
         lastName: candidateFromAnotherDivision.lastName,
@@ -157,26 +194,50 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
         division: '3ème A',
       }).id;
 
-      const thirdInAlphabeticOrderCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        lastName: 'Zen',
-        firstName: 'Bob',
-        sessionId,
-        organizationLearnerId: aOrganizationLearnerId,
-      });
+      const thirdInAlphabeticOrderCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .withIdentity({
+          lastName: 'Zen',
+          firstName: 'Bob',
+        })
+        .asScoCandidate({
+          organizationLearnerId: aOrganizationLearnerId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
 
-      const firstInAlphabeticOrderCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        firstName: 'Smith',
-        lastName: 'Aaron',
-        sessionId,
-        organizationLearnerId: yetAnotherOrganizationLearnerId,
-      });
+      const firstInAlphabeticOrderCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .withIdentity({
+          firstName: 'Smith',
+          lastName: 'Aaron',
+        })
+        .asScoCandidate({
+          organizationLearnerId: yetAnotherOrganizationLearnerId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
 
-      const secondInAlphabeticOrderCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        firstName: 'Smith',
-        lastName: 'Ben',
-        sessionId,
-        organizationLearnerId: anotherOrganizationLearnerId,
-      });
+      const secondInAlphabeticOrderCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .withIdentity({
+          firstName: 'Smith',
+          lastName: 'Ben',
+        })
+        .asScoCandidate({
+          organizationLearnerId: anotherOrganizationLearnerId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder });
 
       databaseBuilder.factory.buildCertificationCourse({
         sessionId,
@@ -223,25 +284,43 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
       // given
       const division = '3ème A';
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const candidate = {
-        firstName: 'Smith',
-        lastName: 'Aaron',
-        organizationLearnerId: databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organizationId,
-          division,
-        }).id,
-      };
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organizationId,
+        division,
+      }).id;
       const sessionIdOne = databaseBuilder.factory.buildSession({ publishedAt: '2024-02-01' }).id;
       const sessionIdTwo = databaseBuilder.factory.buildSession({ publishedAt: '2024-01-01' }).id;
       // This candidate has no related certification-course
-      databaseBuilder.factory.buildCertificationCandidate({
-        ...candidate,
-        sessionId: sessionIdOne,
-      });
-      const candidateThatEnteredTheSession = databaseBuilder.factory.buildCertificationCandidate({
-        ...candidate,
-        sessionId: sessionIdTwo,
-      });
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .withIdentity({
+          firstName: 'Smith',
+          lastName: 'Aaron',
+        })
+        .asScoCandidate({
+          organizationLearnerId,
+        })
+        .withParameters({
+          sessionId: sessionIdOne,
+        })
+        .insertToDB({ databaseBuilder });
+
+      const candidateThatEnteredTheSession = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .withIdentity({
+          firstName: 'Smith',
+          lastName: 'Aaron',
+        })
+        .asScoCandidate({
+          organizationLearnerId,
+        })
+        .withParameters({
+          sessionId: sessionIdTwo,
+        })
+        .insertToDB({ databaseBuilder });
+
       databaseBuilder.factory.buildCertificationCourse({
         sessionId: candidateThatEnteredTheSession.sessionId,
         lastName: candidateThatEnteredTheSession.lastName,
@@ -267,24 +346,41 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
         // given
         const division = '3ème A';
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const candidate = {
-          firstName: 'Smith',
-          lastName: 'Aaron',
-          organizationLearnerId: databaseBuilder.factory.buildOrganizationLearner({
-            organizationId: organizationId,
-            division,
-          }).id,
-        };
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationId,
+          division,
+        }).id;
         const sessionPublishedId = databaseBuilder.factory.buildSession({ publishedAt: '2024-01-01' }).id;
         const unpublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: null }).id;
-        const candidateFromUnpublishedSession = databaseBuilder.factory.buildCertificationCandidate({
-          ...candidate,
-          sessionId: unpublishedSessionId,
-        });
-        const candidateFromPublishedSession = databaseBuilder.factory.buildCertificationCandidate({
-          ...candidate,
-          sessionId: sessionPublishedId,
-        });
+        const candidateFromUnpublishedSession = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .withIdentity({
+            firstName: 'Smith',
+            lastName: 'Aaron',
+          })
+          .asScoCandidate({
+            organizationLearnerId,
+          })
+          .withParameters({
+            sessionId: unpublishedSessionId,
+          })
+          .insertToDB({ databaseBuilder });
+
+        const candidateFromPublishedSession = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled()
+          .withIdentity({
+            firstName: 'Smith',
+            lastName: 'Aaron',
+          })
+          .asScoCandidate({
+            organizationLearnerId,
+          })
+          .withParameters({
+            sessionId: sessionPublishedId,
+          })
+          .insertToDB({ databaseBuilder });
+
         databaseBuilder.factory.buildCertificationCourse({
           sessionId: unpublishedSessionId,
           lastName: candidateFromUnpublishedSession.lastName,
@@ -316,24 +412,30 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
         // given
         const division = '3ème A';
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const candidate = {
-          firstName: 'Smith',
-          lastName: 'Aaron',
-          organizationLearnerId: databaseBuilder.factory.buildOrganizationLearner({
-            organizationId: organizationId,
-            division,
-          }).id,
-        };
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationId,
+          division,
+        }).id;
         const firstCertificationCourseStartDate = new Date('2022-01-01T09:00:33Z');
         const secondCertificationCourseStartDate = new Date('2022-01-01T09:23:00Z');
 
         const sessionIdOne = databaseBuilder.factory.buildSession({ publishedAt: '2024-02-01' }).id;
         const sessionIdTwo = databaseBuilder.factory.buildSession({ publishedAt: '2024-01-01' }).id;
 
-        const candidateLinkedToTheFirstSession = databaseBuilder.factory.buildCertificationCandidate({
-          ...candidate,
-          sessionId: sessionIdOne,
-        });
+        const candidateLinkedToTheFirstSession = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled()
+          .withIdentity({
+            firstName: 'Smith',
+            lastName: 'Aaron',
+          })
+          .asScoCandidate({
+            organizationLearnerId,
+          })
+          .withParameters({
+            sessionId: sessionIdOne,
+          })
+          .insertToDB({ databaseBuilder });
 
         databaseBuilder.factory.buildCertificationCourse({
           createdAt: firstCertificationCourseStartDate,
@@ -345,10 +447,20 @@ describe('Certification | Course | Integration | Repository | SCOCertificationCa
           pixCertificationStatus: 'rejected',
         });
 
-        const candidateLinkedToTheSecondSession = databaseBuilder.factory.buildCertificationCandidate({
-          ...candidate,
-          sessionId: sessionIdTwo,
-        });
+        const candidateLinkedToTheSecondSession = domainBuilder.certification.enrolment
+          .candidateBuilder()
+          .asReconciled()
+          .withIdentity({
+            firstName: 'Smith',
+            lastName: 'Aaron',
+          })
+          .asScoCandidate({
+            organizationLearnerId,
+          })
+          .withParameters({
+            sessionId: sessionIdTwo,
+          })
+          .insertToDB({ databaseBuilder });
 
         databaseBuilder.factory.buildCertificationCourse({
           createdAt: secondCertificationCourseStartDate,

--- a/api/tests/certification/session-management/acceptance/application/companion-alert-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/companion-alert-route_test.js
@@ -3,6 +3,7 @@ import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certif
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | companion-alert', function () {
@@ -17,9 +18,11 @@ describe('Certification | Session Management | Acceptance | Application | Routes
       // given
       const { id: certificationCenterId } = databaseBuilder.factory.buildCertificationCenter();
       const { id: sessionId } = databaseBuilder.factory.buildSession({ certificationCenterId });
-      const { userId } = databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-      });
+      const { userId } = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled()
+        .withParameters({ sessionId })
+        .insertToDB({ databaseBuilder });
       const { id: certificationCourseId } = databaseBuilder.factory.buildCertificationCourse({
         sessionId,
         userId,

--- a/api/tests/certification/session-management/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
@@ -26,7 +26,7 @@ describe('Unit | UseCase | delete-unlinked-certification-candidate', function ()
     beforeEach(function () {
       candidateRepository.get
         .withArgs({ certificationCandidateId: candidateId })
-        .resolves(domainBuilder.certification.enrolment.buildCandidate({ userId: null }));
+        .resolves(domainBuilder.certification.enrolment.candidateBuilder().build());
     });
 
     it('should delete the certification candidate', async function () {
@@ -58,15 +58,11 @@ describe('Unit | UseCase | delete-unlinked-certification-candidate', function ()
   });
 
   context('When the certification candidate is reconciled', function () {
-    beforeEach(function () {
+    it('should throw a forbidden deletion error', async function () {
       candidateRepository.get
         .withArgs({ certificationCandidateId: candidateId })
-        .resolves(
-          domainBuilder.certification.enrolment.buildCandidate({ userId: 123, reconciledAt: new Date('2024-09-25') }),
-        );
-    });
+        .resolves(domainBuilder.certification.enrolment.candidateBuilder().asReconciled({ userId: 123 }).build());
 
-    it('should throw a forbidden deletion error', async function () {
       // when
       const err = await catchErr(deleteUnlinkedCertificationCandidate)({
         candidateId,

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -8,6 +8,7 @@ import { Assessment } from '../../../../../../src/shared/domain/models/Assessmen
 import { Challenge } from '../../../../../../src/shared/domain/models/Challenge.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Infrastructure | Repositories | certification-assessment-repository', function () {
@@ -393,10 +394,15 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       const firstUserId = databaseBuilder.factory.buildUser({}).id;
       const secondUserId = databaseBuilder.factory.buildUser({}).id;
 
-      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        userId: firstUserId,
-      }).id;
+      const certificationCandidateId = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled({
+          userId: firstUserId,
+        })
+        .withParameters({
+          sessionId,
+        })
+        .insertToDB({ databaseBuilder }).id;
 
       const firstUserCertificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         sessionId,

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -18,7 +18,10 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
     beforeEach(function () {
       userId = databaseBuilder.factory.buildUser().id;
       sessionId = databaseBuilder.factory.buildSession({ version: 3 }).id;
-      candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
+      candidateId = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({ sessionId })
+        .insertToDB({ databaseBuilder }).id;
       const version = domainBuilder.certification.configuration
         .versionBuilder()
         .withParameters({ scope: SCOPES.CORE, tubeIds: [] })
@@ -47,7 +50,11 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
         framework: Frameworks.CORE,
       };
 
-      databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId });
+      domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .asReconciled({ userId })
+        .withParameters({ sessionId })
+        .insertToDB({ databaseBuilder });
       certificationCourse = domainBuilder.buildCertificationCourse.unpersisted(certificationCourseData);
 
       return databaseBuilder.commit();
@@ -467,11 +474,11 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
 function _buildCertificationCourse({ createdAt, description, version = 2 }) {
   const userId = databaseBuilder.factory.buildUser().id;
   const sessionId = databaseBuilder.factory.buildSession().id;
-  const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-    userId,
-    sessionId,
-    accessibilityAdjustmentNeeded: true,
-  });
+  const certificationCandidate = domainBuilder.certification.enrolment
+    .candidateBuilder()
+    .asReconciled({ userId })
+    .withParameters({ accessibilityAdjustmentNeeded: true, sessionId })
+    .insertToDB({ databaseBuilder });
   const expectedCertificationCourse = databaseBuilder.factory.buildCertificationCourse({
     userId,
     sessionId,

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
@@ -1,62 +1,205 @@
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 
-const buildCandidate = function ({
-  id = 123,
-  createdAt = new Date(),
-  firstName = 'Pat',
-  lastName = 'Atrak',
-  sex = 'F',
-  birthCity = 'Nice',
-  birthCountry = 'France',
-  birthPostalCode = '06000',
-  birthINSEECode = '06088',
-  birthProvinceCode = '93',
-  email = 'pat.atrak@example.com',
-  resultRecipientEmail = 'otto.mate@example.com',
-  birthdate = '1990-05-06',
-  extraTimePercentage = 0.3,
-  externalId = 'externalId',
-  userId,
-  reconciledAt,
-  sessionId = 456,
-  organizationLearnerId = null,
-  billingMode = null,
-  prepaymentCode = null,
-  hasSeenCertificationInstructions = false,
-  accessibilityAdjustmentNeeded,
-  subscription = Frameworks.CORE,
-  hasStartedTest = false,
-  doubleCertificationEligibility = false,
-} = {}) {
-  return new Candidate({
+/**
+ * Entry point of the fluent Candidate builder. Returns the builder, NOT a Candidate:
+ * Note: end the chain with build() for in-memory storage or insertToDB() for DB storage.
+ *
+ * @returns {CandidateBuilder}
+ */
+export function candidateBuilder() {
+  return new CandidateBuilder();
+}
+
+class CandidateBuilder {
+  constructor() {
+    this.firstName = 'Pat';
+    this.lastName = 'Atrak';
+    this.birthdate = '1990-05-06';
+    this.sex = 'F';
+    this.accessibilityAdjustmentNeeded = false;
+    this.authorizedToStart = false;
+    this.hasSeenCertificationInstructions = false;
+    this.doubleCertificationEligibility = false;
+    this.userId = null;
+    this.resultRecipientEmail = null;
+    this.reconciledAt = null;
+    this.prepaymentCode = null;
+    this.organizationLearnerId = null;
+    this.externalId = null;
+    this.email = null;
+    this.birthProvinceCode = null;
+    this.birthPostalCode = null;
+    this.birthINSEECode = null;
+    this.birthCountry = null;
+    this.birthCity = null;
+    this.billingMode = null;
+    this.subscription = Frameworks.CORE;
+    this.sessionId = null;
+  }
+
+  withSubscription(subscription) {
+    this.subscription = subscription;
+    return this;
+  }
+
+  withIdentity({ firstName = 'Colette', lastName = 'Inspiration', birthdate = '2016-10-23' }) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.birthdate = birthdate;
+    return this;
+  }
+
+  asScoCandidate({ organizationLearnerId }) {
+    this.organizationLearnerId = organizationLearnerId;
+    return this;
+  }
+
+  asReconciled({ userId = null, reconciledAt = new Date() } = {}) {
+    this.userId = userId;
+    this.reconciledAt = reconciledAt;
+    return this;
+  }
+
+  withParameters({
     id,
-    createdAt,
-    firstName,
-    lastName,
+    sessionId,
     sex,
+    birthCity,
+    birthCountry,
     birthPostalCode,
     birthINSEECode,
-    birthCity,
     birthProvinceCode,
-    birthCountry,
     email,
     resultRecipientEmail,
-    birthdate,
     extraTimePercentage,
     externalId,
-    userId,
-    reconciledAt,
-    sessionId,
-    organizationLearnerId,
-    billingMode,
-    prepaymentCode,
+    authorizedToStart,
+    authorizedToStartAt,
     hasSeenCertificationInstructions,
     accessibilityAdjustmentNeeded,
-    subscription,
-    hasStartedTest,
     doubleCertificationEligibility,
-  });
-};
+    createdAt,
+    billingMode,
+    prepaymentCode,
+  } = {}) {
+    this.id = id ?? this.id;
+    this.sex = sex ?? this.sex;
+    this.birthCity = birthCity ?? this.birthCity;
+    this.birthCountry = birthCountry ?? this.birthCountry;
+    this.birthPostalCode = birthPostalCode ?? this.birthPostalCode;
+    this.birthINSEECode = birthINSEECode ?? this.birthINSEECode;
+    this.birthProvinceCode = birthProvinceCode ?? this.birthProvinceCode;
+    this.email = email ?? this.email;
+    this.resultRecipientEmail = resultRecipientEmail ?? this.resultRecipientEmail;
+    this.extraTimePercentage = extraTimePercentage ?? this.extraTimePercentage;
+    this.externalId = externalId ?? this.externalId;
+    this.sessionId = sessionId ?? this.sessionId;
+    this.authorizedToStart = authorizedToStart ?? this.authorizedToStart;
+    this.authorizedToStartAt = authorizedToStartAt ?? this.authorizedToStartAt;
+    this.hasSeenCertificationInstructions = hasSeenCertificationInstructions ?? this.hasSeenCertificationInstructions;
+    this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded ?? this.accessibilityAdjustmentNeeded;
+    this.doubleCertificationEligibility = doubleCertificationEligibility ?? this.doubleCertificationEligibility;
+    this.createdAt = createdAt;
+    this.billingMode = billingMode ?? this.billingMode;
+    this.prepaymentCode = prepaymentCode ?? this.prepaymentCode;
+    return this;
+  }
 
-export { buildCandidate };
+  /**
+   * Inserts the candidate row
+   * then returns the built domain Candidate carrying the persisted id.
+   * Must be called before `await databaseBuilder.commit()`.
+   *
+   * @param {object} params
+   * @param {DatabaseBuilder} params.databaseBuilder
+   * @returns {Candidate} the persisted candidate
+   */
+  insertToDB({ databaseBuilder }) {
+    if (!this.sessionId) {
+      this.sessionId = databaseBuilder.factory.buildSession().id;
+    }
+
+    if (!this.userId && this.reconciledAt) {
+      this.userId = databaseBuilder.factory.buildUser().id;
+    }
+
+    if (!this.createAt) {
+      this.createdAt = new Date();
+    }
+
+    const candidate = this.build();
+
+    const row = databaseBuilder.factory.buildCertificationCandidate({
+      id: candidate.id ?? undefined,
+      firstName: candidate.firstName,
+      lastName: candidate.lastName,
+      sex: candidate.sex,
+      birthdate: candidate.birthdate,
+      birthCity: candidate.birthCity,
+      birthCountry: candidate.birthCountry,
+      birthPostalCode: candidate.birthPostalCode,
+      birthINSEECode: candidate.birthINSEECode,
+      birthProvinceCode: candidate.birthProvinceCode,
+      email: candidate.email,
+      resultRecipientEmail: candidate.resultRecipientEmail,
+      extraTimePercentage: candidate.extraTimePercentage,
+      subscription: candidate.subscription,
+      externalId: candidate.externalId,
+      sessionId: candidate.sessionId,
+      userId: candidate.userId,
+      reconciledAt: candidate.reconciledAt,
+      organizationLearnerId: candidate.organizationLearnerId,
+      authorizedToStart: candidate.authorizedToStart,
+      authorizedToStartAt: candidate.authorizedToStartAt,
+      hasSeenCertificationInstructions: candidate.hasSeenCertificationInstruction,
+      accessibilityAdjustmentNeeded: candidate.accessibilityAdjustmentNeeded,
+      doubleCertificationEligibility: candidate.doubleCertificationEligibility,
+      billingMode: candidate.billingMode,
+      prepaymentCode: candidate.prepaymentCode,
+      createdAt: candidate.createdAt,
+    });
+
+    this.id = row.id;
+    this.sessionId = row.sessionId;
+    this.userId = row.userId;
+    return this.build();
+  }
+
+  /**
+   * Materializes the domain Candidate without touching the database.
+   *
+   * @returns {Candidate}
+   */
+  build() {
+    return new Candidate({
+      id: this.id ?? undefined,
+      firstName: this.firstName,
+      lastName: this.lastName,
+      sex: this.sex,
+      birthdate: this.birthdate,
+      birthCity: this.birthCity,
+      birthCountry: this.birthCountry,
+      birthPostalCode: this.birthPostalCode,
+      birthINSEECode: this.birthINSEECode,
+      birthProvinceCode: this.birthProvinceCode,
+      email: this.email,
+      resultRecipientEmail: this.resultRecipientEmail,
+      extraTimePercentage: this.extraTimePercentage,
+      subscription: this.subscription,
+      externalId: this.externalId,
+      sessionId: this.sessionId,
+      reconciledAt: this.reconciledAt,
+      userId: this.userId,
+      organizationLearnerId: this.organizationLearnerId,
+      authorizedToStart: this.authorizedToStart,
+      authorizedToStartAt: this.authorizedToStartAt,
+      hasSeenCertificationInstructions: this.hasSeenCertificationInstruction,
+      accessibilityAdjustmentNeeded: this.accessibilityAdjustmentNeeded,
+      doubleCertificationEligibility: this.doubleCertificationEligibility,
+      createdAt: this.createdAt,
+      billingMode: this.billingMode,
+      prepaymentCode: this.prepaymentCode,
+    });
+  }
+}

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate.js
@@ -1,7 +1,7 @@
 import { Candidate } from '../../../../../../src/certification/evaluation/domain/models/Candidate.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 
-export const buildEvaluationCandidate = function ({
+export const buildCandidate = function ({
   id = 123,
   userId = 456,
   sessionId = 789,

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -171,7 +171,7 @@ import {
 } from './certification/configuration/build-sco-blocked-access-date.js';
 import { versionBuilder } from './certification/configuration/build-version.js';
 import { versionDetailsBuilder } from './certification/configuration/build-version-details.js';
-import { buildCandidate } from './certification/enrolment/build-candidate.js';
+import { candidateBuilder } from './certification/enrolment/build-candidate.js';
 import { buildCertificationEligibility } from './certification/enrolment/build-certification-eligibility.js';
 import { buildComplementaryCertificationBadgeWithOffsetVersion as buildComplementaryCertificationBadgeForEnrolment } from './certification/enrolment/build-complementary-certification-badge.js';
 import { buildComplementaryCertificationCourseWithResultsEnrolment } from './certification/enrolment/build-complementary-certification-course-with-results.js';
@@ -184,7 +184,7 @@ import { buildAssessmentResult as buildCertificationScoringAssessmentResult } fr
 import { buildAssessmentSheet } from './certification/evaluation/build-assessment-sheet.js';
 import { buildCalibratedChallenge } from './certification/evaluation/build-calibrated-challenge.js';
 import { buildCalibratedChallengeSkill } from './certification/evaluation/build-calibrated-challenge-skill.js';
-import { buildEvaluationCandidate } from './certification/evaluation/build-candidate.js';
+import { buildCandidate } from './certification/evaluation/build-candidate.js';
 import { candidateAuthorizationBuilder } from './certification/evaluation/build-candidate-authorization.js';
 import { buildCertificationAssessmentHistory } from './certification/evaluation/build-certification-assessment-history.js';
 import { buildCertificationChallengeCapacity } from './certification/evaluation/build-certification-challenge-capacity.js';
@@ -265,7 +265,7 @@ const certification = {
     buildMatchingOrganization,
     buildHabilitation,
     buildCertificationSessionCandidate,
-    buildCandidate,
+    candidateBuilder,
     buildEditedCandidate,
     buildUser: buildUserEnrolment,
     buildComplementaryCertificationCourseWithResults: buildComplementaryCertificationCourseWithResultsEnrolment,
@@ -277,7 +277,7 @@ const certification = {
   evaluation: {
     buildCalibratedChallenge,
     buildCalibratedChallengeSkill,
-    buildCandidate: buildEvaluationCandidate,
+    buildCandidate,
     buildSession,
     buildComplementaryCertificationScoringCriteria,
     buildComplementaryCertificationScoringWithoutComplementaryReferential,


### PR DESCRIPTION
## 🪧 Problème

> On constate que c’est pénible dans :
> - tous les tests
>    - se souvenir des valeurs à mettre à des attributs pour faire en sorte que les modèles utilisés reflètent un état métier spécifique
> - intégration/acceptance
>    - créer à la fois le modèle domaine mais aussi les données sous-jacentes en BDD 
>    - en particulier pour les plus nouveaux, se souvenir quand utiliser le domainBuilder VS databaseBuilder
>
> Ces builders n’en portent que le nom, et sont frustrant à l’usage.

https://1024pix.atlassian.net/wiki/spaces/DC/pages/6276775948/BACK+Builders

## 🌈 Proposition

> Pour adresser toutes les frustrations énoncées ci-dessus, on a proposé une revisite du domainBuilder pour que ça ressemble à un Builder, à savoir une entité sur laquelle on peut chaîner des méthodes expressives afin de construire un modèle dans un état spécifique. Ce Builder propose également une méthode permettant d’insérer les données sous-jacentes en BDD.

Ici, c'est le builder de candidat du contexte `enrolment` qui est migré. 

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
