### PR TITLE
[FEATURE] Modifier les textes liés à l'abandon de candidat de certif (PIX-23785).

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1632,7 +1632,7 @@
           "title": "Details",
           "v3": {
             "abort-reason": {
-              "candidate": "Withdrawal: Lack of time or early departure",
+              "candidate": "Test not completed within the allotted time",
               "technical": "Technical problem"
             },
             "answer-status": {
@@ -1658,7 +1658,7 @@
             },
             "general-informations": {
               "labels": {
-                "abort-reason": "Reason for withdrawal",
+                "abort-reason": "Reason for interruption",
                 "created-at": "Created on",
                 "ended-by": "Certification completed by",
                 "last-answer-at": "Last answer on",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1635,7 +1635,7 @@
           "title": "Détails",
           "v3": {
             "abort-reason": {
-              "candidate": "Abandon : Manque de temps ou départ prématuré",
+              "candidate": "Test non finalisé dans le délai imparti",
               "technical": "Problème technique"
             },
             "answer-status": {
@@ -1661,7 +1661,7 @@
             },
             "general-informations": {
               "labels": {
-                "abort-reason": "Raison de l'abandon",
+                "abort-reason": "Motif d'interruption",
                 "created-at": "Créée le",
                 "ended-by": "Certification terminée par",
                 "last-answer-at": "Dernière réponse le",

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -1,6 +1,7 @@
 import { visit, visit as visitScreen, within } from '@1024pix/ember-testing-library';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -432,7 +433,7 @@ module('Acceptance | Session Finalization', function (hooks) {
           assert
             .dom(
               screen.getByText(
-                'Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son test de certification entre temps. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser.',
+                t('common.api-error-messages.SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE'),
               ),
             )
             .exists();

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step-test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step-test.js
@@ -111,10 +111,16 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
   @onChangeAbortReason={{this.abort}}
 />`);
 
-    await click(screen.getByRole('button', { name: "Sélectionner la raison de l'abandon" }));
+    await click(
+      screen.getByRole('button', {
+        name: t(
+          'pages.session-finalization.reporting.uncompleted-reports-information.table.labels.abandonment-reason-label',
+        ),
+      }),
+    );
     await click(
       await screen.findByRole('option', {
-        name: 'Problème technique',
+        name: t('pages.session-finalization.reporting.uncompleted-reports-information.table.labels.technical-problem'),
       }),
     );
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -30,8 +30,8 @@
       "SESSION_DOES_NOT_EXIST_OR_ACCESS_RESTRICTED": "The session doesn't exist or it's access is restricted.",
       "SESSION_STARTED_CANDIDATE_ALREADY_LINKED_TO_USER": "The session has begun, you can’t upload a candidates' list anymore.<br />If you want to edit the list, you can enrol a candidate directly in the table below.",
       "SESSION_WITHOUT_STARTED_CERTIFICATION": "This session hasn't started, you can't finalise it. However, you may delete it.",
-      "SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE": "The field \"Reason for abandonment\" has been filled in for a candidate who has finished their certification exam in between. The session therefore can't be finalised. Please refresh the page before finalising.",
-      "UNTERMINATED_CERTIFICATION_WITHOUT_ABORT_REASON": "One or more unterminated certifications have missing \"Abandon reason\". The session cannot be finalised",
+      "SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE": "The field \"Reason for interruption\" has been filled in for a candidate who has finished their certification exam in between. The session therefore can't be finalised. Please refresh the page before finalising.",
+      "UNTERMINATED_CERTIFICATION_WITHOUT_ABORT_REASON": "One or more unterminated certifications have missing \"Reason for interruption\". The session cannot be finalised",
       "authorize-resume-error": "An error has occurred, {firstName} {lastName} couldn't be allowed to resume his/her Pix certification exam.",
       "bad-request-error": "The data entered was not in the correct format.",
       "certification-candidate": {
@@ -410,7 +410,7 @@
         "warning": "Warning :"
       },
       "errors": {
-        "no-abort-reason": "One or more unfinished certification(s) don't have a reason for abandonment. Please fill them in."
+        "no-abort-reason": "One or more unfinished certification(s) don't have a reason for interruption. Please fill them in."
       },
       "issue-reports-modal": {
         "actions": {
@@ -442,12 +442,12 @@
         "title": "Reporting: Signal, for each candidate, the incidents inputted into the incident report",
         "uncompleted-reports-information": {
           "description": "These candidates haven’t finished their Pix certification exam or the invigilator has ended their exam",
-          "extra-information": "List of candidates who haven’t finished their certification exam, ordered by birth name, with a link to add a reporting if needed and a drop-down list enabling you to select the reason for abandonment",
+          "extra-information": "List of candidates who haven’t finished their certification exam, ordered by birth name, with a link to add a reporting if needed and a drop-down list enabling you to select the reason for interruption",
           "table": {
             "labels": {
-              "abandonment": "Abandonment : lack of time or early departure",
-              "abandonment-reason": "Reason for abandonment",
-              "abandonment-reason-label": "Select the reason for abandonment",
+              "abandonment": "Test not completed within the allotted time",
+              "abandonment-reason": "Reason for interruption",
+              "abandonment-reason-label": "Select the reason for interruption",
               "technical-problem": "Technical problem"
             },
             "tooltip": {
@@ -455,7 +455,7 @@
                 "enough-time-description": "The candidate didn’t have enough time to answer all the questions",
                 "left-deliberately-description": "The candidate left deliberately before the end of the exam"
               },
-              "extra-information": "Reason for abandonment's description",
+              "extra-information": "Reason for interruption's description",
               "technical-problem-description": "The candidate encountered a technical problem that prevented him from finishing his exam"
             }
           }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -30,8 +30,8 @@
       "SESSION_DOES_NOT_EXIST_OR_ACCESS_RESTRICTED": "La session n'existe pas ou son accès est restreint.",
       "SESSION_STARTED_CANDIDATE_ALREADY_LINKED_TO_USER": "La session a débuté, vous ne pouvez plus importer une liste de candidats.<br />Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.",
       "SESSION_WITHOUT_STARTED_CERTIFICATION": "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer.",
-      "SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE": "Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son test de certification entre temps. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser.",
-      "UNTERMINATED_CERTIFICATION_WITHOUT_ABORT_REASON": "Une ou plusieurs certifications non terminées n'ont pas de \"Raison de l’abandon\" renseignées. La session ne peut donc pas être finalisée.",
+      "SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE": "Le champ “Motif d’interruption” a été renseigné pour un candidat qui a terminé son test de certification entre temps. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser.",
+      "UNTERMINATED_CERTIFICATION_WITHOUT_ABORT_REASON": "Une ou plusieurs certifications non terminées n'ont pas de \"Motif d’interruption\" renseigné. La session ne peut donc pas être finalisée.",
       "authorize-resume-error": "Une erreur est survenue, {firstName} {lastName} n'a pas pu être autorisé à reprendre son test.",
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
       "certification-candidate": {
@@ -410,7 +410,7 @@
         "warning": "Attention :"
       },
       "errors": {
-        "no-abort-reason": "Une ou plusieurs certification(s) non terminée(s) n'ont pas de motif d'abandon. Veuillez les renseigner."
+        "no-abort-reason": "Une ou plusieurs certification(s) non terminée(s) n'ont pas de motif d'interruption. Veuillez les renseigner."
       },
       "issue-reports-modal": {
         "actions": {
@@ -442,12 +442,12 @@
         "title": "Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident",
         "uncompleted-reports-information": {
           "description": "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test",
-          "extra-information": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
+          "extra-information": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner le motif d’interruption.",
           "table": {
             "labels": {
-              "abandonment": "Abandon : Manque de temps ou départ prématuré",
-              "abandonment-reason": "Raison de l'abandon",
-              "abandonment-reason-label": "Sélectionner la raison de l'abandon",
+              "abandonment": "Test non finalisé dans le délai imparti",
+              "abandonment-reason": "Motif d'interruption",
+              "abandonment-reason-label": "Sélectionner le motif d'interruption",
               "technical-problem": "Problème technique"
             },
             "tooltip": {
@@ -455,7 +455,7 @@
                 "enough-time-description": "Le candidat n'a pas eu le temps de répondre à toutes ses questions",
                 "left-deliberately-description": "Le candidat est parti volontairement avant la fin du test"
               },
-              "extra-information": "Description de la raison de l'abandon",
+              "extra-information": "Description du motif d'interruption",
               "technical-problem-description": "Le candidat a rencontré un problème technique l'empêchant de poursuivre son test jusqu’à la fin"
             }
           }

--- a/high-level-tests/e2e-playwright/pages/pix-certif/SessionFinalizationPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-certif/SessionFinalizationPage.ts
@@ -28,7 +28,7 @@ export class SessionFinalizationPage {
       has: this.page.getByText(lastName),
     });
     await row.locator('.pix-select-button').click();
-    await row.getByRole('option', { name: 'Abandon : Manque de temps ou départ prématuré' }).click();
+    await row.getByRole('option', { name: 'Test non finalisé dans le délai imparti' }).click();
   }
 
   async close() {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_BY_FINALIZATION_ABANDONMENT_ENOUGH_ANSWERS.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_BY_FINALIZATION_ABANDONMENT_ENOUGH_ANSWERS.spec.ts
@@ -108,7 +108,7 @@ test(
         expect(certificationDetails.nbQuestionsAband).toBe(0);
         expect(certificationDetails.nbValidatedTechnicalIssues).toBe(0);
         expect(certificationDetails.testEndedBy).toBe('Finalisation session');
-        expect(certificationDetails.abortReason).toBe('Abandon : Manque de temps ou départ prématuré');
+        expect(certificationDetails.abortReason).toBe('Test non finalisé dans le délai imparti');
         snapshotHandler.push('adminCertificationDetails_result', certificationDetails.result ?? null);
         snapshotHandler.push('adminCertificationDetails_status', certificationDetails.status ?? null);
       });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_BY_FINALIZATION_ABANDONMENT_FEW_ANSWERS.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_BY_FINALIZATION_ABANDONMENT_FEW_ANSWERS.spec.ts
@@ -106,7 +106,7 @@ test(
         expect(certificationDetails.nbQuestionsAband).toBe(0);
         expect(certificationDetails.nbValidatedTechnicalIssues).toBe(0);
         expect(certificationDetails.testEndedBy).toBe('Finalisation session');
-        expect(certificationDetails.abortReason).toBe('Abandon : Manque de temps ou départ prématuré');
+        expect(certificationDetails.abortReason).toBe('Test non finalisé dans le délai imparti');
         snapshotHandler.push('adminCertificationDetails_result', certificationDetails.result ?? null);
         snapshotHandler.push('adminCertificationDetails_status', certificationDetails.status ?? null);
       });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_BY_INVIGILATOR_ABANDONMENT_ENOUGH_ANSWERS.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_BY_INVIGILATOR_ABANDONMENT_ENOUGH_ANSWERS.spec.ts
@@ -112,7 +112,7 @@ test(
         expect(certificationDetails.nbQuestionsAband).toBe(0);
         expect(certificationDetails.nbValidatedTechnicalIssues).toBe(0);
         expect(certificationDetails.testEndedBy).toBe('Le surveillant');
-        expect(certificationDetails.abortReason).toBe('Abandon : Manque de temps ou départ prématuré');
+        expect(certificationDetails.abortReason).toBe('Test non finalisé dans le délai imparti');
         snapshotHandler.push('adminCertificationDetails_result', certificationDetails.result ?? null);
         snapshotHandler.push('adminCertificationDetails_status', certificationDetails.status ?? null);
       });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_BY_INVIGILATOR_ABANDONMENT_FEW_ANSWERS.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_BY_INVIGILATOR_ABANDONMENT_FEW_ANSWERS.spec.ts
@@ -110,7 +110,7 @@ test(
         expect(certificationDetails.nbQuestionsAband).toBe(0);
         expect(certificationDetails.nbValidatedTechnicalIssues).toBe(0);
         expect(certificationDetails.testEndedBy).toBe('Le surveillant');
-        expect(certificationDetails.abortReason).toBe('Abandon : Manque de temps ou départ prématuré');
+        expect(certificationDetails.abortReason).toBe('Test non finalisé dans le délai imparti');
         snapshotHandler.push('adminCertificationDetails_result', certificationDetails.result ?? null);
         snapshotHandler.push('adminCertificationDetails_status', certificationDetails.status ?? null);
       });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_DUE_TO_DURATION_EXCEEDED_ABANDONMENT_ENOUGH_ANSWERS.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_DUE_TO_DURATION_EXCEEDED_ABANDONMENT_ENOUGH_ANSWERS.spec.ts
@@ -120,7 +120,7 @@ test(
         expect(certificationDetails.nbQuestionsAband).toBe(0);
         expect(certificationDetails.nbValidatedTechnicalIssues).toBe(0);
         expect(certificationDetails.testEndedBy).toBe('Finalisation session');
-        expect(certificationDetails.abortReason).toBe('Abandon : Manque de temps ou départ prématuré');
+        expect(certificationDetails.abortReason).toBe('Test non finalisé dans le délai imparti');
         snapshotHandler.push('adminCertificationDetails_result', certificationDetails.result ?? null);
         snapshotHandler.push('adminCertificationDetails_status', certificationDetails.status ?? null);
       });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_DUE_TO_DURATION_EXCEEDED_ABANDONMENT_FEW_ANSWERS.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/common/RESULTS_ENDED_DUE_TO_DURATION_EXCEEDED_ABANDONMENT_FEW_ANSWERS.spec.ts
@@ -118,7 +118,7 @@ test(
         expect(certificationDetails.nbQuestionsAband).toBe(0);
         expect(certificationDetails.nbValidatedTechnicalIssues).toBe(0);
         expect(certificationDetails.testEndedBy).toBe('Finalisation session');
-        expect(certificationDetails.abortReason).toBe('Abandon : Manque de temps ou départ prématuré');
+        expect(certificationDetails.abortReason).toBe('Test non finalisé dans le délai imparti');
         snapshotHandler.push('adminCertificationDetails_result', certificationDetails.result ?? null);
         snapshotHandler.push('adminCertificationDetails_status', certificationDetails.status ?? null);
       });


### PR DESCRIPTION
## ☀️ Problème

Pour s'aligner avec les nouvelles règles du cadrage temporel, on a besoin d'adapter les textes de la page de finalisation de session.

## ⛱️ Proposition

Remplacer les textes : 
- Le titre de la dernière colonne du tableau `“Raison de l’abandon”` ➡️ `“Motif d’interruption”`
- L’item `“Abandon : manque de temps ou départ prématuré”` ➡️ `“Test non finalisé dans le délai imparti”`
- Et dans l’infobulle : `"Abandon : manque de temps ou départ prématuré”` ➡️ `“Test non finalisé dans le délai imparti”`

## 🧴 Remarques

- Les textes en lien ont aussi été modifiés
- On profite du changement de formulation pour utiliser les clés de traduction dans les tests 
- Les changements ont aussi été effectués dans les tests e2e-certif

## 🏊 Pour tester

- Tests verts
- Possible vérification sur les PixCertif et PixAdmin en RA
