### PR TITLE
[TECH] Oblige et modifie le style de déclaration de function pour le contexte `certification/evaluation`

### DIFF
--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -64,7 +64,11 @@ export default defineConfig([
     },
   },
   {
-    files: ['src/certification/configuration/**/*.{js,mjs}', 'src/certification/results/**/*.{js,mjs}'],
+    files: [
+      'src/certification/configuration/**/*.{js,mjs}',
+      'src/certification/results/**/*.{js,mjs}',
+      'src/certification/evaluation/**/*.{js,mjs}',
+    ],
     rules: {
       'func-style': ['error', 'declaration'],
     },

--- a/api/src/certification/evaluation/application/certification-admin-controller.js
+++ b/api/src/certification/evaluation/application/certification-admin-controller.js
@@ -1,7 +1,7 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../domain/usecases/index.js';
 
-const neutralizeChallenge = async function (request, h) {
+async function neutralizeChallenge(request, h) {
   const { challengeRecId, certificationCourseId } = request.payload.data.attributes;
   const { userId: juryId } = request.auth.credentials;
 
@@ -15,9 +15,9 @@ const neutralizeChallenge = async function (request, h) {
   });
 
   return h.response().code(204);
-};
+}
 
-const deneutralizeChallenge = async function (request, h) {
+async function deneutralizeChallenge(request, h) {
   const { challengeRecId, certificationCourseId } = request.payload.data.attributes;
   const { userId: juryId } = request.auth.credentials;
 
@@ -31,11 +31,9 @@ const deneutralizeChallenge = async function (request, h) {
   });
 
   return h.response().code(204);
-};
+}
 
-const certificationAdminController = {
+export const certificationAdminController = {
   neutralizeChallenge,
   deneutralizeChallenge,
 };
-
-export { certificationAdminController };

--- a/api/src/certification/evaluation/application/certification-admin-route.js
+++ b/api/src/certification/evaluation/application/certification-admin-route.js
@@ -4,7 +4,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { certificationAdminController } from './certification-admin-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'POST',
@@ -65,6 +65,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const certificationAdminRoute = { name: 'certification/evaluation/evaluation-certification-api', register };

--- a/api/src/certification/evaluation/application/certification-course-route.js
+++ b/api/src/certification/evaluation/application/certification-course-route.js
@@ -5,7 +5,7 @@ import { V3_CERTIFICATION_AVAILABLE_LOCALES } from '../../shared/domain/models/C
 import { certificationCourseController } from './certification-course-controller.js';
 import { evaluationSecurityPreHandlers } from './security-pre-handlers.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'POST',
@@ -60,6 +60,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const certificationCourseRoute = { name: 'certification/evaluation/certification-courses-api', register };

--- a/api/src/certification/evaluation/application/certification-rescoring-controller.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-controller.js
@@ -5,7 +5,7 @@ import * as certificationCourseRepository from '../../shared/infrastructure/repo
 import CertificationRescored from '../domain/events/CertificationRescored.js';
 import { usecases } from '../domain/usecases/index.js';
 
-const rescoreCertification = async function (
+async function rescoreCertification(
   request,
   h,
   dependencies = { certificationCourseRepository, courseAssessmentResultRepository },
@@ -35,14 +35,12 @@ const rescoreCertification = async function (
   }
 
   return h.response().code(201);
-};
+}
 
-const _isAssessmentResultNotRescorable = (latestAssessmentResult) => {
+function _isAssessmentResultNotRescorable(latestAssessmentResult) {
   return latestAssessmentResult?.status === 'cancelled' || latestAssessmentResult?.status === 'rejected';
-};
+}
 
-const certificationRescoringController = {
+export const certificationRescoringController = {
   rescoreCertification,
 };
-
-export { certificationRescoringController };

--- a/api/src/certification/evaluation/application/certification-rescoring-route.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-route.js
@@ -4,7 +4,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { certificationRescoringController } from './certification-rescoring-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   server.route([
     {
       method: 'POST',
@@ -32,6 +32,6 @@ const register = async function (server) {
       },
     },
   ]);
-};
+}
 
 export const certificationRescoringRoute = { name: 'certification/evaluation/certification-rescoring-api', register };

--- a/api/src/certification/evaluation/application/companion-alert-controller.js
+++ b/api/src/certification/evaluation/application/companion-alert-controller.js
@@ -1,13 +1,11 @@
 import { usecases } from '../domain/usecases/index.js';
 
-const createCertificationCompanionLiveAlert = async function (request, h) {
+async function createCertificationCompanionLiveAlert(request, h) {
   const assessmentId = request.params.assessmentId;
   await usecases.createCompanionAlert({ assessmentId });
   return h.response().code(204);
-};
+}
 
-const companionAlertController = {
+export const companionAlertController = {
   createCertificationCompanionLiveAlert,
 };
-
-export { companionAlertController };

--- a/api/src/certification/evaluation/application/companion-alert-route.js
+++ b/api/src/certification/evaluation/application/companion-alert-route.js
@@ -4,7 +4,7 @@ import { assessmentAuthorization } from '../../../evaluation/application/pre-han
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { companionAlertController } from './companion-alert-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   const routes = [
     {
       method: 'POST',
@@ -27,6 +27,6 @@ const register = async function (server) {
     },
   ];
   server.route(routes);
-};
+}
 
 export const companionAlertRoute = { name: 'certification/evaluation/evaluation-companion-alert-api', register };

--- a/api/src/certification/evaluation/application/live-alert-route.js
+++ b/api/src/certification/evaluation/application/live-alert-route.js
@@ -4,7 +4,7 @@ import { assessmentAuthorization } from '../../../evaluation/application/pre-han
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { liveAlertController } from './live-alert-controller.js';
 
-const register = async function (server) {
+async function register(server) {
   const routes = [
     {
       method: 'POST',
@@ -34,6 +34,6 @@ const register = async function (server) {
     },
   ];
   server.route(routes);
-};
+}
 
 export const liveAlertRoute = { name: 'certification/evaluation/evaluation-live-alert-api', register };

--- a/api/src/certification/evaluation/application/scenario-simulator-route.js
+++ b/api/src/certification/evaluation/application/scenario-simulator-route.js
@@ -4,7 +4,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { getChallengeLocales } from '../../../shared/domain/services/locale-service.js';
 import { scenarioSimulatorController } from './scenario-simulator-controller.js';
 
-const register = async (server) => {
+async function register(server) {
   server.route([
     {
       method: 'POST',
@@ -46,6 +46,6 @@ const register = async (server) => {
       },
     },
   ]);
-};
+}
 
 export const scenarioSimulatorRoute = { name: 'certification/evaluation/scenario-simulator-api', register };

--- a/api/src/certification/evaluation/application/scoring-and-capacity-simulator-controller.js
+++ b/api/src/certification/evaluation/application/scoring-and-capacity-simulator-controller.js
@@ -1,7 +1,7 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as serializer from '../infrastructure/serializers/scoring-and-capacity-simulator-report-serializer.js';
 
-const simulateScoringOrCapacity = async (req, h) => {
+async function simulateScoringOrCapacity(req, h) {
   const { capacity, score, date } = req.payload.data;
 
   let scoringAndCapacitySimulatorReport;
@@ -20,10 +20,8 @@ const simulateScoringOrCapacity = async (req, h) => {
   }
 
   return h.response(serializer.serialize(scoringAndCapacitySimulatorReport)).code(200);
-};
+}
 
-const scoringAndCapacitySimulatorController = {
+export const scoringAndCapacitySimulatorController = {
   simulateScoringOrCapacity,
 };
-
-export { scoringAndCapacitySimulatorController };

--- a/api/src/certification/evaluation/application/scoring-and-capacity-simulator-route.js
+++ b/api/src/certification/evaluation/application/scoring-and-capacity-simulator-route.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { scoringAndCapacitySimulatorController } from './scoring-and-capacity-simulator-controller.js';
 
-const register = async (server) => {
+async function register(server) {
   server.route([
     {
       method: 'POST',
@@ -33,7 +33,7 @@ const register = async (server) => {
       },
     },
   ]);
-};
+}
 
 export const scoringAndCapacitySimulatorRoute = {
   name: 'certification/evaluation/scoring-and-capacity-simulator-api',

--- a/api/src/certification/evaluation/domain/models/FlashAssessmentAlgorithmNonAnsweredSkillsRule.js
+++ b/api/src/certification/evaluation/domain/models/FlashAssessmentAlgorithmNonAnsweredSkillsRule.js
@@ -10,9 +10,8 @@ export class FlashAssessmentAlgorithmNonAnsweredSkillsRule {
       .map((answer) => this._findChallengeForAnswer(allChallenges, answer))
       .map((challenge) => challenge.skill.id);
 
-    const isNonAnsweredSkill = (skill) => !alreadyAnsweredSkillsIds.includes(skill.id);
     const challengesForNonAnsweredSkills = availableChallenges.filter((challenge) =>
-      isNonAnsweredSkill(challenge.skill),
+      isNonAnsweredSkill(alreadyAnsweredSkillsIds, challenge.skill),
     );
 
     return challengesForNonAnsweredSkills;
@@ -25,4 +24,7 @@ export class FlashAssessmentAlgorithmNonAnsweredSkillsRule {
     }
     return challengeAssociatedToAnswer;
   }
+}
+function isNonAnsweredSkill(alreadyAnsweredSkillsIds, skill) {
+  return !alreadyAnsweredSkillsIds.includes(skill.id);
 }

--- a/api/src/certification/evaluation/domain/models/FlashAssessmentAlgorithmOneQuestionPerTubeRule.js
+++ b/api/src/certification/evaluation/domain/models/FlashAssessmentAlgorithmOneQuestionPerTubeRule.js
@@ -9,11 +9,14 @@ export class FlashAssessmentAlgorithmOneQuestionPerTubeRule {
         FlashAssessmentAlgorithmOneQuestionPerTubeRule._findChallengeForAnswer(allChallenges, answer).skill.tubeId,
     );
 
-    const isNonAnsweredTube = (skill) => !alreadyAnsweredTubeIds.includes(skill.tubeId);
-    return availableChallenges.filter((challenge) => isNonAnsweredTube(challenge.skill));
+    return availableChallenges.filter((challenge) => isNonAnsweredTube(alreadyAnsweredTubeIds, challenge.skill));
   }
 
   static _findChallengeForAnswer(challenges, answer) {
     return challenges.find((challenge) => challenge.id === answer.challengeId);
   }
+}
+
+function isNonAnsweredTube(alreadyAnsweredTubeIds, skill) {
+  return !alreadyAnsweredTubeIds.includes(skill.tubeId);
 }

--- a/api/src/certification/evaluation/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/evaluation/domain/services/algorithm-methods/flash.js
@@ -221,12 +221,16 @@ export function getChallengesForNonAnsweredSkills({ allAnswers, challenges }) {
     .map((answer) => _findChallengeForAnswer(challenges, answer))
     .map((challenge) => challenge.skill.id);
 
-  const isNonAnsweredSkill = (skill) => !alreadyAnsweredSkillsIds.includes(skill.id);
-  const challengesForNonAnsweredSkills = challenges.filter((challenge) => isNonAnsweredSkill(challenge.skill));
+  const challengesForNonAnsweredSkills = challenges.filter((challenge) =>
+    isNonAnsweredSkill(alreadyAnsweredSkillsIds, challenge.skill),
+  );
 
   return challengesForNonAnsweredSkills;
 }
 
+function isNonAnsweredSkill(alreadyAnsweredSkillsIds, skill) {
+  return !alreadyAnsweredSkillsIds.includes(skill.id);
+}
 /**
  * @private
  * @param {number} previousCapacity

--- a/api/src/certification/evaluation/domain/services/scoring/calibrated-challenge-service.js
+++ b/api/src/certification/evaluation/domain/services/scoring/calibrated-challenge-service.js
@@ -68,11 +68,11 @@ export async function findCalibratedChallenges({
  * @param {ChallengeCalibrationRepository} params.challengeCalibrationRepository
  * @returns {Promise<FindByCertificationCourseIdObject>}
  */
-const _findByCertificationCourseId = async ({
+async function _findByCertificationCourseId({
   compatibleChallenges,
   certificationCourseId,
   challengeCalibrationRepository,
-}) => {
+}) {
   const challengesCalibrations = await challengeCalibrationRepository.getByCertificationCourseId({
     certificationCourseId,
   });
@@ -81,7 +81,7 @@ const _findByCertificationCourseId = async ({
     return challengesCalibrations.find((calibration) => challenge.id === calibration.id);
   });
   return { allChallenges: compatibleChallenges, askedChallenges, challengesCalibrations };
-};
+}
 
 /**
  * @param {Array<ChallengeCalibration>} challengesCalibrations - only calibrations of challenges PRESENTED to candidate

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-degradation-service.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-degradation-service.js
@@ -25,13 +25,13 @@ const PROBABILITY_TO_PICK_THE_MOST_USEFUL_CHALLENGE_FOR_CANDIDATE_EVALUATION = 1
  * @param {FlashAssessmentAlgorithmConfiguration} params.flashAssessmentAlgorithmConfiguration - The flash assessment algorithm configuration.
  * @returns {number} The downgraded capacity.
  */
-export const downgradeCapacity = ({
+export function downgradeCapacity({
   algorithm,
   capacity,
   allChallenges,
   allAnswers,
   flashAssessmentAlgorithmConfiguration,
-}) => {
+}) {
   const numberOfUnansweredChallenges =
     flashAssessmentAlgorithmConfiguration.maximumAssessmentLength - allAnswers.length;
 
@@ -57,4 +57,4 @@ export const downgradeCapacity = ({
   const result = simulator.run({ challengesAnswers: allAnswers });
 
   return result.at(-1).capacity;
-};
+}

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
@@ -34,7 +34,7 @@ import { CertificationContract } from '../CertificationContract.js';
  * @param {object} params.dependencies
  * @param {calculateCertificationAssessmentScore} params.dependencies.calculateCertificationAssessmentScore
  */
-export const handleV2CertificationScoring = async ({
+export async function handleV2CertificationScoring({
   event,
   certificationAssessment,
   assessmentResultRepository,
@@ -45,7 +45,7 @@ export const handleV2CertificationScoring = async ({
   scoringService,
   candidateRepository,
   dependencies = { calculateCertificationAssessmentScore },
-}) => {
+}) {
   const certificationAssessmentScore = await dependencies.calculateCertificationAssessmentScore({
     certificationAssessment,
     areaRepository,
@@ -76,7 +76,7 @@ export const handleV2CertificationScoring = async ({
   });
 
   return certificationCourse;
-};
+}
 
 /**
  * @param {object} params
@@ -84,7 +84,7 @@ export const handleV2CertificationScoring = async ({
  * @param {ScoringService} params.scoringService
  * @param {CandidateRepository} params.candidateRepository
  */
-export const calculateCertificationAssessmentScore = async function ({
+export async function calculateCertificationAssessmentScore({
   certificationAssessment,
   areaRepository,
   placementProfileService,
@@ -114,7 +114,7 @@ export const calculateCertificationAssessmentScore = async function ({
 
   const allAreas = await areaRepository.list();
   return _getResult(matchingAnswers, matchingCertificationChallenges, testedCompetences, allAreas, scoringService);
-};
+}
 
 /**
  * @param {object} params

--- a/api/src/certification/evaluation/domain/services/verify-certificate-code-service.js
+++ b/api/src/certification/evaluation/domain/services/verify-certificate-code-service.js
@@ -17,7 +17,7 @@ function _generateCode() {
   return 'P-' + chars.slice(0, NB_CHAR).join('');
 }
 
-const generateCertificateVerificationCode = async function ({
+export async function generateCertificateVerificationCode({
   generateCode = _generateCode,
   dependencies = { certificationCourseRepository },
 } = {}) {
@@ -29,6 +29,4 @@ const generateCertificateVerificationCode = async function ({
     if (isCodeAvailable) return verificationCode;
   }
   throw new CertificateVerificationCodeGenerationTooManyTrials(NB_OF_TRIALS);
-};
-
-export { generateCertificateVerificationCode };
+}

--- a/api/src/certification/evaluation/domain/usecases/complete-certification-assessment.js
+++ b/api/src/certification/evaluation/domain/usecases/complete-certification-assessment.js
@@ -2,29 +2,33 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCompletedJob } from '../events/CertificationCompleted.js';
 
-export const completeCertificationAssessment =
-  /**
-   * @param {object} params
-   * @param {number} params.certificationCourseId
-   * @param {string} params.locale
-   * @param {import('./index.js').AssessmentSheetRepository} params.assessmentSheetRepository
-   * @param {import('./index.js').CertificationCompletedJobRepository} params.certificationCompletedJobRepository
-   **/
-  async function ({ certificationCourseId, locale, assessmentSheetRepository, certificationCompletedJobRepository }) {
-    const assessmentSheet = await assessmentSheetRepository.findByCertificationCourseId(certificationCourseId);
+/**
+ * @param {object} params
+ * @param {number} params.certificationCourseId
+ * @param {string} params.locale
+ * @param {import('./index.js').AssessmentSheetRepository} params.assessmentSheetRepository
+ * @param {import('./index.js').CertificationCompletedJobRepository} params.certificationCompletedJobRepository
+ **/
+export async function completeCertificationAssessment({
+  certificationCourseId,
+  locale,
+  assessmentSheetRepository,
+  certificationCompletedJobRepository,
+}) {
+  const assessmentSheet = await assessmentSheetRepository.findByCertificationCourseId(certificationCourseId);
 
-    if (!assessmentSheet) throw new NotFoundError('Assessment not found');
+  if (!assessmentSheet) throw new NotFoundError('Assessment not found');
 
-    if (assessmentSheet.isStarted) {
-      assessmentSheet.complete();
-      await assessmentSheetRepository.update(assessmentSheet);
-      await DomainTransaction.addSuccessHandler(async () => {
-        await certificationCompletedJobRepository.performAsync(
-          new CertificationCompletedJob({
-            certificationCourseId,
-            locale,
-          }),
-        );
-      });
-    }
-  };
+  if (assessmentSheet.isStarted) {
+    assessmentSheet.complete();
+    await assessmentSheetRepository.update(assessmentSheet);
+    await DomainTransaction.addSuccessHandler(async () => {
+      await certificationCompletedJobRepository.performAsync(
+        new CertificationCompletedJob({
+          certificationCourseId,
+          locale,
+        }),
+      );
+    });
+  }
+}

--- a/api/src/certification/evaluation/domain/usecases/deneutralize-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/deneutralize-challenge.js
@@ -12,7 +12,7 @@ import { ChallengeDeneutralized } from '../events/ChallengeDeneutralized.js';
  * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
  * @returns {Promise<ChallengeDeneutralizedEvent>}
  */
-export const deneutralizeChallenge = async function ({
+export async function deneutralizeChallenge({
   certificationCourseId,
   challengeRecId,
   juryId,
@@ -24,4 +24,4 @@ export const deneutralizeChallenge = async function ({
   certificationAssessment.deneutralizeChallengeByRecId(challengeRecId);
   await certificationAssessmentRepository.save(certificationAssessment);
   return new ChallengeDeneutralized({ certificationCourseId, juryId });
-};
+}

--- a/api/src/certification/evaluation/domain/usecases/neutralize-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/neutralize-challenge.js
@@ -12,7 +12,7 @@ import { ChallengeNeutralized } from '../events/ChallengeNeutralized.js';
  * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
  * @returns {Promise<ChallengeNeutralizedEvent>}
  */
-export const neutralizeChallenge = async function ({
+export async function neutralizeChallenge({
   certificationCourseId,
   challengeRecId,
   juryId,
@@ -24,4 +24,4 @@ export const neutralizeChallenge = async function ({
   certificationAssessment.neutralizeChallengeByRecId(challengeRecId);
   await certificationAssessmentRepository.save(certificationAssessment);
   return new ChallengeNeutralized({ certificationCourseId, juryId });
-};
+}

--- a/api/src/certification/evaluation/domain/usecases/rescore-v2-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/rescore-v2-certification.js
@@ -44,14 +44,14 @@ const eventTypes = [
  * @throws {NotFinalizedSessionError}
  * @throws {SessionAlreadyPublishedError}
  */
-export const rescoreV2Certification = async ({
+export async function rescoreV2Certification({
   event,
   assessmentResultRepository,
   certificationAssessmentRepository,
   complementaryCertificationScoringCriteriaRepository,
   sessionRepository,
   services,
-}) => {
+}) {
   checkEventTypes(event, eventTypes);
 
   const certificationCourseId = event.certificationCourseId;
@@ -69,7 +69,7 @@ export const rescoreV2Certification = async ({
     complementaryCertificationScoringCriteriaRepository,
     services,
   });
-};
+}
 
 /**
  * @param {object} params
@@ -80,7 +80,7 @@ export const rescoreV2Certification = async ({
  * @throws {NotFinalizedSessionError}
  * @throws {SessionAlreadyPublishedError}
  */
-const _verifySessionIsPublishable = async ({ certificationCourseId, sessionRepository }) => {
+async function _verifySessionIsPublishable({ certificationCourseId, sessionRepository }) {
   const session = await sessionRepository.getByCertificationCourseId({ certificationCourseId });
 
   if (!session.isFinalized) {
@@ -90,7 +90,7 @@ const _verifySessionIsPublishable = async ({ certificationCourseId, sessionRepos
   if (session.isPublished) {
     throw new SessionAlreadyPublishedError();
   }
-};
+}
 
 async function _handleV2CertificationScoring({
   event,

--- a/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
@@ -136,12 +136,12 @@ export async function scoreV3Certification({
  * @throws {NotFinalizedSessionError}
  * @throws {SessionAlreadyPublishedError}
  */
-const _verifyCertificationIsScorable = async ({
+async function _verifyCertificationIsScorable({
   certificationCourseId,
   answers,
   maximumAssessmentLength,
   sessionRepository,
-}) => {
+}) {
   const session = await sessionRepository.getByCertificationCourseId({ certificationCourseId });
 
   if (session.isPublished) {
@@ -153,7 +153,7 @@ const _verifyCertificationIsScorable = async ({
   if (!session.isFinalized && !hasCandidateSeenEndScreen) {
     throw new NotFinalizedSessionError();
   }
-};
+}
 
 /**
  * @param {object} params

--- a/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
@@ -48,7 +48,7 @@ export async function update(assessmentSheet) {
     .where({ id: assessmentSheet.certificationCourseId });
 }
 
-const baseQuery = () => {
+function baseQuery() {
   const knexConn = DomainTransaction.getConnection();
   return knexConn
     .select({
@@ -73,4 +73,4 @@ const baseQuery = () => {
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
     .join('certification-candidates', 'certification-candidates.id', 'certification-courses.candidateId');
-};
+}

--- a/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
@@ -28,7 +28,14 @@ export async function findActiveFlashCompatible({ locale, version }) {
 
   const certificationChallengeIds = calibrations.map(({ challengeId }) => challengeId);
 
-  const findCallback = async (lcmsKnex) => {
+  const lcmsChallengeDtos = await getInstance().find(cacheKey, findCallback(certificationChallengeIds, locale));
+
+  const calibratedSkillsMap = await loadCalibratedSkillsMap(lcmsChallengeDtos);
+  return toDomainMap({ lcmsChallengeDtos, calibrations, calibratedSkillsMap });
+}
+
+function findCallback(certificationChallengeIds, locale) {
+  return (lcmsKnex) => {
     return lcmsKnex
       .select('id', 'skillId', 'accessibility1', 'accessibility2')
       .whereIn('id', certificationChallengeIds)
@@ -36,11 +43,6 @@ export async function findActiveFlashCompatible({ locale, version }) {
       .whereRaw('?=ANY(??)', [locale, 'locales'])
       .orderBy('id');
   };
-
-  const lcmsChallengeDtos = await getInstance().find(cacheKey, findCallback);
-
-  const calibratedSkillsMap = await loadCalibratedSkillsMap(lcmsChallengeDtos);
-  return toDomainMap({ lcmsChallengeDtos, calibrations, calibratedSkillsMap });
 }
 
 /**

--- a/api/src/certification/evaluation/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/candidate-repository.js
@@ -106,9 +106,9 @@ export async function findByUserIdAndSessionId({ userId, sessionId }) {
  * @param {CandidateRecord}
  * @returns {Candidate}
  */
-const _toDomain = (data) => {
+function _toDomain(data) {
   return new Candidate({
     ...data,
     subscriptionFramework: data.subscription,
   });
-};
+}

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-assessment-history-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-assessment-history-repository.js
@@ -1,9 +1,9 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
-export const save = (certificationChallengeHistory) => {
+export function save(certificationChallengeHistory) {
   const knexConn = DomainTransaction.getConnection();
   return knexConn('certification-challenge-capacities')
     .insert(certificationChallengeHistory.capacityHistory)
     .onConflict('certificationChallengeId')
     .merge();
-};
+}

--- a/api/src/certification/evaluation/infrastructure/repositories/challenge-calibration-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/challenge-calibration-repository.js
@@ -6,7 +6,7 @@ import { ChallengeCalibration } from '../../domain/read-models/ChallengeCalibrat
  * @param {number} params.certificationCourseId
  * @returns {Promise<Array<ChallengeCalibration>>}
  */
-export const getByCertificationCourseId = async ({ certificationCourseId }) => {
+export async function getByCertificationCourseId({ certificationCourseId }) {
   const knexConn = DomainTransaction.getConnection();
   const challengeCalibrations = await knexConn('certification-challenges')
     .select({
@@ -19,7 +19,7 @@ export const getByCertificationCourseId = async ({ certificationCourseId }) => {
     .orderBy('createdAt', 'asc');
 
   return _toDomain(challengeCalibrations);
-};
+}
 
 /**
  * @param {Array<object>} challengeCalibrations

--- a/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
@@ -1,7 +1,7 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertificationScoringCriteria } from '../../domain/models/ComplementaryCertificationScoringCriteria.js';
 
-export const findByCertificationCourseId = async function ({ certificationCourseId }) {
+export async function findByCertificationCourseId({ certificationCourseId }) {
   const knexConn = DomainTransaction.getConnection();
   const results = await knexConn('complementary-certification-courses')
     .select({
@@ -44,4 +44,4 @@ export const findByCertificationCourseId = async function ({ certificationCourse
       });
     },
   );
-};
+}

--- a/api/src/certification/evaluation/infrastructure/repositories/pix-plus-certification-course-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/pix-plus-certification-course-repository.js
@@ -2,7 +2,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { PixPlusCertificationCourse } from '../../domain/models/PixPlusCertificationCourse.js';
 
-const getByCertificationCourseId = async function (certificationCourseId) {
+export async function getByCertificationCourseId(certificationCourseId) {
   const knexConn = DomainTransaction.getConnection();
   const PIX_PLUS_START_DATE = '2025-07-01';
 
@@ -25,10 +25,8 @@ const getByCertificationCourseId = async function (certificationCourseId) {
   }
 
   return _toDomain(pixPlusCertificationCourse);
-};
+}
 
-const _toDomain = (pixPlusCertificationCourse) => {
+function _toDomain(pixPlusCertificationCourse) {
   return new PixPlusCertificationCourse(pixPlusCertificationCourse);
-};
-
-export { getByCertificationCourseId };
+}

--- a/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
@@ -5,7 +5,7 @@ import * as versionApi from '../../../configuration/application/api/version-api.
 import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 import { V3CertificationScoring } from '../../domain/models/V3CertificationScoring.js';
 
-export const getLatestByDateAndLocale = async ({ locale, date }) => {
+export async function getLatestByDateAndLocale({ locale, date }) {
   const certificationVersion = await versionApi.getByFrameworkAndDate({ date, framework: Frameworks.CORE });
 
   if (
@@ -29,9 +29,9 @@ export const getLatestByDateAndLocale = async ({ locale, date }) => {
     minimumAnswersRequiredToValidateACertification: certificationVersion.minimumAnswersRequiredToValidateACertification,
     versionId: certificationVersion.id,
   });
-};
+}
 
-export const getLatestByVersion = async ({ version }) => {
+export async function getLatestByVersion({ version }) {
   const allAreas = await areaRepository.list();
   const competenceList = await competenceRepository.list();
 
@@ -43,4 +43,4 @@ export const getLatestByVersion = async ({ version }) => {
     minimumAnswersRequiredToValidateACertification: version.minimumAnswersRequiredToValidateACertification,
     versionId: version.id,
   });
-};
+}

--- a/api/src/certification/evaluation/infrastructure/serializers/scenario-simulator-batch-serializer.js
+++ b/api/src/certification/evaluation/infrastructure/serializers/scenario-simulator-batch-serializer.js
@@ -29,10 +29,12 @@ function serialize(scenarioSimulator = {}) {
 
 export const scenarioSimulatorBatchSerializer = { serialize };
 
-const _transformSimulationReport = (answer) => ({
-  ...answer,
-  challengeId: answer.challenge.id,
-  minimumCapability: answer.challenge.minimumCapability,
-  difficulty: answer.challenge.difficulty,
-  discriminant: answer.challenge.discriminant,
-});
+function _transformSimulationReport(answer) {
+  return {
+    ...answer,
+    challengeId: answer.challenge.id,
+    minimumCapability: answer.challenge.minimumCapability,
+    difficulty: answer.challenge.difficulty,
+    discriminant: answer.challenge.discriminant,
+  };
+}

--- a/api/src/certification/evaluation/infrastructure/serializers/scoring-and-capacity-simulator-report-serializer.js
+++ b/api/src/certification/evaluation/infrastructure/serializers/scoring-and-capacity-simulator-report-serializer.js
@@ -5,10 +5,8 @@ const { Serializer } = jsonapiSerializer;
 /**
  * @param {ScoringAndCapacitySimulatorReport} scoringAndCapacitySimulatorReport
  */
-const serialize = function (scoringAndCapacitySimulatorReport = {}) {
+export function serialize(scoringAndCapacitySimulatorReport = {}) {
   return new Serializer('scoring-and-capacity-simulator-report', {
     attributes: ['capacity', 'score', 'competences'],
   }).serialize(scoringAndCapacitySimulatorReport);
-};
-
-export { serialize };
+}


### PR DESCRIPTION
## ☀️ Problème

Nous avons des déclarations de fonctions et d'export très disparate. C'est gênant pour la lecture (perte de temps lié à une forme de contexte switching)

## ⛱️ Proposition

Étendre la règle eslint pour forcer à déclarer les fonctions d'une certaine manières (et les exports aussi) dans le contexte `certification/evaluation`

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
