### PR TITLE
[TECH] Uniformiser l'utilisation de sinon.useFakeTimers dans les tests API

### DIFF
--- a/api/tests/certification/complementary-certification/unit/domain/usecases/generate-calibration-report-check_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/generate-calibration-report-check_test.js
@@ -13,11 +13,11 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Unit | UseCase | generate-calibration-report-check', function () {
-  let versionRepository, calibrationRepository, dependencies, clock;
+  let versionRepository, calibrationRepository, dependencies;
   const now = new Date('2025-06-15T12:00:00Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     versionRepository = {
       getById: sinon.stub(),
     };
@@ -30,10 +30,6 @@ describe('Certification | Configuration | Unit | UseCase | generate-calibration-
       versionRepository,
       calibrationRepository,
     };
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   context('when version does not exist', function () {

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -401,14 +401,8 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
   describe('POST /api/admin/certification-versions', function () {
     const now = new Date('2025-06-15T12:00:00Z');
 
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return 201 HTTP status code and a new version as a draft and link his challenges', async function () {
@@ -595,14 +589,9 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
   describe('GET /api/admin/certification-versions/{certificationVersionId}/calibrations/{calibrationId}/report', function () {
     const now = new Date('2025-06-15T12:00:00Z');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return 200 HTTP status code and a the calibration report', async function () {

--- a/api/tests/certification/configuration/unit/domain/models/BadgeToAttach_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/BadgeToAttach_test.js
@@ -5,15 +5,10 @@ import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | Domain | Models | BadgeToAttach', function () {
-  let clock;
   const now = new Date('2023-02-02');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('static from', function () {

--- a/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
@@ -15,13 +15,8 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 
 describe('Unit | Certification | Configuration | Domain | Models | Calibration Report', function () {
   const now = new Date('2025-06-15T12:00:00Z');
-  let clock;
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#build', function () {

--- a/api/tests/certification/configuration/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/attach-badges_test.js
@@ -10,7 +10,6 @@ import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | attach-badges', function () {
   let complementaryCertificationForTargetProfileAttachmentRepository, complementaryCertificationBadgesRepository;
-  let clock;
   const now = new Date('2023-02-02');
 
   beforeEach(function () {
@@ -20,11 +19,7 @@ describe('Unit | UseCase | attach-badges', function () {
     complementaryCertificationBadgesRepository = {
       countAttachableBadges: sinon.stub(),
     };
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when levels checks are not ok', function () {

--- a/api/tests/certification/enrolment/acceptance/application/session-mass-import-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-mass-import-route_test.js
@@ -18,17 +18,11 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
   });
 
   describe('POST /api/certification-centers/{certificationCenterId}/sessions/validate-for-mass-import', function () {
-    let clock;
-
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({
+      sinon.useFakeTimers({
         now: new Date('2023-01-01'),
         toFake: ['Date'],
       });
-    });
-
-    afterEach(async function () {
-      clock.restore();
     });
 
     context('when user validate sessions for import', function () {

--- a/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
@@ -43,17 +43,11 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
   });
 
   context('#isSessionScheduledInThePast', function () {
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers({
+      sinon.useFakeTimers({
         now: new Date('2023-01-01'),
         toFake: ['Date'],
       });
-    });
-
-    afterEach(async function () {
-      clock.restore();
     });
 
     context('when session is scheduled in the past', function () {

--- a/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
@@ -10,13 +10,12 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 
 describe('Certification | Enrolment | Unit | Service | sessions import validation Service', function () {
   describe('#validateSession', function () {
-    let clock;
     let sessionRepository;
     let sessionAuthorizationAdapter;
     let dependencies;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({
+      sinon.useFakeTimers({
         now: new Date('2023-01-01'),
         toFake: ['Date'],
       });
@@ -33,7 +32,6 @@ describe('Certification | Enrolment | Unit | Service | sessions import validatio
     });
 
     afterEach(async function () {
-      clock.restore();
       sinon.restore();
     });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -25,11 +25,10 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
     eventAdapter,
     sessionAuthorizationAdapter,
     dependencies;
-  let clock;
   const sessionId = 456;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now: new Date('2026-04-05T03:04:05Z') });
+    sinon.useFakeTimers({ now: new Date('2026-04-05T03:04:05Z'), toFake: ['Date'] });
     sessionAuthorizationAdapter = {
       find: sinon.stub(),
     };
@@ -72,7 +71,6 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
   });
 
   afterEach(function () {
-    clock.restore();
     sinon.restore();
   });
 

--- a/api/tests/certification/evaluation/integration/domain/usecases/complete-certification-assessment_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/complete-certification-assessment_test.js
@@ -12,11 +12,11 @@ const { completeCertificationAssessment } = usecases;
 
 describe('Certification | Evaluation | Integration | Domain | UseCase | complete-certification-assessment', function () {
   const locale = 'someLocale';
-  let certificationCourseId, assessmentId, args, clock;
+  let certificationCourseId, assessmentId, args;
   const now = new Date();
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
       firstName: 'A',
       lastName: 'B',
@@ -35,10 +35,6 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | complete
       certificationCourseId,
       locale,
     };
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   context('when certification does not exist', function () {

--- a/api/tests/certification/evaluation/unit/application/scoring-and-capacity-simulator-controller_test.js
+++ b/api/tests/certification/evaluation/unit/application/scoring-and-capacity-simulator-controller_test.js
@@ -7,19 +7,11 @@ import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
 
 describe('Unit | Application | scoringAndCapacitySimulatorController', function () {
   describe('#simulateScoringOrCapacity', function () {
-    let clock;
     let now;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({
-        now: new Date(),
-        toFake: ['Date'],
-      });
-      now = new Date(clock.now);
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      now = new Date();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     describe('when given a capacity', function () {

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -37,7 +37,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
   });
 
   context('#complete', function () {
-    let clock, assessmentSheetBaseData;
+    let assessmentSheetBaseData;
     const now = new Date();
 
     beforeEach(function () {
@@ -48,11 +48,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
         isRejectedForFraud: true,
         answers: [domainBuilder.buildAnswer()],
       };
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it(`should update state and assessmentUpdatedAt when assessment sheet is in state ${STATES.STARTED}`, function () {
@@ -361,7 +357,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
   });
 
   context('#endDueToCertificationDurationExceeded', function () {
-    let clock, assessmentSheetBaseData;
+    let assessmentSheetBaseData;
     const now = new Date();
 
     beforeEach(function () {
@@ -372,11 +368,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
         isRejectedForFraud: true,
         answers: [domainBuilder.buildAnswer()],
       };
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it(`should set state to ${STATES.ENDED_DUE_TO_DURATION_EXCEEDED} and update assessmentUpdatedAt`, function () {

--- a/api/tests/certification/evaluation/unit/domain/services/certification-duration-service_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/certification-duration-service_test.js
@@ -7,15 +7,10 @@ const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
 
 describe('Unit | Certification | Evaluation | Domain | Service | certification-duration', function () {
   describe('#isDurationExceeded', function () {
-    let clock;
     const now = new Date('2026-01-02T00:00:00Z');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('returns true when the elapsed duration exceeds 24 hours by one millisecond', function () {

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -20,14 +20,13 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
     let algorithm;
     let scoringDegradationService;
 
-    let clock;
     const now = new Date('2019-01-01T05:06:07Z');
 
     beforeEach(function () {
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
         return callback();
       });
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
       scoringDegradationService = {
         downgradeCapacity: sinon.stub().rejects(new Error('Args mismatch')),
       };
@@ -39,10 +38,6 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
         configuration: flashAssessmentAlgorithmConfiguration,
       });
       sinon.stub(createV3AssessmentResult);
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     context('when scoring a CORE certification', function () {

--- a/api/tests/certification/evaluation/unit/domain/usecases/start-or-resume-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/start-or-resume-certification_test.js
@@ -26,13 +26,12 @@ describe('Certification | Evaluation | Unit | UseCase | start-or-resume-certific
     versionApi,
     certificationBadgesService,
     verifyCertificateCodeService,
-    dependencies,
-    clock;
+    dependencies;
   const now = new Date('2026-01-01');
   const clientTimezone = 'Europe/London';
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     assessmentRepository = {
       save: sinon.stub(),
     };
@@ -94,7 +93,6 @@ describe('Certification | Evaluation | Unit | UseCase | start-or-resume-certific
   });
 
   afterEach(function () {
-    clock.restore();
     sinon.restore();
   });
 

--- a/api/tests/certification/results/acceptance/application/certification-results-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certification-results-route_test.js
@@ -251,14 +251,9 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
 
   describe('GET /api/admin/sessions/download-selection-results', function () {
     const now = new Date('2026-01-01T05:06:07Z');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return 200 HTTP status code', async function () {

--- a/api/tests/certification/results/integration/domain/usecases/get-selected-sessions-results-zip_test.js
+++ b/api/tests/certification/results/integration/domain/usecases/get-selected-sessions-results-zip_test.js
@@ -7,18 +7,13 @@ import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 
 describe('Integration | Certification | Results | UseCase | get-selected-sessions-results-zip', function () {
-  let clock;
   const now = new Date('2026-05-01');
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({
+    sinon.useFakeTimers({
       now,
       toFake: ['Date'],
     });
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   it('returns a ZIP file with expected CSVs in it', async function () {

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -355,14 +355,9 @@ describe('Certification | Results | Unit | Application | certificate-controller'
 
   describe('#downloadDivisionCertificates', function () {
     const now = new Date('2019-01-01T05:06:07Z');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     describe('when there are at least one v3 attestation', function () {

--- a/api/tests/certification/results/unit/application/organization-controller_test.js
+++ b/api/tests/certification/results/unit/application/organization-controller_test.js
@@ -10,14 +10,9 @@ import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
 describe('Certification | Course | Unit | Application | Organizations | organization-controller', function () {
   describe('#downloadCertificationResults', function () {
     const now = new Date('2019-01-01T05:06:07Z');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return a response with CSV results', async function () {

--- a/api/tests/certification/session-management/acceptance/application/session-publication-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-publication-route_test.js
@@ -75,15 +75,9 @@ describe('Certification | Session-Management | Acceptance | Application | Routes
           let certificationId;
           const now = new Date('2000-01-01T10:00:00Z');
 
-          let clock;
-
-          afterEach(async function () {
-            clock.restore();
-          });
-
           context('when the certification course contains challenges', function () {
             beforeEach(function () {
-              clock = sinon.useFakeTimers({
+              sinon.useFakeTimers({
                 now,
                 toFake: ['Date'],
               });
@@ -129,7 +123,7 @@ describe('Certification | Session-Management | Acceptance | Application | Routes
 
           context('when the certification course does not contain challenges', function () {
             beforeEach(function () {
-              clock = sinon.useFakeTimers({
+              sinon.useFakeTimers({
                 now,
                 toFake: ['Date'],
               });

--- a/api/tests/certification/session-management/integration/application/api/session-api_test.js
+++ b/api/tests/certification/session-management/integration/application/api/session-api_test.js
@@ -7,15 +7,10 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 
 describe('Certification | Session Management | Integration | Application | Api | Session', function () {
   describe('#onCertificationStartedOrResumed', function () {
-    let clock;
     const now = new Date('2022-11-28T01:00:00Z');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('returns without altering any sessions when no session found for provided session id and without unauthorizing', async function () {

--- a/api/tests/certification/session-management/integration/application/jobs/cpf-export-builder-job-controller_test.js
+++ b/api/tests/certification/session-management/integration/application/jobs/cpf-export-builder-job-controller_test.js
@@ -27,20 +27,15 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 describe('Integration | Application | Certification | Sessions Management | jobs | cpf-export-builder-job-controller', function () {
   let cpfCertificationResultRepository;
   let uploadCpfFiles;
-  let clock;
   const expectedFileName = 'pix-cpf-export-20220102-114327.xml.gz';
   let logger;
   let uuidService;
 
   beforeEach(function () {
     const now = dayjs('2022-01-02T10:43:27Z').tz('Europe/Paris').toDate();
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     logger = { error: noop, info: noop, trace: noop };
     uuidService = { randomUUID: sinon.stub() };
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   it('should build an xml export file and upload it to an external storage', async function () {

--- a/api/tests/certification/session-management/integration/domain/usecases/finalize-session_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/finalize-session_test.js
@@ -17,15 +17,11 @@ describe('Certification | Session Management | Integration | Domain | UseCase | 
   const hasIncident = true;
   const hasJoiningIssue = true;
   const examinerGlobalComment = 'Le meilleur global comment de tous les temps';
-  let sessionId, clock;
+  let sessionId;
   const now = new Date('2026-01-01');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when session does not exist', function () {

--- a/api/tests/certification/session-management/integration/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/process-auto-jury_test.js
@@ -11,21 +11,17 @@ import { preventStubsToBeCalledUnexpectedly } from '../../../../../tooling/test-
 describe('Certification | Session Management | Integration | Domain | UseCase | process-auto-jury_test ', function () {
   context('when it is a V3 certification', function () {
     let certificationEvaluationRepository_rescoreV3CertificationStub;
-    let certificationEvaluationRepository, clock;
+    let certificationEvaluationRepository;
     const now = new Date('2025-06-15');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
       certificationEvaluationRepository_rescoreV3CertificationStub = sinon.stub().named('rescoreV3Certification');
       preventStubsToBeCalledUnexpectedly([certificationEvaluationRepository_rescoreV3CertificationStub]);
 
       certificationEvaluationRepository = {
         rescoreV3Certification: certificationEvaluationRepository_rescoreV3CertificationStub,
       };
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     context('when certification is started', function () {

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-repository_test.js
@@ -62,18 +62,11 @@ describe('Certification | Session-management | Integration | Infrastructure | Re
     context(
       'when all certification latest assessment result are validated, rejected or certification is cancelled',
       function () {
-        let clock, now;
+        let now;
 
         beforeEach(function () {
-          clock = sinon.useFakeTimers({
-            now: new Date('2022-12-25'),
-            toFake: ['Date'],
-          });
-          now = new Date(clock.now);
-        });
-
-        afterEach(async function () {
-          clock.restore();
+          now = new Date('2022-12-25');
+          sinon.useFakeTimers({ now, toFake: ['Date'] });
         });
 
         it('should set certifications as published within the session and update pixCertificationStatus according to assessment result status', async function () {

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/supervised-candidate-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/supervised-candidate-repository_test.js
@@ -8,15 +8,11 @@ import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 
 describe('Certification | SessionManagement | Integration | Repository | Supervised candidate', function () {
-  let clock, now;
+  let now;
 
   beforeEach(function () {
     now = new Date('2003-04-05T03:04:05Z');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#authorizeToStart', function () {

--- a/api/tests/certification/session-management/unit/application/jobs/cpf-export-builder-job-controller_test.js
+++ b/api/tests/certification/session-management/unit/application/jobs/cpf-export-builder-job-controller_test.js
@@ -23,12 +23,11 @@ describe('Unit | Application | Certification | Sessions Management | jobs | cpf-
   let cpfCertificationResultRepository;
   let cpfCertificationXmlExportService;
   let loggerSpy;
-  let clock;
   let logger;
 
   beforeEach(function () {
     const now = dayjs('2022-01-01T10:43:27Z').tz('Europe/Paris').toDate();
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     cpfCertificationResultRepository = {
       findByBatchId: sinon.stub(),
@@ -41,10 +40,6 @@ describe('Unit | Application | Certification | Sessions Management | jobs | cpf-
     usecases.uploadCpfFiles = sinon.stub();
     logger = { error: noop, info: noop };
     loggerSpy = sinon.spy(logger, 'error');
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   describe('when there are data to export', function () {

--- a/api/tests/certification/session-management/unit/domain/models/SessionJuryComment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/SessionJuryComment_test.js
@@ -28,14 +28,8 @@ describe('Unit | Domain | Models | SessionJuryComment', function () {
   });
 
   context('#update', function () {
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: new Date('2003-04-05T03:04:05Z'), toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: new Date('2003-04-05T03:04:05Z'), toFake: ['Date'] });
     });
 
     it('should update the comment', function () {

--- a/api/tests/certification/session-management/unit/domain/models/Session_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/Session_test.js
@@ -62,15 +62,11 @@ describe('Certification | SessionManagement | Unit | Domain | Models | Session',
   });
 
   context('#finalize', function () {
-    let clock, now;
+    let now;
 
     beforeEach(function () {
       now = new Date('2024-11-16');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('finalizes the session and the certification courses', function () {

--- a/api/tests/certification/session-management/unit/domain/models/SupervisedSession_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/SupervisedSession_test.js
@@ -5,15 +5,10 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 
 describe('Certification | SessionManagement | Unit | Domain | Models | SupervisedSession', function () {
   describe('setStartDate', function () {
-    let clock;
     const now = new Date('2022-11-28T01:00:00Z');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     context('when session has no started certifications yet', function () {

--- a/api/tests/certification/session-management/unit/domain/read-models/CandidateAuthorizationInfo_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/CandidateAuthorizationInfo_test.js
@@ -7,15 +7,10 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
 
 describe('Certification | Session-management | Unit | Domain | Read-models | CandidateAuthorizationInfo', function () {
-  let clock;
   const now = new Date('2026-01-02T00:00:00Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#isSessionJoinable', function () {

--- a/api/tests/certification/session-management/unit/domain/services/cpf-certification-xml-export-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/cpf-certification-xml-export-service_test.js
@@ -16,17 +16,12 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 
 describe('Unit | Services | cpf-certification-xml-export-service', function () {
-  let clock;
   let uuidService;
 
   beforeEach(function () {
     const now = dayjs('2022-02-01T10:43:27Z').tz('Europe/Paris').toDate();
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     uuidService = { randomUUID: sinon.stub() };
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   describe('getXmlExport', function () {

--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -31,7 +31,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
   const recipient2WithUpperCases = 'EMAIL2@EXAMPLE.NET';
 
   const certificationCenter = 'certificationCenter';
-  let clock;
   let candidateWithRecipient1,
     candidateWithRecipient2,
     candidate2WithRecipient2,
@@ -63,12 +62,8 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
       ],
       publishedAt: null,
     });
-    clock = sinon.useFakeTimers({ now: new Date('2019-01-01T05:06:07Z'), toFake: ['Date'] });
-    now = new Date(clock.now);
-  });
-
-  afterEach(function () {
-    clock.restore();
+    now = new Date('2019-01-01T05:06:07Z');
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#publishSession', function () {

--- a/api/tests/certification/session-management/unit/infrastructure/adapters/event-adapter_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/adapters/event-adapter_test.js
@@ -4,11 +4,11 @@ import * as eventAdapter from '../../../../../../src/certification/session-manag
 import { EVENT_NAMES } from '../../../../../../src/certification/shared/domain/constants/event-names.js';
 
 describe('Certification | SessionManagement | Unit | Adapter | event', function () {
-  let eventApi, dependencies, clock;
+  let eventApi, dependencies;
   const now = new Date('2023-02-02');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     eventApi = {
       pushEvents: sinon.stub(),
     };
@@ -16,10 +16,6 @@ describe('Certification | SessionManagement | Unit | Adapter | event', function 
     dependencies = {
       eventApi,
     };
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   context('#onCandidateAuthorizedToStart', function () {

--- a/api/tests/certification/shared/integration/application/api/event-api_test.js
+++ b/api/tests/certification/shared/integration/application/api/event-api_test.js
@@ -5,16 +5,15 @@ import { logger } from '../../../../../../src/shared/infrastructure/utils/logger
 import { knex } from '../../../../../tooling/databases.js';
 
 describe('Certification | Shared | Integration | Application | API | Event', function () {
-  let clock, warnSpy;
+  let warnSpy;
   const now = new Date('2023-02-02T00:00:00Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     warnSpy = sinon.spy(logger, 'warn');
   });
 
   afterEach(function () {
-    clock.restore();
     sinon.restore();
     return knex('certification_events').truncate();
   });

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -9,15 +9,11 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Shared | Integration | Repository | Certification Center', function () {
-  let clock, now;
+  let now;
 
   beforeEach(function () {
     now = new Date('2021-11-16');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#get', function () {

--- a/api/tests/db-history/unit/application/jobs/schedule-historize-answers-job-controller_test.js
+++ b/api/tests/db-history/unit/application/jobs/schedule-historize-answers-job-controller_test.js
@@ -10,7 +10,7 @@ describe('DB-History | Unit | Application | Jobs | ScheduleHistorizeAnswersJobCo
     it('schedules answers historization usecase call', async function () {
       // given
       const now = new Date('2025-06-11T00:00:00Z');
-      const clock = sinon.useFakeTimers(now);
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
       sinon.stub(usecases, 'historizeAnswers');
       const scheduleHistorizeAnswersJobController = new ScheduleHistorizeAnswersJobController();
       const [expectedDate] = getDatesOneYearEarlier(now);
@@ -20,8 +20,6 @@ describe('DB-History | Unit | Application | Jobs | ScheduleHistorizeAnswersJobCo
 
       // then
       expect(usecases.historizeAnswers).to.have.been.calledWith({ targetDate: expectedDate });
-
-      clock.restore();
     });
   });
 
@@ -29,7 +27,7 @@ describe('DB-History | Unit | Application | Jobs | ScheduleHistorizeAnswersJobCo
     it('should not run the usecase ', async function () {
       // given
       const now = new Date('2024-02-29T00:00:00Z');
-      const clock = sinon.useFakeTimers(now);
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
       sinon.stub(usecases, 'historizeAnswers');
       const scheduleHistorizeAnswersJobController = new ScheduleHistorizeAnswersJobController();
 
@@ -38,8 +36,6 @@ describe('DB-History | Unit | Application | Jobs | ScheduleHistorizeAnswersJobCo
 
       // then
       expect(usecases.historizeAnswers).to.not.have.been.called;
-
-      clock.restore();
     });
   });
 
@@ -47,7 +43,7 @@ describe('DB-History | Unit | Application | Jobs | ScheduleHistorizeAnswersJobCo
     it('should run the usecase twice', async function () {
       // given
       const now = new Date('2025-03-01T00:00:00Z');
-      const clock = sinon.useFakeTimers(now);
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
       sinon.stub(usecases, 'historizeAnswers');
       const scheduleHistorizeAnswersJobController = new ScheduleHistorizeAnswersJobController();
       const expectedDates = getDatesOneYearEarlier(now);
@@ -60,8 +56,6 @@ describe('DB-History | Unit | Application | Jobs | ScheduleHistorizeAnswersJobCo
       expect(usecases.historizeAnswers).to.have.been.calledTwice;
       expect(usecaseCalls[0]).to.have.been.calledWith({ targetDate: expectedDates[0] });
       expect(usecaseCalls[1]).to.have.been.calledWith({ targetDate: expectedDates[1] });
-
-      clock.restore();
     });
   });
 });

--- a/api/tests/deprecated/acceptance/application/user-admin.route.test.js
+++ b/api/tests/deprecated/acceptance/application/user-admin.route.test.js
@@ -13,17 +13,11 @@ describe('Acceptance | Deprecated | Application | Route | User admin', function 
   });
 
   describe('GET /api/admin/users/{id}', function () {
-    let clock;
-
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({
+      sinon.useFakeTimers({
         now: Date.now(),
         toFake: ['Date'],
       });
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     describe('Resource access management', function () {

--- a/api/tests/devcomp/integration/application/api/modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/modules-api_test.js
@@ -10,15 +10,11 @@ import { databaseBuilder } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Devcomp | Application | Api | Modules', function () {
-  let clock, now;
+  let now;
 
   beforeEach(function () {
     now = new Date('2023-10-05T18:02:00Z');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#getModulesByIds', function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/element-answer-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/element-answer-repository_test.js
@@ -9,14 +9,9 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 describe('Integration | DevComp | Repositories | ElementAnswerRepository', function () {
   describe('#save', function () {
     const fakeDate = new Date('2023-12-31');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: fakeDate, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: fakeDate, toFake: ['Date'] });
     });
 
     it('should have an element answer', async function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/passage-event-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/passage-event-repository_test.js
@@ -10,14 +10,8 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | DevComp | Repositories | PassageEventRepository', function () {
   describe('#record', function () {
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-12-31'), 'Date');
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: new Date('2023-12-31'), toFake: ['Date'] });
     });
 
     it('should record a passage event', async function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/passage-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/passage-repository_test.js
@@ -9,14 +9,8 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | DevComp | Repositories | PassageRepository', function () {
   describe('#save', function () {
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-12-31'), 'Date');
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: new Date('2023-12-31'), toFake: ['Date'] });
     });
 
     it('should save a passage with a userId provided', async function () {
@@ -72,14 +66,8 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
   });
 
   describe('#update', function () {
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2024-01-02'), 'Date');
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: new Date('2024-01-02'), toFake: ['Date'] });
     });
 
     it('should update a passage', async function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/target-profile-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/target-profile-training-repository_test.js
@@ -5,16 +5,11 @@ import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 
 describe('Integration | Repository | target-profile-training-repository', function () {
-  let clock;
   let now;
 
   beforeEach(function () {
     now = new Date('2022-02-13');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#create', function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -168,16 +168,11 @@ describe('Integration | Repository | training-trigger-repository', function () {
     });
 
     context('when trigger already exists', function () {
-      let clock;
       let now;
 
       beforeEach(function () {
         now = new Date('2022-02-02');
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      });
-
-      afterEach(function () {
-        clock.restore();
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       it('should update it', async function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -420,13 +420,10 @@ describe('Integration | Repository | user-recommended-training-repository', func
   });
 
   describe(deleteCampaignParticipationIds.name, function () {
-    let now, clock;
+    let now;
     beforeEach(function () {
       now = new Date('2025-01-01');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should set campaignParticipationId to null for given campaignParticipationIds', async function () {

--- a/api/tests/devcomp/unit/domain/models/Passage_test.js
+++ b/api/tests/devcomp/unit/domain/models/Passage_test.js
@@ -27,14 +27,8 @@ describe('Unit | Devcomp | Domain | Models | Passage', function () {
   });
 
   describe('#terminate', function () {
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2024-01-02'), 'Date');
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: new Date('2024-01-02'), toFake: ['Date'] });
     });
 
     it('should create a passage and keep attributes', function () {

--- a/api/tests/devcomp/unit/domain/models/module/UserModuleStatus_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/UserModuleStatus_test.js
@@ -9,10 +9,9 @@ import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | UserModuleStatus', function () {
   let userId, moduleId, passages;
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now: new Date('2024-05-01'), toFake: ['Date'] });
+    sinon.useFakeTimers({ now: new Date('2024-05-01'), toFake: ['Date'] });
     userId = '1';
     moduleId = '66f6dea7-1bb3-4ec2-b33d-1c5e7bde3675';
 
@@ -42,10 +41,6 @@ describe('Unit | Devcomp | Domain | Models | Module | UserModuleStatus', functio
         terminatedAt: null,
       }),
     ];
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   it('should init and keep attributes', function () {

--- a/api/tests/devcomp/unit/domain/usecases/get-user-module-statuses_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-user-module-statuses_test.js
@@ -7,14 +7,9 @@ import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | UseCases | get-user-module-statuses', function () {
   const now = new Date('2025-07-02T14:00:00Z');
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('should return a list of UserModuleStatuses', async function () {

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
@@ -81,8 +81,6 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-campai
     const userId = 1234;
 
     context('When there still are challenges to answer', function () {
-      let clock;
-
       beforeEach(async function () {
         databaseBuilder.factory.buildUser({ id: userId });
         const campaign = databaseBuilder.factory.buildCampaign({ assessmentMethod: 'SMART_RANDOM' });
@@ -106,14 +104,10 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-campai
         });
         await databaseBuilder.commit();
 
-        clock = sinon.useFakeTimers({
+        sinon.useFakeTimers({
           now: Date.now(),
           toFake: ['Date'],
         });
-      });
-
-      afterEach(async function () {
-        clock.restore();
       });
 
       it('should return an assessment', async function () {

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -109,8 +109,6 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
     const userId = 1234;
 
     context('When there are still challenges to answer', function () {
-      let clock;
-
       beforeEach(async function () {
         const user = databaseBuilder.factory.buildUser({ id: userId });
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -183,14 +181,10 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
         databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
         await databaseBuilder.commit();
 
-        clock = sinon.useFakeTimers({
+        sinon.useFakeTimers({
           now: Date.now(),
           toFake: ['Date'],
         });
-      });
-
-      afterEach(async function () {
-        clock.restore();
       });
 
       it('should save and return an assessment', async function () {

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -77,8 +77,6 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
     const userId = 1234;
 
     context('When there is still challenges to answer', function () {
-      let clock;
-
       beforeEach(async function () {
         databaseBuilder.factory.buildUser({ id: userId });
         databaseBuilder.factory.buildAssessment({
@@ -106,14 +104,10 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         });
         await databaseBuilder.commit();
 
-        clock = sinon.useFakeTimers({
+        sinon.useFakeTimers({
           now: Date.now(),
           toFake: ['Date'],
         });
-      });
-
-      afterEach(async function () {
-        clock.restore();
       });
 
       it('should return assessment with title', async function () {

--- a/api/tests/evaluation/acceptance/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/scorecards/scorecard-controller_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import Sinon from 'sinon';
+import sinon from 'sinon';
 
 import { createServer } from '../../../../../server.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
@@ -529,7 +529,7 @@ describe('Acceptance | Controller | scorecard-controller', function () {
         beforeEach(async function () {
           options.headers = generateAuthenticatedUserRequestHeaders({ userId });
 
-          Sinon.useFakeTimers({
+          sinon.useFakeTimers({
             now: new Date('2019-01-10'),
             toFake: ['Date'],
           });

--- a/api/tests/evaluation/unit/application/api/correction-api_test.js
+++ b/api/tests/evaluation/unit/application/api/correction-api_test.js
@@ -8,14 +8,9 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 describe('Evaluation | Unit | Application | API | correction-api', function () {
   describe('#correctAnswer', function () {
     const now = new Date('2025-06-15T12:00:00Z');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('corrects the answer and return the corrected versions of the answer', async function () {

--- a/api/tests/evaluation/unit/domain/models/Badge_test.js
+++ b/api/tests/evaluation/unit/domain/models/Badge_test.js
@@ -6,14 +6,9 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 
 describe('Unit | Domain | Models | Badge', function () {
   const now = new Date();
-  let clock;
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers(now);
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#updateBadgeProperties', function () {

--- a/api/tests/evaluation/unit/domain/services/correction-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/correction-service_test.js
@@ -7,14 +7,9 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 
 describe('Unit | Domain | Service | correction-service', function () {
   const now = new Date('2025-06-15T12:00:00Z');
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#evaluateAnswer', function () {

--- a/api/tests/evaluation/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/complete-assessment_test.js
@@ -13,7 +13,6 @@ describe('Unit | UseCase | complete-assessment', function () {
   let assessmentRepository;
   let certificationEvaluationRepository;
   const now = new Date('2019-01-01T05:06:07Z');
-  let clock;
 
   beforeEach(function () {
     assessmentRepository = {
@@ -25,11 +24,7 @@ describe('Unit | UseCase | complete-assessment', function () {
       completeCertificationAssessment: _.noop,
     };
 
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when assessment is already completed', function () {

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -27,7 +27,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
   let validator;
   let correctAnswerValue;
   let answer;
-  let clock;
   let answerRepository,
     challengeRepository,
     competenceRepository,
@@ -46,7 +45,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
   beforeEach(function () {
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
     nowDate.setMilliseconds(1);
-    clock = sinon.useFakeTimers({ now: nowDate, toFake: ['Date'] });
+    sinon.useFakeTimers({ now: nowDate, toFake: ['Date'] });
     sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer');
     answerRepository = { save: sinon.stub() };
     challengeRepository = { get: sinon.stub() };
@@ -106,10 +105,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       areaRepository,
       competenceRepository,
     };
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   context('when the user which want to save the answer is not the right user', function () {

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
@@ -24,7 +24,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
   let validator;
   let correctAnswerValue;
   let answer;
-  let clock;
   let answerRepository,
     challengeRepository,
     competenceRepository,
@@ -43,7 +42,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
   beforeEach(function () {
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
     nowDate.setMilliseconds(1);
-    clock = sinon.useFakeTimers({ now: nowDate, toFake: ['Date'] });
+    sinon.useFakeTimers({ now: nowDate, toFake: ['Date'] });
     sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer');
     answerRepository = { save: sinon.stub() };
     challengeRepository = { get: sinon.stub() };
@@ -90,10 +89,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       areaRepository,
       competenceRepository,
     };
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   context('when the user which want to save the answer is not the right user', function () {

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-demo-and-preview_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-demo-and-preview_test.js
@@ -21,7 +21,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
   let validator;
   let correctAnswerValue;
   let answer;
-  let clock;
   let answerRepository, challengeRepository;
 
   const nowDate = new Date('2021-03-11T11:00:04Z');
@@ -33,7 +32,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
   beforeEach(function () {
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
     nowDate.setMilliseconds(1);
-    clock = sinon.useFakeTimers({ now: nowDate, toFake: ['Date'] });
+    sinon.useFakeTimers({ now: nowDate, toFake: ['Date'] });
     answerRepository = { save: sinon.stub() };
     challengeRepository = { get: sinon.stub() };
 
@@ -59,10 +58,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
       challengeRepository,
       correctionService,
     };
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   context('when an answer for that challenge has already been provided', function () {

--- a/api/tests/evaluation/unit/domain/usecases/update-assessment-with-next-challenge_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/update-assessment-with-next-challenge_test.js
@@ -492,11 +492,10 @@ describe('Evaluation | Unit | Domain | Use Cases | update-assessment-with-next-c
 
     context('Assessment updates', function () {
       context('updating last question date', function () {
-        let clock;
         let assessment;
 
         beforeEach(function () {
-          clock = sinon.useFakeTimers(new Date('2023-10-05'));
+          sinon.useFakeTimers({ now: new Date('2023-10-05'), toFake: ['Date'] });
           assessment = domainBuilder.buildAssessment({
             state: Assessment.states.STARTED,
             id: assessmentId,
@@ -511,10 +510,6 @@ describe('Evaluation | Unit | Domain | Use Cases | update-assessment-with-next-c
           getNextChallengeForDemoStub.withArgs({ assessment }).resolves('someChallengeId');
           challengeToPlayRepository_getStub.withArgs('someChallengeId').resolves(nextChallenge);
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
-        });
-
-        afterEach(async function () {
-          clock.restore();
         });
 
         it(`should update the last question date`, async function () {

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -529,18 +529,13 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
 
   describe('PATCH /api/users/{id}/has-seen-last-data-protection-policy-information', function () {
     describe('Success case', function () {
-      let clock;
       const now = new Date('2022-12-07');
 
       beforeEach(async function () {
-        clock = sinon.useFakeTimers({
+        sinon.useFakeTimers({
           now,
           toFake: ['Date'],
         });
-      });
-
-      afterEach(function () {
-        clock.restore();
       });
 
       it('returns a response with HTTP status code 200', async function () {

--- a/api/tests/identity-access-management/integration/domain/services/account-recovery-service.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/account-recovery-service.test.js
@@ -119,7 +119,7 @@ describe('Integration | Identity Access Management | Domain | Service | account-
     describe('when recovery demand has expired', function () {
       it('throws an error', async function () {
         // given
-        sinon.useFakeTimers({ now: new Date('2022-01-03') });
+        sinon.useFakeTimers({ now: new Date('2022-01-03'), toFake: ['Date'] });
         const user = databaseBuilder.factory.buildUser();
         const learner = databaseBuilder.factory.buildOrganizationLearner({ userId: user.id });
         const recoveryDemand = databaseBuilder.factory.buildAccountRecoveryDemand({

--- a/api/tests/identity-access-management/integration/domain/services/pix-authentication-service.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/pix-authentication-service.test.js
@@ -20,10 +20,9 @@ const password = 'Password123';
 describe('Integration | Identity Access Management | Domain | Services | pix-authentication-service', function () {
   describe('#getUserByUsernameAndPassword', function () {
     let user;
-    let clock;
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       user = databaseBuilder.factory.buildUser.withRawPassword({
         email: 'user@example.net',
@@ -31,10 +30,6 @@ describe('Integration | Identity Access Management | Domain | Services | pix-aut
         rawPassword: password,
       });
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     context('When user credentials are valid', function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/assert-user-is-blocked.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/assert-user-is-blocked.test.js
@@ -7,15 +7,10 @@ import { databaseBuilder } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Identity Access Management | Integration | Domain | UseCase | assert-user-is-blocked', function () {
-  let clock;
   const now = new Date('2024-04-05T03:04:05Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when the user is not blocked', function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/authenticate-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/authenticate-user.usecase.test.js
@@ -20,15 +20,10 @@ describe('Integration | Identity Access Management | Domain | UseCase | authenti
   });
 
   context('when authentication succeeds', function () {
-    let clock;
     const now = new Date('2001-01-01');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('returns a valid JWT Access Token', async function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-details-by-admin.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-details-by-admin.usecase.test.js
@@ -17,7 +17,6 @@ describe('Integration | Identity Access Management | Domain | UseCase | updateUs
   let userId;
   let updatedByAdminId;
 
-  let clock;
   const now = new Date('2024-12-25');
 
   beforeEach(async function () {
@@ -29,11 +28,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | updateUs
     databaseBuilder.factory.buildUser({ email: 'alreadyexist@example.net' });
     await databaseBuilder.commit();
 
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('updates user email, firstname and lastname', async function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-email-with-validation.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-email-with-validation.usecase.test.js
@@ -18,16 +18,11 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 const verifyEmailTemporaryStorage = temporaryStorage.withPrefix('verify-email:');
 
 describe('Integration | Identity Access Management | Domain | UseCase | updateUserEmailWithValidation', function () {
-  let clock;
   const now = new Date('2024-12-25');
 
   beforeEach(function () {
     verifyEmailTemporaryStorage.flushAll();
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('updates the user email checking the verification code', async function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-for-account-recovery.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-for-account-recovery.usecase.test.js
@@ -54,16 +54,11 @@ describe('Integration | Identity Access Management | Domain | UseCase | update-u
   });
 
   context('success cases', function () {
-    let clock;
     let now;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: new Date(), toFake: ['Date'] });
-      now = new Date(clock.now);
-    });
-
-    afterEach(function () {
-      clock.restore();
+      now = new Date();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     context('when user has no Pix authentication method', function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-password.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-password.usecase.test.js
@@ -205,15 +205,10 @@ describe('Integration | Identity Access Management | Domain | UseCase | update-u
   });
 
   context('emailConfirmedAt', function () {
-    let clock;
     const now = new Date('2002-02-02');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('is updated', async function () {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
@@ -150,16 +150,11 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
   describe('#updatePassword', function () {
     let userId;
-    let clock;
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
       userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     it('updates the password in database', async function () {
@@ -483,14 +478,8 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
   describe('#updateExternalIdentifierByUserIdAndIdentityProvider', function () {
     context('When authentication method exists', function () {
-      let clock;
-
       beforeEach(async function () {
-        clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
-      });
-
-      afterEach(function () {
-        clock.restore();
+        sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
       });
 
       it('updates external identifier by userId and identity provider', async function () {
@@ -692,10 +681,9 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   describe('#updateAuthenticationComplementByUserIdAndIdentityProvider', function () {
     context('When authentication method exists', function () {
       let authenticationMethod;
-      let clock;
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
+        sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
         const userId = databaseBuilder.factory.buildUser().id;
         authenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
           id: 123,
@@ -706,10 +694,6 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           userId,
         });
         return databaseBuilder.commit();
-      });
-
-      afterEach(function () {
-        clock.restore();
       });
 
       it('updates the authentication complement in database', async function () {
@@ -969,7 +953,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         // given
         const now = new Date('2021-01-02');
         const createdAt = new Date('2020-01-02');
-        const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
         const identityProvider = NON_OIDC_IDENTITY_PROVIDERS.PIX.code;
         const userId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
@@ -992,8 +976,6 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(updatedAuthenticationMethod).to.exist;
         expect(updatedAuthenticationMethod.createdAt.toISOString()).to.equal(createdAt.toISOString());
         expect(updatedAuthenticationMethod.lastLoggedAt.toISOString()).to.equal(now.toISOString());
-
-        clock.restore();
       });
     });
   });
@@ -1172,15 +1154,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   });
 
   describe('#updateAuthenticationMethodUserId', function () {
-    let clock;
     const now = new Date('2022-02-16');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('updates authentication method user id', async function () {
@@ -1207,16 +1184,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   });
 
   describe('#update', function () {
-    let clock;
-
-    afterEach(async function () {
-      clock.restore();
-    });
-
     it('updates authentication method complement', async function () {
       // given
       const now = new Date('2022-03-15');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       const userId = databaseBuilder.factory.buildUser().id;
       const authenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user-login-repository_test.js
@@ -86,15 +86,10 @@ describe('Integration | Shared | Infrastructure | Repositories | UserLoginReposi
   });
 
   describe('#update', function () {
-    let clock;
     const now = new Date('2022-11-24');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('returns the updated user-login', async function () {
@@ -189,15 +184,10 @@ describe('Integration | Shared | Infrastructure | Repositories | UserLoginReposi
   });
 
   describe('#updateLastLoggedAt', function () {
-    let clock;
     const now = new Date('2020-01-02');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     context('when a user-login exists for given user id', function () {
@@ -233,15 +223,10 @@ describe('Integration | Shared | Infrastructure | Repositories | UserLoginReposi
   });
 
   describe('#batchUnblock', function () {
-    let clock;
     const now = new Date('2025-05-05');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('resets account blocking for the given accounts', async function () {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -32,15 +32,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   let userInDB;
   let passwordAuthenticationMethodInDB;
 
-  let clock;
   const now = new Date('2022-12-24');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   function _insertUserWithOrganizationsAndCertificationCenterAccesses() {

--- a/api/tests/identity-access-management/unit/domain/models/AccountRecoveryDemand.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/AccountRecoveryDemand.test.js
@@ -7,7 +7,7 @@ describe('Unit | Identity Access Management | Domain | Model | AccountRecoveryDe
   const now = new Date('2022-11-28T12:00:00Z');
 
   beforeEach(function () {
-    sinon.useFakeTimers({ now });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#hasExpired', function () {

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -313,15 +313,11 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
   });
 
   describe('#markEmailAsValid', function () {
-    let clock, now;
+    let now;
 
     beforeEach(function () {
       now = new Date('2024-06-11');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('marks user email as valid by setting a date on "emailConfirmedAt" attribute', function () {
@@ -406,15 +402,10 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
   });
 
   describe('#anonymize', function () {
-    let clock;
     const now = new Date('2023-09-19T01:02:03Z');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('anonymizes user info', function () {
@@ -447,15 +438,10 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
   });
 
   describe('#convertAnonymousToRealUser', function () {
-    let clock;
     const now = new Date('2023-09-19T01:02:03Z');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('upgrades anonymous user to real user', function () {

--- a/api/tests/identity-access-management/unit/domain/models/UserLogin_test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserLogin_test.js
@@ -6,15 +6,10 @@ import { expect } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | Domain | Models | UserLogin', function () {
-  let clock;
   const now = new Date('2022-11-28T12:00:00Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#remainingAttempts', function () {

--- a/api/tests/identity-access-management/unit/domain/models/UserToCreate.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserToCreate.test.js
@@ -74,7 +74,7 @@ describe('Unit | Identity Access Management | Domain | Model | UserToCreate', fu
     it('creates a user', function () {
       // given
       const now = new Date('2022-04-01');
-      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       // when
       const user = UserToCreate.create({ email: '  anneMAIL@example.net ', locale: 'fr-FR' });
@@ -84,7 +84,6 @@ describe('Unit | Identity Access Management | Domain | Model | UserToCreate', fu
       expect(user.updatedAt).to.deep.equal(now);
       expect(user.createdAt).to.deep.equal(now);
       expect(user.locale).to.equal('fr-FR');
-      clock.restore();
     });
   });
 
@@ -92,7 +91,7 @@ describe('Unit | Identity Access Management | Domain | Model | UserToCreate', fu
     it('should create a user from pole emploi', function () {
       // given
       const now = new Date('2022-04-01');
-      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       // when
       const user = UserToCreate.createWithTermsOfServiceAccepted({ email: '  anneMAIL@example.net ' });
@@ -102,7 +101,6 @@ describe('Unit | Identity Access Management | Domain | Model | UserToCreate', fu
       expect(user.lastTermsOfServiceValidatedAt).to.deep.equal(now);
       expect(user.updatedAt).to.deep.equal(now);
       expect(user.createdAt).to.deep.equal(now);
-      clock.restore();
     });
   });
 
@@ -110,7 +108,7 @@ describe('Unit | Identity Access Management | Domain | Model | UserToCreate', fu
     it('should create an anonymous user', function () {
       // given
       const now = new Date('2022-04-01');
-      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       // when
       const user = UserToCreate.createAnonymous({ email: '  anneMAIL@example.net ' });
@@ -119,7 +117,6 @@ describe('Unit | Identity Access Management | Domain | Model | UserToCreate', fu
       expect(user.isAnonymous).to.equal(true);
       expect(user.updatedAt).to.deep.equal(now);
       expect(user.createdAt).to.deep.equal(now);
-      clock.restore();
     });
   });
 });

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -29,10 +29,6 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     openidClient = createOpenIdClientMock(MOCK_OIDC_PROVIDER_CONFIG);
   });
 
-  afterEach(function () {
-    clock.restore();
-  });
-
   describe('constructor', function () {
     context('when no parameter provided', function () {
       it('creates an instance with default values', function () {

--- a/api/tests/identity-access-management/unit/domain/usecases/anonymize-gar-authentication-methods.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/anonymize-gar-authentication-methods.usecase.test.js
@@ -7,18 +7,13 @@ import { AuditLoggingJob } from '../../../../../src/shared/domain/models/jobs/Au
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | anonymize-gar-authentication-methods', function () {
-  let clock;
   let auditLoggingJobRepository;
 
   beforeEach(function () {
     const now = new Date('2023-08-17');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     auditLoggingJobRepository = { performAsync: sinon.stub().resolves() };
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   it('processes user GAR anonymisation in batch and returns anonymized / total of userIds', async function () {

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
@@ -106,7 +106,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
 
     it('saves last login date when authentication succeeds', async function () {
       // given
-      const clock = sinon.useFakeTimers({
+      sinon.useFakeTimers({
         now: new Date(),
         toFake: ['Date'],
       });
@@ -160,7 +160,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
         application: requestedApplication.applicationName,
         lastLoggedAt: new Date(),
       });
-      clock.restore();
     });
 
     it("throws an UnexpectedUserAccountError (with expected user's username or email) when the authenticated user does not match the expected one", async function () {

--- a/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
@@ -80,15 +80,10 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   });
 
   context('when user already exists in database', function () {
-    let clock;
     const now = new Date('2022-03-13');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return access token url', async function () {

--- a/api/tests/identity-access-management/unit/domain/usecases/remember-user-has-seen-last-data-protection-policy-information.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/remember-user-has-seen-last-data-protection-policy-information.usecase.test.js
@@ -6,19 +6,14 @@ import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | remember-user-has-seen-data-protection-policy-information', function () {
   let userRepository;
-  let clock;
   let now;
 
   beforeEach(function () {
     now = new Date('2022-12-24');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     userRepository = {
       updateLastDataProtectionPolicySeenAt: sinon.stub(),
     };
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   it('updates the last data protection policy to now', async function () {

--- a/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
@@ -7,7 +7,7 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 
 describe('Unit | Identity Access Management | Domain | UseCase | validate-user-account-email', function () {
   let emailValidationDemandRepository, userRepository;
-  let clock, now;
+  let now;
 
   const token = '00000000-0000-0000-0000-000000000000';
   const defaultRedirectionUrl = 'https://test.app.pix.fr/connexion';
@@ -22,14 +22,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | validate-user-a
       update: sinon.stub(),
     };
 
-    clock = sinon.useFakeTimers({ now: new Date('2024-06-26'), toFake: ['Date'] });
-    now = new Date(clock.now);
+    now = new Date('2024-06-26');
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     sinon.stub(logger, 'error');
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   context('when token property is not given', function () {

--- a/api/tests/legal-documents/integration/scripts/convert-users-pix-app-cgu-data.test.js
+++ b/api/tests/legal-documents/integration/scripts/convert-users-pix-app-cgu-data.test.js
@@ -41,18 +41,13 @@ describe('Integration | Legal documents | Scripts | convert-users-pix-app-cgu-da
   });
 
   describe('#handle', function () {
-    let clock;
     let legalDocumentVersion;
     let logger;
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now: new Date('2024-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2024-01-01'), toFake: ['Date'] });
       legalDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({ type: TOS, service: PIX_APP });
       logger = { info: sinon.stub() };
-    });
-
-    afterEach(async function () {
-      clock.restore();
     });
 
     it('converts Pix App user cgus to legal document user acceptances', async function () {

--- a/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
@@ -13,12 +13,8 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
     let clock, now;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2025-09-26'));
-      now = new Date(clock.now);
-    });
-
-    afterEach(function () {
-      clock.restore();
+      now = new Date('2025-09-26');
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     context('when there is no chats or messages existing in database with chat id passed in parameter', function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/add-organization-feature-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/add-organization-feature-in-batch.usecase.test.js
@@ -67,12 +67,12 @@ describe('Integration | Organizational Entities | Domain | UseCase | add-organiz
     let activeOrganizationLearnerId, deletedOrganizationLearnerId;
     let oldUserDeletedLearnerId;
     let oldDeletedAt;
-    let clock, now;
+    let now;
 
     beforeEach(async function () {
       now = new Date('2025-01-01');
 
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
       oldDeletedAt = new Date('2024-12-12');
 
       oldUserDeletedLearnerId = databaseBuilder.factory.buildUser().id;
@@ -88,10 +88,6 @@ describe('Integration | Organizational Entities | Domain | UseCase | add-organiz
       }).id;
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     it('should not delete learners without parameters', async function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-certification-center.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-certification-center.usecase.test.js
@@ -13,7 +13,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     const creationDate = new Date(2021, 1, 1);
     const lastUpdateBeforeArchive = new Date(2022, 2, 2);
     const now = new Date(2023, 3, 3);
-    const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     const pendingStatus = CertificationCenterInvitation.StatusType.PENDING;
     const superAdminUser = databaseBuilder.factory.buildUser();
     const user = databaseBuilder.factory.buildUser({});
@@ -63,8 +63,6 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     expect(disabledCertificationCenterMembership.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
 
     expect(deletedCertificationCenterInvitation).to.be.empty;
-
-    clock.restore();
   });
 
   it('throws an error if certification center does not exist', async function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-certification-centers-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-certification-centers-in-batch.usecase.test.js
@@ -14,7 +14,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     const creationDate = new Date(2021, 1, 1);
     const lastUpdateBeforeArchive = new Date(2022, 2, 2);
     const now = new Date(2023, 3, 3);
-    const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     const pendingStatus = CertificationCenterInvitation.StatusType.PENDING;
     const superAdminUser = databaseBuilder.factory.buildUser();
     const user = databaseBuilder.factory.buildUser({});
@@ -103,8 +103,6 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-cer
     expect(disabledCertificationCenter2Membership.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
 
     expect(deletedCertificationCenter2Invitation).to.be.empty;
-
-    clock.restore();
   });
 
   context('when certification center does not exist', function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
@@ -14,7 +14,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
       it('archives the organization', async function () {
         // given
         const now = new Date('2022-02-22');
-        const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
         const superAdminUser = databaseBuilder.factory.buildUser.withRole();
         const organization = databaseBuilder.factory.buildOrganization();
         await databaseBuilder.commit();
@@ -29,14 +29,12 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
         expect(archivedOrganization.archivedAt).to.deep.equal(now);
         expect(archivedOrganization.archivistFirstName).to.deep.equal(superAdminUser.firstName);
         expect(archivedOrganization.archivistLastName).to.deep.equal(superAdminUser.lastName);
-
-        clock.restore();
       });
 
       it('deletes the active campaigns of the organization', async function () {
         // given
         const now = new Date('2022-02-02');
-        const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
         const previousDate = new Date('2021-01-01');
         const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -60,14 +58,12 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
 
         const previouslyArchivedCampaigns = await knex('campaigns').where({ archivedAt: previousDate });
         expect(previouslyArchivedCampaigns).to.have.lengthOf(1);
-
-        clock.restore();
       });
 
       it('deletes the organization learners', async function () {
         // given
         const now = new Date('2022-02-02');
-        const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
         const previousDate = new Date('2021-01-01');
         const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -91,14 +87,12 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
 
         const previouslyDeletedLearners = await knex('organization-learners').where({ deletedAt: previousDate });
         expect(previouslyDeletedLearners).to.have.lengthOf(1);
-
-        clock.restore();
       });
 
       it('deletes the campaign participations of the organization', async function () {
         // given
         const now = new Date('2022-02-02');
-        const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
         const previousDate = new Date('2021-01-01');
         const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -124,8 +118,6 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
           deletedAt: previousDate,
         });
         expect(previouslyDeletedParticipations).to.have.lengthOf(1);
-
-        clock.restore();
       });
     });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
@@ -8,15 +8,11 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | archive-organizations-in-batch', function () {
-  let now, clock;
+  let now;
 
   beforeEach(function () {
     now = new Date('2025-01-01');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('success', function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin.repository.test.js
@@ -8,15 +8,10 @@ import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 
 describe('Integration | Organizational Entities | Infrastructure | Repository | certification-center-for-admin', function () {
-  let clock;
   const now = new Date('2021-11-16');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#save', function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
@@ -11,15 +11,11 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Organizational Entities | Infrastructure | Repository | Certification Center', function () {
-  let clock, now;
+  let now;
 
   beforeEach(function () {
     now = new Date('2021-11-16');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#getById', function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -14,21 +14,17 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Organizational Entities | Infrastructure | Repository | organization-for-admin', function () {
-  let clock, byDefaultFeatureId, administrationTeam, organizationLearnerType, domainOrganizationLearnerType;
+  let byDefaultFeatureId, administrationTeam, organizationLearnerType, domainOrganizationLearnerType;
   const now = new Date('2022-02-02');
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     administrationTeam = databaseBuilder.factory.buildAdministrationTeam({ name: 'ma team' });
     organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType();
     domainOrganizationLearnerType = domainBuilder.acquisition.buildOrganizationLearnerType({
       ...organizationLearnerType,
     });
     await databaseBuilder.commit();
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   describe('#findPaginatedFiltered', function () {

--- a/api/tests/organizational-entities/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/organizational-entities/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -312,7 +312,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
   context('#isAccessBlockedCollege', function () {
     let validData;
-    let clock;
 
     beforeEach(function () {
       validData = {
@@ -326,13 +325,9 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       };
     });
 
-    afterEach(function () {
-      clock.restore();
-    });
-
     it('should return false when certification center is not a college', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['COLLEGEee', 'some_other_tag'],
@@ -347,7 +342,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is also a lycee', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['COLLEGE', 'LYCEE', 'some_other_tag'],
@@ -362,7 +357,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is whitelisted', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         center: { ...validData.center, isInWhitelist: true },
@@ -377,7 +372,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when current date is after the college date limit', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess(validData);
 
       // when
@@ -389,7 +384,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true otherwise all above conditions', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess(validData);
 
       // when
@@ -402,7 +397,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
   context('#isAccessBlockedLycee', function () {
     let validData;
-    let clock;
 
     beforeEach(function () {
       validData = {
@@ -416,13 +410,9 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       };
     });
 
-    afterEach(function () {
-      clock.restore();
-    });
-
     it('should return false when certification center is not a lycee', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['LYCEE PROU', 'some_other_tag'],
@@ -437,7 +427,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is whitelisted', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         center: { ...validData.center, isInWhitelist: true },
@@ -452,7 +442,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when current date is after the lycee date limit', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess(validData);
 
       // when
@@ -464,7 +454,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true otherwise all above conditions', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccessLycee = new AllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['LYCEE'],
@@ -486,7 +476,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
   context('#isAccessBlockedAEFE', function () {
     let validData;
-    let clock;
 
     beforeEach(function () {
       validData = {
@@ -500,13 +489,9 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       };
     });
 
-    afterEach(function () {
-      clock.restore();
-    });
-
     it('should return false when certification center is not AEFE', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['LYCEE PROU', 'some_other_tag'],
@@ -521,7 +506,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is whitelisted', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         center: { ...validData.center, isInWhitelist: true },
@@ -536,7 +521,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when current date is after the lycee date limit', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess(validData);
 
       // when
@@ -548,7 +533,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true otherwise all above conditions', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccessAEFE = new AllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['AEFE'],
@@ -564,7 +549,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
   context('#isAccessBlockedAgri', function () {
     let validData;
-    let clock;
 
     beforeEach(function () {
       validData = {
@@ -578,13 +562,9 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       };
     });
 
-    afterEach(function () {
-      clock.restore();
-    });
-
     it('should return false when certification center is not AGRICULTURE', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['LYCEE PROU', 'some_other_tag'],
@@ -599,7 +579,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is whitelisted', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess({
         ...validData,
         center: { ...validData.center, isInWhitelist: true },
@@ -614,7 +594,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when current date is after the lycee date limit', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = new AllowedCertificationCenterAccess(validData);
 
       // when
@@ -626,7 +606,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true otherwise all above conditions', function () {
       // given
-      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccessAgri = new AllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['AGRICULTURE'],

--- a/api/tests/organizational-entities/unit/domain/read-models/PlacesLot_test.js
+++ b/api/tests/organizational-entities/unit/domain/read-models/PlacesLot_test.js
@@ -4,15 +4,10 @@ import { PlacesLot } from '../../../../../src/organizational-entities/domain/rea
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Domain | ReadModels | PlacesLot', function () {
-  let clock;
   const now = new Date('2021-05-01');
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#count', function () {

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -375,11 +375,11 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
 
     let server, badge1, badge2, stage;
 
-    let recentDate, clock;
+    let recentDate;
 
     beforeEach(async function () {
       server = await createServer();
-      clock = sinon.useFakeTimers({ now: new Date('2018-05-07'), toFake: ['Date'] });
+      sinon.useFakeTimers({ now: new Date('2018-05-07'), toFake: ['Date'] });
       const oldDate = new Date('2018-02-03');
       recentDate = new Date('2018-05-06');
       const futureDate = new Date('2018-07-10');
@@ -561,9 +561,6 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
       databaseBuilder.factory.learningContent.build(learningContentObjects);
       await databaseBuilder.commit();
-    });
-    afterEach(function () {
-      clock.restore();
     });
 
     it('should return the campaign assessment result', async function () {

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
@@ -20,7 +20,7 @@ const {
 } = databaseBuilder.factory;
 
 describe('Integration | UseCases | delete-campaign-participation', function () {
-  let clock, now;
+  let now;
   let adminUserId;
   let campaignId;
   let userId;
@@ -30,7 +30,7 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
 
   beforeEach(async function () {
     now = new Date('2023-03-03');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     adminUserId = databaseBuilder.factory.buildUser().id;
     userId = databaseBuilder.factory.buildUser().id;
@@ -48,10 +48,6 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
     }).id;
 
     await databaseBuilder.commit();
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   it('should delete all campaignParticipations with anonymization', async function () {

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -30,7 +30,6 @@ const { STARTED, SHARED } = CampaignParticipationStatuses;
 describe('Integration | Repository | Campaign Participation', function () {
   describe('#updateWithSnapshot', function () {
     context('when campaign is of type ASSESSMENT', function () {
-      let clock;
       let campaignParticipation;
       let ke;
       const frozenTime = new Date('1987-09-01T00:00:00Z');
@@ -50,13 +49,9 @@ describe('Integration | Repository | Campaign Participation', function () {
           userId: campaignParticipation.userId,
           createdAt: new Date('1985-09-01T00:00:00Z'),
         });
-        clock = sinon.useFakeTimers({ now: frozenTime, toFake: ['Date'] });
+        sinon.useFakeTimers({ now: frozenTime, toFake: ['Date'] });
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(function () {
-        clock.restore();
       });
 
       it('persists the campaign-participation changes shared status and date only', async function () {

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -21,15 +21,10 @@ const { SHARED } = CampaignParticipationStatuses;
 
 describe('Unit | Domain | Models | CampaignParticipation', function () {
   describe('delete', function () {
-    let clock;
     const now = new Date('2021-09-25');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
     });
 
     it('updates attributes deletedAt,deletedBy and userId', function () {
@@ -112,15 +107,10 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
 
   describe('share', function () {
     context('when the campaign is not archived nor deleted', function () {
-      let clock;
       const now = new Date('2021-09-25');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
-      });
-
-      afterEach(function () {
-        clock.restore();
+        sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
       });
 
       context('when the campaign is already shared', function () {

--- a/api/tests/prescription/campaign-participation/unit/domain/models/PreviousCampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/PreviousCampaignParticipation_test.js
@@ -38,11 +38,11 @@ describe('Unit | Domain | Read-Models | PreviousCampaignParticipation', function
   });
 
   describe('#canReset', function () {
-    let clock, now, baseProps;
+    let now, baseProps;
 
     beforeEach(function () {
       now = new Date('2020-01-07T05:06:07Z');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       baseProps = {
         id: 1,
@@ -56,10 +56,6 @@ describe('Unit | Domain | Read-Models | PreviousCampaignParticipation', function
         isOrganizationLearnerActive: true,
         sharedAt: new Date('2020-01-01T01:02:03Z'),
       };
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     describe('when isShared is not defined', function () {

--- a/api/tests/prescription/campaign-participation/unit/domain/read-models/AssessmentResult_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/read-models/AssessmentResult_test.js
@@ -378,15 +378,11 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
   });
 
   describe('#remainingSecondsBeforeRetrying', function () {
-    let clock, now;
+    let now;
 
     beforeEach(function () {
       now = new Date('2020-01-05T05:06:07Z');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     context('when participation is not shared', function () {
@@ -757,15 +753,11 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
   });
 
   describe('#canReset', function () {
-    let clock, now;
+    let now;
 
     beforeEach(function () {
       now = new Date('2020-01-05T05:06:07Z');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     context('when the campaign does not allow multiple sendings', function () {

--- a/api/tests/prescription/campaign-participation/unit/domain/read-models/CampaignParticipationOverview_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/read-models/CampaignParticipationOverview_test.js
@@ -114,15 +114,10 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
   });
 
   describe('#computeCanRetry', function () {
-    let clock;
     const now = new Date('2023-01-15');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return true when all conditions are met', function () {
@@ -327,15 +322,10 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
   });
 
   describe('#_timeBeforeRetryingPassed', function () {
-    let clock;
     const now = new Date('2023-01-15');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return true when delay has passed', function () {

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -18,11 +18,11 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
     const isCampaignArchived = false;
     const sharedAt = new Date('2020-01-01');
     let participationResults, competences, stages, badgeResultsDTO, reachedStage;
-    let clock, now;
+    let now;
 
     beforeEach(function () {
       now = new Date('2020-01-04');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       const knowledgeElements = [
         domainBuilder.buildKnowledgeElement({
@@ -94,9 +94,6 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           acquisitionPercentage: null,
         },
       ];
-    });
-    afterEach(function () {
-      clock.restore();
     });
 
     it('should convert a CampaignParticipationResult model object into JSON API data', function () {

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -6,15 +6,9 @@ import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer', function () {
-  let clock;
-
-  afterEach(function () {
-    clock.restore();
-  });
-
   beforeEach(function () {
     const now = new Date('2020-01-02');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   let profileSharedForCampaign;

--- a/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
@@ -32,16 +32,11 @@ const {
 
 describe('Integration | UseCases | delete-campaign', function () {
   describe('success case', function () {
-    let clock;
     let now;
 
     beforeEach(function () {
       now = new Date('1992-07-07');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should not throw when user is admin of the organization', async function () {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -687,11 +687,10 @@ describe('Integration | Repository | Campaign Administration', function () {
 
   describe('#removeInBatch', function () {
     let campaign1, campaign2, userId;
-    let clock;
     const frozenTime = new Date('1992-07-07');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: frozenTime, toFake: ['Date'] });
+      sinon.useFakeTimers({ now: frozenTime, toFake: ['Date'] });
 
       campaign1 = new Campaign(
         databaseBuilder.factory.buildCampaign({
@@ -711,10 +710,6 @@ describe('Integration | Repository | Campaign Administration', function () {
       userId = databaseBuilder.factory.buildUser().id;
 
       return databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     it('should remove the correct campaigns', async function () {
@@ -863,15 +858,10 @@ describe('Integration | Repository | Campaign Administration', function () {
   });
 
   describe('#archiveCampaigns', function () {
-    let clock;
     const now = new Date('2023-02-02');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('Mark list of campaign to archived', async function () {

--- a/api/tests/prescription/campaign/unit/domain/models/Campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/Campaign_test.js
@@ -13,11 +13,10 @@ import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Campaign', function () {
   let campaign;
-  let clock;
   const now = new Date('2022-11-28T12:00:00Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     campaign = new Campaign({
       id: 1,
       type: CampaignTypes.ASSESSMENT,
@@ -29,10 +28,6 @@ describe('Campaign', function () {
       title: 'Minus One',
       multipleSendings: true,
     });
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   describe('#isDeleted', function () {

--- a/api/tests/prescription/campaign/unit/domain/usecases/archive-campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/archive-campaign_test.js
@@ -5,21 +5,16 @@ import { archiveCampaign } from '../../../../../../src/prescription/campaign/dom
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | archive-campaign', function () {
-  let clock;
   let now;
   let campaignAdministrationRepository;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
-    now = new Date(clock.now);
+    now = new Date('2022-01-01');
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     campaignAdministrationRepository = {
       get: sinon.stub(),
       update: sinon.stub(),
     };
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   it('should update the campaign', async function () {

--- a/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
@@ -34,7 +34,7 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
   let campaignParticipation1;
   const participantExternalId = 'foo';
   let adminUserId;
-  let now, clock;
+  let now;
 
   beforeEach(async function () {
     adminUserId = buildUser().id;
@@ -59,11 +59,7 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
     await databaseBuilder.commit();
 
     now = new Date('2023-03-03');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when no organization learner is provided', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
@@ -111,16 +111,12 @@ describe('Integration | Repository | Organization Learner Management | Organizat
     });
   });
   describe('#save', function () {
-    let clock, userId;
+    let userId;
     const now = new Date('2022-02-02');
     const updatedAt = new Date('2020-01-01');
 
-    afterEach(function () {
-      clock.restore();
-    });
-
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       userId = databaseBuilder.factory.buildUser().id;
       // First format

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -67,15 +67,10 @@ describe('Integration | Repository | Organization Learner Management | Organizat
   });
 
   describe('#updateInBatchByIds', function () {
-    let clock;
     const now = new Date('2023-02-02');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('update given organization learner', async function () {
@@ -648,15 +643,10 @@ describe('Integration | Repository | Organization Learner Management | Organizat
     });
 
     context('update existing learner', function () {
-      let clock;
       const now = new Date('2023-02-02');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      });
-
-      afterEach(function () {
-        clock.restore();
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       it('should update existing learner', async function () {
@@ -724,17 +714,12 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
   describe('#disableCommonOrganizationLearnersFromOrganizationId', function () {
     let organizationId;
-    let clock;
     const now = new Date('2023-08-17');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
       organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     it('should set isDisabled to true and set updatedAt with today on organization learner', async function () {

--- a/api/tests/prescription/learner-management/unit/application/jobs/schedule-compute-organization-learners-certificability-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/schedule-compute-organization-learners-certificability-job-controller_test.js
@@ -17,7 +17,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
     let computeCertificabilityJobRepository;
     let organizationLearnerRepository;
     let logger;
-    let clock;
     let config;
     let fromUserActivityDate;
     let toUserActivityDate;
@@ -31,7 +30,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         });
 
       const now = dayjs('2023-10-02T21:00:01').tz('Europe/Paris').toDate();
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       config = {
         features: {
@@ -65,10 +64,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
       logger = {
         info: sinon.stub(),
       };
-    });
-
-    afterEach(async function () {
-      clock.restore();
     });
 
     context('when computation is asynchronous', function () {

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationImportStatus_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationImportStatus_test.js
@@ -5,17 +5,11 @@ import { OrganizationImportStatus } from '../../../../../../src/prescription/lea
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Models | OrganizationImportStatus', function () {
-  let clock;
-
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({
+    sinon.useFakeTimers({
       now: new Date('2023-01-01'),
       toFake: ['Date'],
     });
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   it('should instantiate an OrganizationImportStatus', function () {

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
@@ -52,16 +52,11 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
   });
 
   describe('#delete', function () {
-    let clock;
     let now;
 
     beforeEach(function () {
       now = new Date('2025-01-01');
-      clock = sinon.useFakeTimers(now, 'Date');
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should anonymize attributes using importFormat rules', function () {
@@ -220,16 +215,11 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
   });
 
   describe('#detachUser', function () {
-    let clock;
     let now;
 
     beforeEach(function () {
       now = new Date('2025-01-01');
-      clock = sinon.useFakeTimers(now, 'Date');
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should detach userId', function () {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
@@ -20,8 +20,7 @@ const supOrganizationLearnerImportHeader = new SupHeader(i18n).columns.map((colu
 describe('Unit | UseCase | uploadCsvFile', function () {
   const organizationId = 1;
   const userId = 2;
-  let timer,
-    fakeDate,
+  let fakeDate,
     organizationImportRepositoryStub,
     importStorageStub,
     payload,
@@ -50,7 +49,7 @@ describe('Unit | UseCase | uploadCsvFile', function () {
     filepath = await createTempFile('file.csv', csvContent);
     payload = { path: filepath };
     fakeDate = new Date('2019-01-10');
-    timer = sinon.useFakeTimers({
+    sinon.useFakeTimers({
       now: fakeDate,
       toFake: ['Date'],
     });
@@ -82,7 +81,6 @@ describe('Unit | UseCase | uploadCsvFile', function () {
   });
 
   afterEach(async function () {
-    timer.restore();
     await removeTempFile(filepath);
   });
 

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/generate-organization-learners-username-and-temporary-password_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/generate-organization-learners-username-and-temporary-password_test.js
@@ -14,7 +14,6 @@ describe('Integration | UseCases | generate organization learners username and t
   const generatedPassword = 'abcdef12';
   let cryptoService, passwordGenerator;
 
-  let clock;
   const now = new Date('2025-05-05');
 
   const allAuthenticationMethodUsername = 'laurent.bar';
@@ -31,7 +30,7 @@ describe('Integration | UseCases | generate organization learners username and t
   let aNotToTouchBlockedUserId;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     organization = domainBuilder.buildOrganization({ id: undefined });
     cryptoService = { hashPassword: sinon.stub().resolves(hashedPassword) };
@@ -92,10 +91,6 @@ describe('Integration | UseCases | generate organization learners username and t
     });
 
     userId = databaseBuilder.factory.buildUser().id;
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   context('When organization is of type SCO and has isManagingStudents at true', function () {

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/compute-organization-learner-certificability_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/compute-organization-learner-certificability_test.js
@@ -5,17 +5,11 @@ import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | UseCase | compute-organization-learner-certificabilty', function () {
-  let clock;
-
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({
+    sinon.useFakeTimers({
       now: Date.now(),
       toFake: ['Date'],
     });
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   it('should update certificability for an organization learner', async function () {

--- a/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
@@ -9,15 +9,10 @@ import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 
 describe('Integration | UseCases | get-data-organizations-places-statistics', function () {
-  let clock;
   const now = new Date('2021-05-01');
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('should return places statistics for all organizations', async function () {

--- a/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
+++ b/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
@@ -314,17 +314,11 @@ describe('Integration | Repository | Organization Places Lot', function () {
   });
 
   describe('#delete', function () {
-    let clock;
-
     beforeEach(function () {
-      clock = sinon.useFakeTimers({
+      sinon.useFakeTimers({
         now: Date.now(),
         toFake: ['Date'],
       });
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     it('should mark place as deleted', async function () {

--- a/api/tests/prescription/organization-place/unit/domain/read-models/DataOrganizationPlacesStatistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/DataOrganizationPlacesStatistics_test.js
@@ -7,15 +7,10 @@ import { PlaceStatistics } from '../../../../../../src/prescription/organization
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | ReadModels | DataOrganizationPlacesStatistics', function () {
-  let clock;
   const now = new Date('2021-05-01');
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('create DataOrganizationPlacesStatistics', function () {

--- a/api/tests/prescription/organization-place/unit/domain/read-models/OrganizationPlacesLotManagement_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/OrganizationPlacesLotManagement_test.js
@@ -37,15 +37,10 @@ describe('Unit | Domain | ReadModels | organizationPlacesLotManagement', functio
   });
 
   describe('#status', function () {
-    let clock;
     const now = new Date('2021-05-01');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('have expired status when expirationDate has passed.', function () {

--- a/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
@@ -6,15 +6,10 @@ import { config } from '../../../../../../src/shared/config.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
-  let clock;
   const now = new Date('2021-05-01');
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#buildFrom', function () {

--- a/api/tests/prescription/organization-place/unit/domain/read-models/PlacesLot_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/PlacesLot_test.js
@@ -4,15 +4,10 @@ import { PlacesLot } from '../../../../../../src/prescription/organization-place
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | ReadModels | PlacesLot', function () {
-  let clock;
   const now = new Date('2021-05-01');
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#count', function () {

--- a/api/tests/prescription/scripts/integration/delete-and-anonymise-organization-learners_test.js
+++ b/api/tests/prescription/scripts/integration/delete-and-anonymise-organization-learners_test.js
@@ -39,11 +39,11 @@ describe('DeleteAndAnonymiseOrganizationLearnerScript', function () {
     });
 
     describe('anonymise organization learners', function () {
-      let learner, otherLearner, campaign, organization, clock, now;
+      let learner, otherLearner, campaign, organization, now;
 
       beforeEach(async function () {
         now = new Date('2024-01-17');
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
 
         databaseBuilder.factory.buildUser({ id: ENGINEERING_USER_ID });
         organization = databaseBuilder.factory.buildOrganization();
@@ -60,10 +60,6 @@ describe('DeleteAndAnonymiseOrganizationLearnerScript', function () {
         });
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(function () {
-        clock.restore();
       });
 
       it('delete organization learners', async function () {

--- a/api/tests/prescription/scripts/integration/delete-organization-learners-from-organization_test.js
+++ b/api/tests/prescription/scripts/integration/delete-organization-learners-from-organization_test.js
@@ -33,21 +33,17 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
   });
 
   describe('Handle', function () {
-    let clock, now, script, logger;
+    let now, script, logger;
     const ENGINEERING_USER_ID = 99999;
 
     beforeEach(async function () {
       script = new DeleteOrganizationLearnersFromOrganizationScript();
       now = new Date('2024-01-17');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
       logger = { info: sinon.spy(), error: sinon.spy() };
       sinon.stub(process, 'env').value({ ENGINEERING_USER_ID });
       databaseBuilder.factory.buildUser({ id: process.env.ENGINEERING_USER_ID });
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      clock.restore();
     });
 
     it('delete one learner from given organizationId', async function () {

--- a/api/tests/prescription/shared/integration/domain/services/knowledge-element-for-participation-service_test.js
+++ b/api/tests/prescription/shared/integration/domain/services/knowledge-element-for-participation-service_test.js
@@ -142,14 +142,8 @@ describe('Integration | Prescription | Shared | Service | KnowledgeElementForPar
       });
 
       context('when campaign is of type EXAM', function () {
-        let clock;
-
         beforeEach(function () {
-          clock = sinon.useFakeTimers(new Date('2021-10-29'));
-        });
-
-        afterEach(function () {
-          clock.restore();
+          sinon.useFakeTimers({ now: new Date('2021-10-29'), toFake: ['Date'] });
         });
 
         context('when a snapshot for this participation already exists', function () {

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profile-controller_test.js
@@ -8,14 +8,8 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
 
 describe('Unit | Controller | admin-target-profile-controller', function () {
-  let clock;
-
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now: new Date('2022-02-01'), toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now: new Date('2022-02-01'), toFake: ['Date'] });
   });
 
   describe('#updateTargetProfile', function () {

--- a/api/tests/privacy/integration/domain/services/anonymize-services/anonymize-user.service.test.js
+++ b/api/tests/privacy/integration/domain/services/anonymize-services/anonymize-user.service.test.js
@@ -16,15 +16,10 @@ const { PIX_ORGA } = LegalDocumentService.VALUES;
 const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Privacy | Domain | Services | AnonymizeServices | anonymize-user', function () {
-  let clock;
   const now = new Date('2024-04-05T03:04:05Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it(`deletes all user’s authentication methods,

--- a/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
@@ -10,18 +10,13 @@ import { mockAttestationStorage } from '../../../../tooling/mocks/attestation-st
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Profile | Integration | Domain | get-attestation-data-for-users', function () {
-  let clock;
   const now = new Date('2022-12-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({
+    sinon.useFakeTimers({
       now,
       toFake: ['Date'],
     });
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   describe('#getAttestationDataForUsers', function () {

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
@@ -10,15 +10,10 @@ import { mockAttestationStorage } from '../../../../tooling/mocks/attestation-st
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Profile | Integration | Domain | get-shared-attestations-for-organization-by-user-ids', function () {
-  let clock;
   const now = new Date('2022-12-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(async function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#getAttestationDataForUsers', function () {

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-user-detail-by-organization-id_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-user-detail-by-organization-id_test.js
@@ -10,18 +10,13 @@ import { buildAttestationUserDetail } from '../../../../tooling/domain-builder/f
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Profile | Integration | Domain | get-shared-attestations-user-detail-by-organization-id', function () {
-  let clock;
   const now = new Date('2022-12-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({
+    sinon.useFakeTimers({
       now,
       toFake: ['Date'],
     });
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   describe('#getSharedAttestationsUserDetailByOrganizationId', function () {

--- a/api/tests/profile/unit/domain/models/User_test.js
+++ b/api/tests/profile/unit/domain/models/User_test.js
@@ -5,18 +5,13 @@ import { normalizeAndRemoveAccents } from '../../../../../src/shared/infrastruct
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Profile | Domain | Models | User', function () {
-  let clock;
   const now = new Date('2022-12-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({
+    sinon.useFakeTimers({
       now,
       toFake: ['Date'],
     });
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   it('should return uppercased firstName', function () {

--- a/api/tests/quest/integration/domain/usecases/can-manage-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/can-manage-combined-course_test.js
@@ -7,15 +7,10 @@ import { databaseBuilder } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Quest | Integration | Application | Usecases | canManageCombinedCourse', function () {
-  let clock;
   const now = new Date('2003-04-05T03:04:05Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when user has membership in combined course organization', function () {

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -12,15 +12,10 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprint-by-id', function () {
-  let clock;
   const now = new Date('2022-11-28T12:00:00Z');
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('should return a combined course blueprint for a given id', async function () {

--- a/api/tests/quest/integration/domain/usecases/has-access-to-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/has-access-to-combined-course_test.js
@@ -6,15 +6,10 @@ import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 
 describe('Quest | Integration | Application | Usecases | hasAccessToCombinedCourse', function () {
-  let clock;
   const now = new Date('2003-04-05T03:04:05Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when user has organization learner in combined course organization', function () {

--- a/api/tests/quest/integration/domain/usecases/update-combined-course-progress_test.js
+++ b/api/tests/quest/integration/domain/usecases/update-combined-course-progress_test.js
@@ -15,15 +15,10 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | Quest | Domain | UseCases | update-combined-course-progress', function () {
-  let clock;
   const now = new Date('2025-07-07');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when combined course is completed', function () {

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -629,15 +629,10 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
   });
 
   describe('#update', function () {
-    let clock;
     const now = new Date('2025-07-07');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should update only given field', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
@@ -213,7 +213,6 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
     let organizationLearner;
     let modulesApi;
     let organizationLearnerApi;
-    let clock;
     const now = new Date('2022-11-28T12:00:00Z');
 
     beforeEach(async function () {
@@ -228,11 +227,7 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
       organizationLearnerApi = {
         get: sinon.stub(),
       };
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should create passage when participations does not exist', async function () {

--- a/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseParticipation_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseParticipation_test.js
@@ -6,15 +6,10 @@ import { expect } from '../../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | CombinedCourseParticipation ', function () {
   describe('complete', function () {
-    let clock;
     const now = new Date('2025-07-07');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should set status to completed, and update date', function () {

--- a/api/tests/school/unit/domain/usecases/activate-school-session_test.js
+++ b/api/tests/school/unit/domain/usecases/activate-school-session_test.js
@@ -4,15 +4,10 @@ import { activateSchoolSession } from '../../../../../src/school/domain/usecases
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Use Cases | activate-school-session', function () {
-  let clock;
   const now = new Date('2022-11-28T12:00:00Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('should update sessionExpirationDate to now + 4h', async function () {

--- a/api/tests/school/unit/domain/usecases/is-school-session-active_test.js
+++ b/api/tests/school/unit/domain/usecases/is-school-session-active_test.js
@@ -4,15 +4,9 @@ import { isSchoolSessionActive } from '../../../../../src/school/domain/usecases
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Use Cases | is-session-active', function () {
-  let clock;
-
   beforeEach(function () {
     const now = new Date('2022-08-04');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('should return false if no sessionExpirationDate found for school', async function () {

--- a/api/tests/shared/integration/infrastructure/repositories/admin-member.repository.test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/admin-member.repository.test.js
@@ -44,15 +44,10 @@ describe('Integration | Shared | Infrastructure | Repositories | adminMember', f
     });
 
     context('when admin member is disabled', function () {
-      let clock;
       const now = new Date('2022-02-16');
 
       beforeEach(async function () {
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      });
-
-      afterEach(async function () {
-        clock.restore();
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       it('should return admin member details', async function () {

--- a/api/tests/shared/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -53,14 +53,9 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
   describe('#findByOrganizationIdAndUpdatedAtOrderByDivision', function () {
     const afterBeginningOfThe2020SchoolYear = new Date('2020-10-15');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: afterBeginningOfThe2020SchoolYear, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: afterBeginningOfThe2020SchoolYear, toFake: ['Date'] });
     });
 
     it('should return instances of OrganizationLearner', async function () {

--- a/api/tests/shared/unit/application/jobs/audit-logging.job-controller.test.js
+++ b/api/tests/shared/unit/application/jobs/audit-logging.job-controller.test.js
@@ -6,14 +6,9 @@ import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Application | Jobs | AuditLoggingJobController', function () {
   const now = new Date(2024, 1, 1);
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('sets up the job controller configuration', async function () {

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -56,15 +56,11 @@ describe('Unit | Domain | Models | Assessment', function () {
   });
 
   describe('#detachCampaignParticipation', function () {
-    let clock, now;
+    let now;
 
     beforeEach(function () {
       now = new Date(2023, 3, 3);
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return the same object without info on campaign and participation', function () {

--- a/api/tests/shared/unit/domain/models/jobs/AuditLoggingJob.test.js
+++ b/api/tests/shared/unit/domain/models/jobs/AuditLoggingJob.test.js
@@ -7,14 +7,9 @@ import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Shared | Domain | Model | Jobs | AuditLoggingJob', function () {
   const now = new Date(2024, 1, 1);
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('AuditLoggingJob.forUser', function () {

--- a/api/tests/shared/unit/infrastructure/jobs/MonitoredJobHandler_test.js
+++ b/api/tests/shared/unit/infrastructure/jobs/MonitoredJobHandler_test.js
@@ -10,7 +10,7 @@ describe('Unit | Share | Infrastructure | Jobs | MonitoringJobHandler', function
       const metricsMock = { addMetricPoint: sinon.stub() };
       const handlerMock = { handle: sinon.stub() };
       const loggerMock = { info: sinon.stub(), error: sinon.stub() };
-      sinon.useFakeTimers({ now: new Date('2022-02-27T13:00:00Z') });
+      sinon.useFakeTimers({ now: new Date('2022-02-27T13:00:00Z'), toFake: ['Date'] });
       const jobData = {
         id: '123',
         data: { foo: 'bar' },
@@ -52,7 +52,7 @@ describe('Unit | Share | Infrastructure | Jobs | MonitoringJobHandler', function
       const metricsMock = { addMetricPoint: sinon.stub() };
       const handlerMock = { handle: sinon.stub().rejects(new Error('error in handler')) };
       const loggerMock = { info: sinon.stub(), error: sinon.stub() };
-      sinon.useFakeTimers({ now: new Date('2022-02-27T13:00:00Z') });
+      sinon.useFakeTimers({ now: new Date('2022-02-27T13:00:00Z'), toFake: ['Date'] });
       const jobData = {
         id: '123',
         data: { foo: 'bar' },

--- a/api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js
+++ b/api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js
@@ -42,7 +42,8 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
     let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers();
+      // InMemoryKeyValueStorage expires its keys with setTimeout
+      clock = sinon.useFakeTimers({ toFake: ['Date', 'setTimeout'] });
     });
 
     it('should resolve with the generated key', async function () {
@@ -133,7 +134,8 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
 
     it('should not change the time to live', async function () {
       // given
-      const clock = sinon.useFakeTimers();
+      // InMemoryKeyValueStorage expires its keys with setTimeout
+      const clock = sinon.useFakeTimers({ toFake: ['Date', 'setTimeout'] });
       const keyWithTtl = await inMemoryKeyValueStorage.save({
         value: {},
         expirationDelaySeconds: 1,
@@ -172,7 +174,8 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
   describe('#expire', function () {
     it('should add an expiration time to the list', async function () {
       // given
-      const clock = sinon.useFakeTimers();
+      // InMemoryKeyValueStorage expires its keys with setTimeout
+      const clock = sinon.useFakeTimers({ toFake: ['Date', 'setTimeout'] });
       const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
 
       // when

--- a/api/tests/shared/unit/infrastructure/repositories/audit-logger-repository.test.js
+++ b/api/tests/shared/unit/infrastructure/repositories/audit-logger-repository.test.js
@@ -10,14 +10,8 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 const { auditLogger } = config;
 
 describe('Unit | Shared | Infrastructure | Repositories | audit-logger-repository', function () {
-  let clock;
-
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now: new Date('2023-08-18T08:31:21Z'), toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now: new Date('2023-08-18T08:31:21Z'), toFake: ['Date'] });
   });
 
   describe('#logEvent', function () {

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
@@ -75,18 +75,13 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
   });
 
   describe('POST /api/admin/certification-centers/{certificationCenterId}/invitations', function () {
-    let clock;
     const now = new Date('2021-05-01');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({
+      sinon.useFakeTimers({
         now,
         toFake: ['Date'],
       });
-    });
-
-    afterEach(async function () {
-      clock.restore();
     });
 
     it('returns 201 HTTP status code with created invitation', async function () {

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -524,18 +524,13 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
   });
 
   describe('PATCH /api/organizations/{id}/resend-invitation', function () {
-    let clock;
     const now = new Date('2022-12-25');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({
+      sinon.useFakeTimers({
         now,
         toFake: ['Date'],
       });
-    });
-
-    afterEach(async function () {
-      clock.restore();
     });
 
     it('should return the matching organization invitation as JSON API', async function () {

--- a/api/tests/team/integration/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/integration/domain/services/organization-invitation.service.test.js
@@ -19,15 +19,10 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Team | Domain | Service | organizationInvitationService', function () {
   describe('#createOrUpdateOrganizationInvitation', function () {
-    let clock;
     const now = new Date('2021-01-02');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('creates a new organization invitation with organizationId, email, role and status', async function () {

--- a/api/tests/team/integration/domain/usecases/cancel-certification-center-invitation_test.js
+++ b/api/tests/team/integration/domain/usecases/cancel-certification-center-invitation_test.js
@@ -10,15 +10,10 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Team | Domain | UseCase | cancel-certification-center-invitation', function () {
   describe('when the invitation exists', function () {
-    let clock;
     const now = new Date('2022-09-25');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
     });
 
     describe('when the invitation is pending', function () {

--- a/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -14,18 +14,13 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Team | UseCase | create-or-update-certification-center-invitation-for-admin', function () {
-  let clock;
   const now = new Date('2022-09-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
+    sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
     sinon
       .stub(mailService, 'sendCertificationCenterInvitationEmail')
       .resolves(EmailingAttempt.success('stub@example.net'));
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   it('creates a new invitation if there isn’t an already pending existing one with given email', async function () {

--- a/api/tests/team/integration/domain/usecases/disable-own-organization-membership.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/disable-own-organization-membership.usecase.test.js
@@ -6,14 +6,8 @@ import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 
 describe('Integration | Team | Domain | UseCase | disable-own-membership', function () {
-  let clock;
-
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now: new Date('2023-08-01T11:15:00Z'), toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now: new Date('2023-08-01T11:15:00Z'), toFake: ['Date'] });
   });
 
   context('success', function () {

--- a/api/tests/team/integration/domain/usecases/update-membership-last-accessed-at.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/update-membership-last-accessed-at.usecase.test.js
@@ -10,15 +10,10 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Team | UseCases | update-membership-last-accessed-at', function () {
-  let clock;
   const now = new Date('2022-12-01');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when the membership does not exist', function () {

--- a/api/tests/team/integration/infrastructure/repositories/admin-member.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/admin-member.repository.test.js
@@ -117,15 +117,10 @@ describe('Integration | Team | Infrastructure | Repositories | adminMember', fun
     });
 
     context('when admin member is disabled', function () {
-      let clock;
       const now = new Date('2022-02-16');
 
       beforeEach(async function () {
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      });
-
-      afterEach(async function () {
-        clock.restore();
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       it('should return admin member details', async function () {
@@ -191,15 +186,10 @@ describe('Integration | Team | Infrastructure | Repositories | adminMember', fun
     });
 
     context('when admin member is disabled', function () {
-      let clock;
       const now = new Date('2022-02-16');
 
       beforeEach(async function () {
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      });
-
-      afterEach(async function () {
-        clock.restore();
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       it('should return admin member details', async function () {
@@ -231,15 +221,10 @@ describe('Integration | Team | Infrastructure | Repositories | adminMember', fun
   });
 
   describe('#update', function () {
-    let clock;
     const now = new Date('2022-02-16');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should return the given Admin role with new role', async function () {
@@ -293,15 +278,10 @@ describe('Integration | Team | Infrastructure | Repositories | adminMember', fun
   });
 
   describe('#deactivate', function () {
-    let clock;
     const now = new Date('2022-02-16');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     it('should update Admin role with disabledAt and updatedAt filled with the date', async function () {

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-invitation-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-invitation-repository_test.js
@@ -7,15 +7,11 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Integration | Team | Infrastructure | Repositories | CertificationCenterInvitationRepository', function () {
-  let clock, now;
+  let now;
 
   beforeEach(function () {
     now = new Date('2023-10-13');
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#update', function () {
@@ -48,7 +44,6 @@ describe('Integration | Team | Infrastructure | Repositories | CertificationCent
         createdAt: invitation.createdAt,
         updatedAt: now,
       });
-      clock.restore();
     });
   });
 
@@ -72,7 +67,6 @@ describe('Integration | Team | Infrastructure | Repositories | CertificationCent
         .where({ id: certificationCenterInvitation.id })
         .first();
       expect(updatedCertificationCenterInvitation.updatedAt).to.deep.equal(now);
-      clock.restore();
     });
   });
 

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-invited-user.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-invited-user.repository.test.js
@@ -110,8 +110,6 @@ describe('Integration | Team | Infrastructure | Repositories | CertificationCent
   });
 
   describe('#save', function () {
-    let clock;
-
     it('creates membership', async function () {
       // given
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ id: 123 }).id;
@@ -144,7 +142,7 @@ describe('Integration | Team | Infrastructure | Repositories | CertificationCent
     it('marks certification center invitation as accepted', async function () {
       // given
       const now = new Date('2021-05-27');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ id: 123 }).id;
       const user = databaseBuilder.factory.buildUser({ id: 6789, email: 'user@example.net' });
@@ -176,7 +174,6 @@ describe('Integration | Team | Infrastructure | Repositories | CertificationCent
       expect(certificationCenterInvitationUpdated.status).to.equal(CertificationCenterInvitation.StatusType.ACCEPTED);
       expect(certificationCenterInvitationUpdated.role).to.equal(CertificationCenterInvitation.Roles.ADMIN);
       expect(certificationCenterInvitationUpdated.updatedAt).to.deep.equal(now);
-      clock.restore();
     });
   });
 });

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -366,7 +366,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
     it('returns certification center membership associated to the certification center', async function () {
       // given
       const now = new Date('2021-01-02');
-      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ updatedAt: now });
       const user = databaseBuilder.factory.buildUser();
@@ -413,7 +413,6 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
 
       expect(associatedUser).to.be.an.instanceOf(User);
       expect(pick(associatedUser, ['id', 'firstName', 'lastName', 'email'])).to.deep.equal(expectedUser);
-      clock.restore();
     });
 
     it('returns certification center membership ordered by role, then lastName and firstName', async function () {
@@ -687,14 +686,9 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
 
   describe('#disableById', function () {
     const now = new Date('2019-01-01T05:06:07Z');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     context('When certification center membership exist', function () {
@@ -866,14 +860,9 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
   describe('#disableMembershipsByUserId', function () {
     const creationDate = new Date('2022-12-05');
     const now = new Date('2024-10-04');
-    let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     context('when there is multiple memberships for the specified user id', function () {

--- a/api/tests/team/integration/infrastructure/repositories/membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/membership.repository.test.js
@@ -15,15 +15,10 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Team | Infrastructure | Repository | membership-repository', function () {
-  let clock;
   const now = new Date('2022-12-01');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#create', function () {

--- a/api/tests/team/integration/infrastructure/repositories/organization-invitation.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/organization-invitation.repository.test.js
@@ -10,15 +10,10 @@ import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Team | Infrastructure | Repository | organization-invitation', function () {
-  let clock;
   const now = new Date('2021-01-02');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('#create', function () {

--- a/api/tests/team/integration/infrastructure/repositories/organization-invited-user.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/organization-invited-user.repository.test.js
@@ -187,15 +187,10 @@ describe('Integration | Team | Infrastructure | Repository | OrganizationInvited
 
   describe('#save', function () {
     describe('when membership exists', function () {
-      let clock;
       const now = new Date('2021-05-27');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      });
-
-      afterEach(function () {
-        clock.restore();
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       it('updates membership role if invitation contains a new role', async function () {
@@ -329,15 +324,10 @@ describe('Integration | Team | Infrastructure | Repository | OrganizationInvited
     });
 
     describe('when membership does not exist', function () {
-      let clock;
       const now = new Date('2021-05-27');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      });
-
-      afterEach(function () {
-        clock.restore();
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       it('creates membership', async function () {

--- a/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -40,22 +40,17 @@ describe('Integration | Team | Infrastructure | Repository | UserOrgaSettings', 
     'organizationLearnerTypeId',
   ];
 
-  let clock;
   const now = new Date('2022-12-01');
 
   let user;
   let organization;
 
   beforeEach(async function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     user = databaseBuilder.factory.buildUser();
     organization = databaseBuilder.factory.buildOrganization();
     await databaseBuilder.commit();
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   describe('#create', function () {

--- a/api/tests/team/unit/domain/models/CertificationCenterMembership_test.js
+++ b/api/tests/team/unit/domain/models/CertificationCenterMembership_test.js
@@ -9,14 +9,9 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 
 describe('Unit | Domain | Models | CertificationCenterMembership', function () {
   const now = new Date('2023-09-12');
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   describe('getters', function () {

--- a/api/tests/team/unit/domain/usecases/create-certification-center-membership-for-sco-organization-admin-member.usecase.test.js
+++ b/api/tests/team/unit/domain/usecases/create-certification-center-membership-for-sco-organization-admin-member.usecase.test.js
@@ -14,11 +14,10 @@ describe('Unit | Team | Domain | UseCase | create-certification-center-membershi
   let membershipRepository;
   let certificationCenterRepository;
   let certificationCenterMembershipRepository;
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(new Date('2023-11-01'));
-    now = new Date(clock.now);
+    now = new Date('2023-11-01');
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
     membershipRepository = {
       get: sinon.stub(),
     };
@@ -31,10 +30,6 @@ describe('Unit | Team | Domain | UseCase | create-certification-center-membershi
       findByCertificationCenterIdAndUserId: sinon.stub(),
       update: sinon.stub(),
     };
-  });
-
-  afterEach(function () {
-    clock.restore();
   });
 
   context('when the organizationRole is ADMIN', function () {

--- a/api/tests/team/unit/domain/usecases/disable-certification-center-membership-from-pix-certif_test.js
+++ b/api/tests/team/unit/domain/usecases/disable-certification-center-membership-from-pix-certif_test.js
@@ -9,7 +9,6 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | disable-certification-center-membership', function () {
   let certificationCenterMembershipRepository;
-  let clock;
   const certificationCenterMembershipId = 100;
   const certificationCenterId = 101;
   const updatedByUserId = 10;
@@ -22,11 +21,7 @@ describe('Unit | UseCase | disable-certification-center-membership', function ()
       findById: sinon.stub(),
       update: sinon.stub(),
     };
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-  });
-
-  afterEach(function () {
-    clock.restore();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   context('when certification-center-membership does not exist', function () {

--- a/api/tests/team/unit/domain/usecases/update-certification-center-membership_test.js
+++ b/api/tests/team/unit/domain/usecases/update-certification-center-membership_test.js
@@ -7,15 +7,10 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 
 describe('Unit | Team | Domain | UseCase | update-certification-center-membership', function () {
   let now;
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now: new Date('2023-09-12'), toFake: ['Date'] });
-    now = new Date(clock.now);
-  });
-
-  afterEach(function () {
-    clock.restore();
+    now = new Date('2023-09-12');
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it("updates the user's role", async function () {


### PR DESCRIPTION
## ☀️ Problème

`sinon.useFakeTimers` était utilisé de 3 façons différentes dans less test API :

```js
sinon.useFakeTimer({ now, toFake: ['Date'] })
sinon.useFakeTimer(date, 'Date') // legacy
sinon.useFakeTimer(date) // legacy et fige tous les timers
```

De plus : 
- Plusieurs appels sans `toFake` figeaient **tous** les timers (`setTimeout`, `setInterval`, `nextTick`...) au lieu du seul `Date`. Dans un test d'intégration qui attend knex ou nock, c'est une source potentielle de blocage ou de flakiness.
- Plusieurs appels à `clock.restore()` qui ne servent à rien. Le `sinon.restore()` du `afterEach` global de `tests/test-helper.js` restaure déjà les timers.

## ⛱️ Proposition

Une seule forme dans tous les tests :

```js
sinon.useFakeTimers({ now, toFake: ['Date'] });
```

- toFake est toujours explicite. 
- Plus de clock.restore() : le `afterEach` global s'en charge.
- On ne garde la variable clock que là où on avance réellement le temps avec tick()

## 🧴 Remarques

N/A

## 🏊 Pour tester

La CI est verte.
