### PR TITLE
[TECH] Ajouter la colonne category_id sur la table structures (PIX-23552)

### DIFF
--- a/api/db/migrations/20260810093719_add-category-id-on-structures-table.js
+++ b/api/db/migrations/20260810093719_add-category-id-on-structures-table.js
@@ -1,0 +1,26 @@
+const TABLE_NAME = 'structures';
+const COLUMN_NAME = 'category_id';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .defaultTo(null)
+      .references('structure_categories.id')
+      .comment('Structure category identifier');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}


### PR DESCRIPTION
## ☀️ Problème

La catégorisation des structures nécessite de lier chaque structure à une catégorie.

## ⛱️ Proposition

Ajout d'une migration créant la colonne `category_id` sur la table `structures`, nullable dans un premier temps, référençant `structure_categories.id`.

## 🏊 Pour tester

- [ ] Lancer `npm run db:migrate` : la colonne `category_id` doit être ajoutée sur la table `structures`
- [ ] Lancer `npm run db:migrate:rollback` : la colonne doit être supprimée sans erreur
