### PR TITLE
[TECH] Utiliser un modèle answer spécifique à certif

### DIFF
--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import('../../../shared/domain/models/CertificationChallengeWithType.js').CertificationChallengeWithType} CertificationChallengeWithType
- * @typedef {import('../../../../evaluation/domain/models/Answer.js').Answer} Answer
+ * @typedef {import('../../../shared/domain/models/CertificationAnswer.js').CertificationAnswer} CertificationAnswer
  */
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
@@ -42,7 +42,7 @@ export class CertificationAssessment {
    * @param {object} params
    * @param {Date} params.createdAt certification course creation date
    * @param {Array<CertificationChallengeWithType>} params.certificationChallenges
-   * @param {Array<Answer>} params.certificationAnswersByDate
+   * @param {Array<CertificationAnswer>} params.certificationAnswersByDate
    */
   constructor({
     id,

--- a/api/src/certification/shared/dependencies.json
+++ b/api/src/certification/shared/dependencies.json
@@ -6,7 +6,6 @@
     "certification/evaluation",
     "certification/results",
     "certification/session-management",
-    "evaluation",
     "shared"
   ],
   "circular": "forbidden"

--- a/api/src/certification/shared/domain/models/CertificationAnswer.js
+++ b/api/src/certification/shared/domain/models/CertificationAnswer.js
@@ -1,0 +1,21 @@
+import { AnswerStatus } from '../../../../shared/domain/models/AnswerStatus.js';
+
+export class CertificationAnswer {
+  /**
+   * @param {object} params
+   * @param {number} params.id
+   * @param {string} params.challengeId
+   * @param {AnswerStatus|string} params.result
+   * @param {string} params.value
+   */
+  constructor({ id, challengeId, result, value }) {
+    this.id = id;
+    this.challengeId = challengeId;
+    this.result = AnswerStatus.from(result);
+    this.value = value;
+  }
+
+  isOk() {
+    return this.result.isOK();
+  }
+}

--- a/api/src/certification/shared/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-assessment-repository.js
@@ -1,9 +1,8 @@
-import { Answer } from '../../../../evaluation/domain/models/Answer.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
-import * as answerStatusDatabaseAdapter from '../../../../shared/infrastructure/adapters/answer-status-database-adapter.js';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import { CertificationAssessment } from '../../../session-management/domain/models/CertificationAssessment.js';
+import { CertificationAnswer } from '../../domain/models/CertificationAnswer.js';
 import { CertificationChallengeWithType } from '../../domain/models/CertificationChallengeWithType.js';
 
 export async function getByCertificationCourseId({ certificationCourseId }) {
@@ -88,9 +87,7 @@ export async function save(certificationAssessment) {
     });
   }
   for (const answer of certificationAssessment.certificationAnswersByDate) {
-    await knexConn('answers')
-      .where({ id: answer.id })
-      .update({ result: answerStatusDatabaseAdapter.toSQLString(answer.result) });
+    await knexConn('answers').where({ id: answer.id }).update({ result: answer.result.status });
   }
 
   await knexConn('assessments')
@@ -117,17 +114,12 @@ async function _getCertificationChallenges(certificationCourseId, knexConn) {
 
 async function _getCertificationAnswersByDate(certificationAssessmentId, knexConn) {
   const answerDTOs = await knexConn
-    .select(['id', 'result', 'resultDetails', 'timeout', 'value', 'assessmentId', 'challengeId', 'timeSpent'])
+    .select(['id', 'result', 'value', 'challengeId'])
     .from('answers')
     .where({ assessmentId: certificationAssessmentId })
     .orderBy('createdAt', 'asc');
   const dedupedAnswerDTOs = uniqByChallenge(answerDTOs);
-  return dedupedAnswerDTOs.map((answerDTO) => {
-    return new Answer({
-      ...answerDTO,
-      result: answerStatusDatabaseAdapter.fromSQLString(answerDTO.result),
-    });
-  });
+  return dedupedAnswerDTOs.map((answerDTO) => new CertificationAnswer(answerDTO));
 }
 
 function uniqByChallenge(answerDTOs) {

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
+import { CertificationAnswer } from '../../../../../../src/certification/shared/domain/models/CertificationAnswer.js';
 import * as certificationAssessmentRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
@@ -127,6 +128,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
           assessmentId: expectedCertificationAssessmentId,
           createdAt: new Date('2020-06-24T00:00:00Z'),
           challengeId: 'recChalB',
+          result: 'ok',
+          value: 'first answer value',
         }).id;
 
         dbf.buildAnswer({
@@ -156,6 +159,13 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
 
         expect(certificationAssessment.certificationAnswersByDate).to.have.lengthOf(2);
         expect(certificationAssessment.certificationChallenges).to.have.lengthOf(2);
+
+        const firstAnswer = certificationAssessment.certificationAnswersByDate[0];
+        expect(firstAnswer).to.be.an.instanceOf(CertificationAnswer);
+        expect(firstAnswer.id).to.equal(firstAnswerInTime);
+        expect(firstAnswer.challengeId).to.equal('recChalB');
+        expect(firstAnswer.value).to.equal('first answer value');
+        expect(firstAnswer.result).to.deep.equal(AnswerStatus.OK);
       });
 
       it('should return the certification answers ordered by date', async function () {

--- a/api/tests/certification/shared/unit/domain/models/CertificationAnswer_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationAnswer_test.js
@@ -1,0 +1,57 @@
+import { CertificationAnswer } from '../../../../../../src/certification/shared/domain/models/CertificationAnswer.js';
+import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Shared | Domain | Models | CertificationAnswer', function () {
+  describe('#constructor', function () {
+    it('initializes the certification answer with its properties', function () {
+      // when
+      const certificationAnswer = new CertificationAnswer({
+        id: 123,
+        challengeId: 'recChallenge',
+        result: AnswerStatus.OK,
+        value: 'user answer',
+      });
+
+      // then
+      expect(certificationAnswer.id).to.equal(123);
+      expect(certificationAnswer.challengeId).to.equal('recChallenge');
+      expect(certificationAnswer.result).to.deep.equal(AnswerStatus.OK);
+      expect(certificationAnswer.value).to.equal('user answer');
+    });
+
+    it('builds the result as an AnswerStatus when given its database string representation', function () {
+      // when
+      const certificationAnswer = new CertificationAnswer({ result: 'aband' });
+
+      // then
+      expect(certificationAnswer.result).to.deep.equal(AnswerStatus.SKIPPED);
+    });
+
+    it('keeps the result as-is when given an AnswerStatus', function () {
+      // when
+      const certificationAnswer = new CertificationAnswer({ result: AnswerStatus.FOCUSEDOUT });
+
+      // then
+      expect(certificationAnswer.result).to.deep.equal(AnswerStatus.FOCUSEDOUT);
+    });
+  });
+
+  describe('#isOk', function () {
+    it('returns true when the result is OK', function () {
+      // given
+      const certificationAnswer = new CertificationAnswer({ result: AnswerStatus.OK });
+
+      // when / then
+      expect(certificationAnswer.isOk()).to.be.true;
+    });
+
+    it('returns false when the result is not OK', function () {
+      // given
+      const certificationAnswer = new CertificationAnswer({ result: AnswerStatus.KO });
+
+      // when / then
+      expect(certificationAnswer.isOk()).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## ☀️ Problème

On utilise modèle `Answer` général dans le contexte certification.

Dans notre objectif d'éviter les dépendances cycliques entre les domaines, il est pratique d'avoir des modèles légers dans leur domaine dédié.

## ⛱️ Proposition

Créer et utiliser un modèle `CertificationAnswer` dans `certification/shared`.

## 🏊 Pour tester

Tester en RA
