### PR TITLE
[TECH] Suppression de la génération de positionnement V1 

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -108,6 +108,10 @@ export default class Certification extends Model {
       }, []);
   }
 
+  get isV1() {
+    return this.version === 1;
+  }
+
   get isV3() {
     return this.version === 3;
   }

--- a/admin/app/templates/authenticated/sessions/certification.gjs
+++ b/admin/app/templates/authenticated/sessions/certification.gjs
@@ -20,9 +20,11 @@ import SearchForm from 'pix-admin/components/certifications/search-form';
         Neutralisation
       </LinkTo>
     {{/unless}}
-    <LinkTo @route="authenticated.sessions.certification.details" @model={{@model.id}}>
-      {{t "pages.certifications.certification.details.title"}}
-    </LinkTo>
+    {{#unless @model.isV1}}
+      <LinkTo @route="authenticated.sessions.certification.details" @model={{@model.id}}>
+        {{t "pages.certifications.certification.details.title"}}
+      </LinkTo>
+    {{/unless}}
     {{#unless @model.isV3}}
       <LinkTo @route="authenticated.sessions.certification.profile" @model={{@model.id}}>
         Profil

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
@@ -10,7 +10,6 @@
  */
 
 import CertificationCancelled from '../../../../../../src/shared/domain/events/CertificationCancelled.js';
-import { AlgorithmEngineVersion } from '../../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { AnswerCollectionForScoring } from '../../../../shared/domain/models/AnswerCollectionForScoring.js';
 import { CompetenceMark } from '../../../../shared/domain/models/CompetenceMark.js';
 import { ReproducibilityRate } from '../../../../shared/domain/models/ReproducibilityRate.js';
@@ -98,7 +97,6 @@ export async function calculateCertificationAssessmentScore({
   const testedCompetences = await _getTestedCompetences({
     userId: certificationAssessment.userId,
     limitDate: candidate.reconciledAt,
-    version: AlgorithmEngineVersion.V2,
     placementProfileService,
   });
 
@@ -120,8 +118,8 @@ export async function calculateCertificationAssessmentScore({
  * @param {object} params
  * @param {PlacementProfileService} params.placementProfileService
  */
-async function _getTestedCompetences({ userId, limitDate, version, placementProfileService }) {
-  const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate, version });
+async function _getTestedCompetences({ userId, limitDate, placementProfileService }) {
+  const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate });
   const certifiableUserCompetences = placementProfile.userCompetences.filter((uc) => uc.isCertifiable());
   return certifiableUserCompetences.map((cuc) => {
     return {

--- a/api/src/certification/session-management/domain/usecases/get-certification-details.js
+++ b/api/src/certification/session-management/domain/usecases/get-certification-details.js
@@ -33,7 +33,6 @@ export async function getCertificationDetails({
   const placementProfile = await placementProfileService.getPlacementProfile({
     userId: candidate.userId,
     limitDate: candidate.reconciledAt,
-    version: certificationAssessment.version,
     allowExcessPixAndLevels: false,
   });
 

--- a/api/src/shared/domain/services/placement-profile-service.js
+++ b/api/src/shared/domain/services/placement-profile-service.js
@@ -1,76 +1,20 @@
-import { AlgorithmEngineVersion } from '../../../certification/shared/domain/models/AlgorithmEngineVersion.js';
 import * as scoringService from '../../../evaluation/domain/services/scoring/scoring-service.js';
 import * as knowledgeElementSnapshotRepository from '../../../prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import { PlacementProfile } from '../../domain/models/PlacementProfile.js';
 import { UserCompetence } from '../../domain/models/UserCompetence.js';
-import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
-import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
 import * as competenceRepository from '../../infrastructure/repositories/competence-repository.js';
 import * as knowledgeElementRepository from '../../infrastructure/repositories/knowledge-element-repository.js';
 import * as skillRepository from '../../infrastructure/repositories/skill-repository.js';
-import { PromiseUtils } from '../../infrastructure/utils/promise-utils.js';
 
-async function getPlacementProfile({
-  userId,
-  limitDate,
-  version = AlgorithmEngineVersion.V2,
-  allowExcessPixAndLevels = true,
-  locale,
-}) {
+async function getPlacementProfile({ userId, limitDate, allowExcessPixAndLevels = true, locale }) {
   const pixCompetences = await competenceRepository.listPixCompetencesOnly({ locale });
 
-  if (!AlgorithmEngineVersion.isV1(version)) {
-    return _generatePlacementProfile({
-      userId,
-      profileDate: limitDate,
-      competences: pixCompetences,
-      allowExcessPixAndLevels,
-    });
-  }
-  return _generatePlacementProfileV1({ userId, profileDate: limitDate, competences: pixCompetences });
-}
-
-async function _createUserCompetencesV1({ competences, userLastAssessments, limitDate }) {
-  return PromiseUtils.mapSeries(competences, async (competence) => {
-    const assessment = userLastAssessments.find((userAssessment) => userAssessment.competenceId === competence.id);
-    let estimatedLevel = 0;
-    let pixScore = 0;
-    if (assessment) {
-      const assessmentResultLevelAndPixScore =
-        await assessmentResultRepository.findLatestLevelAndPixScoreByAssessmentId({
-          assessmentId: assessment.id,
-          limitDate,
-        });
-      estimatedLevel = assessmentResultLevelAndPixScore.level;
-      pixScore = assessmentResultLevelAndPixScore.pixScore;
-    }
-    return new UserCompetence({
-      id: competence.id,
-      areaId: competence.areaId,
-      index: competence.index,
-      name: competence.name,
-      estimatedLevel,
-      pixScore,
-    });
-  });
-}
-
-async function _generatePlacementProfileV1({ userId, profileDate, competences }) {
-  const placementProfile = new PlacementProfile({
+  return _generatePlacementProfile({
     userId,
-    profileDate,
+    profileDate: limitDate,
+    competences: pixCompetences,
+    allowExcessPixAndLevels,
   });
-  const userLastAssessments = await assessmentRepository.findLastCompletedAssessmentsForEachCompetenceByUser(
-    placementProfile.userId,
-    placementProfile.profileDate,
-  );
-  placementProfile.userCompetences = await _createUserCompetencesV1({
-    competences,
-    userLastAssessments,
-    limitDate: placementProfile.profileDate,
-  });
-
-  return placementProfile;
 }
 
 function _createUserCompetencesV2({

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -10,7 +10,6 @@ import {
 } from '../../../../../../../src/certification/evaluation/domain/services/scoring/scoring-v2.js';
 import { CertificationAssessment } from '../../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { ABORT_REASONS } from '../../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
-import { AlgorithmEngineVersion } from '../../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { AutoJuryCommentKeys } from '../../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import * as scoringService from '../../../../../../../src/evaluation/domain/services/scoring/scoring-service.js';
 import CertificationCancelled from '../../../../../../../src/shared/domain/events/CertificationCancelled.js';
@@ -974,7 +973,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           .withArgs({
             userId: certificationAssessment.userId,
             limitDate: candidate.reconciledAt,
-            version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
         candidateRepository.findByAssessmentId
@@ -1031,7 +1029,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           .withArgs({
             userId: certificationAssessment.userId,
             limitDate: candidate.reconciledAt,
-            version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
         candidateRepository.findByAssessmentId
@@ -1151,7 +1148,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           .withArgs({
             userId: certificationAssessment.userId,
             limitDate: candidate.reconciledAt,
-            version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
         candidateRepository.findByAssessmentId
@@ -1194,7 +1190,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           .withArgs({
             userId: certificationAssessment.userId,
             limitDate: candidate.reconciledAt,
-            version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
         candidateRepository.findByAssessmentId
@@ -1455,7 +1450,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
                 .withArgs({
                   userId: certificationAssessment.userId,
                   limitDate: candidate.reconciledAt,
-                  version: AlgorithmEngineVersion.V2,
                 })
                 .resolves({ userCompetences });
 
@@ -1502,7 +1496,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           .withArgs({
             userId: certificationAssessment.userId,
             limitDate: candidate.reconciledAt,
-            version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
       });
@@ -1694,7 +1687,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
             .withArgs({
               userId: certificationAssessment.userId,
               limitDate: candidate.reconciledAt,
-              version: AlgorithmEngineVersion.V2,
             })
             .resolves({ userCompetences });
           certificationAssessment.certificationAnswersByDate = _.map(
@@ -1800,7 +1792,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
             .withArgs({
               userId: certificationAssessment.userId,
               limitDate: candidate.reconciledAt,
-              version: AlgorithmEngineVersion.V2,
             })
             .resolves({ userCompetences });
         });
@@ -1928,7 +1919,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           .withArgs({
             userId: certificationAssessment.userId,
             limitDate: candidate.reconciledAt,
-            version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
       });

--- a/api/tests/certification/session-management/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-certification-details_test.js
@@ -68,7 +68,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | get-ce
         .withArgs({
           userId: candidate.userId,
           limitDate: candidate.reconciledAt,
-          version: certificationAssessment.version,
           allowExcessPixAndLevels: false,
         })
         .resolves(placementProfile);

--- a/api/tests/shared/integration/domain/services/placement-profile-service_test.js
+++ b/api/tests/shared/integration/domain/services/placement-profile-service_test.js
@@ -107,137 +107,231 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
     return databaseBuilder.commit();
   });
 
-  context('V1 Profile', function () {
-    describe('#getPlacementProfile', function () {
-      let assessment1;
-      let assessment2;
-      let assessment3;
-
-      beforeEach(async function () {
-        assessment1 = databaseBuilder.factory.buildAssessment({
-          id: 13,
-          status: 'completed',
-          competenceId: 'competenceRecordIdOne',
-        });
-        assessment2 = databaseBuilder.factory.buildAssessment({
-          id: 1637,
-          status: 'completed',
-          competenceId: 'competenceRecordIdTwo',
-        });
-        assessment3 = databaseBuilder.factory.buildAssessment({
-          id: 145,
-          status: 'completed',
-          competenceId: 'competenceRecordIdUnknown',
-        });
-        databaseBuilder.factory.buildAssessmentResult({ level: 1, pixScore: 12, assessmentId: assessment1.id });
-        databaseBuilder.factory.buildAssessmentResult({ level: 2, pixScore: 23, assessmentId: assessment2.id });
-        databaseBuilder.factory.buildAssessmentResult({ level: 0, pixScore: 2, assessmentId: assessment3.id });
-
-        await databaseBuilder.commit();
+  describe('#getPlacementProfile', function () {
+    it('should assign 0 pixScore and level of 0 to user competence when not assessed', async function () {
+      // when
+      const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+        userId,
+        limitDate: '2020-10-27 08:44:25',
+        version: 2,
       });
 
-      it('should load achieved assessments', async function () {
+      // then
+      expect(actualPlacementProfile.userCompetences).to.deep.equal([
+        {
+          id: 'competenceRecordIdOne',
+          index: '1.1',
+          areaId: 'areaOne',
+          name: 'Construire un flipper',
+          skills: [],
+          pixScore: 0,
+          estimatedLevel: 0,
+        },
+        {
+          id: 'competenceRecordIdTwo',
+          index: '1.2',
+          areaId: 'areaOne',
+          name: 'Adopter un dauphin',
+          skills: [],
+          pixScore: 0,
+          estimatedLevel: 0,
+        },
+        {
+          id: 'competenceRecordIdThree',
+          index: '1.3',
+          areaId: 'areaOne',
+          name: 'Se faire manger par un requin',
+          skills: [],
+          pixScore: 0,
+          estimatedLevel: 0,
+        },
+      ]);
+    });
+
+    it('should return competence name according to given locale', async function () {
+      // when
+      const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+        userId,
+        limitDate: new Date(),
+        version: 2,
+        locale: ENGLISH_SPOKEN,
+      });
+
+      // then
+      const competenceName = actualPlacementProfile.userCompetences.map((competence) => competence.name);
+      expect(competenceName).to.have.members(['Build a pinball', 'Adopt a dolphin', 'Getting eaten by a shark']);
+    });
+
+    it('should return competence name according to default locale', async function () {
+      // when
+      const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+        userId,
+        limitDate: new Date(),
+        version: 2,
+      });
+
+      // then
+      const competenceName = actualPlacementProfile.userCompetences.map((competence) => competence.name);
+      expect(competenceName).to.have.members([
+        'Construire un flipper',
+        'Adopter un dauphin',
+        'Se faire manger par un requin',
+      ]);
+    });
+
+    describe('PixScore by competences', function () {
+      it('should assign pixScore and level to user competence based on knowledge elements', async function () {
         // given
-        const limitDate = '2020-10-27 08:44:25';
+        databaseBuilder.factory.buildKnowledgeElement({
+          competenceId: 'competenceRecordIdTwo',
+          skillId: 'recRemplir2',
+          earnedPix: 23,
+          userId,
+          assessmentId,
+        });
+        await databaseBuilder.commit();
 
         // when
         const actualPlacementProfile = await placementProfileService.getPlacementProfile({
           userId,
-          limitDate,
-          version: 1,
+          limitDate: new Date(),
+          version: 2,
         });
 
         // then
-        expect(actualPlacementProfile.userCompetences).to.deep.equal([
-          {
+        expect(actualPlacementProfile.userCompetences[0]).to.deep.include({
+          id: 'competenceRecordIdOne',
+          pixScore: 0,
+          estimatedLevel: 0,
+          skills: [],
+        });
+        expect(actualPlacementProfile.userCompetences[1]).to.deep.include({
+          id: 'competenceRecordIdTwo',
+          pixScore: 23,
+          estimatedLevel: 2,
+          skills: [
+            domainBuilder.buildSkill({
+              ...skillRemplir2DB,
+              difficulty: skillRemplir2DB.level,
+              hint: skillRemplir2DB.hint_i18n.fr,
+            }),
+          ],
+        });
+        expect(actualPlacementProfile.userCompetences[2]).to.deep.include({
+          id: 'competenceRecordIdThree',
+          pixScore: 0,
+          estimatedLevel: 0,
+          skills: [],
+        });
+      });
+
+      it('should include both inferred and direct KnowlegdeElements to compute PixScore', async function () {
+        // given
+        databaseBuilder.factory.buildKnowledgeElement({
+          competenceId: 'competenceRecordIdTwo',
+          skillId: 'recRemplir2',
+          earnedPix: 8,
+          source: KnowledgeElement.SourceType.INFERRED,
+          userId,
+          assessmentId,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          competenceId: 'competenceRecordIdTwo',
+          skillId: 'recRemplir4',
+          earnedPix: 9,
+          source: KnowledgeElement.SourceType.DIRECT,
+          userId,
+          assessmentId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+          userId,
+          limitDate: new Date(),
+          version: 2,
+        });
+
+        // then
+        expect(actualPlacementProfile.userCompetences[1].pixScore).to.equal(17);
+      });
+
+      context('when we dont want to limit pix score', function () {
+        it('should not limit pixScore and level to the max reachable for user competence based on knowledge elements', async function () {
+          databaseBuilder.factory.buildKnowledgeElement({
+            competenceId: 'competenceRecordIdOne',
+            earnedPix: 64,
+            userId,
+            assessmentId,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+            userId,
+            limitDate: new Date(),
+            version: 2,
+            allowExcessPixAndLevels: true,
+          });
+
+          // then
+          expect(actualPlacementProfile.userCompetences[0]).to.deep.include({
             id: 'competenceRecordIdOne',
-            index: '1.1',
-            areaId: 'areaOne',
-            name: 'Construire un flipper',
-            skills: [],
-            pixScore: 0,
-            estimatedLevel: 0,
-          },
-          {
-            id: 'competenceRecordIdTwo',
-            index: '1.2',
-            areaId: 'areaOne',
-            name: 'Adopter un dauphin',
-            skills: [],
-            pixScore: 0,
-            estimatedLevel: 0,
-          },
-          {
-            id: 'competenceRecordIdThree',
-            index: '1.3',
-            areaId: 'areaOne',
-            name: 'Se faire manger par un requin',
-            skills: [],
-            pixScore: 0,
-            estimatedLevel: 0,
-          },
-        ]);
+            pixScore: 64,
+            estimatedLevel: 8,
+          });
+        });
+      });
+
+      context('when we want to limit pix score', function () {
+        it('should limit pixScore to 40 and level to 5', async function () {
+          databaseBuilder.factory.buildKnowledgeElement({
+            competenceId: 'competenceRecordIdOne',
+            earnedPix: 64,
+            userId,
+            assessmentId,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+            userId,
+            limitDate: new Date(),
+            version: 2,
+            allowExcessPixAndLevels: false,
+          });
+
+          // then
+          expect(actualPlacementProfile.userCompetences[0]).to.include({
+            id: 'competenceRecordIdOne',
+            pixScore: 40,
+            estimatedLevel: 5,
+          });
+        });
       });
     });
-  });
 
-  context('V2 Profile', function () {
-    describe('#getPlacementProfile', function () {
-      it('should assign 0 pixScore and level of 0 to user competence when not assessed', async function () {
-        // when
-        const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+    describe('Skills not found in learningContent', function () {
+      it('should skip not found skills', async function () {
+        // given
+        databaseBuilder.factory.buildKnowledgeElement({
+          competenceId: 'competenceRecordIdTwo',
+          skillId: 'recRemplir2',
+          earnedPix: 11,
           userId,
-          limitDate: '2020-10-27 08:44:25',
-          version: 2,
+          assessmentId,
         });
 
-        // then
-        expect(actualPlacementProfile.userCompetences).to.deep.equal([
-          {
-            id: 'competenceRecordIdOne',
-            index: '1.1',
-            areaId: 'areaOne',
-            name: 'Construire un flipper',
-            skills: [],
-            pixScore: 0,
-            estimatedLevel: 0,
-          },
-          {
-            id: 'competenceRecordIdTwo',
-            index: '1.2',
-            areaId: 'areaOne',
-            name: 'Adopter un dauphin',
-            skills: [],
-            pixScore: 0,
-            estimatedLevel: 0,
-          },
-          {
-            id: 'competenceRecordIdThree',
-            index: '1.3',
-            areaId: 'areaOne',
-            name: 'Se faire manger par un requin',
-            skills: [],
-            pixScore: 0,
-            estimatedLevel: 0,
-          },
-        ]);
-      });
-
-      it('should return competence name according to given locale', async function () {
-        // when
-        const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+        databaseBuilder.factory.buildKnowledgeElement({
+          competenceId: 'competenceRecordIdTwo',
+          skillId: 'missing skill id',
+          earnedPix: 11,
           userId,
-          limitDate: new Date(),
-          version: 2,
-          locale: ENGLISH_SPOKEN,
+          assessmentId,
         });
+        await databaseBuilder.commit();
 
-        // then
-        const competenceName = actualPlacementProfile.userCompetences.map((competence) => competence.name);
-        expect(competenceName).to.have.members(['Build a pinball', 'Adopt a dolphin', 'Getting eaten by a shark']);
-      });
-
-      it('should return competence name according to default locale', async function () {
         // when
         const actualPlacementProfile = await placementProfileService.getPlacementProfile({
           userId,
@@ -246,199 +340,29 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
         });
 
         // then
-        const competenceName = actualPlacementProfile.userCompetences.map((competence) => competence.name);
-        expect(competenceName).to.have.members([
-          'Construire un flipper',
-          'Adopter un dauphin',
-          'Se faire manger par un requin',
-        ]);
-      });
-
-      describe('PixScore by competences', function () {
-        it('should assign pixScore and level to user competence based on knowledge elements', async function () {
-          // given
-          databaseBuilder.factory.buildKnowledgeElement({
-            competenceId: 'competenceRecordIdTwo',
-            skillId: 'recRemplir2',
-            earnedPix: 23,
-            userId,
-            assessmentId,
-          });
-          await databaseBuilder.commit();
-
-          // when
-          const actualPlacementProfile = await placementProfileService.getPlacementProfile({
-            userId,
-            limitDate: new Date(),
-            version: 2,
-          });
-
-          // then
-          expect(actualPlacementProfile.userCompetences[0]).to.deep.include({
-            id: 'competenceRecordIdOne',
-            pixScore: 0,
-            estimatedLevel: 0,
-            skills: [],
-          });
-          expect(actualPlacementProfile.userCompetences[1]).to.deep.include({
-            id: 'competenceRecordIdTwo',
-            pixScore: 23,
-            estimatedLevel: 2,
-            skills: [
-              domainBuilder.buildSkill({
-                ...skillRemplir2DB,
-                difficulty: skillRemplir2DB.level,
-                hint: skillRemplir2DB.hint_i18n.fr,
-              }),
-            ],
-          });
-          expect(actualPlacementProfile.userCompetences[2]).to.deep.include({
-            id: 'competenceRecordIdThree',
-            pixScore: 0,
-            estimatedLevel: 0,
-            skills: [],
-          });
+        expect(actualPlacementProfile.userCompetences[0]).to.deep.include({
+          id: 'competenceRecordIdOne',
+          pixScore: 0,
+          estimatedLevel: 0,
+          skills: [],
         });
-
-        it('should include both inferred and direct KnowlegdeElements to compute PixScore', async function () {
-          // given
-          databaseBuilder.factory.buildKnowledgeElement({
-            competenceId: 'competenceRecordIdTwo',
-            skillId: 'recRemplir2',
-            earnedPix: 8,
-            source: KnowledgeElement.SourceType.INFERRED,
-            userId,
-            assessmentId,
-          });
-
-          databaseBuilder.factory.buildKnowledgeElement({
-            competenceId: 'competenceRecordIdTwo',
-            skillId: 'recRemplir4',
-            earnedPix: 9,
-            source: KnowledgeElement.SourceType.DIRECT,
-            userId,
-            assessmentId,
-          });
-          await databaseBuilder.commit();
-
-          // when
-          const actualPlacementProfile = await placementProfileService.getPlacementProfile({
-            userId,
-            limitDate: new Date(),
-            version: 2,
-          });
-
-          // then
-          expect(actualPlacementProfile.userCompetences[1].pixScore).to.equal(17);
+        expect(actualPlacementProfile.userCompetences[1]).to.deep.include({
+          id: 'competenceRecordIdTwo',
+          pixScore: 22,
+          estimatedLevel: 2,
+          skills: [
+            domainBuilder.buildSkill({
+              ...skillRemplir2DB,
+              difficulty: skillRemplir2DB.level,
+              hint: skillRemplir2DB.hint_i18n.fr,
+            }),
+          ],
         });
-
-        context('when we dont want to limit pix score', function () {
-          it('should not limit pixScore and level to the max reachable for user competence based on knowledge elements', async function () {
-            databaseBuilder.factory.buildKnowledgeElement({
-              competenceId: 'competenceRecordIdOne',
-              earnedPix: 64,
-              userId,
-              assessmentId,
-            });
-            await databaseBuilder.commit();
-
-            // when
-            const actualPlacementProfile = await placementProfileService.getPlacementProfile({
-              userId,
-              limitDate: new Date(),
-              version: 2,
-              allowExcessPixAndLevels: true,
-            });
-
-            // then
-            expect(actualPlacementProfile.userCompetences[0]).to.deep.include({
-              id: 'competenceRecordIdOne',
-              pixScore: 64,
-              estimatedLevel: 8,
-            });
-          });
-        });
-
-        context('when we want to limit pix score', function () {
-          it('should limit pixScore to 40 and level to 5', async function () {
-            databaseBuilder.factory.buildKnowledgeElement({
-              competenceId: 'competenceRecordIdOne',
-              earnedPix: 64,
-              userId,
-              assessmentId,
-            });
-            await databaseBuilder.commit();
-
-            // when
-            const actualPlacementProfile = await placementProfileService.getPlacementProfile({
-              userId,
-              limitDate: new Date(),
-              version: 2,
-              allowExcessPixAndLevels: false,
-            });
-
-            // then
-            expect(actualPlacementProfile.userCompetences[0]).to.include({
-              id: 'competenceRecordIdOne',
-              pixScore: 40,
-              estimatedLevel: 5,
-            });
-          });
-        });
-      });
-
-      describe('Skills not found in learningContent', function () {
-        it('should skip not found skills', async function () {
-          // given
-          databaseBuilder.factory.buildKnowledgeElement({
-            competenceId: 'competenceRecordIdTwo',
-            skillId: 'recRemplir2',
-            earnedPix: 11,
-            userId,
-            assessmentId,
-          });
-
-          databaseBuilder.factory.buildKnowledgeElement({
-            competenceId: 'competenceRecordIdTwo',
-            skillId: 'missing skill id',
-            earnedPix: 11,
-            userId,
-            assessmentId,
-          });
-          await databaseBuilder.commit();
-
-          // when
-          const actualPlacementProfile = await placementProfileService.getPlacementProfile({
-            userId,
-            limitDate: new Date(),
-            version: 2,
-          });
-
-          // then
-          expect(actualPlacementProfile.userCompetences[0]).to.deep.include({
-            id: 'competenceRecordIdOne',
-            pixScore: 0,
-            estimatedLevel: 0,
-            skills: [],
-          });
-          expect(actualPlacementProfile.userCompetences[1]).to.deep.include({
-            id: 'competenceRecordIdTwo',
-            pixScore: 22,
-            estimatedLevel: 2,
-            skills: [
-              domainBuilder.buildSkill({
-                ...skillRemplir2DB,
-                difficulty: skillRemplir2DB.level,
-                hint: skillRemplir2DB.hint_i18n.fr,
-              }),
-            ],
-          });
-          expect(actualPlacementProfile.userCompetences[2]).to.deep.include({
-            id: 'competenceRecordIdThree',
-            pixScore: 0,
-            estimatedLevel: 0,
-            skills: [],
-          });
+        expect(actualPlacementProfile.userCompetences[2]).to.deep.include({
+          id: 'competenceRecordIdThree',
+          pixScore: 0,
+          estimatedLevel: 0,
+          skills: [],
         });
       });
     });


### PR DESCRIPTION
## ☀️ Problème

Le service de positionnement permet encore de générer un profil V1, et cela implique une dépendance vers certification/shared. 

## ⛱️ Proposition

Cet usage étant globalement devenu obsolète, supprimer la génération de positionnement V1 et retirer ainsi une dépendance vers certif/shared

## 🧴 Remarques

Le principal impact est que l'onglet "Détails" n'est plus disponible sur les certifications V1. Le métier a validé ce changement

## 🏊 Pour tester

Onglet "Détails" pas impacté en V2 mais plus présent en V1 (pas de seed V1, testable uniquement en recette. Scoring V2 pas impacté
