### PR TITLE
[TECH]: Envoyer un message quand la mise en recette échoue.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           changelogTitle: "# Pix Changelog"
         env:
           GITHUB_TOKEN: ${{ secrets.PIX_SERVICE_RELEASE_ACTION_TOKEN }}
+
       - name: Notify to a slack channel
         if: env.new_release_published == 'true'
         uses: slackapi/slack-github-action@v4.0.0
@@ -32,3 +33,13 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
             text: "Coucou 🙃, je lance la mise en recette de la v${{ env.new_release_version }} !"
+
+      - name: Warn when no release was published
+        if: env.new_release_published != 'true'
+        uses: slackapi/slack-github-action@v4.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+            text: "⚠️ Aucune version n'a été publiée, rien ne sera déployé en recette. Il s'agit le plus souvent d'une race condition : la branche a bougé pendant la release, il faut relancer le job ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Peut-être n'y avait-il rien à publier."


### PR DESCRIPTION
## ☀️ Problème

Il arrive parfois que le workflow release échoue. 
Si un commit est éffectué sur la branche pendant l'éxecution du workflow, on obtient ce genre d'erreur: 
[`The local branch dev is behind the remote one, therefore a new version won't be published.`](https://github.com/1024pix/pix/actions/runs/31690611796/job/94416818390 )

## ⛱️ Proposition

La moindre des choses quand on échoue, c'est de prévenir, on ajoute donc un message qui nous prévient sur Slack.

## 🏊 Pour tester

Excellente question, on verra bien j'imagine :shrug
