### PR TITLE
[TECH] Refactorer KnowledgeElementCollection pour supprimer une dépendance de shared

### DIFF
--- a/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
+++ b/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
@@ -1,26 +1,14 @@
 import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
 
+// bounded-context: should be transformed to a KnowledgeElementSnapshot model with a factory fromCollection(KEs)
 class KnowledgeElementCollection {
   constructor(knowledgeElements = []) {
     this.knowledgeElements = knowledgeElements;
   }
 
-  get latestUniqNonResetKnowledgeElements() {
-    const seen = new Set();
-
-    return this.knowledgeElements
-      .toSorted((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-      .filter((el) => {
-        if (seen.has(el.skillId)) return false;
-        seen.add(el.skillId);
-        return true;
-      })
-      .filter((el) => el.status !== KnowledgeElement.StatusType.RESET);
-  }
-
   toSnapshot() {
     return JSON.stringify(
-      this.latestUniqNonResetKnowledgeElements.map(
+      KnowledgeElement.toLatestUniqNonResetCollection(this.knowledgeElements).map(
         ({ createdAt, source, status, earnedPix, skillId, competenceId }) => {
           return { createdAt, source, status, earnedPix, skillId, competenceId };
         },

--- a/api/src/shared/domain/models/KnowledgeElement.js
+++ b/api/src/shared/domain/models/KnowledgeElement.js
@@ -64,6 +64,19 @@ class KnowledgeElement {
     });
   }
 
+  static toLatestUniqNonResetCollection(knowledgeElementRows) {
+    const seen = new Set();
+    return knowledgeElementRows
+      .map((knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow))
+      .toSorted((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+      .filter((el) => {
+        if (seen.has(el.skillId)) return false;
+        seen.add(el.skillId);
+        return true;
+      })
+      .filter((el) => el.status !== KnowledgeElement.StatusType.RESET);
+  }
+
   /*
   Historiquement, on force la création d'un KE inferré sur un acquis sur lequel l'utilisateur s'est
   possiblement déjà positionné par le passé (dans le cadre d'un assessment différent) pour :

--- a/api/src/shared/domain/models/KnowledgeElement.js
+++ b/api/src/shared/domain/models/KnowledgeElement.js
@@ -74,7 +74,7 @@ class KnowledgeElement {
         seen.add(el.skillId);
         return true;
       })
-      .filter((el) => el.status !== KnowledgeElement.StatusType.RESET);
+      .filter((el) => el.status !== statuses.RESET);
   }
 
   /*

--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -1,4 +1,3 @@
-import { KnowledgeElementCollection } from '../../../prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { KnowledgeElement } from '../../domain/models/KnowledgeElement.js';
 
@@ -19,11 +18,7 @@ function _findByUserIdAndLimitDateQuery({ userId, limitDate, skillIds = [] }) {
 
 async function findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, skillIds }) {
   const knowledgeElementRows = await _findByUserIdAndLimitDateQuery({ userId, limitDate, skillIds });
-
-  const keCollection = new KnowledgeElementCollection(
-    knowledgeElementRows.map((knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow)),
-  );
-  return keCollection.latestUniqNonResetKnowledgeElements;
+  return KnowledgeElement.toLatestUniqNonResetCollection(knowledgeElementRows);
 }
 
 const groupUniqKnowledgeElementsByUserId = ({ userIds, knowledgeElementRows }) => {
@@ -31,12 +26,10 @@ const groupUniqKnowledgeElementsByUserId = ({ userIds, knowledgeElementRows }) =
   for (const row of knowledgeElementRows) {
     knowledgeElementsByUserId.get(row.userId)?.push(new KnowledgeElement(row));
   }
-
   return userIds.map((userId) => {
-    const keCollection = new KnowledgeElementCollection(knowledgeElementsByUserId.get(userId));
     return {
       userId,
-      knowledgeElements: keCollection.latestUniqNonResetKnowledgeElements,
+      knowledgeElements: KnowledgeElement.toLatestUniqNonResetCollection(knowledgeElementsByUserId.get(userId)),
     };
   });
 };

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
@@ -1,5 +1,4 @@
 import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
-import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -103,8 +102,8 @@ describe('Unit | Domain | Models | CampaignResultLevelsPerTubesAndCompetences', 
       });
 
       keData = {
-        participationId1: new KnowledgeElementCollection([user1ke1, user1ke2]).latestUniqNonResetKnowledgeElements,
-        participationId2: new KnowledgeElementCollection([user2ke1, user2ke2]).latestUniqNonResetKnowledgeElements,
+        participationId1: KnowledgeElement.toLatestUniqNonResetCollection([user1ke1, user1ke2]),
+        participationId2: KnowledgeElement.toLatestUniqNonResetCollection([user2ke1, user2ke2]),
       };
     });
 

--- a/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
@@ -1,5 +1,4 @@
 import { TubeResultForKnowledgeElementSnapshots } from '../../../../../../src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js';
-import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -72,8 +71,8 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
       });
 
       knowledgeElementSnapshots = [
-        new KnowledgeElementCollection([user1ke1, user1ke2]).latestUniqNonResetKnowledgeElements,
-        new KnowledgeElementCollection([user2ke1, user2ke2]).latestUniqNonResetKnowledgeElements,
+        KnowledgeElement.toLatestUniqNonResetCollection([user1ke1, user1ke2]),
+        KnowledgeElement.toLatestUniqNonResetCollection([user2ke1, user2ke2]),
       ];
     });
 

--- a/api/tests/prescription/shared/unit/domain/models/KnowledgeElementCollection_test.js
+++ b/api/tests/prescription/shared/unit/domain/models/KnowledgeElementCollection_test.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { expect } from '../../../../../test-helper.js';
@@ -24,27 +22,6 @@ describe('Unit | Domain | Models | KnowledgeElementCollection', function () {
       );
     });
 
-    it('should call latestUniqNonResetKnowledgeElements method', function () {
-      const ke1 = buildKnowledgeElement({
-        skillId: 'rec1',
-        competenceId: 5,
-        createdAt: new Date('2025-01-10'),
-        earnedPix: 4,
-        answerId: 1,
-        assessmentId: 2,
-        id: 1,
-        userId: 1,
-      });
-      const keCollection = new KnowledgeElementCollection([ke1]);
-
-      // we stub the method to contorl its output
-      const stub = sinon.stub(keCollection, 'latestUniqNonResetKnowledgeElements');
-      stub.get(() => []);
-
-      const snapshot = keCollection.toSnapshot();
-      expect(snapshot).equals('[]');
-    });
-
     it('should drop id, userId, assessmentId, answerId', function () {
       const ke1 = buildKnowledgeElement({
         skillId: 'rec1',
@@ -64,34 +41,6 @@ describe('Unit | Domain | Models | KnowledgeElementCollection', function () {
       expect(snapshot).not.match(/"id":/i);
       expect(snapshot).not.match(/"assessmentId":/i);
       expect(snapshot).not.match(/"answerId":/i);
-    });
-  });
-
-  describe('latestUniqNonResetKnowledgeElements', function () {
-    it('should returns ke', function () {
-      const ke1 = buildKnowledgeElement({ skillId: 'rec1', answerId: 1, createdAt: new Date('2025-01-10'), id: 1 });
-      const ke2 = buildKnowledgeElement({ skillId: 'rec2', answerId: 2, createdAt: new Date('2025-01-11'), id: 2 });
-      const keCollection = new KnowledgeElementCollection([ke1, ke2]);
-      expect(keCollection.latestUniqNonResetKnowledgeElements).to.deep.equal([ke2, ke1]);
-    });
-
-    it('should drop reset skillId', function () {
-      const ke1 = buildKnowledgeElement({
-        skillId: 'rec1',
-        answerId: 1,
-        status: KnowledgeElement.StatusType.RESET,
-        createdAt: new Date('2025-01-10'),
-        id: 1,
-      });
-      const keCollection = new KnowledgeElementCollection([ke1]);
-      expect(keCollection.latestUniqNonResetKnowledgeElements).to.deep.equal([]);
-    });
-
-    it('should return most recent uniq skillId', function () {
-      const ke1 = buildKnowledgeElement({ skillId: 'rec1', answerId: 1, createdAt: new Date('2025-01-10'), id: 1 });
-      const ke2 = buildKnowledgeElement({ skillId: 'rec1', answerId: 2, createdAt: new Date('2025-01-11'), id: 2 });
-      const keCollection = new KnowledgeElementCollection([ke1, ke2]);
-      expect(keCollection.latestUniqNonResetKnowledgeElements).to.deep.equal([ke2]);
     });
   });
 });

--- a/api/tests/shared/unit/domain/models/KnowledgeElement_test.js
+++ b/api/tests/shared/unit/domain/models/KnowledgeElement_test.js
@@ -406,4 +406,52 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
       expect(resetKe.id).to.be.undefined;
     });
   });
+
+  describe('#toLatestUniqNonResetCollection', function () {
+    it('should returns ke collection', function () {
+      const ke1 = domainBuilder.buildKnowledgeElement({
+        skillId: 'rec1',
+        answerId: 1,
+        createdAt: new Date('2025-01-10'),
+        id: 1,
+      });
+      const ke2 = domainBuilder.buildKnowledgeElement({
+        skillId: 'rec2',
+        answerId: 2,
+        createdAt: new Date('2025-01-11'),
+        id: 2,
+      });
+      const keCollection = KnowledgeElement.toLatestUniqNonResetCollection([ke1, ke2]);
+      expect(keCollection).to.deep.equal([ke2, ke1]);
+    });
+
+    it('should drop reset skillId', function () {
+      const ke1 = domainBuilder.buildKnowledgeElement({
+        skillId: 'rec1',
+        answerId: 1,
+        status: KnowledgeElement.StatusType.RESET,
+        createdAt: new Date('2025-01-10'),
+        id: 1,
+      });
+      const keCollection = KnowledgeElement.toLatestUniqNonResetCollection([ke1]);
+      expect(keCollection).to.deep.equal([]);
+    });
+
+    it('should return most recent uniq skillId', function () {
+      const ke1 = domainBuilder.buildKnowledgeElement({
+        skillId: 'rec1',
+        answerId: 1,
+        createdAt: new Date('2025-01-10'),
+        id: 1,
+      });
+      const ke2 = domainBuilder.buildKnowledgeElement({
+        skillId: 'rec1',
+        answerId: 2,
+        createdAt: new Date('2025-01-11'),
+        id: 2,
+      });
+      const keCollection = KnowledgeElement.toLatestUniqNonResetCollection([ke1, ke2]);
+      expect(keCollection).to.deep.equal([ke2]);
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/prescription/campaign/build-campaign-result-levels-per-tubes-and-competences.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/campaign/build-campaign-result-levels-per-tubes-and-competences.js
@@ -1,5 +1,4 @@
 import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
-import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { buildArea } from '../../build-area.js';
 import { buildCompetence } from '../../build-competence.js';
@@ -76,9 +75,9 @@ function buildCampaignResultLevelsPerTubesAndCompetences() {
   });
 
   const keData = {
-    participationId1: new KnowledgeElementCollection([user1ke1]).latestUniqNonResetKnowledgeElements,
-    participationId2: new KnowledgeElementCollection([user2ke1]).latestUniqNonResetKnowledgeElements,
-    participationId3: new KnowledgeElementCollection([user3ke1]).latestUniqNonResetKnowledgeElements,
+    participationId1: KnowledgeElement.toLatestUniqNonResetCollection([user1ke1]),
+    participationId2: KnowledgeElement.toLatestUniqNonResetCollection([user2ke1]),
+    participationId3: KnowledgeElement.toLatestUniqNonResetCollection([user3ke1]),
   };
 
   const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({


### PR DESCRIPTION
## 🪧 Problème

`KnowledgeElementCollection` est importé dans `shared` depuis `prescription/shared`. Or `shared` ne devrait pas dépendre de `prescription/shared`.

## 🌈 Proposition

Le but de `KnowledgeElementCollection` dans `shared` est de partager la fonction `latestUniqNonResetKnowledgeElements` dans le `knowledgeRepository`, la seconde chose qu'apporte `KnowledgeElementCollection` est la fonction `toSnapshot()` qui est uniquement utilisée dans `prescription`.

La méthode `latestUniqNonResetKnowledgeElements` a été déplacée en méthode statique de `KnowledgeElement` : `KnowledgeElement.toLatestUniqNonResetCollection(KEs)`. Elle est utilisée partout où `latestUniqNonResetKnowledgeElements` était utilisée et supprimée de `KnowledgeElementCollection`.

Donc `KnowledgeElementCollection` n'a plus besoin d'être importé dans `shared`.

## ✊ Remarques

**Note :** `KnowledgeElementCollection` devrait être tramnsformé en un modèle `KnowledgeElementSnapshot` et avoir une factory `fromCollection` qui remplace le `toSnapshot` (cc @1024pix/team-prescription).

## 🎉 Pour tester

???
