### PR TITLE
[TECH]: Modification des règles de lancement des tests e2e pour une pull request

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -10,6 +10,9 @@
 # - Each job halts early via `circleci step halt` if its parameter is false
 # - On the `dev` branch, all jobs always run (full post-merge run)
 # - The `build-and-test` gate job is the single required status check in GitHub
+# - e2e_test_mon_pix, e2e_test_orga and e2e_playwright_test are restricted via
+#   `filters: branches: only: dev` in the workflow: they never run on PR commits,
+#   only automatically after a merge to `dev`
 
 version: 2.1
 
@@ -331,6 +334,9 @@ workflows:
           context: Pix
           requires:
             - mon_pix_install
+          filters:
+            branches:
+              only: dev
 
       # --- Orga ---
       - orga_install:
@@ -349,6 +355,9 @@ workflows:
           context: Pix
           requires:
             - orga_install
+          filters:
+            branches:
+              only: dev
 
       # --- Certif ---
       - certif_install:
@@ -400,6 +409,9 @@ workflows:
             - mon_pix_install
             - orga_install
             - certif_install
+          filters:
+            branches:
+              only: dev
       - e2e_playwright_test_recette_certif:
           context: Pix
           requires:
@@ -980,12 +992,6 @@ jobs:
     parallelism: 4
     working_directory: ~/pix/high-level-tests/e2e
     steps:
-      - run:
-          name: Skip if not needed
-          command: |
-            if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-mon-pix >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
-              circleci step halt
-            fi
       - browser-tools/install_browser_tools
       - run:
           name: Manual safety start of X11 server
@@ -1064,12 +1070,6 @@ jobs:
       name: node-browsers-redis-postgres-docker
     working_directory: ~/pix/high-level-tests/e2e
     steps:
-      - run:
-          name: Skip if not needed
-          command: |
-            if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-orga >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
-              circleci step halt
-            fi
       - browser-tools/install_browser_tools
       - run:
           name: Manual safety start of X11 server

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -11,8 +11,11 @@
 # - On the `dev` branch, all jobs always run (full post-merge run)
 # - The `build-and-test` gate job is the single required status check in GitHub
 # - e2e_test_mon_pix, e2e_test_orga and e2e_playwright_test are restricted via
-#   `filters: branches: only: dev` in the workflow: they never run on PR commits,
-#   only automatically after a merge to `dev`
+#   `filters: branches: only: dev` in the `build-and-test` workflow: they never
+#   run automatically on PR commits, only after a merge to `dev`
+# - They can still be run on-demand on a PR by commenting `/run e2e`, which
+#   triggers CircleCI with GHA_Meta=run-e2e-comment, gating the dedicated
+#   `e2e-on-demand` workflow below (see .github/workflows/run-e2e-on-comment.yaml)
 
 version: 2.1
 
@@ -283,8 +286,14 @@ workflows:
   # It will execute job of modified folder
   # all e2e test must be triggered if api or referred frontend modified
   # With no other workflows, normal push events will be ignored currently.
+  # It is skipped for the dedicated `/run e2e` on-demand trigger (see below),
+  # so that a comment-triggered pipeline only runs the 3 e2e jobs.
   build-and-test:
-    when: << pipeline.parameters.GHA_Action >>
+    when:
+      and:
+        - << pipeline.parameters.GHA_Action >>
+        - not:
+            equal: ['run-e2e-comment', << pipeline.parameters.GHA_Meta >>]
     jobs:
       - checkout:
           context: Pix
@@ -422,6 +431,48 @@ workflows:
           filters:
             branches:
               only: dev
+
+  # This workflow is triggered on-demand from a `/run e2e` PR comment
+  # (see .github/workflows/run-e2e-on-comment.yaml), which sets GHA_Meta to
+  # `run-e2e-comment`. It runs only the 3 e2e jobs (plus their required
+  # installs) on the PR branch, without running the rest of build-and-test.
+  e2e-on-demand:
+    when:
+      equal: ['run-e2e-comment', << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - checkout:
+          context: Pix
+      - api_install:
+          context: Pix
+          requires:
+            - checkout
+      - mon_pix_install:
+          context: Pix
+          requires:
+            - checkout
+      - orga_install:
+          context: Pix
+          requires:
+            - checkout
+      - certif_install:
+          context: Pix
+          requires:
+            - checkout
+      - e2e_test_mon_pix:
+          context: Pix
+          requires:
+            - mon_pix_install
+      - e2e_test_orga:
+          context: Pix
+          requires:
+            - orga_install
+      - e2e_playwright_test:
+          context: Pix
+          requires:
+            - api_install
+            - mon_pix_install
+            - orga_install
+            - certif_install
 
 # ---------------------------------------------------------------------------
 # Jobs

--- a/.github/workflows/run-e2e-on-comment.yaml
+++ b/.github/workflows/run-e2e-on-comment.yaml
@@ -1,0 +1,49 @@
+name: Run E2E tests on demand
+
+# Lets a maintainer comment "/run e2e" on a PR to trigger, on CircleCI, only
+# the 3 e2e jobs (e2e_test_mon_pix, e2e_test_orga, e2e_playwright_test) on
+# the PR branch, without running the rest of the build-and-test pipeline.
+# See the `e2e-on-demand` workflow in .circleci/jobs.yml.
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  run-e2e-on-demand:
+    runs-on: ubuntu-latest
+
+    # Only for a "/run e2e" comment on an open PR, from someone with write access
+    if: >
+      github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open' &&
+      startsWith(github.event.comment.body, '/run e2e') &&
+      contains(fromJson('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.comment.author_association)
+
+    steps:
+      - name: Acknowledge command
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='+1'
+
+      - name: Resolve PR head branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch=$(gh pr view "${{ github.event.issue.number }}" --repo "${{ github.repository }}" --json headRefName -q .headRefName)
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger CircleCI e2e-only run
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
+        with:
+          target-branch: ${{ steps.pr.outputs.branch }}
+          GHA_Meta: run-e2e-comment
+        env:
+          CCI_TOKEN: ${{ secrets.PIX_SERVICE_CIRCLE_CI_TOKEN }}


### PR DESCRIPTION
## 🪧 Problème

Les CI e2e sont assez énergievore, et sur des petites PR on en à pas toujours besoin.

## 🌈 Proposition

Donner la possibilité de lancer les e2e à la demande et aussi de les cancel pour économiser des ressources.

## ✊ Remarques

RAS

## 🎉 Pour tester

