### PR TITLE
[FEATURE] Rendre la recherche de prescrit par filtre Prénom Nom plus stricte (PIX-23757)

### DIFF
--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -176,7 +176,7 @@ async function findPaginatedLearnersForAdmin({ page, filter, sort }) {
   if (filter) {
     const { fullName, organizationExternalId, hideDisabled } = filter;
     if (fullName) {
-      filterByFullName(query, fullName, 'firstName', 'lastName');
+      filterByFullName(query, fullName, 'firstName', 'lastName', 0.6);
     }
     if (organizationExternalId) {
       const searchUpperCase = organizationExternalId.trim().toUpperCase();

--- a/api/src/shared/infrastructure/utils/filter-utils.js
+++ b/api/src/shared/infrastructure/utils/filter-utils.js
@@ -1,14 +1,14 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 
-const DISTANCE = 0.8;
+const DEFAULT_DISTANCE = 0.8;
 
-const filterByFullName = function (queryBuilder, search, firstName, lastName) {
+const filterByFullName = function (queryBuilder, search, firstName, lastName, distance = DEFAULT_DISTANCE) {
   const searchLowerCase = search.trim().toLowerCase();
   queryBuilder.where(function () {
     //the search is performed by pg_search which uses the distances between the pattern and the data
     //if the distance is too large then pg-search won't find anything
     //this is why the others where are used
-    this.where(knex.raw(`CONCAT (??, ' ', ??) <-> ?`, [firstName, lastName, searchLowerCase]), '<=', DISTANCE);
+    this.where(knex.raw(`CONCAT (??, ' ', ??) <-> ?`, [firstName, lastName, searchLowerCase]), '<=', distance);
     this.orWhereRaw('LOWER(??) LIKE ?', [firstName, `%${searchLowerCase}%`]);
     this.orWhereRaw('LOWER(??) LIKE ?', [lastName, `%${searchLowerCase}%`]);
   });


### PR DESCRIPTION
## 🪧 Problème

Aujourd’hui, la recherche par prénom nom dans la liste des prescrits de pix admin n’est pas assez stricte : pour une saisie donnée, on retourne de nombreux prescrits dont nom et prénom sont trop éloignés de la saisie, remontant trop de résultats.

## 🌈 Proposition

Réduire la distance de levenshtein dans le calcul de correspondance du champ prénom nom uniquement pour la route qui remonte la liste des prescrits dans Pix Admin.

## ✊ Remarques

On ajoute un paramètre distance à ce filtrage par fullName avec une valeur par défaut pour ne pas impacter les routes qui l'utilise déjà.

## 🎉 Pour tester

Afficher la liste des prescrits dans Pix Admin
Voir que la recherche par prénom nom fonctionne toujours
Aller sur une autre liste qui utilise ce même filtre (liste des participants d’orga ?)
Voir que la recherche fonctionne toujours à cet endroit aussi

=> L’usage du support sur Pix Admin en prod avec des cas concrets déterminera s’il faut augmenter ou réduire davantage cette distance par la suite.