### PR TITLE
[BUGFIX] Réparer la génération de mot de passe lors de l'import de session en masse (PIX-23835).

### DIFF
--- a/api/src/certification/enrolment/domain/services/session-code-service.js
+++ b/api/src/certification/enrolment/domain/services/session-code-service.js
@@ -1,5 +1,8 @@
 import { config } from '../../../../../src/shared/config.js';
 
+const INVIGILATOR_PASSWORD_LENGTH = 6;
+const INVIGILATOR_PASSWORD_CHARS = '23456789bcdfghjkmpqrstvwxyBCDFGHJKMPQRSTVWXY!*?'.split('');
+
 function sample(array) {
   const len = array == null ? 0 : array.length;
   return len ? array[Math.floor(Math.random() * len)] : undefined;
@@ -27,8 +30,21 @@ function _generateSessionCode() {
   return code;
 }
 
+function _generateInvigilatorPassword() {
+  const chars = Array.from(INVIGILATOR_PASSWORD_CHARS);
+  for (let i = INVIGILATOR_PASSWORD_LENGTH; i >= 0; i--) {
+    const j = Math.floor(Math.random() * (chars.length - 1));
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+  return chars.slice(0, INVIGILATOR_PASSWORD_LENGTH).join('');
+}
+
 const getNewSessionCode = function () {
   return _generateSessionCode();
 };
 
-export { getNewSessionCode };
+const getNewInvigilatorPassword = function () {
+  return _generateInvigilatorPassword();
+};
+
+export { getNewInvigilatorPassword, getNewSessionCode };

--- a/api/src/certification/enrolment/domain/usecases/create-session.js
+++ b/api/src/certification/enrolment/domain/usecases/create-session.js
@@ -3,8 +3,6 @@
  * @typedef {import ("./index.js").SessionCodeService} SessionCodeService
  */
 
-const INVIGILATOR_PASSWORD_LENGTH = 6;
-const INVIGILATOR_PASSWORD_CHARS = '23456789bcdfghjkmpqrstvwxyBCDFGHJKMPQRSTVWXY!*?'.split('');
 /**
  * @param {object} params
  * @param {number} params.userId
@@ -30,8 +28,6 @@ export async function createSession({
   sessionRepository,
   sessionCodeService,
 }) {
-  const accessCode = sessionCodeService.getNewSessionCode();
-  const invigilatorPassword = generateInvigilatorPassword();
   return sessionRepository.create({
     userId,
     certificationCenterId,
@@ -41,16 +37,7 @@ export async function createSession({
     time,
     examiner,
     description,
-    accessCode,
-    invigilatorPassword,
+    accessCode: sessionCodeService.getNewSessionCode(),
+    invigilatorPassword: sessionCodeService.getNewInvigilatorPassword(),
   });
-}
-
-function generateInvigilatorPassword() {
-  const chars = Array.from(INVIGILATOR_PASSWORD_CHARS);
-  for (let i = INVIGILATOR_PASSWORD_LENGTH; i >= 0; i--) {
-    const j = Math.floor(Math.random() * (chars.length - 1));
-    [chars[i], chars[j]] = [chars[j], chars[i]];
-  }
-  return chars.slice(0, INVIGILATOR_PASSWORD_LENGTH).join('');
 }

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -5,13 +5,13 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Candidate } from '../models/Candidate.js';
-import { SessionEnrolment } from '../models/SessionEnrolment.js';
 
 /**
  * @param {object} params
  * @param {deps["candidateRepository"]} params.candidateRepository
  * @param {deps["sessionRepository"]} params.sessionRepository
  * @param {deps["eventAdapter"]} params.eventAdapter
+ * @param {deps["sessionCodeService"]} params.sessionCodeService
  * @param {deps["temporarySessionsStorageForMassImportService"]} params.temporarySessionsStorageForMassImportService
  */
 export async function createSessions({
@@ -20,6 +20,7 @@ export async function createSessions({
   candidateRepository,
   sessionRepository,
   eventAdapter,
+  sessionCodeService,
   temporarySessionsStorageForMassImportService,
 }) {
   const temporaryCachedSessions = await temporarySessionsStorageForMassImportService.getByKeyAndUserId({
@@ -39,11 +40,7 @@ export async function createSessions({
       if (sessionId) {
         await _deleteExistingCandidatesInSession({ candidateRepository, sessionId });
       } else {
-        const { id } = await _saveNewSessionReturningId({
-          sessionRepository,
-          sessionDTO: { ...sessionDTO, createdBy: userId },
-        });
-        sessionId = id;
+        sessionId = await _createSession({ sessionRepository, sessionCodeService, sessionDTO, userId });
       }
 
       if (candidates.length > 0) {
@@ -63,9 +60,19 @@ export async function createSessions({
   });
 }
 
-async function _saveNewSessionReturningId({ sessionRepository, sessionDTO }) {
-  const sessionToSave = new SessionEnrolment(sessionDTO);
-  return await sessionRepository.save({ session: sessionToSave });
+async function _createSession({ sessionRepository, sessionCodeService, sessionDTO, userId }) {
+  return sessionRepository.create({
+    userId,
+    certificationCenterId: sessionDTO.certificationCenterId,
+    address: sessionDTO.address,
+    room: sessionDTO.room,
+    examiner: sessionDTO.examiner,
+    date: sessionDTO.date,
+    time: sessionDTO.time,
+    description: sessionDTO.description,
+    accessCode: sessionDTO.accessCode,
+    invigilatorPassword: sessionCodeService.getNewInvigilatorPassword(),
+  });
 }
 
 async function _deleteExistingCandidatesInSession({ candidateRepository, sessionId }) {

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -5,38 +5,6 @@ import { Candidate } from '../../domain/models/Candidate.js';
 import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
 
 /**
- * @deprecated use create
- * @function
- * @param {object} params
- * @param {SessionEnrolment} params.session
- * @returns {Promise<SessionEnrolment>}
- */
-export async function save({ session }) {
-  const knexConn = DomainTransaction.getConnection();
-  const [savedSession] = await knexConn('sessions')
-    .insert({
-      accessCode: session.accessCode,
-      address: session.address,
-      certificationCenter: session.certificationCenter,
-      date: session.date,
-      description: session.description,
-      examiner: session.examiner,
-      room: session.room,
-      time: session.time,
-      certificationCenterId: session.certificationCenterId,
-      invigilatorPassword: session.invigilatorPassword,
-      version: session.version,
-      createdBy: session.createdBy,
-    })
-    .returning('*');
-
-  return new SessionEnrolment({
-    ...savedSession,
-    certificationCandidates: [],
-  });
-}
-
-/**
  * @function
  * @param {object} params
  * @param {number} params.id

--- a/api/tests/certification/enrolment/acceptance/application/session-mass-import-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-mass-import-route_test.js
@@ -177,7 +177,6 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
           date: '2023-01-01',
           time: '11:00',
           accessCode: 'accessCode',
-          invigilatorPassword: 'KV2CPA',
           certificationCandidates: [],
         };
         const newCachedSessionUUID = await temporarySessionsStorageForMassImportService.save({
@@ -201,7 +200,7 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
         const sessions = await knex('sessions');
         expect(sessions).to.have.lengthOf(1);
         expect(sessions[0].certificationCenter).to.equal(certificationCenter);
-        expect(sessions[0].invigilatorPassword).to.equal(sessionToSave.invigilatorPassword);
+        expect(sessions[0].invigilatorPassword).to.match(/^[23456789bcdfghjkmpqrstvwxyBCDFGHJKMPQRSTVWXY!*?]{6}$/);
         expect(sessions[0].version).to.equal(3);
         expect(response.statusCode).to.equal(201);
       });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -8,44 +8,6 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Repository | certification | enrolment | SessionEnrolment', function () {
-  describe('#save', function () {
-    it('should persist and return the session', async function () {
-      databaseBuilder.factory.buildCertificationCenter({
-        id: 456,
-        name: 'Centre de certif fictif',
-        type: 'SCO',
-      });
-      databaseBuilder.factory.buildUser({
-        id: 123,
-      });
-      await databaseBuilder.commit();
-      const sessionToSave = domainBuilder.certification.enrolment
-        .sessionEnrolmentBuilder()
-        .createdBy({
-          userId: 123,
-          certificationCenterId: 456,
-          certificationCenterName: 'Centre de certif fictif',
-          certificationCenterType: 'SCO',
-        })
-        .withParameters({
-          date: '2026-01-01',
-          time: '19:30:05',
-          examiner: 'terminator',
-          room: 'CFA-330',
-          accessCode: 'SOME1ACCESS2CODE',
-          address: '2 rue des coquelicots',
-          description: 'une description pleine de sens',
-          invigilatorPassword: 'INVIG7',
-        })
-        .build();
-
-      const savedSession = await sessionRepository.save({ session: sessionToSave });
-
-      const readSession = await sessionRepository.get({ id: savedSession.id });
-      expect(readSession).to.deepEqualInstance(readSession);
-    });
-  });
-
   describe('#get', function () {
     it('returns the SessionEnrolment model with candidates', async function () {
       const candidateABuilder = domainBuilder.certification.enrolment

--- a/api/tests/certification/enrolment/unit/domain/services/session-code-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/session-code-service_test.js
@@ -11,4 +11,14 @@ describe('Unit | Service | CodeSession', function () {
       expect(result).to.match(/[B,C,D,F,G,H,J,K,M,P,Q,R,T,V,W,X,Y]{4}[2,3,4,6,7,8,9]{2}/);
     });
   });
+
+  describe('#getNewInvigilatorPassword', function () {
+    it('should return a 6 characters password made of non ambiguous characters', function () {
+      // when
+      const result = sessionCodeService.getNewInvigilatorPassword();
+
+      // then
+      expect(result).to.match(/^[23456789bcdfghjkmpqrstvwxyBCDFGHJKMPQRSTVWXY!*?]{6}$/);
+    });
+  });
 });

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-session_test.js
@@ -8,7 +8,10 @@ describe('Certification | Enrolment | Unit | UseCase | create-session', function
 
   beforeEach(function () {
     sessionRepository = { create: sinon.fake.resolves(123) };
-    sessionCodeService = { getNewSessionCode: sinon.fake.returns('MONSUPERCODE') };
+    sessionCodeService = {
+      getNewSessionCode: sinon.fake.returns('MONSUPERCODE'),
+      getNewInvigilatorPassword: sinon.fake.returns('Y722GA'),
+    };
     dependencies = { sessionCodeService, sessionRepository };
   });
 
@@ -38,7 +41,7 @@ describe('Certification | Enrolment | Unit | UseCase | create-session', function
         examiner: 'Louise',
         description: 'coucou',
         accessCode: 'MONSUPERCODE',
-        invigilatorPassword: sinon.match.string,
+        invigilatorPassword: 'Y722GA',
       }),
     );
   });

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
 import { createSessions } from '../../../../../../src/certification/enrolment/domain/usecases/create-sessions.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
@@ -10,17 +9,17 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | sessions-mass-import | create-sessions', function () {
-  let centerRepository;
   let candidateRepository;
   let sessionRepository;
+  let sessionCodeService;
   let eventAdapter;
   let dependencies;
   let temporarySessionsStorageForMassImportService;
 
   beforeEach(function () {
-    centerRepository = { getById: sinon.stub() };
     candidateRepository = { deleteBySessionId: sinon.stub(), save: sinon.stub() };
-    sessionRepository = { save: sinon.stub() };
+    sessionRepository = { create: sinon.stub() };
+    sessionCodeService = { getNewInvigilatorPassword: sinon.stub().returns('Y722GA') };
     eventAdapter = { onCandidatesEnrolledWithMassSessionsImport: sinon.stub() };
     temporarySessionsStorageForMassImportService = {
       getByKeyAndUserId: sinon.stub(),
@@ -28,9 +27,9 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
     };
 
     dependencies = {
-      centerRepository,
       candidateRepository,
       sessionRepository,
+      sessionCodeService,
       eventAdapter,
       temporarySessionsStorageForMassImportService,
     };
@@ -60,10 +59,8 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
   context('when there are cached sessions matching the key', function () {
     context('when at least one of the sessions does NOT exist', function () {
       context('when session has no candidate', function () {
-        it('should only save the session', async function () {
+        it('should only create the session, with a freshly generated invigilator password', async function () {
           // given
-          const center = domainBuilder.certification.enrolment.buildCenter();
-          centerRepository.getById.withArgs({ id: center.id }).resolves(center);
           const temporaryCachedSessions = [
             {
               id: undefined,
@@ -75,7 +72,6 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
               time: '01:00',
               examiner: 'Pierre',
               description: 'desc',
-              invigilatorPassword: 'Y722GA',
               accessCode: 'accessCode',
               certificationCandidates: [],
             },
@@ -84,29 +80,36 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           const sessionCreatorId = 1234;
           const cachedValidatedSessionsKey = 'uuid';
           sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
-          sessionRepository.save.resolves({ id: 1234 });
+          sessionRepository.create.resolves(1234);
 
           // when
           await createSessions({
             cachedValidatedSessionsKey,
             userId: sessionCreatorId,
-            certificationCenterId: center.id,
             ...dependencies,
           });
 
           // then
-          const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
-          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
+          expect(sessionRepository.create).to.have.been.calledOnceWithExactly({
+            userId: sessionCreatorId,
+            certificationCenterId: 567,
+            address: 'Site 1',
+            room: 'Salle 1',
+            examiner: 'Pierre',
+            date: '2023-03-12',
+            time: '01:00',
+            description: 'desc',
+            accessCode: 'accessCode',
+            invigilatorPassword: 'Y722GA',
+          });
           expect(candidateRepository.save).not.to.have.been.called;
           expect(eventAdapter.onCandidatesEnrolledWithMassSessionsImport).not.to.have.been.called;
         });
       });
 
       context('when session has at least one candidate', function () {
-        it('should save the session and the candidates', async function () {
+        it('should create the session and the candidates', async function () {
           // given
-          const center = domainBuilder.certification.enrolment.buildCenter({ id: 567 });
-          centerRepository.getById.withArgs({ id: center.id }).resolves(center);
           const candidate = domainBuilder.certification.enrolment
             .candidateBuilder()
             .withSubscription(Frameworks.DROIT)
@@ -116,23 +119,21 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
             {
               id: undefined,
               certificationCenter: 'Centre de Certifix',
-              certificationCenterId: center.id,
+              certificationCenterId: 567,
               address: 'Site 1',
               room: 'Salle 1',
               date: '2023-03-12',
               time: '01:00',
               examiner: 'Pierre',
               description: 'desc',
-              invigilatorPassword: 'Y722GA',
               accessCode: 'accessCode',
               certificationCandidates: [candidate],
-              createdBy: sessionCreatorId,
             },
           ];
           temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
           const cachedValidatedSessionsKey = 'uuid';
           sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
-          sessionRepository.save.resolves({ id: 1234 });
+          sessionRepository.create.resolves(1234);
           const savedCandidate = domainBuilder.certification.enrolment
             .candidateBuilder()
             .withSubscription(Frameworks.DROIT)
@@ -147,13 +148,22 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           await createSessions({
             cachedValidatedSessionsKey,
             userId: sessionCreatorId,
-            certificationCenterId: center.id,
             ...dependencies,
           });
 
           // then
-          const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
-          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
+          expect(sessionRepository.create).to.have.been.calledOnceWithExactly({
+            userId: sessionCreatorId,
+            certificationCenterId: 567,
+            address: 'Site 1',
+            room: 'Salle 1',
+            examiner: 'Pierre',
+            date: '2023-03-12',
+            time: '01:00',
+            description: 'desc',
+            accessCode: 'accessCode',
+            invigilatorPassword: 'Y722GA',
+          });
           expect(candidateRepository.save).to.have.been.calledOnceWith({
             candidates: [savedCandidate],
           });
@@ -165,10 +175,8 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
     });
 
     context('when at least one of the sessions already exists', function () {
-      it('should delete previous candidates and save the new candidates', async function () {
+      it('should delete previous candidates and save the new candidates, without touching the session', async function () {
         // given
-        const center = domainBuilder.certification.enrolment.buildCenter();
-        centerRepository.getById.withArgs({ id: center.id }).resolves(center);
         const candidate = domainBuilder.certification.enrolment
           .candidateBuilder()
           .withSubscription(Frameworks.DROIT)
@@ -197,11 +205,12 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         await createSessions({
           cachedValidatedSessionsKey,
           userId: sessionCreatorId,
-          certificationCenterId: center.id,
           ...dependencies,
         });
 
         // then
+        expect(sessionRepository.create).not.to.have.been.called;
+        expect(sessionCodeService.getNewInvigilatorPassword).not.to.have.been.called;
         expect(candidateRepository.deleteBySessionId).to.have.been.calledOnceWith({
           sessionId: 1234,
         });
@@ -216,8 +225,6 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
 
     it('should delete cached sessions', async function () {
       // given
-      const center = domainBuilder.certification.enrolment.buildCenter();
-      centerRepository.getById.withArgs({ id: center.id }).resolves(center);
       const certificationCandidate = domainBuilder.certification.enrolment
         .candidateBuilder()
         .withSubscription(Frameworks.DROIT)
@@ -238,7 +245,6 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       await createSessions({
         cachedValidatedSessionsKey,
         userId: sessionCreatorId,
-        certificationCenterId: center.id,
         ...dependencies,
       });
 

--- a/certif/app/adapters/certification-report.js
+++ b/certif/app/adapters/certification-report.js
@@ -15,9 +15,9 @@ export default class CertificationReportAdapter extends ApplicationAdapter {
   }
 
   abort({ certificationCourseId, reason }) {
-    const data = { reason };
+    const payload = { data: { reason } };
     const url = `${this.host}/${this.namespace}/certification-reports/${certificationCourseId}/abort`;
 
-    return this.ajax(url, 'POST', { data });
+    return this.ajax(url, 'POST', { data: payload });
   }
 }

--- a/certif/tests/unit/adapters/certification-report-test.js
+++ b/certif/tests/unit/adapters/certification-report-test.js
@@ -12,14 +12,14 @@ module('Unit | Adapter | certification issue report', function (hooks) {
       sinon.stub(adapter, 'ajax');
 
       const certificationCourseId = 1;
-      const reason = 'reason';
+      const reason = 'technical';
 
       // when
       await adapter.abort({ certificationCourseId, reason });
 
       // then
       const expectedUrl = 'http://localhost:3000/api/certification-reports/1/abort';
-      assert.ok(adapter.ajax.calledWith(expectedUrl, 'POST', { data: { reason } }));
+      assert.true(adapter.ajax.calledOnceWithExactly(expectedUrl, 'POST', { data: { data: { reason: 'technical' } } }));
     });
   });
 });


### PR DESCRIPTION
## ☀️ Problème

Depuis https://github.com/1024pix/pix/pull/17053 , on passe par le usecase `create-session` pour générer le mot de passe de session.
Mais la modification n’a pas été intégrée pour l’import de session en masse.

Aussi, ici https://github.com/1024pix/pix/pull/17087/changes#diff-216e4b8e6b074922221ca8db130dcad3186cad8681a6631523b4ee6a05bb3f17, une payload incomplète était passée (il manque un niveau `data` d'imbrication).

## ⛱️ Proposition

- Passer la génération de mot de passe dans le service `session-code-service`
- Utiliser le service dans le usecase `create-session`
- Supprimer la méthode `save` (devenue inutilisée) de `session-repository`
- Réparer l'adapter `abort` côté PixCertif

## 🏊 Pour tester

- Lancer le test e2e-certif `MASS_IMPORT_ENROLMENT`