### PR TITLE
[FEATURE] Pouvoir créer un centre de certification lié à une organisation (PIX-23465)

### DIFF
--- a/admin/app/components/organizations/attached-certification-center.gjs
+++ b/admin/app/components/organizations/attached-certification-center.gjs
@@ -1,7 +1,9 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
@@ -129,8 +131,15 @@ export default class AttachedCertificationCenter extends Component {
         </:columns>
       </PixTable>
     {{else}}
-      <AttachedCertificationCenterForm @onFormSubmitted={{this.handleAttachCertificationCenter}} />
-
+      <div class="attached-certification-center-form-container">
+        <PixButtonLink
+          @iconBefore="add"
+          @variant="secondary"
+          @route="authenticated.certification-centers.new"
+          @query={{hash attachedOrganizationId=@organizationId}}
+        >{{t "components.organizations.attached-certification-center.creation-button"}}</PixButtonLink>
+        <AttachedCertificationCenterForm @onFormSubmitted={{this.handleAttachCertificationCenter}} />
+      </div>
     {{/if}}
 
     <PixModal

--- a/admin/app/components/organizations/attached-certification-center.scss
+++ b/admin/app/components/organizations/attached-certification-center.scss
@@ -1,0 +1,6 @@
+.attached-certification-center-form-container {
+  display: flex;
+  gap: var(--pix-spacing-10x);
+  align-items: end;
+  justify-content: flex-start;
+}

--- a/admin/app/controllers/authenticated/certification-centers/new.js
+++ b/admin/app/controllers/authenticated/certification-centers/new.js
@@ -1,14 +1,23 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class NewController extends Controller {
   @service router;
 
   queryParams = ['attachedOrganizationId'];
 
+  @tracked attachedOrganizationId = null;
+
   @action
-  goBackToCertificationCentersList() {
+  redirectOnCancel() {
+    if (this.attachedOrganizationId) {
+      return this.router.transitionTo(
+        'authenticated.organizations.get.attached-certification-centers',
+        this.attachedOrganizationId,
+      );
+    }
     this.router.transitionTo('authenticated.certification-centers');
   }
 }

--- a/admin/app/routes/authenticated/certification-centers/new.js
+++ b/admin/app/routes/authenticated/certification-centers/new.js
@@ -4,6 +4,10 @@ import { service } from '@ember/service';
 export default class NewRoute extends Route {
   @service store;
 
+  queryParams = {
+    attachedOrganizationId: { refreshModel: true },
+  };
+
   async model(_, transition) {
     const habilitations = await this.store.findAll('complementary-certification');
     let attachedOrganization = null;
@@ -12,5 +16,11 @@ export default class NewRoute extends Route {
       attachedOrganization = await this.store.findRecord('organization', attachedOrganizationId);
     }
     return { habilitations, attachedOrganization };
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.attachedOrganizationId = null;
+    }
   }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -124,6 +124,7 @@
 @use 'networks/head-information' as *;
 @use 'networks/information-view' as *;
 @use 'organizations/attached-certification-centers/attach-certification-center-form' as *;
+@use 'organizations/attached-certification-center' as *;
 @use 'organizations/creation-form' as *;
 @use 'organizations/features-section' as *;
 @use 'organizations/head-information' as *;

--- a/admin/app/templates/authenticated/certification-centers/new.gjs
+++ b/admin/app/templates/authenticated/certification-centers/new.gjs
@@ -13,7 +13,7 @@ import CreationForm from 'pix-admin/components/certification-centers/creation-fo
   <CreationForm
     class="main-admin-form"
     @habilitations={{@model.habilitations}}
-    @onCancel={{@controller.goBackToCertificationCentersList}}
+    @onCancel={{@controller.redirectOnCancel}}
     @attachedOrganization={{@model.attachedOrganization}}
   />
 </template>

--- a/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
+++ b/admin/tests/integration/components/organizations/attached-certification-center-test.gjs
@@ -54,6 +54,30 @@ module('Integration | Component | organizations/attached-certification-center', 
         .exists();
     });
 
+    test('it displays a link to create a certification center prefilled with the organization', async function (assert) {
+      // given
+      const attachedCertificationCenters = [];
+
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter
+            @attachedCertificationCenters={{attachedCertificationCenters}}
+            @organizationId="42"
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('link', {
+            name: t('components.organizations.attached-certification-center.creation-button'),
+          }),
+        )
+        .hasAttribute('href', '/certification-centers/new?attachedOrganizationId=42');
+    });
+
     module('when attaching a certification center', function () {
       test('it sends a success notification and refreshes model', async function (assert) {
         // given
@@ -163,85 +187,160 @@ module('Integration | Component | organizations/attached-certification-center', 
         });
       });
     });
-
-    module('when there are attached certification centers', function () {
-      test('it does not display a form to attach a certification center', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const certificationCenter = store.createRecord('attached-certification-center', {
-          id: '123',
-          name: 'Centre Pix',
-          externalId: 'EXT-456',
-        });
-        const attachedCertificationCenters = [certificationCenter];
-
-        // when
-        const screen = await render(
-          <template>
-            <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenters}} />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.queryByRole('form', { name: 'Rattacher un centre de certification' })).doesNotExist();
+  });
+  module('when there are attached certification centers', function () {
+    test('it does not display a form to attach a certification center', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationCenter = store.createRecord('attached-certification-center', {
+        id: '123',
+        name: 'Centre Pix',
+        externalId: 'EXT-456',
       });
+      const attachedCertificationCenters = [certificationCenter];
 
-      test('it displays the table with caption and column headers', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const certificationCenter = store.createRecord('attached-certification-center', {
-          id: '123',
-          name: 'Centre Pix',
-          externalId: 'EXT-456',
-        });
-        const attachedCertificationCenters = [certificationCenter];
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenters}} />
+        </template>,
+      );
 
-        // when
-        const screen = await render(
-          <template>
-            <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenters}} />
-          </template>,
-        );
+      // then
+      assert.dom(screen.queryByRole('form', { name: 'Rattacher un centre de certification' })).doesNotExist();
+    });
 
-        // then
-        assert
-          .dom(
-            screen.getByRole('table', {
-              name: t('components.organizations.attached-certification-center.table.caption'),
-            }),
-          )
-          .exists();
-        assert
-          .dom(
-            screen.getByRole('columnheader', {
-              name: t('components.organizations.attached-certification-center.table.headers.id'),
-            }),
-          )
-          .exists();
-        assert
-          .dom(
-            screen.getByRole('columnheader', {
-              name: t('components.organizations.attached-certification-center.table.headers.name'),
-            }),
-          )
-          .exists();
-        assert
-          .dom(
-            screen.getByRole('columnheader', {
-              name: t('components.organizations.attached-certification-center.table.headers.external-id'),
-            }),
-          )
-          .exists();
-        assert
-          .dom(
-            screen.getByRole('columnheader', {
-              name: t('components.organizations.attached-certification-center.table.headers.actions'),
-            }),
-          )
-          .exists();
+    test('it does not display a link to create a certification center', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationCenter = store.createRecord('attached-certification-center', {
+        id: '123',
+        name: 'Centre Pix',
+        externalId: 'EXT-456',
       });
+      const attachedCertificationCenters = [certificationCenter];
 
-      test('it displays the certification centers in a table', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter
+            @attachedCertificationCenters={{attachedCertificationCenters}}
+            @organizationId="42"
+          />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.queryByRole('link', {
+            name: t('components.organizations.attached-certification-center.creation-button'),
+          }),
+        )
+        .doesNotExist();
+    });
+
+    test('it displays the table with caption and column headers', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationCenter = store.createRecord('attached-certification-center', {
+        id: '123',
+        name: 'Centre Pix',
+        externalId: 'EXT-456',
+      });
+      const attachedCertificationCenters = [certificationCenter];
+
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenters}} />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('table', {
+            name: t('components.organizations.attached-certification-center.table.caption'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('columnheader', {
+            name: t('components.organizations.attached-certification-center.table.headers.id'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('columnheader', {
+            name: t('components.organizations.attached-certification-center.table.headers.name'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('columnheader', {
+            name: t('components.organizations.attached-certification-center.table.headers.external-id'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('columnheader', {
+            name: t('components.organizations.attached-certification-center.table.headers.actions'),
+          }),
+        )
+        .exists();
+    });
+
+    test('it displays the certification centers in a table', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationCenter = store.createRecord('attached-certification-center', {
+        id: '123',
+        name: 'Centre Pix',
+        externalId: 'EXT-456',
+      });
+      const attachedCertificationCenter = [certificationCenter];
+
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('cell', { name: '123' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Centre Pix' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'EXT-456' })).exists();
+    });
+
+    test('it displays a link to the certification center page', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationCenter = store.createRecord('attached-certification-center', {
+        id: '123',
+        name: 'Centre Pix',
+        externalId: 'EXT-456',
+      });
+      const attachedCertificationCenter = [certificationCenter];
+
+      // when
+      const screen = await render(
+        <template>
+          <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('link', { name: '123' })).hasAttribute('href', '/certification-centers/123');
+    });
+
+    module('when detaching a certification center', function () {
+      test('it opens a confirmation modal when clicking the detach button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const certificationCenter = store.createRecord('attached-certification-center', {
@@ -254,18 +353,76 @@ module('Integration | Component | organizations/attached-certification-center', 
         // when
         const screen = await render(
           <template>
-            <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
+            <AttachedCertificationCenter
+              @attachedCertificationCenters={{attachedCertificationCenter}}
+              @organizationId="42"
+            />
           </template>,
         );
+        await click(
+          screen.getByRole('button', {
+            name: t('components.organizations.attached-certification-center.actions.detach.button'),
+          }),
+        );
+        const modal = await screen.findByRole('dialog');
 
         // then
-        assert.dom(screen.getByRole('cell', { name: '123' })).exists();
-        assert.dom(screen.getByRole('cell', { name: 'Centre Pix' })).exists();
-        assert.dom(screen.getByRole('cell', { name: 'EXT-456' })).exists();
+        assert
+          .dom(
+            within(modal).getByRole('heading', {
+              name: t('components.organizations.attached-certification-center.actions.detach.confirm-modal-title'),
+            }),
+          )
+          .exists();
+
+        assert.dom(within(modal).getByText('Centre Pix')).exists();
       });
 
-      test('it displays a link to the certification center page', async function (assert) {
+      test('it detaches the certification center and removes the table when confirming the modal', async function (assert) {
         // given
+        requestManager.request.resolves();
+
+        const store = this.owner.lookup('service:store');
+        const certificationCenter = store.createRecord('attached-certification-center', {
+          id: '123',
+          name: 'Centre Pix',
+          externalId: 'EXT-456',
+        });
+        const state = new State([certificationCenter]);
+        router.refresh.callsFake(() => {
+          state.attachedCertificationCenters = [];
+        });
+
+        const screen = await render(
+          <template>
+            <AttachedCertificationCenter
+              @attachedCertificationCenters={{state.attachedCertificationCenters}}
+              @organizationId="42"
+            />
+          </template>,
+        );
+        await click(
+          screen.getByRole('button', {
+            name: t('components.organizations.attached-certification-center.actions.detach.button'),
+          }),
+        );
+        await screen.findByRole('dialog');
+        await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+
+        // then
+        assert.true(requestManager.request.called);
+        assert.true(
+          pixToast.sendSuccessNotification.calledWith({
+            message: t('components.organizations.attached-certification-center.actions.detach.success'),
+          }),
+        );
+        assert.dom(screen.queryByRole('table')).doesNotExist();
+      });
+
+      test('it displays an error notification and keeps the table when detaching fails', async function (assert) {
+        // given
+        requestManager.request.rejects();
+
         const store = this.owner.lookup('service:store');
         const certificationCenter = store.createRecord('attached-certification-center', {
           id: '123',
@@ -274,133 +431,29 @@ module('Integration | Component | organizations/attached-certification-center', 
         });
         const attachedCertificationCenter = [certificationCenter];
 
-        // when
         const screen = await render(
           <template>
-            <AttachedCertificationCenter @attachedCertificationCenters={{attachedCertificationCenter}} />
+            <AttachedCertificationCenter
+              @attachedCertificationCenters={{attachedCertificationCenter}}
+              @organizationId="42"
+            />
           </template>,
         );
+        await click(
+          screen.getByRole('button', {
+            name: t('components.organizations.attached-certification-center.actions.detach.button'),
+          }),
+        );
+        await screen.findByRole('dialog');
+        await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
 
         // then
-        assert.dom(screen.getByRole('link', { name: '123' })).hasAttribute('href', '/certification-centers/123');
-      });
-
-      module('when detaching a certification center', function () {
-        test('it opens a confirmation modal when clicking the detach button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const certificationCenter = store.createRecord('attached-certification-center', {
-            id: '123',
-            name: 'Centre Pix',
-            externalId: 'EXT-456',
-          });
-          const attachedCertificationCenter = [certificationCenter];
-
-          // when
-          const screen = await render(
-            <template>
-              <AttachedCertificationCenter
-                @attachedCertificationCenters={{attachedCertificationCenter}}
-                @organizationId="42"
-              />
-            </template>,
-          );
-          await click(
-            screen.getByRole('button', {
-              name: t('components.organizations.attached-certification-center.actions.detach.button'),
-            }),
-          );
-          const modal = await screen.findByRole('dialog');
-
-          // then
-          assert
-            .dom(
-              within(modal).getByRole('heading', {
-                name: t('components.organizations.attached-certification-center.actions.detach.confirm-modal-title'),
-              }),
-            )
-            .exists();
-
-          assert.dom(within(modal).getByText('Centre Pix')).exists();
-        });
-
-        test('it detaches the certification center and removes the table when confirming the modal', async function (assert) {
-          // given
-          requestManager.request.resolves();
-
-          const store = this.owner.lookup('service:store');
-          const certificationCenter = store.createRecord('attached-certification-center', {
-            id: '123',
-            name: 'Centre Pix',
-            externalId: 'EXT-456',
-          });
-          const state = new State([certificationCenter]);
-          router.refresh.callsFake(() => {
-            state.attachedCertificationCenters = [];
-          });
-
-          const screen = await render(
-            <template>
-              <AttachedCertificationCenter
-                @attachedCertificationCenters={{state.attachedCertificationCenters}}
-                @organizationId="42"
-              />
-            </template>,
-          );
-          await click(
-            screen.getByRole('button', {
-              name: t('components.organizations.attached-certification-center.actions.detach.button'),
-            }),
-          );
-          await screen.findByRole('dialog');
-          await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
-
-          // then
-          assert.true(requestManager.request.called);
-          assert.true(
-            pixToast.sendSuccessNotification.calledWith({
-              message: t('components.organizations.attached-certification-center.actions.detach.success'),
-            }),
-          );
-          assert.dom(screen.queryByRole('table')).doesNotExist();
-        });
-
-        test('it displays an error notification and keeps the table when detaching fails', async function (assert) {
-          // given
-          requestManager.request.rejects();
-
-          const store = this.owner.lookup('service:store');
-          const certificationCenter = store.createRecord('attached-certification-center', {
-            id: '123',
-            name: 'Centre Pix',
-            externalId: 'EXT-456',
-          });
-          const attachedCertificationCenter = [certificationCenter];
-
-          const screen = await render(
-            <template>
-              <AttachedCertificationCenter
-                @attachedCertificationCenters={{attachedCertificationCenter}}
-                @organizationId="42"
-              />
-            </template>,
-          );
-          await click(
-            screen.getByRole('button', {
-              name: t('components.organizations.attached-certification-center.actions.detach.button'),
-            }),
-          );
-          await screen.findByRole('dialog');
-          await click(screen.getByRole('button', { name: t('common.actions.confirm') }));
-
-          // then
-          assert.true(
-            pixToast.sendErrorNotification.calledWith({
-              message: t('common.notifications.generic-error'),
-            }),
-          );
-          assert.dom(screen.getByRole('table')).exists();
-        });
+        assert.true(
+          pixToast.sendErrorNotification.calledWith({
+            message: t('common.notifications.generic-error'),
+          }),
+        );
+        assert.dom(screen.getByRole('table')).exists();
       });
     });
   });

--- a/admin/tests/unit/controllers/authenticated/certification-centers/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/new-test.js
@@ -1,12 +1,36 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/certification-centers/new', function (hooks) {
   setupTest(hooks);
+  let transitionToStub;
+  hooks.beforeEach(function () {
+    const router = this.owner.lookup('service:router');
+    transitionToStub = sinon.stub(router, 'transitionTo');
+  });
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    const controller = this.owner.lookup('controller:authenticated/certification-centers/new');
-    assert.ok(controller);
+  module('redirectOnCancel', function () {
+    test('it should redirect to organization page related to attachedOrganizationId param', async function (assert) {
+      const attachedOrganizationId = 123;
+      const controller = this.owner.lookup('controller:authenticated/certification-centers/new');
+      controller.set('attachedOrganizationId', attachedOrganizationId);
+
+      controller.redirectOnCancel();
+
+      assert.ok(
+        transitionToStub.calledWith(
+          'authenticated.organizations.get.attached-certification-centers',
+          attachedOrganizationId,
+        ),
+      );
+    });
+    test('it should redirect to certification center list when no attachedOrganizationId param is provided', async function (assert) {
+      const controller = this.owner.lookup('controller:authenticated/certification-centers/new');
+
+      controller.redirectOnCancel();
+
+      assert.ok(transitionToStub.calledWith('authenticated.certification-centers'));
+    });
   });
 });

--- a/admin/tests/unit/routes/authenticated/certification-centers/new-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/new-test.js
@@ -43,4 +43,30 @@ module('Unit | Route | authenticated/certification-centers/new', function (hooks
     assert.strictEqual(result.habilitations, habilitations);
     assert.strictEqual(result.attachedOrganization, attachedOrganization);
   });
+
+  module('#resetController', function () {
+    test('it should reset the attachedOrganizationId query param when leaving the page', function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certification-centers/new');
+      controller.attachedOrganizationId = '123';
+
+      // when
+      route.resetController(controller, true);
+
+      // then
+      assert.strictEqual(controller.attachedOrganizationId, null);
+    });
+
+    test('it should keep the attachedOrganizationId query param when staying on the page', function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certification-centers/new');
+      controller.attachedOrganizationId = '123';
+
+      // when
+      route.resetController(controller, false);
+
+      // then
+      assert.strictEqual(controller.attachedOrganizationId, '123');
+    });
+  });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -986,6 +986,7 @@
           "input-sublabel": "ID of the center",
           "name": "Attach a certification center"
         },
+        "creation-button": "Create a certification center",
         "empty": "No certification center attached.",
         "notifications": {
           "attach-success": "The certification center has been successfully attached to the organization.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -994,6 +994,7 @@
           "input-sublabel": "ID du centre",
           "name": "Rattacher un centre de certification"
         },
+        "creation-button": "Créer un centre de certification",
         "empty": "Aucun centre de certification rattaché.",
         "notifications": {
           "attach-success": "Le centre de certification a bien été rattaché à l'organisation.",


### PR DESCRIPTION
## ☀️ Problème
Suite de la PR #17004 
Maintenant que la page de création d'un centre de certif peut prendre un param pour attacher une organisation, il faut pouvoir atteindre cette page.

## ⛱️ Proposition
On ajoute un bouton pour créer un centre de certif depuis la page organisation lorsque celle-ci n'a pas déjà un centre lié.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- Aller sur une organisation,
- Aller sur Lien Certif, 
- Vérifier que si elle à déjà un centre lié, le bouton n'apparait pas, le cas échéant, cliquer sur le bouton pour créer un cdc et vérifier qu'on atterit bien sur la page de la PR précédente.
- 🐈‍⬛ 