### PR TITLE
[BUGFIX] Vérifie que la session existe avant de passer au cas d'utilisation (PIX-23846)

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
+++ b/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {import ('../../domain/models/Candidate.js').Candidate} Candidate
  */
-import { UserNotAuthorizedToCertifyError } from '../../../../shared/domain/errors.js';
+import { NotFoundError, UserNotAuthorizedToCertifyError } from '../../../../shared/domain/errors.js';
 import {
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
@@ -38,6 +38,10 @@ export async function registerCandidateParticipation({
   sessionAuthorizationAdapter,
 }) {
   const sessionAuthorization = await sessionAuthorizationAdapter.find({ sessionId });
+
+  if (!sessionAuthorization) {
+    throw new NotFoundError(`Session ${sessionId} does not exist`);
+  }
 
   if (!sessionAuthorization.canJoinSession) {
     throw new SessionExpiredError();

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -5,7 +5,7 @@ import { SessionExpiredError } from '../../../../../../src/certification/enrolme
 import { registerCandidateParticipation } from '../../../../../../src/certification/enrolment/domain/usecases/register-candidate-participation.js';
 import { CenterHabilitationError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { UserNotAuthorizedToCertifyError } from '../../../../../../src/shared/domain/errors.js';
+import { NotFoundError, UserNotAuthorizedToCertifyError } from '../../../../../../src/shared/domain/errors.js';
 import {
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
@@ -74,6 +74,24 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
   afterEach(function () {
     clock.restore();
     sinon.restore();
+  });
+
+  it('throws NotFoundError when the session does not exist', async function () {
+    const userId = 123;
+    const sessionId = 456;
+
+    sessionAuthorizationAdapter.find.resolves(null);
+
+    const error = await catchErr(registerCandidateParticipation)({
+      firstName: 'Tony',
+      lastName: 'Stark',
+      birthdate: '1994-07-18',
+      userId,
+      sessionId,
+      ...dependencies,
+    });
+
+    expect(error).to.be.instanceOf(NotFoundError);
   });
 
   it('throws SessionExpiredError when session has expired', async function () {


### PR DESCRIPTION
## ☀️ Problème

Nous avons découvert un bug aujourd'hui, un cas que nous ne prenons pas en compte : tenter de rejoindre une session qui n'existe pas (ID bidon).

https://1024pix.atlassian.net/wiki/spaces/DC/pages/6337724456/Erreur+en+PROD+Erreur+500+en+production+li+l+entr+e+en+session+11+ao+t+2026

## ⛱️ Proposition

Dans le usecase `register-candidate-participation`, déclencher une erreur si la session n’existe pas. 

## 🧴 Remarques

On a hésité à utiliser un pre-handler, mais un peu overkill à ce niveau.

## 🏊 Pour tester

- Essayer d'entrer en certification (via mon pix) avec un numéro de session bidon
- Le message d'erreur `Les informations saisies ne correspondent à aucun candidat inscrit à la session. Vérifiez le numéro de session …` est censé apparaître.