### PR TITLE
[FEATURE] Empêcher le candidat d'entrer en certification lorsque la validité de son autorisation à démarrer est dépassée (PIX-23666)

### DIFF
--- a/api/src/certification/session-management/domain/read-models/CandidateAuthorizationInfo.js
+++ b/api/src/certification/session-management/domain/read-models/CandidateAuthorizationInfo.js
@@ -1,5 +1,6 @@
 import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 const MAXIMAL_CERTIFICATION_DURATION_IN_MS = 24 * 60 * 60 * 1000; // 24h
+const AUTHORIZED_TO_START_DURATION_VALIDITY_IN_MS = 15 * 60 * 1000; // 15min
 
 export class CandidateAuthorizationInfo {
   constructor({
@@ -40,7 +41,7 @@ export class CandidateAuthorizationInfo {
 
   get hasExceededCertificationDuration() {
     if (this.certificationId) {
-      return Date.now() - this.certificationStartedAt.getTime() > MAXIMAL_CERTIFICATION_DURATION_IN_MS;
+      return this.#elapsedTimeSinceCertificationStarted() > MAXIMAL_CERTIFICATION_DURATION_IN_MS;
     }
     return false;
   }
@@ -50,6 +51,17 @@ export class CandidateAuthorizationInfo {
   }
 
   get authorizedToStart() {
-    return Boolean(this.authorizedToStartAt);
+    if (this.authorizedToStartAt) {
+      return this.#elapsedTimeSinceInvigilatorAuthorizedToStart() < AUTHORIZED_TO_START_DURATION_VALIDITY_IN_MS;
+    }
+    return false;
+  }
+
+  #elapsedTimeSinceInvigilatorAuthorizedToStart() {
+    return Date.now() - this.authorizedToStartAt.getTime();
+  }
+
+  #elapsedTimeSinceCertificationStarted() {
+    return Date.now() - this.certificationStartedAt.getTime();
   }
 }

--- a/api/tests/certification/session-management/unit/domain/read-models/CandidateAuthorizationInfo_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/CandidateAuthorizationInfo_test.js
@@ -101,7 +101,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Can
   });
 
   describe('#get authorizedToStart', function () {
-    it('returns true when candidate has been authorized to start', function () {
+    it('returns true when candidate has been authorized to start within the last 15 minutes', function () {
       const candidateAuthorizationInfo = domainBuilder.certification.sessionManagement
         .candidateAuthorizationInfoBuilder()
         .asAuthorizedToStart()
@@ -114,6 +114,15 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Can
       const candidateAuthorizationInfo = domainBuilder.certification.sessionManagement
         .candidateAuthorizationInfoBuilder()
         .asNotAuthorizedToStart()
+        .build();
+
+      expect(candidateAuthorizationInfo.authorizedToStart).to.be.false;
+    });
+
+    it('returns false when candidate was authorized beyond 15 minutes ago', function () {
+      const candidateAuthorizationInfo = domainBuilder.certification.sessionManagement
+        .candidateAuthorizationInfoBuilder()
+        .asObsoleteAuthorizedToStart()
         .build();
 
       expect(candidateAuthorizationInfo.authorizedToStart).to.be.false;

--- a/api/tests/tooling/domain-builder/factory/certification/session-management/build-candidate-authorization-info.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session-management/build-candidate-authorization-info.js
@@ -87,6 +87,17 @@ class CandidateAuthorizationInfoBuilder {
   }
 
   /**
+   * As if the invigilator authorized the candidate a long time ago
+   *
+   * @returns {CandidateAuthorizationInfoBuilder}
+   */
+  asObsoleteAuthorizedToStart() {
+    this.authorizedToStartAt = new Date();
+    this.authorizedToStartAt.setMinutes(this.authorizedToStartAt.getMinutes() - 16);
+    return this;
+  }
+
+  /**
    * As if the invigilator authorized the candidate to enter the session
    *
    * @returns {CandidateAuthorizationInfoBuilder}


### PR DESCRIPTION
## 🪧 Problème

Le métier souhaite que l'autorisation d'entrer en session de certification délivrée par le surveillant depuis son espace ne soit valable que 15 minutes.
En cas de dépassement, le surveillant devra alors re-autoriser le candidat.

## 🌈 Proposition

Ajouter une vérification pour valider qu'on est toujours dans les 15 minutes au moment d'entrer le code d'accès

## ✊ Remarques

## 🎉 Pour tester
Autoriser le début du test de certif.
Attendre 16 minutes OU altérer la valeur de certification-candidates.authorizedToStartAt en BDD
Essayer de passer la page du code d'accès et se prendre un stop