### PR TITLE
[TECH] Augmentation de la taille des lots de copie sur les réplications parcoursup

### DIFF
--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -1,6 +1,7 @@
 export const replications = [
   {
     name: 'sco_certification_results',
+    chunkSize: 4500,
     before: async ({ datamartKnex }) => {
       await datamartKnex('sco_certification_results').truncate();
     },
@@ -28,6 +29,7 @@ export const replications = [
   },
   {
     name: 'certification_results',
+    chunkSize: 5000,
     before: async ({ datamartKnex }) => {
       await datamartKnex('certification_results').truncate();
     },


### PR DESCRIPTION
## ☀️ Problème

Les réplications parcoursup sont très lentes. Ceci est en partie dû à l'utilisation d'INSERT par chunk trop petits qui occasionne une perte de temps importante sur la latence des itérations de lecture/écriture.

## ⛱️ Proposition

Augmenter la taille des lots.

## 🧴 Remarques

La taille des chunks est contraint par le nombre de paramètres autorisés dans une requête postgresql (65 535).

Les enregistrements n'étant pas volumineux, nous souhaitons positionner la taille de chunk maximal possible. Celle-ci dépend du nombre de colonnes de la table : 
- sco_certification_results a 14 colonnes, un chunk à 4500 enregistrements permet de ne pas dépasser le nombre de paramètres maximum (65535 / 14 ≈ 4681).
- certification_results a 13 colonnes, un chunk à 5000 enregistrements permet de ne pas dépasser le nombre de paramètres maximum (65535 / 13 ≈ 5041).

## 🏊 Pour tester

Ajouter des données dans les tables au delà de la taille des chunks (4500 et 5000) `data_export_parcoursup_certif_result` et `data_export_parcoursup_certif_result_code_validation` de la base de données [pix-datawarehouse-integration](https://dashboard.scalingo.com/apps/osc-fr1/pix-datawarehouse-integration).

Créer un token avec le scope `replication` :

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr17111.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

Lancer les réplications :

```
curl -X POST "https://pix-api-maddo-review-pr17111.osc-fr1.scalingo.io/api/replications/sco_certification_results" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
curl -X POST "https://pix-api-maddo-review-pr17111.osc-fr1.scalingo.io/api/replications/certification_results" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
```

Vérifier que les tables `sco_certification_results` et `data_export_parcoursup_certif_result` ont bien les enregistrements répliqués.
<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
