### PR TITLE
[BUGFIX] Résoudre les problèmes front sur la création d'un schéma de parcours combiné (PIX-23619)

### DIFF
--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -174,10 +174,8 @@ export default class CombinedCourseBlueprintForm extends Component {
   }
 
   @action
-  removeRequirement(value) {
-    this.blueprint.content = this.blueprint.content.filter(
-      (item) => item.id !== value.id || item.shortId !== value.shortId,
-    );
+  removeRequirement(index) {
+    this.blueprint.content = this.blueprint.content.filter((item, i) => i !== index);
   }
 
   async refreshAreas() {
@@ -464,7 +462,7 @@ const ContentSection = <template>
         <div>
           {{#if (gt @blueprint.content.length 0)}}
             <PixTable @variant="admin" @data={{@blueprint.content}} class="table">
-              <:columns as |row context|>
+              <:columns as |row context index|>
                 <PixTableColumn @context={{context}}>
                   <:header>
                     {{t "components.combined-course-blueprints.items.item-type-header"}}
@@ -493,8 +491,9 @@ const ContentSection = <template>
                   <:cell>
                     <PixIconButton
                       @iconName="delete"
-                      @triggerAction={{fn @removeRequirement row}}
+                      @triggerAction={{fn @removeRequirement index}}
                       @ariaLabel="Supprimer"
+                      data-testid="delete-{{index}}"
                     />
                   </:cell>
                 </PixTableColumn>

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -294,9 +294,11 @@ export default class CombinedCourseBlueprintForm extends Component {
       {{/if}}
 
       <fieldset class="controls">
-        <PixButton class="combined-course-blueprint-form__button" @triggerAction={{this.save}} @variant="secondary">{{t
-            "common.actions.cancel"
-          }}</PixButton>
+        <PixButton
+          class="combined-course-blueprint-form__button"
+          @triggerAction={{this.goToListPage}}
+          @variant="secondary"
+        >{{t "common.actions.cancel"}}</PixButton>
         <PixButton class="combined-course-blueprint-form__button" @triggerAction={{this.save}} @variant="success">{{if
             @updateMode
             (t "components.combined-course-blueprints.update.updateButton")

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -147,9 +147,9 @@ export default class CombinedCourseBlueprintForm extends Component {
   @action
   setItemType(e) {
     this.itemType = e.target.value;
-    if (this.itemValue === '') {
-      this.itemAddDisabled = true;
-    }
+    this.itemValue = '';
+    this.itemAddDisabled = true;
+    this.itemToAdd = null;
   }
 
   @action
@@ -267,6 +267,7 @@ export default class CombinedCourseBlueprintForm extends Component {
           @updateMode={{@updateMode}}
           @handleKeyPress={{this.handleKeyPress}}
           @removeRequirement={{this.removeRequirement}}
+          @itemValue={{this.itemValue}}
           @itemAddDisabled={{this.itemAddDisabled}}
           @itemToAdd={{this.itemToAdd}}
           @getItemColor={{this.getItemColor}}

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -827,5 +827,50 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       //then
       assert.notOk(screen.queryByRole('cell', { name: /super pc/ }));
     });
+    test('it should remove only the selected item in a list of duplicates when user clicks on remove button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const findRecordStub = sinon.stub(store, 'findRecord');
+
+      findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
+
+      const frameworks = [
+        {
+          id: '123',
+          name: 'Pix',
+          areas: [],
+        },
+      ];
+      const model = { frameworks };
+
+      //when
+
+      const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
+
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
+        1,
+      );
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
+      );
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
+        1,
+      );
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
+      );
+
+      let itemsInTable = screen.getAllByRole('cell', { name: /super pc/ });
+      assert.strictEqual(itemsInTable.length, 2);
+
+      await click(screen.getByTestId('delete-1'));
+
+      //then
+      itemsInTable = screen.getAllByRole('cell', { name: /super pc/ });
+      assert.strictEqual(itemsInTable.length, 1);
+    });
   });
 });


### PR DESCRIPTION
## ☀️ Problème

Suite aux modifs faites dans PixAdmin sur la page de création d’un blueprint, voici quelques ajustements : 

1. quand on entre un id dans l’input pour sélectionner un PC ou un module, qu’on a l’aperçu puis qu’on change de type d'élément, on ne veut plus voir l’aperçu 
2. quand on clique sur “annuler”, une erreur apparaît en `toast` au lieu de revenir à la page “Tous les schémas de parcours”
3. quand on sélectionne 2 éléments et que l'on veut en supprimer un, tous les éléments de ce type sont supprimés

## ⛱️ Proposition

Pas de sujet particulier si ce n'est pour le bug `1.`: le fait de changer le type d'élément (module ou PC) reset le champ de saisie du code. De cette manière la recherche de l'élément se relance lorsque l'utilisateur saisit le code et la recherche se place dans le bon contexte de type d'élément.

## 🧴 Remarques

Les modifications de cette PR résolvent les bugs rencontrés. Des changements de comportement sur cette partie du formulaire lors de la création du schéma de parcours pourraient améliorer dans le futur l'expérience utilisateur:

- Hypothèse 1: en conservant le fonctionnement actuel avec un reset de l'input, on pourrait désactiver l'input tant qu'aucun type d'élément n'est sélectionné (pour éviter que l'utilisateur saisisse un code, puis sélectionne un type, ce qui réinitialiserait son code).
- Hypothèse 2: ne pas reset l'input et plutôt lancer une nouvelle recherche du code lorsque le type sélectionné est modifié (si le champ est non-vide) afin de permettre une nouvelle recherche si l'utilisateur est certain de son code mais pas du type d'élément

Autre amélioration possible: lorsque l'on ajoute un élément dans le schéma de parcours, ce dernier élément est conservé. Sans aucune saisie supplémentaire, le fait de cliquer une nouvelle fois sur l'ajout de l'élément, ajoute cet élément une deuxième fois dans le contenu du parcours. Nous pourrions supprimer l'élément actuel à ajouter lors de l'ajout de celui-ci. Mais il faudrait refaire la recherche de l'élément si on souhaite l'ajouter deux fois (ou plus).

## 🏊 Pour tester

1. Lancer `pix-admin` et se rendre sur `Schémas de parcours` > `Création de schéma de parcours`
2. Sélectionner dans le formulaire `Module` et renseigner un identifiant. Lancer la recherche. L'aperçu apparaît.
3. Sélectionner l'option `Profil cible` (sans ajouter l'élément en cours) -> l'aperçu et le code disparaissent, le bouton d'ajout n'est plus disponible
4. Renseigner un code de `Profil cible` -> Rechercher -> Ajouter. Le PC apparaît une fois dans les éléments sélectionnés.
5. Ajouter une seconde fois le même `Profil cible` -> Le PC apparaît deux fois dans le tableau des éléments sélectionnés.
6. Supprimer un des 2 PC -> il reste 1 PC dans le tableau des éléments sélectionnés
7. Cliquer sur Annuler -> on est renvoyés à la page de liste sans message d'erreur
