### PR TITLE
[TECH] Oblige et corrige la façon de déclarer des fonctions dans le contexte certification-result

### DIFF
--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -64,7 +64,7 @@ export default defineConfig([
     },
   },
   {
-    files: ['src/certification/configuration/**/*.{js,mjs}'],
+    files: ['src/certification/configuration/**/*.{js,mjs}', 'src/certification/results/**/*.{js,mjs}'],
     rules: {
       'func-style': ['error', 'declaration'],
     },

--- a/api/src/certification/results/application/certificate-route.js
+++ b/api/src/certification/results/application/certificate-route.js
@@ -6,7 +6,7 @@ import { certificationVerificationCodeType, identifiersType } from '../../../sha
 import { certificateController } from './certificate-controller.js';
 import { resultsSecurityPreHandlers } from './security-pre-handlers.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -156,6 +156,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const certificateRoute = { name: 'certification/results/certificate-api', register };

--- a/api/src/certification/results/application/certification-reports-controller.js
+++ b/api/src/certification/results/application/certification-reports-controller.js
@@ -1,14 +1,13 @@
 import { certificationReportSerializer } from '../../shared/infrastructure/serializers/jsonapi/certification-report-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 
-const getCertificationReports = async function (request, h, dependencies = { certificationReportSerializer }) {
+async function getCertificationReports(request, h, dependencies = { certificationReportSerializer }) {
   const sessionId = request.params.sessionId;
 
   const certificationReports = await usecases.getSessionCertificationReports({ sessionId });
   return dependencies.certificationReportSerializer.serialize(certificationReports);
-};
+}
 
-const certificationReportsController = {
+export const certificationReportsController = {
   getCertificationReports,
 };
-export { certificationReportsController };

--- a/api/src/certification/results/application/certification-reports-route.js
+++ b/api/src/certification/results/application/certification-reports-route.js
@@ -4,7 +4,7 @@ import { identifiersType } from '../../../shared/domain/types/identifiers-type.j
 import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { certificationReportsController } from './certification-reports-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -30,6 +30,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const certificationReportsRoute = { name: 'certification/results/certification-reports', register };

--- a/api/src/certification/results/application/certification-results-controller.js
+++ b/api/src/certification/results/application/certification-results-controller.js
@@ -8,7 +8,8 @@ import { usecases } from '../domain/usecases/index.js';
 import * as certifiedProfileRepository from '../infrastructure/repositories/certified-profile-repository.js';
 import * as certifiedProfileSerializer from '../infrastructure/serializers/certified-profile-serializer.js';
 import { getCleaCertifiedCandidateCsv } from '../infrastructure/utils/csv/certification-results/get-clea-certified-candidate-csv.js';
-const getCleaCertifiedCandidateDataCsv = async function (request, h, dependencies = { getCleaCertifiedCandidateCsv }) {
+
+async function getCleaCertifiedCandidateDataCsv(request, h, dependencies = { getCleaCertifiedCandidateCsv }) {
   const sessionId = request.params.sessionId;
   const { session, cleaCertifiedCandidateData } = await usecases.getCleaCertifiedCandidateBySession({ sessionId });
   const csvResult = await dependencies.getCleaCertifiedCandidateCsv({
@@ -24,9 +25,9 @@ const getCleaCertifiedCandidateDataCsv = async function (request, h, dependencie
     .response(csvResult)
     .header('Content-Type', 'text/csv;charset=utf-8')
     .header('Content-Disposition', `attachment; filename=${fileName}`);
-};
+}
 
-const getSessionResultsByRecipientEmail = async function (request, h) {
+async function getSessionResultsByRecipientEmail(request, h) {
   const i18n = getI18nFromRequest(request);
 
   const token = request.params.token;
@@ -47,9 +48,9 @@ const getSessionResultsByRecipientEmail = async function (request, h) {
     .response(csvResult.content)
     .header('Content-Type', 'text/csv;charset=utf-8')
     .header('Content-Disposition', `attachment; filename=${csvResult.filename}`);
-};
+}
 
-const postSessionResultsToDownload = async function (request, h) {
+async function postSessionResultsToDownload(request, h) {
   const i18n = getI18nFromRequest(request);
 
   const { sessionId } = CertificationResultsLinkToken.decode(request.payload.token);
@@ -65,9 +66,9 @@ const postSessionResultsToDownload = async function (request, h) {
     .response(csvResult.content)
     .header('Content-Type', 'text/csv;charset=utf-8')
     .header('Content-Disposition', `attachment; filename=${csvResult.filename}`);
-};
+}
 
-const getCertifiedProfile = async function (
+async function getCertifiedProfile(
   request,
   h,
   dependencies = { certifiedProfileRepository, certifiedProfileSerializer },
@@ -76,18 +77,18 @@ const getCertifiedProfile = async function (
   //TODO add passthrough usecase to remove link between application and infrastructure
   const certifiedProfile = await dependencies.certifiedProfileRepository.get(certificationCourseId);
   return dependencies.certifiedProfileSerializer.serialize(certifiedProfile);
-};
+}
 
-const generateSessionResultsDownloadLink = function (request, h, dependencies = { sessionResultsLinkService }) {
+function generateSessionResultsDownloadLink(request, h, dependencies = { sessionResultsLinkService }) {
   const i18n = getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const sessionResultsLink = dependencies.sessionResultsLinkService.generateResultsLink({ sessionId, i18n });
 
   return h.response({ sessionResultsLink });
-};
+}
 
-const downloadSelectedSessionsResults = async function (request, h) {
+async function downloadSelectedSessionsResults(request, h) {
   const i18n = getI18nFromRequest(request);
   const { sessionIds } = request.query;
 
@@ -97,9 +98,9 @@ const downloadSelectedSessionsResults = async function (request, h) {
     .response(zip.content)
     .header('Content-Type', 'application/zip')
     .header('Content-Disposition', `attachment; filename=${zip.filename}`);
-};
+}
 
-const certificationResultsController = {
+export const certificationResultsController = {
   downloadSelectedSessionsResults,
   getCleaCertifiedCandidateDataCsv,
   getSessionResultsByRecipientEmail,
@@ -107,5 +108,3 @@ const certificationResultsController = {
   getCertifiedProfile,
   generateSessionResultsDownloadLink,
 };
-
-export { certificationResultsController };

--- a/api/src/certification/results/application/certification-results-route.js
+++ b/api/src/certification/results/application/certification-results-route.js
@@ -6,7 +6,7 @@ import { identifiersType } from '../../../shared/domain/types/identifiers-type.j
 import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { certificationResultsController } from './certification-results-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -156,6 +156,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const certificationResultsRoute = { name: 'certification/results/certification-results-api', register };

--- a/api/src/certification/results/application/livret-scolaire-controller.js
+++ b/api/src/certification/results/application/livret-scolaire-controller.js
@@ -1,7 +1,7 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as certificationsResultsForLivretScolaireSerializer from '../infrastructure/serializers/certification-livret-scolaire-serializer.js';
 
-const getCertificationsByOrganizationUAI = async function (
+async function getCertificationsByOrganizationUAI(
   request,
   _h,
   dependencies = { certificationsResultsForLivretScolaireSerializer },
@@ -9,10 +9,8 @@ const getCertificationsByOrganizationUAI = async function (
   const uai = request.params.uai;
   const certifications = await usecases.getCertificationsResultsForLivretScolaire({ uai });
   return dependencies.certificationsResultsForLivretScolaireSerializer.serialize(certifications);
-};
+}
 
-const livretScolaireController = {
+export const livretScolaireController = {
   getCertificationsByOrganizationUAI,
 };
-
-export { livretScolaireController };

--- a/api/src/certification/results/application/livret-scolaire-route.js
+++ b/api/src/certification/results/application/livret-scolaire-route.js
@@ -5,7 +5,7 @@ import { responseObjectErrorDoc } from '../../../shared/infrastructure/open-api-
 import { certificationsResultsDoc } from '../infrastructure/open-api-doc/livret-scolaire/certifications-results-doc.js';
 import { livretScolaireController } from './livret-scolaire-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -44,6 +44,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const livretScolaireRoute = { name: 'certification/results/livret-scolaire-api', register };

--- a/api/src/certification/results/application/organization-controller.js
+++ b/api/src/certification/results/application/organization-controller.js
@@ -2,11 +2,7 @@ import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js'
 import { usecases } from '../domain/usecases/index.js';
 import { getDivisionCertificationResultsCsv } from '../infrastructure/utils/csv/certification-results/get-division-certification-results-csv.js';
 
-const downloadCertificationResults = async function (
-  request,
-  h,
-  dependencies = { getDivisionCertificationResultsCsv },
-) {
+async function downloadCertificationResults(request, h, dependencies = { getDivisionCertificationResultsCsv }) {
   const i18n = getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
@@ -24,10 +20,8 @@ const downloadCertificationResults = async function (
     .response(csvResult.content)
     .header('Content-Type', 'text/csv;charset=utf-8')
     .header('Content-Disposition', `attachment; filename="${csvResult.filename}"`);
-};
+}
 
-const organizationController = {
+export const organizationController = {
   downloadCertificationResults,
 };
-
-export { organizationController };

--- a/api/src/certification/results/application/organization-route.js
+++ b/api/src/certification/results/application/organization-route.js
@@ -4,7 +4,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { organizationController } from './organization-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -34,6 +34,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const organizationRoute = { name: 'certification/results/organization-api', register };

--- a/api/src/certification/results/application/parcoursup-controller.js
+++ b/api/src/certification/results/application/parcoursup-controller.js
@@ -3,7 +3,7 @@ import { getI18n } from '../../../shared/infrastructure/i18n/i18n.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as parcoursupCertificationSerializer from '../infrastructure/serializers/parcoursup-certification-serializer.js';
 
-const getCertificationResultForParcoursup = async function (
+async function getCertificationResultForParcoursup(
   request,
   h,
   dependencies = {
@@ -26,7 +26,7 @@ const getCertificationResultForParcoursup = async function (
     certificationResult,
     translate: i18n.__,
   });
-};
+}
 
 export const parcoursupController = {
   getCertificationResultForParcoursup,

--- a/api/src/certification/results/application/parcoursup-route.js
+++ b/api/src/certification/results/application/parcoursup-route.js
@@ -8,7 +8,7 @@ import { jwtApplicationAuthenticationStrategyName } from '../../../shared/infras
 import { responseObjectErrorDoc } from '../../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
 import { parcoursupController } from './parcoursup-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'POST',
@@ -90,5 +90,5 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 export const parcoursupRoute = { name: 'certification/results/parcoursup-api', register };

--- a/api/src/certification/results/application/usecases/checkUserOwnsCertificationCourse.js
+++ b/api/src/certification/results/application/usecases/checkUserOwnsCertificationCourse.js
@@ -1,8 +1,6 @@
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
 
-const execute = async function ({ userId, certificationCourseId, dependencies = { certificationCourseRepository } }) {
+export async function execute({ userId, certificationCourseId, dependencies = { certificationCourseRepository } }) {
   const certificationCourse = await dependencies.certificationCourseRepository.get({ id: certificationCourseId });
   return certificationCourse.getUserId() === userId;
-};
-
-export { execute };
+}

--- a/api/src/certification/results/application/user-controller.js
+++ b/api/src/certification/results/application/user-controller.js
@@ -1,7 +1,7 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as userCertificationCoursesSerializer from '../infrastructure/serializers/user-certification-courses-serializer.js';
 
-const findAllCertificationCourses = async function (
+async function findAllCertificationCourses(
   request,
   h,
   dependencies = {
@@ -11,10 +11,8 @@ const findAllCertificationCourses = async function (
   const userId = request.params.userId;
   const userCertificationCourses = await usecases.findUserCertificationCourses({ userId });
   return dependencies.userCertificationCoursesSerializer.serialize(userCertificationCourses);
-};
+}
 
-const userController = {
+export const userController = {
   findAllCertificationCourses,
 };
-
-export { userController };

--- a/api/src/certification/results/application/user-route.js
+++ b/api/src/certification/results/application/user-route.js
@@ -4,7 +4,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { userController } from './user-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'GET',
@@ -36,6 +36,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const userRoute = { name: 'certification/results/certification-results-user-api', register };

--- a/api/src/certification/results/domain/read-models/CleaCertifiedCandidate.js
+++ b/api/src/certification/results/domain/read-models/CleaCertifiedCandidate.js
@@ -1,4 +1,4 @@
-class CleaCertifiedCandidate {
+export class CleaCertifiedCandidate {
   constructor({
     firstName,
     lastName,
@@ -38,13 +38,11 @@ class CleaCertifiedCandidate {
   }
 
   get isBornInFrenchOutermostRegion() {
-    const INSEECodeFrenchOutermostRegion = ['97', '98'];
-
-    const isCodeStartsWithFrenchOutermostRegion = (birthCode) =>
-      INSEECodeFrenchOutermostRegion.some((frenchOutermostRegion) => birthCode?.startsWith(frenchOutermostRegion));
-
     return [this.birthPostalCode, this.birthINSEECode].some(isCodeStartsWithFrenchOutermostRegion);
   }
 }
 
-export { CleaCertifiedCandidate };
+function isCodeStartsWithFrenchOutermostRegion(birthCode) {
+  const INSEECodeFrenchOutermostRegion = ['97', '98'];
+  return INSEECodeFrenchOutermostRegion.some((frenchOutermostRegion) => birthCode?.startsWith(frenchOutermostRegion));
+}

--- a/api/src/certification/results/domain/services/session-results-link-service.js
+++ b/api/src/certification/results/domain/services/session-results-link-service.js
@@ -1,11 +1,11 @@
 import { getPixAppUrl } from '../../../../shared/domain/services/url-service.js';
 import { CertificationResultsLinkToken } from '../models/tokens/CertificationResultsLinkToken.js';
 
-export const generateResultsLink = function ({ sessionId, i18n }) {
+export function generateResultsLink({ sessionId, i18n }) {
   const token = CertificationResultsLinkToken.generate({ sessionId });
   const locale = i18n.getLocale();
   return getPixAppUrl(locale, {
     pathname: '/resultats-session',
     hash: token,
   });
-};
+}

--- a/api/src/certification/results/domain/usecases/find-certificates-for-division.js
+++ b/api/src/certification/results/domain/usecases/find-certificates-for-division.js
@@ -1,6 +1,6 @@
 import { NoCertificateForDivisionError } from '../../../../shared/domain/errors.js';
 
-const findCertificatesForDivision = async function ({ organizationId, division, locale, certificateRepository }) {
+export async function findCertificatesForDivision({ organizationId, division, locale, certificateRepository }) {
   const certificates = await certificateRepository.findByDivisionForScoIsManagingStudentsOrganization({
     organizationId,
     division,
@@ -11,6 +11,4 @@ const findCertificatesForDivision = async function ({ organizationId, division, 
     throw new NoCertificateForDivisionError(division);
   }
   return certificates;
-};
-
-export { findCertificatesForDivision };
+}

--- a/api/src/certification/results/domain/usecases/find-certification-attestations-for-division.js
+++ b/api/src/certification/results/domain/usecases/find-certification-attestations-for-division.js
@@ -1,6 +1,6 @@
 import { NoCertificateForDivisionError } from '../../../../shared/domain/errors.js';
 
-const findCertificationAttestationsForDivision = async function ({ organizationId, division, certificateRepository }) {
+export async function findCertificationAttestationsForDivision({ organizationId, division, certificateRepository }) {
   const certificationAttestations = await certificateRepository.findByDivisionForScoIsManagingStudentsOrganization({
     organizationId,
     division,
@@ -10,6 +10,4 @@ const findCertificationAttestationsForDivision = async function ({ organizationI
     throw new NoCertificateForDivisionError(division);
   }
   return certificationAttestations;
-};
-
-export { findCertificationAttestationsForDivision };
+}

--- a/api/src/certification/results/domain/usecases/find-user-certificate-summaries.js
+++ b/api/src/certification/results/domain/usecases/find-user-certificate-summaries.js
@@ -7,8 +7,6 @@
  * @param {number} params.userId
  * @param {CertificateSummaryRepository} params.certificateSummaryRepository
  */
-const findUserCertificateSummaries = function ({ userId, certificateSummaryRepository }) {
+export function findUserCertificateSummaries({ userId, certificateSummaryRepository }) {
   return certificateSummaryRepository.findByUserId({ userId });
-};
-
-export { findUserCertificateSummaries };
+}

--- a/api/src/certification/results/domain/usecases/find-user-certification-courses.js
+++ b/api/src/certification/results/domain/usecases/find-user-certification-courses.js
@@ -3,8 +3,6 @@
  * @param {number} params.userId
  * @param {import('./index.js').sharedCertificationCourseRepository} params.sharedCertificationCourseRepository
  **/
-const findUserCertificationCourses = async function ({ userId, sharedCertificationCourseRepository }) {
+export async function findUserCertificationCourses({ userId, sharedCertificationCourseRepository }) {
   return sharedCertificationCourseRepository.findAllByUserId({ userId });
-};
-
-export { findUserCertificationCourses };
+}

--- a/api/src/certification/results/domain/usecases/get-certificate.js
+++ b/api/src/certification/results/domain/usecases/get-certificate.js
@@ -6,6 +6,6 @@
  * @param {object} params
  * @param {CertificateRepository} params.certificateRepository
  */
-export const getCertificate = async function ({ certificationCourseId, locale, certificateRepository }) {
+export async function getCertificate({ certificationCourseId, locale, certificateRepository }) {
   return certificateRepository.getCertificate({ certificationCourseId, locale });
-};
+}

--- a/api/src/certification/results/domain/usecases/get-certification-course-by-verification-code.js
+++ b/api/src/certification/results/domain/usecases/get-certification-course-by-verification-code.js
@@ -7,9 +7,6 @@
  * @param {string} params.verificationCode
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  */
-export const getCertificationCourseByVerificationCode = async function ({
-  verificationCode,
-  certificationCourseRepository,
-}) {
+export async function getCertificationCourseByVerificationCode({ verificationCode, certificationCourseRepository }) {
   return certificationCourseRepository.getByVerificationCode({ verificationCode });
-};
+}

--- a/api/src/certification/results/domain/usecases/get-certification-course-version.js
+++ b/api/src/certification/results/domain/usecases/get-certification-course-version.js
@@ -3,8 +3,6 @@
  * @param {number} params.certificationCourseId
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  */
-const getCertificationCourseVersion = async function ({ certificationCourseId, certificationCourseRepository }) {
+export async function getCertificationCourseVersion({ certificationCourseId, certificationCourseRepository }) {
   return certificationCourseRepository.getVersion({ certificationCourseId });
-};
-
-export { getCertificationCourseVersion };
+}

--- a/api/src/certification/results/domain/usecases/get-certification-result-for-parcoursup.js
+++ b/api/src/certification/results/domain/usecases/get-certification-result-for-parcoursup.js
@@ -20,7 +20,7 @@ import { MoreThanOneMatchingCertificationError } from '../errors.js';
  * @throws {MoreThanOneMatchingCertificationError} in some cases (INE for example) there might be duplicates
  * @throws {NotFoundError} if no certification exists for this candidate
  **/
-export const getCertificationResultForParcoursup = async ({
+export async function getCertificationResultForParcoursup({
   ine,
   organizationUai,
   lastName,
@@ -28,7 +28,7 @@ export const getCertificationResultForParcoursup = async ({
   birthdate,
   verificationCode,
   certificationParcoursupRepository,
-}) => {
+}) {
   let certifications = [];
 
   if (ine) {
@@ -52,4 +52,4 @@ export const getCertificationResultForParcoursup = async ({
   }
 
   return certifications.shift();
-};
+}

--- a/api/src/certification/results/domain/usecases/get-clea-certified-candidate-by-session.js
+++ b/api/src/certification/results/domain/usecases/get-clea-certified-candidate-by-session.js
@@ -1,4 +1,4 @@
-const getCleaCertifiedCandidateBySession = async function ({
+export async function getCleaCertifiedCandidateBySession({
   sessionId,
   cleaCertifiedCandidateRepository,
   sessionEnrolmentRepository,
@@ -7,6 +7,4 @@ const getCleaCertifiedCandidateBySession = async function ({
   const session = await sessionEnrolmentRepository.get({ id: sessionId });
 
   return { session, cleaCertifiedCandidateData };
-};
-
-export { getCleaCertifiedCandidateBySession };
+}

--- a/api/src/certification/results/domain/usecases/get-private-certificate.js
+++ b/api/src/certification/results/domain/usecases/get-private-certificate.js
@@ -10,8 +10,6 @@
  *
  * @returns {PrivateCertificate}
  **/
-const getPrivateCertificate = async function ({ certificationCourseId, locale, certificateRepository }) {
+export async function getPrivateCertificate({ certificationCourseId, locale, certificateRepository }) {
   return certificateRepository.getPrivateCertificate(certificationCourseId, { locale });
-};
-
-export { getPrivateCertificate };
+}

--- a/api/src/certification/results/domain/usecases/get-sco-certification-results-by-division.js
+++ b/api/src/certification/results/domain/usecases/get-sco-certification-results-by-division.js
@@ -10,7 +10,7 @@ import { NoCertificationResultForDivision } from '../errors.js';
  * @param {CertificationResultRepository} params.certificationResultRepository
  * @param {ScoCertificationCandidateRepository} params.scoCertificationCandidateRepository
  */
-const getScoCertificationResultsByDivision = async function ({
+export async function getScoCertificationResultsByDivision({
   organizationId,
   division,
   scoCertificationCandidateRepository,
@@ -32,6 +32,4 @@ const getScoCertificationResultsByDivision = async function ({
   }
 
   return certificationResults;
-};
-
-export { getScoCertificationResultsByDivision };
+}

--- a/api/src/certification/results/domain/usecases/get-session-certification-reports.js
+++ b/api/src/certification/results/domain/usecases/get-session-certification-reports.js
@@ -6,8 +6,6 @@
  * @param {object} params
  * @param {CertificationReportRepository} params.certificationReportRepository
  */
-const getSessionCertificationReports = async function ({ sessionId, certificationReportRepository }) {
+export async function getSessionCertificationReports({ sessionId, certificationReportRepository }) {
   return certificationReportRepository.findBySessionId({ sessionId });
-};
-
-export { getSessionCertificationReports };
+}

--- a/api/src/certification/results/domain/usecases/get-session-results-by-result-recipient-email.js
+++ b/api/src/certification/results/domain/usecases/get-session-results-by-result-recipient-email.js
@@ -1,4 +1,4 @@
-const getSessionResultsByResultRecipientEmail = async function ({
+export async function getSessionResultsByResultRecipientEmail({
   sessionId,
   resultRecipientEmail,
   certificationResultRepository,
@@ -9,6 +9,4 @@ const getSessionResultsByResultRecipientEmail = async function ({
   return await certificationResultRepository.findByCertificationCandidateIds({
     certificationCandidateIds: resultRecipient.candidateIds,
   });
-};
-
-export { getSessionResultsByResultRecipientEmail };
+}

--- a/api/src/certification/results/domain/usecases/get-session-results.js
+++ b/api/src/certification/results/domain/usecases/get-session-results.js
@@ -6,8 +6,6 @@
  * @param {object} params
  * @param {CertificationResultRepository} params.certificationResultRepository
  */
-const getSessionResults = async function ({ sessionId, certificationResultRepository }) {
+export async function getSessionResults({ sessionId, certificationResultRepository }) {
   return await certificationResultRepository.findBySessionId({ sessionId });
-};
-
-export { getSessionResults };
+}

--- a/api/src/certification/results/domain/usecases/get-shareable-certificate.js
+++ b/api/src/certification/results/domain/usecases/get-shareable-certificate.js
@@ -9,11 +9,9 @@
  * @param {CertificateRepository} params.certificateRepository
  */
 
-const getShareableCertificate = async function ({ certificationCourseId, locale, certificateRepository }) {
+export async function getShareableCertificate({ certificationCourseId, locale, certificateRepository }) {
   return certificateRepository.getShareableCertificate({
     certificationCourseId,
     locale,
   });
-};
-
-export { getShareableCertificate };
+}

--- a/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -2,7 +2,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
 import { Certificate } from '../../domain/read-models/livret-scolaire/Certificate.js';
 
-const getCertificatesByOrganizationUAI = async function (uai) {
+export async function getCertificatesByOrganizationUAI(uai) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn
     .select({
@@ -90,6 +90,4 @@ const getCertificatesByOrganizationUAI = async function (uai) {
     .orderBy('id', 'ASC');
 
   return result.map(Certificate.from);
-};
-
-export { getCertificatesByOrganizationUAI };
+}

--- a/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
@@ -14,7 +14,7 @@ import {
   CertifiedTube,
 } from '../../domain/read-models/CertifiedProfile.js';
 
-const get = async function (certificationCourseId) {
+export async function get(certificationCourseId) {
   const knexConn = DomainTransaction.getConnection();
   const certificationDatas = await knexConn
     .select({
@@ -38,7 +38,6 @@ const get = async function (certificationCourseId) {
     limitDate: createdAt,
   });
 
-  const isKnowledgeElementValidated = (knowledgeElement) => knowledgeElement.status === 'validated';
   const skillIds = knowledgeElements
     .filter((knowledgeElement) => isKnowledgeElementValidated(knowledgeElement))
     .map((pixKnowledgeElement) => pixKnowledgeElement.skillId);
@@ -56,9 +55,11 @@ const get = async function (certificationCourseId) {
     certifiedTubes,
     certifiedSkills,
   });
-};
+}
 
-export { get };
+function isKnowledgeElementValidated(knowledgeElement) {
+  return knowledgeElement.status === 'validated';
+}
 
 async function _createCertifiedSkills(skillIds, askedSkillIds) {
   const skills = await skillRepository.findByRecordIds(skillIds);

--- a/api/src/certification/results/infrastructure/repositories/clea-certified-candidate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/clea-certified-candidate-repository.js
@@ -2,7 +2,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { CleaCertifiedCandidate } from '../../domain/read-models/CleaCertifiedCandidate.js';
 
-const getBySessionId = async function (sessionId) {
+export async function getBySessionId(sessionId) {
   const knexConn = DomainTransaction.getConnection();
   const results = await knexConn
     .from('certification-courses')
@@ -45,6 +45,4 @@ const getBySessionId = async function (sessionId) {
       'complementary-certification-course-results.acquired': true,
     });
   return results.map((candidate) => new CleaCertifiedCandidate(candidate));
-};
-
-export { getBySessionId };
+}

--- a/api/src/certification/results/infrastructure/repositories/competence-tree-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/competence-tree-repository.js
@@ -1,9 +1,7 @@
 import { CompetenceTree } from '../../../../shared/domain/models/CompetenceTree.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 
-const get = async function ({ locale, dependencies = { areaRepository } } = {}) {
+export async function get({ locale, dependencies = { areaRepository } } = {}) {
   const areas = await dependencies.areaRepository.listWithPixCompetencesOnly({ locale });
   return new CompetenceTree({ areas });
-};
-
-export { get };
+}

--- a/api/src/certification/results/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -6,7 +6,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
  * @param {string} params.division
  * @returns {Promise<Array<number>>} candidates identifiers of active students participants to certification sessions within given division
  */
-const findIdsByOrganizationIdAndDivision = function ({ organizationId, division }) {
+export function findIdsByOrganizationIdAndDivision({ organizationId, division }) {
   const knexConn = DomainTransaction.getConnection();
   const uniqLastCandidatesByOrganizationLearners = knexConn
     .select(
@@ -41,15 +41,17 @@ const findIdsByOrganizationIdAndDivision = function ({ organizationId, division 
     .pluck('id')
     .from(uniqLastCandidatesByOrganizationLearners)
     .where('uniqLastCandidatesByOrganizationLearners.session_number', 1);
-};
+}
 
-const _sessionHasBeenPublished = (builder) =>
-  builder.whereNotNull('sessions.publishedAt').where('certification-courses.isPublished', '=', true);
+function _sessionHasBeenPublished(builder) {
+  return builder.whereNotNull('sessions.publishedAt').where('certification-courses.isPublished', '=', true);
+}
 
-const _candidateJoinedTheSession = (builder) =>
-  builder.whereNotNull('certification-candidates.userId').whereNotNull('certification-courses.id');
+function _candidateJoinedTheSession(builder) {
+  return builder.whereNotNull('certification-candidates.userId').whereNotNull('certification-courses.id');
+}
 
-const _candidateIsAnActiveStudentOfTheDivision = ({ organizationId, division }) => {
+function _candidateIsAnActiveStudentOfTheDivision({ organizationId, division }) {
   return (builder) =>
     builder
       .whereNotNull('certification-candidates.organizationLearnerId')
@@ -58,6 +60,4 @@ const _candidateIsAnActiveStudentOfTheDivision = ({ organizationId, division }) 
         'learners.isDisabled': false,
       })
       .whereRaw('LOWER(learners.division) = ?', division.toLowerCase());
-};
-
-export { findIdsByOrganizationIdAndDivision };
+}

--- a/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
@@ -2,14 +2,14 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const typeForAttribute = (attribute) => {
+function typeForAttribute(attribute) {
   if (attribute === 'resultCompetenceTree') {
     return 'result-competence-trees';
   }
   if (attribute === 'resultCompetences') {
     return 'result-competences';
   }
-};
+}
 
 const resultCompetenceTree = {
   included: true,
@@ -56,7 +56,7 @@ const attributes = [
   'badgeUrl',
 ];
 
-const serialize = function ({ certificate, translate, context }) {
+export function serialize({ certificate, translate, context }) {
   let globalLevel = {};
 
   if (certificate?.globalLevel) {
@@ -80,10 +80,8 @@ const serialize = function ({ certificate, translate, context }) {
     attributes,
     resultCompetenceTree,
   }).serialize(certificate);
-};
+}
 
 function _getLevel(certificate) {
   return certificate.globalLevel.meshLevel.split('_').at(-1);
 }
-
-export { serialize };

--- a/api/src/certification/results/infrastructure/serializers/certificate-summary-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certificate-summary-serializer.js
@@ -2,7 +2,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function (certificateSummaries, { translate }) {
+export function serialize(certificateSummaries, { translate }) {
   return new Serializer('certificate-summaries', {
     transform(certificateSummary) {
       return {
@@ -26,6 +26,4 @@ const serialize = function (certificateSummaries, { translate }) {
       'badgeUrl',
     ],
   }).serialize(certificateSummaries);
-};
-
-export { serialize };
+}

--- a/api/src/certification/results/infrastructure/serializers/certification-livret-scolaire-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certification-livret-scolaire-serializer.js
@@ -18,7 +18,7 @@ const attributes = [
   'certificationCenter',
 ];
 
-const serialize = function (certificate) {
+export function serialize(certificate) {
   return new Serializer('certificationsResults', {
     attributes: ['certifications', 'competences'],
     certifications: {
@@ -36,6 +36,4 @@ const serialize = function (certificate) {
       },
     },
   }).serialize(certificate);
-};
-
-export { serialize };
+}

--- a/api/src/certification/results/infrastructure/serializers/certified-profile-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certified-profile-serializer.js
@@ -2,12 +2,12 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const typeForAttribute = (attribute) => {
+function typeForAttribute(attribute) {
   return attribute
     .replace(/([a-z])([A-Z])/g, '$1-$2')
     .replace(/[\s_]+/g, '-')
     .toLowerCase();
-};
+}
 
 export function serialize(certifiedProfile) {
   return new Serializer('certified-profiles', {

--- a/api/src/certification/results/infrastructure/serializers/factory/build-area-for-livret-scolaire.js
+++ b/api/src/certification/results/infrastructure/serializers/factory/build-area-for-livret-scolaire.js
@@ -1,8 +1,6 @@
-const buildArea = function ({ id, name } = {}) {
+export function buildArea({ id, name } = {}) {
   return {
     id,
     name,
   };
-};
-
-export { buildArea };
+}

--- a/api/src/certification/results/infrastructure/serializers/factory/build-competences-for-livret-scolaire.js
+++ b/api/src/certification/results/infrastructure/serializers/factory/build-competences-for-livret-scolaire.js
@@ -1,12 +1,10 @@
 import { Competence } from '../response-objects/Competence.js';
 import { buildArea as buildAreaForLivretScolaire } from './build-area-for-livret-scolaire.js';
 
-const buildCompetenceForLivretScolaire = function ({ id, name, area = buildAreaForLivretScolaire() } = {}) {
+export function buildCompetenceForLivretScolaire({ id, name, area = buildAreaForLivretScolaire() } = {}) {
   return new Competence({
     id,
     name,
     area,
   });
-};
-
-export { buildCompetenceForLivretScolaire };
+}

--- a/api/src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js
@@ -9,7 +9,7 @@
  * @param {CertificateMeshLevel} params.globalMeshLevel
  * @param {object} params.translate
  */
-const serialize = ({ certificationResult, translate }) => {
+export function serialize({ certificationResult, translate }) {
   return {
     organizationUai: certificationResult.organizationUai,
     ine: certificationResult.ine,
@@ -22,6 +22,4 @@ const serialize = ({ certificationResult, translate }) => {
     certificationDate: certificationResult.certificationDate,
     competences: certificationResult.competences,
   };
-};
-
-export { serialize };
+}

--- a/api/src/certification/results/infrastructure/serializers/private-certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/private-certificate-serializer.js
@@ -2,14 +2,14 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const typeForAttribute = (attribute) => {
+function typeForAttribute(attribute) {
   if (attribute === 'resultCompetenceTree') {
     return 'result-competence-trees';
   }
   if (attribute === 'resultCompetences') {
     return 'result-competences';
   }
-};
+}
 
 const resultCompetenceTree = {
   included: true,
@@ -51,7 +51,7 @@ const attributes = [
   'algorithmEngineVersion',
 ];
 
-const serialize = function (certificate, { translate }) {
+export function serialize(certificate, { translate }) {
   return new Serializer('certifications', {
     transform(privateCertificate) {
       return {
@@ -63,6 +63,4 @@ const serialize = function (certificate, { translate }) {
     attributes,
     resultCompetenceTree,
   }).serialize(certificate);
-};
-
-export { serialize };
+}

--- a/api/src/certification/results/infrastructure/serializers/user-certification-courses-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/user-certification-courses-serializer.js
@@ -2,13 +2,11 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function (userCertificationCourses) {
+export function serialize(userCertificationCourses) {
   return new Serializer('user-certification-course', {
     transform(currentCertificationCourse) {
       return currentCertificationCourse.toDTO();
     },
     attributes: ['id', 'createdAt', 'isPublished', 'sessionId'],
   }).serialize(userCertificationCourses);
-};
-
-export { serialize };
+}

--- a/api/src/certification/results/infrastructure/utils/csv/certification-results/get-clea-certified-candidate-csv.js
+++ b/api/src/certification/results/infrastructure/utils/csv/certification-results/get-clea-certified-candidate-csv.js
@@ -2,12 +2,12 @@ import dayjs from 'dayjs';
 
 import { getCsvContent } from '../../../../../../shared/infrastructure/utils/csv/write-csv-utils.js';
 
-const getCleaCertifiedCandidateCsv = async function ({ cleaCertifiedCandidates }) {
+export async function getCleaCertifiedCandidateCsv({ cleaCertifiedCandidates }) {
   const fileHeaders = _buildFileHeadersForCleaCandidates(cleaCertifiedCandidates);
   const data = _buildFileDataForCleaCandidates(cleaCertifiedCandidates);
 
   return getCsvContent({ data, fileHeaders });
-};
+}
 
 function _buildFileHeadersForCleaCandidates() {
   return [
@@ -122,5 +122,3 @@ const _headers = {
   CCPI: 'CCPI',
   FIRST_SHOT: 'Obtention après la première évaluation ?',
 };
-
-export { getCleaCertifiedCandidateCsv };

--- a/api/src/certification/results/infrastructure/utils/pdf/generate-v2-pdf-attestation.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/generate-v2-pdf-attestation.js
@@ -9,7 +9,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 /**
  * @param {object} params
  */
-const generate = ({ certificates, i18n, isFrenchDomainExtension }) => {
+export function generate({ certificates, i18n, isFrenchDomainExtension }) {
   const doc = new PDFDocument({
     size: 'A4',
   });
@@ -51,6 +51,4 @@ const generate = ({ certificates, i18n, isFrenchDomainExtension }) => {
   doc.end();
 
   return doc;
-};
-
-export { generate };
+}

--- a/api/src/certification/results/infrastructure/utils/pdf/generate-v3-pdf-certificate.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/generate-v3-pdf-certificate.js
@@ -15,7 +15,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
  * @param {object} params
  * @param {Array<Certificate>} params.certificates
  */
-const generate = async ({ certificates, i18n }) => {
+export async function generate({ certificates, i18n }) {
   const doc = new PDFDocument({
     size: 'A4',
     layout: 'landscape',
@@ -64,6 +64,4 @@ const generate = async ({ certificates, i18n }) => {
   doc.end();
 
   return doc;
-};
-
-export { generate };
+}


### PR DESCRIPTION
## ☀️ Problème

Nous avons des déclarations de fonctions et d'export très disparate. C'est gênant pour la lecture (perte de temps lié à une forme de contexte switching)

## ⛱️ Proposition

Étendre la règle eslint pour forcer à déclarer les fonctions d'une certaine manières (et les exports aussi) dans le contexte `certification/results`

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
