### PR TITLE
[TECH] Ajout d'une colonne `externalCalibrationId` dans la table `certification_versions` (PIX-23775)

### DIFF
--- a/api/db/migrations/20260803053942_add-column-external-calibration-id-in-certification-versions.js
+++ b/api/db/migrations/20260803053942_add-column-external-calibration-id-in-certification-versions.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'certification_versions';
+const COLUMN_NAME = 'externalCalibrationId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .defaultTo(null)
+      .comment('External identifier for a record in data_calibrations table (data)');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}


### PR DESCRIPTION
## ☀️ Problème

On veut se souvenir depuis quelle calibration côté data on veut et on s'est synchronisé depuis Data pour la version en cours d'élaboration

## ⛱️ Proposition

Ajouter une colonne `externalCalibrationId` dans la table `certification_versions`, qui correspond à l'ID de la table côté Data `data_calibrations`

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

```
npm run db:migrate
npm run db:rollback:latest
```
