### PR TITLE
[FEATURE] Ajout du choix d'ensembles de sujets cappés dans la création d'un schéma de parcours combiné (pix-23635)

### DIFF
--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
@@ -6,7 +7,7 @@ import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
-import { fn } from '@ember/helper';
+import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -17,7 +18,7 @@ import { t } from 'ember-intl';
 import { and, eq, gt, not, or } from 'ember-truth-helpers';
 
 import Card from '../card';
-import TubesSelection from '../common/tubes-selection';
+import CappedTubesCriterion from '../target-profiles/badge-form/capped-tubes-criterion';
 import SelectAttestation from './select-attestation';
 
 export default class CombinedCourseBlueprintForm extends Component {
@@ -28,9 +29,12 @@ export default class CombinedCourseBlueprintForm extends Component {
   @tracked itemType = 'evaluation';
   @tracked itemValue = '';
   @tracked blueprint;
-  @tracked selectedTubes;
   @tracked itemAddDisabled = true;
   @tracked itemToAdd = null;
+  @tracked hasUniqueCappedTubesSubset = false;
+  @tracked hasMultipleCappedTubeSubsets = false;
+  @tracked cappedTubeRequirements = [{}];
+  @tracked areas;
 
   constructor() {
     super(...arguments);
@@ -40,6 +44,11 @@ export default class CombinedCourseBlueprintForm extends Component {
         this.blueprint.unloadRecord();
       }
     });
+    if (!this.args.updateMode){
+      Promise.resolve(this.args.model.frameworks).then(async () => {
+        await this.refreshAreas();
+      });
+    }
   }
 
   @action
@@ -100,10 +109,9 @@ export default class CombinedCourseBlueprintForm extends Component {
   async save() {
     try {
       await this.blueprint.save({
-        adapterOptions:
-          this.selectedTubes && this.selectedTubes.length
-            ? { cappedTubeRequirements: [{ tubes: this.selectedTubes, threshold: this.threshold }] }
-            : null,
+        adapterOptions: this.validCappedTubeRequirements.length
+          ? { cappedTubeRequirements: this.validCappedTubeRequirements }
+          : null,
       });
       this.pixToast.sendSuccessNotification({
         message: this.args.updateMode
@@ -172,17 +180,35 @@ export default class CombinedCourseBlueprintForm extends Component {
     );
   }
 
-  @action
-  updateTubes(tubes) {
-    this.selectedTubes = tubes.map(({ id, level }) => ({
-      tubeId: id,
-      level,
-    }));
+  async refreshAreas() {
+    const framework = this.args.model.frameworks.find((framework) => framework.name === 'Pix');
+    this.areas = Promise.resolve(await framework.areas).then((areasByFramework) => areasByFramework.flat());
+  }
+
+  get validCappedTubeRequirements() {
+    return this.cappedTubeRequirements.filter((requirement) => requirement.tubes?.length && requirement.threshold);
   }
 
   @action
-  onThresholdChange(e) {
-    this.threshold = e.target.value;
+  onCappedTubesThresholdChange(criterion, e) {
+    criterion.threshold = e.target.value;
+  }
+
+  @action
+  onCappedTubesNameChange(criterion, e) {
+    criterion.name = e.target.value;
+  }
+
+  @action
+  onCappedTubesSelectionChange(criterion, selection) {
+    criterion.tubes = selection.map(({ id, level }) => ({ tubeId: id, level }));
+  }
+
+  @action
+  removeCappedTubeCriterion(index) {
+    const updatedCappedTubeRequirements = [...this.cappedTubeRequirements];
+    updatedCappedTubeRequirements.splice(index, 1);
+    this.cappedTubeRequirements = updatedCappedTubeRequirements;
   }
 
   @action
@@ -193,6 +219,23 @@ export default class CombinedCourseBlueprintForm extends Component {
   @action
   getItemColor(type) {
     return type === 'evaluation' ? 'purple' : 'blue';
+  }
+
+  @action
+  hasUniqueCappedTubesSubsetChange(e) {
+    this.hasUniqueCappedTubesSubset = e.target.checked;
+    this.hasMultipleCappedTubeSubsets = false;
+  }
+
+  @action
+  hasMultipleCappedTubeSubsetsChange(e) {
+    this.hasMultipleCappedTubeSubsets = e.target.checked;
+    this.hasUniqueCappedTubesSubset = false;
+  }
+
+  @action
+  addCappedTubeSubset() {
+    this.cappedTubeRequirements = [...this.cappedTubeRequirements, {}];
   }
 
   <template>
@@ -232,10 +275,17 @@ export default class CombinedCourseBlueprintForm extends Component {
           @blueprint={{this.blueprint}}
           @setData={{this.setData}}
           @updateMode={{@updateMode}}
-          @model={{@model}}
-          @updateTubes={{this.updateTubes}}
-          @onThresholdChange={{this.onThresholdChange}}
-          @selectedTubes={{this.selectedTubes}}
+          @areas={{this.areas}}
+          @onCappedTubesThresholdChange={{this.onCappedTubesThresholdChange}}
+          @onCappedTubesNameChange={{this.onCappedTubesNameChange}}
+          @onCappedTubesSelectionChange={{this.onCappedTubesSelectionChange}}
+          @removeCappedTubeCriterion={{this.removeCappedTubeCriterion}}
+          @cappedTubeRequirements={{this.cappedTubeRequirements}}
+          @hasMultipleCappedTubeSubsets={{this.hasMultipleCappedTubeSubsets}}
+          @hasMultipleCappedTubeSubsetsChange={{this.hasMultipleCappedTubeSubsetsChange}}
+          @hasUniqueCappedTubesSubset={{this.hasUniqueCappedTubesSubset}}
+          @hasUniqueCappedTubesSubsetChange={{this.hasUniqueCappedTubesSubsetChange}}
+          @addCappedTubeSubset={{this.addCappedTubeSubset}}
         />
       {{/if}}
 
@@ -472,19 +522,46 @@ const RewardRequirementsSection = <template>
 
     {{#unless @updateMode}}
       {{#if @blueprint.rewardId}}
-        <TubesSelection @frameworks={{@model.frameworks}} @onChange={{@updateTubes}} />
-        {{#if @selectedTubes.length}}
-          <PixInput
-            @id="blueprintThreshold"
-            class="combined-course-blueprint-form__threshold"
-            type="number"
-            min="0"
-            max="100"
-            @requiredLabel={{t "common.forms.mandatory"}}
-            {{on "change" @onThresholdChange}}
+        <div class="badge-form-criteria-choice">
+          <p>Définir un critère d'obtention&nbsp;:</p>
+          <PixCheckbox
+            @id="hasUniqueCappedTubesSubset"
+            @checked={{@hasUniqueCappedTubesSubset}}
+            {{on "change" @hasUniqueCappedTubesSubsetChange}}
           >
-            <:label>Taux de réussite requis</:label>
-          </PixInput>
+            <:label>sur l'ensemble du schéma de parcours</:label>
+          </PixCheckbox>
+          <PixCheckbox
+            @id="hasMultipleCappedTubeSubsets"
+            @checked={{@hasMultipleCappedTubeSubsets}}
+            {{on "change" @hasMultipleCappedTubeSubsetsChange}}
+          >
+            <:label>sur une sélection de sujets du schéma de parcours</:label>
+          </PixCheckbox>
+        </div>
+
+        {{#if (or @hasMultipleCappedTubeSubsets @hasUniqueCappedTubesSubset)}}
+          {{#each @cappedTubeRequirements as |criterion index|}}
+            <CappedTubesCriterion
+              @id={{concat "cappedTubeCriterion" index}}
+              @areas={{@areas}}
+              @onThresholdChange={{fn @onCappedTubesThresholdChange criterion}}
+              @onNameChange={{fn @onCappedTubesNameChange criterion}}
+              @onTubesSelectionChange={{fn @onCappedTubesSelectionChange criterion}}
+              @remove={{fn @removeCappedTubeCriterion index}}
+            />
+          {{/each}}
+          {{#if @hasMultipleCappedTubeSubsets}}
+            <PixButton
+              class="badge-form-criterion__add"
+              @variant="primary"
+              @size="small"
+              @triggerAction={{@addCappedTubeSubset}}
+              @iconBefore="add"
+            >
+              Ajouter une nouvelle sélection de sujets
+            </PixButton>
+          {{/if}}
         {{/if}}
       {{/if}}
     {{/unless}}

--- a/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
+++ b/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
@@ -87,7 +87,7 @@ export default class CappedTubesCriterion extends Component {
   }
 
   <template>
-    <section class="badge-form-criterion">
+    <article class="badge-form-criterion" data-testid={{@id}}>
       <header>
         <h3>Critère d’obtention sur une sélection de sujets du profil cible</h3>
         <PixButton @variant="secondary" @size="small" @triggerAction={{@remove}}>
@@ -120,6 +120,6 @@ export default class CappedTubesCriterion extends Component {
           @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
         />
       </main>
-    </section>
+    </article>
   </template>
 }

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
@@ -64,6 +64,7 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
     );
     await screen.findByRole('listbox');
     await click(screen.getByRole('option', { name: 'Parentalite' }));
+    await click(screen.getByRole('checkbox', { name: "sur l'ensemble du schéma de parcours" }));
 
     await clickByName('1 · Titre domaine');
     await clickByName('1 Titre competence');

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -91,13 +91,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       );
 
       await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.prescriber-description'), {
-          exact: false,
-        }),
-        'description prescripteur',
-      );
-
-      await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.survey-link')),
         'http://survey-link.fr',
       );
@@ -124,7 +117,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       ]);
       assert.strictEqual(blueprintStub.illustration, 'illustrations/hello.svg');
       assert.strictEqual(blueprintStub.description, 'description');
-      assert.strictEqual(blueprintStub.prescriberDescription, 'description prescripteur');
       assert.strictEqual(blueprintStub.surveyLink, 'http://survey-link.fr');
       assert.strictEqual(blueprintStub.rewardId, 5);
       assert.strictEqual(blueprintStub.rewardType, 'ATTESTATION');
@@ -150,12 +142,12 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
 
       const attestations = [
-        { id: '5', key: 'PARENTHOOD', label: 'Parentalite' },
-        { id: '6', key: 'SIXTH_GRADE', label: '6eme' },
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
       ];
       const frameworks = [
         {
-          id: '123',
+          id: 123,
           name: 'Pix',
           areas: [],
         },
@@ -174,12 +166,12 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
     test('it should display tubes selection component only if the user selects an attestation', async function (assert) {
       //given
       const attestations = [
-        { id: '5', key: 'PARENTHOOD', label: 'Parentalite' },
-        { id: '6', key: 'SIXTH_GRADE', label: '6eme' },
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
       ];
       const frameworks = [
         {
-          id: '123',
+          id: 123,
           name: 'Pix',
           areas: [],
         },
@@ -210,15 +202,15 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       const store = this.owner.lookup('service:store');
 
       const blueprint = store.createRecord('combined-course-blueprint', {
-        id: '1',
+        id: 1,
         name: 'name',
       });
       sinon.stub(blueprint, 'save');
       blueprint.save.resolves();
 
       const attestations = [
-        { id: '5', key: 'PARENTHOOD', label: 'Parentalite' },
-        { id: '6', key: 'SIXTH_GRADE', label: '6eme' },
+        { id: 5, key: 'PARENTHOOD', label: 'Parentalite' },
+        { id: 6, key: 'SIXTH_GRADE', label: '6eme' },
       ];
 
       const tube = store.createRecord('tube', {
@@ -305,7 +297,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       const router = this.owner.lookup('service:router');
 
       const blueprint = store.createRecord('combined-course-blueprint', {
-        id: '1',
+        id: 1,
         name: 'name',
         internalName: 'internalName',
         content: [
@@ -314,7 +306,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         ],
         illustration: 'illustrations/hello.svg',
         description: 'description',
-        prescriberDescription: 'prescriberDescription',
         surveyLink: 'http://survey-link.fr',
         rewardId: 5,
         rewardType: 'ATTESTATION',
@@ -353,13 +344,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       );
 
       await fillIn(
-        screen.getByLabelText(t('components.combined-course-blueprints.labels.prescriber-description-sublabel'), {
-          exact: false,
-        }),
-        'updatedPrescriberDescription',
-      );
-
-      await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.survey-link')),
         'http://updated-survey-link.fr',
       );
@@ -381,7 +365,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       ]);
       assert.strictEqual(blueprint.illustration, 'illustrations/updatedHello.svg');
       assert.strictEqual(blueprint.description, 'updatedDescription');
-      assert.strictEqual(blueprint.prescriberDescription, 'updatedPrescriberDescription');
       assert.strictEqual(blueprint.surveyLink, 'http://updated-survey-link.fr');
       assert.strictEqual(blueprint.rewardId, 5);
       assert.strictEqual(blueprint.rewardType, 'ATTESTATION');
@@ -397,7 +380,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
     test('it should display reward requirements when reward exists', async function (assert) {
       // given
       const blueprint = {
-        id: '1',
+        id: 1,
         name: 'name',
         internalName: 'internalName',
         attestationLabel: 'Label',
@@ -422,7 +405,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
   module('error cases', function () {
     const frameworks = [
       {
-        id: '123',
+        id: 123,
         name: 'Pix',
         areas: [],
       },
@@ -629,7 +612,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       const frameworks = [
         {
-          id: '123',
+          id: 123,
           name: 'Pix',
           areas: [],
         },
@@ -670,7 +653,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       const frameworks = [
         {
-          id: '123',
+          id: 123,
           name: 'Pix',
           areas: [],
         },


### PR DESCRIPTION
## 🪧 Problème

À la rentrée 26/27, on aimerait basculer les parcours 6ème avec attestation qui sont des quests reposant sur des PC, vers des combined_courses avec attestation. 

Dans le dispositif 6ème, on a besoin de vérifier que les élèves on validé 50% des acquis de 2 sous-ensemble du référentiel. 
À date, il n’est possible que de créer un seul critère. 

On a donc besoin de pouvoir attribuer une attestation en fonction de n critères, reposants sur des sous-ensemble du référentiel. 

## 🌈 Proposition

Côté back, tout est déjà branché pour recevoir plusieurs sélections de sujets cappés.
On a besoin côté front d’envoyer un tableau d’objets de cappedTube. 
Côté front, on s'est inspirés de l’affichage sur la création de badges sur plusieurs sélections de sujets cappés.

## ✊ Remarques

Le composant `TubeSelection` n'était pas adapté pour recevoir plusieurs sélections de sujets cappés, donc nous avons repris le composant `CappedTubesCriterion`.

## 🎉 Pour tester

Sur pix-admin, relever 2 profils cibles et les sujets sur lesquels ils portent.

Créer un schéma avec 2 ces deux profils cibles et une attestation. Les critères de l’attestation : 

- 50% des tubes cappés de l'éval 1 
- 50% des tubes cappés de l'éval 2 

Déployer un parcours combiné avec ce schéma sous pix-admin.

Sur pix-app:

- Jouer le parcours combiné déployé
- Vérifier que l’on n'obtient pas l’attestation lorsqu’on rate tout 
- Vérifier que l’on n'obtient pas l’attestation lorsqu’on a 50% à l’une mais pas à l’autre 
- Vérifier que l’on obtient l’attestation lorsqu’on a + de 50% sur chaque éval
