### PR TITLE
[BUGFIX] Réparer la création d'un schéma de parcours (PIX-23854)

### DIFF
--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -69,7 +69,9 @@ export default class Details extends Component {
               </DescriptionList.Item>
 
               {{#if @model.rewardRequirementsDescription}}
-                <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.reward-requirements"}}>
+                <DescriptionList.Item
+                  @label={{t "components.combined-course-blueprints.labels.reward-requirements.description"}}
+                >
                   <SafeMarkdownToHtml @markdown={{@model.rewardRequirementsDescription}} />
                 </DescriptionList.Item>
               {{/if}}

--- a/admin/app/serializers/combined-course-blueprint.js
+++ b/admin/app/serializers/combined-course-blueprint.js
@@ -19,6 +19,10 @@ export default class CombinedCourseBlueprintSerializer extends ApplicationSerial
       }
     }
 
+    if (json.data.relationships) {
+      delete json.data.relationships;
+    }
+
     return json;
   }
 }

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/update-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/update-combined-course-blueprint-test.js
@@ -66,8 +66,21 @@ module('Acceptance | Combined course blueprint | Update', function (hooks) {
 
     await fillIn(
       screen.getByLabelText(t('components.combined-course-blueprints.labels.description-sublabel'), { exact: false }),
-      'description',
+      'description prescrit',
     );
+
+    await fillIn(
+      screen.getByLabelText(t('components.combined-course-blueprints.labels.prescriber-description-sublabel'), {
+        exact: false,
+      }),
+      'description prescripteur',
+    );
+
+    await fillIn(
+      screen.getByLabelText(t('components.combined-course-blueprints.labels.survey-link'), { exact: false }),
+      'https://link.example.net',
+    );
+
     await fillIn(
       screen.getByRole('textbox', {
         name: t('components.combined-course-blueprints.labels.reward-requirements.description'),

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -189,7 +189,7 @@ const register = async function (server) {
                 description: Joi.string().allow(null),
                 'prescriber-description': Joi.string().allow(null),
                 'survey-link': Joi.string().allow(null),
-                'reward-requirements': Joi.string().allow(null),
+                'reward-requirements-description': Joi.string().allow(null),
               },
             },
           }),

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -245,7 +245,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               description: 'La description combinix',
               'prescriber-description': 'La description prescripteur',
               illustration: 'illustration.svg',
-              'reward-requirements': 'Description of the reward requirements',
+              'reward-requirements-description': 'Description of the reward requirements',
             },
           },
         };

--- a/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
@@ -201,7 +201,7 @@ describe('Quest | Unit | Routes | combined-course-blueprint-route', function () 
             'internal-name': 'Mon schéma de parcours combiné',
             description: 'La description combinix',
             illustration: 'illustration.svg',
-            'reward-requirements': 'Description of the reward requirements',
+            'reward-requirements-description': 'Description of the reward requirements',
           },
         },
       };


### PR DESCRIPTION
## ☀️ Problème

Lorsqu’on modifie un blueprint depuis admin, on a une erreur en lien avec la reward alors qu’il n’y en pas. 

---

<img width="884" height="208" alt="image" src="https://github.com/user-attachments/assets/04b28ddc-a2dc-4075-af20-b1ec5083d782" />

---

Détails du message d'erreur: 

```json
"errors": [
    {
        "status": "400",
        "title": "Bad Request",
        "detail": "\"data.attributes.reward-requirements-description\" is not allowed"
    }
]
```

## ⛱️ Proposition

Lors de la PR #16947 `[FEATURE] Affichage des sujets cappés sélectionnés sur la page admin des détails d'un schéma de parcours (Pix-22771)`, le terme `reward-requirements` a été remplacé par `reward-requirements-description` dans le [commit 0eb6b65](https://github.com/1024pix/pix/pull/16947/changes/0eb6b6504fb451ac9c51bc47d16aab475d68fd3d).

Or, tous les impacts n'ont pas l'air d'avoir été pris en compte, notamment dans `api/src/quest/application/combined-course-blueprint-route.js`.

Ensuite, dans le [commit 3752e52](https://github.com/1024pix/pix/pull/16947/changes/3752e52aaafc30b7d0c70911dcbf84cd978410fc#diff-bdb02914a534999c5b18de18c2fef9c8186cd382bfda1d1768b4e9987d181a31) de la même PR #16947, l'ajout de relations dans le modèle inclue dans le payload lors du `save()` un objet relationships qui n'est pas prévu par le sérialiseur.

Les modifications apportées dans la présente PR sont la mise en cohérence des propriétés, des tests et la suppression de l'objet vide `relationships` lors de la requête à l'API.

## 🧴 Remarques

J'émets des doutes sur la solution que je propose ici:
- ne devrait-il pas y avoir des tests automatisés de bout-en-bout pour une création/modification d'un schéma de parcours – ou est-ce le rôle de la revue fonctionnelle?
- au sujet de l'objet `relationships` passé dans le payload: fallait-il bien que je le neutralise dans le sérialiseur ([commit 238880b](https://github.com/1024pix/pix/pull/17123/changes/238880b663f1df6b642159285c06d51984cc8978)) ou aurais-je du procéder autrement?

## 🏊 Pour tester

Dans l'app `admin`, se rendre dans Schémas de parcours et choisir un schéma de parcours
Modifier le schéma de parcours et valider.
Un toast de succès devrait apparaître avant la redirection vers la liste des schémas de parcours où figure le schéma de parcours modifié avec les nouvelles informations.
