### PR TITLE
[FEATURE] Permettre de déplier / replier tous les accordéons à la création ou consultation d'un PC (PIX-23862)

### DIFF
--- a/admin/app/components/common/expandable-accordions.gjs
+++ b/admin/app/components/common/expandable-accordions.gjs
@@ -1,0 +1,79 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import { modifier } from 'ember-modifier';
+
+const MAX_EXPAND_PASSES = 20;
+
+export default class ExpandableAccordions extends Component {
+  container;
+  pendingPass = null;
+
+  setContainer = modifier((element) => {
+    this.container = element;
+  });
+
+  @action
+  expandAll() {
+    this.cancelPendingPass();
+    this.applyExpandState(true);
+  }
+
+  @action
+  collapseAll() {
+    this.cancelPendingPass();
+    this.applyExpandState(false);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.cancelPendingPass();
+  }
+
+  cancelPendingPass() {
+    if (this.pendingPass !== null) {
+      cancelAnimationFrame(this.pendingPass);
+      this.pendingPass = null;
+    }
+  }
+
+  applyExpandState(shouldExpand, remainingPasses = MAX_EXPAND_PASSES) {
+    if (!this.container) return;
+
+    let clicked = false;
+    const buttons = this.container.querySelectorAll('button.pix-accordions__title');
+    buttons.forEach((button) => {
+      const isExpanded = button.getAttribute('aria-expanded') === 'true';
+      if (isExpanded !== shouldExpand) {
+        button.click();
+        clicked = true;
+      }
+    });
+
+    if (shouldExpand && clicked && remainingPasses > 0) {
+      this.pendingPass = requestAnimationFrame(() => {
+        this.pendingPass = null;
+        this.applyExpandState(shouldExpand, remainingPasses - 1);
+      });
+    }
+  }
+
+  <template>
+    <div class="expandable-accordions">
+      <div class="expandable-accordions__toolbar">
+        <PixButton @variant="tertiary" @size="small" @triggerAction={{this.expandAll}}>
+          {{t "common.actions.expand-all"}}
+        </PixButton>
+        <span class="expandable-accordions__separator" aria-hidden="true">-</span>
+        <PixButton @variant="tertiary" @size="small" @triggerAction={{this.collapseAll}}>
+          {{t "common.actions.collapse-all"}}
+        </PixButton>
+      </div>
+
+      <div {{this.setContainer}}>
+        {{yield}}
+      </div>
+    </div>
+  </template>
+}

--- a/admin/app/components/common/expandable-accordions.scss
+++ b/admin/app/components/common/expandable-accordions.scss
@@ -1,0 +1,13 @@
+.expandable-accordions {
+  &__toolbar {
+    display: flex;
+    gap: var(--pix-spacing-1x);
+    align-items: center;
+    justify-content: flex-end;
+    margin-bottom: var(--pix-spacing-4x);
+  }
+
+  &__separator {
+    color: var(--pix-neutral-500);
+  }
+}

--- a/admin/app/components/common/tubes-selection.gjs
+++ b/admin/app/components/common/tubes-selection.gjs
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import Card from '../card';
+import ExpandableAccordions from './expandable-accordions';
 import Areas from './tubes-selection/areas';
 
 const MAX_TUBE_LEVEL = 8;
@@ -261,18 +262,20 @@ export default class TubesSelection extends Component {
 
       {{#if this.hasNoFrameworksSelected}}
         Aucun référentiel de sélectionné
-      {{else}}
-        <Areas
-          @areas={{this.areas}}
-          @setLevelTube={{this.setLevelTube}}
-          @selectedTubeIds={{this.selectedTubeIds}}
-          @checkTube={{this.checkTube}}
-          @uncheckTube={{this.uncheckTube}}
-          @tubeLevels={{this.tubeLevels}}
-          @displayDeviceCompatibility={{@displayDeviceCompatibility}}
-          @displaySkillDifficultyAvailability={{@displaySkillDifficultyAvailability}}
-          @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
-        />
+      {{else if this.areas.length}}
+        <ExpandableAccordions>
+          <Areas
+            @areas={{this.areas}}
+            @setLevelTube={{this.setLevelTube}}
+            @selectedTubeIds={{this.selectedTubeIds}}
+            @checkTube={{this.checkTube}}
+            @uncheckTube={{this.uncheckTube}}
+            @tubeLevels={{this.tubeLevels}}
+            @displayDeviceCompatibility={{@displayDeviceCompatibility}}
+            @displaySkillDifficultyAvailability={{@displaySkillDifficultyAvailability}}
+            @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
+          />
+        </ExpandableAccordions>
       {{/if}}
     </div>
   </template>

--- a/admin/app/components/target-profiles/details.gjs
+++ b/admin/app/components/target-profiles/details.gjs
@@ -1,21 +1,26 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 
+import ExpandableAccordions from '../common/expandable-accordions';
 import Area from '../common/tubes-details/area';
 
 <template>
   <PixBlock @variant="admin">
-    {{#each @areas as |area|}}
-      <Area
-        @title={{area.title}}
-        @color={{area.color}}
-        @competences={{area.competences}}
-        @displayDeviceCompatibility={{true}}
-        @displaySkillDifficultyAvailability={{true}}
-      />
+    {{#if @areas.length}}
+      <ExpandableAccordions>
+        {{#each @areas as |area|}}
+          <Area
+            @title={{area.title}}
+            @color={{area.color}}
+            @competences={{area.competences}}
+            @displayDeviceCompatibility={{true}}
+            @displaySkillDifficultyAvailability={{true}}
+          />
+        {{/each}}
+      </ExpandableAccordions>
     {{else}}
       <section class="page-section">
         <div class="table__empty">Profil cible vide.</div>
       </section>
-    {{/each}}
+    {{/if}}
   </PixBlock>
 </template>

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -109,6 +109,7 @@
 @use 'display/footer-modal' as *;
 
 /* App/Components */
+@use 'common/expandable-accordions' as *;
 @use 'ui/copyable-id' as *;
 @use 'ui/deletion-modal' as *;
 @use 'ui/head-information-block' as *;

--- a/admin/tests/integration/components/common/expandable-accordions-test.gjs
+++ b/admin/tests/integration/components/common/expandable-accordions-test.gjs
@@ -1,0 +1,179 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import { waitUntil } from '@ember/test-helpers';
+import ExpandableAccordions from 'pix-admin/components/common/expandable-accordions';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Common::ExpandableAccordions', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  function isExpanded(screen, name) {
+    return screen.getByRole('button', { name }).getAttribute('aria-expanded') === 'true';
+  }
+
+  async function renderTwoAccordions() {
+    return render(
+      <template>
+        <ExpandableAccordions>
+          <PixAccordions>
+            <:title>Domaine 1</:title>
+            <:content>Contenu domaine 1</:content>
+          </PixAccordions>
+          <PixAccordions>
+            <:title>Domaine 2</:title>
+            <:content>Contenu domaine 2</:content>
+          </PixAccordions>
+        </ExpandableAccordions>
+      </template>,
+    );
+  }
+
+  test('it should display both actions and keep accordions collapsed by default', async function (assert) {
+    // when
+    const screen = await renderTwoAccordions();
+
+    // then
+    assert.dom(screen.getByRole('button', { name: 'Tout déplier' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Tout replier' })).exists();
+    assert.false(isExpanded(screen, 'Domaine 1'));
+    assert.false(isExpanded(screen, 'Domaine 2'));
+  });
+
+  test('it should expand every accordion', async function (assert) {
+    // given
+    const screen = await renderTwoAccordions();
+
+    // when
+    await clickByName('Tout déplier');
+
+    // then
+    assert.true(isExpanded(screen, 'Domaine 1'));
+    assert.true(isExpanded(screen, 'Domaine 2'));
+  });
+
+  test('it should collapse every accordion', async function (assert) {
+    // given
+    const screen = await renderTwoAccordions();
+    await clickByName('Tout déplier');
+
+    // when
+    await clickByName('Tout replier');
+
+    // then
+    assert.false(isExpanded(screen, 'Domaine 1'));
+    assert.false(isExpanded(screen, 'Domaine 2'));
+  });
+
+  test('it should stay collapsed when collapsing right after expanding', async function (assert) {
+    // given
+    const screen = await renderTwoAccordions();
+
+    // when
+    // Sans annulation de la passe d'ouverture en attente, la frame suivante rouvrirait tout.
+    await clickByName('Tout déplier');
+    await clickByName('Tout replier');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // then
+    assert.false(isExpanded(screen, 'Domaine 1'));
+    assert.false(isExpanded(screen, 'Domaine 2'));
+  });
+
+  test('it should expand nested accordions that are only rendered once their parent is open', async function (assert) {
+    // given
+    const screen = await render(
+      <template>
+        <ExpandableAccordions>
+          <PixAccordions>
+            <:title>Domaine 1</:title>
+            <:content>
+              <PixAccordions>
+                <:title>Compétence 1</:title>
+                <:content>Contenu compétence 1</:content>
+              </PixAccordions>
+            </:content>
+          </PixAccordions>
+        </ExpandableAccordions>
+      </template>,
+    );
+
+    // when
+    await clickByName('Tout déplier');
+
+    // then
+    // Les accordéons imbriqués ne sont rendus qu'une fois leur parent ouvert : l'ouverture se
+    // propage sur plusieurs frames, d'où l'attente explicite.
+    await waitUntil(() => screen.queryByRole('button', { name: 'Compétence 1' }));
+    await waitUntil(() => isExpanded(screen, 'Compétence 1'));
+
+    assert.true(isExpanded(screen, 'Domaine 1'));
+    assert.true(isExpanded(screen, 'Compétence 1'));
+    assert.dom(screen.getByText('Contenu compétence 1')).exists();
+  });
+
+  test('it should leave an accordion already expanded by the user untouched', async function (assert) {
+    // given
+    const screen = await renderTwoAccordions();
+    await clickByName('Domaine 1');
+
+    // when
+    await clickByName('Tout déplier');
+
+    // then
+    assert.true(isExpanded(screen, 'Domaine 1'));
+    assert.true(isExpanded(screen, 'Domaine 2'));
+  });
+
+  test('it should not touch accordions rendered outside of the block', async function (assert) {
+    // given
+    const screen = await render(
+      <template>
+        <ExpandableAccordions>
+          <PixAccordions>
+            <:title>Domaine dans le bloc</:title>
+            <:content>Contenu du bloc</:content>
+          </PixAccordions>
+        </ExpandableAccordions>
+        <PixAccordions>
+          <:title>Domaine hors du bloc</:title>
+          <:content>Contenu hors du bloc</:content>
+        </PixAccordions>
+      </template>,
+    );
+
+    // when
+    await clickByName('Tout déplier');
+
+    // then
+    assert.true(isExpanded(screen, 'Domaine dans le bloc'));
+    assert.false(isExpanded(screen, 'Domaine hors du bloc'));
+  });
+
+  test('it should stop clicking after a bounded number of passes', async function (assert) {
+    // given
+    // Un accordéon dont le clic ne bascule jamais `aria-expanded` : sans garde-fou,
+    // la récursion le recliquerait à chaque frame indéfiniment.
+    const screen = await render(
+      <template>
+        <ExpandableAccordions>
+          <button type="button" class="pix-accordions__title" aria-expanded="false">Accordéon bloqué</button>
+        </ExpandableAccordions>
+      </template>,
+    );
+    const stuck = screen.getByRole('button', { name: 'Accordéon bloqué' });
+    let clickCount = 0;
+    stuck.addEventListener('click', () => (clickCount += 1));
+
+    // when
+    await clickByName('Tout déplier');
+    await waitUntil(() => clickCount >= 21, { timeout: 2000 });
+    const countWhenBoundReached = clickCount;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // then
+    assert.strictEqual(clickCount, countWhenBoundReached, 'la récursion est arrêtée');
+    assert.strictEqual(countWhenBoundReached, 21, 'une passe initiale puis MAX_EXPAND_PASSES au maximum');
+  });
+});

--- a/admin/tests/integration/components/common/tubes-selection-test.gjs
+++ b/admin/tests/integration/components/common/tubes-selection-test.gjs
@@ -1,12 +1,13 @@
 import { clickByName, render, within } from '@1024pix/ember-testing-library';
-import { click, triggerEvent } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
+import { click, triggerEvent, waitUntil } from '@ember/test-helpers';
 import TubesSelection from 'pix-admin/components/common/tubes-selection';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Common::TubesSelection', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let screen;
 
   hooks.beforeEach(async function () {
@@ -157,6 +158,45 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
 
     // then
     assert.dom(screen.getByText('Compatibilité')).exists();
+  });
+
+  module('#expand all accordions', function () {
+    test('it should display an action to expand and an action to collapse every accordion', async function (assert) {
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Tout déplier' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Tout replier' })).exists();
+    });
+
+    test('it should display every tube without expanding the accordions one by one', async function (assert) {
+      // when
+      await clickByName('Tout déplier');
+
+      // then
+      // Les accordéons Compétence ne sont rendus qu'une fois leur Domaine ouvert : l'ouverture se
+      // propage sur plusieurs frames, d'où l'attente explicite.
+      await waitUntil(() => screen.queryByText('@tubeName1 : Tube 1'));
+
+      assert.dom(screen.getByText('@tubeName1 : Tube 1')).exists();
+      assert.dom(screen.getByText('@tubeName2 : Tube 2')).exists();
+      assert.dom(screen.getByText('@tubeName3 : Tube 3')).exists();
+    });
+
+    test('it should collapse every accordion back', async function (assert) {
+      // given
+      await clickByName('Tout déplier');
+      await waitUntil(() => screen.queryByText('@tubeName1 : Tube 1'));
+
+      // when
+      await clickByName('Tout replier');
+
+      // then
+      // PixAccordions garde le contenu dans le DOM une fois ouvert et se contente de le masquer :
+      // on vérifie donc l'état des accordéons, pas la disparition du texte.
+      assert.dom(screen.getByRole('button', { name: '1 · Titre domaine' })).hasAria('expanded', 'false');
+      // Une fois le Domaine replié, son contenu passe en aria-hidden : l'accordéon Compétence
+      // sort de l'arbre d'accessibilité, d'où `hidden: true`.
+      assert.dom(screen.getByRole('button', { name: '1 Titre competence', hidden: true })).hasAria('expanded', 'false');
+    });
   });
 
   module('#import tubes preselection or target profile export', function () {

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/details-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/details-test.gjs
@@ -1,10 +1,11 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import Details from 'pix-admin/components/target-profiles/details';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | routes/authenticated/target-profiles/target-profile | details', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should display specific text when profile has no content', async function (assert) {
     // given

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -6,6 +6,7 @@
       "are-you-sure": "By ticking this box, you confirm that you have the right to perform this action.",
       "cancel": "Cancel",
       "close": "Close",
+      "collapse-all": "Collapse all",
       "confirm": "Confirm",
       "confirm-deletion": "Yes, delete",
       "confirm-title": "Please confirm",
@@ -14,6 +15,7 @@
       "deactivate": "Deactivate",
       "download-template": "Download template",
       "edit": "Edit",
+      "expand-all": "Expand all",
       "next": "Next",
       "save": "Save",
       "validate": "Validate"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -6,6 +6,7 @@
       "are-you-sure": "En cochant cette case vous affirmer avoir les droits d'effectuer cette action.",
       "cancel": "Annuler",
       "close": "Fermer",
+      "collapse-all": "Tout replier",
       "confirm": "Confirmer",
       "confirm-deletion": "Oui, je supprime",
       "confirm-title": "Merci de confirmer",
@@ -14,6 +15,7 @@
       "deactivate": "Désactiver",
       "download-template": "Télécharger le template",
       "edit": "Modifier",
+      "expand-all": "Tout déplier",
       "next": "Suivant",
       "save": "Enregistrer",
       "validate": "Valider"


### PR DESCRIPTION
☀️ Problème

Lorsque l'on veut créer / modifier / consulter un PC, on doit ouvrir à la main tous les accordéons. 
C'est chiant. 

## ⛱️ Proposition

Ajouter 2 ButtonLinks qui permettent de déplier ou replier tous les accordéons.
  
## 🧴 Remarques

Cet ajout impacte également la création d'un seuil pour un CF 


Peut-être que c'est un peu too much tous les tests ? 

## 🏊 Pour tester

- se connecter sur pix admin avec le compte super admin 
- consulter un profil cible, cliquer sur "tout déplier" puis "tout replier" 
- "tout déplier" puis refermer à la main certains sujets, puis cliquer sur "tout déplier" 
- "tout déplier" puis refermer à la main certains sujets, puis cliquer sur "tout replier" 
- Vérifier que c'est bien ok aux autres endroits où le composant est utilisé : 
	- CF 