### PR TITLE
[FEATURE]: retirer la fk asnswer de flash-assessment-results

### DIFF
--- a/api/db/migrations/20260728161125_remove-answer-fk-from-flash-assessment-results.js
+++ b/api/db/migrations/20260728161125_remove-answer-fk-from-flash-assessment-results.js
@@ -1,0 +1,38 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'flash-assessment-results';
+const COLUMN_NAME = 'answerId';
+const REF_TABLE_NAME = 'answers';
+const REF_COLUMN_NAME = 'id';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropForeign(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.foreign(COLUMN_NAME).references(REF_COLUMN_NAME).inTable(REF_TABLE_NAME);
+  });
+}


### PR DESCRIPTION
## 🪧 Problème

il existe encore une FK qui pointe sur answer et qui empêche la suppression 

## 🌈 Proposition

supprimer le FK

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
