### PR TITLE
[TECH] Rendre la colonne Subscription de la table certification-candidate not nullable (PIX-23461)

### DIFF
--- a/api/db/migrations/20260813000000_make-subscription-not-nullable-in-certification-candidates.js
+++ b/api/db/migrations/20260813000000_make-subscription-not-nullable-in-certification-candidates.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'certification-candidates';
+const COLUMN_NAME = 'subscription';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).notNullable().alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).nullable().alter();
+  });
+}


### PR DESCRIPTION
## ☀️ Problème

La colonne `Subscription` de la table `certification-candidate` est nullable.
Il existe 46 candidats dans la base de production ayant ce champ à `null`.

## ⛱️ Proposition

- Demander aux captain d'exécuter  en production : 
`UPDATE "certification-candidates"
SET subscription = 'CORE'
WHERE subscription IS NULL;`
- Faire une migration pour rendre la colonne not nullable

## 🧴 Remarques

Analyse des candidats sans subscription :

- Aucun n’est relié à un `certificationCourse` par le `candidateId`
- 6 appartiennent à des sessions non finalisées, les autres sessions sont publiées depuis plusieurs mois
- Seuls deux candidats ont été inscrits par des centres ayant des habilitations complémentaire. Dans leurs sessions, tous les autres candidats sont inscrits en CORE.

**Les subscriptions manquantes sont très probablement des CORE**.

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
