### PR TITLE
[TECH] Supprimer la dépendance au domaine "évaluation" dans "certification/configuration"

### DIFF
--- a/api/src/certification/configuration/dependencies.json
+++ b/api/src/certification/configuration/dependencies.json
@@ -1,5 +1,5 @@
 {
   "name": "certification/configuration",
-  "dependsOn": ["certification/shared", "evaluation", "shared"],
+  "dependsOn": ["certification/shared", "shared"],
   "circular": "forbidden"
 }

--- a/api/src/certification/configuration/domain/usecases/attach-badges.js
+++ b/api/src/certification/configuration/domain/usecases/attach-badges.js
@@ -152,9 +152,9 @@ async function _verifyThatBadgesToAttachExist({
   }
 
   const ids = complementaryCertificationBadgesToAttachDTO.map((ccBadgeToAttach) => ccBadgeToAttach.badgeId);
-  const badges = await complementaryCertificationBadgesRepository.findAttachableBadgesByIds({ ids });
+  const attachableBadgesCount = await complementaryCertificationBadgesRepository.countAttachableBadges({ ids });
 
-  if (badges?.length !== ids.length) {
+  if (attachableBadgesCount !== ids.length) {
     throw new NotFoundError('One or several badges are not attachable.');
   }
 }

--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -1,4 +1,3 @@
-import { Badge } from '../../../../evaluation/domain/models/Badge.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 export async function getAllIdsByTargetProfileId({ targetProfileId }) {
@@ -28,9 +27,9 @@ export async function attach({ complementaryCertificationBadges }) {
     .transacting(knexConn.isTransaction ? knexConn : null);
 }
 
-export async function findAttachableBadgesByIds({ ids }) {
+export async function countAttachableBadges({ ids }) {
   const knexConn = DomainTransaction.getConnection();
-  const badges = await knexConn
+  const result = await knexConn
     .from('badges')
     .whereIn('badges.id', ids)
     .andWhere('badges.isCertifiable', true)
@@ -39,9 +38,9 @@ export async function findAttachableBadgesByIds({ ids }) {
         .select(1)
         .from('complementary-certification-badges')
         .whereRaw('"complementary-certification-badges"."badgeId" = "badges"."id"'),
-    );
+    )
+    .count('id')
+    .first();
 
-  return badges.map((badge) => {
-    return new Badge(badge);
-  });
+  return result.count;
 }

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
@@ -181,8 +181,8 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
     });
   });
 
-  context('#findAttachableBadgesByIds', function () {
-    it('should return certifiable badges and eligible to a complementary', async function () {
+  context('#countAttachableBadges', function () {
+    it('should return the number of certifiable badges eligible to a complementary', async function () {
       // given
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       databaseBuilder.factory.buildBadge({ id: 123, targetProfileId, key: 'key_xx', isCertifiable: true }).id;
@@ -191,63 +191,37 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
       await databaseBuilder.commit();
 
       // when
-      const results = await complementaryCertificationBadgeRepository.findAttachableBadgesByIds({
+      const results = await complementaryCertificationBadgeRepository.countAttachableBadges({
         ids: [123],
       });
 
       // then
-      expect(results).to.deep.equal([
-        {
-          altMessage: 'alt message',
-          complementaryCertificationBadge: null,
-          id: 123,
-          imageUrl: '/img_funny.svg',
-          isAlwaysVisible: false,
-          isCertifiable: true,
-          key: 'key_xx',
-          message: 'message',
-          targetProfileId,
-          title: 'title',
-        },
-      ]);
+      expect(results).to.equal(1);
     });
 
-    it('should not return inexistent badges', async function () {
-      // given
-      const nonExistingBadgeId = 123456789;
-      const nonExistingBadge = await knex('complementary-certification-badges').whereIn('id', [nonExistingBadgeId]);
-      expect(nonExistingBadge).to.be.empty;
+    context('when there is no attached badge', function () {
+      it('should return zero', async function () {
+        // given
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        databaseBuilder.factory.buildBadge({ id: 123, targetProfileId, isCertifiable: true }).id;
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          id: 456,
+          badgeId: 123,
+          complementaryCertificationId,
+          detachedAt: '2022-01-01',
+        });
 
-      // when
-      const results = await complementaryCertificationBadgeRepository.findAttachableBadgesByIds({
-        ids: [nonExistingBadgeId],
+        await databaseBuilder.commit();
+
+        // when
+        const results = await complementaryCertificationBadgeRepository.countAttachableBadges({
+          ids: [123],
+        });
+
+        // then
+        expect(results).to.equal(0);
       });
-
-      // then
-      expect(results).to.be.empty;
-    });
-
-    it('should not return badges tied to a complementary', async function () {
-      // given
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildBadge({ id: 123, targetProfileId, isCertifiable: true }).id;
-      const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
-      databaseBuilder.factory.buildComplementaryCertificationBadge({
-        id: 456,
-        badgeId: 123,
-        complementaryCertificationId,
-        detachedAt: '2022-01-01',
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      const results = await complementaryCertificationBadgeRepository.findAttachableBadgesByIds({
-        ids: [123],
-      });
-
-      // then
-      expect(results).to.be.empty;
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/attach-badges_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | attach-badges', function () {
       getById: sinon.stub(),
     };
     complementaryCertificationBadgesRepository = {
-      findAttachableBadgesByIds: sinon.stub(),
+      countAttachableBadges: sinon.stub(),
     };
     clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
@@ -127,7 +127,7 @@ describe('Unit | UseCase | attach-badges', function () {
         id: 123,
         hasExternalJury: true,
       });
-      complementaryCertificationBadgesRepository.findAttachableBadgesByIds.resolves([{ badgeId: 1 }, { badgeId: 2 }]);
+      complementaryCertificationBadgesRepository.countAttachableBadges.resolves(2);
 
       // when
       const error = await catchErr(attachBadges)({
@@ -150,13 +150,13 @@ describe('Unit | UseCase | attach-badges', function () {
 
   context('when one or more badges do not exist', function () {
     [
-      { label: 'no badges found', resolve: [] },
-      { label: 'not all badges are certifiable', resolve: [{ badgeId: 1, level: 1, isCertifiable: true }] },
+      { label: 'no badges found', resolve: 0 },
+      { label: 'not all badges are certifiable', resolve: 1 },
     ].forEach((assessment) => {
       context(`when  ${assessment.label}`, function () {
         it('should throw a not found error', async function () {
           // given
-          complementaryCertificationBadgesRepository.findAttachableBadgesByIds.resolves(assessment.resolve);
+          complementaryCertificationBadgesRepository.countAttachableBadges.resolves(assessment.resolve);
 
           // when
           const error = await catchErr(attachBadges)({
@@ -183,8 +183,6 @@ describe('Unit | UseCase | attach-badges', function () {
         sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
           return callback();
         });
-        const badge1 = domainBuilder.buildBadge({ id: 123 });
-        const badge2 = domainBuilder.buildBadge({ id: 456 });
 
         const complementaryCertification = domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
           id: 123,
@@ -194,7 +192,7 @@ describe('Unit | UseCase | attach-badges', function () {
           attach: sinon.stub().resolves(),
           detachByIds: sinon.stub(),
           getAllIdsByTargetProfileId: sinon.stub(),
-          findAttachableBadgesByIds: sinon.stub().resolves([badge1, badge2]),
+          countAttachableBadges: sinon.stub().resolves(2),
         };
 
         complementaryCertificationBadgesRepository.getAllIdsByTargetProfileId
@@ -225,7 +223,6 @@ describe('Unit | UseCase | attach-badges', function () {
         sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
           return callback();
         });
-        const badge1 = domainBuilder.buildBadge({ id: 123 });
 
         const complementaryCertificationBadge = {
           badgeId: 123,
@@ -252,7 +249,7 @@ describe('Unit | UseCase | attach-badges', function () {
               level: 1,
             }).badgeId,
           ]),
-          findAttachableBadgesByIds: sinon.stub().resolves([badge1]),
+          countAttachableBadges: sinon.stub().resolves(1),
         };
 
         // when
@@ -283,7 +280,6 @@ describe('Unit | UseCase | attach-badges', function () {
         sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
           return callback();
         });
-        const badge1 = domainBuilder.buildBadge({ id: 123 });
 
         const complementaryCertificationBadge = {
           badgeId: 123,
@@ -310,7 +306,7 @@ describe('Unit | UseCase | attach-badges', function () {
               level: 1,
             }).badgeId,
           ]),
-          findAttachableBadgesByIds: sinon.stub().resolves([badge1]),
+          countAttachableBadges: sinon.stub().resolves(1),
         };
 
         // when
@@ -348,8 +344,6 @@ describe('Unit | UseCase | attach-badges', function () {
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
         return callback();
       });
-      const badge1 = domainBuilder.buildBadge({ id: 123 });
-      const badge2 = domainBuilder.buildBadge({ id: 456 });
 
       const complementaryCertification = domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
         id: 123,
@@ -359,7 +353,7 @@ describe('Unit | UseCase | attach-badges', function () {
         attach: sinon.stub().resolves(),
         detachByIds: sinon.stub(),
         getAllIdsByTargetProfileId: sinon.stub(),
-        findAttachableBadgesByIds: sinon.stub().resolves([badge1, badge2]),
+        countAttachableBadges: sinon.stub().resolves(2),
       };
       const BadgeToAttachValidator = {
         validate: sinon.stub().resolves(),


### PR DESCRIPTION
## ☀️ Problème

On veut éviter les dépendances entre bounded context dans l'api.

Dans le domaine `certification/configuration`, on fait appel au modèle `Badge` du bounded context `evaluation` pour au final ne se servir d'aucun de ses attributs.

## ⛱️ Proposition

Supprimer la dépendance au modèle `Badge` dans `certification/configuration`.

## 🧴 Remarques

Le BD `certification/configuration` ne dépend ainsi plus de `evaluation`.

## 🏊 Pour tester

Tests verts
