### PR TITLE
[TECH] Supprimer la dépendance à prescription/campaign dans certification/enrolment

### DIFF
--- a/api/src/certification/enrolment/dependencies.json
+++ b/api/src/certification/enrolment/dependencies.json
@@ -4,7 +4,6 @@
     "certification/session-management",
     "certification/shared",
     "organizational-entities",
-    "prescription/campaign",
     "prescription/organization-learner",
     "shared"
   ],

--- a/api/src/certification/enrolment/domain/models/Division.js
+++ b/api/src/certification/enrolment/domain/models/Division.js
@@ -1,0 +1,7 @@
+class Division {
+  constructor({ name } = {}) {
+    this.name = name;
+  }
+}
+
+export { Division };

--- a/api/src/certification/enrolment/domain/usecases/find-divisions-by-certification-center.js
+++ b/api/src/certification/enrolment/domain/usecases/find-divisions-by-certification-center.js
@@ -13,5 +13,5 @@ export async function findDivisionsByCertificationCenter({
     throw new NotFoundError('No organization found for this certification center');
   }
 
-  return divisionRepository.findByOrganizationIdForCurrentSchoolYear({ organizationId: activeOrganizationId });
+  return divisionRepository.findActiveDivisionsByOrganizationId({ organizationId: activeOrganizationId });
 }

--- a/api/src/certification/enrolment/domain/usecases/index.js
+++ b/api/src/certification/enrolment/domain/usecases/index.js
@@ -1,5 +1,3 @@
-// eslint-disable import/no-restricted-paths
-import * as divisionRepository from '../../../../prescription/campaign/infrastructure/repositories/division-repository.js';
 import * as organizationLearnerRepository from '../../../../prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import * as countryRepository from '../../../../shared/infrastructure/repositories/country-repository.js';
@@ -65,7 +63,6 @@ import { validateSessions } from './validate-sessions.js';
  * @typedef {import('../services/certification-candidates-ods-service.js')} CertificationCandidatesOdsService
  * @typedef {import('../services/eligibility-service.js')} EligibilityService
  * @typedef {import('../../../../shared/domain/services/placement-profile-service.js')} PlacementProfileService
- * @typedef {import('../../../../prescription/campaign/infrastructure/repositories/division-repository.js')} divisionRepository
  * @typedef {import('../../../shared/infrastructure/repositories/certification-center-repository.js')} CertificationCenterRepository
  * @typedef {import('../../infrastructure/adapters/event-adapter.js')} EventAdapter
  * @typedef {import('../../infrastructure/adapters/session-authorization-adapter.js')} SessionAuthorizationAdapter
@@ -95,7 +92,7 @@ import { validateSessions } from './validate-sessions.js';
  * @typedef {CertificationCandidatesOdsService} CertificationCandidatesOdsService
  * @typedef {EligibilityService} EligibilityService
  * @typedef {PlacementProfileService} PlacementProfileService
- * @typedef {divisionRepository} DivisionRepository
+ * @typedef {import('../../infrastructure/repositories/index.js').DivisionRepository} DivisionRepository
  * @typedef {certificationCourseRepository} CertificationCourseRepository
  * @typedef {eventAdapter} EventAdapter
  * @typedef {sessionAuthorizationAdapter} SessionAuthorizationAdapter
@@ -110,7 +107,6 @@ const dependencies = {
   sessionValidator,
   attendanceSheetPdfUtils,
   certificationCpfService,
-  divisionRepository,
   certificationCandidatesOdsService,
   eligibilityService,
   placementProfileService,

--- a/api/src/certification/enrolment/infrastructure/repositories/division-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/division-repository.js
@@ -1,0 +1,14 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { Division } from '../../domain/models/Division.js';
+
+export async function findActiveDivisionsByOrganizationId({ organizationId }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const divisionRows = await knexConn('view-active-organization-learners')
+    .distinct('division')
+    .where({ organizationId, isDisabled: false })
+    .whereNotNull('division')
+    .orderBy('division', 'asc');
+
+  return divisionRows.map(({ division }) => new Division({ name: division }));
+}

--- a/api/src/certification/enrolment/infrastructure/repositories/index.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/index.js
@@ -11,6 +11,7 @@ import * as certificationCpfCityRepository from './certification-cpf-city-reposi
 import * as certificationCpfCountryRepository from './certification-cpf-country-repository.js';
 import * as complementaryCertificationBadgeWithOffsetVersionRepository from './complementary-certification-badge-with-offset-version-repository.js';
 import * as complementaryCertificationCourseRepository from './complementary-certification-course-repository.js';
+import * as divisionRepository from './division-repository.js';
 import * as sessionForAttendanceSheetRepository from './session-for-attendance-sheet-repository.js';
 import * as sessionRepository from './session-repository.js';
 
@@ -30,11 +31,13 @@ import * as sessionRepository from './session-repository.js';
  * @typedef {targetProfileHistoryRepository} TargetProfileHistoryRepository
  * @typedef {complementaryCertificationCourseRepository} ComplementaryCertificationCourseRepository
  * @typedef {complementaryCertificationBadgeWithOffsetVersionRepository} ComplementaryCertificationBadgeWithOffsetVersionRepository
+ * @typedef {divisionRepository} DivisionRepository
  */
 const repositoriesWithoutInjectedDependencies = {
   candidateRepository,
   centerRepository,
   certificationCenterRepository,
+  divisionRepository,
   certificationCpfCountryRepository,
   certificationCpfCityRepository,
   dataProtectionOfficerRepository,

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/division-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/division-repository_test.js
@@ -1,0 +1,96 @@
+import * as divisionRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/division-repository.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+
+describe('Integration | Certification | Enrolment | Infrastructure | Repository | division-repository', function () {
+  describe('#findActiveDivisionsByOrganizationId', function () {
+    it('should return the distinct divisions of the organization ordered by name', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, division: '5A' });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, division: '_3A' });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, division: '3A' });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, division: 'T2' });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, division: 't1' });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, division: 't1' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const divisions = await divisionRepository.findActiveDivisionsByOrganizationId({
+        organizationId: organization.id,
+      });
+
+      // then
+      expect(divisions).to.deep.equal([
+        { name: '3A' },
+        { name: '5A' },
+        { name: 'T2' },
+        { name: '_3A' },
+        { name: 't1' },
+      ]);
+    });
+
+    it('should only return divisions of the given organization', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, division: '5A' });
+      databaseBuilder.factory.buildOrganizationLearner({ division: '5B' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const divisions = await divisionRepository.findActiveDivisionsByOrganizationId({
+        organizationId: organization.id,
+      });
+
+      // then
+      expect(divisions).to.deep.equal([{ name: '5A' }]);
+    });
+
+    it('should omit divisions of disabled organization learners', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        division: '5A',
+        isDisabled: false,
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        division: '5B',
+        isDisabled: true,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const divisions = await divisionRepository.findActiveDivisionsByOrganizationId({
+        organizationId: organization.id,
+      });
+
+      // then
+      expect(divisions).to.deep.equal([{ name: '5A' }]);
+    });
+
+    it('should return nothing when the organization learner has no division', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        division: null,
+        isDisabled: false,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const divisions = await divisionRepository.findActiveDivisionsByOrganizationId({
+        organizationId: organization.id,
+      });
+
+      // then
+      expect(divisions).to.be.empty;
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/usecases/find-divisions-by-certification-center_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/find-divisions-by-certification-center_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | find-divisions-by-certification-center', function () 
       findActiveScoOrganizationId: sinon.stub(),
     };
     divisionRepository = {
-      findByOrganizationIdForCurrentSchoolYear: sinon.stub(),
+      findActiveDivisionsByOrganizationId: sinon.stub(),
     };
   });
 
@@ -30,7 +30,7 @@ describe('Unit | UseCase | find-divisions-by-certification-center', function () 
       centerRepository.findActiveScoOrganizationId
         .withArgs({ certificationCenterId: certificationCenter.id })
         .resolves(organization.id);
-      divisionRepository.findByOrganizationIdForCurrentSchoolYear
+      divisionRepository.findActiveDivisionsByOrganizationId
         .withArgs({ organizationId: organization.id })
         .resolves([{ name: '3a' }, { name: '3b' }, { name: '5c' }]);
 


### PR DESCRIPTION
## ☀️ Problème

On veut éviter des dépendances cross-domaines.

`certification/enrolment` venait récupérer les classes via un repo de `prescription/campaign`, et ce n'est pas souhaitable !

## ⛱️ Proposition

Créer un repository spécifique dans `certification/enrolment` pour récupérer les `divisions`.

## 🏊 Pour tester

- Tester l'ajout de candidats sur [PixCertif en RA](https://certif-pr17017.review.pix.fr/) dans une session SCO managing students