### PR TITLE
[TECH] Sortir les erreurs jetées des repositories de session/enrolment.

### DIFF
--- a/api/src/certification/enrolment/application/session-controller.js
+++ b/api/src/certification/enrolment/application/session-controller.js
@@ -4,7 +4,7 @@ import * as sessionRepository from '../infrastructure/repositories/session-repos
 import { candidateSerializer } from '../infrastructure/serializers/candidate-serializer.js';
 import { sessionSerializer } from '../infrastructure/serializers/session-serializer.js';
 
-async function createSession(request, _h, dependencies = { sessionSerializer, sessionRepository }) {
+async function createSession(request, h, dependencies = { sessionSerializer, sessionRepository }) {
   const userId = request.auth.credentials.userId;
   const certificationCenterId = request.params.certificationCenterId;
   const { address, room, date, time, examiner, description } = request.payload.data.attributes;
@@ -19,6 +19,7 @@ async function createSession(request, _h, dependencies = { sessionSerializer, se
     examiner,
     description,
   });
+
   const session = await dependencies.sessionRepository.get({ id: newSessionId });
 
   return dependencies.sessionSerializer.serialize(session);
@@ -30,6 +31,10 @@ async function update(request, h, dependencies = { sessionSerializer, sessionRep
 
   await usecases.updateSession({ address, room, date, time, examiner, description, sessionId });
   const updatedSession = await dependencies.sessionRepository.get({ id: sessionId });
+
+  if (!updatedSession) {
+    return h.response().code(404);
+  }
 
   return dependencies.sessionSerializer.serialize(updatedSession);
 }
@@ -45,6 +50,11 @@ async function remove(request, h) {
 async function get(request, h, dependencies = { sessionSerializer, sessionRepository }) {
   const sessionId = request.params.sessionId;
   const session = await dependencies.sessionRepository.get({ id: sessionId });
+
+  if (!session) {
+    return h.response().code(404);
+  }
+
   return dependencies.sessionSerializer.serialize(session);
 }
 

--- a/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
@@ -10,6 +10,7 @@
 import {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidatesError,
+  NotFoundError,
 } from '../../../../shared/domain/errors.js';
 import { mailCheck as mailCheckImplementation } from '../../../../shared/mail/infrastructure/services/mail-check.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
@@ -40,11 +41,16 @@ export async function addCandidateToSession({
   candidate.sessionId = sessionId;
   const sessionAuthorization = await sessionAuthorizationAdapter.find({ sessionId });
 
+  if (!sessionAuthorization) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   if (!sessionAuthorization.canEnrollCandidateIndividually) {
     throw new CannotEnrollCandidateIndividuallyError();
   }
 
   const session = await sessionRepository.get({ id: sessionId });
+
   try {
     candidate.validate({ isSco: session.isSco });
   } catch (error) {

--- a/api/src/certification/enrolment/domain/usecases/delete-session.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-session.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionStartedDeletionError } from '../errors.js';
 
 /**
@@ -17,7 +18,11 @@ const deleteSession = async ({ sessionId, sessionRepository, sessionManagementRe
   }
 
   await DomainTransaction.execute(async () => {
-    await sessionRepository.remove({ id: sessionId });
+    const deletedSession = await sessionRepository.remove({ id: sessionId });
+
+    if (!deletedSession) {
+      throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+    }
   });
 };
 

--- a/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
@@ -6,7 +6,7 @@
  * @typedef {import('./index.js').SessionRepository} SessionRepository
  * @typedef {import('./index.js').EventAdapter} EventAdapter
  */
-import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
+import { ForbiddenAccess, NotFoundError } from '../../../../shared/domain/errors.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { CannotEnrollScoCandidateError, UnknownCountryForStudentEnrolmentError } from '../errors.js';
@@ -38,6 +38,11 @@ export async function enrolStudentsToSession({
     return;
   }
   const sessionAuthorization = await sessionAuthorizationAdapter.find({ sessionId });
+
+  if (!sessionAuthorization) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   if (!sessionAuthorization.canEnrollScoCandidate) {
     throw new CannotEnrollScoCandidateError();
   }

--- a/api/src/certification/enrolment/domain/usecases/get-attendance-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/get-attendance-sheet.js
@@ -3,6 +3,8 @@
  * @typedef {import('./index.js').AttendanceSheetPdfUtils} AttendanceSheetPdfUtils
  */
 
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
 /**
  * @param {object} params
  * @param {SessionForAttendanceSheetRepository} params.sessionForAttendanceSheetRepository
@@ -15,6 +17,10 @@ const getAttendanceSheet = async function ({
   attendanceSheetPdfUtils,
 }) {
   const session = await sessionForAttendanceSheetRepository.getWithCertificationCandidates({ id: sessionId });
+
+  if (!session) {
+    throw new NotFoundError("La session n'existe pas ou aucun candidat n'est inscrit à celle-ci");
+  }
 
   const { attendanceSheet, fileName } = await attendanceSheetPdfUtils.getAttendanceSheetPdfBuffer({
     session,

--- a/api/src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js
@@ -2,6 +2,7 @@
  * @typedef {import('./index.js').SessionRepository} SessionRepository
  * @typedef {import('./index.js').CenterRepository} CenterRepository
  */
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Candidate } from '../models/Candidate.js';
 /**
  * @param {object} params
@@ -10,6 +11,11 @@ import { Candidate } from '../models/Candidate.js';
  */
 export async function getCandidateImportSheetData({ sessionId, sessionRepository, centerRepository }) {
   const session = await sessionRepository.get({ id: sessionId });
+
+  if (!session) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   const enrolledCandidates = session.certificationCandidates.sort(Candidate.sortByLastNameAndFirstName);
   const center = await centerRepository.getById({ id: session.certificationCenterId });
   return {

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -5,7 +5,7 @@
  */
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CandidateAlreadyLinkedToUserError } from '../../../../shared/domain/errors.js';
+import { CandidateAlreadyLinkedToUserError, NotFoundError } from '../../../../shared/domain/errors.js';
 
 /**
  * @param {object} params
@@ -28,11 +28,17 @@ export async function importCertificationCandidatesFromCandidatesImportSheet({
   certificationCpfService,
 }) {
   const sessionAuthorization = await sessionAuthorizationAdapter.find({ sessionId });
+
+  if (!sessionAuthorization) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   if (!sessionAuthorization.canEnrollCandidateViaODS) {
     throw new CandidateAlreadyLinkedToUserError('At least one candidate is already linked to a user');
   }
 
   const session = await sessionRepository.get({ id: sessionId });
+
   const candidates = await certificationCandidatesOdsService.extractCertificationCandidatesFromCandidatesImportSheet({
     i18n,
     session,

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -4,7 +4,6 @@
 
 // @ts-check
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
 import { Candidate } from '../../domain/models/Candidate.js';
 
 /**
@@ -71,9 +70,7 @@ export async function update(candidate) {
     .update(candidateDataToSave)
     .returning('*');
 
-  if (!updatedCertificationCandidate) {
-    throw new CertificationCandidateNotFoundError();
-  }
+  return updatedCertificationCandidate;
 }
 
 /**

--- a/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
@@ -1,5 +1,4 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCandidateForAttendanceSheet } from '../../domain/read-models/CertificationCandidateForAttendanceSheet.js';
 import { SessionForAttendanceSheet } from '../../domain/read-models/SessionForAttendanceSheet.js';
 
@@ -59,7 +58,7 @@ export async function getWithCertificationCandidates({ id }) {
     .first();
 
   if (!results || results.certificationCandidates === null) {
-    throw new NotFoundError("La session n'existe pas ou aucun candidat n'est inscrit à celle-ci");
+    return null;
   }
 
   return _toDomain(results);

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -9,7 +9,6 @@ import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
  * @param {object} params
  * @param {number} params.id
  * @returns {Promise<SessionEnrolment>}
- * @throws {NotFoundError}
  */
 export async function get({ id }) {
   const knexConn = DomainTransaction.getConnection();
@@ -69,8 +68,9 @@ export async function get({ id }) {
     .join('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
     .where('sessions.id', id)
     .first();
+
   if (!foundSession) {
-    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+    return null;
   }
 
   const certificationCandidates =

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -1,5 +1,4 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { Candidate } from '../../domain/models/Candidate.js';
 import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
@@ -191,12 +190,11 @@ export async function updateInfo({ id, address, room, examiner, date, time, desc
  * @param {object} params
  * @param {number} params.id
  * @returns {Promise<void>}
- * @throws {NotFoundError}
  */
 export async function remove({ id }) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('invigilator_accesses').where({ sessionId: id }).del();
   await knexConn('certification-candidates').where({ sessionId: id }).del();
   const nbSessionsDeleted = await knexConn('sessions').where({ id }).del();
-  if (nbSessionsDeleted === 0) throw new NotFoundError();
+  if (nbSessionsDeleted === 0) return null;
 }

--- a/api/src/certification/session-management/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/unfinalize-session.js
@@ -4,6 +4,7 @@
  */
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionAlreadyPublishedError } from '../errors.js';
 
 /**
@@ -17,7 +18,12 @@ const unfinalizeSession = async function ({ sessionId, sessionManagementReposito
   }
 
   return DomainTransaction.execute(async () => {
-    await finalizedSessionRepository.remove({ sessionId });
+    const session = await finalizedSessionRepository.remove({ sessionId });
+
+    if (!session) {
+      throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+    }
+
     await sessionManagementRepository.unfinalize({ id: sessionId });
   });
 };

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -1,11 +1,9 @@
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import * as candidateRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/candidate-repository.js';
-import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Certification | Enrolment | Repository | Candidate', function () {
   describe('#get', function () {
@@ -147,59 +145,41 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
   });
 
   describe('#update', function () {
-    context('when the candidate exists', function () {
-      it('should update the candidate', async function () {
-        // when
-        const certificationCandidate = domainBuilder.certification.enrolment
-          .candidateBuilder()
-          .withIdentity({ firstName: 'toto' })
-          .insertToDB({ databaseBuilder });
+    it('updates the candidate', async function () {
+      // when
+      const certificationCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({ firstName: 'toto' })
+        .insertToDB({ databaseBuilder });
 
-        await databaseBuilder.commit();
+      await databaseBuilder.commit();
 
-        // when
-        await candidateRepository.update({ ...certificationCandidate, firstName: 'tutu' });
+      // when
+      await candidateRepository.update({ ...certificationCandidate, firstName: 'tutu' });
 
-        const candidate = await candidateRepository.get({
-          certificationCandidateId: certificationCandidate.id,
-        });
-
-        // then
-        expect(candidate).to.be.instanceOf(Candidate);
-        expect(candidate.firstName).to.equal('tutu');
+      const candidate = await candidateRepository.get({
+        certificationCandidateId: certificationCandidate.id,
       });
 
-      it('should update its subscription', async function () {
-        // given
-        const certificationCandidate = domainBuilder.certification.enrolment
-          .candidateBuilder()
-          .withSubscription(Frameworks.DROIT)
-          .insertToDB({ databaseBuilder });
-        await databaseBuilder.commit();
-
-        // when
-        await candidateRepository.update({ ...certificationCandidate, subscription: Frameworks.EDU_1ER_DEGRE });
-
-        // then
-        const updated = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
-        expect(updated.subscription).to.equal(Frameworks.EDU_1ER_DEGRE);
-      });
+      // then
+      expect(candidate).to.be.instanceOf(Candidate);
+      expect(candidate.firstName).to.equal('tutu');
     });
 
-    context('when the candidate does not exist', function () {
-      it('should throw', async function () {
-        // when
-        const certificationCandidateToUpdate = domainBuilder.certification.enrolment.buildCertificationSessionCandidate(
-          { firstName: 'candidate unknown' },
-        );
+    it('updates its subscription', async function () {
+      // given
+      const certificationCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withSubscription(Frameworks.DROIT)
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
 
-        certificationCandidateToUpdate.firstName = 'tutu';
+      // when
+      await candidateRepository.update({ ...certificationCandidate, subscription: Frameworks.EDU_1ER_DEGRE });
 
-        const error = await catchErr(candidateRepository.update)(certificationCandidateToUpdate);
-
-        // then
-        expect(error).to.be.instanceOf(CertificationCandidateNotFoundError);
-      });
+      // then
+      const updated = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
+      expect(updated.subscription).to.equal(Frameworks.EDU_1ER_DEGRE);
     });
   });
 

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-for-attendance-sheet-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-for-attendance-sheet-repository_test.js
@@ -1,11 +1,9 @@
 import { CertificationCandidateForAttendanceSheet } from '../../../../../../src/certification/enrolment/domain/read-models/CertificationCandidateForAttendanceSheet.js';
 import { SessionForAttendanceSheet } from '../../../../../../src/certification/enrolment/domain/read-models/SessionForAttendanceSheet.js';
 import * as sessionForAttendanceSheetRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Repository | Session-for-attendance-sheet', function () {
   describe('#getWithCertificationCandidates', function () {
@@ -190,31 +188,31 @@ describe('Integration | Repository | Session-for-attendance-sheet', function () 
     });
 
     context('when no session was found', function () {
-      it('should return a Not found error', async function () {
+      it('returns null', async function () {
         // when
-        const error = await catchErr(sessionForAttendanceSheetRepository.getWithCertificationCandidates)({
+        const session = await sessionForAttendanceSheetRepository.getWithCertificationCandidates({
           id: 12434354,
         });
 
         // then
-        expect(error).to.be.instanceOf(NotFoundError);
+        expect(session).to.be.null;
       });
     });
 
     context('when no certification candidates was found', function () {
-      it('should return a Not found error', async function () {
+      it('returns null', async function () {
         // given
         const sessionId = 1234;
         databaseBuilder.factory.buildSession({ id: sessionId });
         await databaseBuilder.commit();
 
         // when
-        const error = await catchErr(sessionForAttendanceSheetRepository.getWithCertificationCandidates)({
+        const session = await sessionForAttendanceSheetRepository.getWithCertificationCandidates({
           id: sessionId,
         });
 
         // then<
-        expect(error).to.be.instanceOf(NotFoundError);
+        expect(session).to.be.null;
       });
     });
   });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -1,11 +1,9 @@
 import * as sessionRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/session-repository.js';
 import { BILLING_MODES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Repository | certification | enrolment | SessionEnrolment', function () {
   describe('#get', function () {
@@ -297,15 +295,15 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
     });
 
     context('when session does not exist', function () {
-      it('should throw a not found error', async function () {
+      it('return null', async function () {
         // given
         const sessionId = 123456;
 
         // when
-        const error = await catchErr(sessionRepository.remove)({ id: sessionId });
+        const result = await sessionRepository.remove({ id: sessionId });
 
         // then
-        expect(error).to.be.instanceOf(NotFoundError);
+        expect(result).to.be.null;
       });
     });
   });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -93,7 +93,7 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
       expect(actualSession).to.deepEqualInstance(expectedSession);
     });
 
-    it('should return a Not found error when no session was found', async function () {
+    it('returns null when no session was found', async function () {
       domainBuilder.certification.enrolment
         .sessionEnrolmentBuilder()
         .createdBy({
@@ -116,11 +116,12 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
         })
         .insertToDB({ databaseBuilder });
       await databaseBuilder.commit();
+
       // when
-      const error = await catchErr(sessionRepository.get)({ id: 777 });
+      const session = await sessionRepository.get({ id: 777 });
 
       // then
-      expect(error).to.be.instanceOf(NotFoundError);
+      expect(session).to.be.null;
     });
   });
 

--- a/api/tests/certification/enrolment/unit/application/session-controller_test.js
+++ b/api/tests/certification/enrolment/unit/application/session-controller_test.js
@@ -96,6 +96,39 @@ describe('Certification | Enrolment | Unit | Application | Controller | session-
       // then
       expect(response).to.equal('json');
     });
+
+    context('when the updated session cannot be retrieved', function () {
+      it('should return a 404 response', async function () {
+        // given
+        const request = {
+          auth: { credentials: { userId: 1 } },
+          params: { sessionId: 345 },
+          payload: {
+            data: {
+              attributes: {
+                address: '1 rue des lauriers',
+                room: '2B',
+                date: '2021-01-01',
+                time: '14:00',
+                examiner: 'Louise',
+                description: 'coucou',
+              },
+            },
+          },
+        };
+        sinon.stub(usecases, 'updateSession').resolves();
+        const sessionSerializer = { serialize: sinon.stub() };
+        const sessionRepository = { get: sinon.stub() };
+        sessionRepository.get.withArgs({ id: 345 }).resolves(null);
+
+        // when
+        const response = await sessionController.update(request, hFake, { sessionSerializer, sessionRepository });
+
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(sessionSerializer.serialize).to.not.have.been.called;
+      });
+    });
   });
 
   describe('#delete', function () {
@@ -141,6 +174,26 @@ describe('Certification | Enrolment | Unit | Application | Controller | session-
 
       // then
       expect(response).to.equal('json');
+    });
+
+    context('when the session does not exist', function () {
+      it('should return a 404 response', async function () {
+        // given
+        const request = {
+          auth: { credentials: { userId: 1 } },
+          params: { sessionId: 345 },
+        };
+        const sessionSerializer = { serialize: sinon.stub() };
+        const sessionRepository = { get: sinon.stub() };
+        sessionRepository.get.withArgs({ id: 345 }).resolves(null);
+
+        // when
+        const response = await sessionController.get(request, hFake, { sessionSerializer, sessionRepository });
+
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(sessionSerializer.serialize).to.not.have.been.called;
+      });
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -12,6 +12,7 @@ import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/constan
 import {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidatesError,
+  NotFoundError,
 } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr, preventStubsToBeCalledUnexpectedly } from '../../../../../tooling/test-utils/error.js';
@@ -100,6 +101,27 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
       mailCheck,
       normalizeStringFnc,
     };
+  });
+
+  context('when session is not found', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      candidateToEnroll = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({ sessionId })
+        .build();
+      sessionAuthorizationAdapter.find.withArgs({ sessionId }).resolves(null);
+
+      // when
+      const error = await catchErr(addCandidateToSession)({
+        sessionId,
+        candidate: candidateToEnroll,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+    });
   });
 
   context('when session cannot enrol any candidate', function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/delete-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/delete-session_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { SessionStartedDeletionError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { deleteSession } from '../../../../../../src/certification/enrolment/domain/usecases/delete-session.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
@@ -26,6 +27,29 @@ describe('Unit | UseCase | delete-session', function () {
 
       // then
       expect(sessionRepository.remove).to.have.been.calledWithExactly({ id: 123 });
+    });
+  });
+
+  context('when session does not exist', function () {
+    it('throw a NotFoundError', async function () {
+      // given
+      const sessionId = 123;
+      const sessionRepository = { remove: sinon.stub() };
+      const sessionManagementRepository = {
+        hasNoStartedCertification: sinon.stub(),
+      };
+      sessionManagementRepository.hasNoStartedCertification.resolves(true);
+      sessionRepository.remove.withArgs({ id: sessionId }).resolves(null);
+
+      // when
+      const error = await catchErr(deleteSession)({
+        sessionId,
+        sessionRepository,
+        sessionManagementRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
@@ -8,7 +8,7 @@ import {
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { enrolStudentsToSession } from '../../../../../../src/certification/enrolment/domain/usecases/enrol-students-to-session.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
-import { ForbiddenAccess } from '../../../../../../src/shared/domain/errors.js';
+import { ForbiddenAccess, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr, preventStubsToBeCalledUnexpectedly } from '../../../../../tooling/test-utils/error.js';
 
@@ -98,6 +98,21 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
 
       // then
       sinon.assert.notCalled(sessionAuthorizationAdapter.find);
+    });
+  });
+
+  context('when the session does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      sessionAuthorizationAdapter.find.withArgs({ sessionId }).resolves(null);
+
+      const err = await catchErr(enrolStudentsToSession)({
+        ...dependencies,
+        sessionId,
+        studentIds: [michelStudentData.id, jeannetteStudentData.id],
+      });
+
+      // then
+      expect(err).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-attendance-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-attendance-sheet_test.js
@@ -1,19 +1,48 @@
 import sinon from 'sinon';
 
 import { getAttendanceSheet } from '../../../../../../src/certification/enrolment/domain/usecases/get-attendance-sheet.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | get-attendance-sheet', function () {
   describe('getAttendanceSheet', function () {
+    describe('when no session is found', function () {
+      it('throws a SessionNotFound error', async function () {
+        // given
+        const userId = 'dummyUserId';
+        const i18n = 'dummyi18n';
+        const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
+
+        sessionForAttendanceSheetRepository.getWithCertificationCandidates.withArgs({ id: 1 }).resolves(null);
+
+        const attendanceSheetPdfUtilsStub = {
+          getAttendanceSheetPdfBuffer: sinon.stub(),
+        };
+
+        // when
+        const error = await catchErr(getAttendanceSheet)({
+          userId,
+          sessionId: 1,
+          i18n,
+          sessionForAttendanceSheetRepository,
+          attendanceSheetPdfUtils: attendanceSheetPdfUtilsStub,
+        });
+
+        // then
+        expect(error).to.deepEqualInstance(
+          new NotFoundError("La session n'existe pas ou aucun candidat n'est inscrit à celle-ci"),
+        );
+      });
+    });
+
     it('should return the attendance sheet in pdf format', async function () {
       // given
       const userId = 'dummyUserId';
       const i18n = 'dummyi18n';
-      const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
       const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
       const session = _buildSessionWithCandidate('SUP', true);
 
-      sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
       sessionForAttendanceSheetRepository.getWithCertificationCandidates.withArgs({ id: 1 }).resolves(session);
 
       const pdfBuffer = Buffer.from('some pdf file');
@@ -31,7 +60,6 @@ describe('Unit | UseCase | get-attendance-sheet', function () {
         userId,
         sessionId: 1,
         i18n,
-        sessionRepository,
         sessionForAttendanceSheetRepository,
         attendanceSheetPdfUtils: attendanceSheetPdfUtilsStub,
       });

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-import-sheet-data_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-import-sheet-data_test.js
@@ -4,7 +4,9 @@ import sinon from 'sinon';
 import { getCandidateImportSheetData } from '../../../../../../src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/constants.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Enrolment | Unit | UseCase | get-candidate-import-sheet-data', function () {
   let sessionRepository;
@@ -17,6 +19,26 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate-import-shee
     centerRepository = {
       getById: sinon.stub(),
     };
+  });
+
+  describe('when the session does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      const userId = 123;
+      const sessionId = 456;
+      sessionRepository.get.withArgs({ id: sessionId }).resolves(null);
+
+      // when
+      const error = await catchErr(getCandidateImportSheetData)({
+        userId,
+        sessionId,
+        sessionRepository,
+        centerRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+    });
   });
 
   it('should get a session with candidates and the certification center habilitations', async function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -5,7 +5,7 @@ import { importCertificationCandidatesFromCandidatesImportSheet } from '../../..
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/constants.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
-import { CandidateAlreadyLinkedToUserError } from '../../../../../../src/shared/domain/errors.js';
+import { CandidateAlreadyLinkedToUserError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
@@ -65,6 +65,26 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
   });
 
   describe('#importCertificationCandidatesFromCandidatesImportSheet', function () {
+    context('when session does not exist', function () {
+      it('throws a NotFoundError', async function () {
+        // given
+        const sessionId = 'sessionId';
+        const odsBuffer = 'buffer';
+        sessionAuthorizationAdapter.find.withArgs({ sessionId }).resolves(null);
+
+        // when
+        const error = await catchErr(importCertificationCandidatesFromCandidatesImportSheet)({
+          i18n,
+          sessionId,
+          odsBuffer,
+          ...dependencies,
+        });
+
+        // then
+        expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+      });
+    });
+
     context('when session cannot enrolled candidates', function () {
       it('should throw a BadRequestError', async function () {
         // given

--- a/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
@@ -3,12 +3,43 @@ import sinon from 'sinon';
 import { SessionAlreadyPublishedError } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { unfinalizeSession } from '../../../../../../src/certification/session-management/domain/usecases/unfinalize-session.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | unfinalize-session', function () {
   let sessionManagementRepository;
   let finalizedSessionRepository;
+
+  describe('when session does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn({}));
+
+      const sessionId = 123;
+      sessionManagementRepository = {
+        unfinalize: sinon.stub(),
+        isPublished: sinon.stub(),
+      };
+      finalizedSessionRepository = {
+        remove: sinon.stub(),
+      };
+
+      sessionManagementRepository.isPublished.withArgs({ id: sessionId }).resolves(false);
+      finalizedSessionRepository.remove.withArgs({ id: sessionId }).resolves(null);
+
+      // when
+      const error = await catchErr(unfinalizeSession)({
+        sessionId,
+        sessionManagementRepository,
+        finalizedSessionRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+      expect(sessionManagementRepository.unfinalize).to.not.have.been.called;
+    });
+  });
 
   describe('when session is not published', function () {
     it('should call repositories with transaction', async function () {


### PR DESCRIPTION
## ☀️ Problème

Plusieurs repositories du sous-contexte `certification/enrolment` lèvent des erreurs du domaine lorsqu'ils ne trouvent pas de ligne en base.
L'infrastructure porte ainsi une décision métier alors que son seul rôle devrait être de rapporter ce qu'elle a trouvé, ou non.

  ## ⛱️ Proposition

Les repositories renvoient désormais `null` au lieu de lever une erreur, et la décision métier remonte d'un cran :

  **Repositories (`enrolment/infrastructure`)**

  | Repository | Méthode | Avant | Après |
  | --- | --- | --- | --- |
  | `session-repository` | `get` | `throw NotFoundError` | `return null` |
  | `session-repository` | `remove` | `throw NotFoundError` | `return null` |
  | `session-for-attendance-sheet-repository` | `getWithCertificationCandidates` | `throw NotFoundError` | `return null` |
  | `candidate-repository` | `update` | `throw CertificationCandidateNotFoundError` | retourne le candidat mis à jour |

  ## 🧴 Remarques

  - Le refacto porte uniquement sur `certification/enrolment`
- `unfinalize-session` introduit un changement de comportement, pas seulement un déplacement d'erreur : finalizedSessionRepository.remove (dans session-management, non touché par la branche) n'a jamais levé d'erreur. Avant, dé-finaliser une session absente de finalized-sessions passait silencieusement et appelait quand même sessionManagementRepository.unfinalize.
  - ⚠️ Point d'attention pour la revue : sur `GET`/`PATCH` d'une session inexistante, le 404 n'est plus produit par l'`error-manager` mais directement par le contrôleur. Le statut est identique, mais le corps de la réponse n'est plus un payload d'erreur JSON:API. (Renvoi d'un statusCode 404 au lieu d'une erreur)

  ## 🏊 Pour tester

  - Tests verts.
  - Non-régression sur les erreurs levées dans le sous-contexte `enrolment` :
    - `GET`/`PATCH` d'une session inexistante → `404`
    - suppression d'une session inexistante → `404`
    - PV de session (feuille d'émargement) sans session ou sans candidat inscrit → `404`
    - téléchargement du modèle d'import de candidats sur une session inexistante → `404`
    - ajout d'un candidat / enrôlement d'élèves SCO / import ODS sur une session inaccessible → `404`
    - modification d'un candidat inexistant → erreur candidat non trouvé
    - dé-finalisation d'une session non finalisée → `404`

