### PR TITLE
[TECH] Ajouter une dépendance manquante pour le lint de certif.

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -61,6 +61,7 @@
         "ember-template-lint-plugin-prettier": "^5.0.0",
         "ember-truth-helpers": "^5.0.0",
         "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-chai-expect": "^4.0.0",
         "eslint-plugin-ember": "^13.0.0",
         "eslint-plugin-i18n-json": "^4.0.1",
@@ -19016,6 +19017,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
+      "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-context": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -102,6 +102,7 @@
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "ember-truth-helpers": "^5.0.0",
     "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-chai-expect": "^4.0.0",
     "eslint-plugin-ember": "^13.0.0",
     "eslint-plugin-i18n-json": "^4.0.1",


### PR DESCRIPTION
## ☀️ Problème
Suite à un nettoyage des dépendances dans cette [PR](https://github.com/1024pix/pix/pull/17044), il manque en manque une pour le lint utilisé pour le scope certif

## ⛱️ Proposition
Remettre la dépendance manquante.

## 🧴 Remarques
Cette erreur est arrivée sans qu'on puisse s'en apercevoir, car la modification des dépendances racine ne relance pas un `lint` des dossiers enfants.

## 🏊 Pour tester
CI verte 🤞🏻 