### PR TITLE
[TECH] Déplacer les pre-handlers de shared dans leur bon bouded Context (PIX-XXXX)

### DIFF
--- a/api/src/prescription/campaign-participation/application/campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-route.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { campaignSecurityPreHandlers } from '../../campaign/application/security-pre-handlers.js';
 import { campaignParticipationController } from './campaign-participation-controller.js';
 import { campaignParticipationPreHandlers } from './pre-handlers.js';
 
@@ -71,7 +72,7 @@ const register = async function (server) {
       config: {
         pre: [
           { method: securityPreHandlers.checkAuthorizationToManageCampaign },
-          { method: securityPreHandlers.checkCampaignBelongsToCombinedCourse },
+          { method: campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse },
         ],
         validate: {
           params: Joi.object({
@@ -231,7 +232,7 @@ const register = async function (server) {
               ])(request, h),
           },
           {
-            method: securityPreHandlers.checkCampaignBelongsToCombinedCourse,
+            method: campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse,
           },
         ],
         validate: {

--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -5,6 +5,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { MAX_FILE_SIZE_UPLOAD } from '../../../shared/constants.js';
 import { identifiersType, queriesType } from '../../../shared/domain/types/identifiers-type.js';
 import { campaignAdministrationController } from './campaign-administration-controller.js';
+import { campaignSecurityPreHandlers } from './security-pre-handlers.js';
 
 const ERRORS = {
   PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
@@ -41,7 +42,7 @@ const register = async function (server) {
             assign: 'isAdminOrCreatorFromTheCampaign',
           },
           {
-            method: securityPreHandlers.checkCampaignBelongsToCombinedCourse,
+            method: campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse,
             assign: 'campaignBelongsToCombinedCourse',
           },
         ],
@@ -80,7 +81,7 @@ const register = async function (server) {
         pre: [
           { method: securityPreHandlers.checkAuthorizationToManageCampaign },
           {
-            method: securityPreHandlers.checkCampaignBelongsToCombinedCourse,
+            method: campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse,
             assign: 'campaignBelongsToCombinedCourse',
           },
         ],

--- a/api/src/prescription/campaign/application/security-pre-handlers.js
+++ b/api/src/prescription/campaign/application/security-pre-handlers.js
@@ -1,0 +1,16 @@
+import * as checkCampaignBelongsToCombinedCourseUsecase from './usecases/checkCampaignBelongsToCombinedCourse.js';
+
+async function checkCampaignBelongsToCombinedCourse(
+  request,
+  h,
+  dependencies = { checkCampaignBelongsToCombinedCourseUsecase },
+) {
+  const campaignId = parseInt(request.params.campaignId);
+
+  await dependencies.checkCampaignBelongsToCombinedCourseUsecase.execute({ campaignId });
+  return h.response(true);
+}
+
+export const campaignSecurityPreHandlers = {
+  checkCampaignBelongsToCombinedCourse,
+};

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -4,7 +4,6 @@ import * as checkUserIsCandidateUseCase from '../../certification/enrolment/appl
 import * as centerRepository from '../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import { Organization } from '../../organizational-entities/domain/models/Organization.js';
-import * as checkCampaignBelongsToCombinedCourseUsecase from '../../prescription/campaign/application/usecases/checkCampaignBelongsToCombinedCourse.js';
 import * as checkCampaignParticipationBelongsToUserUsecase from '../../prescription/campaign/application/usecases/checkCampaignParticipationBelongsToUser.js';
 import { PIX_ADMIN } from '../../shared/constants.js';
 import { ForbiddenAccess } from '../domain/errors.js';
@@ -769,17 +768,6 @@ async function checkOrganizationLearnerBelongsToOrganization(
   }
 }
 
-async function checkCampaignBelongsToCombinedCourse(
-  request,
-  h,
-  dependencies = { checkCampaignBelongsToCombinedCourseUsecase },
-) {
-  const campaignId = parseInt(request.params.campaignId);
-
-  await dependencies.checkCampaignBelongsToCombinedCourseUsecase.execute({ campaignId });
-  return h.response(true);
-}
-
 export const securityPreHandlers = {
   hasAtLeastOneAccessOf,
   validateAllAccess,
@@ -789,7 +777,6 @@ export const securityPreHandlers = {
   checkAdminMemberHasRoleSupport,
   checkAuthorizationToManageCampaign,
   checkAuthorizationToAccessCampaign,
-  checkCampaignBelongsToCombinedCourse,
   checkCertificationCenterIsNotScoManagingStudents,
   checkOrganizationHasFeature,
   checkRequestedUserIsAuthenticatedUser,

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-route_test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import { campaignSecurityPreHandlers } from '../../../../../src/prescription/campaign/application/security-pre-handlers.js';
 import { campaignParticipationController } from '../../../../../src/prescription/campaign-participation/application/campaign-participation-controller.js';
 import { campaignParticipationRoute as moduleUnderTest } from '../../../../../src/prescription/campaign-participation/application/campaign-participation-route.js';
 import { campaignParticipationPreHandlers } from '../../../../../src/prescription/campaign-participation/application/pre-handlers.js';
@@ -226,7 +227,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       // given
       sinon.stub(securityPreHandlers, 'checkAuthorizationToManageCampaign').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkCampaignBelongsToCombinedCourse')
+        .stub(campaignSecurityPreHandlers, 'checkCampaignBelongsToCombinedCourse')
         .callsFake((request, h) => h.response(true));
       sinon
         .stub(campaignParticipationController, 'deleteParticipation')
@@ -242,7 +243,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
 
       // then
       expect(securityPreHandlers.checkAuthorizationToManageCampaign.called).true;
-      expect(securityPreHandlers.checkCampaignBelongsToCombinedCourse.called).true;
+      expect(campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse.called).true;
       expect(response.statusCode).to.equal(204);
     });
 
@@ -286,7 +287,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       // given
       const superAdminStub = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
       const hasRoleSupportStub = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport');
-      sinon.stub(securityPreHandlers, 'checkCampaignBelongsToCombinedCourse').returns(() => true);
+      sinon.stub(campaignSecurityPreHandlers, 'checkCampaignBelongsToCombinedCourse').returns(() => true);
       sinon
         .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([superAdminStub, hasRoleSupportStub])
@@ -301,7 +302,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       // then
       expect(securityPreHandlers.hasAtLeastOneAccessOf.calledOnce, 'hasAtLeastOnAccessOf').true;
       expect(
-        securityPreHandlers.checkCampaignBelongsToCombinedCourse.calledOnce,
+        campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse.calledOnce,
         'checkCampaignBelongsToCombinedCourse',
       ).true;
       expect(campaignParticipationController.deleteParticipation.calledOnce, 'deleteParticipation').true;

--- a/api/tests/prescription/campaign/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/security-pre-handlers_test.js
@@ -1,0 +1,60 @@
+import { createServer } from '../../../../../server.js';
+import { campaignSecurityPreHandlers } from '../../../../../src/prescription/campaign/application/security-pre-handlers.js';
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Prescription | Campaign | Acceptance | Application | SecurityPreHandlers', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('#checkCampaignBelongsToCombinedCourse', function () {
+    let campaignId;
+    beforeEach(async function () {
+      server.route({
+        method: 'GET',
+        path: '/api/pate-de-campagne/{campaignId}',
+        handler: (r, h) => h.response({}).code(200),
+        config: {
+          auth: false,
+          pre: [
+            {
+              method: campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse,
+            },
+          ],
+        },
+      });
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+      const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+        successRequirements: [CombinedCourseBlueprint.buildRequirementForCombinedCourse({ campaignId }).toDTO()],
+      });
+      databaseBuilder.factory.buildCombinedCourse({
+        code: 'ABCDE1234',
+        name: 'Mon parcours Combiné',
+        organizationId,
+        questId,
+      });
+      await databaseBuilder.commit();
+    });
+
+    it('should return a well formed JSON API error when campaign belongs to a combined course', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: `/api/pate-de-campagne/${campaignId}`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result.errors[0].code).equal('CAMPAIGN_BELONGS_TO_COMBINED_COURSE');
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import { campaignAdministrationController } from '../../../../../src/prescription/campaign/application/campaign-administration-controller.js';
 import { campaignAdministrationRoute as moduleUnderTest } from '../../../../../src/prescription/campaign/application/campaign-administration-route.js';
+import { campaignSecurityPreHandlers } from '../../../../../src/prescription/campaign/application/security-pre-handlers.js';
 import {
   CampaignCodeFormatError,
   CampaignUniqueCodeError,
@@ -45,7 +46,7 @@ describe('Unit | Application | Router | campaign-administration-router', functio
       // given
       sinon.stub(securityPreHandlers, 'checkAuthorizationToManageCampaign').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkCampaignBelongsToCombinedCourse')
+        .stub(campaignSecurityPreHandlers, 'checkCampaignBelongsToCombinedCourse')
         .callsFake((request, h) => h.response(true));
 
       const httpTestServer = new HttpTestServer();
@@ -57,7 +58,7 @@ describe('Unit | Application | Router | campaign-administration-router', functio
       });
 
       // then
-      expect(securityPreHandlers.checkCampaignBelongsToCombinedCourse).called;
+      expect(campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse).called;
     });
   });
 
@@ -405,7 +406,9 @@ describe('Unit | Application | Router | campaign-administration-router', functio
     // given
     sinon.stub(campaignAdministrationController, 'archiveCampaign').returns(null);
     sinon.stub(securityPreHandlers, 'checkAuthorizationToManageCampaign').callsFake((request, h) => h.response(true));
-    sinon.stub(securityPreHandlers, 'checkCampaignBelongsToCombinedCourse').callsFake((request, h) => h.response(true));
+    sinon
+      .stub(campaignSecurityPreHandlers, 'checkCampaignBelongsToCombinedCourse')
+      .callsFake((request, h) => h.response(true));
 
     const httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
@@ -414,7 +417,7 @@ describe('Unit | Application | Router | campaign-administration-router', functio
     await httpTestServer.request('PUT', '/api/campaigns/123/archive');
 
     // then
-    expect(securityPreHandlers.checkCampaignBelongsToCombinedCourse).called;
+    expect(campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse).called;
   });
 
   describe('DELETE /api/campaigns/{campaignId}/archive', function () {

--- a/api/tests/prescription/campaign/unit/application/security-pre-handlers_test.js
+++ b/api/tests/prescription/campaign/unit/application/security-pre-handlers_test.js
@@ -1,0 +1,53 @@
+import sinon from 'sinon';
+
+import { campaignSecurityPreHandlers } from '../../../../../src/prescription/campaign/application/security-pre-handlers.js';
+import { CampaignBelongsToCombinedCourseError } from '../../../../../src/prescription/campaign/domain/errors.js';
+import { expect } from '../../../../test-helper.js';
+import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+describe('Prescription | Campaign | Unit | Application | SecurityPreHandlers', function () {
+  describe('#checkCampaignBelongsToCombinedCourse', function () {
+    context('Successful case', function () {
+      it('should authorize access when campaign does not belongs to a combined course', async function () {
+        // given
+        const checkCampaignBelongsToCombinedCourseUsecaseStub = {
+          execute: sinon.stub().resolves(),
+        };
+
+        // when
+        const response = await campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse(
+          { params: { campaignId: '123' } },
+          hFake,
+          {
+            checkCampaignBelongsToCombinedCourseUsecase: checkCampaignBelongsToCombinedCourseUsecaseStub,
+          },
+        );
+
+        // then
+        expect(response.source).to.be.true;
+      });
+    });
+
+    context('Error cases', function () {
+      it('should forbid access when the user is not the certificartion candidate', async function () {
+        // given
+        const checkCampaignBelongsToCombinedCourseUsecaseStub = {
+          execute: sinon.stub().rejects(new CampaignBelongsToCombinedCourseError()),
+        };
+
+        // when
+        const error = await catchErr(campaignSecurityPreHandlers.checkCampaignBelongsToCombinedCourse)(
+          { params: { campaignId: '123' } },
+          hFake,
+          {
+            checkCampaignBelongsToCombinedCourseUsecase: checkCampaignBelongsToCombinedCourseUsecaseStub,
+          },
+        );
+
+        // then
+        expect(error).instanceOf(CampaignBelongsToCombinedCourseError);
+      });
+    });
+  });
+});

--- a/api/tests/shared/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/shared/acceptance/application/security-pre-handlers_test.js
@@ -1,5 +1,4 @@
 import { createServer } from '../../../../server.js';
-import { CombinedCourseBlueprint } from '../../../../src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { ORGANIZATION_FEATURE } from '../../../../src/shared/constants.js';
 import { Membership } from '../../../../src/shared/domain/models/Membership.js';
@@ -22,53 +21,6 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
 
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  describe('#checkCampaignBelongsToCombinedCourse', function () {
-    let campaignId;
-    beforeEach(async function () {
-      server.route({
-        method: 'GET',
-        path: '/api/pate-de-campagne/{campaignId}',
-        handler: (r, h) => h.response({}).code(200),
-        config: {
-          auth: false,
-          pre: [
-            {
-              method: securityPreHandlers.checkCampaignBelongsToCombinedCourse,
-            },
-          ],
-        },
-      });
-
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-      const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
-        successRequirements: [CombinedCourseBlueprint.buildRequirementForCombinedCourse({ campaignId }).toDTO()],
-      });
-      databaseBuilder.factory.buildCombinedCourse({
-        code: 'ABCDE1234',
-        name: 'Mon parcours Combiné',
-        organizationId,
-        questId,
-      });
-      await databaseBuilder.commit();
-    });
-
-    it('should return a well formed JSON API error when campaign belongs to a combined course', async function () {
-      // given
-      const options = {
-        method: 'GET',
-        url: `/api/pate-de-campagne/${campaignId}`,
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      expect(response.result.errors[0].code).equal('CAMPAIGN_BELONGS_TO_COMBINED_COURSE');
-    });
   });
 
   describe('#checkAdminMemberHasRoleSuperAdmin', function () {

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -1,58 +1,12 @@
 import sinon from 'sinon';
 
-import { CampaignBelongsToCombinedCourseError } from '../../../../src/prescription/campaign/domain/errors.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
 import { expect } from '../../../test-helper.js';
 import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
 import { hFake } from '../../../tooling/mocks/hapi.mock.js';
-import { catchErr } from '../../../tooling/test-utils/error.js';
 
 describe('Shared | Unit | Application | SecurityPreHandlers', function () {
-  describe('#checkCampaignBelongsToCombinedCourse', function () {
-    context('Successful case', function () {
-      it('should authorize access when campaign does not belongs to a combined course', async function () {
-        // given
-        const checkCampaignBelongsToCombinedCourseUsecaseStub = {
-          execute: sinon.stub().resolves(),
-        };
-
-        // when
-        const response = await securityPreHandlers.checkCampaignBelongsToCombinedCourse(
-          { params: { campaignId: '123' } },
-          hFake,
-          {
-            checkCampaignBelongsToCombinedCourseUsecase: checkCampaignBelongsToCombinedCourseUsecaseStub,
-          },
-        );
-
-        // then
-        expect(response.source).to.be.true;
-      });
-    });
-
-    context('Error cases', function () {
-      it('should forbid access when the user is not the certificartion candidate', async function () {
-        // given
-        const checkCampaignBelongsToCombinedCourseUsecaseStub = {
-          execute: sinon.stub().rejects(new CampaignBelongsToCombinedCourseError()),
-        };
-
-        // when
-        const error = await catchErr(securityPreHandlers.checkCampaignBelongsToCombinedCourse)(
-          { params: { campaignId: '123' } },
-          hFake,
-          {
-            checkCampaignBelongsToCombinedCourseUsecase: checkCampaignBelongsToCombinedCourseUsecaseStub,
-          },
-        );
-
-        // then
-        expect(error).instanceOf(CampaignBelongsToCombinedCourseError);
-      });
-    });
-  });
-
   describe('#checkAdminMemberHasRoleSuperAdmin', function () {
     let request;
 


### PR DESCRIPTION
## 🪧 Problème

1. Comme c'est fait actuellement, cela peut créer des dépendances cycliques 
2. les éléments du dossier Shared ne devrait dépendre de personne

## 🌈 Proposition

Certains de ces pre-handlers sont utilisés uniquement dans leur bounded context associé, où se trouve le usecase utilisé.
Autant déplacer ces pre-handlers dans ces BC.

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
- lancer les tests, être sûr que ça marche
- vérifier fonctionnellement tous les accès aux routes dont nous avons déplacés le pre-handler
