### PR TITLE
[TECH] Corrige un problème dans les seeds : utilise la connexion au datamart directement

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,6 +1,6 @@
+import { knex as datamartKnex } from '../../datamart/knex-database-connection.js';
 import { config } from '../../src/shared/config.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
-import { datamartKnex } from '../../tests/tooling/databases.js';
 import { DatabaseBuilder } from '../database-builder/database-builder.js';
 import { commonBuilder } from './data/common/common-builder.js';
 import { complementaryCertificationBuilder } from './data/common/complementary-certification-builder.js';


### PR DESCRIPTION
## ☀️ Problème

Nous passons par un fichier dans le répertoire de `tests` pour récupérer une connexion à la base `datamart`. 
Le répertoire de `tests` n'est pas disponible sur les applications scalingo. Il est ignoré volontairement au déploiement.

## ⛱️ Proposition

Utiliser directement la connexion au datamart via le répertoire datamart.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
Tests verts et déploiement de l'API OK !