### PR TITLE
[FEATURE] Afficher les sessions les plus récentes en premier dans pix Admin (PIX-23836)

### DIFF
--- a/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
@@ -52,7 +52,7 @@ const findFinalizedSessionsWithRequiredAction = async function ({ version } = {}
       'finalized-sessions.publishedAt': null,
     })
     .select('finalized-sessions.*')
-    .orderBy('finalized-sessions.finalizedAt');
+    .orderBy('finalized-sessions.finalizedAt', 'DESC');
 
   return publishableFinalizedSessions.map(_toDomainObject);
 };

--- a/api/src/certification/session-management/infrastructure/repositories/jury-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-session-repository.js
@@ -51,9 +51,9 @@ export async function findPaginatedFiltered({ filters, page }) {
     .leftJoin('users', 'users.id', 'sessions.assignedCertificationOfficerId')
     .leftJoin({ 'jury-comment-authors': 'users' }, 'jury-comment-authors.id', 'sessions.juryCommentAuthorId')
     .modify(_setupFilters, filters)
-    .orderByRaw('?? ASC NULLS FIRST', 'publishedAt')
-    .orderByRaw('?? ASC', 'finalizedAt')
-    .orderBy('id');
+    .orderByRaw('?? DESC NULLS FIRST', 'publishedAt')
+    .orderByRaw('?? DESC', 'finalizedAt')
+    .orderBy('sessions.date', 'DESC');
 
   const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
   const jurySessions = results.map(_toDomain);

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -162,7 +162,7 @@ describe('Integration | Repository | Finalized-session', function () {
 
   describe('#findFinalizedSessionsToPublish', function () {
     context('when there are publishable sessions', function () {
-      it('finds a list of publishable finalized session order by finalization date', async function () {
+      it('finds a list of publishable finalized session order by finalization date (most recent first)', async function () {
         // given
         const session1 = databaseBuilder.factory.buildSession();
         const session2 = databaseBuilder.factory.buildSession();
@@ -170,19 +170,19 @@ describe('Integration | Repository | Finalized-session', function () {
         const session4 = databaseBuilder.factory.buildSession();
         const session5 = databaseBuilder.factory.buildSession();
         const session6 = databaseBuilder.factory.buildSession({ version: 3 });
-        const publishableFinalizedSession1 = databaseBuilder.factory.buildFinalizedSession({
-          isPublishable: true,
-          publishedAt: null,
-          finalizedAt: new Date('2020-01-01'),
-          sessionId: session1.id,
-        });
-        const publishableFinalizedSession2 = databaseBuilder.factory.buildFinalizedSession({
+        const firstPublishableFinalizedSession = databaseBuilder.factory.buildFinalizedSession({
           isPublishable: true,
           publishedAt: null,
           finalizedAt: new Date('2019-01-01'),
+          sessionId: session1.id,
+        });
+        const secondPublishableFinalizedSession = databaseBuilder.factory.buildFinalizedSession({
+          isPublishable: true,
+          publishedAt: null,
+          finalizedAt: new Date('2020-01-01'),
           sessionId: session2.id,
         });
-        const publishableFinalizedSession3 = databaseBuilder.factory.buildFinalizedSession({
+        const thirdPublishableFinalizedSession = databaseBuilder.factory.buildFinalizedSession({
           isPublishable: true,
           publishedAt: null,
           finalizedAt: new Date('2021-01-01'),
@@ -216,32 +216,32 @@ describe('Integration | Repository | Finalized-session', function () {
         expect(result).to.have.lengthOf(3);
         expect(result).to.have.deep.ordered.members([
           {
-            sessionId: publishableFinalizedSession2.sessionId,
-            finalizedAt: publishableFinalizedSession2.finalizedAt,
-            certificationCenterName: publishableFinalizedSession2.certificationCenterName,
-            sessionDate: publishableFinalizedSession2.date,
-            sessionTime: publishableFinalizedSession2.time,
-            isPublishable: publishableFinalizedSession2.isPublishable,
+            sessionId: firstPublishableFinalizedSession.sessionId,
+            finalizedAt: firstPublishableFinalizedSession.finalizedAt,
+            certificationCenterName: firstPublishableFinalizedSession.certificationCenterName,
+            sessionDate: firstPublishableFinalizedSession.date,
+            sessionTime: firstPublishableFinalizedSession.time,
+            isPublishable: firstPublishableFinalizedSession.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
           },
           {
-            sessionId: publishableFinalizedSession1.sessionId,
-            finalizedAt: publishableFinalizedSession1.finalizedAt,
-            certificationCenterName: publishableFinalizedSession1.certificationCenterName,
-            sessionDate: publishableFinalizedSession1.date,
-            sessionTime: publishableFinalizedSession1.time,
-            isPublishable: publishableFinalizedSession1.isPublishable,
+            sessionId: secondPublishableFinalizedSession.sessionId,
+            finalizedAt: secondPublishableFinalizedSession.finalizedAt,
+            certificationCenterName: secondPublishableFinalizedSession.certificationCenterName,
+            sessionDate: secondPublishableFinalizedSession.date,
+            sessionTime: secondPublishableFinalizedSession.time,
+            isPublishable: secondPublishableFinalizedSession.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
           },
           {
-            sessionId: publishableFinalizedSession3.sessionId,
-            finalizedAt: publishableFinalizedSession3.finalizedAt,
-            certificationCenterName: publishableFinalizedSession3.certificationCenterName,
-            sessionDate: publishableFinalizedSession3.date,
-            sessionTime: publishableFinalizedSession3.time,
-            isPublishable: publishableFinalizedSession3.isPublishable,
+            sessionId: thirdPublishableFinalizedSession.sessionId,
+            finalizedAt: thirdPublishableFinalizedSession.finalizedAt,
+            certificationCenterName: thirdPublishableFinalizedSession.certificationCenterName,
+            sessionDate: thirdPublishableFinalizedSession.date,
+            sessionTime: thirdPublishableFinalizedSession.time,
+            isPublishable: thirdPublishableFinalizedSession.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
           },
@@ -262,7 +262,7 @@ describe('Integration | Repository | Finalized-session', function () {
 
   describe('#findFinalizedSessionsWithRequiredAction', function () {
     context('when there are finalized sessions with required action', function () {
-      it('finds a list of finalized session with required action ordered by finalization date', async function () {
+      it('finds a list of finalized session with required action ordered by finalization date (oldest first)', async function () {
         // given
         const session1 = databaseBuilder.factory.buildSession();
         const session2 = databaseBuilder.factory.buildSession();
@@ -307,12 +307,12 @@ describe('Integration | Repository | Finalized-session', function () {
         expect(result).to.have.lengthOf(3);
         expect(result).to.have.deep.ordered.members([
           {
-            sessionId: firstFinalizedSession.sessionId,
-            finalizedAt: firstFinalizedSession.finalizedAt,
-            certificationCenterName: firstFinalizedSession.certificationCenterName,
-            sessionDate: firstFinalizedSession.date,
-            sessionTime: firstFinalizedSession.time,
-            isPublishable: firstFinalizedSession.isPublishable,
+            sessionId: thirdFinalizedSession.sessionId,
+            finalizedAt: thirdFinalizedSession.finalizedAt,
+            certificationCenterName: thirdFinalizedSession.certificationCenterName,
+            sessionDate: thirdFinalizedSession.date,
+            sessionTime: thirdFinalizedSession.time,
+            isPublishable: thirdFinalizedSession.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
           },
@@ -327,12 +327,12 @@ describe('Integration | Repository | Finalized-session', function () {
             assignedCertificationOfficerName: null,
           },
           {
-            sessionId: thirdFinalizedSession.sessionId,
-            finalizedAt: thirdFinalizedSession.finalizedAt,
-            certificationCenterName: thirdFinalizedSession.certificationCenterName,
-            sessionDate: thirdFinalizedSession.date,
-            sessionTime: thirdFinalizedSession.time,
-            isPublishable: thirdFinalizedSession.isPublishable,
+            sessionId: firstFinalizedSession.sessionId,
+            finalizedAt: firstFinalizedSession.finalizedAt,
+            certificationCenterName: firstFinalizedSession.certificationCenterName,
+            sessionDate: firstFinalizedSession.date,
+            sessionTime: firstFinalizedSession.time,
+            isPublishable: firstFinalizedSession.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
           },

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -186,33 +186,39 @@ describe('Integration | Repository | JurySession', function () {
     });
 
     context('orders', function () {
-      let firstSessionId;
-      let secondSessionId;
-      let thirdSessionId;
-      let fourthSessionId;
+      let firstPublishedSessionId,
+        secondPublishedSessionId,
+        firstFinalizedSessionId,
+        secondFinalizedSessionId,
+        firstCreatedSessionId,
+        secondCreatedSessionId;
 
       beforeEach(function () {
-        firstSessionId = databaseBuilder.factory.buildSession({
-          finalizedAt: new Date('2020-01-01T00:00:00Z'),
-          resultsSentToPrescriberAt: null,
+        firstPublishedSessionId = databaseBuilder.factory.buildSession({
+          publishedAt: new Date('2020-01-01T00:00:00Z'),
+          resultsSentToPrescriberAt: new Date('2020-01-01T00:00:00Z'),
         }).id;
-        secondSessionId = databaseBuilder.factory.buildSession({
+        secondPublishedSessionId = databaseBuilder.factory.buildSession({
+          publishedAt: new Date('2021-01-02T00:00:00Z'),
+          resultsSentToPrescriberAt: new Date('2021-01-01T00:00:00Z'),
+        }).id;
+        firstFinalizedSessionId = databaseBuilder.factory.buildSession({
           finalizedAt: new Date('2020-01-02T00:00:00Z'),
-          resultsSentToPrescriberAt: null,
         }).id;
-        thirdSessionId = databaseBuilder.factory.buildSession({
-          finalizedAt: new Date('2020-01-02T00:00:00Z'),
-          resultsSentToPrescriberAt: new Date('2020-01-03T00:00:00Z'),
+        secondFinalizedSessionId = databaseBuilder.factory.buildSession({
+          finalizedAt: new Date('2021-01-02T00:00:00Z'),
         }).id;
-        fourthSessionId = databaseBuilder.factory.buildSession({
-          finalizedAt: null,
-          resultsSentToPrescriberAt: null,
+        firstCreatedSessionId = databaseBuilder.factory.buildSession({
+          date: new Date('2020-01-02T00:00:00Z'),
+        }).id;
+        secondCreatedSessionId = databaseBuilder.factory.buildSession({
+          date: new Date('2021-01-02T00:00:00Z'),
         }).id;
 
         return databaseBuilder.commit();
       });
 
-      it('should order sessions by returning first finalized but not published, then neither of those, and finally the processed ones', async function () {
+      it('should order sessions by returning first created, then finalized and finally published, from newest to oldest', async function () {
         // given
         const filters = {};
         const page = { number: 1, size: 10 };
@@ -224,10 +230,12 @@ describe('Integration | Repository | JurySession', function () {
         });
 
         // then
-        expect(matchingJurySessions[0].id).to.equal(firstSessionId);
-        expect(matchingJurySessions[1].id).to.equal(secondSessionId);
-        expect(matchingJurySessions[2].id).to.equal(thirdSessionId);
-        expect(matchingJurySessions[3].id).to.equal(fourthSessionId);
+        expect(matchingJurySessions[0].id).to.equal(secondCreatedSessionId);
+        expect(matchingJurySessions[1].id).to.equal(firstCreatedSessionId);
+        expect(matchingJurySessions[2].id).to.equal(secondFinalizedSessionId);
+        expect(matchingJurySessions[3].id).to.equal(firstFinalizedSessionId);
+        expect(matchingJurySessions[4].id).to.equal(secondPublishedSessionId);
+        expect(matchingJurySessions[5].id).to.equal(firstPublishedSessionId);
       });
     });
 


### PR DESCRIPTION
## ☀️ Problème

Nous travaillons généralement sur les sessions les plus récentes, mais elles se retrouvent à la fin du tableau (sur la dernière page). Ce n’est pas très pratique.

## ⛱️ Proposition

Mettre les sessions les plus récentes en premier sur les onglets "Sessions à traiter" et "Toutes les sessions". Sur ce second conserver le tri principal par statut.
<img width="2048" height="787" alt="IMG_20260811_121115_301" src="https://github.com/user-attachments/assets/9ded419a-9e94-415d-8f2d-a4d9c5d9bf2f" />


## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
Créer des sessions, les finalisées, publier etc pour vérifier que l'ordre est correct. Pour remplir l'onglet "Sessions à traiter", déclarer des fraudes lors de la finalisation des sessions.
