### PR TITLE
[TECH] Déplacer le pré-handler checkCampaignParticipationBelongsToUser dans le context de participation

### DIFF
--- a/api/src/prescription/campaign-participation/application/pre-handlers.js
+++ b/api/src/prescription/campaign-participation/application/pre-handlers.js
@@ -1,7 +1,10 @@
 import boom from '@hapi/boom';
 
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as checkCampaignParticipationBelongsToUserUsecase from './usecases/checkCampaignParticipationBelongsToUser.js';
 
+// as organization's member, can he see the participation of this learner
 async function checkUserCanAccessCampaignParticipation(
   request,
   h,
@@ -19,7 +22,20 @@ async function checkUserCanAccessCampaignParticipation(
   return h.continue;
 }
 
+// as user, is it your participation ?
+async function checkCampaignParticipationBelongsToUser(request, h) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return securityPreHandlers.replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const { campaignParticipationId } = request.params;
+  await checkCampaignParticipationBelongsToUserUsecase.execute({ userId, campaignParticipationId });
+  return h.response(true);
+}
+
 const campaignParticipationPreHandlers = {
+  checkCampaignParticipationBelongsToUser,
   checkUserCanAccessCampaignParticipation,
 };
 

--- a/api/src/prescription/campaign-participation/application/usecases/checkCampaignParticipationBelongsToUser.js
+++ b/api/src/prescription/campaign-participation/application/usecases/checkCampaignParticipationBelongsToUser.js
@@ -1,5 +1,5 @@
-import * as campaignParticipationRepository from '../../../campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
-import { CampaignParticipationDoesNotBelongToUser } from '../../domain/errors.js';
+import { CampaignParticipationDoesNotBelongToUser } from '../../../campaign/domain/errors.js';
+import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 
 const execute = async function ({
   userId,

--- a/api/src/prescription/campaign/application/security-pre-handlers.js
+++ b/api/src/prescription/campaign/application/security-pre-handlers.js
@@ -1,8 +1,8 @@
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import * as checkCampaignParticipationBelongsToUserUsecase from '../../campaign-participation/application/usecases/checkCampaignParticipationBelongsToUser.js';
 import * as checkAuthorizationToAccessCampaignUsecase from './usecases/checkAuthorizationToAccessCampaign.js';
 import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
 import * as checkCampaignBelongsToCombinedCourseUsecase from './usecases/checkCampaignBelongsToCombinedCourse.js';
-import * as checkCampaignParticipationBelongsToUserUsecase from './usecases/checkCampaignParticipationBelongsToUser.js';
 
 async function checkCampaignBelongsToCombinedCourse(
   request,

--- a/api/src/quest/application/quest-route.js
+++ b/api/src/quest/application/quest-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { campaignSecurityPreHandlers } from '../../prescription/campaign/application/security-pre-handlers.js';
+import { campaignParticipationPreHandlers } from '../../prescription/campaign-participation/application/pre-handlers.js';
 import { PayloadTooLargeError, sendJsonApiError } from '../../shared/application/errors/http-errors.js';
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { MAX_FILE_SIZE_UPLOAD } from '../../shared/constants.js';
@@ -19,7 +19,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: campaignSecurityPreHandlers.checkCampaignParticipationBelongsToUser,
+            method: campaignParticipationPreHandlers.checkCampaignParticipationBelongsToUser,
           },
         ],
         handler: questController.getQuestResults,

--- a/api/tests/quest/unit/application/quest-route_test.js
+++ b/api/tests/quest/unit/application/quest-route_test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 
-import { campaignSecurityPreHandlers } from '../../../../src/prescription/campaign/application/security-pre-handlers.js';
+import { campaignParticipationPreHandlers } from '../../../../src/prescription/campaign-participation/application/pre-handlers.js';
 import { questController } from '../../../../src/quest/application/quest-controller.js';
 import { questRoute as moduleUnderTest } from '../../../../src/quest/application/quest-route.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
@@ -11,7 +11,7 @@ describe('Quest | Unit | Router | quest-router', function () {
   describe('GET /api/campaign-participations/{campaignParticipationId}/quest-results', function () {
     it('should call checkCampaignParticipationBelongsToUser prehandler', async function () {
       // given
-      sinon.stub(campaignSecurityPreHandlers, 'checkCampaignParticipationBelongsToUser').returns(() => true);
+      sinon.stub(campaignParticipationPreHandlers, 'checkCampaignParticipationBelongsToUser').returns(() => true);
       sinon.stub(questController, 'getQuestResults').callsFake((request, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
@@ -23,7 +23,7 @@ describe('Quest | Unit | Router | quest-router', function () {
       await httpTestServer.request('GET', `/api/campaign-participations/${campaignParticipationId}/quest-results`);
 
       // then
-      expect(campaignSecurityPreHandlers.checkCampaignParticipationBelongsToUser).to.have.been.called;
+      expect(campaignParticipationPreHandlers.checkCampaignParticipationBelongsToUser).to.have.been.called;
     });
   });
 


### PR DESCRIPTION
## 🪧 Problème

Ce security pré-handlers n'est utilisé que dans le contexte prescription mais est défini dans shared

## 🌈 Proposition

Déplacer le pre-handler checkCampaignParticipationBelongsToUser dans prescription/learner-management


## ✊ Remarques

On en profite pour déplacer le usecase dans le même contexte

## 🎉 Pour tester
**FUNC :** Vérifier que tout se passe bien en allant voir la page de résultats de la quête sur Pix App
**TECH :** Tous les tests au vert ✅ 