### PR TITLE
[TECH] Ajouter un modèle Answer spécifique à certification/evaluation

### DIFF
--- a/api/src/certification/evaluation/domain/models/Answer.js
+++ b/api/src/certification/evaluation/domain/models/Answer.js
@@ -1,0 +1,15 @@
+import { AnswerStatus } from '../../../../shared/domain/models/AnswerStatus.js';
+
+class Answer {
+  constructor({ id, result, challengeId } = {}) {
+    this.id = id;
+    this.result = AnswerStatus.from(result);
+    this.challengeId = challengeId;
+  }
+
+  isOk() {
+    return this.result.isOK();
+  }
+}
+
+export { Answer };

--- a/api/src/certification/evaluation/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
@@ -1,4 +1,4 @@
-import { Answer } from '../../../../evaluation/domain/models/Answer.js';
+import { Answer } from './Answer.js';
 
 export class AssessmentSimulatorSingleMeasureStrategy {
   constructor({ algorithm, challenges, pickChallenge, pickAnswerStatus, initialCapacity }) {

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
+import { Answer } from '../../../../../../src/certification/evaluation/domain/models/Answer.js';
 import { AssessmentSimulatorSingleMeasureStrategy } from '../../../../../../src/certification/evaluation/domain/models/AssessmentSimulatorSingleMeasureStrategy.js';
-import { Answer } from '../../../../../../src/evaluation/domain/models/Answer.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';


### PR DESCRIPTION
## ☀️ Problème

On importe dans certification/evaluation le modèle Answer de evaluation et une grande partie de ce modèle n'est pas utile à certif.

## ⛱️ Proposition

Créer un modèle Answer spécifique à certification/evaluation qui ne contienne uniquement ce dont le contexte à besoin et ainsi ne plus importer celui de evaluation.

## 🧴 Remarques

Ce qui peut devenir perturbant avec l'ajout de ce modèle c'est que le modèle Answer de shared est utilisé partout ailleurs dans certification/shared et que ce serait un gros chantier que de déplacer tous ces usages vers le modèle Answer du contexte. Cependant, je me dis que la création de ce modèle peut encourager à migrer progressivement les usages.

## 🏊 Pour tester

Tests E2E verts :heavy_check_mark: 

