### PR TITLE
[BUGFIX] Fix d'envoie d'erreur des notification (PIX-23739)

### DIFF
--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -48,7 +48,7 @@ export default class AuthenticatedCertificationsController extends Controller {
       await this.fileSaver.save({ url, token });
     } catch (error) {
       if (_isErrorNotFound(error)) {
-        this.notifications.info(
+        this.notifications.sendError(
           this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
           { autoClear: false },
         );
@@ -79,13 +79,13 @@ export default class AuthenticatedCertificationsController extends Controller {
       await this.fileSaver.save({ url, token });
     } catch (error) {
       if (_isErrorNotFound(error)) {
-        this.notifications.info(
+        this.notifications.sendError(
           this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
           { autoClear: false },
         );
       }
       if (_isErrorNoResults(error)) {
-        this.notifications.info(
+        this.notifications.sendError(
           this.intl.t('pages.certifications.errors.no-certificates', { selectedDivision: this.selectedDivision }),
           { autoClear: false },
         );


### PR DESCRIPTION
## 🪧 Problème

Lors des click sur les bouton téléchargement/export , les appels au back retournant des 400 ou 404 ne provoque pas de notification.

<img width="1562" height="470" alt="image" src="https://github.com/user-attachments/assets/1be6e870-d6a9-4238-918d-bb5457b041e9" />

## 🌈 Proposition

Emettre des notification d'erreure dans ces derniers cas.

## ✊ Remarques

RAS

## 🎉 Pour tester

- Aller sur orga avec le user `admin-orga@example.net`.
- Aller sur la page certifications
- Avant et après avoir seléctionné une classe il faut cliquer sur les bouttons export / download et observer la présence de notif d'erreure