### PR TITLE
[BUGFIX] Afficher la notif de passage de niveau au dessus de la bannière d'info (PIX-23827).

### DIFF
--- a/mon-pix/app/styles/components/_levelup-notif.scss
+++ b/mon-pix/app/styles/components/_levelup-notif.scss
@@ -6,7 +6,7 @@
   position: fixed;
   top: 10px;
   right: 10px;
-  z-index: 100;
+  z-index: 901;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## ☀️ Problème

Si une bannière est présente, la notif de passage de niveau s’affiche en dessous.

<img width="400" src="https://media-cdn.atlassian.com/file/53e1a08b-cddd-47ef-a4fc-6ba099ae4e7b/image/cdn?allowAnimated=true&client=acd0bc3e-a12d-449a-b2a1-f48f42838975&collection=&height=125&max-age=2592000&mode=full-fit&source=mediaCard&token=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJhY2QwYmMzZS1hMTJkLTQ0OWEtYjJhMS1mNDhmNDI4Mzg5NzUiLCJhY2Nlc3MiOnsidXJuOmZpbGVzdG9yZTpmaWxlOjUzZTFhMDhiLWNkZGQtNDdlZi1hNGZjLTZiYTA5OWFlNGU3YiI6WyJyZWFkIl19LCJleHAiOjE3ODYzNTczNzksIm5iZiI6MTc4NjM1NjQ3OSwiYWFJZCI6IjYyOTcyZjZkMTY0OGYyMDA2OTYyNjJlNiIsImh0dHBzOi8vaWQuYXRsYXNzaWFuLmNvbS9hcHBBY2NyZWRpdGVkIjpmYWxzZX0.yIwlWVdKoY3r1GduGCyFrg42Bnfi8tBsvaVekrd3Ytw&width=742#media-blob-url=true&id=53e1a08b-cddd-47ef-a4fc-6ba099ae4e7b&clientId=acd0bc3e-a12d-449a-b2a1-f48f42838975&contextId=&collection=" />

## ⛱️ Proposition

Augmenter la z-index de la notif.

## 🏊 Pour tester

- Monter une compétence sur PixApp en RA
- Voir la notif de passage de niveau au dessus de la bannière globale
