### PR TITLE
[TECH] :recycle: Renomme un élément de `CandidateAuthorization` à propos de la session

### DIFF
--- a/api/src/certification/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/certification/evaluation/application/http-error-mapper-configuration.js
@@ -10,7 +10,7 @@ import {
   CenterNotHabilitatedError,
   CertificationDurationExceededError,
   NextChallengeAlreadyComputingError,
-  SessionNotAccessibleError,
+  SessionNotJoinableError,
 } from '../domain/errors.js';
 
 const evaluationDomainErrorMappingConfiguration = [
@@ -31,7 +31,7 @@ const evaluationDomainErrorMappingConfiguration = [
     httpErrorFn: (error) => new ForbiddenError(error.message, error.code, error.meta),
   },
   {
-    name: SessionNotAccessibleError.name,
+    name: SessionNotJoinableError.name,
     httpErrorFn: (error) => new PreconditionFailedError(error.message, error.code, error.meta),
   },
   {

--- a/api/src/certification/evaluation/domain/errors.js
+++ b/api/src/certification/evaluation/domain/errors.js
@@ -39,8 +39,8 @@ export class CandidateNotAuthorizedToResumeCertificationTestError extends Domain
   }
 }
 
-export class SessionNotAccessibleError extends DomainError {
-  constructor(message = 'Certification session is not accessible', code = 'SESSION_NOT_ACCESSIBLE') {
+export class SessionNotJoinableError extends DomainError {
+  constructor(message = 'Certification session is not joinable', code = 'SESSION_NOT_JOINABLE') {
     super(message, code);
   }
 }

--- a/api/src/certification/evaluation/domain/models/CandidateAuthorization.js
+++ b/api/src/certification/evaluation/domain/models/CandidateAuthorization.js
@@ -3,14 +3,14 @@ import {
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
   CenterNotHabilitatedError,
-  SessionNotAccessibleError,
+  SessionNotJoinableError,
 } from '../errors.js';
 
 export class CandidateAuthorization {
   constructor({
     id,
     accessCode,
-    isSessionAccessible,
+    isSessionJoinable,
     userId,
     reconciledAt,
     subscription,
@@ -21,7 +21,7 @@ export class CandidateAuthorization {
   }) {
     this.id = id;
     this.accessCode = accessCode;
-    this.isSessionAccessible = isSessionAccessible;
+    this.isSessionJoinable = isSessionJoinable;
     this.userId = userId;
     this.reconciledAt = reconciledAt;
     this.subscription = subscription;
@@ -37,7 +37,7 @@ export class CandidateAuthorization {
     if (!this.isCenterHabilitatedForCandidateSubscription) {
       throw new CenterNotHabilitatedError();
     }
-    if (!this.hasStartedCertification && !this.isSessionAccessible) throw new SessionNotAccessibleError();
+    if (!this.hasStartedCertification && !this.isSessionJoinable) throw new SessionNotJoinableError();
     if (!this.authorizedToStart) {
       if (this.hasStartedCertification) {
         throw new CandidateNotAuthorizedToResumeCertificationTestError();

--- a/api/src/certification/evaluation/infrastructure/adapters/candidate-authorization-adapter.js
+++ b/api/src/certification/evaluation/infrastructure/adapters/candidate-authorization-adapter.js
@@ -19,7 +19,7 @@ export async function find({ userId, sessionId, dependencies = { candidateAuthor
   return new CandidateAuthorization({
     id: candidateAuthorizationDTO.id,
     accessCode: candidateAuthorizationDTO.accessCode,
-    isSessionAccessible: candidateAuthorizationDTO.isSessionAccessible,
+    isSessionJoinable: candidateAuthorizationDTO.isSessionJoinable,
     userId: candidateAuthorizationDTO.userId,
     reconciledAt: candidateAuthorizationDTO.reconciledAt,
     subscription: candidateAuthorizationDTO.subscription,

--- a/api/src/certification/session-management/application/api/candidate-authorization-api.js
+++ b/api/src/certification/session-management/application/api/candidate-authorization-api.js
@@ -4,7 +4,7 @@ import * as candidateAuthorizationInfoRepository from '../../infrastructure/repo
  * @typedef {Object} DTOCandidateAuthorization
  * @property {number} id
  * @property {string} accessCode
- * @property {boolean} isSessionAccessible
+ * @property {boolean} isSessionJoinable
  * @property {number} userId
  * @property {boolean} authorizedToStart
  * @property {number} certificationId
@@ -39,7 +39,7 @@ export async function findByUserIdAndSessionId({
   return {
     id: candidateAuthorizationInfo.id,
     accessCode: candidateAuthorizationInfo.sessionAccessCode,
-    isSessionAccessible: candidateAuthorizationInfo.isSessionAccessible,
+    isSessionJoinable: candidateAuthorizationInfo.isSessionJoinable,
     userId: candidateAuthorizationInfo.reconciledUserId,
     reconciledAt: candidateAuthorizationInfo.reconciledAt,
     subscription: candidateAuthorizationInfo.subscription,

--- a/api/src/certification/session-management/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session-management/application/http-error-mapper-configuration.js
@@ -16,7 +16,7 @@ import {
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionFinalized,
-  SessionNotAccessible,
+  SessionNotJoinable,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,
 } from '../domain/errors.js';
@@ -47,7 +47,7 @@ const sessionDomainErrorMappingConfiguration = [
     httpErrorFn: (error) => new NotFoundError(error.message, error.code),
   },
   {
-    name: SessionNotAccessible.name,
+    name: SessionNotJoinable.name,
     httpErrorFn: (error) => new PreconditionFailedError(error.message, error.code, error.meta),
   },
   {

--- a/api/src/certification/session-management/domain/errors.js
+++ b/api/src/certification/session-management/domain/errors.js
@@ -66,9 +66,9 @@ class InvalidSessionSupervisingLoginError extends DomainError {
   }
 }
 
-class SessionNotAccessible extends DomainError {
+class SessionNotJoinable extends DomainError {
   constructor(blockedAccessDate) {
-    super('Certification session is not accessible', 'SESSION_NOT_ACCESSIBLE');
+    super('Certification session is not joinable', 'SESSION_NOT_JOINABLE');
     if (blockedAccessDate) {
       this.meta = { blockedAccessDate };
     }
@@ -112,7 +112,7 @@ export {
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionFinalized,
-  SessionNotAccessible,
+  SessionNotJoinable,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,
 };

--- a/api/src/certification/session-management/domain/models/SessionManagement.js
+++ b/api/src/certification/session-management/domain/models/SessionManagement.js
@@ -63,10 +63,6 @@ export class SessionManagement {
     return SESSION_STATUSES.CREATED;
   }
 
-  isAccessible() {
-    return this.status === SESSION_STATUSES.CREATED;
-  }
-
   isPublished() {
     return this.publishedAt !== null;
   }

--- a/api/src/certification/session-management/domain/read-models/CandidateAuthorizationInfo.js
+++ b/api/src/certification/session-management/domain/read-models/CandidateAuthorizationInfo.js
@@ -40,7 +40,7 @@ export class CandidateAuthorizationInfo {
     }
   }
 
-  get isSessionAccessible() {
+  get isSessionJoinable() {
     return !this.sessionFinalizedAt && !this.sessionIsOvertime;
   }
 

--- a/api/src/certification/session-management/domain/read-models/InvigilatorSession.js
+++ b/api/src/certification/session-management/domain/read-models/InvigilatorSession.js
@@ -8,7 +8,7 @@ class InvigilatorSession {
    */
   constructor({ finalizedAt, invigilatorPassword }) {
     this.invigilatorPassword = invigilatorPassword;
-    this.isNotAccessible = !!finalizedAt;
+    this.isNotJoinable = !!finalizedAt;
   }
 
   checkPassword(invigilatorPassword) {

--- a/api/src/certification/session-management/domain/usecases/supervise-session.js
+++ b/api/src/certification/session-management/domain/usecases/supervise-session.js
@@ -38,7 +38,7 @@ export const superviseSession = withTransaction(
 
     const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
 
-    if (session.isNotAccessible) {
+    if (session.isNotJoinable) {
       throw new SessionFinalized();
     }
 

--- a/api/src/certification/session-management/domain/usecases/supervise-session.js
+++ b/api/src/certification/session-management/domain/usecases/supervise-session.js
@@ -11,7 +11,7 @@ import {
   CertificationCenterIsArchivedError,
   InvalidSessionSupervisingLoginError,
   SessionFinalized,
-  SessionNotAccessible,
+  SessionNotJoinable,
 } from '../errors.js';
 
 export const superviseSession = withTransaction(
@@ -47,19 +47,19 @@ export const superviseSession = withTransaction(
     });
 
     if (certificationCenterAccess.isAccessBlockedCollege) {
-      throw new SessionNotAccessible(certificationCenterAccess.pixCertifScoBlockedAccessDateCollege);
+      throw new SessionNotJoinable(certificationCenterAccess.pixCertifScoBlockedAccessDateCollege);
     }
 
     if (certificationCenterAccess.isAccessBlockedLycee) {
-      throw new SessionNotAccessible(certificationCenterAccess.pixCertifScoBlockedAccessDateLycee);
+      throw new SessionNotJoinable(certificationCenterAccess.pixCertifScoBlockedAccessDateLycee);
     }
 
     if (certificationCenterAccess.isAccessBlockedAEFE) {
-      throw new SessionNotAccessible(certificationCenterAccess.pixCertifScoBlockedAccessDateLycee);
+      throw new SessionNotJoinable(certificationCenterAccess.pixCertifScoBlockedAccessDateLycee);
     }
 
     if (certificationCenterAccess.isAccessBlockedAgri) {
-      throw new SessionNotAccessible(certificationCenterAccess.pixCertifScoBlockedAccessDateLycee);
+      throw new SessionNotJoinable(certificationCenterAccess.pixCertifScoBlockedAccessDateLycee);
     }
 
     if (!session.checkPassword(invigilatorPassword)) {

--- a/api/tests/certification/evaluation/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/evaluation/unit/application/http-error-mapper-configuration_test.js
@@ -7,7 +7,7 @@ import {
   CenterNotHabilitatedError,
   CertificationDurationExceededError,
   NextChallengeAlreadyComputingError,
-  SessionNotAccessibleError,
+  SessionNotJoinableError,
 } from '../../../../../src/certification/evaluation/domain/errors.js';
 import {
   ConflictError,
@@ -88,20 +88,20 @@ describe('Unit | Certification | Evaluation | Application | HttpErrorMapperConfi
     });
   });
 
-  context('when mapping "SessionNotAccessible"', function () {
+  context('when mapping "SessionNotJoinable"', function () {
     it('returns an Precondition failed Http Error', function () {
       //given
       const httpErrorMapper = evaluationDomainErrorMappingConfiguration.find(
-        (httpErrorMapper) => httpErrorMapper.name === SessionNotAccessibleError.name,
+        (httpErrorMapper) => httpErrorMapper.name === SessionNotJoinableError.name,
       );
 
       //when
-      const error = httpErrorMapper.httpErrorFn(new SessionNotAccessibleError());
+      const error = httpErrorMapper.httpErrorFn(new SessionNotJoinableError());
 
       //then
       expect(error).to.be.instanceOf(PreconditionFailedError);
-      expect(error.message).to.equal('Certification session is not accessible');
-      expect(error.code).to.equal('SESSION_NOT_ACCESSIBLE');
+      expect(error.message).to.equal('Certification session is not joinable');
+      expect(error.code).to.equal('SESSION_NOT_JOINABLE');
     });
   });
 

--- a/api/tests/certification/evaluation/unit/domain/models/CandidateAuthorization_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/CandidateAuthorization_test.js
@@ -4,7 +4,7 @@ import {
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
   CenterNotHabilitatedError,
-  SessionNotAccessibleError,
+  SessionNotJoinableError,
 } from '../../../../../../src/certification/evaluation/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
@@ -16,7 +16,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
       it('throws a NotFoundError', function () {
         const candidateAuthorization = domainBuilder.certification.evaluation
           .candidateAuthorizationBuilder()
-          .withSession({ accessCode: 'ABCDEF', isAccessible: true })
+          .withSession({ accessCode: 'ABCDEF', isJoinable: true })
           .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
           .asAuthorizedToStart()
           .build();
@@ -27,16 +27,16 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
 
     context('when session is not accessible', function () {
       context('when candidate has not started the test yet', function () {
-        it('throws a SessionNotAccessible', function () {
+        it('throws a SessionNotJoinable', function () {
           const candidateAuthorization = domainBuilder.certification.evaluation
             .candidateAuthorizationBuilder()
-            .withSession({ accessCode: 'ABCDEF', isAccessible: false })
+            .withSession({ accessCode: 'ABCDEF', isJoinable: false })
             .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
             .asAuthorizedToStart()
             .build();
 
           expect(() => candidateAuthorization.verifyCanStartOrResumeCertification('ABCDEF')).to.throw(
-            SessionNotAccessibleError,
+            SessionNotJoinableError,
           );
         });
       });
@@ -45,7 +45,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
         it('returns (successful)', function () {
           const candidateAuthorization = domainBuilder.certification.evaluation
             .candidateAuthorizationBuilder()
-            .withSession({ accessCode: 'ABCDEF', isAccessible: false })
+            .withSession({ accessCode: 'ABCDEF', isJoinable: false })
             .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
             .asAuthorizedToStart()
             .hasACertification({ certificationId: 123 })
@@ -60,7 +60,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
       it('throws a CenterHabilitationError', function () {
         const candidateAuthorization = domainBuilder.certification.evaluation
           .candidateAuthorizationBuilder()
-          .withSession({ accessCode: 'ABCDEF', isAccessible: true })
+          .withSession({ accessCode: 'ABCDEF', isJoinable: true })
           .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: false })
           .asAuthorizedToStart()
           .build();
@@ -76,7 +76,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
         it('throws a CandidateNotAuthorizedToResumeCertificationTestError', function () {
           const candidateAuthorization = domainBuilder.certification.evaluation
             .candidateAuthorizationBuilder()
-            .withSession({ accessCode: 'ABCDEF', isAccessible: true })
+            .withSession({ accessCode: 'ABCDEF', isJoinable: true })
             .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
             .asNotAuthorizedToStart()
             .hasACertification({ certificationId: 123 })
@@ -92,7 +92,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
         it('throws a CandidateNotAuthorizedToJoinSessionError', function () {
           const candidateAuthorization = domainBuilder.certification.evaluation
             .candidateAuthorizationBuilder()
-            .withSession({ accessCode: 'ABCDEF', isAccessible: true })
+            .withSession({ accessCode: 'ABCDEF', isJoinable: true })
             .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
             .asNotAuthorizedToStart()
             .build();
@@ -107,13 +107,13 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate Author
         it('returns (successful)', function () {
           const candidateAuthorizationWithNoTestStarted = domainBuilder.certification.evaluation
             .candidateAuthorizationBuilder()
-            .withSession({ accessCode: 'ABCDEF', isAccessible: true })
+            .withSession({ accessCode: 'ABCDEF', isJoinable: true })
             .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
             .asAuthorizedToStart()
             .build();
           const candidateAuthorizationWithStartedTest = domainBuilder.certification.evaluation
             .candidateAuthorizationBuilder()
-            .withSession({ accessCode: 'ABCDEF', isAccessible: true })
+            .withSession({ accessCode: 'ABCDEF', isJoinable: true })
             .subscribedTo({ framework: Frameworks.CLEA, isCenterHabilitated: true })
             .asAuthorizedToStart()
             .hasACertification({ certificationId: 123 })

--- a/api/tests/certification/evaluation/unit/infrastructure/adapters/candidate-authorization-adapter_test.js
+++ b/api/tests/certification/evaluation/unit/infrastructure/adapters/candidate-authorization-adapter_test.js
@@ -38,7 +38,7 @@ describe('Certification | Evaluation | Unit | Adapter | Candidate authorization'
         candidateAuthorizationApi.findByUserIdAndSessionId.withArgs({ userId: 123, sessionId: 456 }).resolves({
           id: 789,
           accessCode: 'EXPEDITION33',
-          isSessionAccessible: true,
+          isSessionJoinable: true,
           userId: 123,
           reconciledAt: new Date('2023-12-11'),
           subscription: Frameworks.DROIT,
@@ -57,7 +57,7 @@ describe('Certification | Evaluation | Unit | Adapter | Candidate authorization'
         expect(candidateAuthorization).to.deepEqualInstance(
           domainBuilder.certification.evaluation
             .candidateAuthorizationBuilder()
-            .withSession({ accessCode: 'EXPEDITION33', isAccessible: true })
+            .withSession({ accessCode: 'EXPEDITION33', isJoinable: true })
             .reconciled({ userId: 123, at: new Date('2023-12-11') })
             .subscribedTo({ framework: Frameworks.DROIT, isCenterHabilitated: true })
             .asAuthorizedToStart()

--- a/api/tests/certification/session-management/integration/application/api/candidate-authorization-api_test.js
+++ b/api/tests/certification/session-management/integration/application/api/candidate-authorization-api_test.js
@@ -69,7 +69,7 @@ describe('Certification | Session Management | Integration | Application | Api |
       // then
       expect(candidateAuthorizationDTO).to.deep.equal({
         id: 3,
-        isSessionAccessible: false,
+        isSessionJoinable: false,
         accessCode: 'CHACHACHA',
         userId: 2,
         authorizedToStart: true,

--- a/api/tests/certification/session-management/unit/domain/errors_test.js
+++ b/api/tests/certification/session-management/unit/domain/errors_test.js
@@ -22,8 +22,8 @@ describe('Certification | session-management | Unit | Domain | Errors', function
     expect(errors.ChallengeToBeNeutralizedNotFoundError).to.exist;
   });
 
-  it('should export a SessionNotAccessible error', function () {
-    expect(errors.SessionNotAccessible).to.exist;
+  it('should export a SessionNotJoinable error', function () {
+    expect(errors.SessionNotJoinable).to.exist;
   });
 
   it('should export a SessionFinalized error', function () {

--- a/api/tests/certification/session-management/unit/domain/models/SessionManagement_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/SessionManagement_test.js
@@ -144,28 +144,6 @@ describe('Unit | Certification | Session | Domain | Models | SessionManagement',
     });
   });
 
-  context('#isNotAccessible', function () {
-    it('returns true when the session is created', function () {
-      const session = domainBuilder.certification.sessionManagement.buildSessionManagement.created();
-      expect(session.isAccessible()).to.be.true;
-    });
-
-    it('returns false when the session is finalized', function () {
-      const session = domainBuilder.certification.sessionManagement.buildSessionManagement.finalized();
-      expect(session.isAccessible()).to.be.false;
-    });
-
-    it('returns false when the session is in process', function () {
-      const session = domainBuilder.certification.sessionManagement.buildSessionManagement.inProcess();
-      expect(session.isAccessible()).to.be.false;
-    });
-
-    it('returns false when the session is processed', function () {
-      const session = domainBuilder.certification.sessionManagement.buildSessionManagement.processed();
-      expect(session.isAccessible()).to.be.false;
-    });
-  });
-
   describe('#get hasExpired', function () {
     it('returns false when session has no started certification', function () {
       const session = domainBuilder.certification.sessionManagement.buildSessionManagement({

--- a/api/tests/certification/session-management/unit/domain/read-models/CandidateAuthorizationInfo_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/CandidateAuthorizationInfo_test.js
@@ -18,7 +18,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Can
     clock.restore();
   });
 
-  describe('#isSessionAccessible', function () {
+  describe('#isSessionJoinable', function () {
     it('returns true when session is neither finalized nor overtime', function () {
       const twentyThreeHoursBefore = new Date();
       twentyThreeHoursBefore.setHours(twentyThreeHoursBefore.getHours() - 23);
@@ -27,7 +27,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Can
         .withSession({ finalizedAt: null, startedAt: twentyThreeHoursBefore })
         .build();
 
-      expect(candidateAuthorizationInfo.isSessionAccessible).to.be.true;
+      expect(candidateAuthorizationInfo.isSessionJoinable).to.be.true;
     });
 
     it('returns false when session is finalized', function () {
@@ -38,7 +38,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Can
         .withSession({ finalizedAt: new Date(), startedAt: twentyThreeHoursBefore })
         .build();
 
-      expect(candidateAuthorizationInfo.isSessionAccessible).to.be.false;
+      expect(candidateAuthorizationInfo.isSessionJoinable).to.be.false;
     });
 
     it('returns false when session has been started more than 24 hours before and thus is overtime', function () {
@@ -49,7 +49,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Can
         .withSession({ finalizedAt: null, startedAt: twentyFiveHoursBefore })
         .build();
 
-      expect(candidateAuthorizationInfo.isSessionAccessible).to.be.false;
+      expect(candidateAuthorizationInfo.isSessionJoinable).to.be.false;
     });
   });
 

--- a/api/tests/certification/session-management/unit/domain/read-models/InvigilatorSession_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/InvigilatorSession_test.js
@@ -2,15 +2,17 @@ import { InvigilatorSession } from '../../../../../../src/certification/session-
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Certification | Session | Domain | Models | InvigilatorSession', function () {
-  context('#isNotAccessible', function () {
+  context('#isNotJoinable', function () {
     it(`returns false when the session doesn't have finalized date`, function () {
       const invigilatorSession = new InvigilatorSession({ finalizedAt: null });
-      expect(invigilatorSession.isNotAccessible).to.be.false;
+      expect(invigilatorSession.isNotJoinable).to.be.false;
     });
 
     it('returns true when the session has finalized date', function () {
-      const invigilatorSession = new InvigilatorSession({ finalizedAt: new Date() });
-      expect(invigilatorSession.isNotAccessible).to.be.true;
+      const invigilatorSession = new InvigilatorSession({
+        finalizedAt: new Date(),
+      });
+      expect(invigilatorSession.isNotJoinable).to.be.true;
     });
   });
 

--- a/api/tests/certification/session-management/unit/domain/usecases/supervise-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/supervise-session_test.js
@@ -4,7 +4,7 @@ import {
   CertificationCenterIsArchivedError,
   InvalidSessionSupervisingLoginError,
   SessionFinalized,
-  SessionNotAccessible,
+  SessionNotJoinable,
 } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { InvigilatorSession } from '../../../../../../src/certification/session-management/domain/read-models/InvigilatorSession.js';
 import { superviseSession } from '../../../../../../src/certification/session-management/domain/usecases/supervise-session.js';
@@ -132,7 +132,7 @@ describe('Unit | UseCase | supervise-session', function () {
   });
 
   context('when certification center has SCO blocked access', function () {
-    it('should throw SessionNotAccessible when college is blocked', async function () {
+    it('should throw SessionNotJoinable when college is blocked', async function () {
       // given
       const sessionId = 123;
       const certificationCenterId = 456;
@@ -161,7 +161,7 @@ describe('Unit | UseCase | supervise-session', function () {
       });
 
       // then
-      expect(error).to.be.an.instanceOf(SessionNotAccessible);
+      expect(error).to.be.an.instanceOf(SessionNotJoinable);
     });
   });
 

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate-authorization.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate-authorization.js
@@ -10,7 +10,7 @@ const THIRTY_HOURS_IN_MS = 30 * 60 * 60 * 1000;
  * Fluent builder for the {@link CandidateAuthorization} domain model.
  *
  * @example
- * const candidateAuthorization = domainBuilder.certification.sessionManagement
+ * const candidateAuthorization = domainBuilder.certification.evaluation
  *   .candidateAuthorizationBuilder()
  *   .withSession()
  *   .asAuthorizedToStart()
@@ -22,7 +22,7 @@ class CandidateAuthorizationBuilder {
     this.id = null;
     this.accessCode = 'ABC123';
     this.sessionId = null;
-    this.isSessionAccessible = true;
+    this.isSessionJoinable = true;
     this.userId = null;
     this.reconciledAt = null;
     this.subscription = Frameworks.CORE;
@@ -39,12 +39,12 @@ class CandidateAuthorizationBuilder {
    * @param {object} [params]
    * @param {number} [params.sessionId] - explicit id; without it, insertToDB lets the database assign one and build() produces a non-persisted session (id null)
    * @param {string} [params.accessCode]
-   * @param {boolean} [params.isAccessible]
+   * @param {boolean} [params.isJoinable]
    * @returns {CandidateAuthorizationBuilder}
    */
-  withSession({ sessionId = null, accessCode = 'ABC123', isAccessible = true } = {}) {
+  withSession({ sessionId = null, accessCode = 'ABC123', isJoinable = true } = {}) {
     this.sessionId = sessionId;
-    this.isSessionAccessible = isAccessible;
+    this.isSessionJoinable = isJoinable;
     this.accessCode = accessCode;
     return this;
   }
@@ -155,7 +155,7 @@ class CandidateAuthorizationBuilder {
     const sessionId = databaseBuilder.factory.buildSession({
       id: this.sessionId ?? undefined,
       accessCode: candidateAuthorization.accessCode,
-      finalizedAt: candidateAuthorization.isSessionAccessible ? new Date() : null,
+      finalizedAt: candidateAuthorization.isSessionJoinable ? new Date() : null,
       publishedAt: null,
       certificationCenterId,
     }).id;
@@ -202,7 +202,7 @@ class CandidateAuthorizationBuilder {
   build() {
     return new CandidateAuthorization({
       id: this.id,
-      isSessionAccessible: this.isSessionAccessible,
+      isSessionJoinable: this.isSessionJoinable,
       accessCode: this.accessCode,
       userId: this.userId,
       reconciledAt: this.reconciledAt,

--- a/certif/app/components/login-session-invigilator/form.gjs
+++ b/certif/app/components/login-session-invigilator/form.gjs
@@ -51,8 +51,8 @@ export default class LoginSessionInvigilator extends Component {
         case 'SESSION_FINALIZED':
           this.formError = this.intl.t('pages.session-supervising.login.form.errors.session-finalized');
           break;
-        case 'SESSION_NOT_ACCESSIBLE':
-          this.formError = this.intl.t('pages.session-supervising.login.form.errors.session-not-accessible', {
+        case 'SESSION_NOT_JOINABLE':
+          this.formError = this.intl.t('pages.session-supervising.login.form.errors.session-not-joinable', {
             date: dayjsUtcFormat([error.meta?.blockedAccessDate, 'DD/MM/YYYY'], {}),
           });
           break;

--- a/certif/tests/integration/components/login-session-invigilator/form-test.gjs
+++ b/certif/tests/integration/components/login-session-invigilator/form-test.gjs
@@ -131,7 +131,7 @@ module('Integration | Component | Login session invigilator | Form', function (h
         const blockedAccessDate = '2025-09-01';
         const authenticateInvigilator = sinon
           .stub()
-          .rejects({ errors: [{ code: 'SESSION_NOT_ACCESSIBLE', meta: { blockedAccessDate } }] });
+          .rejects({ errors: [{ code: 'SESSION_NOT_JOINABLE', meta: { blockedAccessDate } }] });
 
         // when
         const screen = await render(
@@ -153,7 +153,7 @@ module('Integration | Component | Login session invigilator | Form', function (h
         assert
           .dom(
             within(screen.getByRole('alert')).getByText(
-              t('pages.session-supervising.login.form.errors.session-not-accessible', { date: '01/09/2025' }),
+              t('pages.session-supervising.login.form.errors.session-not-joinable', { date: '01/09/2025' }),
             ),
           )
           .exists();

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -591,7 +591,7 @@
             "incorrect-data": "The session number and/or the session password entered are incorrect.",
             "mandatory-fields": "The fields “Session number” and “Session password” are required.",
             "session-finalized": "The session has been finalized. Access to its invigilator space is no longer possible.",
-            "session-not-accessible": "Opening of your PixCertif space on {date} (00:00, Metropolitan France time)."
+            "session-not-joinable": "Opening of your PixCertif space on {date} (00:00, Metropolitan France time)."
           },
           "session-number": "Session number",
           "session-password": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -591,7 +591,7 @@
             "incorrect-data": "Le numéro de session et/ou le mot de passe saisis sont incorrects.",
             "mandatory-fields": "Les champs \"Numéro de la session\" et \"Mot de passe de session\" sont obligatoires.",
             "session-finalized": "La session a été finalisée. L'accès à son espace surveillant n'est plus possible.",
-            "session-not-accessible": "Ouverture de votre espace PixCertif le {date} (00h00, heure France métropolitaine)."
+            "session-not-joinable": "Ouverture de votre espace PixCertif le {date} (00h00, heure France métropolitaine)."
           },
           "session-number": "Numéro de la session",
           "session-password": {

--- a/mon-pix/app/components/certification-joiner.gjs
+++ b/mon-pix/app/components/certification-joiner.gjs
@@ -330,7 +330,7 @@ const ERROR_HANDLERS = [
   {
     match: (error) => error.status === '412',
     handle(component) {
-      component.errorMessage = component.intl.t('pages.certification-joiner.error-messages.session-not-accessible');
+      component.errorMessage = component.intl.t('pages.certification-joiner.error-messages.session-not-joinable');
     },
   },
   {

--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -154,7 +154,7 @@ export default class CertificationStarter extends Component {
 
     const ERROR_MESSAGE_KEYS = {
       404: 'pages.certification-start.error-messages.access-code-error',
-      412: 'pages.certification-start.error-messages.session-not-accessible',
+      412: 'pages.certification-start.error-messages.session-not-joinable',
     };
 
     const FORBIDDEN_ERROR_MESSAGE_KEYS = {

--- a/mon-pix/tests/integration/components/certification-starter-test.gjs
+++ b/mon-pix/tests/integration/components/certification-starter-test.gjs
@@ -429,7 +429,7 @@ module('Integration | Component | certification-starter', function (hooks) {
           await submitForm();
 
           // then
-          assert.ok(screen.getByText(t('pages.certification-start.error-messages.session-not-accessible')));
+          assert.ok(screen.getByText(t('pages.certification-start.error-messages.session-not-joinable')));
         });
 
         test('should display the appropriate error message when the certification duration has been exceeded', async function (assert) {

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -890,7 +890,7 @@
         "language-not-supported": "Die Pix-Zertifizierung ist derzeit nicht in {userLanguage} verfügbar. '<br>' Die derzeit verfügbaren Sprachen, um die Zertifizierung zu absolvieren, sind : {availableLanguages}. '<br>' Du kannst eine andere Sprache von der Seite",
         "language-not-supported-link": "Mein Konto",
         "missing-center-habilitation": "Du bist für die Zertifizierung {subscription} angemeldet. '<br><br><strong>'Deine Zertifizierungsstelle ist nicht mehr berechtigt, diese Zertifizierung abzunehmen'</strong>'. '<br><br>' Bitte wende dich an deine Aufsichtsperson.",
-        "session-not-accessible": "Die Testung, an der du versuchst teilzunehmen, ist nicht mehr zugänglich.",
+        "session-not-joinable": "Die Testung, an der du versuchst teilzunehmen, ist nicht mehr zugänglich.",
         "wrong-account": "Die eingegebenen Informationen beziehen sich auf einen Kandidaten/eine Kandidatin, der/die sich für die Testung angemeldet hat und bereits mit einem anderen Konto angemeldet ist. Vergewissere dich, dass du mit dem Konto verbunden bist, das die Zertifizierung gestartet hat.",
         "wrong-account-sco": "Du verwendest derzeit ein Konto, das nicht mit deiner Organisation verknüpft ist.\nMelde dich bei dem Konto an, mit dem du deine Laufwege absolviert hast, oder bitte die Aufsichtsperson um Hilfe.",
         "wrong-account-sco-link": {
@@ -968,7 +968,7 @@
         "duration-exceeded": "Die maximale Dauer deines Zertifizierungstests wurde überschritten. Du kannst ihn nicht mehr fortsetzen.",
         "generic": "Ein unerwarteter Serverfehler ist aufgetreten.",
         "missing-code": "Dein Zugangscode ist nicht ausgefüllt.",
-        "session-not-accessible": "Die Zertifizierungssitzung ist nicht mehr zugänglich.",
+        "session-not-joinable": "Die Zertifizierungssitzung ist nicht mehr zugänglich.",
         "unknown": {
           "summary-label": "Weitere Details anzeigen :"
         }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -890,7 +890,7 @@
         "language-not-supported": "The Pix certification is not yet available in {userLanguage}. '<br>' The languages currently available for taking the certification exam are: {availableLanguages}. '<br>' You may choose another language from ",
         "language-not-supported-link": "My account page",
         "missing-center-habilitation": "You are registered for the {subscription} certification. '<br><br><strong>'Your certification centre is no longer authorized to administer this certification'</strong>'. '<br><br>' Please contact your invigilator.",
-        "session-not-accessible": "The session you are trying to join is no longer available.",
+        "session-not-joinable": "The session you are trying to join is no longer available.",
         "wrong-account": "The information entered matches a candidate enrolled in the session and already logged in with another account. Please check that you are logged into the account that started the exam.",
         "wrong-account-sco": "You are currently using an account that is not linked to your school/organisation.\nLog in to the account you used to complete your customised tests or ask the invigilator for help.",
         "wrong-account-sco-link": {
@@ -968,7 +968,7 @@
         "duration-exceeded": "The maximum duration of your certification test has been exceeded. You can no longer resume it.",
         "generic": "An unexpected server error has occurred.",
         "missing-code": "You have not entered your access code.",
-        "session-not-accessible": "The certification session is no longer available.",
+        "session-not-joinable": "The certification session is no longer available.",
         "unknown": {
           "summary-label": "Show more details:"
         }

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -890,7 +890,7 @@
         "language-not-supported": "La certificación Pix aún no está disponible en {userLanguage}. '<br>' Los idiomas disponibles actualmente para la certificación son: {availableLanguages}. '<br>' Puedes elegir otro idioma en la página",
         "language-not-supported-link": "Mi cuenta",
         "missing-center-habilitation": "Estás inscrito en la certificación {subscription}. '<br><br><strong>'Tu centro de certificación ya no está autorizado para realizar esta certificación'</strong>'. '<br><br>' Por favor, ponte en contacto con tu supervisor.",
-        "session-not-accessible": "La sesión a la que intentas unirte ya no está disponible.",
+        "session-not-joinable": "La sesión a la que intentas unirte ya no está disponible.",
         "wrong-account": "La información introducida corresponde a un candidato registrado en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
         "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus test o pide ayuda al supervisor.",
         "wrong-account-sco-link": {
@@ -968,7 +968,7 @@
         "duration-exceeded": "Se ha superado la duración máxima de tu prueba de certificación. Ya no puedes reanudarla.",
         "generic": "Acaba de producirse un error inesperado en el servidor.",
         "missing-code": "No has introducido tu código de acceso.",
-        "session-not-accessible": "La sesión de certificación ya no está disponible.",
+        "session-not-joinable": "La sesión de certificación ya no está disponible.",
         "unknown": {
           "summary-label": "Ver más detalles:"
         }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -890,7 +890,7 @@
         "language-not-supported": "La certification Pix n'est pas encore disponible en {userLanguage}. '<br>' Les langues disponibles actuellement pour passer la certification sont : {availableLanguages}. '<br>' Vous pouvez choisir une autre langue depuis la page ",
         "language-not-supported-link": "Mon compte",
         "missing-center-habilitation": "Vous êtes inscrit à la certification {subscription}. '<br><br><strong>'Votre centre de certification n'est plus habilité à faire passer cette certification'</strong>'. '<br><br>' Merci de vous rapprocher de votre surveillant.",
-        "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
+        "session-not-joinable": "La session que vous tentez de rejoindre n'est plus accessible.",
         "wrong-account": "Les informations saisies correspondent à un(e) candidat(e) inscrit(e) à la session et déjà connecté(e) avec un autre compte. Vérifiez que vous êtes connecté(e) au compte qui a démarré la certification.",
         "wrong-account-sco": "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement.\nConnectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant.",
         "wrong-account-sco-link": {
@@ -968,7 +968,7 @@
         "duration-exceeded": "La durée maximale de votre test de certification a été dépassée. Vous ne pouvez plus le reprendre.",
         "generic": "Une erreur serveur inattendue vient de se produire.",
         "missing-code": "Votre code d'accès n'est pas renseigné.",
-        "session-not-accessible": "La session de certification n'est plus accessible.",
+        "session-not-joinable": "La session de certification n'est plus accessible.",
         "unknown": {
           "summary-label": "Afficher plus de détails :"
         }

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -890,7 +890,7 @@
         "language-not-supported": "La certificazione Pix non è ancora disponibile in {userLanguage}. '<br>' Le lingue attualmente disponibili per ottenere la certificazione sono: {availableLanguages}. '<br>' È possibile scegli un'altra lingua dalla pagina",
         "language-not-supported-link": "Il mio account",
         "missing-center-habilitation": "Sei iscritto alla certificazione {subscription}. '<br><br><strong>'Il tuo centro di certificazione non è più autorizzato a rilasciare questa certificazione'</strong>'. '<br><br>' Ti preghiamo di rivolgerti al tuo sorvegliante.",
-        "session-not-accessible": "La sessione a cui si sta cercando di accedere non è più accessibile.",
+        "session-not-joinable": "La sessione a cui si sta cercando di accedere non è più accessibile.",
         "wrong-account": "Le informazioni inserisci corrispondono a un candidato registrato per la sessione e già loggato con un altro account. Verificare di aver effettuato l'accesso con l'account che ha avviato la certificazione.",
         "wrong-account-sco": "Si sta utilizzando un account non collegato alla propria scuola.\nAccedi all'account con cui hai completato i corsi o chiedete aiuto al tuo sorvegliante.",
         "wrong-account-sco-link": {
@@ -968,7 +968,7 @@
         "duration-exceeded": "La durata massima della tua prova di certificazione è stata superata. Non puoi più riprenderla.",
         "generic": "Si è appena verificato un errore inatteso del server.",
         "missing-code": "Il codice di accesso non è stato inserito.",
-        "session-not-accessible": "La sessione di certificazione non è più accessibile.",
+        "session-not-joinable": "La sessione di certificazione non è più accessibile.",
         "unknown": {
           "summary-label": "Visualizza altri dettagli:"
         }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -890,7 +890,7 @@
         "language-not-supported": "Pix-certificering is nog niet beschikbaar in het {userLanguage}. '<br>' De talen die momenteel beschikbaar zijn voor certificering zijn: {availableLanguages}. '<br>' Je kunt een andere taal kiezen op de pagina",
         "language-not-supported-link": "Mijn account",
         "missing-center-habilitation": "Je bent ingeschreven voor de certificering {subscription}. '<br><br><strong>'Je certificeringscentrum is niet langer bevoegd om deze certificering af te nemen'</strong>'. '<br><br>' Neem contact op met je toezichthouder.",
-        "session-not-accessible": "De sessie die u probeert te bezoeken is niet langer toegankelijk.",
+        "session-not-joinable": "De sessie die u probeert te bezoeken is niet langer toegankelijk.",
         "wrong-account": "De ingevoerde informatie komt overeen met een kandidaat die is geregistreerd voor de sessie en al is ingelogd met een ander account. Controleer of u bent aangemeld bij het account waarmee de certificering is gestart.",
         "wrong-account-sco": "Je gebruikt momenteel een account dat niet aan je school is gekoppeld.\nLog in op het account waarmee je je cursussen hebt afgerond of vraag de toezichthouder om hulp.",
         "wrong-account-sco-link": {
@@ -968,7 +968,7 @@
         "duration-exceeded": "De maximale duur van je certificeringstoets is overschreden. Je kunt de toets niet meer hervatten.",
         "generic": "Er is zojuist een onverwachte serverfout opgetreden.",
         "missing-code": "You have not entered your access code.",
-        "session-not-accessible": "De certificeringssessie is niet langer toegankelijk.",
+        "session-not-joinable": "De certificeringssessie is niet langer toegankelijk.",
         "unknown": {
           "summary-label": "Bekijk meer details:"
         }


### PR DESCRIPTION
## ☀️ Problème

Le terme `IsSessionAccessible` prête à confusion. Nous ne savons pas si c'est une session « accessible » en terme d'accessiblité (RGAA, ...) ou « ouverte ».

## ⛱️ Proposition

Utiliser le terme `joinable` à la place de `accessible`

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
