### PR TITLE
[TECH] Corrige le script drop-database pour pouvoir utiliser le paramètre "WITH FORCE".

### DIFF
--- a/api/db/database-connection.js
+++ b/api/db/database-connection.js
@@ -61,7 +61,11 @@ export class DatabaseConnection {
     const { knex, databaseName } = DatabaseConnection.configForDbManagement(knexConfig);
 
     try {
-      await knex.raw('DROP DATABASE ??', `${databaseName}${withForce ? ' WITH (FORCE)' : ''}`);
+      if (withForce) {
+        await knex.raw('DROP DATABASE ?? with (FORCE)', databaseName);
+      } else {
+        await knex.raw('DROP DATABASE ??', databaseName);
+      }
       logger.info(`Database ${databaseName} dropped`);
     } catch (error) {
       if (error.code === PGSQL_DUPLICATE_DATABASE_ERROR) {


### PR DESCRIPTION
## 🪧 Problème

Quand met la variable d'environnement `FORCE_DROP_DATABASE=true` lors de l'exécution du script `npm run db:delete`, on a une erreur :


<img width="1100" height="394" alt="message d'erreur script Database drop failed error DROP DATABASE pix WITH (FORCE) - database pix WITH (FORCE) does not exist" src="https://github.com/user-attachments/assets/a1dd7215-f383-4cec-8768-309c6678a64c" />


<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌈 Proposition

On constate que la commande SQL essaie de supprimer une base qui s'appelle "pix WITH (FORCE)".
Cela est du à un mauvais binding de la fonction `knex.raw`.

On corrige donc cet appel de fonction.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ✊ Remarques

J'ai tenté avec un seul appel à `knex.raw` et 2 bindings mais sans succès.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester

En local, tester la commande `npm run db:delete` avec et sans `FORCE_DROP_DATABASE=true` et constater le bon fonctionnement.
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
