### PR TITLE
[FEATURE] Ajout de la colonne ID du prescrit dans Pix Admin (PIX-23154)

### DIFF
--- a/admin/app/components/organization-learners/list-table.gjs
+++ b/admin/app/components/organization-learners/list-table.gjs
@@ -10,6 +10,10 @@ import { tracked } from '@glimmer/tracking';
 import formatDate from 'ember-intl/helpers/format-date';
 import t from 'ember-intl/helpers/t';
 
+export const learnerDetailsMetabaseLink = (learnerId) => {
+  return `https://metabase.pix.fr/dashboard/1718?id=${learnerId}`;
+};
+
 export default class AdminLearnerList extends Component {
   @service router;
 
@@ -55,6 +59,23 @@ export default class AdminLearnerList extends Component {
         class="table organization-learner-list"
       >
         <:columns as |organizationLearner context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "common.fields.id"}}
+            </:header>
+            <:cell>
+              <a href={{learnerDetailsMetabaseLink organizationLearner.id}} target="_blank" rel="noreferrer noopener">
+                <span
+                  aria-label={{t
+                    "components.organization-learners.list-table.view-learner"
+                    learner=organizationLearner.fullName
+                  }}
+                >
+                  {{organizationLearner.id}}
+                </span>
+              </a>
+            </:cell>
+          </PixTableColumn>
           <PixTableColumn @context={{context}}>
             <:header>
               {{t "components.organization-learners.list-table.headers.first-name"}}

--- a/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
+++ b/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
@@ -9,6 +9,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import formatDate from 'ember-intl/helpers/format-date';
+import { learnerDetailsMetabaseLink } from 'pix-admin/components/organization-learners/list-table';
 
 export default class OrganizationLearnerInformation extends Component {
   @service accessControl;
@@ -25,6 +26,23 @@ export default class OrganizationLearnerInformation extends Component {
         @data={{@user.organizationLearners}}
       >
         <:columns as |organizationLearner context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "common.fields.id"}}
+            </:header>
+            <:cell>
+              <a href={{learnerDetailsMetabaseLink organizationLearner.id}} target="_blank" rel="noreferrer noopener">
+                <span
+                  aria-label={{t
+                    "components.organization-learners.list-table.view-learner"
+                    learner=organizationLearner.fullName
+                  }}
+                >
+                  {{organizationLearner.id}}
+                </span>
+              </a>
+            </:cell>
+          </PixTableColumn>
           <PixTableColumn @context={{context}} class="break-word">
             <:header>
               {{t "components.organization-learner-information.table.columns.firstName"}}

--- a/admin/app/models/admin-organization-learner.js
+++ b/admin/app/models/admin-organization-learner.js
@@ -12,4 +12,8 @@ export default class AdminOrganizationLearner extends Model {
   @attr() userId;
   @attr() updatedAt;
   @attr() isDisabled;
+
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
 }

--- a/admin/app/models/organization-learner.js
+++ b/admin/app/models/organization-learner.js
@@ -14,4 +14,8 @@ export default class OrganizationLearner extends Model {
   @attr() canBeDissociated;
 
   @belongsTo('user', { async: true, inverse: 'organizationLearners' }) user;
+
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
 }

--- a/admin/tests/integration/components/organization-learners/list-table-test.gjs
+++ b/admin/tests/integration/components/organization-learners/list-table-test.gjs
@@ -19,6 +19,7 @@ module('Integration | Component | OrganizationLearners | ListTable', function (h
     // given
     const organizationLearners = [
       store.createRecord('admin-organization-learner', {
+        id: 321,
         firstName: 'firstname1',
         lastName: 'lastname1',
         birthdate: '2000-01-01',
@@ -45,6 +46,7 @@ module('Integration | Component | OrganizationLearners | ListTable', function (h
     const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
     const rows = within(table).getAllByRole('row');
 
+    assert.ok(screen.getByText('321'));
     assert.dom(within(table).getByRole('cell', { name: 'firstname1' })).exists();
     assert.dom(within(table).getByRole('cell', { name: 'lastname1' })).exists();
     assert.dom(within(table).getByRole('cell', { name: '01/01/2000' })).exists();
@@ -128,6 +130,29 @@ module('Integration | Component | OrganizationLearners | ListTable', function (h
     });
   });
 
+  module('learner link', function () {
+    test('it should display learner link', async function (assert) {
+      //given
+      const organizationLearner = store.createRecord('admin-organization-learner', {
+        id: 456,
+        userId: 123,
+        firstName: 'bob',
+        lastName: 'Henri',
+      });
+      const organizationLearners = [organizationLearner];
+      //when
+      const screen = await render(<template><ListTable @organizationLearners={{organizationLearners}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
+
+      const link = within(table).getByRole('link', {
+        name: t('components.organization-learners.list-table.view-learner', { learner: organizationLearner.fullName }),
+      });
+      assert.ok(link.getAttribute('href').endsWith('456'));
+    });
+  });
+
   module('user link', function () {
     test('it should display user link', async function (assert) {
       //given
@@ -159,7 +184,7 @@ module('Integration | Component | OrganizationLearners | ListTable', function (h
       // then
       const table = screen.getByRole('table', { name: t('components.organization-learners.list-table.caption') });
 
-      assert.dom(within(table).queryByRole('link', { aria: `Voir l'utilisateur` })).doesNotExist();
+      assert.dom(within(table).queryByRole('link', { name: `Voir l'utilisateur` })).doesNotExist();
     });
   });
 

--- a/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
@@ -87,6 +87,33 @@ module(
       assert.dom(screen.getByText('02/10/2020')).exists();
     });
 
+    test('should display organization learner’s id with link', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const learner = { id: 123, fullName: 'Bob' };
+      const user = {
+        organizationLearners: [learner],
+      };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.ok(screen.getByText('123'));
+      const link = screen.getByRole('link', {
+        name: t('components.organization-learners.list-table.view-learner', { learner: learner.fullName }),
+      });
+      assert.ok(link.getAttribute('href').endsWith('123'));
+    });
+
     test('should display organization learner’s division', async function (assert) {
       // given
       const toggleDisplayDissociateModal = sinon.spy();

--- a/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
@@ -12,242 +12,220 @@ module(
   'Integration | Component | users | user-detail-personal-information | organization-learner-information',
   function (hooks) {
     setupIntlRenderingTest(hooks);
+    class AccessControlStub extends Service {
+      hasAccessToUsersActionsScope = false;
+      hasAccessToDeleteOrganizationLearnerScope = false;
+    }
 
-    module('When the admin has access to users actions scope', function () {
+    module('When user has no organizationLearners', function () {
+      test('should display no result in organization learners table', async function (assert) {
+        // given
+        const toggleDisplayDissociateModal = sinon.spy();
+        const user = { organizationLearners: [] };
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          <template>
+            <OrganizationLearnerInformation
+              @user={{user}}
+              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByText('Aucun résultat')).exists();
+      });
+    });
+
+    test('should display organization learners in table', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const user = { organizationLearners: [{ id: 1 }, { id: 2 }] };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      const table = screen.getByRole('table', {
+        name: t('components.organization-learner-information.table.caption'),
+      });
+      const rows = within(table).getAllByRole('row');
+      assert.strictEqual(rows.length, 3);
+    });
+
+    test('should display organization learner’s info', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const user = {
+        organizationLearners: [{ firstName: 'John', lastName: 'Doe', birthdate: new Date('2020-10-02') }],
+      };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('John')).exists();
+      assert.dom(screen.getByText('Doe')).exists();
+      assert.dom(screen.getByText('02/10/2020')).exists();
+    });
+
+    test('should display organization learner’s division', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const user = {
+        organizationLearners: [{ division: '3A' }],
+      };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('3A')).exists();
+    });
+
+    test('should display organization learner’s group', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const user = {
+        organizationLearners: [{ division: 'groupe 2' }],
+      };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('groupe 2')).exists();
+    });
+
+    test('should display organization learner’s organization info', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const user = {
+        organizationLearners: [{ organizationId: 42, organizationName: 'Dragon & Co' }],
+      };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('Dragon & Co')).exists();
+      assert.dom('[href="/organizations/42"]').exists();
+    });
+
+    test('should display organization learner’s import date and re-import date', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const user = {
+        organizationLearners: [{ createdAt: new Date('2020-01-01'), updatedAt: new Date('2020-01-02') }],
+      };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('01/01/2020')).exists();
+      assert.dom(screen.getByText('02/01/2020')).exists();
+    });
+
+    test('should display organization learner as active', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const user = {
+        organizationLearners: [{ isDisabled: false }],
+      };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText(t('components.organization-learner-information.table.active.true'))).exists();
+    });
+
+    test('should display organization learner as inactive', async function (assert) {
+      // given
+      const toggleDisplayDissociateModal = sinon.spy();
+      const user = {
+        organizationLearners: [{ isDisabled: true }],
+      };
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      const screen = await render(
+        <template>
+          <OrganizationLearnerInformation
+            @user={{user}}
+            @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText(t('components.organization-learner-information.table.active.false'))).exists();
+    });
+
+    module('When the admin has access to users actions and deletion learner scopes', function () {
       class AccessControlStub extends Service {
         hasAccessToUsersActionsScope = true;
         hasAccessToDeleteOrganizationLearnerScope = true;
       }
-
-      module('When the admin does not have access to deletion learner scope', function () {
-        test('it should not be able to see deletion action button', async function (assert) {
-          // Given
-          class AccessControlStub extends Service {
-            hasAccessToUsersActionsScope = true;
-            hasAccessToDeleteOrganizationLearnerScope = false;
-          }
-          const user = {
-            organizationLearners: [{ firstName: 'some name', canBeDissociated: true }],
-          };
-          this.owner.register('service:access-control', AccessControlStub);
-
-          // When
-          const screen = await render(<template><OrganizationLearnerInformation @user={{user}} /></template>);
-
-          // Then
-          assert
-            .dom(
-              screen.queryByRole('button', {
-                name: t('components.organization-learner-information.table.actions.delete'),
-              }),
-            )
-            .doesNotExist();
-        });
-      });
-
-      module('When user has no organizationLearners', function () {
-        test('should display no result in organization learners table', async function (assert) {
-          // given
-          const toggleDisplayDissociateModal = sinon.spy();
-          const user = { organizationLearners: [] };
-          this.owner.register('service:access-control', AccessControlStub);
-
-          // when
-          const screen = await render(
-            <template>
-              <OrganizationLearnerInformation
-                @user={{user}}
-                @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-              />
-            </template>,
-          );
-
-          // then
-          assert.dom(screen.getByText('Aucun résultat')).exists();
-        });
-      });
-
-      test('should display organization learners in table', async function (assert) {
-        // given
-        const toggleDisplayDissociateModal = sinon.spy();
-        const user = { organizationLearners: [{ id: 1 }, { id: 2 }] };
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(
-          <template>
-            <OrganizationLearnerInformation
-              @user={{user}}
-              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-            />
-          </template>,
-        );
-
-        // then
-        const table = screen.getByRole('table', {
-          name: t('components.organization-learner-information.table.caption'),
-        });
-        const rows = within(table).getAllByRole('row');
-        assert.strictEqual(rows.length, 3);
-      });
-
-      test('should display organization learner’s info', async function (assert) {
-        // given
-        const toggleDisplayDissociateModal = sinon.spy();
-        const user = {
-          organizationLearners: [{ firstName: 'John', lastName: 'Doe', birthdate: new Date('2020-10-02') }],
-        };
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(
-          <template>
-            <OrganizationLearnerInformation
-              @user={{user}}
-              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByText('John')).exists();
-        assert.dom(screen.getByText('Doe')).exists();
-        assert.dom(screen.getByText('02/10/2020')).exists();
-      });
-
-      test('should display organization learner’s division', async function (assert) {
-        // given
-        const toggleDisplayDissociateModal = sinon.spy();
-        const user = {
-          organizationLearners: [{ division: '3A' }],
-        };
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(
-          <template>
-            <OrganizationLearnerInformation
-              @user={{user}}
-              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByText('3A')).exists();
-      });
-
-      test('should display organization learner’s group', async function (assert) {
-        // given
-        const toggleDisplayDissociateModal = sinon.spy();
-        const user = {
-          organizationLearners: [{ division: 'groupe 2' }],
-        };
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(
-          <template>
-            <OrganizationLearnerInformation
-              @user={{user}}
-              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByText('groupe 2')).exists();
-      });
-
-      test('should display organization learner’s organization info', async function (assert) {
-        // given
-        const toggleDisplayDissociateModal = sinon.spy();
-        const user = {
-          organizationLearners: [{ organizationId: 42, organizationName: 'Dragon & Co' }],
-        };
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(
-          <template>
-            <OrganizationLearnerInformation
-              @user={{user}}
-              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByText('Dragon & Co')).exists();
-        assert.dom('[href="/organizations/42"]').exists();
-      });
-
-      test('should display organization learner’s import date and re-import date', async function (assert) {
-        // given
-        const toggleDisplayDissociateModal = sinon.spy();
-        const user = {
-          organizationLearners: [{ createdAt: new Date('2020-01-01'), updatedAt: new Date('2020-01-02') }],
-        };
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(
-          <template>
-            <OrganizationLearnerInformation
-              @user={{user}}
-              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByText('01/01/2020')).exists();
-        assert.dom(screen.getByText('02/01/2020')).exists();
-      });
-
-      test('should display organization learner as active', async function (assert) {
-        // given
-        const toggleDisplayDissociateModal = sinon.spy();
-        const user = {
-          organizationLearners: [{ isDisabled: false }],
-        };
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(
-          <template>
-            <OrganizationLearnerInformation
-              @user={{user}}
-              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByLabelText(t('components.organization-learner-information.table.active.true'))).exists();
-      });
-
-      test('should display organization learner as inactive', async function (assert) {
-        // given
-        const toggleDisplayDissociateModal = sinon.spy();
-        const user = {
-          organizationLearners: [{ isDisabled: true }],
-        };
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(
-          <template>
-            <OrganizationLearnerInformation
-              @user={{user}}
-              @toggleDisplayDissociateModal={{toggleDisplayDissociateModal}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByLabelText(t('components.organization-learner-information.table.active.false'))).exists();
-      });
 
       test('should be able to delete organization learner', async function (assert) {
         // given
@@ -322,6 +300,32 @@ module(
         // then
         assert
           .dom(screen.queryByText(t('components.organization-learner-information.table.actions.dissociate')))
+          .doesNotExist();
+      });
+    });
+
+    module('When the admin does not have access to deletion learner scope', function () {
+      test('it should not be able to see deletion action button', async function (assert) {
+        // Given
+        class AccessControlStub extends Service {
+          hasAccessToUsersActionsScope = true;
+          hasAccessToDeleteOrganizationLearnerScope = false;
+        }
+        const user = {
+          organizationLearners: [{ firstName: 'some name', canBeDissociated: true }],
+        };
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // When
+        const screen = await render(<template><OrganizationLearnerInformation @user={{user}} /></template>);
+
+        // Then
+        assert
+          .dom(
+            screen.queryByRole('button', {
+              name: t('components.organization-learner-information.table.actions.delete'),
+            }),
+          )
           .doesNotExist();
       });
     });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -964,6 +964,7 @@
           "updated-at": "Updated at",
           "user-id": "User ID"
         },
+        "view-learner": "View more informations about the learner {learner} - external link",
         "view-organization": "View organization",
         "view-user": "View user"
       }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -972,6 +972,7 @@
           "updated-at": "Date MAJ",
           "user-id": "User ID"
         },
+        "view-learner": "Voir plus d'informations sur le prescrit {learner} - lien externe",
         "view-organization": "Voir l'organisation",
         "view-user": "Voir l'utilisateur"
       }


### PR DESCRIPTION
## 🪧 Problème

Actuellement, on dispose d'une quantité d'informations limitée sur les prescrits dans la liste des prescrits globale ou la liste des prescrits associés à un user dans Pix Admin.

## 🌈 Proposition

Un board metabase a été créé pour remonter plus d'informations sur un prescrit. 
On ajoute une colonne ID dans la liste des prescrits globale et la liste des prescrits associés à un user, avec un lien menant à ce board, prenant en paramètre l'id du prescrit choisi.

## ✊ Remarques

Un peu de rangement de tests a été fait pour de la clarification.

## 🎉 Pour tester

Se connecter à Pix Admin
Aller sur la page Prescrits
Faire une recherche par nom pour avoir des prescrits qui remontent
Voir que la colonne ID est présente, avec un lien menant vers le board avec l'id correspondante

Cliquer sur le lien dans UserID d'un prescrit pour afficher le détail du user
Trouver le tableau des prescrits associés au user sur sa page de détails
Voir que la colonne ID est présente, avec un lien menant vers le board avec l'id correspondante
