### PR TITLE
[TECH] Ajouter les infos de corrélation dans les logs d'erreur 500 avec stack trace, ainsi que petite réduction du volume d'un log

### DIFF
--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -11,8 +11,19 @@ const serializersSym = Symbol.for('pino.serializers');
 
 function requestSerializer(req) {
   const request = getInContext('request', req);
+  const requestWithoutHeavyFields = Object.fromEntries(
+    Object.entries(request).filter(
+      ([key]) =>
+        !key.startsWith('_') &&
+        key !== 'raw' &&
+        key !== 'response' &&
+        key !== 'server' &&
+        key !== 'preResponses' &&
+        key !== 'yar',
+    ),
+  );
   const enhancedReq = {
-    ...request,
+    ...requestWithoutHeavyFields,
     version: config.version,
     clientVersion: request.headers['x-app-version'] || '-',
     clientVersionMismatched: config.version !== request.headers['x-app-version'],

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -11,23 +11,10 @@ const serializersSym = Symbol.for('pino.serializers');
 
 function requestSerializer(req) {
   const request = getInContext('request', req);
-  const requestWithoutHeavyFields = Object.fromEntries(
-    Object.entries(request).filter(
-      ([key]) =>
-        !key.startsWith('_') &&
-        key !== 'raw' &&
-        key !== 'response' &&
-        key !== 'server' &&
-        key !== 'preResponses' &&
-        key !== 'yar',
-    ),
-  );
-  const enhancedReq = {
-    ...requestWithoutHeavyFields,
-    version: config.version,
-    clientVersion: request.headers['x-app-version'] || '-',
-    clientVersionMismatched: config.version !== request.headers['x-app-version'],
-  };
+  const serializedRequest = stdSerializers.req(request);
+  serializedRequest.version = config.version;
+  serializedRequest.clientVersion = request.headers['x-app-version'] || '-';
+  serializedRequest.clientVersionMismatched = config.version !== request.headers['x-app-version'];
 
   // monitor api token route
   if (request?.route?.path === '/api/token') {
@@ -38,16 +25,16 @@ function requestSerializer(req) {
     } catch {
       origin = '-';
     }
-    enhancedReq.audience = origin;
-    enhancedReq.grantType = grant_type || '-';
-    enhancedReq.usernameHash = generateHash(username) || '-';
-    enhancedReq.refreshTokenHash = generateHash(refresh_token) || '-';
+    serializedRequest.audience = origin;
+    serializedRequest.grantType = grant_type || '-';
+    serializedRequest.usernameHash = generateHash(username) || '-';
+    serializedRequest.refreshTokenHash = generateHash(refresh_token) || '-';
     setInContext('user_id', request?.response?.source?.user_id);
   }
 
   const metrics = getInContext('metrics', null);
   return {
-    ...enhancedReq,
+    ...serializedRequest,
     ...getCorrelationInfo(),
     metrics,
     route: request?.route?.path,
@@ -58,15 +45,24 @@ function requestSerializer(req) {
   };
 }
 
+function errorSerializer(err) {
+  const serializedError = stdSerializers.err(err);
+  return {
+    ...serializedError,
+    ...getCorrelationInfo(),
+  };
+}
+
 const plugin = {
   name: 'hapi-pino',
   register: async function (server, options) {
     const serializers = {
       req: stdSerializers.wrapRequestSerializer(requestSerializer),
       res: stdSerializers.wrapResponseSerializer(stdSerializers.res),
+      err: stdSerializers.wrapErrorSerializer(errorSerializer),
     };
     const logger = options.instance;
-    logger[serializersSym] = Object.assign({}, serializers, logger[serializersSym]);
+    logger[serializersSym] = Object.assign({}, logger[serializersSym], serializers);
 
     server.ext('onPostStart', async function () {
       logger.info(server.info, 'server started');
@@ -85,7 +81,7 @@ const plugin = {
         return;
       }
       if (event.error) {
-        logger.error({ req: request, tags: event.tags, err: event.error }, 'request error');
+        logger.error({ tags: event.tags, err: event.error }, 'request error');
       }
     });
 

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -74,7 +74,7 @@ const plugin = {
         return;
       }
       if (event.error) {
-        logger.error({ tags: event.tags, err: event.error }, 'request error');
+        logger.error({ req: request, tags: event.tags, err: event.error }, 'request error');
       }
     });
 

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -10,15 +10,15 @@ import { routeDomainToOwnerTeam } from '../utils/route-domain-to-owner-team.js';
 const serializersSym = Symbol.for('pino.serializers');
 
 function requestSerializer(req) {
+  const request = getInContext('request', req);
   const enhancedReq = {
-    ...req,
+    ...request,
     version: config.version,
-    clientVersion: req.headers['x-app-version'] || '-',
-    clientVersionMismatched: config.version !== req.headers['x-app-version'],
+    clientVersion: request.headers['x-app-version'] || '-',
+    clientVersionMismatched: config.version !== request.headers['x-app-version'],
   };
 
   // monitor api token route
-  const request = getInContext('request', null);
   if (request?.route?.path === '/api/token') {
     const { username, refresh_token, grant_type } = request.payload || {};
     let origin;


### PR DESCRIPTION
## 🪧 Problème

Lorsqu'il y a une erreur 500, on n'a pas les infos de corrélation dans Datadog et c'est super dur à retrouver.

## 🌈 Proposition

Le log de l'erreur, lors d'une erreur inattendue qui va finir en 500, se fait dans le `server.events.on('request')`. Pour cette ligne de log, les infos de corrélation n'étaient pas mises. J'ai trouvé plus simple de carrément passer l'objet `request`, car ça provoque la sérialisation de celui-ci avec notre sérializer custom `pino` et ça s'occupe de mettre les bonnes données de corrélation.

J'avais envisagé de mettre la stack dans le log de réponse et ne pas avoir de log dédié pour l'erreur, mais dans le `server.events.on('response')` on n'a malheureusement pas l'erreur 😢 

## ✊ Remarques

Toute contente je m'en vais tester ma modification, en prenant soin de retirer la variable d'env qui me corrige encore les logs en mode `LOG_FOR_HUMANS=compact`.
Trouver ce que je voulais c'était comme chercher une aiguille dans une botte de foin. Je copie un log dans un fichier pour voir à quoi il ressemble, je formatte en JSON pour avoir un joli affichage. Résultat : 6000 lignes pour un seul log.

Sur le conseil de @fael-b , j'utilise le serializer de pino, qui lui fait déjà le travail de trier le grain de l'ivraie.

On passe d'environ 6000 lignes à 100

## 🎉 Pour tester
Mettre `LOG_FOR_HUMANS=null`, puis testez un endpoint avec un javascript en échec (style dans le controller un petit `request.boubou.chouchou = 'yo'` et constater que le log d'erreur avec la stack contient bien les infos de corrélation 

Exemple chez moi
```
   req: {
      "app": {},
      "headers": {
        "x-forwarded-host": "localhost:4203",
        "x-forwarded-proto": "http",
        "x-forwarded-port": "4203",
        "x-forwarded-for": "::ffff:127.0.0.1",
        "x-broccoli": "[object Object]",
        "priority": "u=4",
        "sec-gpc": "1",
        "dnt": "1",
        "sec-fetch-site": "same-origin",
        "sec-fetch-mode": "cors",
        "sec-fetch-dest": "empty",
        "cookie": "locale=fr",
        "connection": "close",
        "x-app-version": "development",
        "authorization": "[Redacted]",
        "referer": "http://localhost:4203/sessions/7406",
        "accept-encoding": "gzip, deflate, br, zstd",
        "accept-language": "fr,fr-FR;q=0.9,en-US;q=0.8,en;q=0.7",
        "accept": "application/vnd.api+json",
        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0",
        "host": "localhost:3000"
      },
      "logs": [],
      "method": "get",
      "mime": null,
      "orig": {
        "params": {
          "sessionId": "7406"
        }
      },
      "params": {
        "sessionId": 7406
      },
      "paramsArray": [
        "7406"
      ],
      "path": "/api/sessions/7406/certification-candidates",
      "plugins": {},
      "pre": {
        "authorizationCheck": true
      },
      "route": "/api/sessions/{sessionId}/certification-candidates",
      "query": {},
      "state": {
        "locale": "fr"
      },
      "info": {
        "acceptEncoding": "gzip",
        "completed": 0,
        "cors": {
          "isOriginMatch": true
        },
        "host": "localhost:3000",
        "hostname": "localhost",
        "id": "1785135192466:macbook-pro-de-laura.home:21240:ms2veb4f:10007",
        "received": 1785135192466,
        "referrer": "http://localhost:4203/sessions/7406",
        "remoteAddress": "::1",
        "remotePort": 49901,
        "responded": 1785135192469
      },
      "auth": {
        "isAuthenticated": true,
        "isAuthorized": false,
        "isInjected": false,
        "credentials": {
          "userId": 7100
        },
        "strategy": "jwt-user",
        "mode": "required",
        "error": null
      },
      "version": "development",
      "clientVersion": "development",
      "clientVersionMismatched": false,
      "user_id": 7100,
      "request_id": "76a088fc-209f-4abe-a092-06356e45ce56",
      "scriptId": null,
      "jobId": null,
      "pix-metadata": null,
      "metrics": {
        "knexQueryCount": 1,
        "knexTotalTimeSpent": 1.2707919999993464
      },
      "routeDomain": "certification/enrolment/certification-candidate-api",
      "teamsToContact": ""
    }
    tags: [
      "internal",
      "implementation",
      "error"
    ]
    err: {
      "type": "TypeError",
      "message": "Cannot create property 'truc' on number '7406'",
      "stack":
          TypeError: Cannot create property 'truc' on number '7406'
              at getEnrolledCandidates (file:///Users/lolob/projects/pix/api/src/certification/enrolment/application/certification-candidate-controller.js:21:33)
              at exports.Manager.execute (/Users/lolob/projects/pix/api/node_modules/@hapi/hapi/lib/toolkit.js:57:29)
              at internals.handler (/Users/lolob/projects/pix/api/node_modules/@hapi/hapi/lib/handler.js:46:48)
              at exports.execute (/Users/lolob/projects/pix/api/node_modules/@hapi/hapi/lib/handler.js:31:36)
              at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
              at async Request._lifecycle (/Users/lolob/projects/pix/api/node_modules/@hapi/hapi/lib/request.js:384:32)
              at async Request._execute (/Users/lolob/projects/pix/api/node_modules/@hapi/hapi/lib/request.js:294:9)
      "isBoom": true,
      "isServer": true,
      "data": null,
      "output": {
        "statusCode": 500,
        "payload": {
          "statusCode": 500,
          "error": "Internal Server Error",
          "message": "An internal server error occurred"
        },
        "headers": {}
      },
      "isDeveloperError": true
    }
```