### PR TITLE
[TECH] Déplacer le pre-handler checkCampaignParticipationBelongsToUser dans prescription/campaign

### DIFF
--- a/api/src/prescription/campaign/application/security-pre-handlers.js
+++ b/api/src/prescription/campaign/application/security-pre-handlers.js
@@ -2,6 +2,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import * as checkAuthorizationToAccessCampaignUsecase from './usecases/checkAuthorizationToAccessCampaign.js';
 import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
 import * as checkCampaignBelongsToCombinedCourseUsecase from './usecases/checkCampaignBelongsToCombinedCourse.js';
+import * as checkCampaignParticipationBelongsToUserUsecase from './usecases/checkCampaignParticipationBelongsToUser.js';
 
 async function checkCampaignBelongsToCombinedCourse(
   request,
@@ -46,8 +47,21 @@ async function checkAuthorizationToAccessCampaign(
   return securityPreHandlers.replyForbiddenError(h);
 }
 
+// bounded-context: this is not tested
+async function checkCampaignParticipationBelongsToUser(request, h) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return securityPreHandlers.replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const { campaignParticipationId } = request.params;
+  await checkCampaignParticipationBelongsToUserUsecase.execute({ userId, campaignParticipationId });
+  return h.response(true);
+}
+
 export const campaignSecurityPreHandlers = {
   checkCampaignBelongsToCombinedCourse,
   checkAuthorizationToManageCampaign,
   checkAuthorizationToAccessCampaign,
+  checkCampaignParticipationBelongsToUser,
 };

--- a/api/src/quest/application/quest-route.js
+++ b/api/src/quest/application/quest-route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { campaignSecurityPreHandlers } from '../../prescription/campaign/application/security-pre-handlers.js';
 import { PayloadTooLargeError, sendJsonApiError } from '../../shared/application/errors/http-errors.js';
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { MAX_FILE_SIZE_UPLOAD } from '../../shared/constants.js';
@@ -18,7 +19,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: securityPreHandlers.checkCampaignParticipationBelongsToUser,
+            method: campaignSecurityPreHandlers.checkCampaignParticipationBelongsToUser,
           },
         ],
         handler: questController.getQuestResults,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -3,7 +3,6 @@ import jsonapiSerializer from 'jsonapi-serializer';
 import * as centerRepository from '../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import { Organization } from '../../organizational-entities/domain/models/Organization.js';
-import * as checkCampaignParticipationBelongsToUserUsecase from '../../prescription/campaign/application/usecases/checkCampaignParticipationBelongsToUser.js';
 import { PIX_ADMIN } from '../../shared/constants.js';
 import { ForbiddenAccess } from '../domain/errors.js';
 import * as organizationRepository from '../infrastructure/repositories/organization-repository.js';
@@ -595,17 +594,6 @@ async function checkUserCanDisableHisOrganizationMembership(
   }
 }
 
-async function checkCampaignParticipationBelongsToUser(request, h) {
-  if (!request.auth.credentials || !request.auth.credentials.userId) {
-    return _replyForbiddenError(h);
-  }
-
-  const userId = request.auth.credentials.userId;
-  const { campaignParticipationId } = request.params;
-  await checkCampaignParticipationBelongsToUserUsecase.execute({ userId, campaignParticipationId });
-  return h.response(true);
-}
-
 function makeCheckOrganizationHasFeature(featureKey) {
   return async function (request, h, dependencies = { checkOrganizationHasFeatureUseCase }) {
     try {
@@ -727,7 +715,6 @@ export const securityPreHandlers = {
   checkRequestedUserIsAuthenticatedUser,
   checkUserBelongsToLearnersOrganization,
   checkUserBelongsToOrganization,
-  checkCampaignParticipationBelongsToUser,
   checkUserBelongsToScoOrganizationAndManagesStudents,
   checkUserBelongsToSupOrganizationAndManagesStudents,
   checkUserCanDisableHisOrganizationMembership,

--- a/api/tests/quest/unit/application/quest-route_test.js
+++ b/api/tests/quest/unit/application/quest-route_test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import { campaignSecurityPreHandlers } from '../../../../src/prescription/campaign/application/security-pre-handlers.js';
 import { questController } from '../../../../src/quest/application/quest-controller.js';
 import { questRoute as moduleUnderTest } from '../../../../src/quest/application/quest-route.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
@@ -10,7 +11,7 @@ describe('Quest | Unit | Router | quest-router', function () {
   describe('GET /api/campaign-participations/{campaignParticipationId}/quest-results', function () {
     it('should call checkCampaignParticipationBelongsToUser prehandler', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkCampaignParticipationBelongsToUser').returns(() => true);
+      sinon.stub(campaignSecurityPreHandlers, 'checkCampaignParticipationBelongsToUser').returns(() => true);
       sinon.stub(questController, 'getQuestResults').callsFake((request, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
@@ -22,7 +23,7 @@ describe('Quest | Unit | Router | quest-router', function () {
       await httpTestServer.request('GET', `/api/campaign-participations/${campaignParticipationId}/quest-results`);
 
       // then
-      expect(securityPreHandlers.checkCampaignParticipationBelongsToUser).to.have.been.called;
+      expect(campaignSecurityPreHandlers.checkCampaignParticipationBelongsToUser).to.have.been.called;
     });
   });
 


### PR DESCRIPTION
## 🪧 Problème

Ce security pré-handlers n'est utilisé que dans le contexte prescription mais est défini dans shared

## 🌈 Proposition

Déplacer le pre-handler`checkCampaignParticipationBelongsToUser` dans prescription/campaign

## ✊ Remarques

Le useCase lié au pre-handler est bien dans prescription, et lié aux campaignParticipations.

Mais ce pre-handler n'est concrètement utilisé que dans le contexte quest, par la route `/api/campaign-participations/{campaignParticipationId}/quest-results`

Par ailleurs, nous n'avons pas de tests associés pour le useCase de ce prehandler.

## 🎉 Pour tester
Connexion sur PixApp avec learneremail1000_1@example.net
"J'ai un code" -> SCOMBINIX
Faire la campagne d'évaluation puis "Voir mes résultats" : pas de bug sur l'appel de /quest-results

+ CI au vert
