### PR TITLE
[TECH] Création d'un README pour chaque bounded context

### DIFF
--- a/api/src/announcements/README.md
+++ b/api/src/announcements/README.md
@@ -1,0 +1,11 @@
+# Announcements context
+
+`announcements` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/banner/README.md
+++ b/api/src/banner/README.md
@@ -1,0 +1,11 @@
+# Banner context
+
+`banner` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/certification/README.md
+++ b/api/src/certification/README.md
@@ -1,0 +1,11 @@
+# Certification context
+
+`certification` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/db-history/README.md
+++ b/api/src/db-history/README.md
@@ -1,0 +1,11 @@
+# DB History context
+
+`db history` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/db-history/dependencies.json
+++ b/api/src/db-history/dependencies.json
@@ -1,0 +1,1 @@
+{ "name": "db-history", "dependsOn": ["shared"], "circular": "forbidden" }

--- a/api/src/devcomp/README.md
+++ b/api/src/devcomp/README.md
@@ -1,0 +1,11 @@
+# Devcomp context
+
+`devcomp` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/evaluation/README.md
+++ b/api/src/evaluation/README.md
@@ -1,0 +1,11 @@
+# Evalutation context
+
+`evaluation` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/identity-access-management/README.md
+++ b/api/src/identity-access-management/README.md
@@ -1,0 +1,11 @@
+# Identity Access Management context
+
+`identity access management` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/learning-content/README.md
+++ b/api/src/learning-content/README.md
@@ -1,0 +1,11 @@
+# Learning Content context
+
+`learning content` is a context used to expose APIs and models allowing to access learning contents in an optimized way.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+This context should not depend on other contexts.

--- a/api/src/legal-documents/README.md
+++ b/api/src/legal-documents/README.md
@@ -1,0 +1,11 @@
+# Legal documents context
+
+`legal documents` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/llm/README.md
+++ b/api/src/llm/README.md
@@ -1,0 +1,11 @@
+# Llm context
+
+`llm` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/maddo/README.md
+++ b/api/src/maddo/README.md
@@ -1,0 +1,11 @@
+# Maddo context
+
+`maddo` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/organizational-entities/README.md
+++ b/api/src/organizational-entities/README.md
@@ -1,0 +1,11 @@
+# Organizational Entities context
+
+`organizational entities` is a context used to handle structures and networks (organizations and certicfication centers).
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/prescription/README.md
+++ b/api/src/prescription/README.md
@@ -1,0 +1,11 @@
+# Prescription context
+
+`prescription` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/privacy/README.md
+++ b/api/src/privacy/README.md
@@ -1,0 +1,11 @@
+# Privacy context
+
+`privacy` is a context used to orchestrate the anonymization of users, in the context of GDPR requirements.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/profile/README.md
+++ b/api/src/profile/README.md
@@ -1,0 +1,11 @@
+# Profile context
+
+`profile` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/quest/README.md
+++ b/api/src/quest/README.md
@@ -1,0 +1,25 @@
+# Quest context
+
+`quest` is a context used to articulate the delivery of rewards to users depending on requirements, based on cross-modalities activity (campaigns, modules, other events, competences, ...)
+
+## Core entities
+
+### Quest
+
+Technical object that bears the requirements to obtain a reward.
+
+### CombinedCourse
+
+Learning path that can be composed of evaluation campaigns only, modules only, or a mix of both, attached to an organization.
+
+### CombinedCourseBlueprint
+
+Blueprint defining the structure of campaigns, modules etc for the combined course, orchestrated by the associated quest.
+
+### CombinedCourseParticipation
+
+Link between a learner and their combined course, with details and status for their participation.
+
+## Important notes
+
+Discussions are in progress between the Quest and Prescription teams to redefine and join some concepts common to both contexts (campaigns/combined-courses, target profile/blueprint, ...)

--- a/api/src/school/README.md
+++ b/api/src/school/README.md
@@ -1,0 +1,11 @@
+# School context
+
+`school` is a context used to XXX.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX

--- a/api/src/shared/README.md
+++ b/api/src/shared/README.md
@@ -1,0 +1,11 @@
+# Shared context
+
+`shared` is a context used to expose elements that are relevant to be used by other contexts.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+`shared` is not a context of transition between two contexts (A -> Shared -> B). It should only be used to share elements common to multiple contexts (Shared -> A, Shared -> B).

--- a/api/src/team/README.md
+++ b/api/src/team/README.md
@@ -1,0 +1,11 @@
+# Team context
+
+`team` is a context used to handle the gestion of members and their roles for organizations, certification centers, and Pix admin.
+
+## Core entities
+
+XXX
+
+## Important notes
+
+XXX


### PR DESCRIPTION
## ☀️ Problème

Le scope et les notions coeur des différents bounded context ne sont pas clairs à appréhender.

## ⛱️ Proposition

Ajouter un README à la racine de chaque contexte, pour indiquer sa raison d'être, son vocabulaire coeur, et des informations nécessaires.

## 🧴 Remarques

La plupart des README sont à l'état de template. Il conviendra aux équipes qui connaissent bien chaque sujet de remplir les informations.

Ajout également d'un dependencies.json pour `db-history`.

## 🏊 Pour tester

RAS
