### PR TITLE
[FEATURE] Permettre au SuperAdmin de saisir un ID de calibration pour vérifier sa cohérence avec la version en cours de création (PIX-23773)

### DIFF
--- a/admin/app/adapters/calibration-report.js
+++ b/admin/app/adapters/calibration-report.js
@@ -1,0 +1,20 @@
+import ApplicationAdapter from './application';
+
+export default class CalibrationReportAdapter extends ApplicationAdapter {
+  createRecord(store, type, snapshot) {
+    if (!snapshot.adapterOptions.calibrationId) {
+      return super.createRecord(...arguments);
+    }
+
+    const url = `${this.host}/${this.namespace}/certification-versions/${snapshot.adapterOptions.versionId}/calibration-report`;
+    const payload = {
+      data: {
+        attributes: {
+          calibrationId: snapshot.adapterOptions.calibrationId,
+        },
+      },
+    };
+
+    return this.ajax(url, 'POST', { data: payload });
+  }
+}

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-form.gjs
@@ -1,35 +1,156 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import formatDate from 'ember-intl/helpers/format-date';
+import { eq } from 'ember-truth-helpers';
 import Card from 'pix-admin/components/card';
+import { DescriptionList } from 'pix-admin/components/ui/description-list';
 
-<template>
-  <Card @title="Calibration des épreuves">
-    <form id="version-calibration-form" class="versions-calibration__form">
-      <section>
-        <PixInput
-          type="text"
-          required={{true}}
-          @requiredLabel={{t "common.forms.mandatory"}}
-          @errorMessage={{t
-            "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
-          }}
-        >
-          <:label>{{t
-              "components.certification-frameworks.certification-framework.versions.calibration.calibration-id-input-label"
-            }}</:label>
-        </PixInput>
+export default class CalibrationForm extends Component {
+  @service store;
+  @service pixToast;
+  @service intl;
+  @tracked calibrationId = null;
+  @tracked report = null;
+  @tracked showMoreInfoForLines = [];
 
-        <PixButton @type="button" @variant="primary">{{t
-            "components.certification-frameworks.certification-framework.versions.calibration.verify-calibration-id-button"
-          }}</PixButton>
-      </section>
-    </form>
-  </Card>
-  <section class="actions-container">
-    <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
-      {{t "common.actions.cancel"}}
-    </PixButtonLink>
-  </section>
-</template>
+  get translatedReportLines() {
+    const translatedReportLines = [];
+    let i = 1;
+    for (const reportLine of this.report.reportLines) {
+      const translatedReportLine = {
+        lineNumber: i,
+        label: this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.calibration.label-for-' +
+            reportLine.label,
+        ),
+        alertLevel: reportLine.alertLevel,
+        additionalContent: reportLine.additionalContent,
+        isExpanded: this.showMoreInfoForLines.includes(i),
+      };
+      ++i;
+      translatedReportLine.content = reportLine.content;
+      if (reportLine.label === 'CALIBRATION_SCOPE') {
+        translatedReportLine.content = this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.calibration.scopes.' +
+            reportLine.content,
+        );
+      }
+      if (reportLine.label === 'CALIBRATION_STATUS') {
+        translatedReportLine.content = this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.calibration.statuses.' +
+            reportLine.content,
+        );
+      }
+      translatedReportLines.push(translatedReportLine);
+    }
+    return translatedReportLines;
+  }
+
+  @action
+  updateCalibrationId(event) {
+    this.calibrationId = Number(event.target.valueAsNumber);
+  }
+
+  @action
+  async onGenerateReport(event) {
+    event.preventDefault();
+    const report = this.store.createRecord('calibration-report');
+    try {
+      await report.save({
+        adapterOptions: {
+          calibrationId: this.calibrationId,
+          versionId: this.args.draftVersion.id,
+        },
+      });
+    } catch (error) {
+      report.deleteRecord();
+      this.pixToast.sendErrorNotification({ message: error.errors?.[0].detail });
+      return;
+    }
+    this.showMoreInfoForLines = [];
+    this.report = report;
+  }
+
+  @action
+  async showMoreInfo(lineNumber) {
+    const index = this.showMoreInfoForLines.indexOf(lineNumber);
+    if (index === -1) {
+      this.showMoreInfoForLines = [...this.showMoreInfoForLines, lineNumber];
+    } else {
+      this.showMoreInfoForLines = this.showMoreInfoForLines.filter((lineExpanded) => lineExpanded !== lineNumber);
+    }
+  }
+
+  @action
+  async shouldShowMoreInfo(lineNumber) {
+    return this.showMoreInfoForLines.some((lineExpanded) => lineExpanded === lineNumber);
+  }
+
+  <template>
+    <Card @title="Calibration des épreuves">
+      <form id="version-calibration-form" class="versions-calibration__form" {{on "submit" this.onGenerateReport}}>
+        <section>
+          <PixInput
+            type="number"
+            required={{true}}
+            @requiredLabel={{t "common.forms.mandatory"}}
+            @errorMessage={{t
+              "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
+            }}
+            {{on "change" this.updateCalibrationId}}
+          >
+            <:label>{{t
+                "components.certification-frameworks.certification-framework.versions.calibration.calibration-id-input-label"
+              }}
+            </:label>
+          </PixInput>
+          <PixButton @type="submit" form="version-calibration-form" @variant="primary">{{t
+              "components.certification-frameworks.certification-framework.versions.calibration.verify-calibration-id-button"
+            }}
+          </PixButton>
+        </section>
+      </form>
+      {{#if this.report}}
+        {{t
+          "components.certification-frameworks.certification-framework.versions.calibration.report-title"
+          calibrationId=this.report.calibrationId
+        }}
+        {{formatDate this.report.generatedAt format="long"}}
+        <DescriptionList>
+          {{#each this.translatedReportLines as |line|}}
+            <DescriptionList.Item @label={{line.label}}>
+              {{line.content}}
+              {{#if line.alertLevel}}
+                <PixIconButton
+                  @ariaLabel={{t
+                    "components.certification-frameworks.certification-framework.versions.calibration.show-additional-info"
+                    lineNumber=line.lineNumber
+                  }}
+                  @iconName={{if (eq line.alertLevel "HIGH") "cancel" "warning"}}
+                  @triggerAction={{fn this.showMoreInfo line.lineNumber}}
+                />
+              {{/if}}
+              {{#if line.isExpanded}}
+                <p>{{line.additionalContent}}</p>
+              {{/if}}
+            </DescriptionList.Item>
+          {{/each}}
+        </DescriptionList>
+      {{/if}}
+    </Card>
+    <section class="actions-container">
+      <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
+        {{t "common.actions.cancel"}}
+      </PixButtonLink>
+    </section>
+  </template>
+}

--- a/admin/app/models/calibration-report.js
+++ b/admin/app/models/calibration-report.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@warp-drive/legacy/model';
+
+export default class CalibrationReport extends Model {
+  @attr('date') generatedAt;
+  @attr('number') calibrationId;
+  @attr() reportLines;
+}

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/calibration-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/calibration-test.js
@@ -1,11 +1,11 @@
-import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { currentURL, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
 import { module, test } from 'qunit';
 
-module('Acceptance | Certification Framework | item | Framework | edit', function (hooks) {
+module('Acceptance | Certification Framework | item | Framework | calibration', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -48,7 +48,7 @@ module('Acceptance | Certification Framework | item | Framework | edit', functio
   });
 
   module('when admin member has role "SUPER ADMIN"', function () {
-    module('when trying to calibrate a non-draft version', function () {
+    module('when trying to load calibration for a non-draft version', function () {
       test('redirects to versions list', async function (assert) {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
@@ -60,13 +60,76 @@ module('Acceptance | Certification Framework | item | Framework | edit', functio
       });
     });
 
-    module('when trying to click on cancel button', function () {
+    module('when clicking on cancel button', function () {
       test('redirects to certification-framework page', async function (assert) {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
-        await visit(`/certification-frameworks/CORE/versions/14/edit`);
+        await visit(`/certification-frameworks/CORE/versions/14/calibration`);
         await clickByName('Annuler');
         assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
+      });
+    });
+
+    module('when loading a report for a version', function () {
+      test('displays the report', async function (assert) {
+        const generatedAt = new Date('2026-08-08T14:00:00Z');
+        server.post('/admin/certification-versions/:id/calibration-report', (schema) => {
+          return schema.create('calibration-report', {
+            id: 999,
+            calibrationId: 1,
+            generatedAt,
+            reportLines: [
+              {
+                additionalContent: null,
+                alertLevel: null,
+                content: 15,
+                label: 'CALIBRATED_CHALLENGE_COUNT',
+              },
+              {
+                additionalContent: 'tubeA',
+                alertLevel: 'LOW',
+                content: 1,
+                label: 'TUBE_ONLY_IN_VERSION_COUNT',
+              },
+              {
+                additionalContent: "La calibration a été démarrée depuis plus d'1 an",
+                alertLevel: 'HIGH',
+                content: new Date('2021-01-01'),
+                label: 'CALIBRATION_STARTED_AT',
+              },
+              {
+                additionalContent: null,
+                alertLevel: null,
+                content: 'CORE',
+                label: 'CALIBRATION_SCOPE',
+              },
+              {
+                additionalContent: null,
+                alertLevel: null,
+                content: 'VALIDATED',
+                label: 'CALIBRATION_STATUS',
+              },
+            ],
+          });
+        });
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        const screen = await visit(`/certification-frameworks/CORE/versions/14/calibration`);
+        await fillByLabel('ID de calibration', 1, { exact: false });
+        await clickByName('Vérifier la calibration');
+
+        await settled();
+        const displayedGeneratedAt = generatedAt.toLocaleString('fr-FR', {
+          year: 'numeric',
+          month: 'numeric',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: 'numeric',
+          second: 'numeric',
+        });
+        assert
+          .dom(screen.getByText(`Rapport de vérification de la calibration d'ID 1 généré le ${displayedGeneratedAt}`))
+          .exists();
       });
     });
   });

--- a/admin/tests/mirage/models.js
+++ b/admin/tests/mirage/models.js
@@ -14,6 +14,7 @@ import autonomousCourseListItem from './models/autonomous-course-list-item';
 import autonomousCourseTargetProfile from './models/autonomous-course-target-profile';
 import badge from './models/badge';
 import badgeCriterion from './models/badge-criterion';
+import calibrationReport from './models/calibration-report';
 import campaign from './models/campaign';
 import campaignParticipation from './models/campaign-participation';
 import certification from './models/certification';
@@ -93,6 +94,7 @@ export default {
   badgeCriterion,
   campaign,
   campaignParticipation,
+  calibrationReport,
   certification,
   certificationCandidate,
   certificationCandidateTimeline,

--- a/admin/tests/mirage/models/calibration-report.js
+++ b/admin/tests/mirage/models/calibration-report.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend();

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -123,6 +123,10 @@ export default function routes() {
     schema.certificationVersionSummaries.find(request.params.id).destroy();
   });
 
+  this.post('/admin/certification-versions/:id/calibration-report', (schema) => {
+    return schema.calibrationReports.first();
+  });
+
   this.get('/admin/certification-frameworks', (schema) => {
     return schema.certificationFrameworks.all();
   });

--- a/admin/tests/mirage/serializers.js
+++ b/admin/tests/mirage/serializers.js
@@ -4,6 +4,7 @@ import area from './serializers/area';
 import attachedCertificationCenter from './serializers/attached-certification-center';
 import autonomousCourseListItem from './serializers/autonomous-course-list-item';
 import badge from './serializers/badge';
+import calibrationReport from './serializers/calibration-report';
 import campaign from './serializers/campaign';
 import campaignParticipation from './serializers/campaign-participation';
 import certification from './serializers/certification';
@@ -39,6 +40,7 @@ export default {
   badge,
   campaign,
   campaignParticipation,
+  calibrationReport,
   certificationCandidate,
   certificationCenter,
   certificationCenterMembership,

--- a/admin/tests/mirage/serializers/calibration-report.js
+++ b/admin/tests/mirage/serializers/calibration-report.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend();

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -580,8 +580,29 @@
         },
         "versions": {
           "calibration": {
-            "calibration-id-input-label": "Calibration ID (provided by Data)*",
-            "verify-calibration-id-button": "Start the calibration recovery process"
+            "calibration-id-input-label": "Calibration ID (provided by Data)",
+            "label-for-CALIBRATED_CHALLENGE_COUNT": "Count of calibrated challenges",
+            "label-for-CALIBRATION_SCOPE": "Planned for scope",
+            "label-for-CALIBRATION_STARTED_AT": "Started at",
+            "label-for-CALIBRATION_STATUS": "Status",
+            "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Tubes in calibration only",
+            "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Tubes in version only",
+            "report-title": "Check calibration report of ID {calibrationId} generated at",
+            "scopes": {
+              "CORE": "Pix Core",
+              "DROIT": "Pix+ Law",
+              "EDU_1ER_DEGRE": "Pix+ Edu Primary School",
+              "EDU_2ND_DEGRE": "Pix+ Edu Secondary School",
+              "EDU_CPE": "Pix+ Edu CPE",
+              "PRO_SANTE": "Pix+ Pro Health"
+            },
+            "show-additional-info": "Show more info about line {lineNumber} of the report",
+            "statuses": {
+              "INVALIDATED": "Invalidated",
+              "TO_VALIDATE": "To validate",
+              "VALIDATED": "Validated"
+            },
+            "verify-calibration-id-button": "Check the calibration"
           },
           "edit": {
             "assessment-duration-label": "Assessment duration (hh:mm):",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -588,8 +588,29 @@
         },
         "versions": {
           "calibration": {
-            "calibration-id-input-label": "ID de calibration (fourni par Data)*",
-            "verify-calibration-id-button": "Lancer la récupération de la calibration"
+            "calibration-id-input-label": "ID de calibration (fourni par Data)",
+            "label-for-CALIBRATED_CHALLENGE_COUNT": "Nombre d'épreuves calibrées",
+            "label-for-CALIBRATION_SCOPE": "Prévue pour le référentiel",
+            "label-for-CALIBRATION_STARTED_AT": "Démarrée le",
+            "label-for-CALIBRATION_STATUS": "Statut",
+            "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Sujet présents dans la calibration uniquement",
+            "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Sujet présents dans la version uniquement",
+            "report-title": "Rapport de vérification de la calibration d'ID {calibrationId} généré le",
+            "scopes": {
+              "CORE": "Pix Cœur (transverse)",
+              "DROIT": "Pix+ Droit",
+              "EDU_1ER_DEGRE": "Pix+ Édu 1er degré",
+              "EDU_2ND_DEGRE": "Pix+ Édu 2nd degré",
+              "EDU_CPE": "Pix+ Édu CPE",
+              "PRO_SANTE": "Pix+ Pro Santé"
+            },
+            "show-additional-info": "Montrer plus d'informations sur la ligne {lineNumber} du rapport",
+            "statuses": {
+              "INVALIDATED": "Invalidée",
+              "TO_VALIDATE": "À valider",
+              "VALIDATED": "Validée"
+            },
+            "verify-calibration-id-button": "Vérifier la calibration"
           },
           "edit": {
             "assessment-duration-label": "Durée de l’épreuve (hh:mm) :",

--- a/api/db/database-builder/database-helpers.js
+++ b/api/db/database-builder/database-helpers.js
@@ -1,41 +1,5 @@
-import { datawarehouseKnex } from '../../tests/tooling/databases.js';
-
 const TABLE_NAME_REGEXP = /(?<=insert into\s)(?<tableName>(".*"))(?=\s\(.*)/i;
 
 export function getTableNameFromInsertSqlQuery(insertSqlQuery) {
   return TABLE_NAME_REGEXP.exec(insertSqlQuery)?.groups?.tableName?.replaceAll('"', '');
 }
-
-export async function createCalibrationTables() {
-  for (const table of tablesOrder) {
-    const hasTable = await datawarehouseKnex.schema.hasTable(table);
-    if (!hasTable) await datawarehouseKnex.schema.createTable(table, schemasForTable[table]);
-  }
-}
-
-export async function cleanCalibrationTables() {
-  const deleteFromStatements = [];
-  for (const table of tablesOrder.toReversed()) {
-    deleteFromStatements.push(`DELETE FROM ${table};`);
-  }
-  // eslint-disable-next-line knex/avoid-injections
-  await datawarehouseKnex.raw(deleteFromStatements.join('\n'));
-}
-
-const tablesOrder = ['data_calibrations', 'data_calibration_challenges'];
-const schemasForTable = {
-  data_calibrations: (t) => {
-    t.increments('id').primary();
-    t.dateTime('calibration_date');
-    t.string('status');
-    t.string('scope');
-  },
-  data_calibration_challenges: (t) => {
-    t.increments('id').primary();
-    t.integer('calibration_id').references('data_calibrations.id');
-    t.string('challenge_id');
-    t.decimal('alpha', 6, 5);
-    t.decimal('delta', 6, 5);
-    t.boolean('is_excluded');
-  },
-};

--- a/api/db/database-builder/database-helpers.js
+++ b/api/db/database-builder/database-helpers.js
@@ -1,6 +1,41 @@
+import { datawarehouseKnex } from '../../tests/tooling/databases.js';
+
 const TABLE_NAME_REGEXP = /(?<=insert into\s)(?<tableName>(".*"))(?=\s\(.*)/i;
 
 export function getTableNameFromInsertSqlQuery(insertSqlQuery) {
-  const tableName = TABLE_NAME_REGEXP.exec(insertSqlQuery)?.groups?.tableName?.replaceAll('"', '');
-  return tableName;
+  return TABLE_NAME_REGEXP.exec(insertSqlQuery)?.groups?.tableName?.replaceAll('"', '');
 }
+
+export async function createCalibrationTables() {
+  for (const table of tablesOrder) {
+    const hasTable = await datawarehouseKnex.schema.hasTable(table);
+    if (!hasTable) await datawarehouseKnex.schema.createTable(table, schemasForTable[table]);
+  }
+}
+
+export async function cleanCalibrationTables() {
+  const deleteFromStatements = [];
+  for (const table of tablesOrder.toReversed()) {
+    deleteFromStatements.push(`DELETE FROM ${table};`);
+  }
+  // eslint-disable-next-line knex/avoid-injections
+  await datawarehouseKnex.raw(deleteFromStatements.join('\n'));
+}
+
+const tablesOrder = ['data_calibrations', 'data_calibration_challenges'];
+const schemasForTable = {
+  data_calibrations: (t) => {
+    t.increments('id').primary();
+    t.dateTime('calibration_date');
+    t.string('status');
+    t.string('scope');
+  },
+  data_calibration_challenges: (t) => {
+    t.increments('id').primary();
+    t.integer('calibration_id').references('data_calibrations.id');
+    t.string('challenge_id');
+    t.decimal('alpha', 6, 5);
+    t.decimal('delta', 6, 5);
+    t.boolean('is_excluded');
+  },
+};

--- a/api/db/seeds/data/team-certification/cases/calibration.js
+++ b/api/db/seeds/data/team-certification/cases/calibration.js
@@ -1,0 +1,56 @@
+let calibrationId = 0;
+
+export async function buildDataCalibrationForVersion({ knex, datawarehouseKnex, versionId, scope, status }) {
+  ++calibrationId;
+  if (calibrationId === 1) {
+    await initTables(datawarehouseKnex);
+  }
+  const fourMonthsAgo = new Date();
+  fourMonthsAgo.setMonth(fourMonthsAgo.getMonth() - 4);
+  const tubeIds = await knex.pluck('tube_id').from('certification_versions_tubes').where('version_id', versionId);
+  const challengeIds = await knex
+    .from({ skills: 'learningcontent.skills' })
+    .join({ challenges: 'learningcontent.challenges' }, 'challenges.skillId', 'skills.id')
+    .whereIn('skills.tubeId', tubeIds)
+    .where('challenges.status', 'validé')
+    .pluck('challenges.id');
+
+  await datawarehouseKnex('data_calibrations').insert({
+    id: calibrationId,
+    calibration_date: fourMonthsAgo,
+    scope,
+    status,
+  });
+
+  const calibratedChallengesToInsert = challengeIds.map((challengeId) => {
+    return {
+      calibration_id: calibrationId,
+      challenge_id: challengeId,
+      alpha: 1,
+      delta: 1,
+      is_excluded: false,
+    };
+  });
+  await datawarehouseKnex('data_calibration_challenges').insert(calibratedChallengesToInsert);
+}
+
+async function initTables(datawarehouseKnex) {
+  if (await datawarehouseKnex.schema.hasTable('data_calibration_challenges')) {
+    await datawarehouseKnex.schema.dropTable('data_calibration_challenges');
+    await datawarehouseKnex.schema.dropTable('data_calibrations');
+  }
+  await datawarehouseKnex.schema.createTable('data_calibrations', (t) => {
+    t.increments('id').primary();
+    t.dateTime('calibration_date');
+    t.string('status');
+    t.string('scope');
+  });
+  await datawarehouseKnex.schema.createTable('data_calibration_challenges', (t) => {
+    t.increments('id').primary();
+    t.integer('calibration_id').references('data_calibrations.id');
+    t.string('challenge_id');
+    t.decimal('alpha', 6, 5);
+    t.decimal('delta', 6, 5);
+    t.boolean('is_excluded');
+  });
+}

--- a/api/db/seeds/data/team-certification/cases/calibration.js
+++ b/api/db/seeds/data/team-certification/cases/calibration.js
@@ -1,10 +1,8 @@
 let calibrationId = 0;
 
-export async function buildDataCalibrationForVersion({ knex, datawarehouseKnex, versionId, scope, status }) {
-  ++calibrationId;
-  if (calibrationId === 1) {
-    await initTables(datawarehouseKnex);
-  }
+export async function buildDataCalibrationForVersion({ knex, datamartKnex, versionId, scope, status }) {
+  calibrationId++;
+
   const fourMonthsAgo = new Date();
   fourMonthsAgo.setMonth(fourMonthsAgo.getMonth() - 4);
   const tubeIds = await knex.pluck('tube_id').from('certification_versions_tubes').where('version_id', versionId);
@@ -15,7 +13,7 @@ export async function buildDataCalibrationForVersion({ knex, datawarehouseKnex, 
     .where('challenges.status', 'validé')
     .pluck('challenges.id');
 
-  await datawarehouseKnex('data_calibrations').insert({
+  await datamartKnex('data_calibrations').insert({
     id: calibrationId,
     calibration_date: fourMonthsAgo,
     scope,
@@ -28,29 +26,7 @@ export async function buildDataCalibrationForVersion({ knex, datawarehouseKnex, 
       challenge_id: challengeId,
       alpha: 1,
       delta: 1,
-      is_excluded: false,
     };
   });
-  await datawarehouseKnex('data_calibration_challenges').insert(calibratedChallengesToInsert);
-}
-
-async function initTables(datawarehouseKnex) {
-  if (await datawarehouseKnex.schema.hasTable('data_calibration_challenges')) {
-    await datawarehouseKnex.schema.dropTable('data_calibration_challenges');
-    await datawarehouseKnex.schema.dropTable('data_calibrations');
-  }
-  await datawarehouseKnex.schema.createTable('data_calibrations', (t) => {
-    t.increments('id').primary();
-    t.dateTime('calibration_date');
-    t.string('status');
-    t.string('scope');
-  });
-  await datawarehouseKnex.schema.createTable('data_calibration_challenges', (t) => {
-    t.increments('id').primary();
-    t.integer('calibration_id').references('data_calibrations.id');
-    t.string('challenge_id');
-    t.decimal('alpha', 6, 5);
-    t.decimal('delta', 6, 5);
-    t.boolean('is_excluded');
-  });
+  await datamartKnex('data_active_calibrated_challenges').insert(calibratedChallengesToInsert);
 }

--- a/api/db/seeds/data/team-certification/cases/pix-plus-droit-v3.js
+++ b/api/db/seeds/data/team-certification/cases/pix-plus-droit-v3.js
@@ -13,9 +13,9 @@ import {
 } from '../shared/constants.js';
 
 export class PixPlusDroitV3Seed {
-  constructor({ databaseBuilder, datawarehouseKnex }) {
+  constructor({ databaseBuilder, datamartKnex }) {
     this.databaseBuilder = databaseBuilder;
-    this.datawarehouseKnex = datawarehouseKnex;
+    this.datawarehouseKnex = datamartKnex;
   }
 
   async create() {
@@ -31,7 +31,7 @@ export class PixPlusDroitV3Seed {
 
     await CommonCertificationVersions.initPixPlusDroitVersion({
       databaseBuilder: this.databaseBuilder,
-      datawarehouseKnex: this.datawarehouseKnex,
+      datamartKnex: this.datamartKnex,
     });
 
     const versionId = CommonCertificationVersions.pixPlusDroitVersion.currentVersionId;

--- a/api/db/seeds/data/team-certification/cases/pix-plus-droit-v3.js
+++ b/api/db/seeds/data/team-certification/cases/pix-plus-droit-v3.js
@@ -13,8 +13,9 @@ import {
 } from '../shared/constants.js';
 
 export class PixPlusDroitV3Seed {
-  constructor({ databaseBuilder }) {
+  constructor({ databaseBuilder, datawarehouseKnex }) {
     this.databaseBuilder = databaseBuilder;
+    this.datawarehouseKnex = datawarehouseKnex;
   }
 
   async create() {
@@ -30,6 +31,7 @@ export class PixPlusDroitV3Seed {
 
     await CommonCertificationVersions.initPixPlusDroitVersion({
       databaseBuilder: this.databaseBuilder,
+      datawarehouseKnex: this.datawarehouseKnex,
     });
 
     const versionId = CommonCertificationVersions.pixPlusDroitVersion.currentVersionId;

--- a/api/db/seeds/data/team-certification/cases/pix-plus-edu-2nd-degre-v3.js
+++ b/api/db/seeds/data/team-certification/cases/pix-plus-edu-2nd-degre-v3.js
@@ -13,8 +13,9 @@ import {
 } from '../shared/constants.js';
 
 export class PixPlusEdu2ndDegreV3Seed {
-  constructor({ databaseBuilder }) {
+  constructor({ databaseBuilder, datawarehouseKnex }) {
     this.databaseBuilder = databaseBuilder;
+    this.datawarehouseKnex = datawarehouseKnex;
   }
 
   async create() {
@@ -30,6 +31,7 @@ export class PixPlusEdu2ndDegreV3Seed {
 
     await CommonCertificationVersions.initPixPlusEdu2ndDegreVersion({
       databaseBuilder: this.databaseBuilder,
+      datawarehouseKnex: this.datawarehouseKnex,
     });
 
     const versionId = CommonCertificationVersions.pixPlusEdu2ndDegreVersion.currentVersionId;

--- a/api/db/seeds/data/team-certification/cases/pix-plus-edu-2nd-degre-v3.js
+++ b/api/db/seeds/data/team-certification/cases/pix-plus-edu-2nd-degre-v3.js
@@ -13,9 +13,9 @@ import {
 } from '../shared/constants.js';
 
 export class PixPlusEdu2ndDegreV3Seed {
-  constructor({ databaseBuilder, datawarehouseKnex }) {
+  constructor({ databaseBuilder, datamartKnex }) {
     this.databaseBuilder = databaseBuilder;
-    this.datawarehouseKnex = datawarehouseKnex;
+    this.datamartKnex = datamartKnex;
   }
 
   async create() {
@@ -31,7 +31,7 @@ export class PixPlusEdu2ndDegreV3Seed {
 
     await CommonCertificationVersions.initPixPlusEdu2ndDegreVersion({
       databaseBuilder: this.databaseBuilder,
-      datawarehouseKnex: this.datawarehouseKnex,
+      datamartKnex: this.datamartKnex,
     });
 
     const versionId = CommonCertificationVersions.pixPlusEdu2ndDegreVersion.currentVersionId;

--- a/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
+++ b/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
@@ -40,9 +40,9 @@ import publishSessionWithValidatedCertification from '../tools/publish-session-w
  *   - I have previously obtained a certif CLEA with ~350 pix
  */
 export class CleaV3Seed {
-  constructor({ databaseBuilder, datawarehouseKnex }) {
+  constructor({ databaseBuilder, datamartKnex }) {
     this.databaseBuilder = databaseBuilder;
-    this.datawarehouseKnex = datawarehouseKnex;
+    this.datamartKnex = datamartKnex;
   }
 
   async create() {
@@ -62,20 +62,32 @@ export class CleaV3Seed {
      * Session with candidat ready to start his certification
      */
     await this.#initCertificationReferentials();
-    const sessionReadyToStart = await this.#addReadyToStartSession({ certificationCenterMember, certificationCenter });
+    const sessionReadyToStart = await this.#addReadyToStartSession({
+      certificationCenterMember,
+      certificationCenter,
+    });
 
     for (const user of certifiableUsers) {
-      await this.#addCandidateToSession({ pixAppUser: user, session: sessionReadyToStart });
+      await this.#addCandidateToSession({
+        pixAppUser: user,
+        session: sessionReadyToStart,
+      });
     }
 
     /**
      * Session with a published certification
      */
-    const sessionToPublish = await this.#addSessionToPublish({ certificationCenterMember, certificationCenter });
+    const sessionToPublish = await this.#addSessionToPublish({
+      certificationCenterMember,
+      certificationCenter,
+    });
 
     const candidatesToPublish = [];
     for (const user of certifiableUsers) {
-      const candidate = await this.#addCandidateToSession({ pixAppUser: user, session: sessionToPublish });
+      const candidate = await this.#addCandidateToSession({
+        pixAppUser: user,
+        session: sessionToPublish,
+      });
       candidatesToPublish.push(candidate);
     }
 
@@ -90,7 +102,7 @@ export class CleaV3Seed {
   async #initCertificationReferentials() {
     await CommonCertificationVersions.initCoreVersions({
       databaseBuilder: this.databaseBuilder,
-      datawarehouseKnex: this.datawarehouseKnex,
+      datamartKnex: this.datamartKnex,
     });
   }
 
@@ -133,7 +145,9 @@ export class CleaV3Seed {
   }
 
   async #addCertifiableUsers() {
-    const { certifiableUsers } = await CommonCertifiableUser.getInstance({ databaseBuilder: this.databaseBuilder });
+    const { certifiableUsers } = await CommonCertifiableUser.getInstance({
+      databaseBuilder: this.databaseBuilder,
+    });
     return certifiableUsers;
   }
 
@@ -213,6 +227,8 @@ export class CleaV3Seed {
       normalizeStringFnc: normalize,
     });
 
-    return enrolmentUseCases.getCandidate({ certificationCandidateId: candidateId });
+    return enrolmentUseCases.getCandidate({
+      certificationCandidateId: candidateId,
+    });
   }
 }

--- a/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
+++ b/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
@@ -40,8 +40,9 @@ import publishSessionWithValidatedCertification from '../tools/publish-session-w
  *   - I have previously obtained a certif CLEA with ~350 pix
  */
 export class CleaV3Seed {
-  constructor({ databaseBuilder }) {
+  constructor({ databaseBuilder, datawarehouseKnex }) {
     this.databaseBuilder = databaseBuilder;
+    this.datawarehouseKnex = datawarehouseKnex;
   }
 
   async create() {
@@ -89,6 +90,7 @@ export class CleaV3Seed {
   async #initCertificationReferentials() {
     await CommonCertificationVersions.initCoreVersions({
       databaseBuilder: this.databaseBuilder,
+      datawarehouseKnex: this.datawarehouseKnex,
     });
   }
 

--- a/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
@@ -29,8 +29,9 @@ import publishSessionWithValidatedCertification from '../tools/publish-session-w
  *   - I have previously obtained a certif PRO with ~250 pix
  */
 export class ProSeed {
-  constructor({ databaseBuilder }) {
+  constructor({ databaseBuilder, datawarehouseKnex }) {
     this.databaseBuilder = databaseBuilder;
+    this.datawarehouseKnex = datawarehouseKnex;
   }
 
   async create() {
@@ -73,6 +74,7 @@ export class ProSeed {
   async #initCertificationReferentials() {
     await CommonCertificationVersions.initCoreVersions({
       databaseBuilder: this.databaseBuilder,
+      datawarehouseKnex: this.datawarehouseKnex,
     });
   }
 

--- a/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
@@ -29,9 +29,9 @@ import publishSessionWithValidatedCertification from '../tools/publish-session-w
  *   - I have previously obtained a certif PRO with ~250 pix
  */
 export class ProSeed {
-  constructor({ databaseBuilder, datawarehouseKnex }) {
+  constructor({ databaseBuilder, datamartKnex }) {
     this.databaseBuilder = databaseBuilder;
-    this.datawarehouseKnex = datawarehouseKnex;
+    this.datamartKnex = datamartKnex;
   }
 
   async create() {
@@ -46,20 +46,32 @@ export class ProSeed {
      * Session with candidat ready to start his certification
      */
     await this.#initCertificationReferentials();
-    const sessionReadyToStart = await this.#addReadyToStartSession({ certificationCenterMember, certificationCenter });
+    const sessionReadyToStart = await this.#addReadyToStartSession({
+      certificationCenterMember,
+      certificationCenter,
+    });
 
     for (const certifiableUser of certifiableUsers) {
-      await this.#addCandidateToSession({ pixAppUser: certifiableUser, session: sessionReadyToStart });
+      await this.#addCandidateToSession({
+        pixAppUser: certifiableUser,
+        session: sessionReadyToStart,
+      });
     }
 
     /**
      * Session with a published certification
      */
-    const sessionToPublish = await this.#addSessionToPublish({ certificationCenterMember, certificationCenter });
+    const sessionToPublish = await this.#addSessionToPublish({
+      certificationCenterMember,
+      certificationCenter,
+    });
 
     const candidatesToPublish = [];
     for (const user of certifiableUsers) {
-      const candidate = await this.#addCandidateToSession({ pixAppUser: user, session: sessionToPublish });
+      const candidate = await this.#addCandidateToSession({
+        pixAppUser: user,
+        session: sessionToPublish,
+      });
       candidatesToPublish.push(candidate);
     }
 
@@ -74,7 +86,7 @@ export class ProSeed {
   async #initCertificationReferentials() {
     await CommonCertificationVersions.initCoreVersions({
       databaseBuilder: this.databaseBuilder,
-      datawarehouseKnex: this.datawarehouseKnex,
+      datamartKnex: this.datamartKnex,
     });
   }
 
@@ -107,7 +119,9 @@ export class ProSeed {
   }
 
   async #addCertifiableUsers() {
-    const { certifiableUsers } = await CommonCertifiableUser.getInstance({ databaseBuilder: this.databaseBuilder });
+    const { certifiableUsers } = await CommonCertifiableUser.getInstance({
+      databaseBuilder: this.databaseBuilder,
+    });
     return certifiableUsers;
   }
 
@@ -186,6 +200,8 @@ export class ProSeed {
       })
       .where({ id: candidateId });
 
-    return enrolmentUseCases.getCandidate({ certificationCandidateId: candidateId });
+    return enrolmentUseCases.getCandidate({
+      certificationCandidateId: candidateId,
+    });
   }
 }

--- a/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
@@ -30,8 +30,9 @@ import publishSessionWithValidatedCertification from '../tools/publish-session-w
  *   - I have previously obtained a certif SCO with ~550 pix
  */
 export class ScoManagingStudent {
-  constructor({ databaseBuilder }) {
+  constructor({ databaseBuilder, datawarehouseKnex }) {
     this.databaseBuilder = databaseBuilder;
+    this.datawarehouseKnex = datawarehouseKnex;
   }
 
   async create() {
@@ -78,6 +79,7 @@ export class ScoManagingStudent {
   async #initCertificationReferentials() {
     await CommonCertificationVersions.initCoreVersions({
       databaseBuilder: this.databaseBuilder,
+      datawarehouseKnex: this.datawarehouseKnex,
     });
   }
 

--- a/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
@@ -30,9 +30,9 @@ import publishSessionWithValidatedCertification from '../tools/publish-session-w
  *   - I have previously obtained a certif SCO with ~550 pix
  */
 export class ScoManagingStudent {
-  constructor({ databaseBuilder, datawarehouseKnex }) {
+  constructor({ databaseBuilder, datamartKnex }) {
     this.databaseBuilder = databaseBuilder;
-    this.datawarehouseKnex = datawarehouseKnex;
+    this.datamartKnex = datamartKnex;
   }
 
   async create() {
@@ -79,7 +79,7 @@ export class ScoManagingStudent {
   async #initCertificationReferentials() {
     await CommonCertificationVersions.initCoreVersions({
       databaseBuilder: this.databaseBuilder,
-      datawarehouseKnex: this.datawarehouseKnex,
+      datamartKnex: this.datamartKnex,
     });
   }
 

--- a/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
+++ b/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
@@ -35,9 +35,9 @@ import addSession from '../tools/add-session.js';
  *   - I'm able to start a certification course
  */
 export class SupWithHabilitationsSeed {
-  constructor({ databaseBuilder, datawarehouseKnex }) {
+  constructor({ databaseBuilder, datamartKnex }) {
     this.databaseBuilder = databaseBuilder;
-    this.datawarehouseKnex = datawarehouseKnex;
+    this.datamartKnex = datamartKnex;
   }
 
   async create() {
@@ -91,17 +91,17 @@ export class SupWithHabilitationsSeed {
   async #initCertificationReferentials() {
     await CommonCertificationVersions.initCoreVersions({
       databaseBuilder: this.databaseBuilder,
-      datawarehouseKnex: this.datawarehouseKnex,
+      datamartKnex: this.datamartKnex,
     });
 
     await CommonCertificationVersions.initPixPlusDroitVersion({
       databaseBuilder: this.databaseBuilder,
-      datawarehouseKnex: this.datawarehouseKnex,
+      datamartKnex: this.datamartKnex,
     });
 
     await CommonCertificationVersions.initPixPlusEdu1erDegreVersion({
       databaseBuilder: this.databaseBuilder,
-      datawarehouseKnex: this.datawarehouseKnex,
+      datamartKnex: this.datamartKnex,
     });
   }
 
@@ -142,7 +142,9 @@ export class SupWithHabilitationsSeed {
   }
 
   async #addCertifiableUsers() {
-    const { certifiableUsers } = await CommonCertifiableUser.getInstance({ databaseBuilder: this.databaseBuilder });
+    const { certifiableUsers } = await CommonCertifiableUser.getInstance({
+      databaseBuilder: this.databaseBuilder,
+    });
     return certifiableUsers;
   }
 
@@ -211,6 +213,8 @@ export class SupWithHabilitationsSeed {
       normalizeStringFnc: normalize,
     });
 
-    return enrolmentUseCases.getCandidate({ certificationCandidateId: candidateId });
+    return enrolmentUseCases.getCandidate({
+      certificationCandidateId: candidateId,
+    });
   }
 }

--- a/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
+++ b/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
@@ -35,8 +35,9 @@ import addSession from '../tools/add-session.js';
  *   - I'm able to start a certification course
  */
 export class SupWithHabilitationsSeed {
-  constructor({ databaseBuilder }) {
+  constructor({ databaseBuilder, datawarehouseKnex }) {
     this.databaseBuilder = databaseBuilder;
+    this.datawarehouseKnex = datawarehouseKnex;
   }
 
   async create() {
@@ -90,14 +91,17 @@ export class SupWithHabilitationsSeed {
   async #initCertificationReferentials() {
     await CommonCertificationVersions.initCoreVersions({
       databaseBuilder: this.databaseBuilder,
+      datawarehouseKnex: this.datawarehouseKnex,
     });
 
     await CommonCertificationVersions.initPixPlusDroitVersion({
       databaseBuilder: this.databaseBuilder,
+      datawarehouseKnex: this.datawarehouseKnex,
     });
 
     await CommonCertificationVersions.initPixPlusEdu1erDegreVersion({
       databaseBuilder: this.databaseBuilder,
+      datawarehouseKnex: this.datawarehouseKnex,
     });
   }
 

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -9,19 +9,19 @@ import { SupWithHabilitationsSeed } from './cases/sup-certification-centre-with-
 import { setupConfigurations } from './shared/setup-configuration.js';
 import { UnseedableError } from './shared/UnseedableError.js';
 
-export async function teamCertificationDataBuilder({ databaseBuilder, datawarehouseKnex }) {
+export async function teamCertificationDataBuilder({ databaseBuilder, datamartKnex }) {
   try {
     // Pix platform configuration
     await setupConfigurations({ databaseBuilder });
 
     // Cases
-    await new SupWithHabilitationsSeed({ databaseBuilder, datawarehouseKnex }).create();
-    await new ProSeed({ databaseBuilder, datawarehouseKnex }).create();
-    await new ScoManagingStudent({ databaseBuilder, datawarehouseKnex }).create();
-    await new CleaV3Seed({ databaseBuilder, datawarehouseKnex }).create();
-    await new PixPlusDroitV2Seed({ databaseBuilder, datawarehouseKnex }).create();
-    await new PixPlusDroitV3Seed({ databaseBuilder, datawarehouseKnex }).create();
-    await new PixPlusEdu2ndDegreV3Seed({ databaseBuilder, datawarehouseKnex }).create();
+    await new SupWithHabilitationsSeed({ databaseBuilder, datamartKnex }).create();
+    await new ProSeed({ databaseBuilder, datamartKnex }).create();
+    await new ScoManagingStudent({ databaseBuilder, datamartKnex }).create();
+    await new CleaV3Seed({ databaseBuilder, datamartKnex }).create();
+    await new PixPlusDroitV2Seed({ databaseBuilder, datamartKnex }).create();
+    await new PixPlusDroitV3Seed({ databaseBuilder, datamartKnex }).create();
+    await new PixPlusEdu2ndDegreV3Seed({ databaseBuilder, datamartKnex }).create();
   } catch (error) {
     if (error instanceof UnseedableError) {
       logger.warn(error, 'Certification seeding is only minimal/partial');

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -9,19 +9,19 @@ import { SupWithHabilitationsSeed } from './cases/sup-certification-centre-with-
 import { setupConfigurations } from './shared/setup-configuration.js';
 import { UnseedableError } from './shared/UnseedableError.js';
 
-export async function teamCertificationDataBuilder({ databaseBuilder }) {
+export async function teamCertificationDataBuilder({ databaseBuilder, datawarehouseKnex }) {
   try {
     // Pix platform configuration
     await setupConfigurations({ databaseBuilder });
 
     // Cases
-    await new SupWithHabilitationsSeed({ databaseBuilder }).create();
-    await new ProSeed({ databaseBuilder }).create();
-    await new ScoManagingStudent({ databaseBuilder }).create();
-    await new CleaV3Seed({ databaseBuilder }).create();
-    await new PixPlusDroitV2Seed({ databaseBuilder }).create();
-    await new PixPlusDroitV3Seed({ databaseBuilder }).create();
-    await new PixPlusEdu2ndDegreV3Seed({ databaseBuilder }).create();
+    await new SupWithHabilitationsSeed({ databaseBuilder, datawarehouseKnex }).create();
+    await new ProSeed({ databaseBuilder, datawarehouseKnex }).create();
+    await new ScoManagingStudent({ databaseBuilder, datawarehouseKnex }).create();
+    await new CleaV3Seed({ databaseBuilder, datawarehouseKnex }).create();
+    await new PixPlusDroitV2Seed({ databaseBuilder, datawarehouseKnex }).create();
+    await new PixPlusDroitV3Seed({ databaseBuilder, datawarehouseKnex }).create();
+    await new PixPlusEdu2ndDegreV3Seed({ databaseBuilder, datawarehouseKnex }).create();
   } catch (error) {
     if (error instanceof UnseedableError) {
       logger.warn(error, 'Certification seeding is only minimal/partial');

--- a/api/db/seeds/data/team-certification/shared/common-certification-versions.js
+++ b/api/db/seeds/data/team-certification/shared/common-certification-versions.js
@@ -24,20 +24,20 @@ export class CommonCertificationVersions {
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
-   * @param {Knex} params.datawarehouseKnex
+   * @param {Knex} params.datamartKnex
    */
-  constructor({ databaseBuilder, datawarehouseKnex }) {
+  constructor({ databaseBuilder, datamartKnex }) {
     this.databaseBuilder = databaseBuilder;
-    this.datawarehouseKnex = datawarehouseKnex;
+    this.datamartKnex = datamartKnex;
   }
 
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
-   * @param {Knex} params.datawarehouseKnex
+   * @param {Knex} params.datamartKnex
    * @returns {Promise<void>}
    */
-  static async initCoreVersions({ databaseBuilder, datawarehouseKnex }) {
+  static async initCoreVersions({ databaseBuilder, datamartKnex }) {
     try {
       if (!this.coreVersion) {
         this.coreVersion = {};
@@ -54,7 +54,7 @@ export class CommonCertificationVersions {
         });
         await buildDataCalibrationForVersion({
           knex: databaseBuilder.knex,
-          datawarehouseKnex,
+          datamartKnex,
           versionId: this.coreVersion.currentVersionId,
           scope: CALIBRATION_SCOPES.COEUR,
           status: CALIBRATION_STATUSES.VALIDATED,
@@ -75,7 +75,7 @@ export class CommonCertificationVersions {
    * @param {Knex} params.datawarehouseKnex
    * @returns {Promise<void>}
    */
-  static async initPixPlusDroitVersion({ databaseBuilder, datawarehouseKnex }) {
+  static async initPixPlusDroitVersion({ databaseBuilder, datamartKnex }) {
     try {
       if (!this.pixPlusDroitVersion) {
         this.pixPlusDroitVersion = {};
@@ -101,13 +101,20 @@ export class CommonCertificationVersions {
           ],
           competencesScoringConfiguration: null,
         });
-        await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: currentVersion.id });
+        await seedVersionChallengesAndTubes({
+          databaseBuilder,
+          challengeIds,
+          versionId: currentVersion.id,
+        });
 
-        await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
+        await this.#simulateCalibration({
+          databaseBuilder,
+          versionId: currentVersion.id,
+        });
         this.pixPlusDroitVersion.currentVersionId = currentVersion.id;
         await buildDataCalibrationForVersion({
           knex: databaseBuilder.knex,
-          datawarehouseKnex,
+          datamartKnex,
           versionId: currentVersion.id,
           scope: CALIBRATION_SCOPES.DROIT,
           status: CALIBRATION_STATUSES.VALIDATED,
@@ -125,10 +132,10 @@ export class CommonCertificationVersions {
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
-   * @param {Knex} params.datawarehouseKnex
+   * @param {Knex} params.datamartKnex
    * @returns {Promise<void>}
    */
-  static async initPixPlusEdu1erDegreVersion({ databaseBuilder, datawarehouseKnex }) {
+  static async initPixPlusEdu1erDegreVersion({ databaseBuilder, datamartKnex }) {
     try {
       if (!this.pixPlusEdu1erDegreVersion) {
         this.pixPlusEdu1erDegreVersion = {};
@@ -150,14 +157,21 @@ export class CommonCertificationVersions {
           competencesScoringConfiguration: null,
         });
 
-        await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: currentVersion.id });
+        await seedVersionChallengesAndTubes({
+          databaseBuilder,
+          challengeIds,
+          versionId: currentVersion.id,
+        });
 
-        await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
+        await this.#simulateCalibration({
+          databaseBuilder,
+          versionId: currentVersion.id,
+        });
 
         this.pixPlusEdu1erDegreVersion.currentVersionId = currentVersion.id;
         await buildDataCalibrationForVersion({
           knex: databaseBuilder.knex,
-          datawarehouseKnex,
+          datamartKnex,
           versionId: currentVersion.id,
           scope: CALIBRATION_SCOPES.EDU_1ER_DEGRE,
           status: CALIBRATION_STATUSES.VALIDATED,
@@ -175,10 +189,10 @@ export class CommonCertificationVersions {
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
-   * @param {Knex} params.datawarehouseKnex
+   * @param {Knex} params.datamartKnex
    * @returns {Promise<void>}
    */
-  static async initPixPlusEdu2ndDegreVersion({ databaseBuilder, datawarehouseKnex }) {
+  static async initPixPlusEdu2ndDegreVersion({ databaseBuilder, datamartKnex }) {
     try {
       if (!this.pixPlusEdu2ndDegreVersion) {
         this.pixPlusEdu2ndDegreVersion = {};
@@ -199,14 +213,21 @@ export class CommonCertificationVersions {
           competencesScoringConfiguration: null,
         });
 
-        await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: currentVersion.id });
+        await seedVersionChallengesAndTubes({
+          databaseBuilder,
+          challengeIds,
+          versionId: currentVersion.id,
+        });
 
-        await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
+        await this.#simulateCalibration({
+          databaseBuilder,
+          versionId: currentVersion.id,
+        });
 
         this.pixPlusEdu2ndDegreVersion.currentVersionId = currentVersion.id;
         await buildDataCalibrationForVersion({
           knex: databaseBuilder.knex,
-          datawarehouseKnex,
+          datamartKnex,
           versionId: currentVersion.id,
           scope: CALIBRATION_SCOPES.EDU_2ND_DEGRE,
           status: CALIBRATION_STATUSES.VALIDATED,
@@ -316,7 +337,11 @@ export class CommonCertificationVersions {
       globalScoringConfiguration: [{ bounds: { max: 8, min: 1 }, meshLevel: 0 }],
       competencesScoringConfiguration: null,
     });
-    await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: expiredVersion.id });
+    await seedVersionChallengesAndTubes({
+      databaseBuilder,
+      challengeIds,
+      versionId: expiredVersion.id,
+    });
 
     await databaseBuilder.commit();
 
@@ -363,9 +388,16 @@ export class CommonCertificationVersions {
       globalScoringConfiguration: GLOBAL_SCORING_CONFIGURATION,
       competencesScoringConfiguration,
     });
-    await seedVersionChallengesAndTubes({ databaseBuilder, challengeIds, versionId: currentVersion.id });
+    await seedVersionChallengesAndTubes({
+      databaseBuilder,
+      challengeIds,
+      versionId: currentVersion.id,
+    });
 
-    await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
+    await this.#simulateCalibration({
+      databaseBuilder,
+      versionId: currentVersion.id,
+    });
 
     return currentVersion.id;
   }

--- a/api/db/seeds/data/team-certification/shared/common-certification-versions.js
+++ b/api/db/seeds/data/team-certification/shared/common-certification-versions.js
@@ -1,10 +1,15 @@
 import _ from 'lodash';
 
+import {
+  CALIBRATION_SCOPES,
+  CALIBRATION_STATUSES,
+} from '../../../../../src/certification/configuration/domain/models/Calibration.js';
 import { VERSION_STATUSES } from '../../../../../src/certification/configuration/domain/models/Version.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../src/certification/shared/domain/constants.js';
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { FRENCH_SPOKEN } from '../../../../../src/shared/domain/services/locale-service.js';
+import { buildDataCalibrationForVersion } from '../cases/calibration.js';
 import { createVersion, seedVersionChallengesAndTubes } from '../tools/certification-version.js';
 import { UnseedableError } from './UnseedableError.js';
 /**
@@ -19,17 +24,20 @@ export class CommonCertificationVersions {
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
+   * @param {Knex} params.datawarehouseKnex
    */
-  constructor({ databaseBuilder }) {
+  constructor({ databaseBuilder, datawarehouseKnex }) {
     this.databaseBuilder = databaseBuilder;
+    this.datawarehouseKnex = datawarehouseKnex;
   }
 
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
+   * @param {Knex} params.datawarehouseKnex
    * @returns {Promise<void>}
    */
-  static async initCoreVersions({ databaseBuilder }) {
+  static async initCoreVersions({ databaseBuilder, datawarehouseKnex }) {
     try {
       if (!this.coreVersion) {
         this.coreVersion = {};
@@ -44,6 +52,13 @@ export class CommonCertificationVersions {
           fromLcmsFrameworkName: coreFrameworkName,
           toFrameworkScope: SCOPES.CORE,
         });
+        await buildDataCalibrationForVersion({
+          knex: databaseBuilder.knex,
+          datawarehouseKnex,
+          versionId: this.coreVersion.currentVersionId,
+          scope: CALIBRATION_SCOPES.COEUR,
+          status: CALIBRATION_STATUSES.VALIDATED,
+        });
       }
     } catch (error) {
       if (error instanceof NotFoundError) {
@@ -57,9 +72,10 @@ export class CommonCertificationVersions {
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
+   * @param {Knex} params.datawarehouseKnex
    * @returns {Promise<void>}
    */
-  static async initPixPlusDroitVersion({ databaseBuilder }) {
+  static async initPixPlusDroitVersion({ databaseBuilder, datawarehouseKnex }) {
     try {
       if (!this.pixPlusDroitVersion) {
         this.pixPlusDroitVersion = {};
@@ -89,6 +105,13 @@ export class CommonCertificationVersions {
 
         await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
         this.pixPlusDroitVersion.currentVersionId = currentVersion.id;
+        await buildDataCalibrationForVersion({
+          knex: databaseBuilder.knex,
+          datawarehouseKnex,
+          versionId: currentVersion.id,
+          scope: CALIBRATION_SCOPES.DROIT,
+          status: CALIBRATION_STATUSES.VALIDATED,
+        });
       }
     } catch (error) {
       if (error instanceof NotFoundError) {
@@ -102,9 +125,10 @@ export class CommonCertificationVersions {
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
+   * @param {Knex} params.datawarehouseKnex
    * @returns {Promise<void>}
    */
-  static async initPixPlusEdu1erDegreVersion({ databaseBuilder }) {
+  static async initPixPlusEdu1erDegreVersion({ databaseBuilder, datawarehouseKnex }) {
     try {
       if (!this.pixPlusEdu1erDegreVersion) {
         this.pixPlusEdu1erDegreVersion = {};
@@ -131,6 +155,13 @@ export class CommonCertificationVersions {
         await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
 
         this.pixPlusEdu1erDegreVersion.currentVersionId = currentVersion.id;
+        await buildDataCalibrationForVersion({
+          knex: databaseBuilder.knex,
+          datawarehouseKnex,
+          versionId: currentVersion.id,
+          scope: CALIBRATION_SCOPES.EDU_1ER_DEGRE,
+          status: CALIBRATION_STATUSES.VALIDATED,
+        });
       }
     } catch (error) {
       if (error instanceof NotFoundError) {
@@ -144,9 +175,10 @@ export class CommonCertificationVersions {
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
+   * @param {Knex} params.datawarehouseKnex
    * @returns {Promise<void>}
    */
-  static async initPixPlusEdu2ndDegreVersion({ databaseBuilder }) {
+  static async initPixPlusEdu2ndDegreVersion({ databaseBuilder, datawarehouseKnex }) {
     try {
       if (!this.pixPlusEdu2ndDegreVersion) {
         this.pixPlusEdu2ndDegreVersion = {};
@@ -172,6 +204,13 @@ export class CommonCertificationVersions {
         await this.#simulateCalibration({ databaseBuilder, versionId: currentVersion.id });
 
         this.pixPlusEdu2ndDegreVersion.currentVersionId = currentVersion.id;
+        await buildDataCalibrationForVersion({
+          knex: databaseBuilder.knex,
+          datawarehouseKnex,
+          versionId: currentVersion.id,
+          scope: CALIBRATION_SCOPES.EDU_2ND_DEGRE,
+          status: CALIBRATION_STATUSES.VALIDATED,
+        });
       }
     } catch (error) {
       if (error instanceof NotFoundError) {

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,6 +1,6 @@
 import { config } from '../../src/shared/config.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
-import { datawarehouseKnex } from '../../tests/tooling/databases.js';
+import { datamartKnex } from '../../tests/tooling/databases.js';
 import { DatabaseBuilder } from '../database-builder/database-builder.js';
 import { commonBuilder } from './data/common/common-builder.js';
 import { complementaryCertificationBuilder } from './data/common/complementary-certification-builder.js';
@@ -68,7 +68,7 @@ export async function seed(knex) {
   if (config.seeds.context.certification) {
     logger.info('Seeding : Certification');
     await complementaryCertificationBuilder({ databaseBuilder });
-    await teamCertificationDataBuilder({ databaseBuilder, datawarehouseKnex });
+    await teamCertificationDataBuilder({ databaseBuilder, datamartKnex });
   }
 
   if (config.seeds.context.evaluation) {

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,5 +1,6 @@
 import { config } from '../../src/shared/config.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { datawarehouseKnex } from '../../tests/tooling/databases.js';
 import { DatabaseBuilder } from '../database-builder/database-builder.js';
 import { commonBuilder } from './data/common/common-builder.js';
 import { complementaryCertificationBuilder } from './data/common/complementary-certification-builder.js';
@@ -67,7 +68,7 @@ export async function seed(knex) {
   if (config.seeds.context.certification) {
     logger.info('Seeding : Certification');
     await complementaryCertificationBuilder({ databaseBuilder });
-    await teamCertificationDataBuilder({ databaseBuilder });
+    await teamCertificationDataBuilder({ databaseBuilder, datawarehouseKnex });
   }
 
   if (config.seeds.context.evaluation) {

--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,7 @@
     "db:prepare": "npm run db:delete && npm run db:create && npm run db:migrate",
     "db:seed": "NODE_OPTIONS=\"--max-old-space-size=380\" knex --knexfile db/knexfile.js seed:run",
     "db:reload": "npm run db:empty && npm run db:seed",
-    "db:reset": "npm run db:prepare && npm run db:seed",
+    "db:reset": "npm run db:prepare && npm run datamart:prepare && npm run db:seed",
     "db:schemalint": "schemalint --config tests/tooling/db-schemalint.cjs",
     "doc:api:prescription": "node --env-file-if-exists=.env scripts/generate-api-documentation.js src/prescription > src/prescription/API.md",
     "doc:api:team": "node --env-file-if-exists=.env scripts/generate-api-documentation.js src/team > src/team/API.md",

--- a/api/src/certification/configuration/application/api/version-api.js
+++ b/api/src/certification/configuration/application/api/version-api.js
@@ -1,4 +1,3 @@
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { toScope } from '../../../shared/domain/models/Frameworks.js';
 import * as versionRepository from '../../infrastructure/repositories/version-repository.js';
 import { Version } from './models/Version.js';
@@ -31,15 +30,7 @@ export async function getByFrameworkAndDate({ framework, date }) {
  * @returns {Promise<Version|null>}
  */
 export async function getById({ id }) {
-  let foundVersion;
-  try {
-    foundVersion = await versionRepository.getById({ id });
-  } catch (err) {
-    if (err instanceof NotFoundError) {
-      return null;
-    }
-    throw err;
-  }
-
+  const foundVersion = await versionRepository.getById({ id });
+  if (!foundVersion) return null;
   return new Version(foundVersion);
 }

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -3,6 +3,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Deserializer } = jsonapiSerializer;
 
 import { usecases } from '../domain/usecases/index.js';
+import * as calibrationReportSerializer from '../infrastructure/serializers/calibration-report-serializer.js';
 import { certificationInfoSerializer } from '../infrastructure/serializers/certification-info-serializer.js';
 import * as versionDetailsSerializer from '../infrastructure/serializers/version-details-serializer.js';
 
@@ -55,6 +56,13 @@ async function createDraft(request, h) {
   return h.response(versionDetailsSerializer.serialize(versionDetails)).code(201);
 }
 
+async function generateCalibrationReport(request, h) {
+  const versionId = request.params.certificationVersionId;
+  const { calibrationId } = request.payload.data.attributes;
+  const report = await usecases.generateCalibrationReportCheck({ versionId, calibrationId });
+  return h.response(calibrationReportSerializer.serialize(report)).code(200);
+}
+
 async function getInfo(request) {
   const framework = request.params.framework;
 
@@ -72,6 +80,7 @@ const certificationVersionController = {
   update,
   updateComments,
   getInfo,
+  generateCalibrationReport,
 };
 
 export { certificationVersionController };

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -54,7 +54,7 @@ async function register(server) {
         handler: certificationVersionController.getVersionById,
         tags: ['api', 'admin'],
         notes: [
-          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Cette route est restreinte aux utilisateurs PixAdmin',
           'Elle permet de récupérer une version par son id',
         ],
       },
@@ -198,6 +198,40 @@ async function register(server) {
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin',
           "Elle permet de créer un nouveau millésime draft d'un référentiel de certification",
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/certification-versions/{certificationVersionId}/calibration-report',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationVersionId: identifiersType.certificationVersionId,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                calibrationId: Joi.number().integer().required(),
+              }).required(),
+            }),
+          }),
+        },
+        handler: certificationVersionController.generateCalibrationReport,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte au SUPER ADMIN',
+          "Elle permet d'obtenir un rapport de vérification qui précède la récupération d'une calibration",
         ],
       },
     },

--- a/api/src/certification/configuration/domain/models/Calibration.js
+++ b/api/src/certification/configuration/domain/models/Calibration.js
@@ -41,8 +41,7 @@ export class Calibration {
 }
 
 export class CalibratedChallenge {
-  constructor({ id, challengeId, tubeId, alpha, delta }) {
-    this.id = id;
+  constructor({ challengeId, tubeId, alpha, delta }) {
     this.challengeId = challengeId;
     this.tubeId = tubeId;
     this.alpha = alpha;

--- a/api/src/certification/configuration/domain/models/Calibration.js
+++ b/api/src/certification/configuration/domain/models/Calibration.js
@@ -1,0 +1,34 @@
+export const CALIBRATION_STATUSES = Object.freeze({
+  TO_VALIDATE: 'TO_VALIDATE',
+  VALIDATED: 'VALIDATED',
+  INVALIDATED: 'INVALIDATED',
+});
+
+export const CALIBRATION_SCOPES = Object.freeze({
+  COEUR: 'COEUR',
+  EDU_2ND_DEGRE: 'EDU_2ND_DEGRE',
+  EDU_1ER_DEGRE: 'EDU_1ER_DEGRE',
+  EDU_CPE: 'EDU_CPE',
+  DROIT: 'DROIT',
+  PRO_SANTE: 'PRO_SANTE',
+});
+
+export class Calibration {
+  constructor({ id, startedAt, status, scope, calibratedChallenges }) {
+    this.id = id;
+    this.startedAt = startedAt;
+    this.status = status;
+    this.scope = scope;
+    this.calibratedChallenges = calibratedChallenges;
+  }
+}
+
+export class CalibratedChallenge {
+  constructor({ id, challengeId, tubeId, alpha, delta }) {
+    this.id = id;
+    this.challengeId = challengeId;
+    this.tubeId = tubeId;
+    this.alpha = alpha;
+    this.delta = delta;
+  }
+}

--- a/api/src/certification/configuration/domain/models/Calibration.js
+++ b/api/src/certification/configuration/domain/models/Calibration.js
@@ -21,6 +21,23 @@ export class Calibration {
     this.scope = scope;
     this.calibratedChallenges = calibratedChallenges;
   }
+
+  get challengeCount() {
+    return this.calibratedChallenges.length;
+  }
+
+  /**
+   *
+   * @returns {Set<string>} tubeIds
+   */
+  get tubeIds() {
+    const tubeIds = new Set();
+    for (const calibratedChallenge of this.calibratedChallenges) {
+      tubeIds.add(calibratedChallenge.tubeId);
+    }
+
+    return tubeIds;
+  }
 }
 
 export class CalibratedChallenge {

--- a/api/src/certification/configuration/domain/models/CalibrationReport.js
+++ b/api/src/certification/configuration/domain/models/CalibrationReport.js
@@ -1,0 +1,124 @@
+/**
+ * @typedef {import('./Version.js').Version} Version
+ * @typedef {import('./Calibration.js').Calibration} Calibration
+ */
+import { fromCalibrationScope } from '../../../shared/domain/models/Scopes.js';
+import { CALIBRATION_STATUSES } from './Calibration.js';
+
+export class CalibrationReport {
+  constructor({ versionId, calibrationId, generatedAt, reportLines }) {
+    this.versionId = versionId;
+    this.calibrationId = calibrationId;
+    this.generatedAt = generatedAt;
+    this.reportLines = reportLines;
+  }
+}
+
+export class CalibrationReportLine {
+  constructor({ content, alertLevel = ALERT_LEVELS.NA, additionalContent = null }) {
+    this.content = content;
+    this.alertLevel = alertLevel;
+    this.additionalContent = additionalContent;
+  }
+}
+
+export const ALERT_LEVELS = Object.freeze({
+  NA: 'N/A',
+  HIGH: 'HIGH',
+  LOW: 'LOW',
+});
+
+/**
+ *
+ * @param {object} params
+ * @param {Version} params.version
+ * @param {Calibration} params.calibration
+ * @returns CalibrationReport
+ */
+export function buildReport({ version, calibration }) {
+  const now = new Date();
+  const reportLines = [];
+  computeReportForLearningContentPerimeter(version, calibration, reportLines);
+  computeReportForStartDate(now, calibration, reportLines);
+  computeReportForScope(version, calibration, reportLines);
+  computeReportForStatus(calibration, reportLines);
+  return new CalibrationReport({
+    versionId: version.id,
+    calibrationId: calibration.id,
+    generatedAt: now,
+    reportLines,
+  });
+}
+
+function computeReportForLearningContentPerimeter(version, calibration, reportLines) {
+  reportLines.push(
+    new CalibrationReportLine({ content: `Nombre d'épreuves calibrées : ${calibration.challengeCount}` }),
+  );
+  const tubeIdsFromCalibration = calibration.tubeIds;
+  const tubeIdsFromVersion = new Set(version.tubeIds);
+  const tubeIdsNotInBoth = tubeIdsFromCalibration.symmetricDifference(tubeIdsFromVersion);
+  if (tubeIdsNotInBoth.size > 0) {
+    const tubeIdsInCalibrationButNotInVersion = tubeIdsNotInBoth.intersection(tubeIdsFromCalibration);
+    if (tubeIdsInCalibrationButNotInVersion.size) {
+      reportLines.push(
+        new CalibrationReportLine({
+          content: `Nombre de sujets dans la calibration non présents dans la version : ${tubeIdsInCalibrationButNotInVersion.size}`,
+          alertLevel: ALERT_LEVELS.HIGH,
+          additionalContent: [...tubeIdsInCalibrationButNotInVersion.values()].join(', '),
+        }),
+      );
+    }
+    const tubeIdsInVersionButNotInCalibration = tubeIdsNotInBoth.intersection(tubeIdsFromVersion);
+    if (tubeIdsInVersionButNotInCalibration.size) {
+      reportLines.push(
+        new CalibrationReportLine({
+          content: `Nombre de sujets dans la version non présents dans la calibration : ${tubeIdsInVersionButNotInCalibration.size}`,
+          alertLevel: ALERT_LEVELS.LOW,
+          additionalContent: [...tubeIdsInVersionButNotInCalibration.values()].join(', '),
+        }),
+      );
+    }
+  }
+}
+
+function computeReportForStartDate(now, calibration, reportLines) {
+  const sixMonthsAgo = new Date(now);
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+  const oneYearAgo = new Date(now);
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+  let alertLevel;
+  if (calibration.startedAt >= sixMonthsAgo) {
+    alertLevel = ALERT_LEVELS.NA;
+  } else if (calibration.startedAt >= oneYearAgo) {
+    alertLevel = ALERT_LEVELS.LOW;
+  } else {
+    alertLevel = ALERT_LEVELS.HIGH;
+  }
+  reportLines.push(
+    new CalibrationReportLine({
+      content: `L'élaboration de cette calibration a débuté le ${calibration.startedAt.toLocaleDateString('fr-FR')}`,
+      alertLevel,
+    }),
+  );
+}
+
+function computeReportForScope(version, calibration, reportLines) {
+  const adaptedCalibrationScope = fromCalibrationScope(calibration.scope);
+  const alertLevel = version.scope !== adaptedCalibrationScope ? ALERT_LEVELS.HIGH : ALERT_LEVELS.NA;
+  reportLines.push(
+    new CalibrationReportLine({
+      content: `Le scope de cette calibration est "${adaptedCalibrationScope}"`,
+      alertLevel,
+    }),
+  );
+}
+
+function computeReportForStatus(calibration, reportLines) {
+  const alertLevel = calibration.status === CALIBRATION_STATUSES.VALIDATED ? ALERT_LEVELS.NA : ALERT_LEVELS.HIGH;
+  reportLines.push(
+    new CalibrationReportLine({
+      content: `Le statut de cette calibration est "${calibration.status}"`,
+      alertLevel,
+    }),
+  );
+}

--- a/api/src/certification/configuration/domain/models/CalibrationReport.js
+++ b/api/src/certification/configuration/domain/models/CalibrationReport.js
@@ -15,15 +15,24 @@ export class CalibrationReport {
 }
 
 export class CalibrationReportLine {
-  constructor({ content, alertLevel = ALERT_LEVELS.NA, additionalContent = null }) {
+  constructor({ label, content, alertLevel = null, additionalContent = null }) {
+    this.label = label;
     this.content = content;
     this.alertLevel = alertLevel;
     this.additionalContent = additionalContent;
   }
 }
 
+export const REPORT_LABELS = Object.freeze({
+  CALIBRATED_CHALLENGE_COUNT: 'CALIBRATED_CHALLENGE_COUNT',
+  TUBE_ONLY_IN_VERSION_COUNT: 'TUBE_ONLY_IN_VERSION_COUNT',
+  TUBE_ONLY_IN_CALIBRATION_COUNT: 'TUBE_ONLY_IN_CALIBRATION_COUNT',
+  CALIBRATION_STARTED_AT: 'CALIBRATION_STARTED_AT',
+  CALIBRATION_STATUS: 'CALIBRATION_STATUS',
+  CALIBRATION_SCOPE: 'CALIBRATION_SCOPE',
+});
+
 export const ALERT_LEVELS = Object.freeze({
-  NA: 'N/A',
   HIGH: 'HIGH',
   LOW: 'LOW',
 });
@@ -52,7 +61,7 @@ export function buildReport({ version, calibration }) {
 
 function computeReportForLearningContentPerimeter(version, calibration, reportLines) {
   reportLines.push(
-    new CalibrationReportLine({ content: `Nombre d'épreuves calibrées : ${calibration.challengeCount}` }),
+    new CalibrationReportLine({ label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT, content: calibration.challengeCount }),
   );
   const tubeIdsFromCalibration = calibration.tubeIds;
   const tubeIdsFromVersion = new Set(version.tubeIds);
@@ -62,7 +71,8 @@ function computeReportForLearningContentPerimeter(version, calibration, reportLi
     if (tubeIdsInCalibrationButNotInVersion.size) {
       reportLines.push(
         new CalibrationReportLine({
-          content: `Nombre de sujets dans la calibration non présents dans la version : ${tubeIdsInCalibrationButNotInVersion.size}`,
+          label: REPORT_LABELS.TUBE_ONLY_IN_CALIBRATION_COUNT,
+          content: tubeIdsInCalibrationButNotInVersion.size,
           alertLevel: ALERT_LEVELS.HIGH,
           additionalContent: [...tubeIdsInCalibrationButNotInVersion.values()].join(', '),
         }),
@@ -72,7 +82,8 @@ function computeReportForLearningContentPerimeter(version, calibration, reportLi
     if (tubeIdsInVersionButNotInCalibration.size) {
       reportLines.push(
         new CalibrationReportLine({
-          content: `Nombre de sujets dans la version non présents dans la calibration : ${tubeIdsInVersionButNotInCalibration.size}`,
+          label: REPORT_LABELS.TUBE_ONLY_IN_VERSION_COUNT,
+          content: tubeIdsInVersionButNotInCalibration.size,
           alertLevel: ALERT_LEVELS.LOW,
           additionalContent: [...tubeIdsInVersionButNotInCalibration.values()].join(', '),
         }),
@@ -86,39 +97,50 @@ function computeReportForStartDate(now, calibration, reportLines) {
   sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
   const oneYearAgo = new Date(now);
   oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-  let alertLevel;
+  let alertLevel, additionalContent;
   if (calibration.startedAt >= sixMonthsAgo) {
-    alertLevel = ALERT_LEVELS.NA;
+    alertLevel = null;
   } else if (calibration.startedAt >= oneYearAgo) {
     alertLevel = ALERT_LEVELS.LOW;
+    additionalContent = 'La calibration a été démarrée depuis plus de 6 mois';
   } else {
     alertLevel = ALERT_LEVELS.HIGH;
+    additionalContent = "La calibration a été démarrée depuis plus d'1 an";
   }
   reportLines.push(
     new CalibrationReportLine({
-      content: `L'élaboration de cette calibration a débuté le ${calibration.startedAt.toLocaleDateString('fr-FR')}`,
+      label: REPORT_LABELS.CALIBRATION_STARTED_AT,
+      content: calibration.startedAt,
       alertLevel,
+      additionalContent,
     }),
   );
 }
 
 function computeReportForScope(version, calibration, reportLines) {
   const adaptedCalibrationScope = fromCalibrationScope(calibration.scope);
-  const alertLevel = version.scope !== adaptedCalibrationScope ? ALERT_LEVELS.HIGH : ALERT_LEVELS.NA;
+  const alertLevel = version.scope !== adaptedCalibrationScope ? ALERT_LEVELS.HIGH : null;
+  const additionalContent =
+    alertLevel === null ? null : 'La calibration ne concerne pas le même référentiel que la version';
   reportLines.push(
     new CalibrationReportLine({
-      content: `Le scope de cette calibration est "${adaptedCalibrationScope}"`,
+      label: REPORT_LABELS.CALIBRATION_SCOPE,
+      content: adaptedCalibrationScope,
       alertLevel,
+      additionalContent,
     }),
   );
 }
 
 function computeReportForStatus(calibration, reportLines) {
-  const alertLevel = calibration.status === CALIBRATION_STATUSES.VALIDATED ? ALERT_LEVELS.NA : ALERT_LEVELS.HIGH;
+  const alertLevel = calibration.status === CALIBRATION_STATUSES.VALIDATED ? null : ALERT_LEVELS.HIGH;
+  const additionalContent = alertLevel === null ? null : 'La calibration ne semble pas encore finalisée';
   reportLines.push(
     new CalibrationReportLine({
-      content: `Le statut de cette calibration est "${calibration.status}"`,
+      label: REPORT_LABELS.CALIBRATION_STATUS,
+      content: calibration.status,
       alertLevel,
+      additionalContent,
     }),
   );
 }

--- a/api/src/certification/configuration/domain/usecases/delete-version.js
+++ b/api/src/certification/configuration/domain/usecases/delete-version.js
@@ -12,7 +12,7 @@ import { CertificationVersionForbiddenDeletionError } from '../errors.js';
 
 export async function deleteVersion({ id, versionRepository }) {
   const version = await versionRepository.getById({ id });
-  if (!version.canRemove) {
+  if (!version || !version.canRemove) {
     throw new CertificationVersionForbiddenDeletionError();
   }
   await versionRepository.remove(id);

--- a/api/src/certification/configuration/domain/usecases/generate-calibration-report-check.js
+++ b/api/src/certification/configuration/domain/usecases/generate-calibration-report-check.js
@@ -1,0 +1,21 @@
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { buildReport } from '../models/CalibrationReport.js';
+
+export async function generateCalibrationReportCheck({
+  versionId,
+  calibrationId,
+  versionRepository,
+  calibrationRepository,
+}) {
+  const version = await versionRepository.getById({ id: versionId });
+  if (!version) {
+    throw new NotFoundError(`Cannot find version of id "${versionId}"`);
+  }
+
+  const calibration = await calibrationRepository.find(calibrationId);
+  if (!calibration) {
+    throw new NotFoundError(`Cannot find calibration of external id "${calibrationId}"`);
+  }
+
+  return buildReport({ version, calibration });
+}

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import * as targetProfileHistoryRepository from '../../../shared/infrastructure/repositories/target-profile-history-repository.js';
 import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
+import * as calibrationRepository from '../../infrastructure/repositories/calibration-repository.js';
 import * as centerRepository from '../../infrastructure/repositories/center-repository.js';
 import * as certificationInfoRepository from '../../infrastructure/repositories/certification-info-repository.js';
 import * as complementaryCertificationBadgesRepository from '../../infrastructure/repositories/complementary-certification-badge-repository.js';
@@ -17,6 +18,7 @@ import { createDraft } from './create-draft.js';
 import { deleteVersion } from './delete-version.js';
 import { exportScoWhitelist } from './export-sco-whitelist.js';
 import { findComplementaryCertifications } from './find-complementary-certifications.js';
+import { generateCalibrationReportCheck } from './generate-calibration-report-check.js';
 import { getComplementaryCertificationForTargetProfileAttachmentRepository } from './get-complementary-certification-for-target-profile-attachment.js';
 import { getComplementaryCertificationTargetProfileHistory } from './get-complementary-certification-target-profile-history.js';
 import { getInfo } from './get-info.js';
@@ -44,6 +46,7 @@ import { updateVersionComment } from './update-version-comment.js';
  * @typedef {ScoBlockedAccessDatesRepository} ScoBlockedAccessDatesRepository
  * @typedef {versionRepository} VersionRepository
  * @typedef {versionDetailsRepository} VersionDetailsRepository
+ * @typedef {calibrationRepository} CalibrationRepository
  **/
 const dependencies = {
   attachableTargetProfileRepository,
@@ -58,6 +61,7 @@ const dependencies = {
   targetProfileHistoryRepository,
   versionRepository,
   versionDetailsRepository,
+  calibrationRepository,
 };
 
 const usecasesWithoutInjectedDependencies = {
@@ -77,6 +81,7 @@ const usecasesWithoutInjectedDependencies = {
   updateScoBlockedAccessDate,
   updateVersion,
   updateVersionComment,
+  generateCalibrationReportCheck,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);

--- a/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
@@ -1,4 +1,4 @@
-import { knex as datawarehouseKnex } from '../../../../../datawarehouse/knex-database-connection.js';
+import { knex as datamartKnex } from '../../../../../datamart/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { logger, SCOPES } from '../../../../shared/infrastructure/utils/logger.js';
 import { CalibratedChallenge, Calibration } from '../../domain/models/Calibration.js';
@@ -6,7 +6,7 @@ import { CalibratedChallenge, Calibration } from '../../domain/models/Calibratio
 export async function find(calibrationId) {
   const knexConn = DomainTransaction.getConnection();
   try {
-    const generalInfo = await datawarehouseKnex
+    const generalInfo = await datamartKnex
       .select({ id: 'id', startedAt: 'calibration_date', status: 'status', scope: 'scope' })
       .from('data_calibrations')
       .where({ id: calibrationId })
@@ -14,11 +14,14 @@ export async function find(calibrationId) {
 
     if (!generalInfo) return null;
 
-    const calibratedChallengesData = await datawarehouseKnex
-      .select({ id: 'id', challengeId: 'challenge_id', alpha: 'alpha', delta: 'delta' })
-      .from('data_calibration_challenges')
-      .where({ calibration_id: calibrationId, is_excluded: false })
-      .orderBy('id');
+    const calibratedChallengesData = await datamartKnex
+      .select({
+        challengeId: 'challenge_id',
+        alpha: 'alpha',
+        delta: 'delta',
+      })
+      .from('data_active_calibrated_challenges')
+      .where({ calibration_id: calibrationId });
 
     let calibratedChallenges = [];
     if (calibratedChallengesData.length > 0) {
@@ -31,6 +34,7 @@ export async function find(calibrationId) {
           calibratedChallengesData.map((data) => data.challengeId),
         );
       const tubeByChallenge = new Map(tubeAndChallengeData.map(({ challengeId, tubeId }) => [challengeId, tubeId]));
+
       calibratedChallenges = calibratedChallengesData.map(
         (calibratedChallengeData) =>
           new CalibratedChallenge({
@@ -49,7 +53,7 @@ export async function find(calibrationId) {
   } catch (err) {
     logger.error(
       { event: SCOPES.CERTIFICATION },
-      `Error while retrieving the calibration data of ID ${calibrationId} from datawarehouse : ${err}`,
+      `Error while retrieving the calibration data of ID ${calibrationId} from datamart : ${err}`,
     );
     throw err;
   }

--- a/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
@@ -1,0 +1,56 @@
+import { knex as datawarehouseKnex } from '../../../../../datawarehouse/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { logger, SCOPES } from '../../../../shared/infrastructure/utils/logger.js';
+import { CalibratedChallenge, Calibration } from '../../domain/models/Calibration.js';
+
+export async function find(calibrationId) {
+  const knexConn = DomainTransaction.getConnection();
+  try {
+    const generalInfo = await datawarehouseKnex
+      .select({ id: 'id', startedAt: 'calibration_date', status: 'status', scope: 'scope' })
+      .from('data_calibrations')
+      .where({ id: calibrationId })
+      .first();
+
+    if (!generalInfo) return null;
+
+    const calibratedChallengesData = await datawarehouseKnex
+      .select({ id: 'id', challengeId: 'challenge_id', alpha: 'alpha', delta: 'delta' })
+      .from('data_calibration_challenges')
+      .where({ calibration_id: calibrationId, is_excluded: false })
+      .orderBy('id');
+
+    let calibratedChallenges = [];
+    if (calibratedChallengesData.length > 0) {
+      const tubeAndChallengeData = await knexConn
+        .select({ challengeId: 'learningcontent.challenges.id', tubeId: 'learningcontent.skills.tubeId' })
+        .from('learningcontent.challenges')
+        .join('learningcontent.skills', 'learningcontent.skills.id', 'learningcontent.challenges.skillId')
+        .whereIn(
+          'learningcontent.challenges.id',
+          calibratedChallengesData.map((data) => data.challengeId),
+        );
+      const tubeByChallenge = new Map(tubeAndChallengeData.map(({ challengeId, tubeId }) => [challengeId, tubeId]));
+      calibratedChallenges = calibratedChallengesData.map(
+        (calibratedChallengeData) =>
+          new CalibratedChallenge({
+            ...calibratedChallengeData,
+            tubeId: tubeByChallenge.get(calibratedChallengeData.challengeId),
+            alpha: Number(calibratedChallengeData.alpha),
+            delta: Number(calibratedChallengeData.delta),
+          }),
+      );
+    }
+
+    return new Calibration({
+      ...generalInfo,
+      calibratedChallenges,
+    });
+  } catch (err) {
+    logger.error(
+      { event: SCOPES.CERTIFICATION },
+      `Error while retrieving the calibration data of ID ${calibrationId} from datawarehouse : ${err}`,
+    );
+    throw err;
+  }
+}

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -4,7 +4,6 @@
  * @typedef {import("../../../../shared/domain/models/Challenge.js").Challenge} Challenge
  */
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { Version } from '../../domain/models/Version.js';
 
@@ -20,14 +19,13 @@ export async function findAll() {
 /**
  * @param {object} params
  * @param {number} params.id
- * @returns {Promise<Version>}
- * @throws {NotFoundError}
+ * @returns {Promise<Version|null>}
  */
 export async function getById({ id }) {
   const versionData = await buildBaseQuery().where({ id }).first();
 
   if (!versionData) {
-    throw new NotFoundError(`Version with id ${id} not found`);
+    return null;
   }
 
   return _toDomain(versionData);

--- a/api/src/certification/configuration/infrastructure/serializers/calibration-report-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/calibration-report-serializer.js
@@ -1,0 +1,17 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+export function serialize(calibrationReport) {
+  return new Serializer('calibration-reports', {
+    attributes: ['calibrationId', 'generatedAt', 'reportLines'],
+    transform: (calibrationReport) => {
+      return {
+        id: `${calibrationReport.versionId}_${calibrationReport.calibrationId}`,
+        generatedAt: calibrationReport.generatedAt,
+        calibrationId: calibrationReport.calibrationId,
+        reportLines: calibrationReport.reportLines,
+      };
+    },
+  }).serialize(calibrationReport);
+}

--- a/api/src/certification/shared/domain/models/Scopes.js
+++ b/api/src/certification/shared/domain/models/Scopes.js
@@ -1,3 +1,5 @@
+import { CALIBRATION_SCOPES } from '../../../configuration/domain/models/Calibration.js';
+
 /**
  * Certification scopes
  * @readonly
@@ -11,3 +13,19 @@ export const SCOPES = Object.freeze({
   PIX_PLUS_EDU_CPE: 'EDU_CPE',
   PIX_PLUS_PRO_SANTE: 'PRO_SANTE',
 });
+
+/**
+ * @param {typeof CALIBRATION_SCOPES[keyof typeof CALIBRATION_SCOPES]} calibrationScope
+ * @returns {SCOPES}
+ */
+export function fromCalibrationScope(calibrationScope) {
+  const mapping = {
+    [CALIBRATION_SCOPES.COEUR]: SCOPES.CORE,
+    [CALIBRATION_SCOPES.EDU_1ER_DEGRE]: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
+    [CALIBRATION_SCOPES.EDU_2ND_DEGRE]: SCOPES.PIX_PLUS_EDU_2ND_DEGRE,
+    [CALIBRATION_SCOPES.EDU_CPE]: SCOPES.PIX_PLUS_EDU_CPE,
+    [CALIBRATION_SCOPES.DROIT]: SCOPES.PIX_PLUS_DROIT,
+    [CALIBRATION_SCOPES.PRO_SANTE]: SCOPES.PIX_PLUS_PRO_SANTE,
+  };
+  return mapping[calibrationScope];
+}

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/generate-calibration-report-check_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/generate-calibration-report-check_test.js
@@ -1,0 +1,120 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { CALIBRATION_SCOPES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import { ALERT_LEVELS } from '../../../../../../src/certification/configuration/domain/models/CalibrationReport.js';
+import { generateCalibrationReportCheck } from '../../../../../../src/certification/configuration/domain/usecases/generate-calibration-report-check.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
+
+describe('Certification | Configuration | Unit | UseCase | generate-calibration-report-check', function () {
+  let versionRepository, calibrationRepository, dependencies, clock;
+  const now = new Date('2025-06-15T12:00:00Z');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    versionRepository = {
+      getById: sinon.stub(),
+    };
+
+    calibrationRepository = {
+      find: sinon.stub(),
+    };
+
+    dependencies = {
+      versionRepository,
+      calibrationRepository,
+    };
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  context('when version does not exist', function () {
+    it('throws a NotFound error', async function () {
+      versionRepository.getById.withArgs({ id: 1 }).resolves(null);
+
+      const err = await catchErr(generateCalibrationReportCheck)({
+        versionId: 1,
+        calibrationId: 2,
+        ...dependencies,
+      });
+
+      expect(err).to.be.instanceOf(NotFoundError);
+      expect(err.message).to.equal('Cannot find version of id "1"');
+    });
+  });
+
+  context('when calibration does not exist', function () {
+    it('throws a NotFound error', async function () {
+      versionRepository.getById
+        .withArgs({ id: 1 })
+        .resolves(domainBuilder.certification.configuration.versionBuilder().build());
+      calibrationRepository.find.withArgs(2).resolves(null);
+
+      const err = await catchErr(generateCalibrationReportCheck)({
+        versionId: 1,
+        calibrationId: 2,
+        ...dependencies,
+      });
+
+      expect(err).to.be.instanceOf(NotFoundError);
+      expect(err.message).to.equal('Cannot find calibration of external id "2"');
+    });
+  });
+
+  context('when version and calibration found', function () {
+    it('returns the corresponding report', async function () {
+      versionRepository.getById.withArgs({ id: 1 }).resolves(
+        domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ id: 1, scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+          .build(),
+      );
+      calibrationRepository.find.withArgs(2).resolves(
+        domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+          .withCalibratredChallenges([{ tubeId: 'tubeA' }])
+          .asValidated({ startedAt: new Date() })
+          .withParameters({ id: 2 })
+          .build(),
+      );
+
+      const report = await generateCalibrationReportCheck({
+        versionId: 1,
+        calibrationId: 2,
+        ...dependencies,
+      });
+
+      expect(report.generatedAt).to.deep.equal(now);
+      expect(report.versionId).to.equal(1);
+      expect(report.calibrationId).to.equal(2);
+      expect(report.reportLines).to.deep.include.members([
+        {
+          additionalContent: null,
+          alertLevel: ALERT_LEVELS.NA,
+          content: "Nombre d'épreuves calibrées : 1",
+        },
+        {
+          additionalContent: null,
+          alertLevel: ALERT_LEVELS.NA,
+          content: "L'élaboration de cette calibration a débuté le 15/06/2025",
+        },
+        {
+          additionalContent: null,
+          alertLevel: ALERT_LEVELS.NA,
+          content: 'Le scope de cette calibration est "CORE"',
+        },
+        {
+          additionalContent: null,
+          alertLevel: ALERT_LEVELS.NA,
+          content: 'Le statut de cette calibration est "VALIDATED"',
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/generate-calibration-report-check_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/generate-calibration-report-check_test.js
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { CALIBRATION_SCOPES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
-import { ALERT_LEVELS } from '../../../../../../src/certification/configuration/domain/models/CalibrationReport.js';
+import {
+  CALIBRATION_SCOPES,
+  CALIBRATION_STATUSES,
+} from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import { REPORT_LABELS } from '../../../../../../src/certification/configuration/domain/models/CalibrationReport.js';
 import { generateCalibrationReportCheck } from '../../../../../../src/certification/configuration/domain/usecases/generate-calibration-report-check.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
@@ -96,23 +99,27 @@ describe('Certification | Configuration | Unit | UseCase | generate-calibration-
       expect(report.reportLines).to.deep.include.members([
         {
           additionalContent: null,
-          alertLevel: ALERT_LEVELS.NA,
-          content: "Nombre d'épreuves calibrées : 1",
+          alertLevel: null,
+          content: 1,
+          label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT,
         },
         {
           additionalContent: null,
-          alertLevel: ALERT_LEVELS.NA,
-          content: "L'élaboration de cette calibration a débuté le 15/06/2025",
+          alertLevel: null,
+          content: new Date(),
+          label: REPORT_LABELS.CALIBRATION_STARTED_AT,
         },
         {
           additionalContent: null,
-          alertLevel: ALERT_LEVELS.NA,
-          content: 'Le scope de cette calibration est "CORE"',
+          alertLevel: null,
+          content: SCOPES.CORE,
+          label: REPORT_LABELS.CALIBRATION_SCOPE,
         },
         {
           additionalContent: null,
-          alertLevel: ALERT_LEVELS.NA,
-          content: 'Le statut de cette calibration est "VALIDATED"',
+          alertLevel: null,
+          content: CALIBRATION_STATUSES.VALIDATED,
+          label: REPORT_LABELS.CALIBRATION_STATUS,
         },
       ]);
     });

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -1,9 +1,5 @@
 import sinon from 'sinon';
 
-import {
-  cleanCalibrationTables,
-  createCalibrationTables,
-} from '../../../../../db/database-builder/database-helpers.js';
 import { createServer } from '../../../../../server.js';
 import {
   CALIBRATION_SCOPES,
@@ -17,7 +13,7 @@ import { VERSION_STATUSES } from '../../../../../src/certification/configuration
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../test-helper.js';
-import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { databaseBuilder, datamartBuilder, knex } from '../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
@@ -603,12 +599,10 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
     beforeEach(function () {
       clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      return createCalibrationTables();
     });
 
     afterEach(function () {
       clock.restore();
-      return cleanCalibrationTables();
     });
 
     it('should return 200 HTTP status code and a the calibration report', async function () {
@@ -616,13 +610,15 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
         .versionBuilder()
         .withParameters({ id: 1, scope: SCOPES.CORE, tubeIds: ['tubeA'] })
         .insertToDB({ databaseBuilder });
+
       await domainBuilder.certification.configuration
         .calibrationBuilder()
         .onScope({ scope: CALIBRATION_SCOPES.COEUR })
-        .withCalibratredChallenges([{ tubeId: 'tubeA' }])
+        .withCalibratredChallenges([{ challengeId: 'challengeA', tubeId: 'tubeA' }])
         .asValidated({ startedAt: new Date('2021-01-01') })
         .withParameters({ id: 2 })
-        .insertToDB();
+        .insertToDB({ datamartBuilder });
+
       const learningContent = {
         skills: [
           {
@@ -638,7 +634,10 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
         ],
       };
       databaseBuilder.factory.learningContent.build(learningContent);
+
       await databaseBuilder.commit();
+      await datamartBuilder.commit();
+
       const options = {
         method: 'POST',
         url: `/api/admin/certification-versions/1/calibration-report`,
@@ -667,14 +666,8 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
             {
               additionalContent: null,
               alertLevel: null,
-              content: 0,
-              label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT,
-            },
-            {
-              additionalContent: 'tubeA',
-              alertLevel: ALERT_LEVELS.LOW,
               content: 1,
-              label: REPORT_LABELS.TUBE_ONLY_IN_VERSION_COUNT,
+              label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT,
             },
             {
               additionalContent: "La calibration a été démarrée depuis plus d'1 an",

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -1,6 +1,18 @@
 import sinon from 'sinon';
 
+import {
+  cleanCalibrationTables,
+  createCalibrationTables,
+} from '../../../../../db/database-builder/database-helpers.js';
 import { createServer } from '../../../../../server.js';
+import {
+  CALIBRATION_SCOPES,
+  CALIBRATION_STATUSES,
+} from '../../../../../src/certification/configuration/domain/models/Calibration.js';
+import {
+  ALERT_LEVELS,
+  REPORT_LABELS,
+} from '../../../../../src/certification/configuration/domain/models/CalibrationReport.js';
 import { VERSION_STATUSES } from '../../../../../src/certification/configuration/domain/models/Version.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
@@ -582,6 +594,109 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
           },
         },
       ]);
+    });
+  });
+
+  describe('POST /api/admin/certification-versions/{certificationVersionId}/calibration-report', function () {
+    const now = new Date('2025-06-15T12:00:00Z');
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      return createCalibrationTables();
+    });
+
+    afterEach(function () {
+      clock.restore();
+      return cleanCalibrationTables();
+    });
+
+    it('should return 200 HTTP status code and a the calibration report', async function () {
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ id: 1, scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+        .insertToDB({ databaseBuilder });
+      await domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+        .withCalibratredChallenges([{ tubeId: 'tubeA' }])
+        .asValidated({ startedAt: new Date('2021-01-01') })
+        .withParameters({ id: 2 })
+        .insertToDB();
+      const learningContent = {
+        skills: [
+          {
+            id: 'skillA',
+            tubeId: 'tubeA',
+          },
+        ],
+        challenges: [
+          {
+            id: 'challengeA',
+            skillId: 'skillA',
+          },
+        ],
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
+      const options = {
+        method: 'POST',
+        url: `/api/admin/certification-versions/1/calibration-report`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        payload: {
+          data: {
+            attributes: {
+              calibrationId: 2,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal({
+        type: 'calibration-reports',
+        id: '1_2',
+        attributes: {
+          'calibration-id': 2,
+          'generated-at': new Date(),
+          'report-lines': [
+            {
+              additionalContent: null,
+              alertLevel: null,
+              content: 0,
+              label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT,
+            },
+            {
+              additionalContent: 'tubeA',
+              alertLevel: ALERT_LEVELS.LOW,
+              content: 1,
+              label: REPORT_LABELS.TUBE_ONLY_IN_VERSION_COUNT,
+            },
+            {
+              additionalContent: "La calibration a été démarrée depuis plus d'1 an",
+              alertLevel: ALERT_LEVELS.HIGH,
+              content: new Date('2021-01-01'),
+              label: REPORT_LABELS.CALIBRATION_STARTED_AT,
+            },
+            {
+              additionalContent: null,
+              alertLevel: null,
+              content: SCOPES.CORE,
+              label: REPORT_LABELS.CALIBRATION_SCOPE,
+            },
+            {
+              additionalContent: null,
+              alertLevel: null,
+              content: CALIBRATION_STATUSES.VALIDATED,
+              label: REPORT_LABELS.CALIBRATION_STATUS,
+            },
+          ],
+        },
+      });
     });
   });
 });

--- a/api/tests/certification/configuration/integration/domain/usecases/delete-version_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/delete-version_test.js
@@ -7,6 +7,24 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Integration | Domain | UseCase | delete-version', function () {
+  it('should throw CertificationVersionForbiddenDeletionError when version cannot be found', async function () {
+    // given
+    domainBuilder.certification.configuration
+      .versionBuilder()
+      .asActive()
+      .withParameters({ id: 1, scope: SCOPES.CORE, tubeIds: ['coucou'] })
+      .insertToDB({ databaseBuilder });
+
+    await databaseBuilder.commit();
+
+    // when
+    const error = await catchErr(usecases.deleteVersion)({
+      id: 2,
+    });
+    // then
+    expect(error).to.be.instanceOf(CertificationVersionForbiddenDeletionError);
+  });
+
   it('should throw CertificationVersionForbiddenDeletionError when version cannot be removed', async function () {
     // given
     const certificationVersion = domainBuilder.certification.configuration

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/calibration-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/calibration-repository_test.js
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+
+import {
+  cleanCalibrationTables,
+  createCalibrationTables,
+} from '../../../../../../db/database-builder/database-helpers.js';
+import { CALIBRATION_SCOPES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import * as calibrationRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/calibration-repository.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Certification | Configuration | Integration | Repository | calibration', function () {
+  beforeEach(function () {
+    return createCalibrationTables();
+  });
+
+  afterEach(function () {
+    return cleanCalibrationTables();
+  });
+
+  describe('#find', function () {
+    it('returns null when no calibration found for id', async function () {
+      await domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .asValidated({ startedAt: new Date('2026-03-04') })
+        .onScope({ scope: CALIBRATION_SCOPES.DROIT })
+        .withParameters({ id: 113 })
+        .insertToDB();
+
+      // when
+      const calibration = await calibrationRepository.find(222);
+
+      // then
+      expect(calibration).to.be.null;
+    });
+
+    it('returns expected calibration when exists', async function () {
+      const expectedCalibration = await domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .asValidated({ startedAt: new Date('2026-03-04') })
+        .onScope({ scope: CALIBRATION_SCOPES.DROIT })
+        .withCalibratredChallenges([
+          { id: 1, alpha: -5.34, delta: 3.321, challengeId: 'challengeA', tubeId: 'tubeA', isExcluded: true },
+          { id: 3, alpha: 1.432, delta: -0.56, challengeId: 'challengeC1', tubeId: 'tubeC', isExcluded: false },
+          { id: 2, alpha: -7.0129, delta: 6.11, challengeId: 'challengeB2', tubeId: 'tubeB', isExcluded: false },
+          { id: 4, alpha: 1.234, delta: 5.098, challengeId: 'challengeC2', tubeId: 'tubeC', isExcluded: false },
+          { id: 5, alpha: 0.872, delta: -2, challengeId: 'challengeB1', tubeId: 'tubeB', isExcluded: false },
+        ])
+        .withParameters({ id: 113 })
+        .insertToDB();
+      const learningContent = {
+        skills: [
+          {
+            id: 'skillA',
+            tubeId: 'tubeA',
+          },
+          {
+            id: 'skillB1',
+            tubeId: 'tubeB',
+          },
+          {
+            id: 'skillB2',
+            tubeId: 'tubeB',
+          },
+          {
+            id: 'skillC',
+            tubeId: 'tubeC',
+          },
+        ],
+        challenges: [
+          {
+            id: 'challengeA',
+            skillId: 'skillA',
+          },
+          {
+            id: 'challengeC1',
+            skillId: 'skillC',
+          },
+          {
+            id: 'challengeC2',
+            skillId: 'skillC',
+          },
+          {
+            id: 'challengeB1',
+            skillId: 'skillB1',
+          },
+          {
+            id: 'challengeB2',
+            skillId: 'skillB2',
+          },
+        ],
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
+
+      // when
+      const calibration = await calibrationRepository.find(113);
+
+      // then
+      expect(calibration).to.deep.equal(expectedCalibration);
+      expect(calibration).to.be.instanceOf(expectedCalibration.constructor);
+    });
+  });
+});

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/calibration-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/calibration-repository_test.js
@@ -1,23 +1,11 @@
 import { expect } from 'chai';
 
-import {
-  cleanCalibrationTables,
-  createCalibrationTables,
-} from '../../../../../../db/database-builder/database-helpers.js';
 import { CALIBRATION_SCOPES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import * as calibrationRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/calibration-repository.js';
-import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { databaseBuilder, datamartBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Certification | Configuration | Integration | Repository | calibration', function () {
-  beforeEach(function () {
-    return createCalibrationTables();
-  });
-
-  afterEach(function () {
-    return cleanCalibrationTables();
-  });
-
   describe('#find', function () {
     it('returns null when no calibration found for id', async function () {
       await domainBuilder.certification.configuration
@@ -25,7 +13,9 @@ describe('Certification | Configuration | Integration | Repository | calibration
         .asValidated({ startedAt: new Date('2026-03-04') })
         .onScope({ scope: CALIBRATION_SCOPES.DROIT })
         .withParameters({ id: 113 })
-        .insertToDB();
+        .insertToDB({ datamartBuilder });
+
+      await datamartBuilder.commit();
 
       // when
       const calibration = await calibrationRepository.find(222);
@@ -40,14 +30,49 @@ describe('Certification | Configuration | Integration | Repository | calibration
         .asValidated({ startedAt: new Date('2026-03-04') })
         .onScope({ scope: CALIBRATION_SCOPES.DROIT })
         .withCalibratredChallenges([
-          { id: 1, alpha: -5.34, delta: 3.321, challengeId: 'challengeA', tubeId: 'tubeA', isExcluded: true },
-          { id: 3, alpha: 1.432, delta: -0.56, challengeId: 'challengeC1', tubeId: 'tubeC', isExcluded: false },
-          { id: 2, alpha: -7.0129, delta: 6.11, challengeId: 'challengeB2', tubeId: 'tubeB', isExcluded: false },
-          { id: 4, alpha: 1.234, delta: 5.098, challengeId: 'challengeC2', tubeId: 'tubeC', isExcluded: false },
-          { id: 5, alpha: 0.872, delta: -2, challengeId: 'challengeB1', tubeId: 'tubeB', isExcluded: false },
+          {
+            alpha: 1.432,
+            delta: -0.56,
+            challengeId: 'challengeC1',
+            tubeId: 'tubeC',
+          },
+          {
+            alpha: -7.0129,
+            delta: 6.11,
+            challengeId: 'challengeB2',
+            tubeId: 'tubeB',
+          },
+          {
+            alpha: 1.234,
+            delta: 5.098,
+            challengeId: 'challengeC2',
+            tubeId: 'tubeC',
+          },
+          {
+            alpha: 0.872,
+            delta: -2,
+            challengeId: 'challengeB1',
+            tubeId: 'tubeB',
+          },
         ])
         .withParameters({ id: 113 })
-        .insertToDB();
+        .insertToDB({ datamartBuilder });
+
+      await domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .asValidated({ startedAt: new Date('2026-03-04') })
+        .onScope({ scope: CALIBRATION_SCOPES.DROIT })
+        .withCalibratredChallenges([
+          {
+            alpha: 1.931,
+            delta: -0.891,
+            challengeId: 'challenge1',
+            tubeId: 'tubeA',
+          },
+        ])
+        .withParameters({ id: 115 })
+        .insertToDB({ datamartBuilder });
+
       const learningContent = {
         skills: [
           {
@@ -90,8 +115,11 @@ describe('Certification | Configuration | Integration | Repository | calibration
           },
         ],
       };
+
       databaseBuilder.factory.learningContent.build(learningContent);
+
       await databaseBuilder.commit();
+      await datamartBuilder.commit();
 
       // when
       const calibration = await calibrationRepository.find(113);

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -3,11 +3,9 @@ import * as versionRepository from '../../../../../../src/certification/configur
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Integration | Repository | Version', function () {
   describe('#save', function () {
@@ -273,15 +271,15 @@ describe('Certification | Configuration | Integration | Repository | Version', f
     });
 
     context('when the version does not exist', function () {
-      it('should throw a NotFoundError', async function () {
+      it('should return null', async function () {
         // given
         const nonExistentVersionId = 99999;
 
         // when
-        const error = await catchErr(versionRepository.getById)({ id: nonExistentVersionId });
+        const nullVersion = await versionRepository.getById({ id: nonExistentVersionId });
 
         // then
-        expect(error).to.deepEqualInstance(new NotFoundError(`Version with id ${nonExistentVersionId} not found`));
+        expect(nullVersion).to.be.null;
       });
     });
   });

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -265,4 +265,95 @@ describe('Unit | Certification | Configuration | Application | Router | certific
       });
     });
   });
+
+  describe('POST /api/admin/certification-versions/{certificationVersionId}/calibration-report', function () {
+    context('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(certificationVersionController, 'generateCalibrationReport').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'POST',
+          `/api/admin/certification-versions/1/calibration-report`,
+          {
+            data: { attributes: { calibrationId: 2 } },
+          },
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(certificationVersionController.generateCalibrationReport);
+      });
+    });
+
+    context('when the params are invalid', function () {
+      it('should return 400 HTTP status code when version id is not valid', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+        sinon.stub(certificationVersionController, 'generateCalibrationReport').returns('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'POST',
+          `/api/admin/certification-versions/NOT_AN_ID/calibration-report`,
+          {
+            data: { attributes: { calibrationId: 2 } },
+          },
+        );
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        sinon.assert.notCalled(certificationVersionController.generateCalibrationReport);
+      });
+
+      it('should return 400 HTTP status code when calibration id is not valid', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+        sinon.stub(certificationVersionController, 'generateCalibrationReport').returns('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'POST',
+          `/api/admin/certification-versions/1/calibration-report`,
+          {
+            data: { attributes: { calibrationId: 'coucou' } },
+          },
+        );
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        sinon.assert.notCalled(certificationVersionController.generateCalibrationReport);
+      });
+    });
+
+    it(`should return OK HTTP status code when everything is fine`, async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+      sinon.stub(certificationVersionController, 'generateCalibrationReport').returns({});
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', `/api/admin/certification-versions/1/calibration-report`, {
+        data: { attributes: { calibrationId: 2 } },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      sinon.assert.called(certificationVersionController.generateCalibrationReport);
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
@@ -1,0 +1,338 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { CALIBRATION_SCOPES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import {
+  ALERT_LEVELS,
+  buildReport,
+} from '../../../../../../src/certification/configuration/domain/models/CalibrationReport.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Certification | Configuration | Domain | Models | Calibration Report', function () {
+  const now = new Date('2025-06-15T12:00:00Z');
+  let clock;
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#build', function () {
+    context('computing diffs between version and calibration in terms of learning content perimeter', function () {
+      let calibrationBuilder, commonReportLines;
+      beforeEach(function () {
+        calibrationBuilder = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+          .asValidated({ startedAt: new Date() });
+
+        commonReportLines = [
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: "Nombre d'épreuves calibrées : 3",
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: "L'élaboration de cette calibration a débuté le 15/06/2025",
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: 'Le scope de cette calibration est "CORE"',
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: 'Le statut de cette calibration est "VALIDATED"',
+          },
+        ];
+      });
+
+      context('when some tubes are in the version but not in the calibration', function () {
+        it('adds a dedicated report line', function () {
+          const version = domainBuilder.certification.configuration
+            .versionBuilder()
+            .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA', 'tubeC', 'tubeD', 'tubeE'] })
+            .build();
+          const calibration = calibrationBuilder
+            .withCalibratredChallenges([{ tubeId: 'tubeA' }, { tubeId: 'tubeA' }, { tubeId: 'tubeD' }])
+            .build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: 'tubeC, tubeE',
+              alertLevel: ALERT_LEVELS.LOW,
+              content: 'Nombre de sujets dans la version non présents dans la calibration : 2',
+            },
+          ]);
+        });
+      });
+
+      context('when some tubes are in the calibration but not in the version', function () {
+        it('adds a dedicated report line', function () {
+          const version = domainBuilder.certification.configuration
+            .versionBuilder()
+            .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+            .build();
+          const calibration = calibrationBuilder
+            .withCalibratredChallenges([{ tubeId: 'tubeA' }, { tubeId: 'tubeD' }, { tubeId: 'tubeF' }])
+            .build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: 'tubeD, tubeF',
+              alertLevel: ALERT_LEVELS.HIGH,
+              content: 'Nombre de sujets dans la calibration non présents dans la version : 2',
+            },
+          ]);
+        });
+      });
+    });
+
+    context('computing info related to start date of the calibration', function () {
+      let calibrationBuilder, version, commonReportLines;
+      beforeEach(function () {
+        calibrationBuilder = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+          .withCalibratredChallenges([{ tubeId: 'tubeA' }]);
+        version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+          .build();
+
+        commonReportLines = [
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: "Nombre d'épreuves calibrées : 1",
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: 'Le scope de cette calibration est "CORE"',
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: 'Le statut de cette calibration est "VALIDATED"',
+          },
+        ];
+      });
+
+      context('when calibration preparation started during last 6 months', function () {
+        it('adds a dedicated report line with no alert level', function () {
+          const closeToSixMonthsAgo = new Date('2024-12-15T13:00:00Z');
+          const calibration = calibrationBuilder.asValidated({ startedAt: closeToSixMonthsAgo }).build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: null,
+              alertLevel: ALERT_LEVELS.NA,
+              content: "L'élaboration de cette calibration a débuté le 15/12/2024",
+            },
+          ]);
+        });
+      });
+
+      context('when calibration preparation started within 1 year ago and 6 months ago', function () {
+        it('adds a dedicated report line with a low alert level', function () {
+          const closeToOneYearAgo = new Date('2024-06-15T13:00:00Z');
+          const calibration = calibrationBuilder.asValidated({ startedAt: closeToOneYearAgo }).build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: null,
+              alertLevel: ALERT_LEVELS.LOW,
+              content: "L'élaboration de cette calibration a débuté le 15/06/2024",
+            },
+          ]);
+        });
+      });
+
+      context('when calibration preparation started before 1 year ago', function () {
+        it('adds a dedicated report line with a high alert level', function () {
+          const aBitBeyondOneYearAgo = new Date('2024-06-15T11:59:00Z');
+          const calibration = calibrationBuilder.asValidated({ startedAt: aBitBeyondOneYearAgo }).build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: null,
+              alertLevel: ALERT_LEVELS.HIGH,
+              content: "L'élaboration de cette calibration a débuté le 15/06/2024",
+            },
+          ]);
+        });
+      });
+    });
+
+    context('computing info related to scope of the calibration', function () {
+      let calibrationBuilder, version, commonReportLines;
+      beforeEach(function () {
+        calibrationBuilder = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .asValidated({ startedAt: new Date() })
+          .withCalibratredChallenges([{ tubeId: 'tubeA' }]);
+        version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+          .build();
+
+        commonReportLines = [
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: "Nombre d'épreuves calibrées : 1",
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: 'Le statut de cette calibration est "VALIDATED"',
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: "L'élaboration de cette calibration a débuté le 15/06/2025",
+          },
+        ];
+      });
+
+      context('when calibration is not on the same scope of the version', function () {
+        it('adds a dedicated report line with high alert level', function () {
+          const calibration = calibrationBuilder.onScope({ scope: CALIBRATION_SCOPES.PRO_SANTE }).build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: null,
+              alertLevel: ALERT_LEVELS.HIGH,
+              content: 'Le scope de cette calibration est "PRO_SANTE"',
+            },
+          ]);
+        });
+      });
+
+      context('when calibration is on the same scope of the version', function () {
+        it('adds a dedicated report line with no alert level', function () {
+          const calibration = calibrationBuilder.onScope({ scope: CALIBRATION_SCOPES.COEUR }).build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: null,
+              alertLevel: ALERT_LEVELS.NA,
+              content: 'Le scope de cette calibration est "CORE"',
+            },
+          ]);
+        });
+      });
+    });
+
+    context('computing info related to status of the calibration', function () {
+      let calibrationBuilder, version, commonReportLines;
+      beforeEach(function () {
+        calibrationBuilder = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+          .withCalibratredChallenges([{ tubeId: 'tubeA' }]);
+        version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+          .build();
+
+        commonReportLines = [
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: "Nombre d'épreuves calibrées : 1",
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: "L'élaboration de cette calibration a débuté le 15/06/2025",
+          },
+          {
+            additionalContent: null,
+            alertLevel: ALERT_LEVELS.NA,
+            content: 'Le scope de cette calibration est "CORE"',
+          },
+        ];
+      });
+
+      context('when calibration is in status VALIDATED', function () {
+        it('adds a dedicated report line with no alert level', function () {
+          const calibration = calibrationBuilder.asValidated({ startedAt: new Date() }).build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: null,
+              alertLevel: ALERT_LEVELS.NA,
+              content: 'Le statut de cette calibration est "VALIDATED"',
+            },
+          ]);
+        });
+      });
+
+      context('when calibration is in status INVALIDATED', function () {
+        it('adds a dedicated report line with high alert level', function () {
+          const calibration = calibrationBuilder.asInvalidated({ startedAt: new Date() }).build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: null,
+              alertLevel: ALERT_LEVELS.HIGH,
+              content: 'Le statut de cette calibration est "INVALIDATED"',
+            },
+          ]);
+        });
+      });
+
+      context('when calibration is in status TO_VALIDATE', function () {
+        it('adds a dedicated report line with high alert level', function () {
+          const calibration = calibrationBuilder.asToValidate({ startedAt: new Date() }).build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            ...commonReportLines,
+            {
+              additionalContent: null,
+              alertLevel: ALERT_LEVELS.HIGH,
+              content: 'Le statut de cette calibration est "TO_VALIDATE"',
+            },
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
@@ -1,10 +1,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { CALIBRATION_SCOPES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import {
+  CALIBRATION_SCOPES,
+  CALIBRATION_STATUSES,
+} from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import {
   ALERT_LEVELS,
   buildReport,
+  REPORT_LABELS,
 } from '../../../../../../src/certification/configuration/domain/models/CalibrationReport.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -32,23 +36,27 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
         commonReportLines = [
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: "Nombre d'épreuves calibrées : 3",
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT,
+            content: 3,
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: "L'élaboration de cette calibration a débuté le 15/06/2025",
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_STARTED_AT,
+            content: new Date(),
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: 'Le scope de cette calibration est "CORE"',
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_SCOPE,
+            content: SCOPES.CORE,
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: 'Le statut de cette calibration est "VALIDATED"',
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_STATUS,
+            content: CALIBRATION_STATUSES.VALIDATED,
           },
         ];
       });
@@ -70,7 +78,8 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
             {
               additionalContent: 'tubeC, tubeE',
               alertLevel: ALERT_LEVELS.LOW,
-              content: 'Nombre de sujets dans la version non présents dans la calibration : 2',
+              label: REPORT_LABELS.TUBE_ONLY_IN_VERSION_COUNT,
+              content: 2,
             },
           ]);
         });
@@ -93,7 +102,8 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
             {
               additionalContent: 'tubeD, tubeF',
               alertLevel: ALERT_LEVELS.HIGH,
-              content: 'Nombre de sujets dans la calibration non présents dans la version : 2',
+              label: REPORT_LABELS.TUBE_ONLY_IN_CALIBRATION_COUNT,
+              content: 2,
             },
           ]);
         });
@@ -115,18 +125,21 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
         commonReportLines = [
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: "Nombre d'épreuves calibrées : 1",
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT,
+            content: 1,
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: 'Le scope de cette calibration est "CORE"',
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_SCOPE,
+            content: SCOPES.CORE,
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: 'Le statut de cette calibration est "VALIDATED"',
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_STATUS,
+            content: CALIBRATION_STATUSES.VALIDATED,
           },
         ];
       });
@@ -142,8 +155,9 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
             ...commonReportLines,
             {
               additionalContent: null,
-              alertLevel: ALERT_LEVELS.NA,
-              content: "L'élaboration de cette calibration a débuté le 15/12/2024",
+              label: REPORT_LABELS.CALIBRATION_STARTED_AT,
+              content: new Date('2024-12-15T13:00:00Z'),
+              alertLevel: null,
             },
           ]);
         });
@@ -159,9 +173,10 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
           expect(report.reportLines).to.deep.include.members([
             ...commonReportLines,
             {
-              additionalContent: null,
+              additionalContent: 'La calibration a été démarrée depuis plus de 6 mois',
               alertLevel: ALERT_LEVELS.LOW,
-              content: "L'élaboration de cette calibration a débuté le 15/06/2024",
+              label: REPORT_LABELS.CALIBRATION_STARTED_AT,
+              content: new Date('2024-06-15T13:00:00Z'),
             },
           ]);
         });
@@ -177,9 +192,10 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
           expect(report.reportLines).to.deep.include.members([
             ...commonReportLines,
             {
-              additionalContent: null,
+              additionalContent: "La calibration a été démarrée depuis plus d'1 an",
               alertLevel: ALERT_LEVELS.HIGH,
-              content: "L'élaboration de cette calibration a débuté le 15/06/2024",
+              label: REPORT_LABELS.CALIBRATION_STARTED_AT,
+              content: new Date('2024-06-15T11:59:00Z'),
             },
           ]);
         });
@@ -201,18 +217,21 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
         commonReportLines = [
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: "Nombre d'épreuves calibrées : 1",
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT,
+            content: 1,
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: 'Le statut de cette calibration est "VALIDATED"',
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_STATUS,
+            content: CALIBRATION_STATUSES.VALIDATED,
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: "L'élaboration de cette calibration a débuté le 15/06/2025",
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_STARTED_AT,
+            content: new Date(),
           },
         ];
       });
@@ -226,9 +245,10 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
           expect(report.reportLines).to.deep.include.members([
             ...commonReportLines,
             {
-              additionalContent: null,
+              additionalContent: 'La calibration ne concerne pas le même référentiel que la version',
               alertLevel: ALERT_LEVELS.HIGH,
-              content: 'Le scope de cette calibration est "PRO_SANTE"',
+              label: REPORT_LABELS.CALIBRATION_SCOPE,
+              content: SCOPES.PIX_PLUS_PRO_SANTE,
             },
           ]);
         });
@@ -244,8 +264,9 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
             ...commonReportLines,
             {
               additionalContent: null,
-              alertLevel: ALERT_LEVELS.NA,
-              content: 'Le scope de cette calibration est "CORE"',
+              alertLevel: null,
+              label: REPORT_LABELS.CALIBRATION_SCOPE,
+              content: SCOPES.CORE,
             },
           ]);
         });
@@ -267,18 +288,21 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
         commonReportLines = [
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: "Nombre d'épreuves calibrées : 1",
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATED_CHALLENGE_COUNT,
+            content: 1,
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: "L'élaboration de cette calibration a débuté le 15/06/2025",
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_STARTED_AT,
+            content: new Date(),
           },
           {
             additionalContent: null,
-            alertLevel: ALERT_LEVELS.NA,
-            content: 'Le scope de cette calibration est "CORE"',
+            alertLevel: null,
+            label: REPORT_LABELS.CALIBRATION_SCOPE,
+            content: SCOPES.CORE,
           },
         ];
       });
@@ -293,8 +317,9 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
             ...commonReportLines,
             {
               additionalContent: null,
-              alertLevel: ALERT_LEVELS.NA,
-              content: 'Le statut de cette calibration est "VALIDATED"',
+              alertLevel: null,
+              label: REPORT_LABELS.CALIBRATION_STATUS,
+              content: CALIBRATION_STATUSES.VALIDATED,
             },
           ]);
         });
@@ -309,9 +334,10 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
           expect(report.reportLines).to.deep.include.members([
             ...commonReportLines,
             {
-              additionalContent: null,
+              additionalContent: 'La calibration ne semble pas encore finalisée',
               alertLevel: ALERT_LEVELS.HIGH,
-              content: 'Le statut de cette calibration est "INVALIDATED"',
+              label: REPORT_LABELS.CALIBRATION_STATUS,
+              content: CALIBRATION_STATUSES.INVALIDATED,
             },
           ]);
         });
@@ -326,9 +352,10 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
           expect(report.reportLines).to.deep.include.members([
             ...commonReportLines,
             {
-              additionalContent: null,
+              additionalContent: 'La calibration ne semble pas encore finalisée',
               alertLevel: ALERT_LEVELS.HIGH,
-              content: 'Le statut de cette calibration est "TO_VALIDATE"',
+              label: REPORT_LABELS.CALIBRATION_STATUS,
+              content: CALIBRATION_STATUSES.TO_VALIDATE,
             },
           ]);
         });

--- a/api/tests/certification/configuration/unit/domain/models/Calibration_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Calibration_test.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Certification | Configuration | Domain | Models | Calibration', function () {
+  describe('#challengeCount', function () {
+    it('returns 0 when no calibrated challenges', function () {
+      const calibration = domainBuilder.certification.configuration.calibrationBuilder().build();
+
+      expect(calibration.challengeCount).to.equal(0);
+    });
+
+    it('returns the challenge count when there are some challenges', function () {
+      const calibration = domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .withCalibratredChallenges([
+          { alpha: 1, delta: 2 },
+          { alpha: 3, delta: 4 },
+          { alpha: 5, delta: 6 },
+        ])
+        .build();
+
+      expect(calibration.challengeCount).to.equal(3);
+    });
+  });
+  describe('#tubeIds', function () {
+    it('returns a Set with the tubeIds of the challenges', function () {
+      const calibration = domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .withCalibratredChallenges([
+          { tubeId: 'tubeB' },
+          { tubeId: 'tubeA' },
+          { tubeId: 'tubeB' },
+          { tubeId: 'tubeA' },
+          { tubeId: 'tubeC' },
+        ])
+        .build();
+
+      expect(calibration.tubeIds).to.deep.equal(new Set(['tubeA', 'tubeB', 'tubeC']));
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/models/Version_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Version_test.js
@@ -1,11 +1,11 @@
-import { VersionNotDraftError } from '../../../../../../../src/certification/configuration/domain/errors.js';
-import { Version } from '../../../../../../../src/certification/configuration/domain/models/Version.js';
-import { SCOPES } from '../../../../../../../src/certification/shared/domain/models/Scopes.js';
-import { EntityValidationError } from '../../../../../../../src/shared/domain/errors.js';
-import { expect } from '../../../../../../test-helper.js';
-import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
+import { VersionNotDraftError } from '../../../../../../src/certification/configuration/domain/errors.js';
+import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
-describe('Certification | Configuration | Unit | Application | Api | Models | Version', function () {
+describe('Certification | Configuration | Unit | Domain | Models | Version', function () {
   describe('#get isDraft', function () {
     context('when the version is archived', function () {
       it('return false', function () {

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/calibration-report-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/calibration-report-serializer_test.js
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+
+import {
+  CalibrationReport,
+  CalibrationReportLine,
+} from '../../../../../../src/certification/configuration/domain/models/CalibrationReport.js';
+import * as serializer from '../../../../../../src/certification/configuration/infrastructure/serializers/calibration-report-serializer.js';
+
+describe('Certification | Configuration | Unit | Infrastructure | Serializer | calibration report', function () {
+  describe('#serialize', function () {
+    it('should serialize a calibration report to JSONAPI format', function () {
+      const calibrationReport = new CalibrationReport({
+        versionId: 1,
+        calibrationId: 2,
+        generatedAt: new Date('2021-02-02'),
+        reportLines: [
+          new CalibrationReportLine({
+            content: 'abc',
+            alertLevel: 'boubou',
+            additionalContent: null,
+            label: 'label1',
+          }),
+          new CalibrationReportLine({
+            content: 'def',
+            alertLevel: null,
+            additionalContent: 'salut',
+            label: 'label2',
+          }),
+        ],
+      });
+
+      const result = serializer.serialize(calibrationReport);
+
+      expect(result).to.deep.equal({
+        data: {
+          type: 'calibration-reports',
+          id: '1_2',
+          attributes: {
+            'calibration-id': 2,
+            'generated-at': new Date('2021-02-02'),
+            'report-lines': [
+              {
+                additionalContent: null,
+                alertLevel: 'boubou',
+                content: 'abc',
+                label: 'label1',
+              },
+              {
+                additionalContent: 'salut',
+                alertLevel: null,
+                content: 'def',
+                label: 'label2',
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+});

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -4,17 +4,15 @@ import { SCOPES } from '../../../../../src/certification/shared/domain/models/Sc
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../test-helper.js';
-import { databaseBuilder, datamartBuilder, knex } from '../../../../tooling/databases.js';
+import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
 describe('Certification | Evaluation | Acceptance | Application |  certification rescoring', function () {
   describe('GET /api/admin/certifications/{certificationCourseId}/rescore', function () {
-    let server, calibrationId;
+    let server;
 
     beforeEach(async function () {
-      calibrationId = 1;
-
       server = await createServer();
     });
 
@@ -212,18 +210,6 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           delta: null,
         });
 
-        datamartBuilder.factory.buildCalibration({
-          id: calibrationId,
-          scope: 'COEUR',
-          status: 'VALIDATED',
-        });
-        datamartBuilder.factory.buildDatamartActiveCalibratedChallenge({
-          calibrationId: calibrationId,
-          challengeId: 'recChallenge0_0_0',
-          alpha: 3.3,
-          delta: 4.4,
-        });
-
         const archivedVersion = domainBuilder.certification.configuration
           .versionBuilder()
           .asArchived({ startDate: new Date('2010-02-01'), expirationDate: new Date('2024-02-01') })
@@ -327,7 +313,6 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
         databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResult.id });
 
         await databaseBuilder.commit();
-        await datamartBuilder.commit();
 
         const request = {
           method: 'POST',

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
@@ -4,16 +4,13 @@ import {
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
 } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
-import { datawarehouseKnex } from '../../../../databases.js';
 
 /**
  * @typedef {Object} CalibratedChallengeData
- * @property {number} id
  * @property {number} alpha
  * @property {number} delta
  * @property {string} challengeId
  * @property {string} tubeId
- * @property {boolean} isExcluded
  */
 
 /**
@@ -24,7 +21,7 @@ import { datawarehouseKnex } from '../../../../databases.js';
  *   .calibrationBuilder()
  *   .onScope(SCOPES.PIX_PLUS_DROIT)
  *   .asValidated()
- *   .withCalibratedChallenges([{ id: 1, challengeId: 'chalABC', alpha: -4, delta: 3.324, isExcluded: false }])
+ *   .withCalibratredChallenges([{ challengeId: 'chalABC', tubeId: 'tubeABC', alpha: -4, delta: 3.324 }])
  *   .withParameters({ id: 123 })
  *   .insertToDB({ databaseBuilder });
  */
@@ -116,31 +113,35 @@ class CalibrationBuilder {
   }
 
   /**
-   * Inserts the calibration row and any subsequent data to DATAWAREHOUSE DB
+   * Buffers the calibration row and any subsequent data into the DATAMART builder
    * then returns the built domain Calibration carrying the persisted id.
-   * PERSISTS DATA IMMEDIATELY
+   * Call `datamartBuilder.commit()` afterwards to actually persist.
+   *
+   * Note: `tubeId` is NOT persisted, it is derived by the repository from
+   * `challengeId` through the learning content, so `challengeId` must reference
+   * a challenge built in the learning content of the test.
    *
    * @returns {Promise<Calibration>} the persisted calibration
    */
-  async insertToDB() {
+  async insertToDB({ datamartBuilder }) {
     const calibration = this.build();
 
-    await datawarehouseKnex('data_calibrations').insert({
+    const persistedCalibration = datamartBuilder.factory.buildCalibration({
       id: calibration.id,
       calibration_date: calibration.startedAt,
       scope: calibration.scope,
       status: calibration.status,
     });
 
-    const calibratedChallengesToInsert = this.calibratedChallengesData.map((calibratedChallengeData) => ({
-      id: calibratedChallengeData.id,
-      calibration_id: calibration.id,
-      challenge_id: calibratedChallengeData.challengeId,
-      alpha: calibratedChallengeData.alpha,
-      delta: calibratedChallengeData.delta,
-      is_excluded: calibratedChallengeData.isExcluded,
-    }));
-    await datawarehouseKnex('data_calibration_challenges').insert(calibratedChallengesToInsert);
+    this.calibratedChallengesData.forEach((calibratedChallengeData) => {
+      datamartBuilder.factory.buildDatamartActiveCalibratedChallenge({
+        calibrationId: persistedCalibration.id,
+        challengeId: calibratedChallengeData.challengeId,
+        alpha: calibratedChallengeData.alpha,
+        delta: calibratedChallengeData.delta,
+      });
+    });
+
     return calibration;
   }
 
@@ -150,10 +151,9 @@ class CalibrationBuilder {
    * @returns {Calibration}
    */
   build() {
-    const calibratedChallenges = this.calibratedChallengesData
-      .filter((calibratedChallengeData) => !calibratedChallengeData.isExcluded)
-      .sort((a, b) => a.id - b.id)
-      .map((calibratedChallengeData) => new CalibratedChallenge(calibratedChallengeData));
+    const calibratedChallenges = this.calibratedChallengesData.map(
+      (calibratedChallengeData) => new CalibratedChallenge(calibratedChallengeData),
+    );
 
     return new Calibration({
       id: this.id,

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
@@ -1,0 +1,176 @@
+import {
+  CalibratedChallenge,
+  Calibration,
+  CALIBRATION_SCOPES,
+  CALIBRATION_STATUSES,
+} from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import { datawarehouseKnex } from '../../../../databases.js';
+
+/**
+ * @typedef {Object} CalibratedChallengeData
+ * @property {number} id
+ * @property {number} alpha
+ * @property {number} delta
+ * @property {string} challengeId
+ * @property {string} tubeId
+ * @property {boolean} isExcluded
+ */
+
+/**
+ * Fluent builder for the {@link Calibration} domain model.
+ *
+ * @example
+ * const calibration = domainBuilder.certification.configuration
+ *   .calibrationBuilder()
+ *   .onScope(SCOPES.PIX_PLUS_DROIT)
+ *   .asValidated()
+ *   .withCalibratedChallenges([{ id: 1, challengeId: 'chalABC', alpha: -4, delta: 3.324, isExcluded: false }])
+ *   .withParameters({ id: 123 })
+ *   .insertToDB({ databaseBuilder });
+ */
+class CalibrationBuilder {
+  constructor() {
+    this.id = 1;
+    this.startedAt = new Date('2000-01-01');
+    this.status = CALIBRATION_STATUSES.VALIDATED;
+    this.scope = CALIBRATION_SCOPES.COEUR;
+    this.calibratedChallengesData = [];
+  }
+
+  /**
+   * Marks calibration as validated.
+   *
+   * @param {object} params
+   * @param {Date} [params.startedAt]
+   * @returns {CalibrationBuilder}
+   */
+  asValidated({ startedAt = new Date() } = {}) {
+    this.status = CALIBRATION_STATUSES.VALIDATED;
+    this.startedAt = startedAt;
+    return this;
+  }
+
+  /**
+   * Marks calibration as invalidated.
+   *
+   * @param {object} params
+   * @param {Date} [params.startedAt]
+   * @returns {CalibrationBuilder}
+   */
+  asInvalidated({ startedAt = new Date() } = {}) {
+    this.status = CALIBRATION_STATUSES.INVALIDATED;
+    this.startedAt = startedAt;
+    return this;
+  }
+
+  /**
+   * Marks calibration as to validate.
+   *
+   * @param {object} params
+   * @param {Date} [params.startedAt]
+   * @returns {CalibrationBuilder}
+   */
+  asToValidate({ startedAt = new Date() } = {}) {
+    this.status = CALIBRATION_STATUSES.TO_VALIDATE;
+    this.startedAt = startedAt;
+    return this;
+  }
+
+  /**
+   * Set calibration on scope
+   *
+   * @param {object} [params]
+   * @param {typeof CALIBRATION_SCOPES[keyof typeof CALIBRATION_SCOPES]} params.scope
+   * @returns {CalibrationBuilder}
+   */
+  onScope({ scope = CALIBRATION_SCOPES.COEUR } = {}) {
+    this.scope = scope;
+    return this;
+  }
+
+  /**
+   * Overrides any subset of the Calibration attributes carried by the builder.
+   * Omitted parameters keep their current value, so the method can be called
+   * several times in the same chain without resetting previous overrides.
+   *
+   * @param {CalibratedChallengeData[]} calibratedChallengesData
+   * @returns {CalibrationBuilder}
+   */
+  withCalibratredChallenges(calibratedChallengesData) {
+    this.calibratedChallengesData = calibratedChallengesData;
+    return this;
+  }
+
+  /**
+   * Overrides any subset of the Calibration attributes carried by the builder.
+   * Omitted parameters keep their current value, so the method can be called
+   * several times in the same chain without resetting previous overrides.
+   *
+   * @param {object} [params]
+   * @param {number} [params.id] - explicit id, must be set
+   * @returns {CalibrationBuilder}
+   */
+  withParameters({ id } = {}) {
+    this.id = id ?? this.id;
+    return this;
+  }
+
+  /**
+   * Inserts the calibration row and any subsequent data to DATAWAREHOUSE DB
+   * then returns the built domain Calibration carrying the persisted id.
+   * PERSISTS DATA IMMEDIATELY
+   *
+   * @returns {Promise<Calibration>} the persisted calibration
+   */
+  async insertToDB() {
+    const calibration = this.build();
+
+    await datawarehouseKnex('data_calibrations').insert({
+      id: calibration.id,
+      calibration_date: calibration.startedAt,
+      scope: calibration.scope,
+      status: calibration.status,
+    });
+
+    const calibratedChallengesToInsert = this.calibratedChallengesData.map((calibratedChallengeData) => ({
+      id: calibratedChallengeData.id,
+      calibration_id: calibration.id,
+      challenge_id: calibratedChallengeData.challengeId,
+      alpha: calibratedChallengeData.alpha,
+      delta: calibratedChallengeData.delta,
+      is_excluded: calibratedChallengeData.isExcluded,
+    }));
+    await datawarehouseKnex('data_calibration_challenges').insert(calibratedChallengesToInsert);
+    return calibration;
+  }
+
+  /**
+   * Materializes the domain Calibration without touching the database.
+   *
+   * @returns {Calibration}
+   */
+  build() {
+    const calibratedChallenges = this.calibratedChallengesData
+      .filter((calibratedChallengeData) => !calibratedChallengeData.isExcluded)
+      .sort((a, b) => a.id - b.id)
+      .map((calibratedChallengeData) => new CalibratedChallenge(calibratedChallengeData));
+
+    return new Calibration({
+      id: this.id,
+      startedAt: this.startedAt,
+      status: this.status,
+      scope: this.scope,
+      calibratedChallenges,
+    });
+  }
+}
+
+/**
+ * Entry point of the fluent Calibration builder. Returns the builder, NOT a Calibration:
+ * Note: end the chain with build() for in-memory storage or insertToDB() for DB storage.
+ *
+ * @returns {CalibrationBuilder}
+ */
+export function calibrationBuilder() {
+  return new CalibrationBuilder();
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -162,6 +162,7 @@ import { buildValidation } from './build-validation.js';
 import { buildValidator } from './build-validator.js';
 import { buildComplementaryCertification } from './certification/complementary-certification/build-complementary-certification.js';
 import { buildComplementaryCertificationBadge } from './certification/complementary-certification/build-complementary-certification-badge.js';
+import { calibrationBuilder } from './certification/configuration/build-calibration.js';
 import { buildCenter as buildConfigurationCenter } from './certification/configuration/build-center.js';
 import { certificationInfoBuilder } from './certification/configuration/build-certification-info.js';
 import { frameworkInfoBuilder } from './certification/configuration/build-framework-info.js';
@@ -254,6 +255,7 @@ const certification = {
     buildScoBlockedAccessDateLycee,
     versionDetailsBuilder,
     frameworkInfoBuilder,
+    calibrationBuilder,
   },
   complementaryCertification: {
     buildComplementaryCertificationBadge: buildComplementaryCertificationBadge,


### PR DESCRIPTION
## ☀️ Problème

Lors de l'élaboration d'une nouvelle version, il y a l'étape de récupération de la calibration depuis les tables de Data.

## ⛱️ Proposition

Après saisie d'un ID de calibration (fourni par Data), on souhaite d'abord voir un rapport listant les différents éléments de la calibration avec une appréciation de la cohérence de certains d'entre eux.

## 🧴 Remarques

Pour le look du front j'ai tout donné déso

## 🏊 Pour tester

Essayer avec coeur, faire une draft et saisir l'id 1 (ancien coeur), puis 2 (autre réf)
