### PR TITLE
[FEATURE] :sparkles: Empêcher un candidat de lancer le test de certification après la saisie du code d'accès si la session est expirée (PIX-23768)

### DIFF
--- a/api/src/certification/evaluation/domain/models/CandidateAuthorization.js
+++ b/api/src/certification/evaluation/domain/models/CandidateAuthorization.js
@@ -27,18 +27,19 @@ export class CandidateAuthorization {
     this.subscription = subscription;
     this.authorizedToStart = authorizedToStart;
     this.certificationId = certificationId;
+    this.hasStartedCertification = !!certificationId;
     this.hasExceededCertificationDuration = hasExceededCertificationDuration;
     this.isCenterHabilitatedForCandidateSubscription = isCenterHabilitatedForCandidateSubscription;
   }
 
   verifyCanStartOrResumeCertification(enteredAccessCode) {
     if (this.accessCode !== enteredAccessCode) throw new NotFoundError('Session not found');
-    if (!this.isSessionAccessible) throw new SessionNotAccessibleError();
     if (!this.isCenterHabilitatedForCandidateSubscription) {
       throw new CenterNotHabilitatedError();
     }
+    if (!this.hasStartedCertification && !this.isSessionAccessible) throw new SessionNotAccessibleError();
     if (!this.authorizedToStart) {
-      if (this.certificationId) {
+      if (this.hasStartedCertification) {
         throw new CandidateNotAuthorizedToResumeCertificationTestError();
       }
       throw new CandidateNotAuthorizedToJoinSessionError();

--- a/api/src/certification/session-management/domain/read-models/CandidateAuthorizationInfo.js
+++ b/api/src/certification/session-management/domain/read-models/CandidateAuthorizationInfo.js
@@ -1,6 +1,9 @@
 import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
-const MAXIMAL_CERTIFICATION_DURATION_IN_MS = 24 * 60 * 60 * 1000; // 24h
-const AUTHORIZED_TO_START_DURATION_VALIDITY_IN_MS = 15 * 60 * 1000; // 15min
+import {
+  AUTHORIZED_TO_START_DURATION_VALIDITY_IN_MS,
+  MAXIMAL_CERTIFICATION_DURATION_IN_MS,
+  MAXIMAL_SESSION_DURATION_IN_MS,
+} from '../constants.js';
 
 export class CandidateAuthorizationInfo {
   constructor({
@@ -8,7 +11,7 @@ export class CandidateAuthorizationInfo {
     sessionId,
     sessionAccessCode,
     sessionFinalizedAt,
-    sessionPublishedAt,
+    sessionStartedAt,
     reconciledUserId,
     reconciledAt,
     subscription,
@@ -21,13 +24,15 @@ export class CandidateAuthorizationInfo {
     this.sessionId = sessionId;
     this.sessionAccessCode = sessionAccessCode;
     this.sessionFinalizedAt = sessionFinalizedAt;
-    this.sessionPublishedAt = sessionPublishedAt;
     this.reconciledUserId = reconciledUserId;
     this.reconciledAt = reconciledAt;
     this.subscription = subscription;
     this.authorizedToStartAt = authorizedToStartAt;
     this.certificationId = certificationId;
     this.certificationStartedAt = certificationStartedAt;
+    this.sessionIsOvertime = sessionStartedAt
+      ? computeElapsedTime(sessionStartedAt) > MAXIMAL_SESSION_DURATION_IN_MS
+      : false;
     this.centerHabilitations = {};
     for (const framework of Object.values(Frameworks)) {
       this.centerHabilitations[framework] =
@@ -36,7 +41,7 @@ export class CandidateAuthorizationInfo {
   }
 
   get isSessionAccessible() {
-    return !this.sessionFinalizedAt && !this.sessionPublishedAt;
+    return !this.sessionFinalizedAt && !this.sessionIsOvertime;
   }
 
   get hasExceededCertificationDuration() {
@@ -62,6 +67,10 @@ export class CandidateAuthorizationInfo {
   }
 
   #elapsedTimeSinceCertificationStarted() {
-    return Date.now() - this.certificationStartedAt.getTime();
+    return computeElapsedTime(this.certificationStartedAt);
   }
+}
+
+function computeElapsedTime(from) {
+  return Date.now() - new Date(from).getTime();
 }

--- a/api/src/certification/session-management/infrastructure/repositories/candidate-authorization-info-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/candidate-authorization-info-repository.js
@@ -27,9 +27,11 @@ export async function findByUserIdAndSessionId({ userId, sessionId }) {
       subscription: 'certification-candidates.subscription',
       authorizedToStartAt: 'certification-candidates.authorizedToStartAt',
       sessionId: 'sessions.id',
+      sessionStartedAt: knexConn('certification-courses')
+        .min('createdAt')
+        .whereRaw('"certification-courses"."sessionId" = "sessions"."id"'),
       sessionAccessCode: 'sessions.accessCode',
       sessionFinalizedAt: 'sessions.finalizedAt',
-      sessionPublishedAt: 'sessions.publishedAt',
       certificationId: 'certification-courses.id',
       certificationStartedAt: 'certification-courses.createdAt',
       centerHabilitations: knexConn.raw(

--- a/api/tests/certification/evaluation/unit/domain/models/CandidateAuthorization_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/CandidateAuthorization_test.js
@@ -16,7 +16,9 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
       it('throws a NotFoundError', function () {
         const candidateAuthorization = domainBuilder.certification.evaluation
           .candidateAuthorizationBuilder()
-          .withSession({ accessCode: 'ABCDEF' })
+          .withSession({ accessCode: 'ABCDEF', isAccessible: true })
+          .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
+          .asAuthorizedToStart()
           .build();
 
         expect(() => candidateAuthorization.verifyCanStartOrResumeCertification('GHIJKL')).to.throw(NotFoundError);
@@ -24,15 +26,33 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
     });
 
     context('when session is not accessible', function () {
-      it('throws a SessionNotAccessible', function () {
-        const candidateAuthorization = domainBuilder.certification.evaluation
-          .candidateAuthorizationBuilder()
-          .withSession({ accessCode: 'ABCDEF', isAccessible: false })
-          .build();
+      context('when candidate has not started the test yet', function () {
+        it('throws a SessionNotAccessible', function () {
+          const candidateAuthorization = domainBuilder.certification.evaluation
+            .candidateAuthorizationBuilder()
+            .withSession({ accessCode: 'ABCDEF', isAccessible: false })
+            .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
+            .asAuthorizedToStart()
+            .build();
 
-        expect(() => candidateAuthorization.verifyCanStartOrResumeCertification('ABCDEF')).to.throw(
-          SessionNotAccessibleError,
-        );
+          expect(() => candidateAuthorization.verifyCanStartOrResumeCertification('ABCDEF')).to.throw(
+            SessionNotAccessibleError,
+          );
+        });
+      });
+
+      context('when candidate has already started the test', function () {
+        it('returns (successful)', function () {
+          const candidateAuthorization = domainBuilder.certification.evaluation
+            .candidateAuthorizationBuilder()
+            .withSession({ accessCode: 'ABCDEF', isAccessible: false })
+            .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
+            .asAuthorizedToStart()
+            .hasACertification({ certificationId: 123 })
+            .build();
+
+          expect(() => candidateAuthorization.verifyCanStartOrResumeCertification('ABCDEF')).to.not.throw();
+        });
       });
     });
 
@@ -42,6 +62,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
           .candidateAuthorizationBuilder()
           .withSession({ accessCode: 'ABCDEF', isAccessible: true })
           .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: false })
+          .asAuthorizedToStart()
           .build();
 
         expect(() => candidateAuthorization.verifyCanStartOrResumeCertification('ABCDEF')).to.throw(
@@ -83,7 +104,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
       });
 
       context('when all conditions are met', function () {
-        it('returns', function () {
+        it('returns (successful)', function () {
           const candidateAuthorizationWithNoTestStarted = domainBuilder.certification.evaluation
             .candidateAuthorizationBuilder()
             .withSession({ accessCode: 'ABCDEF', isAccessible: true })

--- a/api/tests/certification/session-management/integration/application/api/candidate-authorization-api_test.js
+++ b/api/tests/certification/session-management/integration/application/api/candidate-authorization-api_test.js
@@ -43,7 +43,7 @@ describe('Certification | Session Management | Integration | Application | Api |
       }).id;
       domainBuilder.certification.sessionManagement
         .candidateAuthorizationInfoBuilder()
-        .withSession({ sessionId: 1, accessCode: 'CHACHACHA', isAccessible: true })
+        .withSession({ sessionId: 1, accessCode: 'CHACHACHA' })
         .reconciled({ userId: 2, at: new Date('2021-01-01') })
         .subscribedTo({ framework: Frameworks.PRO_SANTE })
         .withCenterHabilitation({ scope: Frameworks.EDU_CPE })
@@ -69,7 +69,7 @@ describe('Certification | Session Management | Integration | Application | Api |
       // then
       expect(candidateAuthorizationDTO).to.deep.equal({
         id: 3,
-        isSessionAccessible: true,
+        isSessionAccessible: false,
         accessCode: 'CHACHACHA',
         userId: 2,
         authorizedToStart: true,

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/candidate-authorization-info-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/candidate-authorization-info-repository_test.js
@@ -40,7 +40,7 @@ describe('Certification | Session Management | Integration | Infrastructure | Re
       }).id;
       const expectedCandidateAuthorizationInfo = domainBuilder.certification.sessionManagement
         .candidateAuthorizationInfoBuilder()
-        .withSession({ sessionId: 1, accessCode: 'CHACHACHA', isAccessible: true })
+        .withSession({ sessionId: 1, accessCode: 'CHACHACHA' })
         .reconciled({ userId: 2, at: new Date() })
         .withCenterHabilitation({ scope: Frameworks.EDU_CPE })
         .withCenterHabilitation({ scope: Frameworks.CLEA })
@@ -70,8 +70,12 @@ describe('Certification | Session Management | Integration | Infrastructure | Re
       }).id;
       const expectedCandidateAuthorizationInfo = domainBuilder.certification.sessionManagement
         .candidateAuthorizationInfoBuilder()
-        .withSession({ sessionId: 1, accessCode: 'CHACHACHA', isAccessible: true })
-        .withCertificationStartedAt({ certificationId: 10, startedAt: new Date('2023-02-02') })
+        .withSession({
+          sessionId: 1,
+          accessCode: 'CHACHACHA',
+          startedAt: new Date('2023-02-02T10:43:00Z'),
+        })
+        .withCertificationStartedAt({ certificationId: 10, startedAt: new Date('2023-02-02T11:00:00Z') })
         .reconciled({ userId: 2 })
         .withCenterHabilitation({ scope: Frameworks.CLEA })
         .asAuthorizedToStart()

--- a/api/tests/certification/session-management/unit/domain/read-models/CandidateAuthorizationInfo_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/CandidateAuthorizationInfo_test.js
@@ -7,19 +7,46 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
 
 describe('Certification | Session-management | Unit | Domain | Read-models | CandidateAuthorizationInfo', function () {
+  let clock;
+  const now = new Date('2026-01-02T00:00:00Z');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
   describe('#isSessionAccessible', function () {
-    it('returns true when session is accessible', function () {
+    it('returns true when session is neither finalized nor overtime', function () {
+      const twentyThreeHoursBefore = new Date();
+      twentyThreeHoursBefore.setHours(twentyThreeHoursBefore.getHours() - 23);
       const candidateAuthorizationInfo = domainBuilder.certification.sessionManagement
         .candidateAuthorizationInfoBuilder()
-        .withSession({ isAccessible: true })
+        .withSession({ finalizedAt: null, startedAt: twentyThreeHoursBefore })
         .build();
 
       expect(candidateAuthorizationInfo.isSessionAccessible).to.be.true;
     });
-    it('returns false when session is not accessible', function () {
+
+    it('returns false when session is finalized', function () {
+      const twentyThreeHoursBefore = new Date();
+      twentyThreeHoursBefore.setHours(twentyThreeHoursBefore.getHours() - 23);
       const candidateAuthorizationInfo = domainBuilder.certification.sessionManagement
         .candidateAuthorizationInfoBuilder()
-        .withSession({ isAccessible: false })
+        .withSession({ finalizedAt: new Date(), startedAt: twentyThreeHoursBefore })
+        .build();
+
+      expect(candidateAuthorizationInfo.isSessionAccessible).to.be.false;
+    });
+
+    it('returns false when session has been started more than 24 hours before and thus is overtime', function () {
+      const twentyFiveHoursBefore = new Date();
+      twentyFiveHoursBefore.setHours(twentyFiveHoursBefore.getHours() - 25);
+      const candidateAuthorizationInfo = domainBuilder.certification.sessionManagement
+        .candidateAuthorizationInfoBuilder()
+        .withSession({ finalizedAt: null, startedAt: twentyFiveHoursBefore })
         .build();
 
       expect(candidateAuthorizationInfo.isSessionAccessible).to.be.false;
@@ -27,17 +54,6 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Can
   });
 
   describe('#hasExceededCertificationDuration', function () {
-    let clock;
-    const now = new Date('2026-01-02T00:00:00Z');
-
-    beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
-    });
-
     it('returns false when candidate has not started a certification', function () {
       const candidateAuthorizationInfo = domainBuilder.certification.sessionManagement
         .candidateAuthorizationInfoBuilder()

--- a/api/tests/tooling/domain-builder/factory/certification/session-management/build-candidate-authorization-info.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session-management/build-candidate-authorization-info.js
@@ -22,7 +22,7 @@ class CandidateAuthorizationInfoBuilder {
     this.sessionId = null;
     this.sessionAccessCode = 'ABC123';
     this.sessionFinalizedAt = null;
-    this.sessionPublishedAt = null;
+    this.sessionStartedAt = null;
     this.reconciledUserId = null;
     this.reconciledAt = null;
     this.subscription = Frameworks.CORE;
@@ -52,14 +52,15 @@ class CandidateAuthorizationInfoBuilder {
    * @param {object} [params]
    * @param {number} [params.sessionId] - explicit id; without it, insertToDB lets the database assign one and build() produces a non-persisted session (id null)
    * @param {string} [params.accessCode]
-   * @param {boolean} [params.isAccessible]
+   * @param {Date} [params.startedAt]
+   * @param {Date} [params.finalizedAt]
    * @returns {CandidateAuthorizationInfoBuilder}
    */
-  withSession({ sessionId = null, accessCode = 'ABC123', isAccessible = true } = {}) {
+  withSession({ sessionId = null, accessCode = 'ABC123', finalizedAt = null, startedAt = null } = {}) {
     this.sessionId = sessionId;
     this.sessionAccessCode = accessCode;
-    this.sessionFinalizedAt = isAccessible ? null : new Date();
-    this.sessionPublishedAt = null;
+    this.sessionFinalizedAt = finalizedAt;
+    this.sessionStartedAt = startedAt;
     return this;
   }
 
@@ -172,7 +173,6 @@ class CandidateAuthorizationInfoBuilder {
       id: candidateAuthorizationInfo.sessionId ?? undefined,
       accessCode: candidateAuthorizationInfo.sessionAccessCode,
       finalizedAt: candidateAuthorizationInfo.sessionFinalizedAt,
-      publishedAt: candidateAuthorizationInfo.sessionPublishedAt,
       certificationCenterId,
     }).id;
     candidateAuthorizationInfo.sessionId = sessionId;
@@ -199,6 +199,13 @@ class CandidateAuthorizationInfoBuilder {
       }).id;
       candidateAuthorizationInfo.certificationId = certificationId;
     }
+
+    if (this.sessionStartedAt && this.sessionStartedAt !== candidateAuthorizationInfo.certificationStartedAt) {
+      databaseBuilder.factory.buildCertificationCourse({
+        sessionId,
+        createdAt: this.sessionStartedAt,
+      });
+    }
     candidateAuthorizationInfo.id = candidateId;
 
     return candidateAuthorizationInfo;
@@ -215,7 +222,7 @@ class CandidateAuthorizationInfoBuilder {
       sessionId: this.sessionId,
       sessionAccessCode: this.sessionAccessCode,
       sessionFinalizedAt: this.sessionFinalizedAt,
-      sessionPublishedAt: this.sessionPublishedAt,
+      sessionStartedAt: this.sessionStartedAt,
       authorizedToStartAt: this.authorizedToStartAt,
       reconciledUserId: this.reconciledUserId,
       reconciledAt: this.reconciledAt,


### PR DESCRIPTION
## ☀️ Problème

On se rend compte que certains centres autorisent leurs candidats à démarrer leurs certifications plusieurs jours après le démarrage de la session, ce qui est contraire au cahier des charges Pix.

Par ailleurs, cette mauvaise pratique fausse la fiabilité de la donnée de la date de session.

## ⛱️ Proposition

Empêcher un candidat de lancer le test de certification après la saisie du code d'accès si la session est expirée

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- Démarrer un test de certification avec un candidat A;
- Démarrer un test de certification avec un candidat B mais s'arrêter après la saisi du code ;
- Modifier la date de début de ce test (`certification-courses`) du candidat A pour que le `createdAt` soit à plus de 24 h (comme si le test avait été démarré par le candidat A il y a plus de 24 h);
- Constater que l'on ne peut pas reprendre le test avec le candidat

