### PR TITLE
[FEATURE] Changer les icônes des parcours du catalogue ainsi que leur couleur de fond (PIX-23740)

### DIFF
--- a/orga/app/components/campaign/create-form/course-selection.gjs
+++ b/orga/app/components/campaign/create-form/course-selection.gjs
@@ -14,7 +14,7 @@ import PixFieldset from '../../ui/pix-fieldset';
           <:title>{{t "pages.campaign-creation.course-label"}}</:title>
           <:content>
             {{#if @campaign.course}}
-              <CourseCard @course={{@campaign.course}} @type={{@campaign.course.type}} />
+              <CourseCard @course={{@campaign.course}} @type={{@campaign.course.type}} @isWide={{true}} />
             {{/if}}
             <PixButtonLink @route="authenticated.catalogue.list" @model={{@tab}} @variant="primary-bis">
               {{t "pages.campaign-creation.course-selection-label"}}

--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -47,6 +47,7 @@ export default class CourseCard extends Component {
         @title={{@course.name}}
         @subtitle={{if @course.category (t (concat "pages.campaign-creation.tags." @course.category))}}
         @image={{this.courseInfo.image}}
+        @wide={{@isWide}}
       >
         <:tag>
           <PixTag @color={{this.courseInfo.color}} class="course-card__tag">{{t this.courseInfo.label}}</PixTag>

--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -17,6 +17,7 @@ export function getCourseInfo(courseType) {
     case TARGET_PROFILE:
     case TARGET_PROFILE_OVERVIEW:
       return {
+        type: 'targetProfile',
         color: 'blue',
         label: 'pages.catalogue.card.tag.target-profile',
         image: 'https://assets.pix.org/sites/orga/target-profile.svg',
@@ -24,6 +25,7 @@ export function getCourseInfo(courseType) {
     case BLUEPRINT:
     case COMBINED_COURSE_BLUEPRINT_OVERVIEW:
       return {
+        type: 'blueprint',
         color: 'yellow',
         label: 'pages.catalogue.card.tag.blueprint',
         image: 'https://assets.pix.org/sites/orga/blueprint.svg',
@@ -39,13 +41,12 @@ export default class CourseCard extends Component {
   }
 
   <template>
-    <div class="course-card">
+    <div class="course-card course-card--{{this.courseInfo.type}}">
       <PixCard
         @variant="orga"
         @title={{@course.name}}
         @subtitle={{if @course.category (t (concat "pages.campaign-creation.tags." @course.category))}}
         @image={{this.courseInfo.image}}
-        class="course-card"
       >
         <:tag>
           <PixTag @color={{this.courseInfo.color}} class="course-card__tag">{{t this.courseInfo.label}}</PixTag>

--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -19,14 +19,14 @@ export function getCourseInfo(courseType) {
       return {
         color: 'blue',
         label: 'pages.catalogue.card.tag.target-profile',
-        image: 'https://assets.pix.org/sites/orga/target-profile.png',
+        image: 'https://assets.pix.org/sites/orga/target-profile.svg',
       };
     case BLUEPRINT:
     case COMBINED_COURSE_BLUEPRINT_OVERVIEW:
       return {
         color: 'yellow',
         label: 'pages.catalogue.card.tag.blueprint',
-        image: 'https://assets.pix.org/sites/orga/combined-course.png',
+        image: 'https://assets.pix.org/sites/orga/blueprint.svg',
       };
     default:
       return null;

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -20,7 +20,7 @@ export default class CourseModal extends Component {
 
   id = crypto.randomUUID();
 
-  get courseTypeInfo() {
+  get courseInfo() {
     return getCourseInfo(this.courseType);
   }
 
@@ -67,7 +67,7 @@ export default class CourseModal extends Component {
       @hasCenteredContent={{true}}
     >
       <div
-        class="course-modal"
+        class="course-modal course-modal--{{this.courseInfo.type}}"
         role="dialog"
         aria-labelledby="modal-title--{{this.id}}"
         aria-describedby="modal-content--{{this.id}}"
@@ -94,10 +94,10 @@ export default class CourseModal extends Component {
           </div>
           <div class="course-modal__body">
             <div class="pix-card__image pix-card__image--orga">
-              <img src={{this.courseTypeInfo.image}} aria-hidden="true" alt={{@currentCourse.type}} />
+              <img src={{this.courseInfo.image}} aria-hidden="true" alt={{@currentCourse.type}} />
             </div>
-            <PixTag @color={{this.courseTypeInfo.color}} class="course-card__tag">
-              {{t this.courseTypeInfo.label}}
+            <PixTag @color={{this.courseInfo.color}} class="course-card__tag">
+              {{t this.courseInfo.label}}
             </PixTag>
             <h1 id="modal-title--{{this.id}}" class="course-modal__body__name">{{@currentCourse.name}}</h1>
             <SafeMarkdownToHtml

--- a/orga/app/styles/components/courses/course-card.scss
+++ b/orga/app/styles/components/courses/course-card.scss
@@ -1,5 +1,20 @@
 @use 'pix-design-tokens/typography';
 
+.course-card .pix-card__image,
+.course-modal .pix-card__image {
+  padding: var(--pix-spacing-3x);
+}
+
+.course-card--targetProfile .pix-card__image,
+.course-modal--targetProfile .pix-card__image {
+  background: var(--pix-orga-50);
+}
+
+.course-card--blueprint .pix-card__image,
+.course-modal--blueprint .pix-card__image {
+  background: var(--pix-secondary-50);
+}
+
 .course-card {
   position: relative;
   transition: 0.2s ease;


### PR DESCRIPTION
## 🪧 Problème

Les icônes des PixCard et PixModal du catalogue et leur couleur de fond ne correspondent pas aux maquettes à jour.

## 🌈 Proposition

Mettre à jour les icônes et leur background selon le type de parcours.

On en profite pour mettre la PixCard en "wide" au niveau de la page de création de parcours du catalogue.

## 🎉 Pour tester

Se connecter à Pix Orga
Aller sur le catalogue de l'orga Pro Classic
Voir les nouvelles icônes mises à jour avec une couleur de fond adaptée selon le type
Ouvrir la modale en cliquant sur chaque type de parcours
Voir que l’icône et sa couleur de fond correspondent à la PixCard