### PR TITLE
[BUGFIX] Erreur du datamart-builder dans les tests unitaires

### DIFF
--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -8,6 +8,7 @@ import { factory } from './factory/index.js';
  */
 class DatamartBuilder {
   constructor({ databaseConnection }) {
+    this.databaseConnection = databaseConnection;
     this.knex = databaseConnection.knex;
     this.datamartBuffer = datamartBuffer;
     this.factory = factory;
@@ -18,6 +19,8 @@ class DatamartBuilder {
   }
 
   async commit() {
+    if (!this.databaseConnection.isConfigured) return;
+
     try {
       const trx = await this.knex.transaction();
       for (const objectToInsert of this.datamartBuffer.objectsToInsert) {
@@ -33,6 +36,8 @@ class DatamartBuilder {
   }
 
   async clean() {
+    if (!this.databaseConnection.isConfigured) return;
+
     let rawQuery = '';
 
     [


### PR DESCRIPTION
## ☀️ Problème

La variable `DATAMART_DATABASE_URL` n'est pas setup pour les tests unitaires ce qui déclenche une erreur lors du clean du `datamartBuilder`

## ⛱️ Proposition

Ne pas réaliser les opérations du `datamartBuilder` si la connection n'est pas configurée.

## 🧴 Remarques

N/A

## 🏊 Pour tester

Les tests unitaires doivent passer.
