### PR TITLE
[FEATURE] Créer une route pour remonter la liste des catégories de structures (PIX-23559)

### DIFF
--- a/api/src/organizational-entities/application/routes.js
+++ b/api/src/organizational-entities/application/routes.js
@@ -3,6 +3,7 @@ import { certificationCenterAdminRoute } from './certification-center/certificat
 import { networkAdminRoute } from './network/network.admin.route.js';
 import { organizationAdminRoute } from './organization/organization.admin.route.js';
 import { organizationLearnerTypeAdminRoute } from './organization-learner-type/organization-learner-type.admin.route.js';
+import { structureCategoryAdminRoute } from './structure-category/structure-category.admin.route.js';
 import { tagAdminRoute } from './tag/tag.admin.route.js';
 
 const organizationalEntitiesRoutes = [
@@ -11,6 +12,7 @@ const organizationalEntitiesRoutes = [
   networkAdminRoute,
   administrationTeamAdminRoute,
   organizationLearnerTypeAdminRoute,
+  structureCategoryAdminRoute,
   tagAdminRoute,
 ];
 

--- a/api/src/organizational-entities/application/structure-category/structure-category.admin.controller.js
+++ b/api/src/organizational-entities/application/structure-category/structure-category.admin.controller.js
@@ -1,0 +1,11 @@
+import { usecases } from '../../domain/usecases/index.js';
+import { structureCategorySerializer } from '../../infrastructure/serializers/jsonapi/structure-category/structure-category-serializer.js';
+
+const findAllCategories = async function (request, h, dependencies = { structureCategorySerializer }) {
+  const structureCategories = await usecases.findAllStructureCategories();
+  return dependencies.structureCategorySerializer.serialize(structureCategories);
+};
+
+const structureCategoriesController = { findAllCategories };
+
+export { structureCategoriesController };

--- a/api/src/organizational-entities/application/structure-category/structure-category.admin.route.js
+++ b/api/src/organizational-entities/application/structure-category/structure-category.admin.route.js
@@ -1,0 +1,35 @@
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { structureCategoriesController } from './structure-category.admin.controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/structure-categories',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => structureCategoriesController.findAllCategories(request, h),
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Renvoie toutes les catégories de structures.',
+        ],
+        tags: ['api', 'structure-categories'],
+      },
+    },
+  ]);
+};
+
+export const structureCategoryAdminRoute = {
+  name: 'organizational-entities/structure-category-admin-api',
+  register,
+};

--- a/api/src/organizational-entities/domain/models/StructureCategory.js
+++ b/api/src/organizational-entities/domain/models/StructureCategory.js
@@ -1,0 +1,13 @@
+class StructureCategory {
+  /**
+   * @param {object} params
+   * @param {number} params.id
+   * @param {string} params.label
+   */
+  constructor({ id, label } = {}) {
+    this.id = id;
+    this.label = label;
+  }
+}
+
+export { StructureCategory };

--- a/api/src/organizational-entities/domain/usecases/find-all-structure-categories.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/find-all-structure-categories.usecase.js
@@ -1,0 +1,9 @@
+/**
+ * @function
+ * @returns {Promise<Array<StructureCategory>>}
+ */
+const findAllStructureCategories = async function ({ structureCategoryRepository }) {
+  return structureCategoryRepository.findAll();
+};
+
+export { findAllStructureCategories };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -23,6 +23,7 @@ import * as organizationLearnerRepository from '../../infrastructure/repositorie
 import * as organizationLearnerTypeRepository from '../../infrastructure/repositories/organization-learner-type-repository.js';
 import * as organizationPlacesLotRepository from '../../infrastructure/repositories/organization-places-lot.repository.js';
 import * as organizationTagRepository from '../../infrastructure/repositories/organization-tag.repository.js';
+import * as structureCategoryRepository from '../../infrastructure/repositories/structure-category-repository.js';
 import { tagRepository } from '../../infrastructure/repositories/tag.repository.js';
 import * as targetProfileShareRepository from '../../infrastructure/repositories/target-profile-share-repository.js';
 import * as organizationVerificationService from '../services/organization-verification.service.js';
@@ -81,6 +82,7 @@ const dependenciesToInject = {
   learnersApi,
   organizationRepository,
   organizationTagRepository,
+  structureCategoryRepository,
   tagRepository,
   targetProfileShareRepository,
   organizationVerificationService,
@@ -105,6 +107,7 @@ import { detachCertificationCenterFromOrganization } from './detach-certificatio
 import { detachParentOrganizationFromOrganization } from './detach-parent-organization-from-organization.usecase.js';
 import { findAllAdministrationTeams } from './find-all-administration-teams.usecase.js';
 import { findAllOrganizationLearnerTypes } from './find-all-organization-learner-types.refactor.js';
+import { findAllStructureCategories } from './find-all-structure-categories.usecase.js';
 import { findAllTags } from './find-all-tags.usecase.js';
 import { findAttachedCertificationCenterForAdmin } from './find-attached-certification-center-for-admin.usecase.js';
 import { findAttachedOrganizationsForAdmin } from './find-attached-organizations-for-admin.usecase.js';
@@ -152,6 +155,7 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedFilteredOrganizations,
   findAllAdministrationTeams,
   findAllOrganizationLearnerTypes,
+  findAllStructureCategories,
   getCenterForAdmin,
   getNetworkDetails,
   getOrganizationById,

--- a/api/src/organizational-entities/infrastructure/repositories/structure-category-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/structure-category-repository.js
@@ -1,0 +1,22 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { StructureCategory } from '../../domain/models/StructureCategory.js';
+
+/**
+ * @function
+ * @returns {Promise<Array<StructureCategory>>}
+ */
+const findAll = async function () {
+  const knexConn = DomainTransaction.getConnection();
+  const structureCategories = await knexConn.select('id', 'label').from('structure_categories').orderBy('id');
+
+  return structureCategories.map(_toDomain);
+};
+
+const _toDomain = function (structureCategoryDTO) {
+  return new StructureCategory({
+    id: structureCategoryDTO.id,
+    label: structureCategoryDTO.label,
+  });
+};
+
+export { findAll };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/structure-category/structure-category-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/structure-category/structure-category-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (structureCategory) {
+  return new Serializer('structure-categories', {
+    attributes: ['label'],
+  }).serialize(structureCategory);
+};
+
+export const structureCategorySerializer = { serialize };

--- a/api/tests/organizational-entities/acceptance/application/structure-category/structure-category.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/structure-category/structure-category.admin.route.test.js
@@ -1,0 +1,43 @@
+import { createServer } from '../../../../../server.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
+
+describe('Acceptance | Organizational Entities | Application | Route | Admin | StructureCategories', function () {
+  describe('GET /api/admin/structure-categories', function () {
+    it('returns a list of structure categories with 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+      const structureCategory1 = databaseBuilder.factory.buildStructureCategory({ id: 123, label: 'Collège' });
+      const structureCategory2 = databaseBuilder.factory.buildStructureCategory({ id: 456, label: 'Lycée' });
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/admin/structure-categories',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal([
+        {
+          attributes: {
+            label: structureCategory1.label,
+          },
+          id: '123',
+          type: 'structure-categories',
+        },
+        {
+          attributes: {
+            label: structureCategory2.label,
+          },
+          id: '456',
+          type: 'structure-categories',
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/structure-category-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/structure-category-repository_test.js
@@ -1,0 +1,32 @@
+import { findAll } from '../../../../../src/organizational-entities/infrastructure/repositories/structure-category-repository.js';
+import { expect } from '../../../../test-helper.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Integration | Repository | structure-category-repository', function () {
+  describe('#findAll', function () {
+    it('should return all structure categories ordered by id', async function () {
+      // given
+      databaseBuilder.factory.buildStructureCategory({ id: 2, label: 'Collège' });
+      databaseBuilder.factory.buildStructureCategory({ id: 1, label: 'Lycée' });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await findAll();
+
+      // then
+      expect(result).to.deep.equal([
+        domainBuilder.buildStructureCategory({ id: 1, label: 'Lycée' }),
+        domainBuilder.buildStructureCategory({ id: 2, label: 'Collège' }),
+      ]);
+    });
+
+    it('should return an empty array if there is no structure category', async function () {
+      // when
+      const result = await findAll();
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/application/structure-category/structure-category.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/structure-category/structure-category.admin.controller.test.js
@@ -1,0 +1,29 @@
+import sinon from 'sinon';
+
+import { structureCategoriesController } from '../../../../../src/organizational-entities/application/structure-category/structure-category.admin.controller.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { hFake } from '../../../../tooling/mocks/hapi.mock.js';
+
+describe('Unit | Organizational Entities | Application | Controller | Admin | StructureCategory', function () {
+  describe('#findAllCategories', function () {
+    it('calls findAllStructureCategories usecase and StructureCategory serializer', async function () {
+      // given
+      const structureCategory1 = domainBuilder.buildStructureCategory({ label: 'Collège' });
+      const structureCategory2 = domainBuilder.buildStructureCategory({ label: 'Lycée' });
+      const structureCategories = [structureCategory1, structureCategory2];
+      sinon.stub(usecases, 'findAllStructureCategories').resolves(structureCategories);
+      const structureCategorySerializer = { serialize: sinon.stub() };
+
+      // when
+      await structureCategoriesController.findAllCategories({}, hFake, {
+        structureCategorySerializer,
+      });
+
+      // then
+      expect(usecases.findAllStructureCategories).to.have.been.calledOnce;
+      expect(structureCategorySerializer.serialize).to.have.been.calledWithExactly(structureCategories);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/domain/usecases/find-all-structure-categories.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/find-all-structure-categories.usecase.test.js
@@ -1,0 +1,30 @@
+import sinon from 'sinon';
+
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | UseCases | find-all-structure-categories', function () {
+  it('should return all structure categories', async function () {
+    // given
+    const secondStructureCategory = domainBuilder.buildStructureCategory({ id: 2, label: 'Collège' });
+    const firstStructureCategory = domainBuilder.buildStructureCategory({ id: 1, label: 'Lycée' });
+    const structureCategoryRepository = {
+      findAll: sinon.stub(),
+    };
+
+    structureCategoryRepository.findAll.resolves([firstStructureCategory, secondStructureCategory]);
+
+    // when
+    const result = await usecases.findAllStructureCategories({ structureCategoryRepository });
+
+    // then
+    expect(result).to.deep.equal([
+      domainBuilder.buildStructureCategory({ id: firstStructureCategory.id, label: firstStructureCategory.label }),
+      domainBuilder.buildStructureCategory({
+        id: secondStructureCategory.id,
+        label: secondStructureCategory.label,
+      }),
+    ]);
+  });
+});

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/structure-category-serializer_test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/structure-category-serializer_test.js
@@ -1,0 +1,26 @@
+import { structureCategorySerializer } from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/structure-category/structure-category-serializer.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Serializer | structure-category-serializer', function () {
+  describe('#serialize', function () {
+    it('should return a JSON API serialized structure category', function () {
+      // given
+      const structureCategory = domainBuilder.buildStructureCategory({ id: 123, label: 'Collège' });
+
+      // when
+      const serializedStructureCategory = structureCategorySerializer.serialize(structureCategory);
+
+      // then
+      expect(serializedStructureCategory).to.deep.equal({
+        data: {
+          id: '123',
+          type: 'structure-categories',
+          attributes: {
+            label: 'Collège',
+          },
+        },
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-structure-category.js
+++ b/api/tests/tooling/domain-builder/factory/build-structure-category.js
@@ -1,0 +1,7 @@
+import { StructureCategory } from '../../../../src/organizational-entities/domain/models/StructureCategory.js';
+
+const buildStructureCategory = function ({ id = 1, label = 'Catégorie' } = {}) {
+  return new StructureCategory({ id, label });
+};
+
+export { buildStructureCategory };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -131,6 +131,7 @@ import { buildSkillLearningContentDataObject } from './build-skill-learning-cont
 import { buildSolution } from './build-solution.js';
 import { buildStage } from './build-stage.js';
 import { buildStageAcquisition } from './build-stage-acquisition.js';
+import { buildStructureCategory } from './build-structure-category.js';
 import { buildSupOrganizationLearner } from './build-sup-organization-learner.js';
 import { buildTag } from './build-tag.js';
 import { buildTargetProfile } from './build-target-profile.js';
@@ -501,6 +502,7 @@ export {
   buildStageAcquisition,
   buildStageCollectionForTargetProfileManagement,
   buildStageCollectionForUserCampaignResults,
+  buildStructureCategory,
   buildSupOrganizationLearner,
   buildTag,
   buildTargetProfile,


### PR DESCRIPTION
## ☀️ Problème

Il n'existe pas de route permettant de récupérer la liste des catégories de structures.

## ⛱️ Proposition

Ajout de la route `GET /api/admin/structure-categories`, exposée via `structureCategoriesController.findAllCategories()`, avec le même accès que la route des types de prescrit (SuperAdmin, Support, Métier). Les catégories sont renvoyées triées par `id`.


## 🏊 Pour tester
```
TOKEN=$(curl -s -X POST https://admin-pr17135.review.pix.fr/api/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=password&username=superadmin@example.net&password=pix123" \
  | jq -r '.access_token') && \
curl -s -X GET https://admin-pr17135.review.pix.fr/api/admin/structure-categories \
  -H "Authorization: Bearer $TOKEN"
