### PR TITLE
[FEATURE] Plausible : Tracker les clics sur le bouton de sélection de parcours et de création de campagne du catalogue (PIX-23639)

### DIFF
--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -1,8 +1,10 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import { EVENT_NAME } from 'pix-orga/helpers/metrics-event-name';
 
 import FormSection from '../ui/form-section';
 import AssessmentGoalCustomization from './create-form/assessment-goal-customization';
@@ -13,6 +15,8 @@ import ProfilesCollectionGoalCustomization from './create-form/profiles-collecti
 import ProfilesCollectionGoalSettings from './create-form/profiles-collection-goal-settings';
 
 export default class CreateForm extends Component {
+  @service pixMetrics;
+
   get isSubmitDisabled() {
     return !(this.isCampaignGoalProfileCollection || this.args.campaign.course);
   }
@@ -50,7 +54,13 @@ export default class CreateForm extends Component {
   @action
   onSubmit(event) {
     event.preventDefault();
+    this.trackCourseCreationClick();
     this.args.onSubmit(this.args.campaign);
+  }
+
+  @action
+  trackCourseCreationClick() {
+    this.pixMetrics.trackEvent(EVENT_NAME.CATALOGUE.CAMPAIGN_CREATION_CLICK);
   }
 
   <template>

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -3,12 +3,15 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixOverlay from '@1024pix/pix-ui/components/pix-overlay';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { hash } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { recordIdentifierFor } from '@warp-drive/core';
 import { t } from 'ember-intl';
 import { gt } from 'ember-truth-helpers';
 import SafeMarkdownToHtml from 'pix-orga/components/safe-markdown-to-html';
+import { EVENT_NAME } from 'pix-orga/helpers/metrics-event-name';
 
 import Badges from '../campaign/badges';
 import { COMBINED_COURSE_BLUEPRINT_OVERVIEW, getCourseInfo, TARGET_PROFILE_OVERVIEW } from './course-card.gjs';
@@ -17,6 +20,7 @@ import TargetProfileContent from './course-modal/target-profile-content.gjs';
 
 export default class CourseModal extends Component {
   @service currentUser;
+  @service pixMetrics;
 
   id = crypto.randomUUID();
 
@@ -63,6 +67,11 @@ export default class CourseModal extends Component {
     if (this.isTargetProfile) return this.args.currentCourse.description;
     if (this.isCombinedCourseBlueprint) return this.args.currentCourse.prescriberDescription;
     return '';
+  }
+
+  @action
+  trackCourseSelection() {
+    this.pixMetrics.trackEvent(EVENT_NAME.CATALOGUE.COURSE_SELECTION_CLICK);
   }
 
   <template>
@@ -115,6 +124,7 @@ export default class CourseModal extends Component {
               @isDisabled={{this.hasReachedPlacesLimit}}
               @size="small"
               class="course-modal__form-link"
+              {{on "click" this.trackCourseSelection}}
             >
               {{t "pages.catalogue.modal.select-course"}}
             </PixButtonLink>

--- a/orga/app/helpers/metrics-event-name.js
+++ b/orga/app/helpers/metrics-event-name.js
@@ -8,6 +8,7 @@ export const EVENT_NAME = {
   },
   CATALOGUE: {
     COURSE_SELECTION_CLICK: 'catalogueCourseSelectionClick',
+    CAMPAIGN_CREATION_CLICK: 'catalogueCampaignCreationClick',
   },
   COMBINED_COURSE: {
     VIEW_CAMPAIGN_CLICK: 'combinedCourseViewCampaignClick',

--- a/orga/app/helpers/metrics-event-name.js
+++ b/orga/app/helpers/metrics-event-name.js
@@ -6,6 +6,9 @@ export const EVENT_NAME = {
   CAMPAIGN: {
     EXPORT_DATA_CLICK: 'campaignExportDataResultClick',
   },
+  CATALOGUE: {
+    COURSE_SELECTION_CLICK: 'catalogueCourseSelectionClick',
+  },
   COMBINED_COURSE: {
     VIEW_CAMPAIGN_CLICK: 'combinedCourseViewCampaignClick',
   },

--- a/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-catalogue-test.gjs
@@ -3,6 +3,7 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import CreateForm from 'pix-orga/components/campaign/create-form-catalogue';
+import { EVENT_NAME } from 'pix-orga/helpers/metrics-event-name';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -314,6 +315,38 @@ module('Integration | Component | Campaign::CreateForm (catalogue)', function (h
 
     sinon.assert.calledWithExactly(createCampaignSpy, data.campaign);
     // then
+    assert.ok(true);
+  });
+
+  test('it should track the event of creating a course', async function (assert) {
+    // given
+    const pixMetrics = this.owner.lookup('service:pix-metrics');
+    sinon.stub(pixMetrics, 'trackEvent');
+
+    data.campaign.course = this.owner
+      .lookup('service:store')
+      .createRecord('course', { name: 'targetProfile1', id: '123', type: 'targetProfile' });
+    const createCampaignSpy = sinon.stub();
+
+    await render(
+      <template>
+        <CreateForm
+          @campaign={{data.campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{data.errors}}
+          @membersSortedByFullName={{data.defaultMembers}}
+          @hasBlueprints={{true}}
+        />
+      </template>,
+    );
+    await clickByName(t('pages.campaign-creation.purpose.assessment'));
+    await fillByLabel(`${t('pages.campaign-creation.name.label')} *`, 'Ma campagne');
+
+    // when
+    await clickByName(t('pages.campaign-creation.actions.create'));
+
+    sinon.assert.calledWithExactly(pixMetrics.trackEvent, EVENT_NAME.CATALOGUE.CAMPAIGN_CREATION_CLICK);
     assert.ok(true);
   });
 

--- a/orga/tests/integration/components/catalogue/course-modal-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-modal-test.gjs
@@ -1,6 +1,8 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CourseModal from 'pix-orga/components/catalogue/course-modal';
+import { EVENT_NAME } from 'pix-orga/helpers/metrics-event-name';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -328,9 +330,11 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
 
       //when
       const screen = await render(
-        <template><CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} /></template>,
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
       );
-      const submitButton = await screen.getByText(t('pages.catalogue.modal.select-course'));
+      const submitButton = await screen.getByRole('link', { name: t('pages.catalogue.modal.select-course') });
 
       //then
       assert.dom(submitButton).hasAttribute('aria-disabled', 'false');
@@ -343,13 +347,38 @@ module('Integration | Component | Catalogue::CourseModal', function (hooks) {
 
       //when
       const screen = await render(
-        <template><CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} /></template>,
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
       );
 
       const submitButton = await screen.getByText(t('pages.catalogue.modal.select-course'));
 
       // then
       assert.dom(submitButton).hasAttribute('aria-disabled', 'true');
+    });
+    test('it should track the event of selecting a course', async function (assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+      const router = this.owner.lookup('service:-routing');
+      sinon.stub(router, 'transitionTo');
+      const pixMetrics = this.owner.lookup('service:pix-metrics');
+      sinon.stub(pixMetrics, 'trackEvent');
+
+      const currentCourse = store.createRecord('target-profile-overview', { id: 123, name: 'Ma super formation' });
+      sinon.stub(currentUser, 'placeStatistics').value({ hasReachedMaximumPlacesLimit: false });
+
+      //when
+      const screen = await render(
+        <template>
+          <CourseModal @currentCourse={{currentCourse}} @closeModal={{closeModal}} @isModalOpen={{true}} />
+        </template>,
+      );
+      await click(screen.getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+
+      // then
+      sinon.assert.calledWithExactly(pixMetrics.trackEvent, EVENT_NAME.CATALOGUE.COURSE_SELECTION_CLICK);
+      assert.ok(true);
     });
   });
 


### PR DESCRIPTION
## ☀️ Problème

Nous avons besoin d'indicateurs de suivi d'usage pour le catalogue une fois qu'il sera déployé.

## ⛱️ Proposition

Ajouter un funnel Plausible `PixOrga / Creation de campagne (catalogue)` pour suivre le taux de complétion de création de campagnes via le catalogue, avec 2 custom events de clic sur :
- Bouton de sélection de parcours
- Bouton de création de campagne 

On propose de rajouter également un event supplémentaire de succès de création de campagne, pour pouvoir savoir combien de campagnes ont été créées avec succès via ce parcours utilisateur.

## 🏊 Pour tester

Se connecter à Plausible
Afficher les stats de `review.pix.fr`
Afficher le funnel `PixOrga / Creation de campagne (catalogue)` et voir les stats actuelles

Se connecter à Pix Orga
Aller sur le catalogue
Sélectionner un parcours
Compléter les informations sur le formulaire de création de campagne
Envoyer le formulaire

Retourner sur Plausible
Voir que sur le funnel les stats ont augmenté