### PR TITLE
[TECH] Utiliser la nouvelle authentification de Pix Editor (PIX-23702)

### DIFF
--- a/api/db/database-builder/factory/learning-content/build.js
+++ b/api/db/database-builder/factory/learning-content/build.js
@@ -32,7 +32,7 @@ export function build(learningContent, { noDefaultValues = false } = {}) {
 
   return nock?.('https://lcms-test.pix.fr/api')
     .get('/releases/latest')
-    .matchHeader('Authorization', 'Bearer test-api-key')
+    .matchHeader('X-Api-Key', 'test-api-key')
     .reply(200, { content: learningContent });
 }
 

--- a/api/db/database-builder/factory/learning-content/build.js
+++ b/api/db/database-builder/factory/learning-content/build.js
@@ -32,6 +32,7 @@ export function build(learningContent, { noDefaultValues = false } = {}) {
 
   return nock?.('https://lcms-test.pix.fr/api')
     .get('/releases/latest')
+    .matchHeader('Authorization', 'Basic dGVzdC1wYXNzd29yZA==') // test-password
     .matchHeader('X-Api-Key', 'test-api-key')
     .reply(200, { content: learningContent });
 }

--- a/api/sample.env
+++ b/api/sample.env
@@ -428,6 +428,16 @@ APIM_URL=http://127.0.0.1:3000/api/application
 # default: none
 LCMS_API_KEY=e5d7b101-d0bd-4a3b-86c9-61edd5d39e8d
 
+# Base64 encoded token provided by the security team.
+#
+# If using production LCMS, and not present and if the Redis cache were not enabled/preloaded, the
+# application will crash during data fetching.
+#
+# presence: optional
+# type: String
+# default: none
+LCMS_API_OAUTH_BASIC_TOKEN=dGVzdC1wYXNzd29yZA==
+
 # Learning content API URL.
 #
 # If not present and if the Redis cache were not enabled/preloaded, the

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -145,6 +145,7 @@ const schema = Joi.object({
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().requiredForApi(),
+  LCMS_API_OAUTH_BASIC_TOKEN: Joi.string(),
   LCMS_API_URL: Joi.string().uri().requiredForApi(),
   LCMS_API_RELEASE_ID: Joi.any(),
   LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS: Joi.string().optional(),
@@ -374,6 +375,7 @@ const configuration = (function () {
         (process.env.IS_RUNNING_PLAYWRIGHT === 'true' && process.env.PLAYWRIGHT_LCMS_API_KEY) ||
         process.env.CYPRESS_LCMS_API_KEY ||
         process.env.LCMS_API_KEY,
+      oauthBasicToken: process.env.LCMS_API_OAUTH_BASIC_TOKEN,
       releaseId: process.env.LCMS_API_RELEASE_ID || null,
     },
     llm: {
@@ -601,6 +603,7 @@ const configuration = (function () {
 
     config.lcms.apiKey = 'test-api-key';
     config.lcms.url = 'https://lcms-test.pix.fr/api';
+    config.lcms.oauthBasicToken = 'dGVzdC1wYXNzd29yZA=='; // test-password
 
     config.llm.configurationEditorApi.getConfigurationUrl = 'https://llm-test.pix.fr/api/configurations';
     config.llm.inferenceApi.postPromptUrl = 'https://llm-test.pix.fr/api/chat';

--- a/api/src/shared/infrastructure/lcms-client.js
+++ b/api/src/shared/infrastructure/lcms-client.js
@@ -15,7 +15,11 @@ const getRelease = async function () {
   const url = lcmsConfig.url + '/releases/' + (lcmsConfig.releaseId ?? 'latest');
   const response = await httpAgent.get({
     url,
-    headers: { 'X-Api-Key': lcmsConfig.apiKey, Referer: signature },
+    headers: {
+      Authorization: `Basic ${lcmsConfig.oauthBasicToken}`,
+      'X-Api-Key': lcmsConfig.apiKey,
+      Referer: signature
+    },
   });
 
   if (!response.isSuccessful) {
@@ -33,7 +37,10 @@ const getRelease = async function () {
 const createRelease = async function () {
   const response = await httpAgent.post({
     url: lcmsConfig.url + '/releases',
-    headers: { 'X-Api-Key': lcmsConfig.apiKey },
+    headers: {
+      Authorization: `Basic ${lcmsConfig.oauthBasicToken}`,
+      'X-Api-Key': lcmsConfig.apiKey,
+    },
   });
 
   if (!response.isSuccessful) {

--- a/api/src/shared/infrastructure/lcms-client.js
+++ b/api/src/shared/infrastructure/lcms-client.js
@@ -15,7 +15,7 @@ const getRelease = async function () {
   const url = lcmsConfig.url + '/releases/' + (lcmsConfig.releaseId ?? 'latest');
   const response = await httpAgent.get({
     url,
-    headers: { Authorization: `Bearer ${lcmsConfig.apiKey}`, Referer: signature },
+    headers: { 'X-Api-Key': lcmsConfig.apiKey, Referer: signature },
   });
 
   if (!response.isSuccessful) {
@@ -33,7 +33,7 @@ const getRelease = async function () {
 const createRelease = async function () {
   const response = await httpAgent.post({
     url: lcmsConfig.url + '/releases',
-    headers: { Authorization: `Bearer ${lcmsConfig.apiKey}` },
+    headers: { 'X-Api-Key': lcmsConfig.apiKey },
   });
 
   if (!response.isSuccessful) {

--- a/api/src/shared/infrastructure/lcms-client.js
+++ b/api/src/shared/infrastructure/lcms-client.js
@@ -18,7 +18,7 @@ const getRelease = async function () {
     headers: {
       Authorization: `Basic ${lcmsConfig.oauthBasicToken}`,
       'X-Api-Key': lcmsConfig.apiKey,
-      Referer: signature
+      Referer: signature,
     },
   });
 

--- a/api/tests/learning-content/integration/application/jobs/create-learning-content-job-controller_test.js
+++ b/api/tests/learning-content/integration/application/jobs/create-learning-content-job-controller_test.js
@@ -1098,7 +1098,8 @@ describe('Learning Content | Integration | Application | Jobs | Create release',
       beforeEach(function () {
         lcmsApiCall = nock('https://lcms-test.pix.fr/api')
           .post('/releases')
-          .matchHeader('Authorization', 'Bearer test-api-key')
+          .matchHeader('authorization', 'Basic dGVzdC1wYXNzd29yZA==')
+          .matchHeader('x-api-key', 'test-api-key')
           .reply(201, { content: newLearningContent });
       });
 
@@ -1838,7 +1839,8 @@ describe('Learning Content | Integration | Application | Jobs | Create release',
         newLearningContent.missions[0].id = null;
         lcmsApiCall = nock('https://lcms-test.pix.fr/api')
           .post('/releases')
-          .matchHeader('Authorization', 'Bearer test-api-key')
+          .matchHeader('authorization', 'Basic dGVzdC1wYXNzd29yZA==')
+          .matchHeader('x-api-key', 'test-api-key')
           .reply(201, { content: newLearningContent });
       });
 

--- a/api/tests/learning-content/integration/application/jobs/refresh-learning-content-job-controller_test.js
+++ b/api/tests/learning-content/integration/application/jobs/refresh-learning-content-job-controller_test.js
@@ -1101,7 +1101,8 @@ describe('Learning Content | Integration | Application | Jobs | Refresh', functi
       beforeEach(function () {
         lcmsApiCall = nock('https://lcms-test.pix.fr/api')
           .get('/releases/latest')
-          .matchHeader('Authorization', 'Bearer test-api-key')
+          .matchHeader('authorization', 'Basic dGVzdC1wYXNzd29yZA==')
+          .matchHeader('x-api-key', 'test-api-key')
           .reply(200, { content: newLearningContent });
       });
 
@@ -1842,7 +1843,8 @@ describe('Learning Content | Integration | Application | Jobs | Refresh', functi
         newLearningContent.missions[0].id = null;
         lcmsApiCall = nock('https://lcms-test.pix.fr/api')
           .get('/releases/latest')
-          .matchHeader('Authorization', 'Bearer test-api-key')
+          .matchHeader('authorization', 'Basic dGVzdC1wYXNzd29yZA==')
+          .matchHeader('x-api-key', 'test-api-key')
           .reply(200, { content: newLearningContent });
       });
 

--- a/api/tests/shared/integration/infrastructure/lcms-client_test.js
+++ b/api/tests/shared/integration/infrastructure/lcms-client_test.js
@@ -37,7 +37,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
         // given
         const lcmsCall = nock('https://lcms-test.pix.fr/api')
           .get('/releases/latest')
-          .matchHeader('Authorization', 'Bearer test-api-key')
+          .matchHeader('X-Api-Key', 'test-api-key')
           .reply(500);
 
         // when
@@ -65,7 +65,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
         const learningContent = { models: [{ id: 'fromRelease123' }] };
         const lcmsCall = nock('https://lcms-test.pix.fr/api')
           .get('/releases/123')
-          .matchHeader('Authorization', 'Bearer test-api-key')
+          .matchHeader('X-Api-Key', 'test-api-key')
           .reply(200, { content: learningContent });
 
         // when
@@ -80,7 +80,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
         // given
         const lcmsCall = nock('https://lcms-test.pix.fr/api')
           .get('/releases/123')
-          .matchHeader('Authorization', 'Bearer test-api-key')
+          .matchHeader('X-Api-Key', 'test-api-key')
           .reply(500);
 
         // when
@@ -99,7 +99,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
       // given
       const lcmsCall = nock('https://lcms-test.pix.fr/api')
         .post('/releases')
-        .matchHeader('Authorization', 'Bearer test-api-key')
+        .matchHeader('X-Api-Key', 'test-api-key')
         .reply(201);
 
       // when
@@ -114,7 +114,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
       const learningContent = { models: [{ id: 'recId' }] };
       nock('https://lcms-test.pix.fr/api')
         .post('/releases')
-        .matchHeader('Authorization', 'Bearer test-api-key')
+        .matchHeader('X-Api-Key', 'test-api-key')
         .reply(201, { content: learningContent });
 
       // when
@@ -128,7 +128,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
       // given
       nock('https://lcms-test.pix.fr/api')
         .post('/releases')
-        .matchHeader('Authorization', 'Bearer test-api-key')
+        .matchHeader('X-Api-Key', 'test-api-key')
         .reply(403);
 
       // when

--- a/api/tests/shared/integration/infrastructure/lcms-client_test.js
+++ b/api/tests/shared/integration/infrastructure/lcms-client_test.js
@@ -37,6 +37,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
         // given
         const lcmsCall = nock('https://lcms-test.pix.fr/api')
           .get('/releases/latest')
+          .matchHeader('Authorization', 'Basic dGVzdC1wYXNzd29yZA==') // test-password
           .matchHeader('X-Api-Key', 'test-api-key')
           .reply(500);
 
@@ -65,6 +66,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
         const learningContent = { models: [{ id: 'fromRelease123' }] };
         const lcmsCall = nock('https://lcms-test.pix.fr/api')
           .get('/releases/123')
+          .matchHeader('Authorization', 'Basic dGVzdC1wYXNzd29yZA==') // test-password
           .matchHeader('X-Api-Key', 'test-api-key')
           .reply(200, { content: learningContent });
 
@@ -80,6 +82,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
         // given
         const lcmsCall = nock('https://lcms-test.pix.fr/api')
           .get('/releases/123')
+          .matchHeader('Authorization', 'Basic dGVzdC1wYXNzd29yZA==') // test-password
           .matchHeader('X-Api-Key', 'test-api-key')
           .reply(500);
 
@@ -99,6 +102,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
       // given
       const lcmsCall = nock('https://lcms-test.pix.fr/api')
         .post('/releases')
+        .matchHeader('Authorization', 'Basic dGVzdC1wYXNzd29yZA==') // test-password
         .matchHeader('X-Api-Key', 'test-api-key')
         .reply(201);
 
@@ -114,6 +118,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
       const learningContent = { models: [{ id: 'recId' }] };
       nock('https://lcms-test.pix.fr/api')
         .post('/releases')
+        .matchHeader('Authorization', 'Basic dGVzdC1wYXNzd29yZA==') // test-password
         .matchHeader('X-Api-Key', 'test-api-key')
         .reply(201, { content: learningContent });
 
@@ -128,6 +133,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
       // given
       nock('https://lcms-test.pix.fr/api')
         .post('/releases')
+        .matchHeader('Authorization', 'Basic dGVzdC1wYXNzd29yZA==') // test-password
         .matchHeader('X-Api-Key', 'test-api-key')
         .reply(403);
 


### PR DESCRIPTION
## 🪧 Problème

Suite à l'[incident Pudding](https://1024pix.atlassian.net/browse/PIX-23698), on ajoute l'OAuth Proxy sur Pix Editor. 

Comme l'en-tête `Authorization` est déjà utilisé sur Pix Editor, on modifie l'en-tête utilisé pour l'authentification.

## 🌈 Proposition

* Changer sur Pix Editor l'en-tête : https://github.com/1024pix/pix-editor/pull/1562
* Utiliser `X-API-KEY` comme en-tête pour l'authentification
* passer un token en Basic Auth pour la release

## ✊ Remarques

nécessite la variable d'environnement `LCMS_API_OAUTH_BASIC_TOKEN`

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
