### PR TITLE
[TECH] Déplacer le pre-handler checkUserIsCandidate dans le domaine certif

### DIFF
--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -7,6 +7,7 @@ import { authorization } from '../../shared/application/pre-handlers/authorizati
 import { SUBSCRIPTION_TYPES } from '../../shared/domain/constants.js';
 import { Frameworks } from '../../shared/domain/models/Frameworks.js';
 import { certificationCandidateController } from './certification-candidate-controller.js';
+import { enrolmentSecurityPreHandlers } from './securiy-pre-handlers.js';
 
 const Joi = BaseJoi.extend(JoiDate);
 
@@ -137,7 +138,7 @@ const register = async function (server) {
         },
         pre: [
           {
-            method: securityPreHandlers.checkUserIsCandidate,
+            method: enrolmentSecurityPreHandlers.checkUserIsCandidate,
             assign: 'authorizationCheck',
           },
         ],
@@ -184,7 +185,7 @@ const register = async function (server) {
         },
         pre: [
           {
-            method: securityPreHandlers.checkUserIsCandidate,
+            method: enrolmentSecurityPreHandlers.checkUserIsCandidate,
             assign: 'authorizationCheck',
           },
         ],

--- a/api/src/certification/enrolment/application/securiy-pre-handlers.js
+++ b/api/src/certification/enrolment/application/securiy-pre-handlers.js
@@ -1,0 +1,23 @@
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import * as checkUserIsCandidateUseCase from './usecases/check-user-is-candidate.js';
+
+async function checkUserIsCandidate(
+  request,
+  h,
+  dependencies = {
+    checkUserIsCandidateUseCase,
+  },
+) {
+  const userId = request.auth.credentials.userId;
+  const certificationCandidateId = request.params.certificationCandidateId;
+
+  const isUserCandidate = await dependencies.checkUserIsCandidateUseCase.execute({ userId, certificationCandidateId });
+
+  if (!isUserCandidate) {
+    return securityPreHandlers.replyForbiddenError(h);
+  }
+
+  return h.response(true);
+}
+
+export const enrolmentSecurityPreHandlers = { checkUserIsCandidate };

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -1,6 +1,5 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
-import * as checkUserIsCandidateUseCase from '../../certification/enrolment/application/usecases/check-user-is-candidate.js';
 import * as centerRepository from '../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import { Organization } from '../../organizational-entities/domain/models/Organization.js';
@@ -56,25 +55,6 @@ function _replyNotFoundError(h) {
   });
 
   return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-}
-
-async function checkUserIsCandidate(
-  request,
-  h,
-  dependencies = {
-    checkUserIsCandidateUseCase,
-  },
-) {
-  const userId = request.auth.credentials.userId;
-  const certificationCandidateId = request.params.certificationCandidateId;
-
-  const isUserCandidate = await dependencies.checkUserIsCandidateUseCase.execute({ userId, certificationCandidateId });
-
-  if (!isUserCandidate) {
-    return _replyForbiddenError(h);
-  }
-
-  return h.response(true);
 }
 
 async function checkAdminMemberHasRoleSuperAdmin(
@@ -761,7 +741,6 @@ export const securityPreHandlers = {
   checkUserIsAdminOfCertificationCenter,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId,
-  checkUserIsCandidate,
   checkUserIsMemberOfCertificationCenter,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,

--- a/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import { certificationCandidateController } from '../../../../../src/certification/enrolment/application/certification-candidate-controller.js';
 import { certificationCandidateRoute as moduleUnderTest } from '../../../../../src/certification/enrolment/application/certification-candidate-route.js';
+import { enrolmentSecurityPreHandlers } from '../../../../../src/certification/enrolment/application/securiy-pre-handlers.js';
 import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
@@ -206,7 +207,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('when the user is not authorized', function () {
       it('should return 403', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'checkUserIsCandidate').callsFake((request, h) =>
+        sinon.stub(enrolmentSecurityPreHandlers, 'checkUserIsCandidate').callsFake((request, h) =>
           h
             .response({ errors: new Error('forbidden') })
             .code(403)
@@ -227,7 +228,7 @@ describe('Unit | Application | Sessions | Routes', function () {
 
     it('should return 200', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserIsCandidate').returns(true);
+      sinon.stub(enrolmentSecurityPreHandlers, 'checkUserIsCandidate').returns(true);
       sinon.stub(certificationCandidateController, 'validateCertificationInstructions').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/certification/enrolment/unit/application/security-pre-handlers_test.js
+++ b/api/tests/certification/enrolment/unit/application/security-pre-handlers_test.js
@@ -1,0 +1,54 @@
+import sinon from 'sinon';
+
+import { enrolmentSecurityPreHandlers } from '../../../../../src/certification/enrolment/application/securiy-pre-handlers.js';
+import { tokenService } from '../../../../../src/shared/domain/services/token-service.js';
+import { expect } from '../../../../test-helper.js';
+import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
+
+describe('Unit | Certification | Enrolment | Application | SecurityPreHandlers', function () {
+  describe('#checkUserIsCandidate', function () {
+    let request;
+
+    beforeEach(function () {
+      sinon.stub(tokenService, 'extractTokenFromAuthorizationHeader');
+      request = {
+        auth: { credentials: { userId: 1234 } },
+        params: {
+          certificationCandidateId: 456,
+        },
+      };
+    });
+
+    context('Successful case', function () {
+      it('should authorize access to resource when the user is the certification candidate', async function () {
+        // given
+        const checkUserIsCandidateUseCaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
+        // when
+        const response = await enrolmentSecurityPreHandlers.checkUserIsCandidate(request, hFake, {
+          checkUserIsCandidateUseCase: checkUserIsCandidateUseCaseStub,
+        });
+
+        // then
+        expect(response.source).to.be.true;
+      });
+    });
+
+    context('Error cases', function () {
+      it('should forbid resource access when the user is not the certification candidate', async function () {
+        // given
+        const checkUserIsCandidateUseCaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
+        // when
+        const response = await enrolmentSecurityPreHandlers.checkUserIsCandidate(request, hFake, {
+          checkUserIsCandidateUseCase: checkUserIsCandidateUseCaseStub,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -82,52 +82,6 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
     });
   });
 
-  describe('#checkUserIsCandidate', function () {
-    let request;
-
-    beforeEach(function () {
-      sinon.stub(tokenService, 'extractTokenFromAuthorizationHeader');
-      request = {
-        auth: { credentials: { userId: 1234 } },
-        params: {
-          certificationCandidateId: 456,
-        },
-      };
-    });
-
-    context('Successful case', function () {
-      it('should authorize access to resource when the user is the certificartion candidate', async function () {
-        // given
-        const checkUserIsCandidateUseCaseStub = {
-          execute: sinon.stub().resolves(true),
-        };
-        // when
-        const response = await securityPreHandlers.checkUserIsCandidate(request, hFake, {
-          checkUserIsCandidateUseCase: checkUserIsCandidateUseCaseStub,
-        });
-
-        // then
-        expect(response.source).to.be.true;
-      });
-    });
-
-    context('Error cases', function () {
-      it('should forbid resource access when the user is not the certificartion candidate', async function () {
-        // given
-        const checkUserIsCandidateUseCaseStub = {
-          execute: sinon.stub().resolves(false),
-        };
-        // when
-        const response = await securityPreHandlers.checkUserIsCandidate(request, hFake, {
-          checkUserIsCandidateUseCase: checkUserIsCandidateUseCaseStub,
-        });
-
-        // then
-        expect(response.statusCode).to.equal(403);
-      });
-    });
-  });
-
   describe('#checkAdminMemberHasRoleCertif', function () {
     let request;
 


### PR DESCRIPTION
## 🪧 Problème

Certains security pré-handlers sont spécifiques à leurs contextes mais sont définis dans shared.

## 🌈 Proposition

Déplacer le pre-handler `checkUserIsCandidate` suivant dans `certification/enrolment`.

## 🎉 Pour tester

- Func: lancer une certification avec une utilisateur et vérifier que les instructions soient bien passées.
- Tech: tests verts !
