### PR TITLE
[BUGFIX] Reset de mot de passe impossible si l'email n'a pas la bonne casse (PIX-23878)

### DIFF
--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -100,6 +100,10 @@ class User {
     return false;
   }
 
+  hasSameEmailAs(email) {
+    return this.email?.toLowerCase() === email?.toLowerCase();
+  }
+
   markEmailAsValid() {
     this.emailConfirmedAt = new Date();
   }

--- a/api/src/identity-access-management/domain/usecases/update-user-password.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-user-password.usecase.js
@@ -34,7 +34,7 @@ export const updateUserPassword = withTransaction(async function ({
 
   await resetPasswordService.assertTemporaryKey(temporaryKey);
   const { email } = await resetPasswordService.verifyDemand(temporaryKey, resetPasswordDemandRepository);
-  if (email != user.email) {
+  if (!user.hasSameEmailAs(email)) {
     throw new UserNotAuthorizedToUpdatePasswordError();
   }
 

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -312,6 +312,30 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
     });
   });
 
+  describe('#hasSameEmailAs', function () {
+    it('returns true when email is the same', function () {
+      // given
+      const user = domainBuilder.buildUser({ email: 'test@example.com' });
+
+      // when
+      const result = user.hasSameEmailAs('TEST@example.com');
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('returns false when email is different', function () {
+      // given
+      const user = domainBuilder.buildUser({ email: 'test@example.com' });
+
+      // when
+      const result = user.hasSameEmailAs('test2@example.com');
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
   describe('#markEmailAsValid', function () {
     let now;
 


### PR DESCRIPTION
## ☀️ Problème

Erreur lors de la réinitialisation de mot de passe.

**Étapes pour reproduire le bug :**

- Avoir un compte en e-mail / mdp avec l’e-mail tout en minuscule
- Faire une demande de réinitialisation de mdp en renseignant son e-mail avec une majuscule
- Cliquer sur le lien reçu dans l’e-mail
- Renseigner un nouveau mdp, valider et constater l’erreur “Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.”

## ⛱️ Proposition

Ne plus vérifier l'email en étant case-sensitive.

## 🧴 Remarques

N/A

## 🏊 Pour tester

- Créer un compte login/password sur Pix App avec email en minuscule
- Se déconnecter
- Faire une demande de réinitialisation de mdp en renseignant son e-mail avec une majuscule
- Cliquer sur le lien reçu dans l’e-mail
- - Renseigner un nouveau mdp, valider et constater que ça fonctionne