### PR TITLE
[TECH] Améliorer les tests d'API

### DIFF
--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -9,10 +9,6 @@ import { securityPreHandlers } from '../../../../../src/shared/application/secur
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 
 describe('Unit | Certification | Configuration | Application | Router | certification-version-route', function () {
-  afterEach(function () {
-    sinon.restore();
-  });
-
   describe('GET /api/certifications/{framework}/info', function () {
     context('when the user is not authenticated', function () {
       it('should reject access', async function () {

--- a/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
@@ -31,10 +31,6 @@ describe('Certification | Enrolment | Unit | Service | sessions import validatio
       };
     });
 
-    afterEach(async function () {
-      sinon.restore();
-    });
-
     context('when the parsed data is valid', function () {
       context('when the session has not started yet', function () {
         context('when there is no sessionId', function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -102,10 +102,6 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
     };
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('when session cannot enrol any candidate', function () {
     it('should throw a CertificationCandidateOnFinalizedSessionError', async function () {
       // given

--- a/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
@@ -88,10 +88,6 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
     };
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('when no ids provided', function () {
     it('does nothing if no student ids is given as input', async function () {
       await enrolStudentsToSession({

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -64,10 +64,6 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
     };
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   describe('#importCertificationCandidatesFromCandidatesImportSheet', function () {
     context('when session cannot enrolled candidates', function () {
       it('should throw a BadRequestError', async function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -70,10 +70,6 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
     };
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   it('throws NotFoundError when the session does not exist', async function () {
     const userId = 123;
     const sessionId = 456;

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-session_test.js
@@ -3,10 +3,6 @@ import sinon from 'sinon';
 import { updateSession } from '../../../../../../src/certification/enrolment/domain/usecases/update-session.js';
 
 describe('Certification | Enrolment | Unit | UseCase | update-session', function () {
-  afterEach(function () {
-    sinon.restore();
-  });
-
   it('submits the update of the session', async function () {
     const sessionRepository = { updateInfo: sinon.fake.resolves() };
 

--- a/api/tests/certification/evaluation/unit/application/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/unit/application/certification-course-controller_test.js
@@ -12,10 +12,6 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 describe('Certification | Evaluation | Unit | Controller | certification-course-controller', function () {
   let certificationCourseInfoRepository, request;
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   describe('#save', function () {
     let startOrResumeStub;
     beforeEach(function () {

--- a/api/tests/certification/evaluation/unit/domain/usecases/start-or-resume-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/start-or-resume-certification_test.js
@@ -92,10 +92,6 @@ describe('Certification | Evaluation | Unit | UseCase | start-or-resume-certific
     };
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('when no candidate found for given user and session', function () {
     it('should throw a UnexpectedUserAccountError', async function () {
       // given

--- a/api/tests/certification/session-management/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-candidate-controller_test.js
@@ -22,10 +22,6 @@ describe('Certification | Session Management | Unit | Application | Controller |
     };
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   describe('#authorizeToStart', function () {
     it('should return a 204 status code and call authorize', async function () {
       // given

--- a/api/tests/certification/shared/integration/application/api/event-api_test.js
+++ b/api/tests/certification/shared/integration/application/api/event-api_test.js
@@ -14,7 +14,6 @@ describe('Certification | Shared | Integration | Application | API | Event', fun
   });
 
   afterEach(function () {
-    sinon.restore();
     return knex('certification_events').truncate();
   });
 

--- a/api/tests/devcomp/unit/scripts/duplicate-module_test.js
+++ b/api/tests/devcomp/unit/scripts/duplicate-module_test.js
@@ -9,10 +9,6 @@ import { catchErr } from '../../../tooling/test-utils/error.js';
 describe('Unit | Scripts | Duplicate Module', function () {
   describe('DuplicateModule', function () {
     describe('#handle', function () {
-      afterEach(function () {
-        sinon.restore();
-      });
-
       it('should read the source module, duplicate it, and write the result next to it', async function () {
         // given
         const moduleData = {

--- a/api/tests/prescription/stages/integration/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/prescription/stages/integration/application/stage-collections/stage-collection-controller_test.js
@@ -113,16 +113,13 @@ describe('Integration | Application | stage-collection-controller', function () 
       // then
       const currentStageCollection = await stageCollectionRepository.getByTargetProfileId(targetProfileId);
       const currentStages = currentStageCollection.toDTO();
-      const newStageIds = currentStageCollection.stages
-        .map(({ id }) => id)
-        .filter((value) => ![123, 456, 789].includes(value))
-        .sort();
+      const stageIdByTitle = (title) => currentStages.stages.find((stage) => stage.title === title)?.id;
 
       expect(currentStages.id).to.equal(targetProfileId);
       expect(currentStages.targetProfileId).to.equal(targetProfileId);
       expect(currentStages.stages).to.have.deep.members([
         {
-          id: newStageIds[0],
+          id: stageIdByTitle('Palier niveau 2 titre'),
           level: 2,
           threshold: null,
           isFirstSkill: false,
@@ -132,7 +129,7 @@ describe('Integration | Application | stage-collection-controller', function () 
           prescriberDescription: 'Palier niveau 2 description prescripteur',
         },
         {
-          id: newStageIds[1],
+          id: stageIdByTitle('Palier premier acquis titre'),
           level: null,
           threshold: null,
           isFirstSkill: true,

--- a/api/tests/scripts/integration/certification/duplicate-english-core-calibration-with-new-ids_test.js
+++ b/api/tests/scripts/integration/certification/duplicate-english-core-calibration-with-new-ids_test.js
@@ -147,10 +147,6 @@ describe('Integration | Scripts | Certification | duplicate-english-core-calibra
     });
 
     context('when an error occurs during insertion', function () {
-      afterEach(function () {
-        sinon.restore();
-      });
-
       it('should rollback the transaction and rethrow the error', async function () {
         // given
         const { id: versionId } = domainBuilder.certification.configuration

--- a/api/tests/tooling/unit/database-builder/database-buffer_test.js
+++ b/api/tests/tooling/unit/database-builder/database-buffer_test.js
@@ -3,7 +3,7 @@ import { expect } from '../../../test-helper.js';
 
 describe('Unit | Tooling | DatabaseBuilder | database-buffer', function () {
   afterEach(function () {
-    databaseBuffer.objectsToInsert = [];
+    databaseBuffer.purge();
   });
 
   describe('#getNextId', function () {
@@ -48,7 +48,7 @@ describe('Unit | Tooling | DatabaseBuilder | database-buffer', function () {
   describe('#purge', function () {
     it('should empty objectsToInsert array', function () {
       // given
-      databaseBuffer.objectsToInsert = ['someValue'];
+      databaseBuffer.objectsToInsert = { someTable: ['someValue'] };
 
       // when
       databaseBuffer.purge();


### PR DESCRIPTION
## ☀️ Problème

On appel `sinon.restore()` alors qu'il est déjà appliqué globalement dans le `afterEach` de `api/tests/test_helpers.js`

## ⛱️ Proposition

Supprimer les `sinon.restore()` des tests

## 🧴 Remarques

N/A

## 🏊 Pour tester

La CI est verte
