### PR TITLE
[BUGFIX] Correction du responsive des filtres du catalogue : marges trop importantes sur petits écrans (PIX-23747)

### DIFF
--- a/orga/app/styles/pages/authenticated/catalogue.scss
+++ b/orga/app/styles/pages/authenticated/catalogue.scss
@@ -1,3 +1,5 @@
+@use 'pix-design-tokens/breakpoints';
+
 .catalogue {
   &__nav {
     margin-bottom: var(--pix-spacing-4x);
@@ -6,8 +8,10 @@
   &__filters {
     margin-bottom: var(--pix-spacing-4x);
 
-    .pix-filter-banner__filter > * {
-      flex-basis: 15rem;
+    @include breakpoints.device-is('desktop') {
+      .pix-filter-banner__filter > * {
+        flex-basis: 15rem;
+      }
     }
   }
 


### PR DESCRIPTION
## 🪧 Problème

Il y a des marges trop élevées sur le catalogue en responsive, et les largeurs de champ sont irrégulières.

## 🌈 Proposition

Réduire les marges en responsive et faire en sorte que tous les champs (celui spécifique à l’onglet Evaluation aussi) ai la même largeur.

## 🎉 Pour tester

Afficher le catalogue en responsive
Constater un affichage lisible des champs, homogène niveau largeur et avec moins de marge
