### PR TITLE
[FEATURE] Afficher la category de l'organisation dans sa page de détail (PIX-23555)

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -99,6 +99,16 @@ class OrganizationDescription extends Component {
                 (t "common.not-specified")
               }}</span>
           </div>
+          <div class="organization-information-section__field">
+            <span class="organization-information-section__label">{{t
+                "components.organizations.information-section-view.category"
+              }}</span>
+            <span class="organization-information-section__value">{{if
+                @organization.categoryLabel
+                @organization.categoryLabel
+                (t "common.not-specified")
+              }}</span>
+          </div>
         </div>
         <div class="organization-information-section__right-block">
           <div class="organization-information-section__field">

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -32,6 +32,8 @@ export default class Organization extends Model {
   @attr('string') countryName;
   @attr() organizationLearnerTypeId;
   @attr('string') organizationLearnerTypeName;
+  @attr() categoryId;
+  @attr('string') categoryLabel;
 
   @hasMany('organization-membership', { async: true, inverse: 'organization' }) organizationMemberships;
   @hasMany('target-profile-summary', { async: true, inverse: null }) targetProfileSummaries;

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -56,6 +56,7 @@
   }
 
   &__label {
+    margin-right: var(--pix-spacing-8x);
     color: var(--pix-neutral-900);
     font-weight: bold;
   }

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -63,6 +63,7 @@ module('Integration | Component | organizations/information-section-view', funct
         countryCode: 99100,
         countryName: 'France',
         organizationLearnerTypeName: 'super-type-de-prescrit',
+        categoryLabel: 'super-label',
       };
 
       // when
@@ -121,6 +122,9 @@ module('Integration | Component | organizations/information-section-view', funct
             .nextElementSibling,
         )
         .hasText('super-type-de-prescrit');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.category')).nextElementSibling)
+        .hasText(organization.categoryLabel);
     });
 
     test('it renders GAR identity provider correctly', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1160,6 +1160,7 @@
             "undone": "This action cannot be undone."
           }
         },
+        "category": "Category",
         "code": "Code",
         "country": {
           "label": "Country (INSEE code)",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1168,6 +1168,7 @@
             "undone": "Cette action est irréversible."
           }
         },
+        "category": "Catégorie",
         "code": "Code",
         "country": {
           "label": "Pays (code INSEE)",


### PR DESCRIPTION
## ☀️ Problème
On remonte côté API l'information sur la catégorie d'une organisation. Mais celle-ci n'est pas encore affichée côté front

## ⛱️ Proposition
Afficher la catégorie d'une organisation dans la page de détail de celle-ci (Le temps de l'epix, si celle-ci n'est pas présente on affiche Non spécifiée. Elle sera obligatoire en fin d'epix)

## 🧴 Remarques
Malgré la discussion sur le positionnement de la catégorie, on a fait le choix de le placer en bas de la première carte. Car sinon ça décalait la colonne de droite et celle-ci n'était plus alignée. On a pas trouver pour l'instant comment faire mieux sans toucher à tout. On pourra revenir dessus plus tard, mais pour avancer sur le sujet on le laisse comme ça pour l'instant

## 🏊 Pour tester

- Se connecter à Pix Admin
- Aller sur l'organisation 1003, 1004 ou 1005.
- Constater l'affichage de la catégorie.
- Aller sur une autre organisation
- Constater l'affichage du Non spécifié
- 🐈‍⬛ 
