### PR TITLE
[BUGFIX] Limite d'affichage de la taille des images sur une page de détails d'un schéma de parcours combiné (PIX-23549)

### DIFF
--- a/admin/app/styles/components/combined-course-blueprints/list.scss
+++ b/admin/app/styles/components/combined-course-blueprints/list.scss
@@ -11,6 +11,10 @@
 
 .combined-course-blueprint {
   &__container {
+    & img {
+      max-width: 320px;
+    }
+
     display: flex;
     flex-direction: column;
 

--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -229,7 +229,7 @@ export const buildCombinedCourseBlueprints = () => {
   const combinedCourseBlueprintId = buildCombinedCourseBlueprint({
     name: 'Mon parcours combiné 2',
     internalName: 'Mon schéma de parcours combiné 2',
-    illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
+    illustration: 'https://assets.pix.org/combined-courses/picto-nr-parcours.png',
     description:
       "#Un parcours\n pour découvrir l'essentiel sur l'intelligence artificielle : [comprendre sa définition](http://pix.fr), ses domaines d'application, comment elle fonctionne, ainsi que ses enjeux, notamment en matière d'impact environnemental.",
     prescriberDescription:


### PR DESCRIPTION
## ☀️ Problème

Les illustrations ne font pas tout le temps la même taille, il faudrait limiter l’affichage de l’illu pour que ça ne mange pas toute la page. 

Ex en recette sur le schéma id 58:

<img width="1440" height="689" alt="image" src="https://github.com/user-attachments/assets/2a8e0915-f37b-4aa8-a7fa-37c055d97e1d" />

## ⛱️ Proposition

Ajout d'une `max-width` sur les images du plus petit bloc BEM. Limite placée à 320px (largeur de la précédente image utilisée).

## 🧴 Remarques

Afin de pouvoir visualiser le comportement avec une image de grande taille, les `seeds` ont été modifiés.

## 🏊 Pour tester

Après avoir relancé les `seeds`, naviguer dans `pix-admin` : `Schémas de parcours` > `Mon schéma de parcours combiné`. L'illustration de ce schéma de parcours combiné utilise une image de grande taille (largeur de 1334px) qui devrait s'afficher correctement.
