### PR TITLE
[TECH] Sortir les erreurs jetées dans les repositories de `certification/enrolment` (PIX-23893).

### DIFF
--- a/api/src/certification/enrolment/application/session-controller.js
+++ b/api/src/certification/enrolment/application/session-controller.js
@@ -4,7 +4,7 @@ import * as sessionRepository from '../infrastructure/repositories/session-repos
 import { candidateSerializer } from '../infrastructure/serializers/candidate-serializer.js';
 import { sessionSerializer } from '../infrastructure/serializers/session-serializer.js';
 
-async function createSession(request, _h, dependencies = { sessionSerializer, sessionRepository }) {
+async function createSession(request, h, dependencies = { sessionSerializer, sessionRepository }) {
   const userId = request.auth.credentials.userId;
   const certificationCenterId = request.params.certificationCenterId;
   const { address, room, date, time, examiner, description } = request.payload.data.attributes;
@@ -19,6 +19,7 @@ async function createSession(request, _h, dependencies = { sessionSerializer, se
     examiner,
     description,
   });
+
   const session = await dependencies.sessionRepository.get({ id: newSessionId });
 
   return dependencies.sessionSerializer.serialize(session);
@@ -30,6 +31,10 @@ async function update(request, h, dependencies = { sessionSerializer, sessionRep
 
   await usecases.updateSession({ address, room, date, time, examiner, description, sessionId });
   const updatedSession = await dependencies.sessionRepository.get({ id: sessionId });
+
+  if (!updatedSession) {
+    return h.response().code(404);
+  }
 
   return dependencies.sessionSerializer.serialize(updatedSession);
 }
@@ -45,6 +50,11 @@ async function remove(request, h) {
 async function get(request, h, dependencies = { sessionSerializer, sessionRepository }) {
   const sessionId = request.params.sessionId;
   const session = await dependencies.sessionRepository.get({ id: sessionId });
+
+  if (!session) {
+    return h.response().code(404);
+  }
+
   return dependencies.sessionSerializer.serialize(session);
 }
 

--- a/api/src/certification/enrolment/application/session-controller.js
+++ b/api/src/certification/enrolment/application/session-controller.js
@@ -25,16 +25,11 @@ async function createSession(request, h, dependencies = { sessionSerializer, ses
   return dependencies.sessionSerializer.serialize(session);
 }
 
-async function update(request, h, dependencies = { sessionSerializer, sessionRepository }) {
+async function update(request, h, dependencies = { sessionSerializer }) {
   const { address, room, date, time, examiner, description } = request.payload.data.attributes;
   const sessionId = request.params.sessionId;
 
-  await usecases.updateSession({ address, room, date, time, examiner, description, sessionId });
-  const updatedSession = await dependencies.sessionRepository.get({ id: sessionId });
-
-  if (!updatedSession) {
-    return h.response().code(404);
-  }
+  const updatedSession = await usecases.updateSession({ address, room, date, time, examiner, description, sessionId });
 
   return dependencies.sessionSerializer.serialize(updatedSession);
 }

--- a/api/src/certification/enrolment/domain/models/SessionEnrolment.js
+++ b/api/src/certification/enrolment/domain/models/SessionEnrolment.js
@@ -46,6 +46,24 @@ export class SessionEnrolment {
     return SESSION_STATUSES.CREATED;
   }
 
+  /**
+   * @param {object} params
+   * @param {string} params.address
+   * @param {string} params.room
+   * @param {string} params.date
+   * @param {string} params.time
+   * @param {string} params.examiner
+   * @param {string} params.description
+   */
+  updateInfo({ address, room, date, time, examiner, description }) {
+    this.address = address;
+    this.room = room;
+    this.date = date;
+    this.time = time;
+    this.examiner = examiner;
+    this.description = description;
+  }
+
   get isSco() {
     return this.certificationCenterType === CERTIFICATION_CENTER_TYPES.SCO;
   }

--- a/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
@@ -10,6 +10,7 @@
 import {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidatesError,
+  NotFoundError,
 } from '../../../../shared/domain/errors.js';
 import { mailCheck as mailCheckImplementation } from '../../../../shared/mail/infrastructure/services/mail-check.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
@@ -40,11 +41,16 @@ export async function addCandidateToSession({
   candidate.sessionId = sessionId;
   const sessionAuthorization = await sessionAuthorizationAdapter.find({ sessionId });
 
+  if (!sessionAuthorization) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   if (!sessionAuthorization.canEnrollCandidateIndividually) {
     throw new CannotEnrollCandidateIndividuallyError();
   }
 
   const session = await sessionRepository.get({ id: sessionId });
+
   try {
     candidate.validate({ isSco: session.isSco });
   } catch (error) {

--- a/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
@@ -24,6 +24,7 @@ import { CannotEnrollCandidateIndividuallyError } from '../errors.js';
  * @param {CertificationCpfCountryRepository} params.certificationCpfCountryRepository
  * @param {CertificationCpfCityRepository} params.certificationCpfCityRepository
  * @param {EventAdapter} params.eventAdapter
+ * @throws {NotFoundError} the session does not exist or its access is restricted
  */
 export async function addCandidateToSession({
   sessionId,

--- a/api/src/certification/enrolment/domain/usecases/delete-session.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-session.js
@@ -11,6 +11,8 @@ import { SessionStartedDeletionError } from '../errors.js';
  * @param {object} params
  * @param {SessionRepository} params.sessionRepository
  * @param {SessionManagementRepository} params.sessionManagementRepository
+ * @throws {SessionStartedDeletionError} the session has already started
+ * @throws {NotFoundError} the session does not exist or its access is restricted
  */
 const deleteSession = async ({ sessionId, sessionRepository, sessionManagementRepository }) => {
   if (!(await sessionManagementRepository.hasNoStartedCertification({ id: sessionId }))) {

--- a/api/src/certification/enrolment/domain/usecases/delete-session.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-session.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionStartedDeletionError } from '../errors.js';
 
 /**
@@ -17,7 +18,11 @@ const deleteSession = async ({ sessionId, sessionRepository, sessionManagementRe
   }
 
   await DomainTransaction.execute(async () => {
-    await sessionRepository.remove({ id: sessionId });
+    const deletedSession = await sessionRepository.remove({ id: sessionId });
+
+    if (!deletedSession) {
+      throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+    }
   });
 };
 

--- a/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
@@ -21,6 +21,7 @@ const INSEE_PREFIX_CODE = '99';
  * @param {CountryRepository} params.countryRepository
  * @param {EventAdapter} params.eventAdapter
  * @param {SessionAuthorizationAdapter} params.sessionAuthorizationAdapter
+ * @throws {NotFoundError} the session does not exist or its access is restricted
  */
 export async function enrolStudentsToSession({
   sessionId,

--- a/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
@@ -6,7 +6,7 @@
  * @typedef {import('./index.js').SessionRepository} SessionRepository
  * @typedef {import('./index.js').EventAdapter} EventAdapter
  */
-import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
+import { ForbiddenAccess, NotFoundError } from '../../../../shared/domain/errors.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { CannotEnrollScoCandidateError, UnknownCountryForStudentEnrolmentError } from '../errors.js';
@@ -38,6 +38,11 @@ export async function enrolStudentsToSession({
     return;
   }
   const sessionAuthorization = await sessionAuthorizationAdapter.find({ sessionId });
+
+  if (!sessionAuthorization) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   if (!sessionAuthorization.canEnrollScoCandidate) {
     throw new CannotEnrollScoCandidateError();
   }

--- a/api/src/certification/enrolment/domain/usecases/get-attendance-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/get-attendance-sheet.js
@@ -3,6 +3,8 @@
  * @typedef {import('./index.js').AttendanceSheetPdfUtils} AttendanceSheetPdfUtils
  */
 
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
 /**
  * @param {object} params
  * @param {SessionForAttendanceSheetRepository} params.sessionForAttendanceSheetRepository
@@ -15,6 +17,10 @@ const getAttendanceSheet = async function ({
   attendanceSheetPdfUtils,
 }) {
   const session = await sessionForAttendanceSheetRepository.getWithCertificationCandidates({ id: sessionId });
+
+  if (!session) {
+    throw new NotFoundError("La session n'existe pas ou aucun candidat n'est inscrit à celle-ci");
+  }
 
   const { attendanceSheet, fileName } = await attendanceSheetPdfUtils.getAttendanceSheetPdfBuffer({
     session,

--- a/api/src/certification/enrolment/domain/usecases/get-attendance-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/get-attendance-sheet.js
@@ -9,6 +9,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
  * @param {object} params
  * @param {SessionForAttendanceSheetRepository} params.sessionForAttendanceSheetRepository
  * @param {AttendanceSheetPdfUtils} params.attendanceSheetPdfUtils
+ * @throws {NotFoundError} the session does not exist or no candidate is enrolled in it
  */
 const getAttendanceSheet = async function ({
   sessionId,

--- a/api/src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js
@@ -8,6 +8,7 @@ import { Candidate } from '../models/Candidate.js';
  * @param {object} params
  * @param {SessionRepository} params.sessionRepository
  * @param {CenterRepository} params.centerRepository
+ * @throws {NotFoundError} the session does not exist or its access is restricted
  */
 export async function getCandidateImportSheetData({ sessionId, sessionRepository, centerRepository }) {
   const session = await sessionRepository.get({ id: sessionId });

--- a/api/src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js
@@ -2,6 +2,7 @@
  * @typedef {import('./index.js').SessionRepository} SessionRepository
  * @typedef {import('./index.js').CenterRepository} CenterRepository
  */
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Candidate } from '../models/Candidate.js';
 /**
  * @param {object} params
@@ -10,6 +11,11 @@ import { Candidate } from '../models/Candidate.js';
  */
 export async function getCandidateImportSheetData({ sessionId, sessionRepository, centerRepository }) {
   const session = await sessionRepository.get({ id: sessionId });
+
+  if (!session) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   const enrolledCandidates = session.certificationCandidates.sort(Candidate.sortByLastNameAndFirstName);
   const center = await centerRepository.getById({ id: session.certificationCenterId });
   return {

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -5,7 +5,7 @@
  */
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CandidateAlreadyLinkedToUserError } from '../../../../shared/domain/errors.js';
+import { CandidateAlreadyLinkedToUserError, NotFoundError } from '../../../../shared/domain/errors.js';
 
 /**
  * @param {object} params
@@ -28,11 +28,17 @@ export async function importCertificationCandidatesFromCandidatesImportSheet({
   certificationCpfService,
 }) {
   const sessionAuthorization = await sessionAuthorizationAdapter.find({ sessionId });
+
+  if (!sessionAuthorization) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   if (!sessionAuthorization.canEnrollCandidateViaODS) {
     throw new CandidateAlreadyLinkedToUserError('At least one candidate is already linked to a user');
   }
 
   const session = await sessionRepository.get({ id: sessionId });
+
   const candidates = await certificationCandidatesOdsService.extractCertificationCandidatesFromCandidatesImportSheet({
     i18n,
     session,

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -12,6 +12,7 @@ import { CandidateAlreadyLinkedToUserError, NotFoundError } from '../../../../sh
  * @param {CandidateRepository} params.candidateRepository
  * @param {SessionRepository} params.sessionRepository
  * @param {EventAdapter} params.eventAdapter
+ * @throws {NotFoundError} the session does not exist or its access is restricted
  */
 export async function importCertificationCandidatesFromCandidatesImportSheet({
   sessionId,

--- a/api/src/certification/enrolment/domain/usecases/update-session.js
+++ b/api/src/certification/enrolment/domain/usecases/update-session.js
@@ -2,6 +2,8 @@
  * @typedef {import('./index.js').SessionRepository} SessionRepository*
  */
 
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
 /**
  * @param {object} params
  * @param {number} params.sessionId
@@ -23,5 +25,23 @@ export async function updateSession({
   description,
   sessionRepository,
 }) {
-  return sessionRepository.updateInfo({ id: sessionId, address, room, date, time, examiner, description });
+  const session = await sessionRepository.get({ id: sessionId });
+
+  if (!session) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
+  session.updateInfo({ address, room, date, time, examiner, description });
+
+  await sessionRepository.updateInfo({
+    id: sessionId,
+    address,
+    room,
+    date,
+    time,
+    examiner,
+    description,
+  });
+
+  return session;
 }

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -4,7 +4,6 @@
 
 // @ts-check
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
 import { Candidate } from '../../domain/models/Candidate.js';
 
 /**
@@ -57,8 +56,7 @@ export async function findByUserId({ userId }) {
  * @function
  * @param {Candidate} candidate
  *
- * @returns {Promise<void>}
- * @throws {CertificationCandidateNotFoundError} Certification candidate not found
+ * @returns {Promise<object|undefined>} the updated candidate, or undefined when no candidate was found
  */
 export async function update(candidate) {
   const candidateDataToSave = adaptModelToDb(candidate);
@@ -71,9 +69,7 @@ export async function update(candidate) {
     .update(candidateDataToSave)
     .returning('*');
 
-  if (!updatedCertificationCandidate) {
-    throw new CertificationCandidateNotFoundError();
-  }
+  return updatedCertificationCandidate;
 }
 
 /**

--- a/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
@@ -1,5 +1,4 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCandidateForAttendanceSheet } from '../../domain/read-models/CertificationCandidateForAttendanceSheet.js';
 import { SessionForAttendanceSheet } from '../../domain/read-models/SessionForAttendanceSheet.js';
 
@@ -59,7 +58,7 @@ export async function getWithCertificationCandidates({ id }) {
     .first();
 
   if (!results || results.certificationCandidates === null) {
-    throw new NotFoundError("La session n'existe pas ou aucun candidat n'est inscrit à celle-ci");
+    return null;
   }
 
   return _toDomain(results);

--- a/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
@@ -6,8 +6,7 @@ import { SessionForAttendanceSheet } from '../../domain/read-models/SessionForAt
  * @function
  * @param {object} params
  * @param {number} params.id
- * @returns {Promise<SessionForAttendanceSheet>}
- * @throws {NotFoundError}
+ * @returns {Promise<SessionForAttendanceSheet|null>} the session with its candidates, or null when the session does not exist or has no enrolled candidate
  */
 export async function getWithCertificationCandidates({ id }) {
   const knexConn = DomainTransaction.getConnection();

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -9,7 +9,6 @@ import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
  * @param {object} params
  * @param {number} params.id
  * @returns {Promise<SessionEnrolment>}
- * @throws {NotFoundError}
  */
 export async function get({ id }) {
   const knexConn = DomainTransaction.getConnection();
@@ -69,8 +68,9 @@ export async function get({ id }) {
     .join('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
     .where('sessions.id', id)
     .first();
+
   if (!foundSession) {
-    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+    return null;
   }
 
   const certificationCandidates =

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -7,7 +7,7 @@ import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
  * @function
  * @param {object} params
  * @param {number} params.id
- * @returns {Promise<SessionEnrolment>}
+ * @returns {Promise<SessionEnrolment|null>} the session, or null when no session was found
  */
 export async function get({ id }) {
   const knexConn = DomainTransaction.getConnection();

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -1,5 +1,4 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { Candidate } from '../../domain/models/Candidate.js';
 import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
@@ -190,13 +189,17 @@ export async function updateInfo({ id, address, room, examiner, date, time, desc
  * @function
  * @param {object} params
  * @param {number} params.id
- * @returns {Promise<void>}
- * @throws {NotFoundError}
+ * @returns {Promise<number|null>} the number of deleted sessions, or null when no session was found
  */
 export async function remove({ id }) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('invigilator_accesses').where({ sessionId: id }).del();
   await knexConn('certification-candidates').where({ sessionId: id }).del();
   const nbSessionsDeleted = await knexConn('sessions').where({ id }).del();
-  if (nbSessionsDeleted === 0) throw new NotFoundError();
+
+  if (nbSessionsDeleted === 0) {
+    return null;
+  }
+
+  return nbSessionsDeleted;
 }

--- a/api/src/certification/session-management/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session-management/application/http-error-mapper-configuration.js
@@ -16,6 +16,7 @@ import {
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionFinalized,
+  SessionNotFinalizedError,
   SessionNotJoinable,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,
@@ -37,6 +38,10 @@ const sessionDomainErrorMappingConfiguration = [
   {
     name: SessionAlreadyPublishedError.name,
     httpErrorFn: (error) => new BadRequestError(error.message, error.code),
+  },
+  {
+    name: SessionNotFinalizedError.name,
+    httpErrorFn: (error) => new ConflictError(error.message, error.code),
   },
   {
     name: ChallengeToBeDeneutralizedNotFoundError.name,

--- a/api/src/certification/session-management/domain/errors.js
+++ b/api/src/certification/session-management/domain/errors.js
@@ -66,6 +66,13 @@ class InvalidSessionSupervisingLoginError extends DomainError {
   }
 }
 
+class SessionNotFinalizedError extends DomainError {
+  constructor(message = "La session n'est pas finalisée.") {
+    super(message);
+    this.code = 'SESSION_NOT_FINALIZED';
+  }
+}
+
 class SessionNotJoinable extends DomainError {
   constructor(blockedAccessDate) {
     super('Certification session is not joinable', 'SESSION_NOT_JOINABLE');
@@ -112,6 +119,7 @@ export {
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionFinalized,
+  SessionNotFinalizedError,
   SessionNotJoinable,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,

--- a/api/src/certification/session-management/domain/models/SessionManagement.js
+++ b/api/src/certification/session-management/domain/models/SessionManagement.js
@@ -67,6 +67,10 @@ export class SessionManagement {
     return this.publishedAt !== null;
   }
 
+  isFinalized() {
+    return this.finalizedAt !== null;
+  }
+
   get hasExpired() {
     const hasACertificationOnGoing = Boolean(this.firstCertificationStartedAt);
     if (hasACertificationOnGoing) {

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -3,6 +3,7 @@
  * @typedef {import('../../../../../src/certification/session-management/domain/usecases/index.js').MailService} MailService
  * @typedef {import('../../../../../src/certification/session-management/domain/usecases/index.js').SessionManagementRepository} SessionManagementRepository
  */
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import {
@@ -27,6 +28,10 @@ async function publishSession({
   sessionManagementRepository,
 }) {
   const session = await sessionManagementRepository.get({ id: sessionId });
+  if (!session) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   if (session.isPublished()) {
     throw new SessionAlreadyPublishedError();
   }

--- a/api/src/certification/session-management/domain/usecases/get-session.js
+++ b/api/src/certification/session-management/domain/usecases/get-session.js
@@ -1,5 +1,12 @@
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
 const getSession = async function ({ sessionId, sessionManagementRepository }) {
   const session = await sessionManagementRepository.get({ id: sessionId });
+
+  if (!session) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+
   const hasSomeCleaAcquired = await sessionManagementRepository.hasSomeCleaAcquired({ id: sessionId });
   return {
     session,

--- a/api/src/certification/session-management/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/unfinalize-session.js
@@ -11,6 +11,8 @@ import { SessionAlreadyPublishedError } from '../errors.js';
  * @param {object} params
  * @param {SessionManagementRepository} params.sessionManagementRepository
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository
+ * @throws {SessionAlreadyPublishedError} the session is already published
+ * @throws {NotFoundError} the finalized session does not exist or its access is restricted
  */
 const unfinalizeSession = async function ({ sessionId, sessionManagementRepository, finalizedSessionRepository }) {
   if (await sessionManagementRepository.isPublished({ id: sessionId })) {

--- a/api/src/certification/session-management/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/unfinalize-session.js
@@ -5,14 +5,15 @@
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { SessionAlreadyPublishedError } from '../errors.js';
+import { SessionAlreadyPublishedError, SessionNotFinalizedError } from '../errors.js';
 
 /**
  * @param {object} params
  * @param {SessionManagementRepository} params.sessionManagementRepository
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository
+ * @throws {NotFoundError} the session does not exist or its access is restricted
  * @throws {SessionAlreadyPublishedError} the session is already published
- * @throws {NotFoundError} the finalized session does not exist or its access is restricted
+ * @throws {SessionNotFinalizedError} the session is not finalized
  */
 const unfinalizeSession = async function ({ sessionId, sessionManagementRepository, finalizedSessionRepository }) {
   return DomainTransaction.execute(async () => {
@@ -24,6 +25,10 @@ const unfinalizeSession = async function ({ sessionId, sessionManagementReposito
 
     if (session.isPublished()) {
       throw new SessionAlreadyPublishedError();
+    }
+
+    if (!session.isFinalized()) {
+      throw new SessionNotFinalizedError();
     }
 
     await finalizedSessionRepository.remove({ sessionId });

--- a/api/src/certification/session-management/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/unfinalize-session.js
@@ -4,6 +4,7 @@
  */
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionAlreadyPublishedError } from '../errors.js';
 
 /**
@@ -17,7 +18,12 @@ const unfinalizeSession = async function ({ sessionId, sessionManagementReposito
   }
 
   return DomainTransaction.execute(async () => {
-    await finalizedSessionRepository.remove({ sessionId });
+    const nbFinalizedSessionsRemoved = await finalizedSessionRepository.remove({ sessionId });
+
+    if (!nbFinalizedSessionsRemoved) {
+      throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+    }
+
     await sessionManagementRepository.unfinalize({ id: sessionId });
   });
 };

--- a/api/src/certification/session-management/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/unfinalize-session.js
@@ -15,16 +15,18 @@ import { SessionAlreadyPublishedError } from '../errors.js';
  * @throws {NotFoundError} the finalized session does not exist or its access is restricted
  */
 const unfinalizeSession = async function ({ sessionId, sessionManagementRepository, finalizedSessionRepository }) {
-  if (await sessionManagementRepository.isPublished({ id: sessionId })) {
-    throw new SessionAlreadyPublishedError();
-  }
-
   return DomainTransaction.execute(async () => {
-    const nbFinalizedSessionsRemoved = await finalizedSessionRepository.remove({ sessionId });
+    const session = await sessionManagementRepository.get({ id: sessionId });
 
-    if (!nbFinalizedSessionsRemoved) {
+    if (!session) {
       throw new NotFoundError("La session n'existe pas ou son accès est restreint");
     }
+
+    if (session.isPublished()) {
+      throw new SessionAlreadyPublishedError();
+    }
+
+    await finalizedSessionRepository.remove({ sessionId });
 
     await sessionManagementRepository.unfinalize({ id: sessionId });
   });

--- a/api/src/certification/session-management/domain/usecases/unpublish-session.js
+++ b/api/src/certification/session-management/domain/usecases/unpublish-session.js
@@ -1,3 +1,5 @@
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
 const unpublishSession = async function ({
   sessionId,
   certificationRepository,
@@ -5,6 +7,10 @@ const unpublishSession = async function ({
   finalizedSessionRepository,
 }) {
   const session = await sessionManagementRepository.get({ id: sessionId });
+
+  if (!session) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
 
   await certificationRepository.unpublishCertificationCoursesBySessionId({ sessionId });
 

--- a/api/src/certification/session-management/infrastructure/repositories/session-management-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-management-repository.js
@@ -58,12 +58,6 @@ const isFinalized = async function ({ id }) {
   return Boolean(session);
 };
 
-const isPublished = async function ({ id }) {
-  const knexConn = DomainTransaction.getConnection();
-  const isPublished = await knexConn.select(1).from('sessions').where({ id }).whereNotNull('publishedAt').first();
-  return Boolean(isPublished);
-};
-
 const doesUserHaveCertificationCenterMembershipForSession = async function ({ userId, sessionId }) {
   const knexConn = DomainTransaction.getConnection();
   const sessions = await knexConn
@@ -150,7 +144,6 @@ export {
   hasNoStartedCertification,
   hasSomeCleaAcquired,
   isFinalized,
-  isPublished,
   unfinalize,
   updatePublishedAt,
 };

--- a/api/src/certification/session-management/infrastructure/repositories/session-management-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-management-repository.js
@@ -37,15 +37,18 @@ const get = async function ({ id }) {
     .from('sessions')
     .where({ id })
     .first();
+
   if (!foundSession) {
-    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+    return null;
   }
+
   const certificationCandidates = await knexConn
     .select('id', 'userId', 'reconciledAt', 'resultRecipientEmail')
     .from('certification-candidates')
     .groupBy('certification-candidates.id')
     .where({ sessionId: id })
     .orderByRaw('LOWER(??) ASC, LOWER(??) ASC', ['lastName', 'firstName']);
+
   return new SessionManagement({ ...foundSession, certificationCandidates });
 };
 

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -1,11 +1,9 @@
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import * as candidateRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/candidate-repository.js';
-import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Certification | Enrolment | Repository | Candidate', function () {
   describe('#get', function () {
@@ -147,59 +145,41 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
   });
 
   describe('#update', function () {
-    context('when the candidate exists', function () {
-      it('should update the candidate', async function () {
-        // when
-        const certificationCandidate = domainBuilder.certification.enrolment
-          .candidateBuilder()
-          .withIdentity({ firstName: 'toto' })
-          .insertToDB({ databaseBuilder });
+    it('updates the candidate', async function () {
+      // when
+      const certificationCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withIdentity({ firstName: 'toto' })
+        .insertToDB({ databaseBuilder });
 
-        await databaseBuilder.commit();
+      await databaseBuilder.commit();
 
-        // when
-        await candidateRepository.update({ ...certificationCandidate, firstName: 'tutu' });
+      // when
+      await candidateRepository.update({ ...certificationCandidate, firstName: 'tutu' });
 
-        const candidate = await candidateRepository.get({
-          certificationCandidateId: certificationCandidate.id,
-        });
-
-        // then
-        expect(candidate).to.be.instanceOf(Candidate);
-        expect(candidate.firstName).to.equal('tutu');
+      const candidate = await candidateRepository.get({
+        certificationCandidateId: certificationCandidate.id,
       });
 
-      it('should update its subscription', async function () {
-        // given
-        const certificationCandidate = domainBuilder.certification.enrolment
-          .candidateBuilder()
-          .withSubscription(Frameworks.DROIT)
-          .insertToDB({ databaseBuilder });
-        await databaseBuilder.commit();
-
-        // when
-        await candidateRepository.update({ ...certificationCandidate, subscription: Frameworks.EDU_1ER_DEGRE });
-
-        // then
-        const updated = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
-        expect(updated.subscription).to.equal(Frameworks.EDU_1ER_DEGRE);
-      });
+      // then
+      expect(candidate).to.be.instanceOf(Candidate);
+      expect(candidate.firstName).to.equal('tutu');
     });
 
-    context('when the candidate does not exist', function () {
-      it('should throw', async function () {
-        // when
-        const certificationCandidateToUpdate = domainBuilder.certification.enrolment.buildCertificationSessionCandidate(
-          { firstName: 'candidate unknown' },
-        );
+    it('updates its subscription', async function () {
+      // given
+      const certificationCandidate = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withSubscription(Frameworks.DROIT)
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
 
-        certificationCandidateToUpdate.firstName = 'tutu';
+      // when
+      await candidateRepository.update({ ...certificationCandidate, subscription: Frameworks.EDU_1ER_DEGRE });
 
-        const error = await catchErr(candidateRepository.update)(certificationCandidateToUpdate);
-
-        // then
-        expect(error).to.be.instanceOf(CertificationCandidateNotFoundError);
-      });
+      // then
+      const updated = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
+      expect(updated.subscription).to.equal(Frameworks.EDU_1ER_DEGRE);
     });
   });
 

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-for-attendance-sheet-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-for-attendance-sheet-repository_test.js
@@ -1,11 +1,9 @@
 import { CertificationCandidateForAttendanceSheet } from '../../../../../../src/certification/enrolment/domain/read-models/CertificationCandidateForAttendanceSheet.js';
 import { SessionForAttendanceSheet } from '../../../../../../src/certification/enrolment/domain/read-models/SessionForAttendanceSheet.js';
 import * as sessionForAttendanceSheetRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Repository | Session-for-attendance-sheet', function () {
   describe('#getWithCertificationCandidates', function () {
@@ -190,31 +188,31 @@ describe('Integration | Repository | Session-for-attendance-sheet', function () 
     });
 
     context('when no session was found', function () {
-      it('should return a Not found error', async function () {
+      it('returns null', async function () {
         // when
-        const error = await catchErr(sessionForAttendanceSheetRepository.getWithCertificationCandidates)({
+        const session = await sessionForAttendanceSheetRepository.getWithCertificationCandidates({
           id: 12434354,
         });
 
         // then
-        expect(error).to.be.instanceOf(NotFoundError);
+        expect(session).to.be.null;
       });
     });
 
     context('when no certification candidates was found', function () {
-      it('should return a Not found error', async function () {
+      it('returns null', async function () {
         // given
         const sessionId = 1234;
         databaseBuilder.factory.buildSession({ id: sessionId });
         await databaseBuilder.commit();
 
         // when
-        const error = await catchErr(sessionForAttendanceSheetRepository.getWithCertificationCandidates)({
+        const session = await sessionForAttendanceSheetRepository.getWithCertificationCandidates({
           id: sessionId,
         });
 
         // then<
-        expect(error).to.be.instanceOf(NotFoundError);
+        expect(session).to.be.null;
       });
     });
   });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -93,7 +93,7 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
       expect(actualSession).to.deepEqualInstance(expectedSession);
     });
 
-    it('should return a Not found error when no session was found', async function () {
+    it('returns null when no session was found', async function () {
       domainBuilder.certification.enrolment
         .sessionEnrolmentBuilder()
         .createdBy({
@@ -116,11 +116,12 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
         })
         .insertToDB({ databaseBuilder });
       await databaseBuilder.commit();
+
       // when
-      const error = await catchErr(sessionRepository.get)({ id: 777 });
+      const session = await sessionRepository.get({ id: 777 });
 
       // then
-      expect(error).to.be.instanceOf(NotFoundError);
+      expect(session).to.be.null;
     });
   });
 

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -1,11 +1,9 @@
 import * as sessionRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/session-repository.js';
 import { BILLING_MODES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Repository | certification | enrolment | SessionEnrolment', function () {
   describe('#get', function () {
@@ -287,25 +285,26 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
           await databaseBuilder.commit();
 
           // when
-          await sessionRepository.remove({ id: sessionId });
+          const result = await sessionRepository.remove({ id: sessionId });
 
           // then
           const foundSession = await knex('sessions').select('id').where({ id: sessionId }).first();
           expect(foundSession).to.be.undefined;
+          expect(result).to.equal(1);
         });
       });
     });
 
     context('when session does not exist', function () {
-      it('should throw a not found error', async function () {
+      it('return null', async function () {
         // given
         const sessionId = 123456;
 
         // when
-        const error = await catchErr(sessionRepository.remove)({ id: sessionId });
+        const result = await sessionRepository.remove({ id: sessionId });
 
         // then
-        expect(error).to.be.instanceOf(NotFoundError);
+        expect(result).to.be.null;
       });
     });
   });

--- a/api/tests/certification/enrolment/unit/application/session-controller_test.js
+++ b/api/tests/certification/enrolment/unit/application/session-controller_test.js
@@ -96,6 +96,39 @@ describe('Certification | Enrolment | Unit | Application | Controller | session-
       // then
       expect(response).to.equal('json');
     });
+
+    context('when the updated session cannot be retrieved', function () {
+      it('should return a 404 response', async function () {
+        // given
+        const request = {
+          auth: { credentials: { userId: 1 } },
+          params: { sessionId: 345 },
+          payload: {
+            data: {
+              attributes: {
+                address: '1 rue des lauriers',
+                room: '2B',
+                date: '2021-01-01',
+                time: '14:00',
+                examiner: 'Louise',
+                description: 'coucou',
+              },
+            },
+          },
+        };
+        sinon.stub(usecases, 'updateSession').resolves();
+        const sessionSerializer = { serialize: sinon.stub() };
+        const sessionRepository = { get: sinon.stub() };
+        sessionRepository.get.withArgs({ id: 345 }).resolves(null);
+
+        // when
+        const response = await sessionController.update(request, hFake, { sessionSerializer, sessionRepository });
+
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(sessionSerializer.serialize).to.not.have.been.called;
+      });
+    });
   });
 
   describe('#delete', function () {
@@ -141,6 +174,26 @@ describe('Certification | Enrolment | Unit | Application | Controller | session-
 
       // then
       expect(response).to.equal('json');
+    });
+
+    context('when the session does not exist', function () {
+      it('should return a 404 response', async function () {
+        // given
+        const request = {
+          auth: { credentials: { userId: 1 } },
+          params: { sessionId: 345 },
+        };
+        const sessionSerializer = { serialize: sinon.stub() };
+        const sessionRepository = { get: sinon.stub() };
+        sessionRepository.get.withArgs({ id: 345 }).resolves(null);
+
+        // when
+        const response = await sessionController.get(request, hFake, { sessionSerializer, sessionRepository });
+
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(sessionSerializer.serialize).to.not.have.been.called;
+      });
     });
   });
 

--- a/api/tests/certification/enrolment/unit/application/session-controller_test.js
+++ b/api/tests/certification/enrolment/unit/application/session-controller_test.js
@@ -74,7 +74,7 @@ describe('Certification | Enrolment | Unit | Application | Controller | session-
       };
       sinon.stub(usecases, 'updateSession');
       const sessionSerializer = { serialize: sinon.stub() };
-      const sessionRepository = { get: sinon.stub() };
+      const updatedSession = Symbol('updatedSession');
       usecases.updateSession
         .withArgs({
           address: '1 rue des lauriers',
@@ -85,49 +85,14 @@ describe('Certification | Enrolment | Unit | Application | Controller | session-
           description: 'coucou',
           sessionId: 345,
         })
-        .resolves();
-      const updatedSession = Symbol('updatedSession');
-      sessionRepository.get.withArgs({ id: 345 }).resolves(updatedSession);
+        .resolves(updatedSession);
       sessionSerializer.serialize.withArgs(updatedSession).returns('json');
 
       // when
-      const response = await sessionController.update(request, hFake, { sessionSerializer, sessionRepository });
+      const response = await sessionController.update(request, hFake, { sessionSerializer });
 
       // then
       expect(response).to.equal('json');
-    });
-
-    context('when the updated session cannot be retrieved', function () {
-      it('should return a 404 response', async function () {
-        // given
-        const request = {
-          auth: { credentials: { userId: 1 } },
-          params: { sessionId: 345 },
-          payload: {
-            data: {
-              attributes: {
-                address: '1 rue des lauriers',
-                room: '2B',
-                date: '2021-01-01',
-                time: '14:00',
-                examiner: 'Louise',
-                description: 'coucou',
-              },
-            },
-          },
-        };
-        sinon.stub(usecases, 'updateSession').resolves();
-        const sessionSerializer = { serialize: sinon.stub() };
-        const sessionRepository = { get: sinon.stub() };
-        sessionRepository.get.withArgs({ id: 345 }).resolves(null);
-
-        // when
-        const response = await sessionController.update(request, hFake, { sessionSerializer, sessionRepository });
-
-        // then
-        expect(response.statusCode).to.equal(404);
-        expect(sessionSerializer.serialize).to.not.have.been.called;
-      });
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -12,6 +12,7 @@ import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/constan
 import {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidatesError,
+  NotFoundError,
 } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr, preventStubsToBeCalledUnexpectedly } from '../../../../../tooling/test-utils/error.js';
@@ -100,6 +101,27 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
       mailCheck,
       normalizeStringFnc,
     };
+  });
+
+  context('when session is not found', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      candidateToEnroll = domainBuilder.certification.enrolment
+        .candidateBuilder()
+        .withParameters({ sessionId })
+        .build();
+      sessionAuthorizationAdapter.find.withArgs({ sessionId }).resolves(null);
+
+      // when
+      const error = await catchErr(addCandidateToSession)({
+        sessionId,
+        candidate: candidateToEnroll,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+    });
   });
 
   context('when session cannot enrol any candidate', function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/delete-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/delete-session_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { SessionStartedDeletionError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { deleteSession } from '../../../../../../src/certification/enrolment/domain/usecases/delete-session.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
@@ -16,6 +17,7 @@ describe('Unit | UseCase | delete-session', function () {
       const sessionRepository = { remove: sinon.stub() };
       const sessionManagementRepository = { hasNoStartedCertification: sinon.stub() };
       sessionManagementRepository.hasNoStartedCertification.resolves(true);
+      sessionRepository.remove.withArgs({ id: 123 }).resolves(1);
 
       // when
       await deleteSession({
@@ -26,6 +28,29 @@ describe('Unit | UseCase | delete-session', function () {
 
       // then
       expect(sessionRepository.remove).to.have.been.calledWithExactly({ id: 123 });
+    });
+  });
+
+  context('when session does not exist', function () {
+    it('throw a NotFoundError', async function () {
+      // given
+      const sessionId = 123;
+      const sessionRepository = { remove: sinon.stub() };
+      const sessionManagementRepository = {
+        hasNoStartedCertification: sinon.stub(),
+      };
+      sessionManagementRepository.hasNoStartedCertification.resolves(true);
+      sessionRepository.remove.withArgs({ id: sessionId }).resolves(null);
+
+      // when
+      const error = await catchErr(deleteSession)({
+        sessionId,
+        sessionRepository,
+        sessionManagementRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/enrol-students-to-session_test.js
@@ -8,7 +8,7 @@ import {
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { enrolStudentsToSession } from '../../../../../../src/certification/enrolment/domain/usecases/enrol-students-to-session.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
-import { ForbiddenAccess } from '../../../../../../src/shared/domain/errors.js';
+import { ForbiddenAccess, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr, preventStubsToBeCalledUnexpectedly } from '../../../../../tooling/test-utils/error.js';
 
@@ -98,6 +98,21 @@ describe('Certification | Enrolment | Unit | UseCase | enrol-students-to-session
 
       // then
       sinon.assert.notCalled(sessionAuthorizationAdapter.find);
+    });
+  });
+
+  context('when the session does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      sessionAuthorizationAdapter.find.withArgs({ sessionId }).resolves(null);
+
+      const err = await catchErr(enrolStudentsToSession)({
+        ...dependencies,
+        sessionId,
+        studentIds: [michelStudentData.id, jeannetteStudentData.id],
+      });
+
+      // then
+      expect(err).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-attendance-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-attendance-sheet_test.js
@@ -1,19 +1,48 @@
 import sinon from 'sinon';
 
 import { getAttendanceSheet } from '../../../../../../src/certification/enrolment/domain/usecases/get-attendance-sheet.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | get-attendance-sheet', function () {
   describe('getAttendanceSheet', function () {
+    describe('when no session is found', function () {
+      it('throws a SessionNotFound error', async function () {
+        // given
+        const userId = 'dummyUserId';
+        const i18n = 'dummyi18n';
+        const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
+
+        sessionForAttendanceSheetRepository.getWithCertificationCandidates.withArgs({ id: 1 }).resolves(null);
+
+        const attendanceSheetPdfUtilsStub = {
+          getAttendanceSheetPdfBuffer: sinon.stub(),
+        };
+
+        // when
+        const error = await catchErr(getAttendanceSheet)({
+          userId,
+          sessionId: 1,
+          i18n,
+          sessionForAttendanceSheetRepository,
+          attendanceSheetPdfUtils: attendanceSheetPdfUtilsStub,
+        });
+
+        // then
+        expect(error).to.deepEqualInstance(
+          new NotFoundError("La session n'existe pas ou aucun candidat n'est inscrit à celle-ci"),
+        );
+      });
+    });
+
     it('should return the attendance sheet in pdf format', async function () {
       // given
       const userId = 'dummyUserId';
       const i18n = 'dummyi18n';
-      const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
       const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
       const session = _buildSessionWithCandidate('SUP', true);
 
-      sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
       sessionForAttendanceSheetRepository.getWithCertificationCandidates.withArgs({ id: 1 }).resolves(session);
 
       const pdfBuffer = Buffer.from('some pdf file');
@@ -31,7 +60,6 @@ describe('Unit | UseCase | get-attendance-sheet', function () {
         userId,
         sessionId: 1,
         i18n,
-        sessionRepository,
         sessionForAttendanceSheetRepository,
         attendanceSheetPdfUtils: attendanceSheetPdfUtilsStub,
       });

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-import-sheet-data_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-import-sheet-data_test.js
@@ -4,7 +4,9 @@ import sinon from 'sinon';
 import { getCandidateImportSheetData } from '../../../../../../src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/constants.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Enrolment | Unit | UseCase | get-candidate-import-sheet-data', function () {
   let sessionRepository;
@@ -17,6 +19,26 @@ describe('Certification | Enrolment | Unit | UseCase | get-candidate-import-shee
     centerRepository = {
       getById: sinon.stub(),
     };
+  });
+
+  describe('when the session does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      const userId = 123;
+      const sessionId = 456;
+      sessionRepository.get.withArgs({ id: sessionId }).resolves(null);
+
+      // when
+      const error = await catchErr(getCandidateImportSheetData)({
+        userId,
+        sessionId,
+        sessionRepository,
+        centerRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+    });
   });
 
   it('should get a session with candidates and the certification center habilitations', async function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -5,7 +5,7 @@ import { importCertificationCandidatesFromCandidatesImportSheet } from '../../..
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/constants.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
-import { CandidateAlreadyLinkedToUserError } from '../../../../../../src/shared/domain/errors.js';
+import { CandidateAlreadyLinkedToUserError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
@@ -65,6 +65,26 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
   });
 
   describe('#importCertificationCandidatesFromCandidatesImportSheet', function () {
+    context('when session does not exist', function () {
+      it('throws a NotFoundError', async function () {
+        // given
+        const sessionId = 'sessionId';
+        const odsBuffer = 'buffer';
+        sessionAuthorizationAdapter.find.withArgs({ sessionId }).resolves(null);
+
+        // when
+        const error = await catchErr(importCertificationCandidatesFromCandidatesImportSheet)({
+          i18n,
+          sessionId,
+          odsBuffer,
+          ...dependencies,
+        });
+
+        // then
+        expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+      });
+    });
+
     context('when session cannot enrolled candidates', function () {
       it('should throw a BadRequestError', async function () {
         // given

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-session_test.js
@@ -1,24 +1,66 @@
 import sinon from 'sinon';
 
 import { updateSession } from '../../../../../../src/certification/enrolment/domain/usecases/update-session.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Enrolment | Unit | UseCase | update-session', function () {
-  it('submits the update of the session', async function () {
-    const sessionRepository = { updateInfo: sinon.fake.resolves() };
+  describe('when session does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      const sessionId = 345;
+      const sessionRepository = { get: sinon.stub() };
+      sessionRepository.get.withArgs({ id: sessionId }).resolves(null);
 
-    await updateSession({
+      // when
+      const error = await catchErr(updateSession)({
+        address: '1 rue des lauriers',
+        room: '2B',
+        date: '2021-01-01',
+        time: '14:00',
+        examiner: 'Louise',
+        description: 'coucou',
+        sessionId,
+        sessionRepository,
+      });
+
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+    });
+  });
+
+  it('submits the update of the session', async function () {
+    const sessionId = 345;
+    const sessionRepository = { get: sinon.stub(), updateInfo: sinon.fake.resolves() };
+    const sessionToUpdate = domainBuilder.certification.enrolment
+      .sessionEnrolmentBuilder()
+      .withParameters({
+        id: sessionId,
+        address: '2 rue des rosiers',
+        room: '1A',
+        date: '2022-02-02',
+        time: '15:10',
+        examiner: 'Bernanrd',
+        description: 'au revoir',
+      })
+      .build();
+
+    sessionRepository.get.withArgs({ id: sessionId }).resolves(sessionToUpdate);
+
+    const session = await updateSession({
       address: '1 rue des lauriers',
       room: '2B',
       date: '2021-01-01',
       time: '14:00',
       examiner: 'Louise',
       description: 'coucou',
-      sessionId: 345,
+      sessionId,
       sessionRepository,
     });
 
     sinon.assert.calledOnceWithExactly(sessionRepository.updateInfo, {
-      id: 345,
+      id: sessionId,
       address: '1 rue des lauriers',
       room: '2B',
       date: '2021-01-01',
@@ -26,5 +68,19 @@ describe('Certification | Enrolment | Unit | UseCase | update-session', function
       examiner: 'Louise',
       description: 'coucou',
     });
+    expect(session).to.deep.equal(
+      domainBuilder.certification.enrolment
+        .sessionEnrolmentBuilder()
+        .withParameters({
+          id: sessionId,
+          address: '1 rue des lauriers',
+          room: '2B',
+          date: '2021-01-01',
+          time: '14:00',
+          examiner: 'Louise',
+          description: 'coucou',
+        })
+        .build(),
+    );
   });
 });

--- a/api/tests/certification/session-management/acceptance/application/unfinalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/unfinalize-route_test.js
@@ -8,7 +8,7 @@ describe('Certification | Session Management | Acceptance | Application | Contro
     it('should return status 204', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser.withRole().id;
-      databaseBuilder.factory.buildSession({ id: 123 });
+      databaseBuilder.factory.buildSession({ id: 123, finalizedAt: new Date('2020-01-01') });
       databaseBuilder.factory.buildFinalizedSession({ sessionId: 123 });
       await databaseBuilder.commit();
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-management-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-management-repository_test.js
@@ -115,36 +115,6 @@ describe('Certification | SessionManagement | Integration | Infrastructure | Rep
     });
   });
 
-  describe('#isPublished', function () {
-    context('when the session has a published date', function () {
-      it('should return true', async function () {
-        //given
-        databaseBuilder.factory.buildSession({ id: 40, publishedAt: new Date() });
-        await databaseBuilder.commit();
-
-        // when
-        const isPublished = await sessionManagementRepository.isPublished({ id: 40 });
-
-        // then
-        expect(isPublished).to.be.equal(true);
-      });
-    });
-
-    context('when the session has no published date', function () {
-      it('should return tre', async function () {
-        //given
-        databaseBuilder.factory.buildSession({ id: 40, publishedAt: null });
-        await databaseBuilder.commit();
-
-        // when
-        const isPublished = await sessionManagementRepository.isPublished({ id: 40 });
-
-        // then
-        expect(isPublished).to.be.equal(false);
-      });
-    });
-  });
-
   describe('#doesUserHaveCertificationCenterMembershipForSession', function () {
     it('should return true if user has membership in the certification center that originated the session', async function () {
       // given

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-management-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-management-repository_test.js
@@ -69,7 +69,7 @@ describe('Certification | SessionManagement | Integration | Infrastructure | Rep
       await databaseBuilder.commit();
     });
 
-    it('should return session informations in a session Object', async function () {
+    it('returns session information in a session Object', async function () {
       // when
       const actualSession = await sessionManagementRepository.get({ id: session.id });
 
@@ -78,12 +78,12 @@ describe('Certification | SessionManagement | Integration | Infrastructure | Rep
       expect(actualSession).to.deep.includes(expectedSessionValues);
     });
 
-    it('should return a Not found error when no session was found', async function () {
+    it('returns null when no session was found', async function () {
       // when
-      const error = await catchErr(sessionManagementRepository.get)({ id: 2 });
+      const session = await sessionManagementRepository.get({ id: 2 });
 
       // then
-      expect(error).to.be.instanceOf(NotFoundError);
+      expect(session).to.be.null;
     });
   });
 

--- a/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
@@ -7,6 +7,7 @@ import {
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
+  SessionNotFinalizedError,
   SessionWithoutStartedCertificationError,
 } from '../../../../../src/certification/session-management/domain/errors.js';
 import {
@@ -70,6 +71,24 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       //then
       expect(error).to.be.instanceOf(BadRequestError);
       expect(error.message).to.equal(message);
+    });
+  });
+
+  context('when mapping "SessionNotFinalizedError"', function () {
+    it('returns a Conflict Http Error', function () {
+      //given
+      const httpErrorMapper = sessionDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === SessionNotFinalizedError.name,
+      );
+      const message = 'Test message error';
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new SessionNotFinalizedError(message));
+
+      //then
+      expect(error).to.be.instanceOf(ConflictError);
+      expect(error.message).to.equal(message);
+      expect(error.code).to.equal('SESSION_NOT_FINALIZED');
     });
   });
 

--- a/api/tests/certification/session-management/unit/domain/models/SessionManagement_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/SessionManagement_test.js
@@ -144,6 +144,30 @@ describe('Unit | Certification | Session | Domain | Models | SessionManagement',
     });
   });
 
+  context('#isFinalized', function () {
+    it('returns true when the session is finalized', function () {
+      // given
+      const session = domainBuilder.certification.sessionManagement.buildSessionManagement({ finalizedAt: new Date() });
+
+      // when
+      const isFinalized = session.isFinalized();
+
+      // then
+      expect(isFinalized).to.be.true;
+    });
+
+    it('returns false when the session is not finalized', function () {
+      // given
+      const session = domainBuilder.certification.sessionManagement.buildSessionManagement({ finalizedAt: null });
+
+      // when
+      const isFinalized = session.isFinalized();
+
+      // then
+      expect(isFinalized).to.be.false;
+    });
+  });
+
   describe('#get hasExpired', function () {
     it('returns false when session has no started certification', function () {
       const session = domainBuilder.certification.sessionManagement.buildSessionManagement({

--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -11,6 +11,7 @@ import {
   manageEmails,
   publishSession,
 } from '../../../../../../src/certification/session-management/domain/services/session-publication-service.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { EmailingAttempt } from '../../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
 import { expect } from '../../../../../test-helper.js';
@@ -194,6 +195,28 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
           // then
           expect(error).to.be.instanceOf(CertificationCourseNotPublishableError);
         });
+      });
+    });
+
+    context('when the session does not exist', function () {
+      it('throws an error', async function () {
+        // given
+        const sessionManagementRepository = {
+          get: sinon.stub(),
+        };
+        sessionManagementRepository.get.withArgs({ id: sessionId }).resolves(null);
+
+        // when
+        const error = await catchErr(publishSession)({
+          sessionId: 'sessionId',
+          publishedAt: now,
+          certificationRepository: undefined,
+          finalizedSessionRepository: undefined,
+          sessionManagementRepository,
+        });
+
+        // then
+        expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
       });
     });
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/get-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-session_test.js
@@ -83,10 +83,10 @@ describe('Unit | UseCase | get-session', function () {
   });
 
   context('when the session does not exist', function () {
-    it('should throw an error the session', async function () {
+    it('throws a NotFoundError', async function () {
       // given
       const sessionId = 123;
-      sessionManagementRepository.get.withArgs({ id: sessionId }).rejects(new NotFoundError());
+      sessionManagementRepository.get.withArgs({ id: sessionId }).resolves(null);
 
       // when
       const err = await catchErr(getSession)({
@@ -95,7 +95,7 @@ describe('Unit | UseCase | get-session', function () {
       });
 
       // then
-      expect(err).to.be.an.instanceof(NotFoundError);
+      expect(err).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
     });
   });
 });

--- a/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
@@ -1,6 +1,9 @@
 import sinon from 'sinon';
 
-import { SessionAlreadyPublishedError } from '../../../../../../src/certification/session-management/domain/errors.js';
+import {
+  SessionAlreadyPublishedError,
+  SessionNotFinalizedError,
+} from '../../../../../../src/certification/session-management/domain/errors.js';
 import { unfinalizeSession } from '../../../../../../src/certification/session-management/domain/usecases/unfinalize-session.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
@@ -12,22 +15,23 @@ describe('Unit | UseCase | unfinalize-session', function () {
   let sessionManagementRepository;
   let finalizedSessionRepository;
 
+  beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn({}));
+
+    sessionManagementRepository = {
+      get: sinon.stub(),
+      unfinalize: sinon.stub(),
+    };
+    finalizedSessionRepository = {
+      remove: sinon.stub(),
+    };
+  });
+
   describe('when session does not exist', function () {
     it('throws a NotFoundError', async function () {
       // given
-      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn({}));
-
       const sessionId = 123;
-      sessionManagementRepository = {
-        get: sinon.stub(),
-        unfinalize: sinon.stub(),
-      };
-      finalizedSessionRepository = {
-        remove: sinon.stub(),
-      };
-
       sessionManagementRepository.get.withArgs({ id: sessionId }).resolves(null);
-      finalizedSessionRepository.remove.withArgs({ sessionId }).resolves(null);
 
       // when
       const error = await catchErr(unfinalizeSession)({
@@ -38,60 +42,80 @@ describe('Unit | UseCase | unfinalize-session', function () {
 
       // then
       expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+      expect(finalizedSessionRepository.remove).to.not.have.been.called;
       expect(sessionManagementRepository.unfinalize).to.not.have.been.called;
     });
   });
 
-  describe('when session is not published', function () {
-    it('should call repositories with transaction', async function () {
-      // given
-      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn({}));
-
-      sessionManagementRepository = {
-        unfinalize: sinon.stub(),
-        get: sinon.stub(),
-      };
-      finalizedSessionRepository = {
-        remove: sinon.stub(),
-      };
-      sessionManagementRepository.get
-        .withArgs({ id: 99 })
-        .resolves(domainBuilder.certification.sessionManagement.buildSessionManagement({ publishedAt: null }));
-      finalizedSessionRepository.remove.withArgs({ sessionId: 99 }).resolves(1);
-
-      // when
-      await unfinalizeSession({ sessionId: 99, sessionManagementRepository, finalizedSessionRepository });
-
-      // then
-      expect(sessionManagementRepository.unfinalize).to.have.been.calledWithMatch({
-        id: 99,
-      });
-
-      expect(finalizedSessionRepository.remove).to.have.been.calledWithMatch({
-        sessionId: 99,
-      });
-    });
-  });
-
   describe('when session is published', function () {
-    it('should throw an SessionAlreadyPublishedError', async function () {
+    it('throws a SessionAlreadyPublishedError', async function () {
       // given
-      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn({}));
-      sessionManagementRepository = {
-        get: sinon.stub(),
-      };
-
-      sessionManagementRepository.get.withArgs({ id: 99 }).resolves(
+      const sessionId = 99;
+      sessionManagementRepository.get.withArgs({ id: sessionId }).resolves(
         domainBuilder.certification.sessionManagement.buildSessionManagement({
-          publishedAt: new Date('2020-01-01'),
+          finalizedAt: new Date('2020-01-01'),
+          publishedAt: new Date('2020-01-02'),
         }),
       );
 
       // when
-      const error = await catchErr(unfinalizeSession)({ sessionId: 99, sessionManagementRepository });
+      const error = await catchErr(unfinalizeSession)({
+        sessionId,
+        sessionManagementRepository,
+        finalizedSessionRepository,
+      });
 
       // then
       expect(error).to.be.instanceOf(SessionAlreadyPublishedError);
+      expect(finalizedSessionRepository.remove).to.not.have.been.called;
+      expect(sessionManagementRepository.unfinalize).to.not.have.been.called;
+    });
+  });
+
+  describe('when session is not finalized', function () {
+    it('throws a SessionNotFinalizedError', async function () {
+      // given
+      const sessionId = 99;
+      sessionManagementRepository.get.withArgs({ id: sessionId }).resolves(
+        domainBuilder.certification.sessionManagement.buildSessionManagement({
+          finalizedAt: null,
+          publishedAt: null,
+        }),
+      );
+
+      // when
+      const error = await catchErr(unfinalizeSession)({
+        sessionId,
+        sessionManagementRepository,
+        finalizedSessionRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new SessionNotFinalizedError());
+      expect(finalizedSessionRepository.remove).to.not.have.been.called;
+      expect(sessionManagementRepository.unfinalize).to.not.have.been.called;
+    });
+  });
+
+  describe('when session is finalized and not published', function () {
+    it('removes the finalized session and unfinalizes the session within a transaction', async function () {
+      // given
+      const sessionId = 99;
+      sessionManagementRepository.get.withArgs({ id: sessionId }).resolves(
+        domainBuilder.certification.sessionManagement.buildSessionManagement({
+          finalizedAt: new Date('2020-01-01'),
+          publishedAt: null,
+        }),
+      );
+      finalizedSessionRepository.remove.withArgs({ sessionId }).resolves(1);
+
+      // when
+      await unfinalizeSession({ sessionId, sessionManagementRepository, finalizedSessionRepository });
+
+      // then
+      expect(DomainTransaction.execute).to.have.been.calledOnce;
+      expect(finalizedSessionRepository.remove).to.have.been.calledWithExactly({ sessionId });
+      expect(sessionManagementRepository.unfinalize).to.have.been.calledWithExactly({ id: sessionId });
     });
   });
 });

--- a/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
@@ -5,6 +5,7 @@ import { unfinalizeSession } from '../../../../../../src/certification/session-m
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | unfinalize-session', function () {
@@ -18,14 +19,14 @@ describe('Unit | UseCase | unfinalize-session', function () {
 
       const sessionId = 123;
       sessionManagementRepository = {
+        get: sinon.stub(),
         unfinalize: sinon.stub(),
-        isPublished: sinon.stub(),
       };
       finalizedSessionRepository = {
         remove: sinon.stub(),
       };
 
-      sessionManagementRepository.isPublished.withArgs({ id: sessionId }).resolves(false);
+      sessionManagementRepository.get.withArgs({ id: sessionId }).resolves(null);
       finalizedSessionRepository.remove.withArgs({ sessionId }).resolves(null);
 
       // when
@@ -48,11 +49,14 @@ describe('Unit | UseCase | unfinalize-session', function () {
 
       sessionManagementRepository = {
         unfinalize: sinon.stub(),
-        isPublished: sinon.stub().resolves(false),
+        get: sinon.stub(),
       };
       finalizedSessionRepository = {
         remove: sinon.stub(),
       };
+      sessionManagementRepository.get
+        .withArgs({ id: 99 })
+        .resolves(domainBuilder.certification.sessionManagement.buildSessionManagement({ publishedAt: null }));
       finalizedSessionRepository.remove.withArgs({ sessionId: 99 }).resolves(1);
 
       // when
@@ -63,8 +67,6 @@ describe('Unit | UseCase | unfinalize-session', function () {
         id: 99,
       });
 
-      expect(sessionManagementRepository.isPublished).to.have.been.calledWithMatch({ id: 99 });
-
       expect(finalizedSessionRepository.remove).to.have.been.calledWithMatch({
         sessionId: 99,
       });
@@ -74,9 +76,16 @@ describe('Unit | UseCase | unfinalize-session', function () {
   describe('when session is published', function () {
     it('should throw an SessionAlreadyPublishedError', async function () {
       // given
+      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn({}));
       sessionManagementRepository = {
-        isPublished: sinon.stub().resolves(true),
+        get: sinon.stub(),
       };
+
+      sessionManagementRepository.get.withArgs({ id: 99 }).resolves(
+        domainBuilder.certification.sessionManagement.buildSessionManagement({
+          publishedAt: new Date('2020-01-01'),
+        }),
+      );
 
       // when
       const error = await catchErr(unfinalizeSession)({ sessionId: 99, sessionManagementRepository });

--- a/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
@@ -3,12 +3,43 @@ import sinon from 'sinon';
 import { SessionAlreadyPublishedError } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { unfinalizeSession } from '../../../../../../src/certification/session-management/domain/usecases/unfinalize-session.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | unfinalize-session', function () {
   let sessionManagementRepository;
   let finalizedSessionRepository;
+
+  describe('when session does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn({}));
+
+      const sessionId = 123;
+      sessionManagementRepository = {
+        unfinalize: sinon.stub(),
+        isPublished: sinon.stub(),
+      };
+      finalizedSessionRepository = {
+        remove: sinon.stub(),
+      };
+
+      sessionManagementRepository.isPublished.withArgs({ id: sessionId }).resolves(false);
+      finalizedSessionRepository.remove.withArgs({ sessionId }).resolves(null);
+
+      // when
+      const error = await catchErr(unfinalizeSession)({
+        sessionId,
+        sessionManagementRepository,
+        finalizedSessionRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
+      expect(sessionManagementRepository.unfinalize).to.not.have.been.called;
+    });
+  });
 
   describe('when session is not published', function () {
     it('should call repositories with transaction', async function () {
@@ -22,6 +53,7 @@ describe('Unit | UseCase | unfinalize-session', function () {
       finalizedSessionRepository = {
         remove: sinon.stub(),
       };
+      finalizedSessionRepository.remove.withArgs({ sessionId: 99 }).resolves(1);
 
       // when
       await unfinalizeSession({ sessionId: 99, sessionManagementRepository, finalizedSessionRepository });

--- a/api/tests/certification/session-management/unit/domain/usecases/unpublish-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/unpublish-session_test.js
@@ -2,8 +2,10 @@ import sinon from 'sinon';
 
 import { FinalizedSession } from '../../../../../../src/certification/session-management/domain/models/FinalizedSession.js';
 import { unpublishSession } from '../../../../../../src/certification/session-management/domain/usecases/unpublish-session.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Session-Management | Unit | Domain | Use Cases | unpublish-session', function () {
   let certificationRepository;
@@ -23,6 +25,22 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | unpub
       save: sinon.stub(),
     };
     sessionManagementRepository.flagResultsAsSentToPrescriber = sinon.stub();
+  });
+
+  it('throws a NotFoundError when no session is found', async function () {
+    // given
+    sessionManagementRepository.get.withArgs({ id: 99 }).resolves(null);
+
+    // when
+    const error = await catchErr(unpublishSession)({
+      sessionId: 99,
+      certificationRepository,
+      sessionManagementRepository,
+      finalizedSessionRepository,
+    });
+
+    // then
+    expect(error).to.deepEqualInstance(new NotFoundError("La session n'existe pas ou son accès est restreint"));
   });
 
   it('should return the session', async function () {


### PR DESCRIPTION
## ☀️ Problème

Plusieurs repositories du sous-contexte `certification/enrolment` lèvent des erreurs du domaine lorsqu'ils ne trouvent pas de ligne en base.
L'infrastructure porte ainsi une décision métier alors que son seul rôle devrait être de rapporter ce qu'elle a trouvé, ou non.

  ## ⛱️ Proposition

Les repositories renvoient désormais `null` au lieu de lever une erreur, et la décision métier remonte d'un cran :

  **Repositories (`enrolment/infrastructure`)**

  | Repository | Méthode | Avant | Après |
  | --- | --- | --- | --- |
  | `session-repository` | `get` | `throw NotFoundError` | `return null` |
  | `session-repository` | `remove` | `throw NotFoundError` | `return null` |
  | `session-for-attendance-sheet-repository` | `getWithCertificationCandidates` | `throw NotFoundError` | `return null` |
  | `candidate-repository` | `update` | `throw CertificationCandidateNotFoundError` | retourne le candidat mis à jour |

  ## 🧴 Remarques

- Le refacto porte uniquement sur `certification/enrolment`
- `unfinalize-session` introduit un changement de comportement, pas seulement un déplacement d'erreur : finalizedSessionRepository.remove (dans session-management, non touché par la branche) n'a jamais levé d'erreur. Avant, dé-finaliser une session absente de finalized-sessions passait silencieusement et appelait quand même sessionManagementRepository.unfinalize.
- ⚠️ Point d'attention pour la revue : sur `GET`/`PATCH` d'une session inexistante, le 404 n'est plus produit par l'`error-manager` mais directement par le contrôleur. Le statut est identique, mais le corps de la réponse n'est plus un payload d'erreur JSON:API. (Renvoi d'un statusCode 404 au lieu d'une erreur)

  ## 🏊 Pour tester

  - Tests verts.
  - Non-régression sur les erreurs levées dans le sous-contexte `enrolment` :
    - `GET`/`PATCH` d'une session inexistante → `404`
    - suppression d'une session inexistante → `404`
    - PV de session (feuille d'émargement) sans session ou sans candidat inscrit → `404`
    - téléchargement du modèle d'import de candidats sur une session inexistante → `404`
    - ajout d'un candidat / enrôlement d'élèves SCO / import ODS sur une session inaccessible → `404`
    - modification d'un candidat inexistant → erreur candidat non trouvé
    - dé-finalisation d'une session non finalisée → `404`

