### PR TITLE
[TECH] Ajoute un pre-handler certif pour ne plus l'importer d'evaluation

### DIFF
--- a/api/src/certification/evaluation/application/companion-alert-route.js
+++ b/api/src/certification/evaluation/application/companion-alert-route.js
@@ -1,8 +1,8 @@
 import Joi from 'joi';
 
-import { assessmentAuthorization } from '../../../evaluation/application/pre-handlers/assessment-authorization.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { companionAlertController } from './companion-alert-controller.js';
+import { evaluationSecurityPreHandlers } from './security-pre-handlers.js';
 
 const register = async function (server) {
   const routes = [
@@ -12,7 +12,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: assessmentAuthorization.verify,
+            method: evaluationSecurityPreHandlers.checkUserOwnsAssessment,
             assign: 'authorizationCheck',
           },
         ],

--- a/api/src/certification/evaluation/application/live-alert-route.js
+++ b/api/src/certification/evaluation/application/live-alert-route.js
@@ -1,8 +1,8 @@
 import Joi from 'joi';
 
-import { assessmentAuthorization } from '../../../evaluation/application/pre-handlers/assessment-authorization.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { liveAlertController } from './live-alert-controller.js';
+import { evaluationSecurityPreHandlers } from './security-pre-handlers.js';
 
 const register = async function (server) {
   const routes = [
@@ -12,7 +12,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: assessmentAuthorization.verify,
+            method: evaluationSecurityPreHandlers.checkUserOwnsAssessment,
             assign: 'authorizationCheck',
           },
         ],

--- a/api/src/certification/evaluation/application/security-pre-handlers.js
+++ b/api/src/certification/evaluation/application/security-pre-handlers.js
@@ -1,4 +1,7 @@
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
+import { validationErrorSerializer } from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as checkUserOwnsCertificationCourseUseCase from './usecases/checkUserOwnsCertificationCourse.js';
 
 async function checkUserOwnsCertificationCourse(
@@ -24,6 +27,26 @@ async function checkUserOwnsCertificationCourse(
   }
 }
 
+async function checkUserOwnsAssessment(request, h, dependencies = { assessmentRepository, validationErrorSerializer }) {
+  const userId = extractUserIdFromRequest(request);
+
+  const assessmentId = parseInt(request.params.id) || parseInt(request.params.assessmentId);
+
+  return dependencies.assessmentRepository.getByAssessmentIdAndUserId(assessmentId, userId).catch(() => {
+    const buildError = _handleWhenInvalidAuthorization('Vous n’êtes pas autorisé à accéder à cette évaluation');
+    return h.response(dependencies.validationErrorSerializer.serialize(buildError)).code(401).takeover();
+  });
+}
+
+function _handleWhenInvalidAuthorization(errorMessage) {
+  return {
+    data: {
+      authorization: [errorMessage],
+    },
+  };
+}
+
 export const evaluationSecurityPreHandlers = {
   checkUserOwnsCertificationCourse,
+  checkUserOwnsAssessment,
 };

--- a/api/tests/certification/evaluation/unit/application/security-pre-handlers_test.js
+++ b/api/tests/certification/evaluation/unit/application/security-pre-handlers_test.js
@@ -3,83 +3,167 @@ import sinon from 'sinon';
 import { evaluationSecurityPreHandlers } from '../../../../../src/certification/evaluation/application/security-pre-handlers.js';
 import { expect } from '../../../../test-helper.js';
 import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
+import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
-describe('#checkUserOwnsCertificationCourse', function () {
-  context('Successful case', function () {
-    it('should authorize access to resource when the user owns the certification course', async function () {
-      // given
-      const preHandlerStub = sinon.stub();
-      const checkUserOwnsCertificationCourseUseCaseStub = {
-        execute: preHandlerStub.resolves(true),
-      };
+describe('Unit | Certification | Evaluation | Application | SecurityPreHandlers', function () {
+  describe('#checkUserOwnsCertificationCourse', function () {
+    context('Successful case', function () {
+      it('should authorize access to resource when the user owns the certification course', async function () {
+        // given
+        const preHandlerStub = sinon.stub();
+        const checkUserOwnsCertificationCourseUseCaseStub = {
+          execute: preHandlerStub.resolves(true),
+        };
 
-      // when
-      const response = await evaluationSecurityPreHandlers.checkUserOwnsCertificationCourse(
-        {
-          auth: { credentials: { accessToken: 'valid.access.token', userId: 123 } },
-          params: { certificationCourseId: 7 },
-        },
-        hFake,
-        {
-          checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
-        },
-      );
+        // when
+        const response = await evaluationSecurityPreHandlers.checkUserOwnsCertificationCourse(
+          {
+            auth: { credentials: { accessToken: 'valid.access.token', userId: 123 } },
+            params: { certificationCourseId: 7 },
+          },
+          hFake,
+          {
+            checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
+          },
+        );
 
-      // then
-      expect(response.source).to.be.true;
-      expect(preHandlerStub).to.have.been.calledOnceWithExactly({ userId: 123, certificationCourseId: 7 });
+        // then
+        expect(response.source).to.be.true;
+        expect(preHandlerStub).to.have.been.calledOnceWithExactly({ userId: 123, certificationCourseId: 7 });
+      });
+    });
+
+    context('Error cases', function () {
+      it('should forbid resource access when user does not own the certification course', async function () {
+        // given
+        const preHandlerStub = sinon.stub();
+        const checkUserOwnsCertificationCourseUseCaseStub = {
+          execute: preHandlerStub.resolves(false),
+        };
+
+        // when
+        const response = await evaluationSecurityPreHandlers.checkUserOwnsCertificationCourse(
+          {
+            auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } },
+            params: { certificationCourseId: 5678 },
+          },
+          hFake,
+          {
+            checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
+          },
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+        expect(preHandlerStub).to.have.been.calledOnceWithExactly({ userId: 1, certificationCourseId: 5678 });
+      });
+
+      it('should forbid resource access when an error is thrown by use case', async function () {
+        // given
+        const preHandlerStub = sinon.stub();
+        const checkUserOwnsCertificationCourseUseCaseStub = {
+          execute: preHandlerStub.rejects(new Error('Some error')),
+        };
+
+        // when
+        const response = await evaluationSecurityPreHandlers.checkUserOwnsCertificationCourse(
+          {
+            auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } },
+            params: { certificationCourseId: 5678 },
+          },
+          hFake,
+          {
+            checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
+          },
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+        expect(preHandlerStub).to.have.been.calledOnceWithExactly({ userId: 1, certificationCourseId: 5678 });
+      });
     });
   });
 
-  context('Error cases', function () {
-    it('should forbid resource access when user does not own the certification course', async function () {
-      // given
-      const preHandlerStub = sinon.stub();
-      const checkUserOwnsCertificationCourseUseCaseStub = {
-        execute: preHandlerStub.resolves(false),
+  describe('#checkUserOwnsAssessment', function () {
+    let assessmentRepository;
+    let validationErrorSerializer;
+
+    beforeEach(function () {
+      assessmentRepository = {
+        getByAssessmentIdAndUserId: sinon.stub(),
       };
-
-      // when
-      const response = await evaluationSecurityPreHandlers.checkUserOwnsCertificationCourse(
-        {
-          auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } },
-          params: { certificationCourseId: 5678 },
-        },
-        hFake,
-        {
-          checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
-        },
-      );
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      expect(response.isTakeOver).to.be.true;
-      expect(preHandlerStub).to.have.been.calledOnceWithExactly({ userId: 1, certificationCourseId: 5678 });
+      validationErrorSerializer = { serialize: sinon.stub() };
     });
 
-    it('should forbid resource access when an error is thrown by use case', async function () {
-      // given
-      const preHandlerStub = sinon.stub();
-      const checkUserOwnsCertificationCourseUseCaseStub = {
-        execute: preHandlerStub.rejects(new Error('Some error')),
-      };
+    describe('When user is the owner of the assessment', function () {
+      it('should return the assessment', async function () {
+        // given
+        const request = {
+          headers: generateAuthenticatedUserRequestHeaders({ userId: 100 }),
+          params: {
+            id: 8,
+          },
+        };
+        const fetchedAssessment = {};
+        assessmentRepository.getByAssessmentIdAndUserId.resolves(fetchedAssessment);
 
-      // when
-      const response = await evaluationSecurityPreHandlers.checkUserOwnsCertificationCourse(
-        {
-          auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } },
-          params: { certificationCourseId: 5678 },
-        },
-        hFake,
-        {
-          checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
-        },
-      );
+        // when
+        const response = await evaluationSecurityPreHandlers.checkUserOwnsAssessment(request, hFake, {
+          assessmentRepository,
+          validationErrorSerializer,
+        });
 
-      // then
-      expect(response.statusCode).to.equal(403);
-      expect(response.isTakeOver).to.be.true;
-      expect(preHandlerStub).to.have.been.calledOnceWithExactly({ userId: 1, certificationCourseId: 5678 });
+        // then
+        sinon.assert.calledWith(assessmentRepository.getByAssessmentIdAndUserId, 8, 100);
+        expect(response).to.deep.equal({});
+      });
+    });
+
+    describe('When the assessment has no owner', function () {
+      it('should return the assessment', async function () {
+        // given
+        const request = {
+          params: {
+            id: 8,
+          },
+        };
+        const fetchedAssessment = {};
+        assessmentRepository.getByAssessmentIdAndUserId.resolves(fetchedAssessment);
+
+        // when
+        const response = await evaluationSecurityPreHandlers.checkUserOwnsAssessment(request, hFake, {
+          assessmentRepository,
+          validationErrorSerializer,
+        });
+
+        // then
+        sinon.assert.calledWith(assessmentRepository.getByAssessmentIdAndUserId, 8, null);
+        expect(response).to.deep.equal({});
+      });
+    });
+
+    describe('When user is not the owner of the assessment', function () {
+      it('should return a status 401', async function () {
+        // given
+        const request = {
+          headers: generateAuthenticatedUserRequestHeaders({ userId: 101 }),
+          params: {
+            id: 8,
+          },
+        };
+        assessmentRepository.getByAssessmentIdAndUserId.rejects();
+
+        // when
+        const response = await evaluationSecurityPreHandlers.checkUserOwnsAssessment(request, hFake, {
+          assessmentRepository,
+          validationErrorSerializer,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
     });
   });
 });


### PR DESCRIPTION
## ☀️ Problème

On importe un pre-handler d'évaluation dans certification pour les routes companion-alert et live-alert

## ⛱️ Proposition
Ajouter ce pré-handler côté certif pour ne plus l'importer d'évaluation

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
Générer une alerte en certif et une alerte pix companion
