### PR TITLE
[FEATURE] POC retours design catalogue (PIX-23847)

### DIFF
--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -60,7 +60,7 @@ export default class CreateForm extends Component {
         {{t "common.form.mandatory-fields"}}
       </p>
 
-      <FormSection @title="Objectif">
+      <FormSection @title={{t "pages.campaign-creation.purpose.title"}}>
         <CampaignGoals @campaign={{@campaign}} @errors={{@errors}} @hasBlueprints={{@hasBlueprints}} />
       </FormSection>
 

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -60,7 +60,9 @@ export default class CreateForm extends Component {
         {{t "common.form.mandatory-fields"}}
       </p>
 
-      <CampaignGoals @campaign={{@campaign}} @errors={{@errors}} @hasBlueprints={{@hasBlueprints}} />
+      <FormSection @title="Objectif">
+        <CampaignGoals @campaign={{@campaign}} @errors={{@errors}} @hasBlueprints={{@hasBlueprints}} />
+      </FormSection>
 
       {{#if this.displaysSettingsSection}}
         <FormSection @title={{t "pages.campaign-creation.settings.title"}}>

--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -20,7 +20,7 @@ export function getCourseInfo(courseType) {
         type: 'targetProfile',
         color: 'blue',
         label: 'pages.catalogue.card.tag.target-profile',
-        image: 'https://assets.pix.org/sites/orga/target-profile.svg',
+        image: 'https://assets.pix.org/sites/orga/target-profile.png',
       };
     case BLUEPRINT:
     case COMBINED_COURSE_BLUEPRINT_OVERVIEW:
@@ -28,7 +28,7 @@ export function getCourseInfo(courseType) {
         type: 'blueprint',
         color: 'yellow',
         label: 'pages.catalogue.card.tag.blueprint',
-        image: 'https://assets.pix.org/sites/orga/blueprint.svg',
+        image: 'https://assets.pix.org/sites/orga/blueprint.png',
       };
     default:
       return null;

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -80,7 +80,7 @@ export default class CourseModal extends Component {
         aria-modal="true"
       >
         <div class="course-modal__course-details">
-          <div class="course-modal__header">
+          <div class="course-modal__top-actions">
             <PixButton
               @variant="tertiary"
               @triggerAction={{@closeModal}}
@@ -91,14 +91,18 @@ export default class CourseModal extends Component {
               {{t "common.actions.exit"}}
             </PixButton>
           </div>
-          <div class="course-modal__body">
+
+          <div class="course-modal__heading">
             <div class="pix-card__image pix-card__image--orga">
               <img src={{this.courseInfo.image}} aria-hidden="true" alt={{@currentCourse.type}} />
             </div>
             <PixTag @color={{this.courseInfo.color}} class="course-card__tag">
               {{t this.courseInfo.label}}
             </PixTag>
-            <h1 id="modal-title--{{this.id}}" class="course-modal__body__name">{{@currentCourse.name}}</h1>
+            <h1 id="modal-title--{{this.id}}" class="course-modal__heading__name">{{@currentCourse.name}}</h1>
+          </div>
+
+          <div class="course-modal__body">
             <SafeMarkdownToHtml
               id="modal-content--{{this.id}}"
               class="course-modal__body__description"
@@ -113,7 +117,9 @@ export default class CourseModal extends Component {
                 <Badges @badges={{@currentCourse.badges}} @hideBadgesAcquisition={{true}} />
               </div>
             {{/if}}
+          </div>
 
+          <div class="course-modal__footer">
             <PixButtonLink
               @route={{this.campaignCreationRoute}}
               @query={{hash courseId=@currentCourse.id}}
@@ -123,8 +129,7 @@ export default class CourseModal extends Component {
             >
               {{t "pages.catalogue.modal.select-course"}}
             </PixButtonLink>
-          </div>
-          <div class="course-modal__footer">
+
             {{#if this.isTargetProfile}}
               <p class="course-modal__footer__text">
                 {{t this.courseLevelLabel}}

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -80,18 +80,6 @@ export default class CourseModal extends Component {
         aria-modal="true"
       >
         <div class="course-modal__course-details">
-          <div class="course-modal__top-actions">
-            <PixButton
-              @variant="tertiary"
-              @triggerAction={{@closeModal}}
-              @size="small"
-              @iconAfter="close"
-              class="course-modal__exit"
-            >
-              {{t "common.actions.exit"}}
-            </PixButton>
-          </div>
-
           <div class="course-modal__heading">
             <div class="pix-card__image pix-card__image--orga">
               <img src={{this.courseInfo.image}} aria-hidden="true" alt={{@currentCourse.type}} />
@@ -143,12 +131,25 @@ export default class CourseModal extends Component {
             {{/if}}
           </div>
         </div>
-        <div class="course-modal__course-content">
-          {{#if this.isTargetProfile}}
-            <TargetProfileContent @currentCourse={{@currentCourse}} />
-          {{else if this.isCombinedCourseBlueprint}}
-            <CombinedCourseBlueprintContent @combinedCourseBlueprint={{@currentCourse}} />
-          {{/if}}
+        <div class="course-modal__course-content__wrapper">
+          <div class="course-modal__top-actions">
+            <PixButton
+              @variant="secondary"
+              @triggerAction={{@closeModal}}
+              @size="small"
+              @iconAfter="close"
+              class="course-modal__top-actions__exit"
+            >
+              {{t "common.actions.exit"}}
+            </PixButton>
+          </div>
+          <div class="course-modal__course-content">
+            {{#if this.isTargetProfile}}
+              <TargetProfileContent @currentCourse={{@currentCourse}} />
+            {{else if this.isCombinedCourseBlueprint}}
+              <CombinedCourseBlueprintContent @combinedCourseBlueprint={{@currentCourse}} />
+            {{/if}}
+          </div>
         </div>
       </div>
     </PixOverlay>

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -93,24 +93,26 @@ export default class CourseModal extends Component {
               class="course-modal__body__description"
               @markdown={{this.courseDescription}}
             />
-
-            {{#if (gt @currentCourse.badges.length 0)}}
-              <h2 class="course-modal__body__badges-title">
-                {{t "pages.catalogue.modal.associated-badges"}}
-              </h2>
-              <div class="course-modal__body__badges">
-                <Badges @badges={{@currentCourse.badges}} @hideBadgesAcquisition={{true}} />
-              </div>
-            {{/if}}
           </div>
 
           <div class="course-modal__footer">
+            {{#if (gt @currentCourse.badges.length 0)}}
+              <div class="course-modal__badges">
+                <h2 class="course-modal__badges__title">
+                  {{t "pages.catalogue.modal.associated-badges"}}
+                </h2>
+                <div class="course-modal__badges__container">
+                  <Badges @badges={{@currentCourse.badges}} @hideBadgesAcquisition={{true}} />
+                </div>
+              </div>
+            {{/if}}
+
             <PixButtonLink
               @route={{this.campaignCreationRoute}}
               @query={{hash courseId=@currentCourse.id}}
               @isDisabled={{this.hasReachedPlacesLimit}}
               @size="small"
-              class="course-modal__body__form-link"
+              class="course-modal__form-link"
             >
               {{t "pages.catalogue.modal.select-course"}}
             </PixButtonLink>

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -81,10 +81,7 @@ export default class CourseModal extends Component {
       >
         <div class="course-modal__course-details">
           <div class="course-modal__heading">
-            <div class="pix-card__image pix-card__image--orga">
-              <img src={{this.courseInfo.image}} aria-hidden="true" alt={{@currentCourse.type}} />
-            </div>
-            <PixTag @color={{this.courseInfo.color}} class="course-card__tag">
+            <PixTag @color={{this.courseInfo.color}}>
               {{t this.courseInfo.label}}
             </PixTag>
             <h1 id="modal-title--{{this.id}}" class="course-modal__heading__name">{{@currentCourse.name}}</h1>

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -79,13 +79,6 @@ export default class CourseModal extends Component {
         aria-describedby="modal-content--{{this.id}}"
         aria-modal="true"
       >
-        <div class="course-modal__course-content">
-          {{#if this.isTargetProfile}}
-            <TargetProfileContent @currentCourse={{@currentCourse}} />
-          {{else if this.isCombinedCourseBlueprint}}
-            <CombinedCourseBlueprintContent @combinedCourseBlueprint={{@currentCourse}} />
-          {{/if}}
-        </div>
         <div class="course-modal__course-details">
           <div class="course-modal__header">
             <PixButton
@@ -144,6 +137,13 @@ export default class CourseModal extends Component {
               </p>
             {{/if}}
           </div>
+        </div>
+        <div class="course-modal__course-content">
+          {{#if this.isTargetProfile}}
+            <TargetProfileContent @currentCourse={{@currentCourse}} />
+          {{else if this.isCombinedCourseBlueprint}}
+            <CombinedCourseBlueprintContent @combinedCourseBlueprint={{@currentCourse}} />
+          {{/if}}
         </div>
       </div>
     </PixOverlay>

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -84,7 +84,9 @@ export default class CourseModal extends Component {
             <PixTag @color={{this.courseInfo.color}}>
               {{t this.courseInfo.label}}
             </PixTag>
-            <h1 id="modal-title--{{this.id}}" class="course-modal__heading__name">{{@currentCourse.name}}</h1>
+            <h1 id="modal-title--{{this.id}}" class="course-modal__heading__name">
+              {{@currentCourse.name}}
+            </h1>
           </div>
 
           <div class="course-modal__body">
@@ -131,7 +133,17 @@ export default class CourseModal extends Component {
           </div>
         </div>
         <div class="course-modal__course-content__wrapper">
-          <div class="course-modal__top-actions">
+          <div class="course-modal__course-content__title">
+            {{#if this.isTargetProfile}}
+              <h3 class="pix-title-xs">
+                {{t "pages.catalogue.modal.target-profile-content.title"}}
+              </h3>
+            {{else if this.isCombinedCourseBlueprint}}
+              <h3 class="pix-title-xs">
+                {{t "pages.catalogue.modal.combined-course-content.title"}}
+              </h3>
+            {{/if}}
+
             <PixButton
               @variant="secondary"
               @triggerAction={{@closeModal}}

--- a/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
+++ b/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
@@ -10,22 +10,20 @@ function getStepIndex(index) {
 <template>
   <div class="combined-course-blueprint-detail">
     <div>
-      <h3 class="pix-title-xs">{{t "pages.catalogue.modal.combined-course-content.title"}}</h3>
-      <p class="pix-body-s combined-course-blueprint-detail__info">
-        {{t "pages.catalogue.modal.combined-course-content.description"}}
-      </p>
+      <h3 class="pix-title-xs">
+        {{t "pages.catalogue.modal.combined-course-content.title"}}
+      </h3>
     </div>
     {{#each @combinedCourseBlueprint.steps as |step index|}}
       <div>
         <div class="combined-course-blueprint-step">
-          <h4 class="pix-title-xs">{{t
-              "pages.catalogue.modal.combined-course-content.step"
-              number=(getStepIndex index)
-            }}</h4>
+          <h4 class="pix-title-xs">
+            {{t "pages.catalogue.modal.combined-course-content.step" number=(getStepIndex index)}}
+          </h4>
           {{#if (eq step.type "module")}}
-            <p class="pix-body-s combined-course-blueprint-step__description">{{t
-                "pages.catalogue.modal.combined-course-content.module-info"
-              }}</p>
+            <p class="pix-body-s combined-course-blueprint-step__description">
+              {{t "pages.catalogue.modal.combined-course-content.module-info"}}
+            </p>
           {{/if}}
         </div>
         <div class="combined-course-blueprint-detail__steps">

--- a/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
+++ b/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
@@ -9,11 +9,6 @@ function getStepIndex(index) {
 
 <template>
   <div class="combined-course-blueprint-detail">
-    <div>
-      <h3 class="pix-title-xs">
-        {{t "pages.catalogue.modal.combined-course-content.title"}}
-      </h3>
-    </div>
     {{#each @combinedCourseBlueprint.steps as |step index|}}
       <div>
         <div class="combined-course-blueprint-step">

--- a/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
+++ b/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
@@ -8,10 +8,10 @@ function getStepIndex(index) {
 }
 
 <template>
-  <div class="combined-course-blueprint-detail">
+  <div class="combined-course-blueprint-content">
     {{#each @combinedCourseBlueprint.steps as |step index|}}
-      <div>
-        <div class="combined-course-blueprint-step">
+      <div class="combined-course-blueprint-step">
+        <div class="combined-course-blueprint-step__title">
           <h4 class="pix-title-xs">
             {{t "pages.catalogue.modal.combined-course-content.step" number=(getStepIndex index)}}
           </h4>
@@ -21,8 +21,7 @@ function getStepIndex(index) {
             </p>
           {{/if}}
         </div>
-        <div class="combined-course-blueprint-detail__steps">
-
+        <div class="combined-course-blueprint-step__items">
           {{#each step.items as |item|}}
             <CombinedCourseBlueprintItem @item={{item}} />
           {{/each}}

--- a/orga/app/components/catalogue/course-modal/target-profile-content.gjs
+++ b/orga/app/components/catalogue/course-modal/target-profile-content.gjs
@@ -3,6 +3,7 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
+const getCompetenceIndexLabel = (label, index) => `${label} ${index}`;
 const getTableName = (index, name) => `${index} - ${name}`;
 
 export default class TargetProfileContent extends Component {
@@ -31,7 +32,10 @@ export default class TargetProfileContent extends Component {
       </div>
       {{#each this.targetProfileCompetences as |competence|}}
         <div class="course-modal__competence">
-          <h2>{{getTableName competence.index competence.name}}</h2>
+          <div class="course-modal__competence__title">
+            <p>{{getCompetenceIndexLabel "Compétence" competence.index}}</p>
+            <h2>{{competence.name}}</h2>
+          </div>
           <PixTable
             @condensed={{true}}
             @variant="orga"

--- a/orga/app/components/catalogue/course-modal/target-profile-content.gjs
+++ b/orga/app/components/catalogue/course-modal/target-profile-content.gjs
@@ -21,7 +21,14 @@ export default class TargetProfileContent extends Component {
   }
 
   <template>
-    <div>
+    <div class="target-profile-detail">
+      <div class="target-profile-detail__header">
+        <h3 class="pix-title-xs">Profils Cibles</h3>
+        <p class="pix-body-s target-profile-detail__description">
+          Les profils cibles permettent de réaliser des évaluations personnalisées et progressive en fonction du niveau
+          de chaque participant. (WIP Description temporaire)
+        </p>
+      </div>
       {{#each this.targetProfileCompetences as |competence|}}
         <div class="course-modal__competence">
           <h2>{{getTableName competence.index competence.name}}</h2>

--- a/orga/app/components/catalogue/course-modal/target-profile-content.gjs
+++ b/orga/app/components/catalogue/course-modal/target-profile-content.gjs
@@ -29,11 +29,6 @@ export default class TargetProfileContent extends Component {
 
   <template>
     <div class="target-profile-detail">
-      <div class="target-profile-detail__header">
-        <h3 class="pix-title-xs">
-          {{t "pages.catalogue.modal.target-profile-content.title"}}
-        </h3>
-      </div>
       {{#each this.targetProfileCompetences as |competence|}}
         <div class="course-modal__competence">
           <div class="course-modal__competence__title">

--- a/orga/app/components/catalogue/course-modal/target-profile-content.gjs
+++ b/orga/app/components/catalogue/course-modal/target-profile-content.gjs
@@ -28,10 +28,10 @@ export default class TargetProfileContent extends Component {
   };
 
   <template>
-    <div class="target-profile-detail">
+    <div class="target-profile-content">
       {{#each this.targetProfileCompetences as |competence|}}
-        <div class="course-modal__competence">
-          <div class="course-modal__competence__title">
+        <div class="target-profile-competence">
+          <div class="target-profile-competence__title">
             <p>{{this.getCompetenceIndexLabel competence.index}}</p>
             <h2>{{competence.name}}</h2>
           </div>
@@ -42,25 +42,25 @@ export default class TargetProfileContent extends Component {
             @data={{competence.tubes}}
           >
             <:columns as |tube context|>
-              <PixTableColumn @context={{context}} class="course-modal__competence__description__column">
+              <PixTableColumn @context={{context}} class="target-profile-competence__description__column">
                 <:header>
                   {{t "pages.catalogue.modal.tube-name-and-description"}}
                 </:header>
                 <:cell>
-                  <span class="course-modal__competence__description__title">
+                  <span class="target-profile-competence__description__title">
                     {{tube.practicalTitle}}
                   </span>
-                  <span class="course-modal__competence__description__text">
+                  <span class="target-profile-competence__description__text">
                     {{tube.practicalDescription}}
                   </span>
                 </:cell>
               </PixTableColumn>
-              <PixTableColumn @context={{context}} class="course-modal__competence__level__column">
+              <PixTableColumn @context={{context}} class="target-profile-competence__level__column">
                 <:header>
                   {{t "pages.catalogue.modal.max-level"}}
                 </:header>
                 <:cell>
-                  <span class="course-modal__competence__level__data">
+                  <span class="target-profile-competence__level__data">
                     {{#if tube.maxLevel}}
                       {{tube.maxLevel}}
                     {{else}}

--- a/orga/app/components/catalogue/course-modal/target-profile-content.gjs
+++ b/orga/app/components/catalogue/course-modal/target-profile-content.gjs
@@ -1,12 +1,14 @@
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-const getCompetenceIndexLabel = (label, index) => `${label} ${index}`;
 const getTableName = (index, name) => `${index} - ${name}`;
 
 export default class TargetProfileContent extends Component {
+  @service intl;
+
   get targetProfileCompetences() {
     return this.args.currentCourse.frameworks
       .flatMap((framework) => framework.hasMany('areas').value())
@@ -21,19 +23,21 @@ export default class TargetProfileContent extends Component {
       });
   }
 
+  getCompetenceIndexLabel = (index) => {
+    return `${this.intl.t('pages.catalogue.modal.target-profile-content.competence')} ${index}`;
+  };
+
   <template>
     <div class="target-profile-detail">
       <div class="target-profile-detail__header">
-        <h3 class="pix-title-xs">Profils Cibles</h3>
-        <p class="pix-body-s target-profile-detail__description">
-          Les profils cibles permettent de réaliser des évaluations personnalisées et progressive en fonction du niveau
-          de chaque participant. (WIP Description temporaire)
-        </p>
+        <h3 class="pix-title-xs">
+          {{t "pages.catalogue.modal.target-profile-content.title"}}
+        </h3>
       </div>
       {{#each this.targetProfileCompetences as |competence|}}
         <div class="course-modal__competence">
           <div class="course-modal__competence__title">
-            <p>{{getCompetenceIndexLabel "Compétence" competence.index}}</p>
+            <p>{{this.getCompetenceIndexLabel competence.index}}</p>
             <h2>{{competence.name}}</h2>
           </div>
           <PixTable

--- a/orga/app/components/ui/pix-fieldset.gjs
+++ b/orga/app/components/ui/pix-fieldset.gjs
@@ -4,10 +4,10 @@ import { t } from 'ember-intl';
   {{! TODO: move this component to Pix UI Later }}
   <fieldset class="pix-fieldset" ...attributes>
     <legend class="pix-fieldset__label">
+      {{yield to="title"}}
       {{#if @required}}
         <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
       {{/if}}
-      {{yield to="title"}}
     </legend>
 
     {{yield to="content"}}

--- a/orga/app/styles/components/courses/course-card.scss
+++ b/orga/app/styles/components/courses/course-card.scss
@@ -1,10 +1,5 @@
 @use 'pix-design-tokens/typography';
 
-.course-card .pix-card__image,
-.course-modal .pix-card__image {
-  padding: var(--pix-spacing-3x);
-}
-
 .course-card--targetProfile .pix-card__image,
 .course-modal--targetProfile .pix-card__image {
   background: var(--pix-orga-50);

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -137,6 +137,7 @@
 
   // body bottom scroll gradient overlay
   $scroll-gradient-height: 2rem;
+
   &__footer {
     position: relative;
     z-index: 10;

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -121,8 +121,8 @@
     padding: var(--pix-spacing-6x);
     background-color: var(--pix-neutral-0);
     border-radius: var(--pix-spacing-4x);
-    border-top-right-radius: var(--pix-spacing-10x);
-    border-bottom-right-radius: var(--pix-spacing-10x);
+    border-top-right-radius: var(--pix-spacing-5x);
+    border-bottom-right-radius: var(--pix-spacing-5x);
   }
 
   &__heading {

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -118,18 +118,10 @@
     align-items: stretch;
     justify-content: center;
     padding: var(--pix-spacing-6x);
-    padding-right: 0;
     background-color: var(--pix-neutral-0);
     border-radius: var(--pix-spacing-4x);
     border-top-right-radius: var(--pix-spacing-10x);
     border-bottom-right-radius: var(--pix-spacing-10x);
-  }
-
-  // For content scrollbar to be right on details block border
-  &__heading,
-  &__body,
-  &__footer {
-    padding-right: var(--pix-spacing-6x);
   }
 
   &__heading {
@@ -147,31 +139,7 @@
     }
   }
 
-  // body bottom scroll gradient overlay
-  $scroll-gradient-height: 2rem;
-
-  &__footer {
-    position: relative;
-    z-index: 10;
-
-    &::before {
-      position: absolute;
-      top: -$scroll-gradient-height;
-      left: 0;
-      z-index: 1;
-      width: 100%;
-      height: $scroll-gradient-height;
-      background: linear-gradient(180deg, rgb(255 255 255 / 0%), rgb(255 255 255 / 100%) 25%);
-      content: '';
-    }
-  }
-
   &__body {
-    position: relative;
-    z-index: 1;
-    padding-bottom: $scroll-gradient-height;
-    overflow-y: scroll;
-
     &__description {
       @extend %pix-body-s;
 
@@ -187,7 +155,6 @@
     flex-direction: column;
     flex-grow: 1;
     flex-shrink: 0;
-    gap: var(--pix-spacing-3x);
     align-items: center;
 
     &__text {
@@ -199,6 +166,7 @@
 
   &__form-link {
     align-self: center;
+    margin-top: var(--pix-spacing-4x);
     margin-bottom: auto;
   }
 

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -68,6 +68,7 @@
 
         & .pix-table-header-container {
           justify-content: center;
+          text-align: center;
         }
       }
 
@@ -214,6 +215,8 @@
 }
 
 .target-profile-detail {
+  padding-bottom: var(--pix-spacing-6x);
+
   &__header {
     margin-bottom: var(--pix-spacing-6x);
   }

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -19,6 +19,7 @@
     flex: 1;
     height: 100%;
   }
+
   &__top-actions {
     position: absolute;
     top: 0;
@@ -35,16 +36,16 @@
   }
 
   &__course-content {
-    z-index: 10;
     position: absolute;
     top: 0;
     left: 0;
-    overflow-y: scroll;
+    z-index: 10;
     display: flex;
     height: 100%;
     padding: var(--pix-spacing-4x);
-    padding-left: var(--pix-spacing-6x);
     padding-top: 4rem;
+    padding-left: var(--pix-spacing-6x);
+    overflow-y: scroll;
   }
 
   &__competence {

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -88,22 +88,29 @@
     flex-direction: column;
     flex-grow: 0;
     flex-shrink: 0;
+    align-items: stretch;
     justify-content: center;
+    padding: var(--pix-spacing-8x);
     padding-top: var(--pix-spacing-10x);
-    padding-right: var(--pix-spacing-8x);
-    padding-bottom: 4.5rem;
-    padding-left: var(--pix-spacing-8x);
+    padding-right: 0;
     background-color: var(--pix-neutral-0);
     border-radius: var(--pix-spacing-4x);
     border-top-right-radius: var(--pix-spacing-10x);
     border-bottom-right-radius: var(--pix-spacing-10x);
   }
 
-  &__header {
+  // For body scrollbar near details block right border
+  &__heading,
+  &__body,
+  &__footer {
+    padding-right: var(--pix-spacing-8x);
+  }
+
+  &__top-actions {
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 10;
+    z-index: 100;
     padding-top: var(--pix-spacing-6x);
     padding-right: var(--pix-spacing-8x);
 
@@ -113,17 +120,44 @@
     }
   }
 
-  &__body {
-    position: relative;
-    z-index: 1;
+  &__heading {
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
+    flex-shrink: 0;
     gap: var(--pix-spacing-2x);
     align-items: flex-start;
+    justify-content: flex-end;
+    padding-bottom: var(--pix-spacing-4x);
 
     &__name {
       @extend %pix-title-xs;
     }
+  }
+
+  // body bottom scroll gradient overlay
+  $scroll-gradient-height: 2rem;
+  &__footer {
+    position: relative;
+    z-index: 10;
+
+    &::before {
+      position: absolute;
+      top: -$scroll-gradient-height;
+      left: 0;
+      z-index: 1;
+      width: 100%;
+      height: $scroll-gradient-height;
+      background: linear-gradient(180deg, rgb(255 255 255 / 0%), rgb(255 255 255 / 100%) 25%);
+      content: '';
+    }
+  }
+
+  &__body {
+    position: relative;
+    z-index: 1;
+    padding-bottom: $scroll-gradient-height;
+    overflow-y: scroll;
 
     &__description {
       @extend %pix-body-m;
@@ -154,22 +188,21 @@
         }
       }
     }
+  }
+
+  &__footer {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    flex-shrink: 0;
+    gap: var(--pix-spacing-3x);
+    align-items: center;
+    justify-content: space-between;
 
     &__form-link {
       align-self: center;
       margin-top: var(--pix-spacing-6x);
     }
-  }
-
-  &__footer {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    z-index: 10;
-    width: 100%;
-    padding-right: var(--pix-spacing-8x);
-    padding-bottom: var(--pix-spacing-8x);
-    padding-left: var(--pix-spacing-8x);
 
     &__text {
       @extend %pix-body-s;

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -38,16 +38,15 @@
     $scrollbar-width: 0.5rem;
 
     &__title {
-      position: absolute;
+      position: sticky;
       top: 0;
-      left: 0;
       z-index: 10;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      width: calc(100% - $scrollbar-width);
+      width: 100%;
       padding: var(--pix-spacing-4x);
-      padding-right: calc(var(--pix-spacing-6x) - ($scrollbar-width * 2));
+      padding-right: var(--pix-spacing-6x);
       padding-left: var(--pix-spacing-6x);
       background-color: var(--pix-orga-50);
 

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -2,6 +2,7 @@
 @use 'pix-design-tokens/shadows';
 
 .course-modal {
+  overflow: hidden;
   position: relative;
   display: flex;
   width: 100%;
@@ -20,32 +21,41 @@
     height: 100%;
   }
 
-  &__top-actions {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 100;
-    padding-top: var(--pix-spacing-4x);
-    padding-right: var(--pix-spacing-4x);
-
-    &__exit {
-      align-self: flex-end;
-      text-decoration: none;
-      background-color: var(--pix-orga-50);
-    }
-  }
+  $content-header-height: 4.5rem;
 
   &__course-content {
     position: absolute;
     top: 0;
     left: 0;
-    z-index: 10;
+    z-index: 1;
     display: flex;
     height: 100%;
     padding: var(--pix-spacing-4x);
-    padding-top: 4rem;
+    padding-top: $content-header-height;
     padding-left: var(--pix-spacing-6x);
     overflow-y: scroll;
+
+    $scrollbar-width: 0.5rem;
+
+    &__title {
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 10;
+      width: calc(100% - $scrollbar-width);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: var(--pix-spacing-4x);
+      padding-left: var(--pix-spacing-6x);
+      padding-right: calc(var(--pix-spacing-6x) - ($scrollbar-width * 2));
+      background-color: var(--pix-orga-50);
+
+      &__exit {
+        align-self: flex-end;
+        text-decoration: none;
+      }
+    }
   }
 
   &__competence {
@@ -111,6 +121,7 @@
     @extend %pix-shadow-orga;
 
     position: relative;
+    z-index: 100;
     display: flex;
     flex-basis: 24rem;
     flex-direction: column;
@@ -199,14 +210,6 @@
 
 .target-profile-detail {
   padding-bottom: var(--pix-spacing-6x);
-
-  &__header {
-    margin-bottom: var(--pix-spacing-6x);
-  }
-
-  &__description {
-    color: var(--pix-neutral-500);
-  }
 }
 
 .combined-course-blueprint-detail {
@@ -215,10 +218,7 @@
   gap: var(--pix-spacing-8x);
   margin-top: auto;
   margin-bottom: auto;
-
-  &__info {
-    color: var(--pix-neutral-500);
-  }
+  padding-top: var(--pix-spacing-4x);
 
   &__steps {
     display: flex;

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -29,11 +29,17 @@
   &__competence {
     padding-bottom: var(--pix-spacing-2x);
 
-    & > h2 {
-      @extend %pix-title-xxs;
-
+    &__title {
       margin-top: var(--pix-spacing-2x);
       margin-bottom: var(--pix-spacing-2x);
+
+      p {
+        @extend %pix-body-s;
+      }
+
+      h2 {
+        @extend %pix-title-xxs;
+      }
     }
 
     &:last-child {

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -178,6 +178,16 @@
   }
 }
 
+.target-profile-detail {
+  &__header {
+    margin-bottom: var(--pix-spacing-6x);
+  }
+
+  &__description {
+    color: var(--pix-neutral-500);
+  }
+}
+
 .combined-course-blueprint-detail {
   display: flex;
   flex-direction: column;

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -24,8 +24,8 @@
     top: 0;
     right: 0;
     z-index: 100;
-    padding-top: var(--pix-spacing-6x);
-    padding-right: var(--pix-spacing-6x);
+    padding-top: var(--pix-spacing-4x);
+    padding-right: var(--pix-spacing-4x);
 
     &__exit {
       align-self: flex-end;
@@ -42,7 +42,8 @@
     overflow-y: scroll;
     display: flex;
     height: 100%;
-    padding: var(--pix-spacing-6x);
+    padding: var(--pix-spacing-4x);
+    padding-left: var(--pix-spacing-6x);
     padding-top: 4rem;
   }
 
@@ -116,8 +117,7 @@
     flex-shrink: 0;
     align-items: stretch;
     justify-content: center;
-    padding: var(--pix-spacing-8x);
-    padding-top: var(--pix-spacing-10x);
+    padding: var(--pix-spacing-6x);
     padding-right: 0;
     background-color: var(--pix-neutral-0);
     border-radius: var(--pix-spacing-4x);
@@ -129,7 +129,7 @@
   &__heading,
   &__body,
   &__footer {
-    padding-right: var(--pix-spacing-8x);
+    padding-right: var(--pix-spacing-6x);
   }
 
   &__heading {

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -2,7 +2,6 @@
 @use 'pix-design-tokens/shadows';
 
 .course-modal {
-  overflow: hidden;
   position: relative;
   display: flex;
   width: 100%;
@@ -11,6 +10,7 @@
   min-height: auto;
   max-height: 42.5rem;
   margin: 0 auto;
+  overflow: hidden;
   background-color: var(--pix-orga-50);
   border-radius: var(--pix-spacing-4x);
   margin-block: auto;
@@ -42,77 +42,18 @@
       top: 0;
       left: 0;
       z-index: 10;
-      width: calc(100% - $scrollbar-width);
       display: flex;
-      justify-content: space-between;
       align-items: center;
+      justify-content: space-between;
+      width: calc(100% - $scrollbar-width);
       padding: var(--pix-spacing-4x);
-      padding-left: var(--pix-spacing-6x);
       padding-right: calc(var(--pix-spacing-6x) - ($scrollbar-width * 2));
+      padding-left: var(--pix-spacing-6x);
       background-color: var(--pix-orga-50);
 
       &__exit {
         align-self: flex-end;
         text-decoration: none;
-      }
-    }
-  }
-
-  &__competence {
-    padding-bottom: var(--pix-spacing-2x);
-
-    &__title {
-      margin-top: var(--pix-spacing-2x);
-      margin-bottom: var(--pix-spacing-2x);
-
-      p {
-        @extend %pix-body-s;
-      }
-
-      h2 {
-        @extend %pix-title-xxs;
-      }
-    }
-
-    &:last-child {
-      padding-bottom: var(--pix-spacing-6x);
-    }
-
-    &__title {
-      margin-top: var(--pix-spacing-2x);
-      margin-bottom: var(--pix-spacing-2x);
-    }
-
-    &__description {
-      &__column {
-        width: 75%;
-      }
-
-      &__title {
-        display: block;
-        margin-bottom: var(--pix-spacing-2x);
-        font-weight: var(--pix-font-bold);
-      }
-
-      &__text {
-        display: block;
-      }
-    }
-
-    &__level {
-      &__column {
-        width: 25%;
-
-        & .pix-table-header-container {
-          justify-content: center;
-          text-align: center;
-        }
-      }
-
-      &__data {
-        display: block;
-        width: 100%;
-        text-align: center;
       }
     }
   }
@@ -208,30 +149,92 @@
   }
 }
 
-.target-profile-detail {
+// TODO move these properties to stay consistent in the css file
+.target-profile-content {
   padding-bottom: var(--pix-spacing-6x);
 }
 
-.combined-course-blueprint-detail {
+.target-profile-competence {
+  padding-bottom: var(--pix-spacing-2x);
+
+  &__title {
+    margin-top: var(--pix-spacing-2x);
+    margin-bottom: var(--pix-spacing-2x);
+
+    p {
+      @extend %pix-body-s;
+    }
+
+    h2 {
+      @extend %pix-title-xxs;
+    }
+  }
+
+  &:last-child {
+    padding-bottom: var(--pix-spacing-6x);
+  }
+
+  &__title {
+    margin-top: var(--pix-spacing-2x);
+    margin-bottom: var(--pix-spacing-2x);
+  }
+
+  &__description {
+    &__column {
+      width: 75%;
+    }
+
+    &__title {
+      display: block;
+      margin-bottom: var(--pix-spacing-2x);
+      font-weight: var(--pix-font-bold);
+    }
+
+    &__text {
+      display: block;
+    }
+  }
+
+  &__level {
+    &__column {
+      width: 25%;
+
+      & .pix-table-header-container {
+        justify-content: center;
+        text-align: center;
+      }
+    }
+
+    &__data {
+      display: block;
+      width: 100%;
+      text-align: center;
+    }
+  }
+}
+
+.combined-course-blueprint-content {
   display: flex;
   flex-direction: column;
   gap: var(--pix-spacing-8x);
   margin-top: auto;
   margin-bottom: auto;
   padding-top: var(--pix-spacing-4x);
-
-  &__steps {
-    display: flex;
-    flex-direction: column;
-    gap: var(--pix-spacing-4x);
-  }
 }
 
 .combined-course-blueprint-step {
-  margin-bottom: var(--pix-spacing-4x);
+  &__title {
+    margin-bottom: var(--pix-spacing-4x);
+  }
 
   &__description {
     color: var(--pix-neutral-500);
+  }
+
+  &__items {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
   }
 }
 

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -17,7 +17,7 @@
   &__course-content {
     display: flex;
     flex: 1;
-    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+    padding: var(--pix-spacing-6x);
     overflow-y: scroll;
     scrollbar-width: none;
 
@@ -32,6 +32,15 @@
     & > h2 {
       @extend %pix-title-xxs;
 
+      margin-top: var(--pix-spacing-2x);
+      margin-bottom: var(--pix-spacing-2x);
+    }
+
+    &:last-child {
+      padding-bottom: var(--pix-spacing-6x);
+    }
+
+    &__title {
       margin-top: var(--pix-spacing-2x);
       margin-bottom: var(--pix-spacing-2x);
     }

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -180,27 +180,6 @@
         text-decoration: underline;
       }
     }
-
-    &__badges-title {
-      @extend %pix-title-xxs;
-
-      margin-top: var(--pix-spacing-4x);
-    }
-
-    &__badges {
-      display: flex;
-      flex-wrap: wrap;
-      width: 100%;
-
-      .pix-tooltip {
-        flex: 0 0 2.25rem;
-
-        img {
-          width: calc(100% + 0.75rem);
-          height: auto;
-        }
-      }
-    }
   }
 
   &__footer {
@@ -210,17 +189,40 @@
     flex-shrink: 0;
     gap: var(--pix-spacing-3x);
     align-items: center;
-    justify-content: space-between;
-
-    &__form-link {
-      align-self: center;
-      margin-top: var(--pix-spacing-6x);
-    }
 
     &__text {
       @extend %pix-body-s;
 
       text-align: center;
+    }
+  }
+
+  &__form-link {
+    align-self: center;
+    margin-bottom: auto;
+  }
+
+  &__badges {
+    &__title {
+      @extend %pix-title-xxs;
+
+      width: 100%;
+      margin-top: var(--pix-spacing-4x);
+    }
+
+    &__container {
+      display: flex;
+      flex-wrap: wrap;
+      width: 100%;
+    }
+
+    .pix-tooltip {
+      flex: 0 0 2.25rem;
+
+      img {
+        width: calc(100% + 0.75rem);
+        height: auto;
+      }
     }
   }
 }

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -14,11 +14,36 @@
   border-radius: var(--pix-spacing-4x);
   margin-block: auto;
 
-  &__course-content {
-    display: flex;
+  &__course-content__wrapper {
+    position: relative;
     flex: 1;
-    padding: var(--pix-spacing-6x);
+    height: 100%;
+  }
+  &__top-actions {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 100;
+    padding-top: var(--pix-spacing-6x);
+    padding-right: var(--pix-spacing-6x);
+
+    &__exit {
+      align-self: flex-end;
+      text-decoration: none;
+      background-color: var(--pix-orga-50);
+    }
+  }
+
+  &__course-content {
+    z-index: 10;
+    position: absolute;
+    top: 0;
+    left: 0;
     overflow-y: scroll;
+    display: flex;
+    height: 100%;
+    padding: var(--pix-spacing-6x);
+    padding-top: 4rem;
   }
 
   &__competence {
@@ -100,25 +125,11 @@
     border-bottom-right-radius: var(--pix-spacing-10x);
   }
 
-  // For body scrollbar near details block right border
+  // For content scrollbar to be right on details block border
   &__heading,
   &__body,
   &__footer {
     padding-right: var(--pix-spacing-8x);
-  }
-
-  &__top-actions {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 100;
-    padding-top: var(--pix-spacing-6x);
-    padding-right: var(--pix-spacing-8x);
-
-    &__exit {
-      align-self: flex-end;
-      text-decoration: none;
-    }
   }
 
   &__heading {

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -19,11 +19,6 @@
     flex: 1;
     padding: var(--pix-spacing-6x);
     overflow-y: scroll;
-    scrollbar-width: none;
-
-    &::-webkit-scrollbar {
-      -webkit-appearance: none;
-    }
   }
 
   &__competence {

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -15,7 +15,7 @@
   margin-block: auto;
 
   &__course-content {
-    display:flex;
+    display: flex;
     flex: 1;
     padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
     overflow-y: scroll;
@@ -85,8 +85,8 @@
     padding-left: var(--pix-spacing-8x);
     background-color: var(--pix-neutral-0);
     border-radius: var(--pix-spacing-4x);
-    border-top-left-radius: var(--pix-spacing-10x);
-    border-bottom-left-radius: var(--pix-spacing-10x);
+    border-top-right-radius: var(--pix-spacing-10x);
+    border-bottom-right-radius: var(--pix-spacing-10x);
   }
 
   &__header {
@@ -181,7 +181,7 @@
   }
 
   &__steps {
-    display:flex;
+    display: flex;
     flex-direction: column;
     gap: var(--pix-spacing-4x);
   }
@@ -196,7 +196,7 @@
 }
 
 .combined-course-blueprint-item {
-  display:flex;
+  display: flex;
   gap: var(--pix-spacing-4x);
   align-items: center;
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
@@ -205,9 +205,9 @@
     display: flex;
 
     img {
-    width: auto;
-    min-width: var(--pix-spacing-8x);
-    height: 42px;
+      width: auto;
+      min-width: var(--pix-spacing-8x);
+      height: 42px;
     }
 
     svg {
@@ -223,13 +223,13 @@
   }
 
   &__description {
-    display:flex;
+    display: flex;
     gap: var(--pix-spacing-4x);
     color: var(--pix-neutral-500);
   }
 
   &-duration {
-    display:flex;
+    display: flex;
     align-items: center;
 
     &__icon {

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -172,17 +172,18 @@
   }
 
   &__badges {
+    width: 100%;
+
     &__title {
       @extend %pix-title-xxs;
 
-      width: 100%;
       margin-top: var(--pix-spacing-4x);
     }
 
     &__container {
       display: flex;
       flex-wrap: wrap;
-      width: 100%;
+      margin-top: var(--pix-spacing-2x);
     }
 
     .pix-tooltip {

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -173,7 +173,7 @@
     overflow-y: scroll;
 
     &__description {
-      @extend %pix-body-m;
+      @extend %pix-body-s;
 
       a {
         color: var(--pix-orga-500);

--- a/orga/app/styles/components/ui/form-section.scss
+++ b/orga/app/styles/components/ui/form-section.scss
@@ -1,13 +1,42 @@
 @use 'pix-design-tokens/typography';
 
 .form-section {
-  & + & {
-    margin-top: var(--pix-spacing-6x);
+  position: relative;
+  padding-top: var(--pix-spacing-8x);
+
+  &::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    max-width: 500px;
+    height: 2px;
+    background-color: var(--pix-neutral-100);
+    content: '';
   }
 
   &__title {
-    @extend %pix-subtitle-l;
+    @extend %pix-subtitle-m;
 
     margin-bottom: var(--pix-spacing-6x);
+    color: var(--pix-neutral-500);
+  }
+
+  .form-field:last-child {
+    margin-bottom: var(--pix-spacing-2x);
+  }
+}
+
+.campaign-creation-form .form-section {
+  margin-top: var(--pix-spacing-6x);
+  margin-bottom: var(--pix-spacing-2x);
+
+  &:first-of-type {
+    margin-top: 0;
+    padding: 0;
+
+    &::before {
+      content: none;
+    }
   }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -5,6 +5,10 @@
   opacity: 0;
 }
 
+.page-title.campaign-creation-form-title {
+  margin-bottom: var(--pix-spacing-2x);
+}
+
 .clean-input-button__tooltip {
   position: absolute;
   top: 0;

--- a/orga/app/templates/authenticated/campaigns/new.gjs
+++ b/orga/app/templates/authenticated/campaigns/new.gjs
@@ -6,7 +6,7 @@ import PageTitle from 'pix-orga/components/ui/page-title';
 <template>
   {{pageTitle (t "pages.campaign-creation.title")}}
 
-  <PageTitle>
+  <PageTitle class="campaign-creation-form-title">
     <:title>{{t "pages.campaign-creation.title"}}</:title>
   </PageTitle>
 

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -41,6 +41,25 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
   });
 
   module('when grouping fields into sections', function () {
+    test('it should always display "Objectif" section', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CreateForm
+            @campaign={{data.campaign}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{data.errors}}
+            @membersSortedByFullName={{data.defaultMembers}}
+            @hasBlueprints={{true}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: t('pages.campaign-creation.purpose.title') })).exists();
+    });
+
     test('it does not display a "Paramétrage" section until a goal is selected', async function (assert) {
       // when
       const screen = await render(
@@ -57,13 +76,7 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
       );
 
       // then
-      assert
-        .dom(
-          screen.queryByRole('heading', {
-            name: t('pages.campaign-creation.settings.title'),
-          }),
-        )
-        .doesNotExist();
+      assert.dom(screen.queryByRole('heading', { name: t('pages.campaign-creation.settings.title') })).doesNotExist();
     });
 
     test('it does not display the "Personnalisation" section until a course is selected for an assessment goal', async function (assert) {

--- a/orga/tests/integration/components/catalogue/combined-course-blueprint-content-test.gjs
+++ b/orga/tests/integration/components/catalogue/combined-course-blueprint-content-test.gjs
@@ -7,25 +7,6 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Catalogue | Course Modale::CombinedCourseBlueprintContent', function (hooks) {
   setupIntlRenderingTest(hooks);
-  test('it shows combined course content title', async function (assert) {
-    const store = this.owner.lookup('service:store');
-
-    //given
-    const blueprint = store.createRecord('combined-course-blueprint-overview', {
-      name: 'Le module EDU',
-      illustration: 'mon-image.svg',
-      description: 'description',
-      items: [],
-    });
-
-    const screen = await render(
-      <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
-    );
-
-    assert
-      .dom(screen.getByRole('heading', { level: 3, name: t('pages.catalogue.modal.combined-course-content.title') }))
-      .exists();
-  });
   test('it shows explanation for module step', async function (assert) {
     const store = this.owner.lookup('service:store');
 

--- a/orga/tests/integration/components/catalogue/combined-course-blueprint-content-test.gjs
+++ b/orga/tests/integration/components/catalogue/combined-course-blueprint-content-test.gjs
@@ -7,7 +7,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Catalogue | Course Modale::CombinedCourseBlueprintContent', function (hooks) {
   setupIntlRenderingTest(hooks);
-  test('it shows combined course explanation', async function (assert) {
+  test('it shows combined course content title', async function (assert) {
     const store = this.owner.lookup('service:store');
 
     //given
@@ -25,7 +25,6 @@ module('Integration | Component | Catalogue | Course Modale::CombinedCourseBluep
     assert
       .dom(screen.getByRole('heading', { level: 3, name: t('pages.catalogue.modal.combined-course-content.title') }))
       .exists();
-    assert.dom(screen.getByText(t('pages.catalogue.modal.combined-course-content.description'))).exists();
   });
   test('it shows explanation for module step', async function (assert) {
     const store = this.owner.lookup('service:store');

--- a/orga/tests/integration/components/catalogue/course-card-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-card-test.gjs
@@ -36,7 +36,7 @@ module('Integration | Component | Catalogue::CourseCard', function (hooks) {
   });
 
   module('for a "targetProfile" type course', function () {
-    test('it shows the "Parcours" type tag', async function (assert) {
+    test('it shows the "Parcours d\'évaluation" type tag', async function (assert) {
       const store = this.owner.lookup('service:store');
       const course = store.createRecord('course', { name: 'Ma formation', type: 'targetProfile', nbTubes: 3 });
 

--- a/orga/tests/integration/components/catalogue/course-modal-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-modal-test.gjs
@@ -164,9 +164,8 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
       );
 
       // then
-      assert
-        .dom(screen.getByRole('heading', { name: `${competencesPix[0].index} - ${competencesPix[0].name}` }))
-        .exists();
+      assert.dom(screen.getByText(`Compétence ${competencesPix[0].index}`)).exists(); // TODO trad
+      assert.dom(screen.getByRole('heading', { name: competencesPix[0].name })).exists();
 
       const firstCompetence = screen.getByRole('table', {
         name: `${competencesPix[0].index} - ${competencesPix[0].name}`,

--- a/orga/tests/integration/components/catalogue/course-modal-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-modal-test.gjs
@@ -50,7 +50,7 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
   });
 
   module('for a "targetProfile" type course', function () {
-    test('it shows the course content', async function (assert) {
+    test('it shows the course details', async function (assert) {
       //given
       const currentCourse = store.createRecord('target-profile-overview', {
         name: 'Ma super formation',
@@ -202,7 +202,7 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
   });
 
   module('for a "combined-course-blueprint" type course', function () {
-    test('it shows the course content', async function (assert) {
+    test('it shows the course details', async function (assert) {
       //given
       const currentCourse = store.createRecord('combined-course-blueprint-overview', {
         name: 'Ma super formation',
@@ -223,6 +223,28 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
       assert.dom(screen.queryByText(currentCourse.description)).doesNotExist();
       assert.dom(screen.getByText(t('pages.catalogue.card.tag.blueprint'))).exists();
     });
+
+    test('it shows combined course content title', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('combined-course-blueprint-overview', {
+        name: 'Ma super formation',
+        description: 'description',
+        prescriberDescription: 'prescriberDescription',
+      });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('heading', { level: 3, name: t('pages.catalogue.modal.combined-course-content.title') }))
+        .exists();
+    });
+
     test('it shows the blueprint items', async function (assert) {
       //given
       const itemEval = store.createRecord('combined-course-blueprint-item', {

--- a/orga/tests/integration/components/catalogue/course-modal-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-modal-test.gjs
@@ -70,6 +70,25 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
       assert.dom(screen.getByText(t('pages.catalogue.card.tag.target-profile'))).exists();
     });
 
+    test('it shows target profile content title', async function (assert) {
+      //given
+      const currentCourse = store.createRecord('target-profile-overview', {
+        name: 'Ma super formation',
+        description: 'description',
+      });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+
+      assert
+        .dom(screen.getByRole('heading', { level: 3, name: t('pages.catalogue.modal.target-profile-content.title') }))
+        .exists();
+    });
+
     test('it shows the target profile tubes', async function (assert) {
       const tubesPix = [
         await store.createRecord('tube', {
@@ -164,7 +183,13 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
       );
 
       // then
-      assert.dom(screen.getByText(`Compétence ${competencesPix[0].index}`)).exists(); // TODO trad
+      assert
+        .dom(
+          screen.getByText(
+            `${t('pages.catalogue.modal.target-profile-content.competence')} ${competencesPix[0].index}`,
+          ),
+        )
+        .exists();
       assert.dom(screen.getByRole('heading', { name: competencesPix[0].name })).exists();
 
       const firstCompetence = screen.getByRole('table', {

--- a/orga/tests/mirage/factories/combined-course-blueprint-overview.js
+++ b/orga/tests/mirage/factories/combined-course-blueprint-overview.js
@@ -3,7 +3,7 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   name() {
-    return 'Parcours Apprenant';
+    return 'Parcours apprenant';
   },
   description() {
     return faker.lorem.sentence();

--- a/orga/tests/mirage/factories/target-profile-overview.js
+++ b/orga/tests/mirage/factories/target-profile-overview.js
@@ -3,7 +3,7 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   name() {
-    return 'Parcours';
+    return "Parcours d'évaluation";
   },
   description() {
     return faker.lorem.sentence();

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -816,7 +816,8 @@
         "label": "Was ist das Ziel Ihrer Kampagne?",
         "profiles-collection": "Sammeln Sie die Pix-Profile der Teilnehmer",
         "profiles-collection-info": "Eine Profilsammelkampagne ruft die Profile der Teilnehmer ab: Niveaustufen pro Fertigkeit und Pix-Score.",
-        "profiles-collection-info-certificability-calculation": "Der Status Zertifizierbar wird automatisch auf der Registerkarte '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Schüler'</a>' aktualisiert."
+        "profiles-collection-info-certificability-calculation": "Der Status Zertifizierbar wird automatisch auf der Registerkarte '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Schüler'</a>' aktualisiert.",
+        "title": "Ziel"
       },
       "settings": {
         "title": "Einstellungen"
@@ -1042,7 +1043,7 @@
         "simplified-access": "Zugang ohne Konto",
         "tag": {
           "blueprint": "Lernpfad",
-          "target-profile": "Kurs"
+          "target-profile": "Bewertungspfad"
         },
         "tubes-count": "{count, plural, =0 {Kein Thema} =1 {{count} thema} other {{count} themen}}"
       },
@@ -1074,17 +1075,20 @@
         "associated-badges": "Zugehörige Abzeichen",
         "combined-course-content": {
           "aria-label-duration": "Geschätzte Dauer: {duration} Minuten",
-          "description": "Lernpfade kombinieren Bewertungen und personalisierte Lernmodule, um das Unterrichten auf der Grundlage des Niveaus jedes Teilnehmers anzupassen.",
           "duration": "≈ {duration} Min",
           "module-info": "Module werden den Teilnehmern basierend auf ihren Ergebnissen empfohlen.",
           "prescribed": "Vorgegeben",
           "recommended": "Empfohlen",
           "step": "Schritt {number}",
-          "title": "Lernpfade"
+          "title": "Inhalt des Lernpfads"
         },
         "max-level": "Max. Stufe",
         "open-modal": "Details zu {name} anzeigen",
         "select-course": "Diesen Kurs auswählen",
+        "target-profile-content": {
+          "competence": "Kompetenz",
+          "title": "Inhalt des Bewertungspfads"
+        },
         "tube-name-and-description": "Name und Beschreibung des Themas",
         "tube-unavailable": "Thema nicht verfügbar"
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -816,7 +816,8 @@
         "label": "What is the purpose of your campaign?",
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score.",
-        "profiles-collection-info-certificability-calculation": "The “Eligible for certification” status is updated automatically in the '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Students'</a>' tab."
+        "profiles-collection-info-certificability-calculation": "The “Eligible for certification” status is updated automatically in the '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Students'</a>' tab.",
+        "title": "Purpose"
       },
       "settings": {
         "title": "Settings"
@@ -1042,7 +1043,7 @@
         "simplified-access": "Access without an account",
         "tag": {
           "blueprint": "Learning course",
-          "target-profile": "Course"
+          "target-profile": "Assessment course"
         },
         "tubes-count": "{count, plural, =0 {No topic} =1 {{count} topic} other {{count} topics}}"
       },
@@ -1074,17 +1075,20 @@
         "associated-badges": "Related badges",
         "combined-course-content": {
           "aria-label-duration": "Estimated duration: {duration} minutes",
-          "description": "Learning courses combine assessments and personalised learning modules, enabling teaching to be tailored to each participant's level.",
           "duration": "≈ {duration} min",
           "module-info": "Modules will be recommended to participants based on their results.",
           "prescribed": "Prescribed",
           "recommended": "Recommended",
           "step": "Step {number}",
-          "title": "Learning courses"
+          "title": "Learning course content"
         },
         "max-level": "Max level.",
         "open-modal": "View {name} details",
         "select-course": "Select course",
+        "target-profile-content": {
+          "competence": "Competence",
+          "title": "Assessment course content"
+        },
         "tube-name-and-description": "Topic name and description",
         "tube-unavailable": "Unavailable topic"
       },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -816,7 +816,8 @@
         "label": "¿Cuál es el objetivo de su campaña?",
         "profiles-collection": "Recoger los perfiles Pix de los participantes",
         "profiles-collection-info": "Se utiliza una campaña de recogida de perfiles para recuperar el perfil de los participantes: niveles por habilidad y puntuación pix.",
-        "profiles-collection-info-certificability-calculation": "El estado certificable se actualiza automáticamente en la pestaña <'a href=\"/eleves\" class=\"{linkClasses}\"'>'Alumnos'</a>'."
+        "profiles-collection-info-certificability-calculation": "El estado certificable se actualiza automáticamente en la pestaña <'a href=\"/eleves\" class=\"{linkClasses}\"'>'Alumnos'</a>'.",
+        "title": "Objetivo"
       },
       "settings": {
         "title": "Configuración"
@@ -1042,7 +1043,7 @@
         "simplified-access": "Acceso sin cuenta",
         "tag": {
           "blueprint": "Ruta de aprendizaje",
-          "target-profile": "Cursos"
+          "target-profile": "Ruta de evaluación"
         },
         "tubes-count": "{count, plural, =0 {Sin temas} =1 {{count} tema} other {{count} temas}}"
       },
@@ -1074,17 +1075,20 @@
         "associated-badges": "Insignias relacionadas",
         "combined-course-content": {
           "aria-label-duration": "Duración estimada: {duration} minutos",
-          "description": "Las rutas de aprendizaje combinan evaluaciones y módulos de aprendizaje personalizados, permitiendo adaptar la enseñanza al nivel de cada participante.",
           "duration": "≈ {duration} min",
           "module-info": "Los módulos se recomendarán a los participantes en función de sus resultados.",
           "prescribed": "Prescrito",
           "recommended": "Recomendado",
           "step": "Paso {number}",
-          "title": "Rutas de aprendizaje"
+          "title": "Contenido de la ruta de aprendizaje"
         },
         "max-level": "Nivel máx.",
         "open-modal": "Ver detalles del curso {name}",
         "select-course": "Seleccionar este curso",
+        "target-profile-content": {
+          "competence": "Competencia",
+          "title": "Contenido de la ruta de evaluación"
+        },
         "tube-name-and-description": "Nombre y descripción del tema",
         "tube-unavailable": "Tema no disponible"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -816,7 +816,8 @@
         "label": "Quel est l'objectif de votre campagne ?",
         "profiles-collection": "Collecter les profils Pix des participants",
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix.",
-        "profiles-collection-info-certificability-calculation": "Le statut Certifiable est mis à jour automatiquement dans l’onglet '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Élèves'</a>'."
+        "profiles-collection-info-certificability-calculation": "Le statut Certifiable est mis à jour automatiquement dans l’onglet '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Élèves'</a>'.",
+        "title": "Objectif"
       },
       "settings": {
         "title": "Paramétrage"
@@ -1042,7 +1043,7 @@
         "simplified-access": "Accès sans compte",
         "tag": {
           "blueprint": "Parcours apprenant",
-          "target-profile": "Parcours"
+          "target-profile": "Parcours d'évaluation"
         },
         "tubes-count": "{count, plural, =0 {Aucun sujet} =1 {{count} sujet} other {{count} sujets}}"
       },
@@ -1074,17 +1075,20 @@
         "associated-badges": "Badges associés",
         "combined-course-content": {
           "aria-label-duration": "Durée estimée : {duration} minutes",
-          "description": "Les parcours apprenants articulent des évaluations et des modules d'apprentissage personnalisés, permettant une adaptation pédagogique fondée sur le niveau de chaque participant.",
           "duration": "≈ {duration} min",
           "module-info": "Les modules seront recommandés aux participants en fonction de leurs résultats.",
           "prescribed": "Prescrit",
           "recommended": "Recommandé",
           "step": "Étape n°{number}",
-          "title": "Parcours apprenants"
+          "title": "Contenu du parcours apprenant"
         },
         "max-level": "Niveau maximum",
         "open-modal": "Voir le détail du parcours {name}",
         "select-course": "Sélectionner ce parcours",
+        "target-profile-content": {
+          "competence": "Compétence",
+          "title": "Contenu du parcours d'évaluation"
+        },
         "tube-name-and-description": "Sujet et description",
         "tube-unavailable": "Sujet indisponible"
       },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -816,7 +816,8 @@
         "label": "Qual è l'obiettivo della vostra campagna?",
         "profiles-collection": "Raccogliere i profili Pix dei partecipanti",
         "profiles-collection-info": "Una campagna di raccolta di profili viene utilizzata per recuperare il profilo dei partecipanti: livelli per abilità e punteggio pix.",
-        "profiles-collection-info-certificability-calculation": "Lo stato di certificabilità viene aggiornato automaticamente nella scheda '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Studenti'</a>'."
+        "profiles-collection-info-certificability-calculation": "Lo stato di certificabilità viene aggiornato automaticamente nella scheda '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Studenti'</a>'.",
+        "title": "Obiettivo"
       },
       "settings": {
         "title": "Impostazioni"
@@ -1042,7 +1043,7 @@
         "simplified-access": "Accesso senza account",
         "tag": {
           "blueprint": "Percorso di apprendimento",
-          "target-profile": "Percorso"
+          "target-profile": "Percorso di valutazione"
         },
         "tubes-count": "{count, plural, =0 {Nessun argomento} =1 {{count} argomento} other {{count} argomenti}}"
       },
@@ -1074,17 +1075,20 @@
         "associated-badges": "Badge associati",
         "combined-course-content": {
           "aria-label-duration": "Durata stimata: {duration} minuti",
-          "description": "I percorsi di apprendimento combinano valutazioni e moduli di apprendimento personalizzati, consentendo un insegnamento adattato al livello di ogni partecipante.",
           "duration": "≈ {duration} min",
           "module-info": "I moduli saranno consigliati ai partecipanti in base ai loro risultati.",
           "prescribed": "Prescritto",
           "recommended": "Consigliato",
           "step": "Passo {number}",
-          "title": "Percorsi di apprendimento"
+          "title": "Contenuto del percorso di apprendimento"
         },
         "max-level": "Livello max.",
         "open-modal": "Visualizza i dettagli del percorso {name}",
         "select-course": "Seleziona questo corso",
+        "target-profile-content": {
+          "competence": "Competenza",
+          "title": "Contenuto del percorso di valutazione"
+        },
         "tube-name-and-description": "Nome e descrizione dell'argomento",
         "tube-unavailable": "Argomento non disponibile"
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -816,7 +816,8 @@
         "label": "Wat is het doel van je campagne?",
         "profiles-collection": "Pix-profielen van deelnemers verzamelen",
         "profiles-collection-info": "Een campagne voor het verzamelen van profielen wordt gebruikt om het profiel van de deelnemers te achterhalen: niveaus per vaardigheid en pix-score.",
-        "profiles-collection-info-certificability-calculation": "De certificeerbare status wordt automatisch bijgewerkt in het tabblad '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Studenten'</a>'."
+        "profiles-collection-info-certificability-calculation": "De certificeerbare status wordt automatisch bijgewerkt in het tabblad '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Studenten'</a>'.",
+        "title": "Doel"
       },
       "settings": {
         "title": "Instellingen"
@@ -1042,7 +1043,7 @@
         "simplified-access": "Toegang zonder account",
         "tag": {
           "blueprint": "Leertraject",
-          "target-profile": "Traject"
+          "target-profile": "Beoordelingstraject"
         },
         "tubes-count": "{count, plural, =0 {Geen onderwerp} =1 {{count} onderwerp} other {{count} onderwerpen}}"
       },
@@ -1074,17 +1075,20 @@
         "associated-badges": "Gerelateerde badges",
         "combined-course-content": {
           "aria-label-duration": "Geschatte duur: {duration} minuten",
-          "description": "Leertrajecten vormen individuele evaluaties en leermodules, waardoor pedagogische aanpassing mogelijk is op basis van het niveau van elke deelnemer.",
           "duration": "≈ {duration} min",
           "module-info": "Modules worden aanbevolen aan deelnemers op basis van hun resultaten.",
           "prescribed": "Voorgeschreven",
           "recommended": "Aanbevolen",
           "step": "Stap nr. {number}",
-          "title": "Leertrajecten"
+          "title": "Inhoud van het leertraject"
         },
         "max-level": "Max. niveau",
         "open-modal": "Bekijk de details van het traject",
         "select-course": "Deze cursus selecteren",
+        "target-profile-content": {
+          "competence": "Competentie",
+          "title": "Inhoud van het beoordelingstraject"
+        },
         "tube-name-and-description": "Naam en beschrijving van het onderwerp",
         "tube-unavailable": "Onderwerp niet beschikbaar"
       },


### PR DESCRIPTION
## ☀️ Problème

Nous avons reçu des retours pour améliorer quelques aspects design du catalogue.

## ⛱️ Proposition

Faire une PR test implémentant différentes idées ayant émergé :

#### Nouveau formulaire de création de campagne

- Titres de sections moins grands
- Titre en plus pour la première section (“Objectif”)
- Séparateur entre chaque partie
- Réduction de l'espacement entre le titre de la page et l'explication des champs obligatoires
- Déplacement des astérisques de champ obligatoire à la fin du texte des fieldsets (précédemment au début)

#### Modal de sélection d'un parcours dans le catalogue

- Inverser panneau de détails et de contenu du parcours
- Déplacement du bouton quitter en haut à droite de la modal
- Panneau de détails :
  - Suppression de l'illustration pour faire de la place
  - Réduction de la taille de police de la description
  - Réduction du padding du panneau
- Panneau de contenu :
  - Modification des titres pour les 2 types de parcours
  - Suppression de la description pour les parcours apprenant
  - Ajout de surtitres au dessus des compétences sous la forme “Compétence X.X” pour les parcours d'évaluation
 
#### Catalogue

- Mise à jour des icônes pour des plus légères, pour limiter les bugs d'affichage 
- Modification du tag "Parcours" en "Parcours d'évaluation"

## 🧴 Remarques

Cette PR a fait l'objet de retour, il subsiste donc dans les commits des modifications qui ont été retravaillées par des commits suivants, rendant ces commits peu utiles dans la lecture. 
 
Quelques points non réalisés au final :
- Limiter la hauteur de la description maximale en ajoutant une scrollbar
- Ajout d'un bouton voir plus / voir moins pour la description 

(la suppression de l'icône dans la modal + la réduction de la taille de police de la description ont été suffisant au vu du nombre de caractères max pour la description)

## 🏊 Pour tester

Se connecter à Pix Orga
Parcourir le catalogue et voir les modifs
Parcourir les modal de parcours de différents type sur le catalogue
Parcourir le nouveau formulaire de création de campagne

Non régression :
On peut toujours quitter la modal d'un parcours avec quitter
On peut toujours sélectionner un parcours via sa modal
On peut toujours créer une campagne (de chaque type)