### PR TITLE
[TECH] S'assurer que la base est clean entre chaque tests

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -149,6 +149,9 @@ export class DatabaseBuilder {
   }
 
   async emptyDatabase({ keepLearningContent = false } = {}) {
+    // Can be called before #init() has loaded the tables (initial test cleanup)
+    if (!this.#tablesOrderedByDependency) await this.#loadTables();
+
     const sortedTableNames = this.#tablesOrderedByDependency
       .map(sanitizeTableName)
       .filter((tableName) => {

--- a/api/db/database-builder/database-helpers.js
+++ b/api/db/database-builder/database-helpers.js
@@ -1,4 +1,4 @@
-const TABLE_NAME_REGEXP = /(?<=insert into\s)(?<tableName>(".*"))(?=\s\(.*)/i;
+const TABLE_NAME_REGEXP = /insert into\s+(?<tableName>"[^"]+"(\."[^"]+")?)/i;
 
 export function getTableNameFromInsertSqlQuery(insertSqlQuery) {
   return TABLE_NAME_REGEXP.exec(insertSqlQuery)?.groups?.tableName?.replaceAll('"', '');

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -37,6 +37,10 @@ Object.values(customChaiHelpers).forEach(chaiUse);
 
 /* eslint-disable mocha/no-top-level-hooks */
 before(async function () {
+  // Always start tests with a clean database
+  const isUnitTest = process.env.TEST_DATABASE_URL?.includes('should.not.reach.db');
+  if (!isUnitTest) await databaseBuilder.emptyDatabase();
+
   nock.disableNetConnect();
   nock.enableNetConnect('localhost:9090'); // Unmock S3 storage
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -38,8 +38,8 @@ Object.values(customChaiHelpers).forEach(chaiUse);
 /* eslint-disable mocha/no-top-level-hooks */
 before(async function () {
   // Always start tests with a clean database
-  const isUnitTest = process.env.TEST_DATABASE_URL?.includes('should.not.reach.db');
-  if (!isUnitTest) await databaseBuilder.emptyDatabase();
+  const isDbReachable = !process.env.TEST_DATABASE_URL?.includes('should.not.reach.db');
+  if (isDbReachable) await databaseBuilder.emptyDatabase();
 
   nock.disableNetConnect();
   nock.enableNetConnect('localhost:9090'); // Unmock S3 storage

--- a/api/tests/tooling/unit/database-builder/database-helpers_test.js
+++ b/api/tests/tooling/unit/database-builder/database-helpers_test.js
@@ -19,6 +19,10 @@ describe('Unit | Tooling | DatabaseBuilder | database-helpers', function () {
         insertSqlQuery:
           '/* path: /api/oidc/user/reconcile */ insert into "user-logins" ("lastLoggedAt", "userId") values ($1, $2) on conflict ("userId") do update set "lastLoggedAt" = excluded."lastLoggedAt", "userId" = excluded."userId"',
       },
+      {
+        expectedTableName: 'structures',
+        insertSqlQuery: '/* path: /api/admin/organizations */ insert into "structures" default values returning *',
+      },
     ].forEach(({ expectedTableName, insertSqlQuery }) => {
       context(`when receiving "${insertSqlQuery}" as insert SQL query`, function () {
         it(`returns "${expectedTableName}" as value`, function () {


### PR DESCRIPTION
## ☀️ Problème

Certains tests d'intégration et d'acceptation sont flaky, parce que la base de test n'est pas complètement nettoyée entre deux tests.

3 cas identifés:
- Parfois on relance les tests dans une base de tests non nettoyée (run précédent coupés trop tôt)
- Le `databaseBuilder` ne vide que les tables réellement touchées par un test. Pour les repérer, il observe les requêtes SQL avec une expression régulière qui ne match pas tous les cas.
- les migrations (`db:migrate`) insèrent des données de référence (`features`, `issue-report-categories`, `complementary-certifications`). Elles restaient présentes jusqu'à la première écriture du `databaseBuilder`, qui les effaçait alors pour tout le reste du run.

## ⛱️ Proposition

**Réécriture de l'expression régulière** du `databaseBuilder` pour capturer le nom de la table immédiatement après `insert into`, sans rien présumer de ce qui suit.

**Vider la base avant le premier test** plutôt qu'à la première écriture du `databaseBuilder`, pour que tous les tests partent du même état.

## 🧴 Remarques

N/A

## 🏊 Pour tester

Les tests doivent être verts.
