### PR TITLE
[BUGFIX] Correction des seeds de certification

### DIFF
--- a/api/db/seeds/data/team-certification/tools/add-session.js
+++ b/api/db/seeds/data/team-certification/tools/add-session.js
@@ -2,29 +2,36 @@
  * @typedef {import('../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js').SessionEnrolment} SessionEnrolment
  */
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
+import * as sessionRepository from '../../../../../src/certification/enrolment/infrastructure/repositories/session-repository.js';
 
 /**
  * @param {Object} params
  * @param {Object} params.databaseBuilder
- * @param {number} params.createdBy - certification center member user id
- * @param {number} params.certificationCenterId
+ * @param {number} params.createdByUserId - certification center member user id
  * @param {number} params.[forceSessionId] - allow for a stable and fixed session ID
- * @param {SessionEnrolment} params.[session] - session details you can customize
+ * @param {SessionEnrolment} params.session - session details you can customize
  * @returns {Promise<SessionEnrolment>}
  */
 export default async function addSession({ databaseBuilder, createdByUserId, forceSessionId, session }) {
-  const generatedSession = await enrolmentUseCases.createSession({
+  const { certificationCenterId, address, room, date, time, examiner, description } = session;
+
+  const generatedSessionId = await enrolmentUseCases.createSession({
     userId: createdByUserId,
-    session,
+    certificationCenterId,
+    address,
+    room,
+    date,
+    time,
+    examiner,
+    description,
   });
-  await databaseBuilder
-    .knex('sessions')
-    .where('id', generatedSession.id)
-    .update({
-      id: forceSessionId || generatedSession.id,
-      accessCode: 'AZERTY',
-    });
+
+  const sessionId = forceSessionId || generatedSessionId;
+  await databaseBuilder.knex('sessions').where('id', generatedSessionId).update({
+    id: sessionId,
+    accessCode: 'AZERTY',
+  });
   await databaseBuilder.commit();
 
-  return enrolmentUseCases.getSession({ sessionId: forceSessionId });
+  return sessionRepository.get({ id: sessionId });
 }

--- a/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
+++ b/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
+import * as sessionRepository from '../../../../../src/certification/enrolment/infrastructure/repositories/session-repository.js';
 import pickChallengeService from '../../../../../src/certification/evaluation/domain/services/pick-challenge-service.js';
 import { usecases as evaluationUseCases } from '../../../../../src/certification/evaluation/domain/usecases/index.js';
 import { usecases as flashUseCases } from '../../../../../src/certification/evaluation/domain/usecases/index.js';
@@ -24,7 +25,7 @@ export default async function publishSessionWithValidatedCertification({
   candidatesIds,
   pixScoreTarget,
 }) {
-  const session = await enrolmentUseCases.getSession({ sessionId });
+  const session = await sessionRepository.get({ id: sessionId });
 
   const version = await knex('certification_versions').where('expirationDate', null).andWhere('scope', 'CORE').first();
 
@@ -33,7 +34,7 @@ export default async function publishSessionWithValidatedCertification({
   for (const candidateId of candidatesIds) {
     const candidate = await enrolmentUseCases.getCandidate({ certificationCandidateId: candidateId });
 
-    const { certificationCourseInfo } = await evaluationUseCases.retrieveLastOrCreateCertificationCourse({
+    const { certificationCourseInfo } = await evaluationUseCases.startOrResumeCertification({
       sessionId,
       accessCode: session.accessCode,
       userId: candidate.userId,


### PR DESCRIPTION
## ☀️ Problème

Les seeds ne fonctionnent plus côté certification à cause de deux problèmes distincts:

  - createSession prend désormais des paramètres à plat au lieu d'un objet session et  retourne maintenant un id brut, non plus un SessionEnrolment
  - Le usecase getSession a été supprimé → remplacé par sessionRepository.get({ id }), exactement comme le fait session-controller.js.


publish-session-with-validated-certification.js utilisait aussi le getSession supprimé, et appelait evaluationUseCases.retrieveLastOrCreateCertificationCourse, renommé en startOrResumeCertification.


## ⛱️ Proposition

Remettre les deux outils en phase avec les nouvelles signatures :

`add-session.js` déstructure le `session` reçu pour alimenter les paramètres à plat de `createSession`, traite le retour comme un identifiant, et relit la session via `sessionRepository.get({ id })`
`publish-session-with-validated-certification.js` lit lui aussi la session via le repository, et appelle `startOrResumeCertification`

`add-session.js` retombe désormais sur l'id généré quand `forceSessionId` n'est pas fourni : l'`update` et le `return` utilisaient deux valeurs différentes dans ce cas.

Les appelants ne changent pas : ils continuent de passer un`SessionEnrolment` qui sera déstructuré

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

Lancer `npm run db:seed` ou `npm run db:reset` sans encombre