### PR TITLE
[TECH] Ajouter la table structures_categories (PIX-23551)

### DIFF
--- a/api/db/migrations/20260807143233_add-structure-categories-table.js
+++ b/api/db/migrations/20260807143233_add-structure-categories-table.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'structure_categories';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This table contains the categories used to classify structures.');
+    table.increments('id').primary();
+    table.string('label').notNullable().unique();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}


### PR DESCRIPTION
## ☀️ Problème

Nous avons besoin de catégoriser les structures. Cela nécessite une nouvelle table `structures_categories` pour stocker ces catégories.

## ⛱️ Proposition

Ajout d'une migration créant la table `structures_categories` avec les colonnes `id` (clé primaire) et `label` (obligatoire).

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- [ ] Lancer `npm run db:migrate` : la table `structures_categories` doit être créée avec les colonnes `id` et `label`
- [ ] Lancer `npm run db:migrate:rollback` : la table doit être supprimée sans erreur

