### PR TITLE
[BUGFIX] Ajoute un script pour corriger les critères de badges (PIX-23779)

### DIFF
--- a/api/src/prescription/scripts/clean-capped-tubes-criteria.js
+++ b/api/src/prescription/scripts/clean-capped-tubes-criteria.js
@@ -1,0 +1,76 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+
+/**
+ *
+ * @returns {Promise<{id: number, missingTubeIds number[], cappedTubes: {id: string, level: number}}>}
+ */
+async function getBadgeCriteriaWitMissingTubesIds(knexConn) {
+  return await knexConn('badge-criteria')
+    .select(
+      'badge-criteria.id',
+      knex.raw('jsonb_agg(cappedTube.value->>\'id\') as "missingTubeIds"'),
+      'badge-criteria.cappedTubes',
+    )
+    .join('badges', 'badges.id', '=', 'badge-criteria.badgeId')
+    .crossJoin(knex.raw('jsonb_array_elements("cappedTubes") AS cappedTube (value)'))
+    .where('badge-criteria.scope', '=', 'CappedTubes')
+    .where('isCertifiable', '=', false)
+    .whereRaw(
+      `cappedTube.value->>'id' NOT IN (
+         SELECT "tubeId"
+         FROM "target-profile_tubes"
+         WHERE "targetProfileId" = badges."targetProfileId"
+       )`,
+    )
+    .groupBy('badge-criteria.id', 'badge-criteria.cappedTubes');
+}
+
+export class CleanCappedTubesCriteriaScript extends Script {
+  constructor() {
+    super({
+      description: "Clean badges-criteria capped tubes which are no more existing in the badge's targe-profile",
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+      const criteria = await getBadgeCriteriaWitMissingTubesIds(knexConn);
+
+      logger.info(`found ${criteria.length} badge criteria referencing invalid tubeId`);
+
+      for (const criterion of criteria) {
+        const filteredCappedTubes = criterion.cappedTubes.filter(({ id }) => !criterion.missingTubeIds.includes(id));
+        if (filteredCappedTubes.length === 0) {
+          logger.warn(`BadgeCriterion id${criterion.id} has empty cappedTubes`);
+        }
+        await knexConn('badge-criteria')
+          .update({ cappedTubes: JSON.stringify(filteredCappedTubes) })
+          .where({ id: criterion.id });
+      }
+
+      if (options.dryRun) {
+        await knexConn.rollback();
+        logger.info('ROLLBACK: no changes were persisted (dry run)');
+        logger.info('remove --dryRun to persist changes');
+        return;
+      }
+      await knexConn.commit();
+      logger.info('COMMIT: changes persisted');
+      logger.info(`update ${criteria.length} badge criteria`);
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CleanCappedTubesCriteriaScript);

--- a/api/tests/prescription/scripts/integration/clean-capped-tubes-criteria_test.js
+++ b/api/tests/prescription/scripts/integration/clean-capped-tubes-criteria_test.js
@@ -1,0 +1,98 @@
+import sinon from 'sinon';
+
+import { CleanCappedTubesCriteriaScript } from '../../../../src/prescription/scripts/clean-capped-tubes-criteria.js';
+import { SCOPES } from '../../../../src/shared/domain/models/BadgeDetails.js';
+import { expect } from '../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../tooling/databases.js';
+describe('Integration | Scripts | clean-capped-tubes-criteria', function () {
+  let script;
+
+  beforeEach(function () {
+    script = new CleanCappedTubesCriteriaScript();
+  });
+
+  describe('handle', function () {
+    let logger, badge;
+
+    beforeEach(async function () {
+      logger = { info: sinon.spy(), warn: sinon.spy() };
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: targetProfile.id,
+        tubeId: 'tubeId1',
+        level: 1,
+      });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: targetProfile.id,
+        tubeId: 'tubeId2',
+        level: 1,
+      });
+      badge = databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id });
+      databaseBuilder.factory.buildBadgeCriterion({
+        badgeId: badge.id,
+        scope: SCOPES.CAPPED_TUBES,
+        cappedTubes: JSON.stringify([
+          { id: 'tubeId1', level: 1 },
+          { id: 'tubeId2', level: 1 },
+        ]),
+      });
+      databaseBuilder.factory.buildBadgeCriterion({
+        badgeId: badge.id,
+        scope: SCOPES.CAPPED_TUBES,
+        cappedTubes: JSON.stringify([
+          { id: 'tubeId1', level: 1 },
+          { id: 'unknownTubeId', level: 1 },
+        ]),
+      });
+      databaseBuilder.factory.buildBadgeCriterion({
+        badgeId: badge.id,
+        scope: SCOPES.CAPPED_TUBES,
+        cappedTubes: JSON.stringify([
+          { id: 'tubeId2', level: 1 },
+          { id: 'unknownTubeId2', level: 1 },
+          { id: 'unknownTubeId3', level: 1 },
+        ]),
+      });
+      await databaseBuilder.commit();
+    });
+
+    describe('when dryRun is true', function () {
+      it('should not persist any changes', async function () {
+        await script.handle({ options: { dryRun: true }, logger });
+        const criteria = await knex('badge-criteria').where({ badgeId: badge.id }).orderBy('id');
+
+        expect(criteria.map((item) => item.cappedTubes)).deep.equal([
+          [
+            { id: 'tubeId1', level: 1 },
+            { id: 'tubeId2', level: 1 },
+          ],
+          [
+            { id: 'tubeId1', level: 1 },
+            { id: 'unknownTubeId', level: 1 },
+          ],
+          [
+            { id: 'tubeId2', level: 1 },
+            { id: 'unknownTubeId2', level: 1 },
+            { id: 'unknownTubeId3', level: 1 },
+          ],
+        ]);
+      });
+    });
+
+    describe('when dryRun is false', function () {
+      it('should remove cappedTube that are missing in the targetProfile', async function () {
+        await script.handle({ options: { dryRun: false }, logger });
+        const criteria = await knex('badge-criteria').where({ badgeId: badge.id }).orderBy('id');
+
+        expect(criteria.map((item) => item.cappedTubes)).deep.equal([
+          [
+            { id: 'tubeId1', level: 1 },
+            { id: 'tubeId2', level: 1 },
+          ],
+          [{ id: 'tubeId1', level: 1 }],
+          [{ id: 'tubeId2', level: 1 }],
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ☀️ Problème

Suite à la PR #16134, l'édition du profils cible contenant des critères invalide est bloquée.

## ⛱️ Proposition

Créer un script pour corriger les données

## 🧴 Remarques

On affiche un message de warning dans le cas où le critère est vide
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- Essayer d'éditer le [PC 1100006](https://admin-pr17045.review.pix.fr/target-profiles/1100006)
- lancer le script sur scalingo
```sh
scalingo --app pix-api-review-pr17045 run bash
node src/prescription/scripts/clean-capped-tubes-criteria.js --dryRun false
```
- Editer le [PC 1100006](https://admin-pr17045.review.pix.fr/target-profiles/1100006)
<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
