### PR TITLE
[FEATURE] Afficher les informations de l'organisation qui sera rattachée lors de la création du centre de certif (PIX-22685)

### DIFF
--- a/admin/app/components/certification-centers/creation-form.gjs
+++ b/admin/app/components/certification-centers/creation-form.gjs
@@ -22,9 +22,9 @@ export default class CreationForm extends Component {
   @service intl;
 
   @tracked form = {
-    name: '',
-    type: '',
-    externalId: '',
+    name: this.args.attachedOrganization?.name ?? '',
+    type: this.args.attachedOrganization?.type ?? '',
+    externalId: this.args.attachedOrganization?.externalId ?? '',
     dataProtectionOfficerLastName: '',
     dataProtectionOfficerFirstName: '',
     dataProtectionOfficerEmail: '',
@@ -37,6 +37,10 @@ export default class CreationForm extends Component {
 
   get sortedHabilitations() {
     return sortBy(this.args.habilitations, 'id');
+  }
+
+  get isExternalIdDisabled() {
+    return Boolean(this.args.attachedOrganization);
   }
 
   get dpoSectionTitle() {
@@ -89,6 +93,7 @@ export default class CreationForm extends Component {
       dataProtectionOfficerLastName: this.form.dataProtectionOfficerLastName,
       dataProtectionOfficerEmail: this.form.dataProtectionOfficerEmail,
       habilitations: [...this.form.selectedHabilitations],
+      organizationId: this.args.attachedOrganization?.id,
     });
 
     try {
@@ -116,11 +121,20 @@ export default class CreationForm extends Component {
           class="admin-form__card certification-center-creation-form__card"
           @title={{t "common.cards.titles.general-information"}}
         >
+          {{#if @attachedOrganization}}
+            <h2 class="admin-form__content title organization-creation-form__attached-organization--full">
+              {{t
+                "components.certification-centers.creation.attached-organization-name"
+                attachedOrganizationName=@attachedOrganization.name
+              }}
+            </h2>
+          {{/if}}
           <div class="certification-center-creation-form__input--full">
             <PixInput
               @id="name"
               @requiredLabel={{t "common.fields.required-field"}}
               required={{false}}
+              @value={{this.form.name}}
               placeholder={{concat
                 (t "common.words.example-abbr")
                 " "
@@ -152,6 +166,8 @@ export default class CreationForm extends Component {
 
           <PixInput
             @id="externalId"
+            @value={{this.form.externalId}}
+            disabled={{this.isExternalIdDisabled}}
             {{on "change" (fn this.handleInputChange "externalId")}}
             placeholder={{t "components.certification-centers.creation.external-id.placeholder"}}
           >

--- a/admin/app/controllers/authenticated/certification-centers/new.js
+++ b/admin/app/controllers/authenticated/certification-centers/new.js
@@ -5,6 +5,8 @@ import { service } from '@ember/service';
 export default class NewController extends Controller {
   @service router;
 
+  queryParams = ['attachedOrganizationId'];
+
   @action
   goBackToCertificationCentersList() {
     this.router.transitionTo('authenticated.certification-centers');

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -19,6 +19,7 @@ export default class CertificationCenter extends Model {
   @attr() dataProtectionOfficerFirstName;
   @attr() dataProtectionOfficerLastName;
   @attr() dataProtectionOfficerEmail;
+  @attr() organizationId;
 
   @hasMany('complementary-certification', { async: true, inverse: null }) habilitations;
   @hasMany('certification-center-membership', { async: true, inverse: 'certificationCenter' })

--- a/admin/app/routes/authenticated/certification-centers/new.js
+++ b/admin/app/routes/authenticated/certification-centers/new.js
@@ -4,8 +4,13 @@ import { service } from '@ember/service';
 export default class NewRoute extends Route {
   @service store;
 
-  async model() {
+  async model(_, transition) {
     const habilitations = await this.store.findAll('complementary-certification');
-    return { habilitations };
+    let attachedOrganization = null;
+    const { attachedOrganizationId } = transition.to.queryParams;
+    if (attachedOrganizationId) {
+      attachedOrganization = await this.store.findRecord('organization', attachedOrganizationId);
+    }
+    return { habilitations, attachedOrganization };
   }
 }

--- a/admin/app/templates/authenticated/certification-centers/new.gjs
+++ b/admin/app/templates/authenticated/certification-centers/new.gjs
@@ -14,5 +14,6 @@ import CreationForm from 'pix-admin/components/certification-centers/creation-fo
     class="main-admin-form"
     @habilitations={{@model.habilitations}}
     @onCancel={{@controller.goBackToCertificationCentersList}}
+    @attachedOrganization={{@model.attachedOrganization}}
   />
 </template>

--- a/admin/tests/integration/components/certification-centers/creation-form-test.gjs
+++ b/admin/tests/integration/components/certification-centers/creation-form-test.gjs
@@ -12,6 +12,13 @@ const habilitations = [
   { id: '2', key: 'S', label: 'Pix+Surf' },
 ];
 
+const attachedOrganization = {
+  id: '123',
+  name: 'Wayne Enterprises',
+  type: 'SCO',
+  externalId: 'WAYNE_123',
+};
+
 module('Integration | Component | certification-centers/creation-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
@@ -69,6 +76,7 @@ module('Integration | Component | certification-centers/creation-form', function
       dataProtectionOfficerLastName: 'Hadis',
       dataProtectionOfficerEmail: 'jacques.hadis@example.com',
       habilitations: [{ id: '1', key: 'E', label: 'Pix+Edu' }],
+      organizationId: undefined,
     });
 
     const message = pixToast.sendSuccessNotification.getCall(0).args[0];
@@ -112,6 +120,7 @@ module('Integration | Component | certification-centers/creation-form', function
       dataProtectionOfficerLastName: '',
       dataProtectionOfficerEmail: '',
       habilitations: [{ id: '2', key: 'S', label: 'Pix+Surf' }],
+      organizationId: undefined,
     });
   });
 
@@ -134,6 +143,138 @@ module('Integration | Component | certification-centers/creation-form', function
     // then
     const record = store.createRecord.getCall(0).args[1];
     assert.deepEqual(record.externalId, null);
+  });
+
+  module('when there is no attached organization', function () {
+    test('it does not display the attached organization name', async function (assert) {
+      // given
+      const onCancel = () => {};
+
+      // when
+      const screen = await render(
+        <template><CreationForm @habilitations={{habilitations}} @onCancel={{onCancel}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('components.certification-centers.creation.attached-organization-name', {
+              attachedOrganizationName: attachedOrganization.name,
+            }),
+            level: 2,
+          }),
+        )
+        .doesNotExist();
+    });
+
+    test('it does not disable the external id input', async function (assert) {
+      // given
+      const onCancel = () => {};
+
+      // when
+      const screen = await render(
+        <template><CreationForm @habilitations={{habilitations}} @onCancel={{onCancel}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('textbox', { name: t('components.certification-centers.creation.external-id.label') }))
+        .isNotDisabled();
+    });
+  });
+
+  module('when there is an attached organization', function () {
+    test('it displays the attached organization name', async function (assert) {
+      // given
+      const onCancel = () => {};
+
+      // when
+      const screen = await render(
+        <template>
+          <CreationForm
+            @habilitations={{habilitations}}
+            @attachedOrganization={{attachedOrganization}}
+            @onCancel={{onCancel}}
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.certification-centers.creation.attached-organization-name', {
+              attachedOrganizationName: attachedOrganization.name,
+            }),
+            level: 2,
+          }),
+        )
+        .exists();
+    });
+
+    test("it prefills the name, the type and the external id (disabled) with the attached organization's ones", async function (assert) {
+      // given
+      const onCancel = () => {};
+
+      // when
+      const screen = await render(
+        <template>
+          <CreationForm
+            @habilitations={{habilitations}}
+            @attachedOrganization={{attachedOrganization}}
+            @onCancel={{onCancel}}
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('textbox', { name: `${t('components.certification-centers.creation.name.label')} *` }))
+        .hasValue('Wayne Enterprises');
+      assert.strictEqual(
+        screen.getByRole('button', { name: `${t('components.certification-centers.creation.type.label')} *` })
+          .innerText,
+        'Établissement scolaire',
+      );
+      assert
+        .dom(screen.getByRole('textbox', { name: t('components.certification-centers.creation.external-id.label') }))
+        .hasValue('WAYNE_123');
+      assert
+        .dom(screen.getByRole('textbox', { name: t('components.certification-centers.creation.external-id.label') }))
+        .isDisabled();
+    });
+
+    test('it creates a certification center attached to the organization', async function (assert) {
+      // given
+      const onCancel = () => {};
+      const screen = await render(
+        <template>
+          <CreationForm
+            @habilitations={{habilitations}}
+            @attachedOrganization={{attachedOrganization}}
+            @onCancel={{onCancel}}
+          />
+        </template>,
+      );
+
+      // when
+      await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
+      // then
+      const record = store.createRecord.getCall(0).args[1];
+      assert.deepEqual(record, {
+        name: 'Wayne Enterprises',
+        type: 'SCO',
+        externalId: 'WAYNE_123',
+        dataProtectionOfficerFirstName: '',
+        dataProtectionOfficerLastName: '',
+        dataProtectionOfficerEmail: '',
+        habilitations: [],
+        organizationId: '123',
+      });
+      assert.ok(router.transitionTo.called);
+    });
   });
 
   module('Errors', function () {

--- a/admin/tests/unit/routes/authenticated/certification-centers/new-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/new-test.js
@@ -1,0 +1,46 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/certification-centers/new', function (hooks) {
+  setupTest(hooks);
+
+  let route, store, habilitations;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/certification-centers/new');
+    store = this.owner.lookup('service:store');
+
+    habilitations = Symbol('some habilitations');
+    store.findAll = sinon.stub();
+    store.findAll.withArgs('complementary-certification').resolves(habilitations);
+    store.findRecord = sinon.stub();
+  });
+
+  test('it should return habilitations and no attached organization', async function (assert) {
+    // given
+    const transition = { to: { queryParams: {} } };
+
+    // when
+    const result = await route.model(undefined, transition);
+
+    // then
+    assert.strictEqual(result.habilitations, habilitations);
+    assert.strictEqual(result.attachedOrganization, null);
+    assert.ok(store.findRecord.notCalled);
+  });
+
+  test('it should return the attached organization when there is an attachedOrganizationId query param', async function (assert) {
+    // given
+    const attachedOrganization = Symbol('the attached organization');
+    store.findRecord.withArgs('organization', '123').resolves(attachedOrganization);
+    const transition = { to: { queryParams: { attachedOrganizationId: '123' } } };
+
+    // when
+    const result = await route.model(undefined, transition);
+
+    // then
+    assert.strictEqual(result.habilitations, habilitations);
+    assert.strictEqual(result.attachedOrganization, attachedOrganization);
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -475,6 +475,7 @@
         }
       },
       "creation": {
+        "attached-organization-name": "Attached organization : {attachedOrganizationName}",
         "complementary-certifications-habilitations": "Habilitations to complementary certifications",
         "configuration": "Configuration",
         "dpo": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -482,6 +482,7 @@
         }
       },
       "creation": {
+        "attached-organization-name": "Organisation rattachée : {attachedOrganizationName}",
         "complementary-certifications-habilitations": "Habilitations aux certifications complémentaires",
         "configuration": "Paramétrage",
         "dpo": {


### PR DESCRIPTION
## 🪧 Problème
Maintenant que l'API est prête à recevoir un organizationId lors de la création d'un CDC pour faire le rattachement.
Il faut pouvoir afficher ces infos lors de la création d'un centre de certif, et envoyer l'organizationId dans le payload

## 🌈 Proposition
Ajouter un queryParam qui prends l'organisation id depuis laquelle on crée le cdc. Afficher le nom de celle-ci dans le formulaire.
Et on pré-rempli Nom, Type et ExternalId 

## ✊ Remarques
On rends le champs externalId non modifiable car il est censé être strictement similaire à celui de l'organisation. Ce choix peut être rediscuté

## 🎉 Pour tester

- Aller sur PixAdmin
- Noter un Id d'orga de côté
- Aller sur la page de création d'un centre de certif
- Ajouter `?attachedOrganizationId=xxx` a la fin de l'url.
- Voir le nom de l'orga correspondate affiché + les champs pré-rempli
- Enfin, créer le centre de certif, et constater que le lien avec l'orga est fait
- 🐈‍⬛ 