### PR TITLE
[TECH] Améliorer l'affichage des log 'human compact' en dev

### DIFF
--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -1,8 +1,4 @@
 import { logs, SeverityNumber } from '@opentelemetry/api-logs';
-import isEmpty from 'lodash/isEmpty.js';
-import isNil from 'lodash/isNil.js';
-import omit from 'lodash/omit.js';
-import omitBy from 'lodash/omitBy.js';
 import pino from 'pino';
 import pretty from 'pino-pretty';
 
@@ -188,29 +184,40 @@ function messageFormatCompact(log, messageKey, _logLevel, { colors }) {
     const request = colors.magentaBright([method, req.url].filter(Boolean).join(' '));
     const details = colors.yellow([queries, queriesTime].filter(Boolean).join(' '));
     const time = colors.gray(`(${responseTime}ms)`);
-    const correlationInfo = colors.gray(
-      JSON.stringify(
-        omitBy(
-          {
-            user_id: req.user_id,
-            request_id: req.request_id,
-            scriptId: req.scriptId,
-            jobId: req.jobId,
-            [CORRELATION_METADATA]: req[CORRELATION_METADATA],
-          },
-          isNil,
-        ),
-      ),
-    );
+
+    const correlationInfoCompacted = omitNilAndKeys({
+      user_id: req.user_id,
+      request_id: req.request_id,
+      scriptId: req.scriptId,
+      jobId: req.jobId,
+      [CORRELATION_METADATA]: req[CORRELATION_METADATA],
+    });
+    const correlationInfo = colors.gray(JSON.stringify(correlationInfoCompacted));
 
     return [statusCode, request, details, time, correlationInfo].filter(Boolean).join(' - ');
   }
 
   // compact log by default and remove null/undefined values
-  const compactLog = omitBy(
-    omit(log, [messageKey, 'id', 'level', 'time', 'pid', 'hostname', 'uri', 'address', 'event', 'started', 'created']),
-    isNil,
-  );
-  const details = !isEmpty(compactLog) ? colors.gray(JSON.stringify(compactLog)) : '';
+  const EXCLUDED_KEYS = new Set([
+    messageKey,
+    'id',
+    'level',
+    'time',
+    'pid',
+    'hostname',
+    'uri',
+    'address',
+    'event',
+    'started',
+    'created',
+  ]);
+  const compactLog = omitNilAndKeys(log, EXCLUDED_KEYS);
+
+  const details = Object.keys(compactLog).length > 0 ? colors.gray(JSON.stringify(compactLog)) : '';
   return `${message} ${details}`;
 }
+
+const omitNilAndKeys = (obj, keys = []) => {
+  const excluded = new Set(keys);
+  return Object.fromEntries(Object.entries(obj).filter(([key, value]) => !excluded.has(key) && value != null));
+};

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -1,6 +1,8 @@
 import { logs, SeverityNumber } from '@opentelemetry/api-logs';
 import isEmpty from 'lodash/isEmpty.js';
+import isNil from 'lodash/isNil.js';
 import omit from 'lodash/omit.js';
+import omitBy from 'lodash/omitBy.js';
 import pino from 'pino';
 import pretty from 'pino-pretty';
 
@@ -187,32 +189,28 @@ function messageFormatCompact(log, messageKey, _logLevel, { colors }) {
     const details = colors.yellow([queries, queriesTime].filter(Boolean).join(' '));
     const time = colors.gray(`(${responseTime}ms)`);
     const correlationInfo = colors.gray(
-      JSON.stringify({
-        user_id: req.user_id,
-        request_id: req.request_id,
-        scriptId: req.scriptId,
-        jobId: req.jobId,
-        [CORRELATION_METADATA]: req[CORRELATION_METADATA],
-      }),
+      JSON.stringify(
+        omitBy(
+          {
+            user_id: req.user_id,
+            request_id: req.request_id,
+            scriptId: req.scriptId,
+            jobId: req.jobId,
+            [CORRELATION_METADATA]: req[CORRELATION_METADATA],
+          },
+          isNil,
+        ),
+      ),
     );
 
     return [statusCode, request, details, time, correlationInfo].filter(Boolean).join(' - ');
   }
 
-  // compact log by default
-  const compactLog = omit(log, [
-    messageKey,
-    'id',
-    'level',
-    'time',
-    'pid',
-    'hostname',
-    'uri',
-    'address',
-    'event',
-    'started',
-    'created',
-  ]);
+  // compact log by default and remove null/undefined values
+  const compactLog = omitBy(
+    omit(log, [messageKey, 'id', 'level', 'time', 'pid', 'hostname', 'uri', 'address', 'event', 'started', 'created']),
+    isNil,
+  );
   const details = !isEmpty(compactLog) ? colors.gray(JSON.stringify(compactLog)) : '';
   return `${message} ${details}`;
 }


### PR DESCRIPTION
## ☀️ Problème

Beaucoup de logs avec des valeurs `null` sont affichées en format `compact` de `LOG_FOR_HUMANS` en environnement de dev. C'est difficile d'identifier les informations importantes.

<img width="1957" height="487" alt="image" src="https://github.com/user-attachments/assets/36e47f77-f9eb-4901-bb29-50c9e67e1260" />


## ⛱️ Proposition

Ne pas afficher les valeurs null de ces objets dans le format `compact` de `LOG_FOR_HUMANS` et là on voit bien :)

**Résultat :**

<img width="1723" height="493" alt="image" src="https://github.com/user-attachments/assets/fdd82dd9-5a4e-4684-bbef-cfaf92b0917a" />


## 🧴 Remarques

N/A

## 🏊 Pour tester

Démarrer le serveur de dev de l'API avec dans le `.env` : 
```
LOG_FOR_HUMANS=true
LOG_FOR_HUMANS_FORMAT=compact
```
