### PR TITLE
[BUGFIX] Gérer le cas ou la currentOrganization d'un prescripteur ne fait plus parti de ses memberships (PIX-23778)

### DIFF
--- a/api/src/deprecated/domain/usecases/get-prescriber.js
+++ b/api/src/deprecated/domain/usecases/get-prescriber.js
@@ -16,16 +16,17 @@ export const getPrescriber = async function ({
   userOrgaSettingsRepository,
 }) {
   const memberships = await membershipRepository.findByUserId(userId);
-  if (memberships?.length === 0) {
+  const activeMemberships = memberships.filter(({ disabledAt }) => !disabledAt);
+  if (activeMemberships.length === 0) {
     throw new UserHasNoOrganizationMembershipError();
   }
 
-  const firstOrganizationId = memberships[0].organizationId;
+  const firstOrganizationId = activeMemberships[0].organizationId;
 
   const userOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(userId);
   if (!userOrgaSettings) {
     await userOrgaSettingsRepository.create(userId, firstOrganizationId);
-  } else if (!_isCurrentOrganizationInMemberships(userOrgaSettings, memberships)) {
+  } else if (!_isCurrentOrganizationInMemberships(userOrgaSettings, activeMemberships)) {
     await userOrgaSettingsRepository.update(userId, firstOrganizationId);
   }
   return prescriberRepository.getPrescriber({ userId });

--- a/api/tests/deprecated/integration/domain/usecases/get-prescriber.test.js
+++ b/api/tests/deprecated/integration/domain/usecases/get-prescriber.test.js
@@ -1,6 +1,8 @@
 import { usecases } from '../../../../../src/deprecated/domain/usecases/index.js';
+import { UserHasNoOrganizationMembershipError } from '../../../../../src/team/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Deprecated | Integration | Domain | UseCases | get-prescriber', function () {
   context('When prescriber does not have a userOrgaSettings', function () {
@@ -62,6 +64,47 @@ describe('Deprecated | Integration | Domain | UseCases | get-prescriber', functi
         expect(userOrgaSettingsInDB).to.exist;
         expect(prescriber.userOrgaSettings).to.exist;
         expect(prescriber.userOrgaSettings.currentOrganization.id).to.equal(firstMembership.organizationId);
+      });
+    });
+
+    context('When the membership on the currentOrganization has been disabled', function () {
+      it("should update the prescriber's userOrgaSettings with the organization of the first active membership", async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const disabledMembership = databaseBuilder.factory.buildMembership({ userId, disabledAt: new Date() });
+        const activeMembership = databaseBuilder.factory.buildMembership({ userId });
+        databaseBuilder.factory.buildUserOrgaSettings({
+          userId,
+          currentOrganizationId: disabledMembership.organizationId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const prescriber = await usecases.getPrescriber({ userId });
+
+        // then
+        const userOrgaSettingsInDB = await knex('user-orga-settings').where({ userId }).first();
+        expect(userOrgaSettingsInDB.currentOrganizationId).to.equal(activeMembership.organizationId);
+        expect(prescriber.userOrgaSettings.currentOrganization.id).to.equal(activeMembership.organizationId);
+      });
+    });
+
+    context('When all the prescriber memberships have been disabled', function () {
+      it('should throw a UserHasNoOrganizationMembershipError', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const disabledMembership = databaseBuilder.factory.buildMembership({ userId, disabledAt: new Date() });
+        databaseBuilder.factory.buildUserOrgaSettings({
+          userId,
+          currentOrganizationId: disabledMembership.organizationId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(usecases.getPrescriber)({ userId });
+
+        // then
+        expect(error).to.be.instanceOf(UserHasNoOrganizationMembershipError);
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-membership.js
+++ b/api/tests/tooling/domain-builder/factory/build-membership.js
@@ -31,6 +31,7 @@ const buildMembership = function ({
   organizationRole = Membership.roles.MEMBER,
   user = _buildUser(),
   lastAccessedAt = null,
+  disabledAt = null,
 } = {}) {
   const membership = new Membership({
     id,
@@ -40,6 +41,7 @@ const buildMembership = function ({
     userId: user.id,
     user,
     lastAccessedAt,
+    disabledAt,
   });
   return membership;
 };


### PR DESCRIPTION
## ☀️ Problème
On a une 500 lorsqu’un prescripteur se connecte sur orga et que le currentOrganizationId référence une orga dont il n’est plus membre.

## ⛱️ Proposition
Gérer le fait que l’orga ne fasse plus parti des memberships du prescripteur, soit en allant chercher une autre de ses orga active, soit en jetant l'erreur existante

## 🧴 Remarques
Bug introduit dans la PR #16968

## 🏊 Pour tester

- Se connecter sur orga avec member-orga@example.net
- Aller sur l’orga sco-fregata
- Sur admin - supprimer le membership de member-orga@example.net sur l’orga sco-fregata
- Aller sur orga et ne pas avoir d’erreur 
- L’orga selectionnée n’est plus sco-fregata.
- 🐈‍⬛ 