### PR TITLE
[BUMP] Mettre à jour le package epreuves-component en version 4.13.0.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.472.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@1024pix/epreuves-components": "^4.6.2",
+        "@1024pix/epreuves-components": "^4.13.0",
         "@1024pix/oppsy": "^1.0.2",
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.2.tgz",
-      "integrity": "sha512-6FVh819+qi37z+EQnwLyJ5t5K/6q7k7+laa1aV9Nkdm6vQaG8/aQpkYa5aZy3s6zHZHri6opXrkUaAEF39CzSg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.13.0.tgz",
+      "integrity": "sha512-2QmGmyRWoDGZOjuwEzbJzisshdayFgwOCLbwgVM8sSPXpky9ujvz8Q6cSqJymCWvvtO4BPC9PKHtQHd1mYBlHA==",
       "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -89,7 +89,7 @@
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/unit/infrastructure/repositories/module-repository_test.js'"
   },
   "dependencies": {
-    "@1024pix/epreuves-components": "^4.6.2",
+    "@1024pix/epreuves-components": "^4.13.0",
     "@1024pix/oppsy": "^1.0.2",
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -1097,7 +1097,8 @@
                 "instruction": "",
                 "tagName": "phishing-message",
                 "props": {
-                  "titleLevel": 2
+                  "titleLevel": 2,
+                  "forcedLocale": "fr-BE"
                 },
                 "title": "",
                 "functionalInstruction": ""

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.41",
-        "@1024pix/epreuves-components": "^4.6.2",
+        "@1024pix/epreuves-components": "^4.13.0",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^61.3.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.2.tgz",
-      "integrity": "sha512-6FVh819+qi37z+EQnwLyJ5t5K/6q7k7+laa1aV9Nkdm6vQaG8/aQpkYa5aZy3s6zHZHri6opXrkUaAEF39CzSg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.13.0.tgz",
+      "integrity": "sha512-2QmGmyRWoDGZOjuwEzbJzisshdayFgwOCLbwgVM8sSPXpky9ujvz8Q6cSqJymCWvvtO4BPC9PKHtQHd1mYBlHA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.41",
-    "@1024pix/epreuves-components": "^4.6.2",
+    "@1024pix/epreuves-components": "^4.13.0",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^61.3.1",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.41",
-        "@1024pix/epreuves-components": "^4.6.2",
+        "@1024pix/epreuves-components": "^4.13.0",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^61.3.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -758,9 +758,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.2.tgz",
-      "integrity": "sha512-6FVh819+qi37z+EQnwLyJ5t5K/6q7k7+laa1aV9Nkdm6vQaG8/aQpkYa5aZy3s6zHZHri6opXrkUaAEF39CzSg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.13.0.tgz",
+      "integrity": "sha512-2QmGmyRWoDGZOjuwEzbJzisshdayFgwOCLbwgVM8sSPXpky9ujvz8Q6cSqJymCWvvtO4BPC9PKHtQHd1mYBlHA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.41",
-    "@1024pix/epreuves-components": "^4.6.2",
+    "@1024pix/epreuves-components": "^4.13.0",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^61.3.1",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/scripts/update-demo-epreuves.sh
+++ b/scripts/update-demo-epreuves.sh
@@ -10,4 +10,4 @@ cd ../junior
 npm i @1024pix/epreuves-components@latest
 
 cd ..
-node api/scripts/modulix/generate-demo-epreuve-component.js
+node api/src/devcomp/scripts/generate-demo-epreuve-component.js


### PR DESCRIPTION
## ☀️ Problème

Un composant à été traduit.

## ⛱️ Proposition

Rendre disponible les nouvelles traductions du composant

## 🧴 Remarques

RAS

## 🏊 Pour tester

test aux vert