### PR TITLE
[TECH] Enlever la dépendance prescription/campaign de IAM

### DIFF
--- a/api/src/identity-access-management/dependencies.json
+++ b/api/src/identity-access-management/dependencies.json
@@ -1,11 +1,5 @@
 {
   "name": "identity-access-management",
-  "dependsOn": [
-    "legal-documents",
-    "organizational-entities",
-    "prescription/campaign",
-    "prescription/organization-learner",
-    "shared"
-  ],
+  "dependsOn": ["legal-documents", "organizational-entities", "prescription/organization-learner", "shared"],
   "circular": "forbidden"
 }

--- a/api/src/identity-access-management/domain/usecases/authenticate-anonymous-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-anonymous-user.usecase.js
@@ -25,8 +25,8 @@ export const authenticateAnonymousUser = async function ({
   userToCreateRepository,
   authenticationSessionService,
 }) {
-  const campaign = await campaignToJoinRepository.getByCode({ code: campaignCode });
-  if (!campaign.isSimplifiedAccess) {
+  const isSimplifiedAccess = await campaignToJoinRepository.isSimplifiedAccessCampaign(campaignCode);
+  if (!isSimplifiedAccess) {
     throw new UserCantBeCreatedError();
   }
 

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -1,4 +1,3 @@
-import * as campaignToJoinRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-to-join-repository.js';
 import * as organizationLearnerRepository from '../../../prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import { config } from '../../../shared/config.js';
 import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
@@ -16,6 +15,7 @@ import * as emailRepository from '../../../shared/mail/infrastructure/repositori
 import boundedContext from '../../dependencies.json' with { type: 'json' };
 import { accountRecoveryDemandRepository } from '../../infrastructure/repositories/account-recovery-demand.repository.js';
 import * as authenticationMethodRepository from '../../infrastructure/repositories/authentication-method.repository.js';
+import * as campaignToJoinRepository from '../../infrastructure/repositories/campaign-to-join-repository.js';
 import { clientApplicationRepository } from '../../infrastructure/repositories/client-application.repository.js';
 import { emailValidationDemandRepository } from '../../infrastructure/repositories/email-validation-demand.repository.js';
 import { lastUserApplicationConnectionsRepository } from '../../infrastructure/repositories/last-user-application-connections.repository.js';

--- a/api/src/identity-access-management/infrastructure/repositories/campaign-to-join-repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/campaign-to-join-repository.js
@@ -1,0 +1,13 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+export const isSimplifiedAccessCampaign = async function (code) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('campaigns')
+    .select({ isSimplifiedAccess: 'target-profiles.isSimplifiedAccess' })
+    .leftJoin('target-profiles', 'target-profiles.id', 'campaigns.targetProfileId')
+    .where('campaigns.code', code.toUpperCase())
+    .first();
+
+  return Boolean(result?.isSimplifiedAccess);
+};

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/campaign-to-join-repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/campaign-to-join-repository.test.js
@@ -1,0 +1,47 @@
+import * as campaignToJoinRepository from '../../../../../src/identity-access-management/infrastructure/repositories/campaign-to-join-repository.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Integration | Identity Access Management | Repository | CampaignToJoin', function () {
+  describe('isSimplifiedAccessCampaign', function () {
+    describe('When campaign is linked to a target profile with simplified access', function () {
+      it('should return true', async function () {
+        // given
+        const targetProfile = databaseBuilder.factory.buildTargetProfile({ isSimplifiedAccess: true });
+        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        await databaseBuilder.commit();
+
+        // when
+        const isSimplifiedAccess = await campaignToJoinRepository.isSimplifiedAccessCampaign(campaign.code);
+
+        // then
+        expect(isSimplifiedAccess).to.be.true;
+      });
+    });
+
+    describe('When campaign is not linked to a target profile with simplified access', function () {
+      it('should return false', async function () {
+        // given
+        const targetProfile = databaseBuilder.factory.buildTargetProfile({ isSimplifiedAccess: false });
+        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        await databaseBuilder.commit();
+
+        // when
+        const isSimplifiedAccess = await campaignToJoinRepository.isSimplifiedAccessCampaign(campaign.code);
+
+        // then
+        expect(isSimplifiedAccess).to.be.false;
+      });
+    });
+
+    describe('when campaign code does not exist', function () {
+      it('should return false', async function () {
+        // when
+        const isSimplifiedAccess = await campaignToJoinRepository.isSimplifiedAccessCampaign('UNKNOWN_CODE');
+
+        // then
+        expect(isSimplifiedAccess).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ☀️ Problème

Le contexte IAM ne devrait pas dépendre de contexte `core` car il est utilisé dans tous les autres contextes. Or il dépend de `prescription/campaign` pour vérifier si une campagne est à accès simplifié.

## ⛱️ Proposition

Créer un repo dans `IAM` qui vérifie si la campagne est a accès simplifié.

## 🧴 Remarques

N/A

## 🏊 Pour tester

Sans être connecté, aller sur **/campagnes**, saisir `AUTOCOUR1` et réaliser la campagne.
