### PR TITLE
[FEATURE] Ajoute la page de configuration de scoring pour la création d'un référentiel de certification (PIX-23863)

### DIFF
--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-form.gjs
@@ -178,7 +178,7 @@ export default class CalibrationForm extends Component {
         {{t "common.actions.cancel"}}
       </PixButtonLink>
       <PixButtonLink
-        @route="authenticated.certification-frameworks.certification-framework.versions.version.meshes-configuration"
+        @route="authenticated.certification-frameworks.certification-framework.versions.version.scoring"
         @variant="primary"
       >
         {{t "common.actions.next"}}

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -6,14 +6,15 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { t } from 'ember-intl';
+  import { t } from 'ember-intl';
 import Card from 'pix-admin/components/card';
 
 export default class ScoringForm extends Component {
   @service pixToast;
   @service intl;
-  @tracked hasError = false;
+  get hasError() {
+    return this.globalScoringConfiguration.some(({ bounds }) => bounds.max <= bounds.min);
+  }
 
   get globalScoringConfiguration() {
     return this.args.draftVersion.globalScoringConfiguration;
@@ -22,6 +23,7 @@ export default class ScoringForm extends Component {
   @action
   async saveCapacityByMesh(event) {
     event.preventDefault();
+    if (this.hasError) return;
 
     try {
       await this.args.draftVersion.save();
@@ -45,15 +47,6 @@ export default class ScoringForm extends Component {
       newArray.at(index + 1).bounds.min = Number(event.target.value);
     }
     this.args.draftVersion.globalScoringConfiguration = newArray;
-    this.fieldValidator();
-  }
-
-  fieldValidator() {
-    const errors = this.globalScoringConfiguration.map(({ bounds }) => {
-      if (bounds.max <= bounds.min) return 'error';
-      return 'default';
-    });
-    this.hasError = errors.some((error) => error === 'error');
   }
 
   @action

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -1,25 +1,26 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import Card from 'pix-admin/components/card';
-import { trackedArray } from '@ember/reactive/collections';
-import { tracked } from '@glimmer/tracking';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import { action } from '@ember/object';
-import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
-import { service } from '@ember/service';
-
 
 export default class ScoringForm extends Component {
-  @service pixToast
-  @tracked globalScoringConfiguration = this.args.draftVersion.globalScoringConfiguration
+  @service pixToast;
+  @service intl;
   @tracked hasError = false;
 
+  get globalScoringConfiguration() {
+    return this.args.draftVersion.globalScoringConfiguration;
+  }
+
   @action
-  saveCapacityByMesh (event) {
+  saveCapacityByMesh(event) {
     event.preventDefault();
 
     try {
@@ -30,49 +31,49 @@ export default class ScoringForm extends Component {
         ),
       });
     } catch (error) {
-      this.pixToast.sendErrorNotification({ message: err.errors?.[0].detail });
+      this.pixToast.sendErrorNotification({ message: error.errors?.[0].detail });
     }
   }
 
   @action
-  updateValue (name , index, event) {
-    const isMax = name === 'max'
+  updateValue(name, index, event) {
+    const isMax = name === 'max';
     const newArray = this.globalScoringConfiguration;
-    newArray.at(index)[name] = Number(event.target.value);
+    newArray.at(index).bounds[name] = Number(event.target.value);
 
-    if (isMax && this.globalScoringConfiguration.at(index + 1) ) {
-      newArray.at(index + 1).min = Number(event.target.value);
+    if (isMax && this.globalScoringConfiguration.at(index + 1)) {
+      newArray.at(index + 1).bounds.min = Number(event.target.value);
     }
     this.globalScoringConfiguration = [...newArray];
     this.fieldValidator();
   }
 
-  fieldValidator () {
-    const errors = this.globalScoringConfiguration.map(({min, max}) => {
-      if (max <= min) return 'error';
-      return 'default'
-    })
+  fieldValidator() {
+    const errors = this.globalScoringConfiguration.map(({ bounds }) => {
+      if (bounds.max <= bounds.min) return 'error';
+      return 'default';
+    });
     this.hasError = errors.some((error) => error === 'error');
   }
 
   @action
-  isNotFirstRow (index) {
+  isNotFirstRow(index) {
     return index !== 0;
   }
 
   @action
-  isFirstRow (index) {
+  isFirstRow(index) {
     return index === 0;
   }
 
   @action
-  lastMaxValue (index) {
-    return this.globalScoringConfiguration.at(index-1)?.max
+  lastMaxValue(index) {
+    return this.globalScoringConfiguration.at(index - 1)?.bounds.max;
   }
 
   @action
-  isGreaterThanMin (index) {
-    return this.globalScoringConfiguration.at(index).max > this.globalScoringConfiguration.at(index).min
+  isGreaterThanMin(index) {
+    return this.globalScoringConfiguration.at(index).bounds.max > this.globalScoringConfiguration.at(index).bounds.min;
   }
 
   <template>
@@ -82,36 +83,45 @@ export default class ScoringForm extends Component {
     >
       <form id="version-scoring-form" class="versions-scoring__form" {{on "submit" this.saveCapacityByMesh}}>
         {{#each this.globalScoringConfiguration as |mesh|}}
-        <h3>{{t "components.certification-frameworks.certification-framework.versions.scoring.level" index=mesh.index}}</h3>
+          <h3>{{t
+              "components.certification-frameworks.certification-framework.versions.scoring.level"
+              index=mesh.meshLevel
+            }}</h3>
           <section>
             <PixInput
               type="number"
-              readonly={{this.isNotFirstRow mesh.index}}
-              required={{this.isFirstRow mesh.index}}
-              @requiredLabel={{if (this.isFirstRow mesh.index) (t "common.forms.mandatory") false}}
-              @value={{if (this.isNotFirstRow mesh.index) (this.lastMaxValue mesh.index) mesh.min}}
-              {{on "change"  (fn this.updateValue "min" mesh.index)}}
+              step="0.01"
+              readonly={{this.isNotFirstRow mesh.meshLevel}}
+              required={{this.isFirstRow mesh.meshLevel}}
+              @requiredLabel={{if (this.isFirstRow mesh.meshLevel) (t "common.forms.mandatory") false}}
+              @value={{if (this.isNotFirstRow mesh.meshLevel) (this.lastMaxValue mesh.meshLevel) mesh.bounds.min}}
+              {{on "change" (fn this.updateValue "min" mesh.meshLevel)}}
             >
-              <:label>{{t "components.certification-frameworks.certification-framework.versions.scoring.minimum-input-label"}}</:label>
+              <:label>{{t
+                  "components.certification-frameworks.certification-framework.versions.scoring.minimum-input-label"
+                }}</:label>
             </PixInput>
 
             <PixInput
               type="number"
-              required={{this.isFirstRow mesh.index}}
-              @requiredLabel={{if (this.isFirstRow mesh.index) (t "common.forms.mandatory") false}}
+              step="0.01"
+              required={{this.isFirstRow mesh.meshLevel}}
+              @requiredLabel={{if (this.isFirstRow mesh.meshLevel) (t "common.forms.mandatory") false}}
               @errorMessage={{t
                 "components.certification-frameworks.certification-framework.versions.scoring.cannot-be-lower-error"
               }}
-              @validationStatus={{if (this.isGreaterThanMin mesh.index) 'default' 'error'}}
-              @value={{mesh.max}}
-              {{on "change" (fn this.updateValue "max" mesh.index)}}
+              @validationStatus={{if (this.isGreaterThanMin mesh.meshLevel) "default" "error"}}
+              @value={{mesh.bounds.max}}
+              {{on "change" (fn this.updateValue "max" mesh.meshLevel)}}
             >
-              <:label>{{t "components.certification-frameworks.certification-framework.versions.scoring.maximum-input-label"}}</:label>
+              <:label>{{t
+                  "components.certification-frameworks.certification-framework.versions.scoring.maximum-input-label"
+                }}</:label>
             </PixInput>
           </section>
         {{/each}}
 
-       <PixButton @type="submit" form="version-scoring-form" @isDisabled={{this.hasError}} @variant="primary-bis">
+        <PixButton @type="submit" form="version-scoring-form" @isDisabled={{this.hasError}} @variant="primary-bis">
           {{t "components.certification-frameworks.certification-framework.versions.scoring.capacity-submit-button"}}
         </PixButton>
       </form>

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -20,11 +20,11 @@ export default class ScoringForm extends Component {
   }
 
   @action
-  saveCapacityByMesh(event) {
+  async saveCapacityByMesh(event) {
     event.preventDefault();
 
     try {
-      this.args.draftVersion.save();
+      await this.args.draftVersion.save();
       this.pixToast.sendSuccessNotification({
         message: this.intl.t(
           'components.certification-frameworks.certification-framework.versions.scoring.success-notification',
@@ -38,13 +38,13 @@ export default class ScoringForm extends Component {
   @action
   updateValue(name, index, event) {
     const isMax = name === 'max';
-    const newArray = this.globalScoringConfiguration;
+    const newArray = [...this.globalScoringConfiguration];
     newArray.at(index).bounds[name] = Number(event.target.value);
 
-    if (isMax && this.globalScoringConfiguration.at(index + 1)) {
+    if (isMax && newArray.at(index + 1)) {
       newArray.at(index + 1).bounds.min = Number(event.target.value);
     }
-    this.globalScoringConfiguration = [...newArray];
+    this.args.draftVersion.globalScoringConfiguration = newArray;
     this.fieldValidator();
   }
 

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -91,7 +91,8 @@ export default class ScoringForm extends Component {
               {{on "change" (fn this.updateValue "min" mesh.meshLevel)}}
             >
               <:label>{{t
-                  "components.certification-frameworks.certification-framework.versions.scoring.minimum-input-label"
+                  "components.certification-frameworks.certification-framework.versions.scoring.previous-version-capacity"
+                  previousVersionCapacity=mesh.bounds.min
                 }}</:label>
             </PixInput>
 
@@ -108,7 +109,8 @@ export default class ScoringForm extends Component {
               {{on "change" (fn this.updateValue "max" mesh.meshLevel)}}
             >
               <:label>{{t
-                  "components.certification-frameworks.certification-framework.versions.scoring.maximum-input-label"
+                  "components.certification-frameworks.certification-framework.versions.scoring.previous-version-capacity"
+                  previousVersionCapacity=mesh.bounds.max
                 }}</:label>
             </PixInput>
           </section>

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -1,0 +1,127 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import Card from 'pix-admin/components/card';
+import { trackedArray } from '@ember/reactive/collections';
+import { tracked } from '@glimmer/tracking';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+import { fn } from '@ember/helper';
+import { service } from '@ember/service';
+
+
+export default class ScoringForm extends Component {
+  @service pixToast
+  @tracked globalScoringConfiguration = this.args.draftVersion.globalScoringConfiguration
+  @tracked hasError = false;
+
+  @action
+  saveCapacityByMesh (event) {
+    event.preventDefault();
+
+    try {
+      this.args.draftVersion.save();
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.scoring.success-notification',
+        ),
+      });
+    } catch (error) {
+      this.pixToast.sendErrorNotification({ message: err.errors?.[0].detail });
+    }
+  }
+
+  @action
+  updateValue (name , index, event) {
+    const isMax = name === 'max'
+    const newArray = this.globalScoringConfiguration;
+    newArray.at(index)[name] = Number(event.target.value);
+
+    if (isMax && this.globalScoringConfiguration.at(index + 1) ) {
+      newArray.at(index + 1).min = Number(event.target.value);
+    }
+    this.globalScoringConfiguration = [...newArray];
+    this.fieldValidator();
+  }
+
+  fieldValidator () {
+    const errors = this.globalScoringConfiguration.map(({min, max}) => {
+      if (max <= min) return 'error';
+      return 'default'
+    })
+    this.hasError = errors.some((error) => error === 'error');
+  }
+
+  @action
+  isNotFirstRow (index) {
+    return index !== 0;
+  }
+
+  @action
+  isFirstRow (index) {
+    return index === 0;
+  }
+
+  @action
+  lastMaxValue (index) {
+    return this.globalScoringConfiguration.at(index-1)?.max
+  }
+
+  @action
+  isGreaterThanMin (index) {
+    return this.globalScoringConfiguration.at(index).max > this.globalScoringConfiguration.at(index).min
+  }
+
+  <template>
+    <Card
+      class="versions-scoring"
+      @title={{t "components.certification-frameworks.certification-framework.versions.scoring.title"}}
+    >
+      <form id="version-scoring-form" class="versions-scoring__form" {{on "submit" this.saveCapacityByMesh}}>
+        {{#each this.globalScoringConfiguration as |mesh|}}
+        <h3>{{t "components.certification-frameworks.certification-framework.versions.scoring.level" index=mesh.index}}</h3>
+          <section>
+            <PixInput
+              type="number"
+              readonly={{this.isNotFirstRow mesh.index}}
+              required={{this.isFirstRow mesh.index}}
+              @requiredLabel={{if (this.isFirstRow mesh.index) (t "common.forms.mandatory") false}}
+              @value={{if (this.isNotFirstRow mesh.index) (this.lastMaxValue mesh.index) mesh.min}}
+              {{on "change"  (fn this.updateValue "min" mesh.index)}}
+            >
+              <:label>{{t "components.certification-frameworks.certification-framework.versions.scoring.minimum-input-label"}}</:label>
+            </PixInput>
+
+            <PixInput
+              type="number"
+              required={{this.isFirstRow mesh.index}}
+              @requiredLabel={{if (this.isFirstRow mesh.index) (t "common.forms.mandatory") false}}
+              @errorMessage={{t
+                "components.certification-frameworks.certification-framework.versions.scoring.cannot-be-lower-error"
+              }}
+              @validationStatus={{if (this.isGreaterThanMin mesh.index) 'default' 'error'}}
+              @value={{mesh.max}}
+              {{on "change" (fn this.updateValue "max" mesh.index)}}
+            >
+              <:label>{{t "components.certification-frameworks.certification-framework.versions.scoring.maximum-input-label"}}</:label>
+            </PixInput>
+          </section>
+        {{/each}}
+
+       <PixButton @type="submit" form="version-scoring-form" @isDisabled={{this.hasError}} @variant="primary-bis">
+          {{t "components.certification-frameworks.certification-framework.versions.scoring.capacity-submit-button"}}
+        </PixButton>
+      </form>
+
+    </Card>
+    <section class="actions-container">
+      <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
+        {{t "common.actions.cancel"}}
+      </PixButtonLink>
+
+    </section>
+  </template>
+}

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -6,7 +6,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-  import { t } from 'ember-intl';
+import { t } from 'ember-intl';
 import Card from 'pix-admin/components/card';
 
 export default class ScoringForm extends Component {

--- a/admin/app/models/certification-version.js
+++ b/admin/app/models/certification-version.js
@@ -16,6 +16,38 @@ export default class CertificationVersion extends Model {
   @attr('string') scope;
   @attr('string') comments;
   @attr('number') externalCalibrationId;
+  @attr({
+    defaultValue: () => ([{
+      max: -7,
+      min: -8,
+      index:0,
+     },
+     {
+       max: -5,
+       min: -7,
+       index:1,
+
+      },
+      {
+        max: -2,
+        min: -5,
+        index:2,
+
+       },
+       {
+         max: 0,
+         min: -2,
+         index:3,
+
+        },
+        {
+          max: 3,
+          min: 0,
+          index:4,
+
+         },
+    ]),
+  }) globalScoringConfiguration;
 
   @hasMany('area', { async: false, inverse: null }) areas;
 

--- a/admin/app/models/certification-version.js
+++ b/admin/app/models/certification-version.js
@@ -16,38 +16,7 @@ export default class CertificationVersion extends Model {
   @attr('string') scope;
   @attr('string') comments;
   @attr('number') externalCalibrationId;
-  @attr({
-    defaultValue: () => ([{
-      max: -7,
-      min: -8,
-      index:0,
-     },
-     {
-       max: -5,
-       min: -7,
-       index:1,
-
-      },
-      {
-        max: -2,
-        min: -5,
-        index:2,
-
-       },
-       {
-         max: 0,
-         min: -2,
-         index:3,
-
-        },
-        {
-          max: 3,
-          min: 0,
-          index:4,
-
-         },
-    ]),
-  }) globalScoringConfiguration;
+  @attr() globalScoringConfiguration;
 
   @hasMany('area', { async: false, inverse: null }) areas;
 

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -133,7 +133,7 @@ Router.map(function () {
           this.route('version', { path: '/:version_id' }, function () {
             this.route('edit');
             this.route('calibration');
-            this.route('meshes-configuration');
+            this.route('scoring');
           });
         });
         this.route('target-profile', function () {

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class FrameworkEditRoute extends Route {
+export default class ScoringRoute extends Route {
   @service store;
   @service router;
 

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -1,0 +1,30 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class FrameworkEditRoute extends Route {
+  @service store;
+  @service router;
+
+  async model() {
+    const { version_id: versionId } = this.paramsFor(
+      'authenticated.certification-frameworks.certification-framework.versions.version',
+    );
+    const draftVersion = await this.store.findRecord('certification-version', versionId);
+
+    return {
+      draftVersion,
+    };
+  }
+
+  afterModel(model) {
+    if (!model.draftVersion.isDraft) {
+      this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
+    }
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting && controller.model.draftVersion.hasDirtyAttributes) {
+      controller.model.draftVersion.rollbackAttributes();
+    }
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -63,6 +63,7 @@
 @use 'components/certification-frameworks/certification-frameworks/framework/certification-version-detail-modal' as *;
 @use 'components/certification-frameworks/certification-frameworks/versions/certification-version-edit-form' as *;
 @use 'components/certification-frameworks/certification-frameworks/versions/certification-version-calibration-form' as *;
+@use 'components/certification-frameworks/certification-frameworks/versions/certification-version-scoring-form' as *;
 @use 'components/certification-frameworks/link-to-current-target-profile' as *;
 @use 'components/certification-frameworks/search-bar' as *;
 @use 'components/certification-frameworks/selected-target-profile' as *;

--- a/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-scoring-form.scss
+++ b/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-scoring-form.scss
@@ -4,17 +4,17 @@
     flex-direction: column;
 
     h3 {
-      font-size: 1.2rem;
       font-weight: 700;
+      font-size: 1.2rem;
       line-height: 20px;
     }
 
     section {
       display: flex;
       gap: 1.5rem;
-      margin-bottom: 1.5rem;
       align-items: start;
       justify-content: space-between;
+      margin-bottom: 1.5rem;
 
       .pix-label {
         font-size: 0.9rem;
@@ -31,10 +31,10 @@
     gap: 24px;
 
     label {
-      cursor: pointer;
       display: flex;
-      align-items: center;
       gap: 0.3rem;
+      align-items: center;
+      cursor: pointer;
     }
   }
 }

--- a/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-scoring-form.scss
+++ b/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-scoring-form.scss
@@ -26,17 +26,6 @@
     }
   }
 
-  &__fields-actions {
-    display: flex;
-    gap: 24px;
-
-    label {
-      display: flex;
-      gap: 0.3rem;
-      align-items: center;
-      cursor: pointer;
-    }
-  }
 }
 
 .actions-container {

--- a/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-scoring-form.scss
+++ b/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-scoring-form.scss
@@ -1,0 +1,47 @@
+.versions-scoring {
+  &__form {
+    display: flex;
+    flex-direction: column;
+
+    h3 {
+      font-size: 1.2rem;
+      font-weight: 700;
+      line-height: 20px;
+    }
+
+    section {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+      align-items: start;
+      justify-content: space-between;
+
+      .pix-label {
+        font-size: 0.9rem;
+      }
+    }
+
+    div {
+      flex: 1.5
+    }
+  }
+
+  &__fields-actions {
+    display: flex;
+    gap: 24px;
+
+    label {
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 0.3rem;
+    }
+  }
+}
+
+.actions-container {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
@@ -1,0 +1,5 @@
+import CertificationVersionScoringForm from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form';
+
+<template>
+  <CertificationVersionScoringForm @draftVersion={{@model.draftVersion}} />
+</template>

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
@@ -1,5 +1,3 @@
 import CertificationVersionScoringForm from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form';
 
-<template>
-  <CertificationVersionScoringForm @draftVersion={{@model.draftVersion}} />
-</template>
+<template><CertificationVersionScoringForm @draftVersion={{@model.draftVersion}} /></template>

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
@@ -1,0 +1,101 @@
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import { t } from '../../../../../helpers/setup-intl-rendering';
+
+module('Acceptance | Certification Framework | item | Framework | scoring', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    const versionSummaries = [];
+    versionSummaries.push(
+      server.create('certification-version-summary', {
+        id: 13,
+        scope: 'CORE',
+        startDate: new Date('2023-10-10'),
+        expirationDate: null,
+        assessmentDuration: 90,
+        maximumAssessmentLength: 32,
+        status: 'active',
+      }),
+    );
+    versionSummaries.push(
+      server.create('certification-version-summary', {
+        id: 14,
+        scope: 'CORE',
+        startDate: null,
+        expirationDate: null,
+        assessmentDuration: 66,
+        maximumAssessmentLength: 67,
+        status: 'draft',
+      }),
+    );
+    versionSummaries.push(
+      server.create('certification-version-summary', {
+        id: 15,
+        scope: 'CORE',
+        startDate: new Date('2020-01-01'),
+        expirationDate: new Date('2021-01-01'),
+        assessmentDuration: 90,
+        maximumAssessmentLength: 32,
+        status: 'archived',
+      }),
+    );
+    server.create('certification-framework', { id: 'CORE', versionSummaries });
+    server.create('certification-version', {
+      id: 14,
+      status: 'draft',
+      globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
+    });
+  });
+
+  module('when admin member has role "SUPER ADMIN"', function () {
+    module('when trying to load scoring for a non-draft version', function () {
+      test('redirects to versions list', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        await visit(`/certification-frameworks/CORE/versions/13/scoring`);
+        assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
+
+        await visit(`/certification-frameworks/CORE/versions/15/scoring`);
+        assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
+      });
+    });
+
+    module('when visiting the scoring page for a draft version', function () {
+      test('displays the scoring form', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+        assert
+          .dom(
+            screen.getByText(t('components.certification-frameworks.certification-framework.versions.scoring.title')),
+          )
+          .exists();
+      });
+    });
+
+    module('when clicking on cancel button', function () {
+      test('redirects to certification-framework page', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+        await clickByName('Annuler');
+        assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
+      });
+    });
+  });
+
+  module('when admin member doesn\'t have the role "SUPER ADMIN"', function () {
+    test('should be redirected to the framework page', async function (assert) {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: false })(server);
+      await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+      assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
+    });
+  });
+});

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
@@ -9,8 +9,22 @@ import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-ren
 const SUBMIT_BUTTON_LABEL =
   'components.certification-frameworks.certification-framework.versions.scoring.capacity-submit-button';
 const LEVEL_KEY = 'components.certification-frameworks.certification-framework.versions.scoring.level';
-const MIN_LABEL = 'components.certification-frameworks.certification-framework.versions.scoring.minimum-input-label';
-const MAX_LABEL = 'components.certification-frameworks.certification-framework.versions.scoring.maximum-input-label';
+const CAPACITY_LABEL =
+  'components.certification-frameworks.certification-framework.versions.scoring.previous-version-capacity';
+
+// Both bounds share the same label key, so they can only be told apart by DOM order:
+// each mesh level renders its min input first, then its max input.
+function getBoundsInputs(screen) {
+  const inputs = screen.getAllByRole('spinbutton');
+  return {
+    min: inputs.filter((_input, index) => index % 2 === 0),
+    max: inputs.filter((_input, index) => index % 2 === 1),
+  };
+}
+
+function labelOf(input) {
+  return input.labels[0];
+}
 
 module(
   'Integration | Component | certification-frameworks/certification-framework/versions/certification-version-scoring-form',
@@ -67,13 +81,38 @@ module(
         );
 
         // then
-        const minInputs = screen.getAllByLabelText(t(MIN_LABEL), { exact: false });
-        const maxInputs = screen.getAllByLabelText(t(MAX_LABEL), { exact: false });
+        const { min: minInputs, max: maxInputs } = getBoundsInputs(screen);
 
         assert.dom(minInputs[0]).hasValue('1');
         assert.dom(maxInputs[0]).hasValue('8');
         assert.dom(minInputs[1]).hasValue('8');
         assert.dom(maxInputs[1]).hasValue('15');
+      });
+
+      test('it labels each input with the capacity of the previous version', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [
+            { bounds: { min: 1, max: 8 }, meshLevel: 0 },
+            { bounds: { min: 8, max: 15 }, meshLevel: 1 },
+          ],
+        });
+
+        // when
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // then
+        const { min: minInputs, max: maxInputs } = getBoundsInputs(screen);
+
+        assert.dom(labelOf(minInputs[0])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 1 }));
+        assert.dom(labelOf(maxInputs[0])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 8 }));
+        assert.dom(labelOf(minInputs[1])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 8 }));
+        assert.dom(labelOf(maxInputs[1])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 15 }));
       });
     });
 
@@ -177,12 +216,10 @@ module(
         );
 
         // when
-        const maxInputs = screen.getAllByLabelText(t(MAX_LABEL), { exact: false });
-        await fillIn(maxInputs[0], '10');
+        await fillIn(getBoundsInputs(screen).max[0], '10');
 
         // then
-        const minInputs = screen.getAllByLabelText(t(MIN_LABEL), { exact: false });
-        assert.dom(minInputs[1]).hasValue('10');
+        assert.dom(getBoundsInputs(screen).min[1]).hasValue('10');
       });
     });
 

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
@@ -1,0 +1,252 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import CertificationVersionScoringForm from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
+
+const SUBMIT_BUTTON_LABEL =
+  'components.certification-frameworks.certification-framework.versions.scoring.capacity-submit-button';
+const LEVEL_KEY = 'components.certification-frameworks.certification-framework.versions.scoring.level';
+const MIN_LABEL = 'components.certification-frameworks.certification-framework.versions.scoring.minimum-input-label';
+const MAX_LABEL = 'components.certification-frameworks.certification-framework.versions.scoring.maximum-input-label';
+
+module(
+  'Integration | Component | certification-frameworks/certification-framework/versions/certification-version-scoring-form',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+
+    let pixToast;
+
+    hooks.beforeEach(function () {
+      pixToast = this.owner.lookup('service:pixToast');
+      sinon.stub(pixToast, 'sendSuccessNotification');
+      sinon.stub(pixToast, 'sendErrorNotification');
+    });
+
+    module('levels display', function () {
+      test('it renders one section per mesh level', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [
+            { bounds: { min: 1, max: 8 }, meshLevel: 0 },
+            { bounds: { min: 8, max: 15 }, meshLevel: 1 },
+          ],
+        });
+
+        // when
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(t(LEVEL_KEY, { index: 0 }))).exists();
+        assert.dom(screen.getByText(t(LEVEL_KEY, { index: 1 }))).exists();
+        assert.dom(screen.queryByText(t(LEVEL_KEY, { index: 2 }))).doesNotExist();
+      });
+
+      test('it pre-fills inputs with model data', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [
+            { bounds: { min: 1, max: 8 }, meshLevel: 0 },
+            { bounds: { min: 8, max: 15 }, meshLevel: 1 },
+          ],
+        });
+
+        // when
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // then
+        const minInputs = screen.getAllByLabelText(t(MIN_LABEL), { exact: false });
+      const maxInputs = screen.getAllByLabelText(t(MAX_LABEL), { exact: false });
+
+        assert.dom(minInputs[0]).hasValue('1');
+        assert.dom(maxInputs[0]).hasValue('8');
+        assert.dom(minInputs[1]).hasValue('8');
+        assert.dom(maxInputs[1]).hasValue('15');
+      });
+    });
+
+    module('submit button state', function () {
+      test('it enables the submit button when all bounds are valid', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
+        });
+
+        // when
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) })).doesNotHaveAttribute('aria-disabled');
+      });
+
+      test('it disables the submit button when max is lower than min on page load', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
+        });
+
+        // when
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) })).hasAttribute('aria-disabled');
+      });
+
+      test('it disables the submit button when max equals min on page load', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [{ bounds: { min: 3, max: 3 }, meshLevel: 0 }],
+        });
+
+        // when
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) })).hasAttribute('aria-disabled');
+      });
+    });
+
+    module('error message', function () {
+      test('it displays an error message when max is lower than min on page load', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
+        });
+
+        // when
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(t('components.certification-frameworks.certification-framework.versions.scoring.cannot-be-lower-error'))).exists();
+      });
+    });
+
+    module('cascade update', function () {
+      test('it updates the min of the next level when the max of a level changes', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [
+            { bounds: { min: 1, max: 8 }, meshLevel: 0 },
+            { bounds: { min: 8, max: 15 }, meshLevel: 1 },
+          ],
+        });
+
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // when
+        const maxInputs = screen.getAllByLabelText(t(MAX_LABEL), { exact: false });
+        await fillIn(maxInputs[0], '10');
+
+        // then
+        const minInputs = screen.getAllByLabelText(t(MIN_LABEL), { exact: false });
+        assert.dom(minInputs[1]).hasValue('10');
+      });
+    });
+
+    module('save notifications', function () {
+      test('it shows a success notification when save succeeds', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
+        });
+        sinon.stub(draftVersion, 'save').resolves();
+
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // when
+        await click(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) }));
+
+        // then
+        assert.ok(
+          pixToast.sendSuccessNotification.calledOnceWith({ message: t('components.certification-frameworks.certification-framework.versions.scoring.success-notification') }),
+        );
+      });
+
+      test('it shows an error notification when save fails', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
+        });
+        sinon.stub(draftVersion, 'save').rejects({ errors: [{ detail: 'Erreur serveur' }] });
+
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // when
+        await click(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) }));
+
+        // then
+        assert.ok(
+          pixToast.sendErrorNotification.calledOnceWith({ message: 'Erreur serveur' }),
+        );
+      });
+
+      test('it does not save when bounds are invalid', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
+        });
+        sinon.stub(draftVersion, 'save').resolves();
+
+        const screen = await render(
+          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+        );
+
+        // when
+        await click(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) }));
+
+        // then
+        assert.ok(draftVersion.save.notCalled);
+      });
+    });
+  },
+);

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
@@ -68,7 +68,7 @@ module(
 
         // then
         const minInputs = screen.getAllByLabelText(t(MIN_LABEL), { exact: false });
-      const maxInputs = screen.getAllByLabelText(t(MAX_LABEL), { exact: false });
+        const maxInputs = screen.getAllByLabelText(t(MAX_LABEL), { exact: false });
 
         assert.dom(minInputs[0]).hasValue('1');
         assert.dom(maxInputs[0]).hasValue('8');
@@ -149,7 +149,13 @@ module(
         );
 
         // then
-        assert.dom(screen.getByText(t('components.certification-frameworks.certification-framework.versions.scoring.cannot-be-lower-error'))).exists();
+        assert
+          .dom(
+            screen.getByText(
+              t('components.certification-frameworks.certification-framework.versions.scoring.cannot-be-lower-error'),
+            ),
+          )
+          .exists();
       });
     });
 
@@ -200,7 +206,11 @@ module(
 
         // then
         assert.ok(
-          pixToast.sendSuccessNotification.calledOnceWith({ message: t('components.certification-frameworks.certification-framework.versions.scoring.success-notification') }),
+          pixToast.sendSuccessNotification.calledOnceWith({
+            message: t(
+              'components.certification-frameworks.certification-framework.versions.scoring.success-notification',
+            ),
+          }),
         );
       });
 
@@ -222,9 +232,7 @@ module(
         await click(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) }));
 
         // then
-        assert.ok(
-          pixToast.sendErrorNotification.calledOnceWith({ message: 'Erreur serveur' }),
-        );
+        assert.ok(pixToast.sendErrorNotification.calledOnceWith({ message: 'Erreur serveur' }));
       });
 
       test('it does not save when bounds are invalid', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -633,8 +633,7 @@
             "cannot-be-lower-error": "The maximal capacity for a given level has to be strictly greater than its minimal capacity.",
             "capacity-submit-button": "Save capacities by mesh",
             "level": "Level {index}",
-            "maximum-input-label": "Maximal capacity",
-            "minimum-input-label": "Minimal capacity",
+            "previous-version-capacity": "Previous value: {previousVersionCapacity}",
             "success-notification": "The scoring has been successfully updated",
             "title": "Bounds of capacity by mesh"
           },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -607,15 +607,6 @@
             "title": "Calibration of challenges",
             "verify-calibration-id-button": "Check the calibration"
           },
-          "scoring": {
-            "title": "Min / max capacity by mesh",
-            "minimum-input-label": "Min capacity",
-            "maximum-input-label": "Max capacity",
-            "level": "Level {index}",
-            "capacity-submit-button": "Save capacities by mesh",
-            "cannot-be-lower-error": "This field cannot be lower than the minimum",
-            "success-notification": "The scoring has been successfully updated"
-          },
           "edit": {
             "assessment-duration-label": "Assessment duration (hh:mm):",
             "challenges-between-same-competence-label": "Number of questions between two questions assessing the same competency:",
@@ -638,6 +629,15 @@
             "title": "Creating a new version of the certification framework for {frameworkLabel}"
           },
           "page-title": "Creation of a new version of the certification in {scope} framework",
+          "scoring": {
+            "cannot-be-lower-error": "This field cannot be lower than the minimum",
+            "capacity-submit-button": "Save capacities by mesh",
+            "level": "Level {index}",
+            "maximum-input-label": "Max capacity",
+            "minimum-input-label": "Min capacity",
+            "success-notification": "The scoring has been successfully updated",
+            "title": "Min / max capacity by mesh"
+          },
           "title": "Creating a Certification Release"
         }
       },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -607,6 +607,15 @@
             "title": "Calibration of challenges",
             "verify-calibration-id-button": "Check the calibration"
           },
+          "scoring": {
+            "title": "Min / max capacity by mesh",
+            "minimum-input-label": "Min capacity",
+            "maximum-input-label": "Max capacity",
+            "level": "Level {index}",
+            "capacity-submit-button": "Save capacities by mesh",
+            "cannot-be-lower-error": "This field cannot be lower than the minimum",
+            "success-notification": "The scoring has been successfully updated"
+          },
           "edit": {
             "assessment-duration-label": "Assessment duration (hh:mm):",
             "challenges-between-same-competence-label": "Number of questions between two questions assessing the same competency:",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -630,13 +630,13 @@
           },
           "page-title": "Creation of a new version of the certification in {scope} framework",
           "scoring": {
-            "cannot-be-lower-error": "This field cannot be lower than the minimum",
+            "cannot-be-lower-error": "The maximal capacity for a given level has to be strictly greater than its minimal capacity.",
             "capacity-submit-button": "Save capacities by mesh",
             "level": "Level {index}",
-            "maximum-input-label": "Max capacity",
-            "minimum-input-label": "Min capacity",
+            "maximum-input-label": "Maximal capacity",
+            "minimum-input-label": "Minimal capacity",
             "success-notification": "The scoring has been successfully updated",
-            "title": "Min / max capacity by mesh"
+            "title": "Bounds of capacity by mesh"
           },
           "title": "Creating a Certification Release"
         }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -643,7 +643,7 @@
             "level": "Niveau {index}",
             "maximum-input-label": "Capacité maximum",
             "minimum-input-label": "Capacité minimum",
-            "success-notification": "Le scoring à bien été mis à jour",
+            "success-notification": "Le scoring a bien été mis à jour",
             "title": "Capacités minimum et maximum par mailles"
           },
           "title": "Création d'une version de certification"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -615,15 +615,6 @@
             "title": "Calibration des épreuves",
             "verify-calibration-id-button": "Vérifier la calibration"
           },
-          "scoring": {
-            "title": "Capacités minimum et maximum par mailles",
-            "minimum-input-label": "Capacité minimum",
-            "maximum-input-label": "Capacité maximum",
-            "level": "Niveau {index}",
-            "capacity-submit-button": "Sauvegarder les capacités par mailles",
-            "cannot-be-lower-error": "Ce champ ne peut pas être inférieur au minimum",
-            "success-notification": "Le scoring à bien été mis à jour"
-          },
           "edit": {
             "assessment-duration-label": "Durée de l’épreuve (hh:mm) :",
             "challenges-between-same-competence-label": "Nombre de question entre 2 questions de la même compétence :",
@@ -646,6 +637,15 @@
             "title": "Création d'une nouvelle version du référentiel de certification"
           },
           "page-title": "Création d’une nouvelle version du référentiel de certification pour {scope}",
+          "scoring": {
+            "cannot-be-lower-error": "Ce champ ne peut pas être inférieur au minimum",
+            "capacity-submit-button": "Sauvegarder les capacités par mailles",
+            "level": "Niveau {index}",
+            "maximum-input-label": "Capacité maximum",
+            "minimum-input-label": "Capacité minimum",
+            "success-notification": "Le scoring à bien été mis à jour",
+            "title": "Capacités minimum et maximum par mailles"
+          },
           "title": "Création d'une version de certification"
         }
       },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -615,6 +615,15 @@
             "title": "Calibration des épreuves",
             "verify-calibration-id-button": "Vérifier la calibration"
           },
+          "scoring": {
+            "title": "Capacités minimum et maximum par mailles",
+            "minimum-input-label": "Capacité minimum",
+            "maximum-input-label": "Capacité maximum",
+            "level": "Niveau {index}",
+            "capacity-submit-button": "Sauvegarder les capacités par mailles",
+            "cannot-be-lower-error": "Ce champ ne peut pas être inférieur au minimum",
+            "success-notification": "Le scoring à bien été mis à jour"
+          },
           "edit": {
             "assessment-duration-label": "Durée de l’épreuve (hh:mm) :",
             "challenges-between-same-competence-label": "Nombre de question entre 2 questions de la même compétence :",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -641,8 +641,7 @@
             "cannot-be-lower-error": "La capacité maximale d'un niveau doit être strictement supérieur à sa capacité minimale.",
             "capacity-submit-button": "Sauvegarder les capacités par mailles",
             "level": "Niveau {index}",
-            "maximum-input-label": "Capacité maximale",
-            "minimum-input-label": "Capacité minimale",
+            "previous-version-capacity": "Ancienne valeur : {previousVersionCapacity}",
             "success-notification": "Le scoring a bien été mis à jour",
             "title": "Bornes de capacités par mailles"
           },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -638,13 +638,13 @@
           },
           "page-title": "Création d’une nouvelle version du référentiel de certification pour {scope}",
           "scoring": {
-            "cannot-be-lower-error": "Ce champ ne peut pas être inférieur au minimum",
+            "cannot-be-lower-error": "La capacité maximale d'un niveau doit être strictement supérieur à sa capacité minimale.",
             "capacity-submit-button": "Sauvegarder les capacités par mailles",
             "level": "Niveau {index}",
-            "maximum-input-label": "Capacité maximum",
-            "minimum-input-label": "Capacité minimum",
+            "maximum-input-label": "Capacité maximale",
+            "minimum-input-label": "Capacité minimale",
             "success-notification": "Le scoring a bien été mis à jour",
-            "title": "Capacités minimum et maximum par mailles"
+            "title": "Bornes de capacités par mailles"
           },
           "title": "Création d'une version de certification"
         }

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -71,7 +71,7 @@ async function getInfo(request) {
   return certificationInfoSerializer.serialize(certificationInfo);
 }
 
-const certificationVersionController = {
+export const certificationVersionController = {
   createDraft,
   getVersionById,
   deleteCertificationVersion,
@@ -80,8 +80,6 @@ const certificationVersionController = {
   getInfo,
   generateCalibrationReport,
 };
-
-export { certificationVersionController };
 
 function deserialize(json) {
   const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -92,6 +92,17 @@ async function register(server) {
                 'default-candidate-capacity': Joi.number().required(),
                 'limit-to-one-question-per-tube': Joi.boolean().required(),
                 'enable-passage-by-all-competences': Joi.boolean().required(),
+                'global-scoring-configuration': Joi.array()
+                  .items(
+                    Joi.object({
+                      bounds: Joi.object({
+                        min: Joi.number().required(),
+                        max: Joi.number().required(),
+                      }),
+                      meshLevel: Joi.number().required(),
+                    }),
+                  )
+                  .empty(),
               })
                 .required()
                 .unknown(true),

--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -26,7 +26,17 @@ export class Version {
     expirationDate: Joi.date().allow(null).optional(),
     assessmentDuration: Joi.number().required(),
     minimumAnswersRequiredToValidateACertification: Joi.number().required(),
-    globalScoringConfiguration: Joi.array().allow(null).optional(),
+    globalScoringConfiguration: Joi.array()
+      .items(
+        Joi.object({
+          bounds: Joi.object({
+            min: Joi.number().required(),
+            max: Joi.number().required(),
+          }),
+          meshLevel: Joi.number().required(),
+        }).optional(),
+      )
+      .min(0),
     competencesScoringConfiguration: Joi.array().allow(null).optional(),
     challengesConfiguration: Joi.object().instance(FlashAssessmentAlgorithmConfiguration).required(),
     comments: Joi.string().allow(null).optional(),
@@ -102,6 +112,7 @@ export class Version {
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
     externalCalibrationId,
+    globalScoringConfiguration,
   }) {
     if (!this.isDraft) {
       throw new VersionNotDraftError();
@@ -119,6 +130,7 @@ export class Version {
       enablePassageByAllCompetences,
     });
     this.externalCalibrationId = externalCalibrationId;
+    this.globalScoringConfiguration = globalScoringConfiguration;
     this.validate();
   }
 

--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -32,6 +32,9 @@ export class Version {
           bounds: Joi.object({
             min: Joi.number().required(),
             max: Joi.number().required(),
+          }).custom((value, helpers) => {
+            if (value.max <= value.min) return helpers.error('any.invalid');
+            return value;
           }),
           meshLevel: Joi.number().required(),
         }).optional(),

--- a/api/src/certification/configuration/domain/read-models/VersionDetails.js
+++ b/api/src/certification/configuration/domain/read-models/VersionDetails.js
@@ -13,6 +13,7 @@ export class VersionDetails {
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
     externalCalibrationId,
+    globalScoringConfiguration,
     scope,
     status,
     comments,
@@ -31,6 +32,7 @@ export class VersionDetails {
     this.limitToOneQuestionPerTube = limitToOneQuestionPerTube;
     this.enablePassageByAllCompetences = enablePassageByAllCompetences;
     this.externalCalibrationId = externalCalibrationId;
+    this.globalScoringConfiguration = globalScoringConfiguration;
     this.scope = scope;
     this.status = status;
     this.comments = comments;

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -84,9 +84,4 @@ const usecasesWithoutInjectedDependencies = {
   generateCalibrationReportCheck,
 };
 
-const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);
-
-/**
- * @typedef {dependencies} dependencies
- */
-export { usecases };
+export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies, boundedContext);

--- a/api/src/certification/configuration/domain/usecases/update-version.js
+++ b/api/src/certification/configuration/domain/usecases/update-version.js
@@ -18,6 +18,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
  * @param {number} params.defaultCandidateCapacity
  * @param {boolean} params.limitToOneQuestionPerTube
  * @param {boolean} params.enablePassageByAllCompetences
+ * @param {object} params.globalScoringConfiguration
  * @param {VersionRepository} params.versionRepository
  */
 export async function updateVersion({
@@ -34,6 +35,7 @@ export async function updateVersion({
   enablePassageByAllCompetences,
   externalCalibrationId,
   versionRepository,
+  globalScoringConfiguration,
 }) {
   const version = await versionRepository.getById({ id });
 
@@ -53,6 +55,7 @@ export async function updateVersion({
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
     externalCalibrationId,
+    globalScoringConfiguration,
   });
 
   return versionRepository.save(version);

--- a/api/src/certification/configuration/infrastructure/repositories/version-details-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-details-repository.js
@@ -38,6 +38,7 @@ export async function getById(id) {
       ),
       status: 'certification_versions.status',
       comments: 'certification_versions.comments',
+      globalScoringConfiguration: 'certification_versions.globalScoringConfiguration',
       externalCalibrationId: 'certification_versions.externalCalibrationId',
       tubeIds: knexConn.raw(`array_agg(certification_versions_tubes.tube_id)`),
     })

--- a/api/src/certification/configuration/infrastructure/serializers/version-details-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/version-details-serializer.js
@@ -19,6 +19,7 @@ export function serialize(versionDetails) {
     externalCalibrationId: versionDetails.externalCalibrationId,
     scope: versionDetails.scope,
     status: versionDetails.status,
+    globalScoringConfiguration: versionDetails.globalScoringConfiguration,
     comments: versionDetails.comments,
     areas: versionDetails.areas,
   };
@@ -37,6 +38,7 @@ export function serialize(versionDetails) {
       'limitToOneQuestionPerTube',
       'enablePassageByAllCompetences',
       'externalCalibrationId',
+      'globalScoringConfiguration',
       'comments',
       'scope',
       'status',

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -128,6 +128,13 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
           variationPercent: 0.5,
           defaultCandidateCapacity: -3,
           defaultProbabilityToPickChallenge: 51,
+          globalScoringConfiguration: [{
+            bounded: {
+              min: -8,
+              max: -2
+            },
+            meshLevel:0
+          }],
           comments: 'Some awesome comments',
         })
         .insertToDB({ databaseBuilder });
@@ -163,6 +170,13 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
           'enable-passage-by-all-competences': true,
           status: VERSION_STATUSES.ARCHIVED,
           scope: SCOPES.CORE,
+          'global-scoring-configuration': [{
+            bounded: {
+              min: -8,
+              max: -2
+            },
+            meshLevel:0
+          }],
           comments: 'Some awesome comments',
         },
         relationships: {

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -128,13 +128,15 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
           variationPercent: 0.5,
           defaultCandidateCapacity: -3,
           defaultProbabilityToPickChallenge: 51,
-          globalScoringConfiguration: [{
-            bounded: {
-              min: -8,
-              max: -2
+          globalScoringConfiguration: [
+            {
+              bounds: {
+                min: -8,
+                max: -2,
+              },
+              meshLevel: 0,
             },
-            meshLevel:0
-          }],
+          ],
           comments: 'Some awesome comments',
         })
         .insertToDB({ databaseBuilder });
@@ -170,13 +172,15 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
           'enable-passage-by-all-competences': true,
           status: VERSION_STATUSES.ARCHIVED,
           scope: SCOPES.CORE,
-          'global-scoring-configuration': [{
-            bounded: {
-              min: -8,
-              max: -2
+          'global-scoring-configuration': [
+            {
+              bounds: {
+                min: -8,
+                max: -2,
+              },
+              meshLevel: 0,
             },
-            meshLevel:0
-          }],
+          ],
           comments: 'Some awesome comments',
         },
         relationships: {
@@ -326,6 +330,15 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
               'default-candidate-capacity': 7,
               'limit-to-one-question-per-tube': true,
               'enable-passage-by-all-competences': true,
+              'global-scoring-configuration': [
+                {
+                  bounds: {
+                    min: 1,
+                    max: 8,
+                  },
+                  meshLevel: 0,
+                },
+              ],
             },
             type: 'certification-versions',
           },
@@ -502,6 +515,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
           'expiration-date': null,
           'external-calibration-id': null,
           'start-date': null,
+          'global-scoring-configuration': [],
           scope: SCOPES.CORE,
           comments: null,
         },

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -351,6 +351,64 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       // then
       expect(response.statusCode).to.equal(204);
     });
+
+    it('returns a 422 when globalScoringConfiguration contains bounds where max is lower than or equal to min', async function () {
+      // given
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-11') })
+        .withParameters({
+          scope: SCOPES.CORE,
+          tubeIds: ['tubeA'],
+          id: 123,
+          assessmentDuration: 100,
+          minimumAnswersRequiredToValidateACertification: 20,
+          challengesConfiguration: {
+            maximumAssessmentLength: 32,
+            challengesBetweenSameCompetence: 2,
+            limitToOneQuestionPerTube: true,
+            enablePassageByAllCompetences: true,
+            variationPercent: 0.5,
+            defaultCandidateCapacity: -3,
+            defaultProbabilityToPickChallenge: 51,
+          },
+        })
+        .insertToDB({ databaseBuilder });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/admin/certification-versions/${version.id}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        payload: {
+          data: {
+            id: version.id,
+            attributes: {
+              'start-date': new Date('2020-02-02'),
+              'assessment-duration': 1,
+              'external-calibration-id': null,
+              'minimum-answers-required-for-validation': 2,
+              'maximum-assessment-length': 3,
+              'challenges-between-same-competence': 4,
+              'default-probability-to-pick-challenge': 5,
+              'variation-percent': 0.6,
+              'default-candidate-capacity': 7,
+              'limit-to-one-question-per-tube': true,
+              'enable-passage-by-all-competences': true,
+              'global-scoring-configuration': [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
+            },
+            type: 'certification-versions',
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+    });
   });
 
   describe('PATCH /api/admin/certification-versions/{certificationVersionId}/comments', function () {

--- a/api/tests/certification/configuration/integration/domain/usecases/update-version_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/update-version_test.js
@@ -48,6 +48,15 @@ describe('Certification | Configuration | Integration | Domain | UseCase | updat
       defaultCandidateCapacity: 700,
       limitToOneQuestionPerTube: true,
       enablePassageByAllCompetences: true,
+      globalScoringConfiguration: [
+        {
+          bounds: {
+            min: 1,
+            max: 8,
+          },
+          meshLevel: 0,
+        },
+      ],
     });
 
     // then
@@ -61,7 +70,15 @@ describe('Certification | Configuration | Integration | Domain | UseCase | updat
           scope: SCOPES.PIX_PLUS_PRO_SANTE,
           assessmentDuration: 100,
           minimumAnswersRequiredToValidateACertification: 200,
-          globalScoringConfiguration: [],
+          globalScoringConfiguration: [
+            {
+              bounds: {
+                min: 1,
+                max: 8,
+              },
+              meshLevel: 0,
+            },
+          ],
           competencesScoringConfiguration: [],
           comments: 'Not Modified',
           challengesConfiguration: {

--- a/api/tests/certification/configuration/unit/domain/models/Version_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Version_test.js
@@ -130,7 +130,7 @@ describe('Certification | Configuration | Unit | Domain | Models | Version', fun
               id: 1,
               assessmentDuration: 11,
               minimumAnswersRequiredToValidateACertification: 11,
-              globalScoringConfiguration: ['some globalScoringConfiguration'],
+              globalScoringConfiguration: [{ bounds: { min: 1, max: 2 }, meshLevel: 0 }],
               competencesScoringConfiguration: ['some competencesScoringConfiguration'],
               challengesConfiguration: {
                 maximumAssessmentLength: 11,
@@ -159,7 +159,7 @@ describe('Certification | Configuration | Unit | Domain | Models | Version', fun
                 tubeIds: ['rec456'],
                 assessmentDuration: 11,
                 minimumAnswersRequiredToValidateACertification: 11,
-                globalScoringConfiguration: ['some globalScoringConfiguration'],
+                globalScoringConfiguration: [{ bounds: { min: 1, max: 2 }, meshLevel: 0 }],
                 competencesScoringConfiguration: ['some competencesScoringConfiguration'],
                 challengesConfiguration: {
                   maximumAssessmentLength: 11,
@@ -255,6 +255,15 @@ describe('Certification | Configuration | Unit | Domain | Models | Version', fun
         limitToOneQuestionPerTube: false,
         enablePassageByAllCompetences: false,
         externalCalibrationId: null,
+        globalScoringConfiguration: [
+          {
+            bounds: {
+              min: 1,
+              max: 8,
+            },
+            meshLevel: 0,
+          },
+        ],
       };
     });
 
@@ -284,6 +293,15 @@ describe('Certification | Configuration | Unit | Domain | Models | Version', fun
               limitToOneQuestionPerTube: validUpdateData.limitToOneQuestionPerTube,
               enablePassageByAllCompetences: validUpdateData.enablePassageByAllCompetences,
             },
+            globalScoringConfiguration: [
+              {
+                bounds: {
+                  min: 1,
+                  max: 8,
+                },
+                meshLevel: 0,
+              },
+            ],
           })
           .build();
         expect(version).to.deepEqualInstance(expectedVersion);

--- a/api/tests/certification/configuration/unit/domain/models/Version_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Version_test.js
@@ -316,5 +316,37 @@ describe('Certification | Configuration | Unit | Domain | Models | Version', fun
         expect(() => version.update(validUpdateData)).to.throw(VersionNotDraftError);
       });
     });
+
+    context('when globalScoringConfiguration contains invalid bounds', function () {
+      it('throws an EntityValidationError when max is lower than min', function () {
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2025-05-05') })
+          .withParameters(baseVersionData)
+          .build();
+
+        expect(() =>
+          version.update({
+            ...validUpdateData,
+            globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
+          }),
+        ).to.throw(EntityValidationError);
+      });
+
+      it('throws an EntityValidationError when max equals min', function () {
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2025-05-05') })
+          .withParameters(baseVersionData)
+          .build();
+
+        expect(() =>
+          version.update({
+            ...validUpdateData,
+            globalScoringConfiguration: [{ bounds: { min: 3, max: 3 }, meshLevel: 0 }],
+          }),
+        ).to.throw(EntityValidationError);
+      });
+    });
   });
 });

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/version-details-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/version-details-serializer_test.js
@@ -128,6 +128,7 @@ describe('Certification | Configuration | Unit | Serializer | version-details-se
             'variation-percent': 0.66,
             'limit-to-one-question-per-tube': true,
             'enable-passage-by-all-competences': true,
+            'global-scoring-configuration': [],
           },
           relationships: {
             areas: {

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-version-details.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-version-details.js
@@ -1,7 +1,4 @@
-import {
-  defaultCompetencesScoringConfiguration,
-  defaultGlobalScoringConfiguration,
-} from '../../../../../../db/database-builder/factory/build-certification-version.js';
+import { defaultCompetencesScoringConfiguration } from '../../../../../../db/database-builder/factory/build-certification-version.js';
 import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { VersionDetails } from '../../../../../../src/certification/configuration/domain/read-models/VersionDetails.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
@@ -190,7 +187,7 @@ class VersionDetailsBuilder {
     this.variationPercent = variationPercent ?? this.variationPercent;
     this.limitToOneQuestionPerTube = limitToOneQuestionPerTube || this.limitToOneQuestionPerTube;
     this.enablePassageByAllCompetences = enablePassageByAllCompetences || this.enablePassageByAllCompetences;
-    this.globalScoringConfiguration = globalScoringConfiguration || this.globalScoringConfiguration;
+    this.globalScoringConfiguration = globalScoringConfiguration ?? this.globalScoringConfiguration;
     this.comments = comments ?? this.comments;
     this.externalCalibrationId = externalCalibrationId ?? this.externalCalibrationId;
     return this;
@@ -207,7 +204,7 @@ class VersionDetailsBuilder {
    */
   insertToDB({ databaseBuilder }) {
     const versionDetails = this.build();
-    
+
     const row = databaseBuilder.factory.buildCertificationVersion({
       id: versionDetails.id ?? undefined,
       scope: versionDetails.scope,

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-version-details.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-version-details.js
@@ -79,6 +79,7 @@ class VersionDetailsBuilder {
     this.limitToOneQuestionPerTube = true;
     this.enablePassageByAllCompetences = false;
     this.externalCalibrationId = null;
+    this.globalScoringConfiguration = [];
     this.comments = null;
     this.areas = [];
   }
@@ -173,6 +174,7 @@ class VersionDetailsBuilder {
     variationPercent,
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
+    globalScoringConfiguration,
     comments,
   } = {}) {
     this.id = id ?? this.id;
@@ -188,6 +190,7 @@ class VersionDetailsBuilder {
     this.variationPercent = variationPercent ?? this.variationPercent;
     this.limitToOneQuestionPerTube = limitToOneQuestionPerTube || this.limitToOneQuestionPerTube;
     this.enablePassageByAllCompetences = enablePassageByAllCompetences || this.enablePassageByAllCompetences;
+    this.globalScoringConfiguration = globalScoringConfiguration || this.globalScoringConfiguration;
     this.comments = comments ?? this.comments;
     this.externalCalibrationId = externalCalibrationId ?? this.externalCalibrationId;
     return this;
@@ -204,7 +207,7 @@ class VersionDetailsBuilder {
    */
   insertToDB({ databaseBuilder }) {
     const versionDetails = this.build();
-
+    
     const row = databaseBuilder.factory.buildCertificationVersion({
       id: versionDetails.id ?? undefined,
       scope: versionDetails.scope,
@@ -213,7 +216,7 @@ class VersionDetailsBuilder {
       externalCalibrationId: versionDetails.externalCalibrationId,
       assessmentDuration: versionDetails.assessmentDuration,
       minimumAnswersRequiredToValidateACertification: versionDetails.minimumAnswersRequiredForValidation,
-      globalScoringConfiguration: defaultGlobalScoringConfiguration,
+      globalScoringConfiguration: versionDetails.globalScoringConfiguration,
       competencesScoringConfiguration: defaultCompetencesScoringConfiguration,
       challengesConfiguration: {
         maximumAssessmentLength: versionDetails.maximumAssessmentLength,
@@ -316,6 +319,7 @@ class VersionDetailsBuilder {
       limitToOneQuestionPerTube: this.limitToOneQuestionPerTube,
       enablePassageByAllCompetences: this.enablePassageByAllCompetences,
       externalCalibrationId: this.externalCalibrationId,
+      globalScoringConfiguration: this.globalScoringConfiguration,
       comments: this.comments,
       status: this.status,
       areas: this.areas,


### PR DESCRIPTION
## ☀️ Problème

La création d'une nouvelle version de référentiel était gérée manuellement en interne. Pour gagner en autonomie et en efficacité, on featurise ce processus directement depuis l'espace Admin.
On souhaite permettre aux super-admins de définir les seuils de capacités par maille et par compétence lors de la création d’une nouvelle version d’un référentiel en minimisant le risque d’erreurs manuelles.

## ⛱️ Proposition

À l'étape 4 de la création d'une nouvelle version, ajouter un formulaire permettant de configurer les valeurs des maille

<img width="1820" height="718" alt="image" src="https://github.com/user-attachments/assets/26fcb304-b21e-45a4-a3e9-6db6ca403d3d" />

## 🧴 Remarques

:no_entry_sign: La PR ne répond pas actuellement au besoin

## 🏊 Pour tester

Créer une nouvelle version, aller jusqu'à la 4e étape et modifier le formulaire, l'enregistrer