### PR TITLE
[TECH] Suppression du FT des épreuves focus

### DIFF
--- a/mon-pix/app/components/challenge-statement.gjs
+++ b/mon-pix/app/components/challenge-statement.gjs
@@ -14,7 +14,6 @@ import ChallengeEmbedSimulator from 'mon-pix/components/challenge-embed-simulato
 import ChallengeIllustration from 'mon-pix/components/challenge-illustration';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
 import MarkdownToHtmlUnsafe from 'mon-pix/components/markdown-to-html-unsafe';
-import ENV from 'mon-pix/config/environment';
 import extractExtension from 'mon-pix/helpers/extract-extension';
 import { SessionStorageEntry } from 'mon-pix/utils/session-storage-entry';
 
@@ -51,9 +50,7 @@ export default class ChallengeStatement extends Component {
             <div class="sr-only">{{t "pages.challenge.statement.sr-only.alternative-instruction"}}</div>
           {{/if}}
 
-          {{#if this.isFocusedChallengeToggleEnabled}}
-            <Tooltip @challenge={{@challenge}} />
-          {{/if}}
+          <Tooltip @challenge={{@challenge}} />
         </div>
       {{/if}}
 
@@ -172,9 +169,6 @@ export default class ChallengeStatement extends Component {
     super(...arguments);
     this._initialiseDefaultAttachment();
     this.stopTextToSpeechOnLeaveOrRefresh();
-  }
-  get isFocusedChallengeToggleEnabled() {
-    return ENV.APP.FT_FOCUS_CHALLENGE_ENABLED;
   }
 
   get challengeInstruction() {

--- a/mon-pix/app/components/challenge/item.gjs
+++ b/mon-pix/app/components/challenge/item.gjs
@@ -3,7 +3,6 @@ import { service } from '@ember/service';
 import { ensureSafeComponent } from '@embroider/util';
 import Component from '@glimmer/component';
 import ChallengeStatement from 'mon-pix/components/challenge-statement';
-import ENV from 'mon-pix/config/environment';
 
 import ChallengeItemQcm from '../challenge-item/challenge-item-qcm';
 import ChallengeItemQcu from '../challenge-item/challenge-item-qcu';
@@ -95,7 +94,7 @@ export default class Item extends Component {
   };
 
   get isFocusedChallenge() {
-    return ENV.APP.FT_FOCUS_CHALLENGE_ENABLED && this.args.challenge.focused;
+    return this.args.challenge.focused;
   }
 
   @action

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -9,7 +9,6 @@ const timedOutPageTitle = 'pages.challenge.title.timed-out';
 const focusedPageTitle = 'pages.challenge.title.focused';
 const focusedOutPageTitle = 'pages.challenge.title.focused-out';
 import isInteger from 'lodash/isInteger';
-import ENV from 'mon-pix/config/environment';
 
 export default class ChallengeController extends Controller {
   queryParams = ['newLevel', 'competenceLeveled', 'challengeId'];
@@ -88,7 +87,7 @@ export default class ChallengeController extends Controller {
   }
 
   get isFocusedChallenge() {
-    return ENV.APP.FT_FOCUS_CHALLENGE_ENABLED && this.model.challenge.focused;
+    return this.model.challenge.focused;
   }
 
   @action

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -51,7 +51,6 @@ module.exports = function (environment) {
         { value: 'nl-BE', nativeName: 'Nederlands (België)', displayedInSwitcher: true },
       ],
       PIX_ASSETS_MANAGER_URL: process.env.PIX_ASSETS_MANAGER_URL,
-      FT_FOCUS_CHALLENGE_ENABLED: _isFeatureEnabled(process.env.FT_FOCUS_CHALLENGE_ENABLED) || false,
       isTimerCountdownEnabled: true,
       LOAD_EXTERNAL_SCRIPT: true,
       NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS: 5,
@@ -198,7 +197,6 @@ module.exports = function (environment) {
     ENV.APP.API_HOST = 'http://localhost:3000';
     ENV.APP.isTimerCountdownEnabled = false;
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
-    ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
     ENV.APP.AUTO_SHARE_AFTER_DATE = '2025-07-18';
 

--- a/mon-pix/sample.env
+++ b/mon-pix/sample.env
@@ -102,11 +102,6 @@
 # Challenges
 # ==========
 
-# presence: optional
-# type: Boolean
-# default: false
-# FT_FOCUS_CHALLENGE_ENABLED=true
-
 # List of allowed origins for external embed challenges
 # type: String
 # default: "https://epreuves.pix.fr,https://1024pix.github.io"


### PR DESCRIPTION
## ☀️ Problème

Le FT des épreuves focus a été ajouté il y a foooooort longtemps. (par your truly)

## ⛱️ Proposition

On le supprime (je boucle la boucle)

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

Pas de régression sur le passage d'épreuves.
Tests verts
