### PR TITLE
[TECH] Réparer une typo dans les tests e2e certif

### DIFF
--- a/high-level-tests/e2e-playwright/pages/pix-admin/CertificationInformationPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/CertificationInformationPage.ts
@@ -60,7 +60,7 @@ export class CertificationInformationPage {
       abortReason: await getStringValueFromDescriptionList(
         this.page,
         'pw-certification-general-information-description-list',
-        "Raison de l'abandon :",
+        "Motif d'interruption :",
         { optional: true },
       ),
       result: await getStringValueFromDescriptionList(


### PR DESCRIPTION
## ☀️ Problème

Des textes ont été changés ici https://github.com/1024pix/pix/pull/17104.

Il reste un endroit dans les tests e2e qui n'a pas été changé en conséquence.

## ⛱️ Proposition

Corriger le texte dans les tests e2e certif.

## 🏊 Pour tester

✅ Tests e2e certif ok 
