### PR TITLE
[TECH] Déplacement du BaseChallenge depuis shared vers evaluation

### DIFF
--- a/api/src/evaluation/domain/models/BaseChallenge.js
+++ b/api/src/evaluation/domain/models/BaseChallenge.js
@@ -1,10 +1,13 @@
 /**
- * @typedef {import ('../../../learning-content/domain/models/Challenge.js').Challenge} Challenge
+ * A challenge record from the learning content referential: its properties are
+ * the columns of the `learningcontent.challenges` table.
+ *
+ * @typedef {object} Challenge
  */
-import {
-  STATUSES as ORIGINAL_STATUSES,
-  TYPES as ORIGINAL_TYPES,
-} from '../../../learning-content/domain/models/Challenge.js';
+/**
+ * @typedef {typeof import('../../../shared/constants.js').CHALLENGE_TYPES} ChallengeTypes
+ */
+import { CHALLENGE_STATUSES as STATUSES } from '../../../shared/constants.js';
 
 export class BaseChallenge {
   /**
@@ -54,7 +57,7 @@ export class BaseChallenge {
 
   /**
    * @readonly
-   * @type {TYPES[keyof TYPES]}
+   * @type {ChallengeTypes[keyof ChallengeTypes]}
    */
   get type() {
     return this.#coreChallenge.type;
@@ -384,6 +387,3 @@ export class BaseChallenge {
     return this.responsive?.includes(type);
   }
 }
-
-export const STATUSES = ORIGINAL_STATUSES;
-export const TYPES = ORIGINAL_TYPES;

--- a/api/src/evaluation/domain/models/ChallengeToPlay.js
+++ b/api/src/evaluation/domain/models/ChallengeToPlay.js
@@ -1,4 +1,4 @@
-import { BaseChallenge } from '../../../shared/domain/models/BaseChallenge.js';
+import { BaseChallenge } from './BaseChallenge.js';
 
 /**
  * @class ChallengeToPlay

--- a/api/src/evaluation/domain/models/SmartRandomChallenge.js
+++ b/api/src/evaluation/domain/models/SmartRandomChallenge.js
@@ -1,4 +1,4 @@
-import { BaseChallenge, STATUSES as ORIGINAL_STATUSES } from '../../../shared/domain/models/BaseChallenge.js';
+import { BaseChallenge } from './BaseChallenge.js';
 
 /**
  * @class SmartRandomChallenge
@@ -18,4 +18,3 @@ export class SmartRandomChallenge extends BaseChallenge {
     super(coreChallenge);
   }
 }
-export const STATUSES = ORIGINAL_STATUSES;

--- a/api/src/learning-content/domain/models/Challenge.js
+++ b/api/src/learning-content/domain/models/Challenge.js
@@ -1,17 +1,7 @@
-export const TYPES = Object.freeze({
-  QCU: 'QCU',
-  QCM: 'QCM',
-  QROC: 'QROC',
-  QROCM_IND: 'QROCM-ind',
-  QROCM_DEP: 'QROCM-dep',
-});
-
-export const STATUSES = Object.freeze({
-  VALIDATED: 'validé',
-  ARCHIVED: 'archivé',
-  OBSOLETE: 'périmé',
-  PROPOSED: 'proposé',
-});
+/**
+ * @typedef {import('../../../shared/constants.js').CHALLENGE_TYPES} TYPES
+ * @typedef {import('../../../shared/constants.js').CHALLENGE_STATUSES} STATUSES
+ */
 
 export class Challenge {
   #cachedChallengeDto;

--- a/api/src/shared/constants.js
+++ b/api/src/shared/constants.js
@@ -100,6 +100,21 @@ export const MAX_LEVEL_TO_BE_AN_EASY_TUBE = 3;
 export const DEFAULT_LEVEL_FOR_FIRST_CHALLENGE = 2;
 export const MAX_DIFF_BETWEEN_USER_LEVEL_AND_SKILL_LEVEL = 2;
 
+export const CHALLENGE_TYPES = Object.freeze({
+  QCU: 'QCU',
+  QCM: 'QCM',
+  QROC: 'QROC',
+  QROCM_IND: 'QROCM-ind',
+  QROCM_DEP: 'QROCM-dep',
+});
+
+export const CHALLENGE_STATUSES = Object.freeze({
+  VALIDATED: 'validé',
+  ARCHIVED: 'archivé',
+  OBSOLETE: 'périmé',
+  PROPOSED: 'proposé',
+});
+
 export const PIX_ORIGIN = 'Pix';
 
 export const STUDENT_RECONCILIATION_ERRORS = {

--- a/api/src/shared/domain/models/Challenge.js
+++ b/api/src/shared/domain/models/Challenge.js
@@ -4,20 +4,7 @@ import { ValidatorQCU } from '../../../evaluation/domain/models/ValidatorQCU.js'
 import { ValidatorQROC } from '../../../evaluation/domain/models/ValidatorQROC.js';
 import { ValidatorQROCMDep } from '../../../evaluation/domain/models/ValidatorQROCMDep.js';
 import { ValidatorQROCMInd } from '../../../evaluation/domain/models/ValidatorQROCMInd.js';
-
-const ChallengeType = Object.freeze({
-  QCU: 'QCU',
-  QCM: 'QCM',
-  QROC: 'QROC',
-  QROCM_IND: 'QROCM-ind',
-  QROCM_DEP: 'QROCM-dep',
-});
-
-const Statuses = Object.freeze({
-  VALIDATED: 'validé',
-  ARCHIVED: 'archivé',
-  OBSOLETE: 'périmé',
-});
+import { CHALLENGE_STATUSES as Statuses, CHALLENGE_TYPES as ChallengeType } from '../../constants.js';
 
 /**
  * Traduction: Épreuve

--- a/api/tests/evaluation/unit/domain/models/BaseChallenge_test.js
+++ b/api/tests/evaluation/unit/domain/models/BaseChallenge_test.js
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 
-import { BaseChallenge } from '../../../../../src/shared/domain/models/BaseChallenge.js';
+import { BaseChallenge } from '../../../../../src/evaluation/domain/models/BaseChallenge.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
-describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
-  const STATUSES = domainBuilder.shared.buildBaseChallenge.STATUSES;
+describe('Evaluation | Unit | Domain | Models | BaseChallenge', function () {
+  const STATUSES = domainBuilder.evaluation.buildBaseChallenge.STATUSES;
 
   const baseData = {
     id: 'challengeId00',
@@ -97,7 +97,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
 
   describe('#isTimed', function () {
     it('returns false when timer is null', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         timer: null,
       });
@@ -106,7 +106,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
     });
 
     it('returns true when timer is not null', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         timer: 123,
       });
@@ -117,7 +117,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
 
   describe('#hasIllustration', function () {
     it('returns false when challenge has no illustration', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         illustrationUrl: null,
       });
@@ -126,7 +126,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
     });
 
     it('returns true when challenge has an illustration', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         illustrationUrl: 'some illustration url',
       });
@@ -137,7 +137,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
 
   describe('#hasEmbed', function () {
     it('returns false when challenge has no embed', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         embedUrl: null,
       });
@@ -146,7 +146,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
     });
 
     it('returns true when challenge has an embed', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         embedUrl: 'some embed url',
       });
@@ -157,11 +157,11 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
 
   describe('#hasAtLeastOneAttachment', function () {
     it('returns false when challenge has no attachments', function () {
-      const baseChallengeA = domainBuilder.shared.buildBaseChallenge({
+      const baseChallengeA = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         attachments: null,
       });
-      const baseChallengeB = domainBuilder.shared.buildBaseChallenge({
+      const baseChallengeB = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         attachments: [],
       });
@@ -171,11 +171,11 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
     });
 
     it('returns true when challenge has at least one attachment', function () {
-      const baseChallengeA = domainBuilder.shared.buildBaseChallenge({
+      const baseChallengeA = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         attachments: ['one'],
       });
-      const baseChallengeB = domainBuilder.shared.buildBaseChallenge({
+      const baseChallengeB = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         attachments: ['two', 'three'],
       });
@@ -187,7 +187,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
 
   describe('#isFocused', function () {
     it('returns false when challenge is not focused', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         focused: false,
       });
@@ -196,7 +196,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
     });
 
     it('returns true when challenge is focused', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         focused: true,
       });
@@ -207,7 +207,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
 
   describe('#get isMobileCompliant', function () {
     it('returns false when challenge is not responsive for mobile', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         responsive: 'Tablet,TV',
       });
@@ -216,7 +216,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
     });
 
     it('returns true when challenge is mobile compliant', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         responsive: 'Tamagotchi,Smartphone,TV',
       });
@@ -227,7 +227,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
 
   describe('#get isTabletCompliant', function () {
     it('returns false when challenge is not responsive for tablet', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         responsive: 'Smartphone,TV',
       });
@@ -236,7 +236,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
     });
 
     it('returns true when challenge is tablet compliant', function () {
-      const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+      const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
         ...baseData,
         responsive: 'Tamagotchi,Tablet,TV',
       });
@@ -251,7 +251,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
       .filter((status) => operative_statuses.includes(status))
       .forEach(function (status) {
         it(`returns true when status is ${status}`, function () {
-          const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+          const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
             ...baseData,
             status,
           });
@@ -264,7 +264,7 @@ describe('Shared | Unit | Domain | Models | BaseChallenge', function () {
       .filter((status) => !operative_statuses.includes(status))
       .forEach(function (status) {
         it(`returns false when status is ${status}`, function () {
-          const baseChallenge = domainBuilder.shared.buildBaseChallenge({
+          const baseChallenge = domainBuilder.evaluation.buildBaseChallenge({
             ...baseData,
             status,
           });

--- a/api/tests/tooling/domain-builder/factory/evaluation/build-base-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/evaluation/build-base-challenge.js
@@ -1,4 +1,5 @@
-import { BaseChallenge, STATUSES, TYPES } from '../../../../../src/shared/domain/models/BaseChallenge.js';
+import { BaseChallenge } from '../../../../../src/evaluation/domain/models/BaseChallenge.js';
+import { CHALLENGE_STATUSES as STATUSES, CHALLENGE_TYPES as TYPES } from '../../../../../src/shared/constants.js';
 
 export const buildBaseChallenge = function ({
   id = 'foo id',

--- a/api/tests/tooling/domain-builder/factory/evaluation/build-challenge-to-play.js
+++ b/api/tests/tooling/domain-builder/factory/evaluation/build-challenge-to-play.js
@@ -1,4 +1,5 @@
 import { ChallengeToPlay } from '../../../../../src/evaluation/domain/models/ChallengeToPlay.js';
+import { CHALLENGE_TYPES as TYPES } from '../../../../../src/shared/constants.js';
 import { buildChallenge } from '../learning-content/build-challenge.js';
 
 export const buildChallengeToPlay = function ({
@@ -6,7 +7,7 @@ export const buildChallengeToPlay = function ({
   instruction = 'foo instruction',
   alternativeInstruction = 'foo alternativeInstruction',
   proposals = 'foo proposals',
-  type = buildChallenge.TYPES.QCM,
+  type = TYPES.QCM,
   shuffled = true,
   illustrationAlt = 'foo illustrationAlt',
   illustrationUrl = 'foo illustrationUrl',
@@ -50,4 +51,4 @@ export const buildChallengeToPlay = function ({
   return new ChallengeToPlay(coreChallenge, webComponentTagName, webComponentProps);
 };
 
-buildChallengeToPlay.TYPES = buildChallenge.TYPES;
+buildChallengeToPlay.TYPES = TYPES;

--- a/api/tests/tooling/domain-builder/factory/evaluation/build-smart-random-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/evaluation/build-smart-random-challenge.js
@@ -1,4 +1,5 @@
-import { SmartRandomChallenge, STATUSES } from '../../../../../src/evaluation/domain/models/SmartRandomChallenge.js';
+import { SmartRandomChallenge } from '../../../../../src/evaluation/domain/models/SmartRandomChallenge.js';
+import { CHALLENGE_STATUSES as STATUSES } from '../../../../../src/shared/constants.js';
 import { buildChallenge } from '../learning-content/build-challenge.js';
 
 export const buildSmartRandomChallenge = function ({

--- a/api/tests/tooling/domain-builder/factory/evaluation/index.js
+++ b/api/tests/tooling/domain-builder/factory/evaluation/index.js
@@ -1,7 +1,9 @@
+import { buildBaseChallenge } from './build-base-challenge.js';
 import { buildChallengeToPlay } from './build-challenge-to-play.js';
 import { buildSmartRandomChallenge } from './build-smart-random-challenge.js';
 
 export const builders = {
+  buildBaseChallenge,
   buildSmartRandomChallenge,
   buildChallengeToPlay,
 };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -232,7 +232,6 @@ import { buildCampaignResultLevelsPerTubesAndCompetences as boundedContextCampai
 import { buildCampaignParticipation as boundedContextCampaignParticipationBuildCampaignParticipation } from './prescription/campaign-participation/build-campaign-participation.js';
 import { buildOrganizationLearnerImportFormat } from './prescription/learner-management/build-organization-learner-import-format.js';
 import { buildOrganizationToJoin } from './prescription/organization-learner/build-organization-to-join.js';
-import { builders as sharedBuilders } from './shared/index.js';
 import { buildStageCollection as buildStageCollectionForTargetProfileManagement } from './target-profile-management/build-stage-collection.js';
 import { buildStageCollection as buildStageCollectionForUserCampaignResults } from './user-campaign-results/build-stage-collection.js';
 
@@ -353,7 +352,6 @@ const maddo = {
 };
 
 const learningContent = learningContentBuilders;
-const shared = sharedBuilders;
 
 const llm = {
   buildAssistantMessage,
@@ -538,5 +536,4 @@ export {
   maddo,
   organizationalEntities,
   prescription,
-  shared,
 };

--- a/api/tests/tooling/domain-builder/factory/learning-content/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/learning-content/build-challenge.js
@@ -1,4 +1,5 @@
-import { Challenge, STATUSES, TYPES } from '../../../../../src/learning-content/domain/models/Challenge.js';
+import { Challenge } from '../../../../../src/learning-content/domain/models/Challenge.js';
+import { CHALLENGE_STATUSES as STATUSES, CHALLENGE_TYPES as TYPES } from '../../../../../src/shared/constants.js';
 
 export const buildChallenge = function buildChallenge({
   id = 'foo id',

--- a/api/tests/tooling/domain-builder/factory/shared/index.js
+++ b/api/tests/tooling/domain-builder/factory/shared/index.js
@@ -1,5 +1,0 @@
-import { buildBaseChallenge } from './build-base-challenge.js';
-
-export const builders = {
-  buildBaseChallenge,
-};


### PR DESCRIPTION
## ☀️ Problème

`BaseChallenge`, dans le contexte `shared`, crée une dépendance de `shared` à `learning-content` car il importe des constantes pour ses types et ses statuts.

## ⛱️ Proposition

`BaseChallenge` n'est utilisé que par `ChallengeToPlay` et `SmartRandomChallenge` dans le BC évaluation.
-> Déplacement de l'objet vers évaluation
-> on sort les statuts et les types dans les constantes exposées par `shared` (utilisées par évaluation, learning content, et les builders pour les tests).

## 🧴 Remarques

Après ce déplacement, on n'a plus qu'une seule dépendance de shared à learning-content : challenge-repository, qui sera traité dans une autre PR.

## 🏊 Pour tester

CI au vert
