### PR TITLE
[TECH] sinon.restore() entre chaque test dans les fronts

### DIFF
--- a/admin/tests/integration/components/administration/access/anonymize-gar-import-test.gjs
+++ b/admin/tests/integration/components/administration/access/anonymize-gar-import-test.gjs
@@ -24,10 +24,6 @@ module('Integration | Component |  administration/anonymize-gar-import', functio
     sinon.stub(window, 'fetch');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('when import fully succeeds', function () {
     test('it displays a success notification', async function (assert) {
       // given

--- a/admin/tests/integration/components/administration/common/create-attestations-test.gjs
+++ b/admin/tests/integration/components/administration/common/create-attestations-test.gjs
@@ -20,10 +20,6 @@ module('Integration | Component | administration/create-attestations', function 
     sinon.stub(requestManagerService, 'request');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('when all fields are filled', function () {
     test('it should enable submit button', async function (assert) {
       const screen = await render(<template><CreateAttestations /></template>);

--- a/admin/tests/integration/components/administration/common/user-quest-checker-test.gjs
+++ b/admin/tests/integration/components/administration/common/user-quest-checker-test.gjs
@@ -12,10 +12,6 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component |  administration/user-quest-checker', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('it should display a form', async function (assert) {
     // when
     const screen = await render(<template><UserQuestChecker /></template>);

--- a/admin/tests/integration/components/administration/deployment/certification-centers-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/certification-centers-batch-archive-test.gjs
@@ -15,10 +15,6 @@ module('Integration | Component | administration/certification-centers-batch-arc
     sinon.stub(window, 'fetch');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('when batch archive succeeds', function () {
     test('it displays a success notification', async function (assert) {
       // given

--- a/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
@@ -17,10 +17,6 @@ module('Integration | Component | administration/organizations-batch-archive', f
     sinon.stub(requestManagerService, 'request');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('when batch archive succeeds', function () {
     test('it displays the correct number of archived organizations in success notification', async function (assert) {
       // given

--- a/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
@@ -24,10 +24,6 @@ module('Integration | Component |  administration/update-organizations-in-batch'
     sinon.stub(window, 'fetch');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('when import succeeds', function () {
     test('it displays a success notification', async function (assert) {
       // given

--- a/admin/tests/integration/components/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/certification-centers/membership-item-test.gjs
@@ -18,10 +18,6 @@ module('Integration | Component |  certification-centers/membership-item', funct
     intl = this.owner.lookup('service:intl');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('displays a certification center membership table row item', function () {
     test('with last access date if exists', async function (assert) {
       // given

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -923,11 +923,7 @@ module('Integration | Component | Certifications | Certification | Information |
       });
     });
 
-    module('when button is displayed', function (hooks) {
-      hooks.afterEach(function () {
-        sinon.restore();
-      });
-
+    module('when button is displayed', function () {
       test('should trigger rescoring and show success notification', async function (assert) {
         assert.expect(1);
 

--- a/admin/tests/integration/components/organizations/member-item-test.gjs
+++ b/admin/tests/integration/components/organizations/member-item-test.gjs
@@ -20,10 +20,6 @@ module('Integration | Component | MemberItem', function (hooks) {
     currentUser.adminMember = { isSuperAdmin: true };
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('displays an organization member details', async function (assert) {
     // given
     const member = {

--- a/admin/tests/integration/components/users/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/users/certification-centers/membership-item-test.gjs
@@ -16,9 +16,6 @@ module('Integration | Component | users | certification-centers | membership-ite
     store = this.owner.lookup('service:store');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
   module('displays a certification center membership table row item', function () {
     test('with last access date if there is one', async function (assert) {
       // given

--- a/admin/tests/test-helper.js
+++ b/admin/tests/test-helper.js
@@ -3,6 +3,7 @@ import { clearAllCookies } from 'ember-cookies/test-support';
 import start from 'ember-exam/test-support/start';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
+import sinon from 'sinon';
 
 import Application from '../app';
 import config from '../config/environment';
@@ -15,6 +16,11 @@ Object.defineProperty(window.navigator, 'languages', { value: [BROWSER_LOCALE], 
 // Reset all cookies before each test to avoid side-effects
 QUnit.hooks.beforeEach(function () {
   clearAllCookies();
+});
+
+// Restore all sinon stubs after each test to avoid side-effects
+QUnit.hooks.afterEach(function () {
+  sinon.restore();
 });
 
 setup(QUnit.assert);

--- a/admin/tests/unit/authenticators/oidc-test.js
+++ b/admin/tests/unit/authenticators/oidc-test.js
@@ -60,10 +60,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
       oidcIdentityProvidersService.set('store', storeStub);
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     test('fetches token with authentication key', async function (assert) {
       // given
       const authenticator = this.owner.lookup('authenticator:oidc');

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
@@ -190,10 +190,6 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       const adapter = store.adapterFor('session');
       getDownloadLinkStub = sinon.stub(adapter, 'getDownloadLink');
     });
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     test('it should retrieve link from api and copy it', async function (assert) {
       // given
       const session = sinon.stub();

--- a/admin/tests/unit/metrics-adapters/plausible-adapter-test.js
+++ b/admin/tests/unit/metrics-adapters/plausible-adapter-test.js
@@ -16,6 +16,7 @@ module('Unit | MetricsAdapter | plausible-adapter', function (hooks) {
   });
 
   hooks.afterEach(function () {
+    sinon.restore(); // must restore before uninstall, which deletes window.plausible
     this.adapter.uninstall();
   });
 

--- a/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
@@ -26,10 +26,6 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
       };
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     module('when queryParams filters are falsy', function () {
       test('it should call store.query with no filters on name and id', async function (assert) {
         // when

--- a/admin/tests/unit/routes/authenticated/users/get-test.js
+++ b/admin/tests/unit/routes/authenticated/users/get-test.js
@@ -5,11 +5,7 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/users/get', function (hooks) {
   setupTest(hooks);
 
-  module('beforeModel', function (hooks) {
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
+  module('beforeModel', function () {
     test('loads all available identity providers', async function (assert) {
       // given
       const route = this.owner.lookup('route:authenticated/users/get');

--- a/admin/tests/unit/routes/authentication/login-oidc-test.js
+++ b/admin/tests/unit/routes/authentication/login-oidc-test.js
@@ -30,10 +30,6 @@ module('Unit | Route | login-oidc', function (hooks) {
         oidcIdentityProvidersService.set('store', storeStub);
       });
 
-      hooks.afterEach(function () {
-        sinon.restore();
-      });
-
       module('when identity provider is not supported', function () {
         test('redirects the user to main login page', async function (assert) {
           // given
@@ -65,7 +61,6 @@ module('Unit | Route | login-oidc', function (hooks) {
           );
           sinon.assert.calledWith(replaceStub, 'https://oidc.example.net/connexion');
           assert.ok(true);
-          sinon.restore();
         });
       });
     });

--- a/admin/tests/unit/routes/login-test.js
+++ b/admin/tests/unit/routes/login-test.js
@@ -10,11 +10,7 @@ module('Unit | Route | login', function (hooks) {
     assert.ok(route);
   });
 
-  module('model', function (hooks) {
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
+  module('model', function () {
     test('loads ready identity providers', async function (assert) {
       // given
       const route = this.owner.lookup('route:login');

--- a/admin/tests/unit/services/current-domain-test.js
+++ b/admin/tests/unit/services/current-domain-test.js
@@ -5,10 +5,6 @@ import sinon from 'sinon';
 
 module('Unit | Service | currentDomain', function (hooks) {
   setupTest(hooks);
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#getExtension', function () {
     module('when location is FR TLD', function () {
       test(`returns fr`, function (assert) {

--- a/admin/tests/unit/services/pix-metrics-test.js
+++ b/admin/tests/unit/services/pix-metrics-test.js
@@ -17,10 +17,6 @@ module('Unit | Service | PixMetrics', function (hooks) {
     sinon.stub(metricsService, 'trackEvent');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('trackPage', function () {
     test('it should redact id from url', function (assert) {
       // given

--- a/admin/tests/unit/services/request-manager-test.js
+++ b/admin/tests/unit/services/request-manager-test.js
@@ -21,10 +21,6 @@ module('Unit | Service | request-manager', function (hooks) {
     sinon.stub(localeService, 'acceptLanguageHeader').value('fr');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('request()', function () {
     test('it requests successfully with default headers', async function (assert) {
       // given

--- a/admin/tests/unit/utils/location-test.js
+++ b/admin/tests/unit/utils/location-test.js
@@ -2,11 +2,7 @@ import Location from 'pix-admin/utils/location';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Utility | location', function (hooks) {
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
+module('Unit | Utility | location', function () {
   module('#getHref', function () {
     test('should return the full URL', function (assert) {
       // given

--- a/certif/tests/integration/components/auth/register-form-test.js
+++ b/certif/tests/integration/components/auth/register-form-test.js
@@ -160,10 +160,6 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
       store = this.owner.lookup('service:store');
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     async function _fillValidForm() {
       await fillByLabel(firstNameInputLabel, 'Alain');
       await fillByLabel(lastNameInputLabel, 'Ternational');

--- a/certif/tests/integration/components/members-list-test.js
+++ b/certif/tests/integration/components/members-list-test.js
@@ -20,10 +20,6 @@ module('Integration | Component | MembersList', function (hooks) {
     sinon.stub(currentUser, 'currentAllowedCertificationCenterAccess').value({ name: 'Certif NextGen' });
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('For edit role button', function () {
     test('displays a modal', async function (assert) {
       // given

--- a/certif/tests/integration/components/members-table-test.gjs
+++ b/certif/tests/integration/components/members-table-test.gjs
@@ -17,10 +17,6 @@ module('Integration | Component | Members Table', function (hooks) {
     currentUser = this.owner.lookup('service:current-user');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('it displays members firstName, lastName and role', async function (assert) {
     // given
     const memberWithMemberRole = store.createRecord('member', {

--- a/certif/tests/integration/components/team/invitations-list-test.js
+++ b/certif/tests/integration/components/team/invitations-list-test.js
@@ -23,10 +23,6 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
     this.set('resendInvitation', resendInvitation);
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('displays email address, last sending date and actions headers', async function (assert) {
     // given
     const invitation = store.createRecord('certification-center-invitation', {

--- a/certif/tests/integration/components/team/modal/remove-member-modal-test.js
+++ b/certif/tests/integration/components/team/modal/remove-member-modal-test.js
@@ -8,10 +8,6 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Components | Team::Modal::RemoveMemberModal', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('when the modal is open', function (hooks) {
     let screen;
     let closeRemoveMembershipModal, onRemoveButtonClicked;

--- a/certif/tests/test-helper.js
+++ b/certif/tests/test-helper.js
@@ -3,6 +3,7 @@ import { clearAllCookies } from 'ember-cookies/test-support';
 import start from 'ember-exam/test-support/start';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
+import sinon from 'sinon';
 
 import Application from '../app';
 import config from '../config/environment';
@@ -15,6 +16,11 @@ Object.defineProperty(window.navigator, 'languages', { value: [BROWSER_LOCALE], 
 // Reset all cookies before each test to avoid side-effects
 QUnit.hooks.beforeEach(function () {
   clearAllCookies();
+});
+
+// Restore all sinon stubs after each test to avoid side-effects
+QUnit.hooks.afterEach(function () {
+  sinon.restore();
 });
 
 setApplication(Application.create(config.APP));

--- a/certif/tests/unit/controllers/authenticated/team/list-test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list-test.js
@@ -17,10 +17,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#shouldDisplayNoRefererSection', function () {
     module('when certification center has CLEA habilitation', function (hooks) {
       hooks.beforeEach(function () {

--- a/certif/tests/unit/controllers/authenticated/team/list/invitations-test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/invitations-test.js
@@ -16,10 +16,6 @@ module('Unit | Controller | authenticated/team/list/invitations', function (hook
     controller = this.owner.lookup('controller:authenticated/team/list/invitations');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#cancelInvitation', function () {
     test('cancel invitation and displays a success notification', async function (assert) {
       // given

--- a/certif/tests/unit/controllers/authenticated/team/list/members-test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/members-test.js
@@ -16,10 +16,6 @@ module('Unit | Controller | authenticated/team/list/members', function (hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#leaveCertificationCenter', function () {
     test('deletes the current user membership', async function (assert) {
       // given

--- a/certif/tests/unit/instance-initializers/session-test.js
+++ b/certif/tests/unit/instance-initializers/session-test.js
@@ -23,7 +23,6 @@ module('Unit | Instance Initializer | session', function (hooks) {
   hooks.afterEach(function () {
     this.instance.destroy();
     this.application.destroy();
-    sinon.restore();
   });
 
   module('when a session exists', function () {

--- a/certif/tests/unit/metrics-adapters/plausible-adapter-test.js
+++ b/certif/tests/unit/metrics-adapters/plausible-adapter-test.js
@@ -17,6 +17,8 @@ module('Unit | MetricsAdapter | plausible-adapter', function (hooks) {
   });
 
   hooks.afterEach(function () {
+    // stubs must be restored before uninstalling the adapter, which removes `window.plausible`
+    sinon.restore();
     this.adapter.uninstall();
   });
 

--- a/certif/tests/unit/routes/application-test.js
+++ b/certif/tests/unit/routes/application-test.js
@@ -14,10 +14,6 @@ module('Unit | Route | application', function (hooks) {
     sinon.stub(this.route.currentUser, 'load').resolves();
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('beforeModel', function () {
     test('sets best locale', async function (assert) {
       // given

--- a/certif/tests/unit/services/pix-metrics-test.js
+++ b/certif/tests/unit/services/pix-metrics-test.js
@@ -17,10 +17,6 @@ module('Unit | Service | PixMetrics', function (hooks) {
     sinon.stub(metricsService, 'trackEvent');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('trackPage', function () {
     test('it should redact id from url', function (assert) {
       // given

--- a/certif/tests/unit/utils/location-test.js
+++ b/certif/tests/unit/utils/location-test.js
@@ -2,11 +2,7 @@ import Location from 'pix-certif/utils/location';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Utility | location (certif)', function (hooks) {
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
+module('Unit | Utility | location (certif)', function () {
   module('#getHref', function () {
     test('should return the full URL', function (assert) {
       // given

--- a/junior/tests/test-helper.js
+++ b/junior/tests/test-helper.js
@@ -4,9 +4,14 @@ import { setApplication } from '@ember/test-helpers';
 import start from 'ember-exam/test-support/start';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
+import sinon from 'sinon';
 
 import Application from '../app';
 import config from '../config/environment';
+
+QUnit.hooks.afterEach(function () {
+  sinon.restore();
+});
 
 setApplication(Application.create(config.APP));
 setup(QUnit.assert);

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -286,7 +286,6 @@ module('Acceptance | Campaigns | Results | Recommendation Engine', function (hoo
 
       hooks.afterEach(function () {
         delete window.IntersectionObserver;
-        sinon.restore();
       });
 
       test('should display the drawer when user has not answered the survey', async function (assert) {

--- a/mon-pix/tests/acceptance/user-account/connection-methods-test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods-test.js
@@ -20,10 +20,6 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('connection method details', function () {
     test("displays user's email and username", async function (assert) {
       // given

--- a/mon-pix/tests/acceptance/user-account/delete-account-test.js
+++ b/mon-pix/tests/acceptance/user-account/delete-account-test.js
@@ -3,7 +3,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import { authenticate } from '../../helpers/authentication';
 import setupIntl from '../../helpers/setup-intl';
@@ -12,10 +11,6 @@ module('Acceptance | user-account | delete-account', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
-
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
 
   module('when user can self-delete their account', function () {
     test('it deletes their account', async function (assert) {

--- a/mon-pix/tests/integration/components/assessments/live-alert-test.gjs
+++ b/mon-pix/tests/integration/components/assessments/live-alert-test.gjs
@@ -10,10 +10,6 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Assessments | live-alert', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('it displays challenge live alert', async function (assert) {
     // given
     const message = t('pages.challenge.live-alerts.companion.message');

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
@@ -99,10 +99,6 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
       sinon.stub(window, 'fetch');
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     module('when the password-reset-demand is successful', function () {
       test('it displays a "password reset demand received" info (without any error message)', async function (assert) {
         // given

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -70,7 +70,6 @@ module(
       module('tracking', function (hooks) {
         hooks.afterEach(function () {
           delete window.IntersectionObserver;
-          sinon.restore();
         });
 
         test('it should send tracking when drawer is displayed', async function (assert) {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -28,7 +28,6 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
 
   hooks.afterEach(function () {
     delete window.IntersectionObserver;
-    sinon.restore();
   });
 
   test('it should display the trainings list', async function (assert) {

--- a/mon-pix/tests/integration/components/challenge/content-test.gjs
+++ b/mon-pix/tests/integration/components/challenge/content-test.gjs
@@ -47,10 +47,6 @@ module('Integration | Component | Challenge | Content', function (hooks) {
       );
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     module('on challenge skip', function () {
       test('should disable the live alert button', async function (assert) {
         // then

--- a/mon-pix/tests/integration/components/challenge/item-test.gjs
+++ b/mon-pix/tests/integration/components/challenge/item-test.gjs
@@ -128,10 +128,6 @@ module('Integration | Component | Challenge | Item', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     async function renderItem() {
       const noop = () => {};
       const screen = await render(

--- a/mon-pix/tests/integration/components/companion/blocker-test.gjs
+++ b/mon-pix/tests/integration/components/companion/blocker-test.gjs
@@ -12,10 +12,6 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Companion | blocker', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('it display children elements when extension is detected', async function (assert) {
     // given
     class PixCompanionStub extends Service {

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner-test.gjs
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner-test.gjs
@@ -13,10 +13,6 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 module('Integration | Component | data-protection-policy-information-banner', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('when user is not logged in', function () {
     test('does not display the data protection policy banner', async function (assert) {
       // given

--- a/mon-pix/tests/integration/components/download-session-results-test.gjs
+++ b/mon-pix/tests/integration/components/download-session-results-test.gjs
@@ -19,10 +19,6 @@ module('Integration | Component | download-session-results', function (hooks) {
     sinon.stub(fileSaver, 'save');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('should display component', async function (assert) {
     // given
     // when

--- a/mon-pix/tests/integration/modifiers/on-intersect-test.gjs
+++ b/mon-pix/tests/integration/modifiers/on-intersect-test.gjs
@@ -25,7 +25,6 @@ module('Integration | Modifier | on-intersect', function (hooks) {
 
   hooks.afterEach(function () {
     delete window.IntersectionObserver;
-    sinon.restore();
   });
 
   test('it observes the element on insertion', async function (assert) {

--- a/mon-pix/tests/test-helper.js
+++ b/mon-pix/tests/test-helper.js
@@ -3,6 +3,7 @@ import { clearAllCookies } from 'ember-cookies/test-support';
 import start from 'ember-exam/test-support/start';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
+import sinon from 'sinon';
 
 import Application from '../app';
 import config from '../config/environment';
@@ -15,6 +16,11 @@ Object.defineProperty(window.navigator, 'languages', { value: [BROWSER_LOCALE], 
 // Reset all cookies before each test to avoid side-effects
 QUnit.hooks.beforeEach(function () {
   clearAllCookies();
+});
+
+// Restore all sinon stubs after each test to avoid side-effects
+QUnit.hooks.afterEach(function () {
+  sinon.restore();
 });
 
 setApplication(Application.create(config.APP));

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -94,7 +94,6 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
         // then
         sinon.assert.notCalled(sessionService.invalidate);
         sinon.assert.calledOnce(RESTAdapter.prototype.handleResponse);
-        sinon.restore();
         assert.ok(true);
       });
     });

--- a/mon-pix/tests/unit/authenticators/gar-test.js
+++ b/mon-pix/tests/unit/authenticators/gar-test.js
@@ -1,13 +1,8 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 module('Unit | Authenticator | gar', function (hooks) {
   setupTest(hooks);
-
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
 
   module('#authenticate', function () {
     test('should authenticate the user', async function (assert) {

--- a/mon-pix/tests/unit/authenticators/oidc-test.js
+++ b/mon-pix/tests/unit/authenticators/oidc-test.js
@@ -57,10 +57,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
       oidcIdentityProvidersService.set('store', storeStub);
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     test('retrieves an access token with authentication key', async function (assert) {
       // given
       const authenticator = this.owner.lookup('authenticator:oidc');
@@ -193,7 +189,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
 
         // then
         assert.strictEqual(authenticator.session.alternativeRootURL, redirectLogoutUrl);
-        sinon.restore();
       });
     });
   });

--- a/mon-pix/tests/unit/controllers/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge-test.js
@@ -15,10 +15,6 @@ module('Unit | Controller | Assessments | Challenge', function (hooks) {
     controller.intl = intl;
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#pageTitle', function () {
     test('should return Épreuve 2 sur 5', function (assert) {
       // given

--- a/mon-pix/tests/unit/errors/factories/create-application-error-test.js
+++ b/mon-pix/tests/unit/errors/factories/create-application-error-test.js
@@ -6,10 +6,6 @@ import sinon from 'sinon';
 module('Unit | Errors | Factories | create-application-error', function (hooks) {
   setupTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('when the error code is provided', function () {
     test('returns an application error with a translated message', function (assert) {
       // Given

--- a/mon-pix/tests/unit/instance-initializers/session-test.js
+++ b/mon-pix/tests/unit/instance-initializers/session-test.js
@@ -43,7 +43,6 @@ module('Unit | Instance Initializer | session', function () {
         assert.notOk(session);
         this.instance.destroy();
         this.application.destroy();
-        sinon.restore();
       });
     });
 
@@ -83,7 +82,6 @@ module('Unit | Instance Initializer | session', function () {
         assert.notOk(session);
         this.instance.destroy();
         this.application.destroy();
-        sinon.restore();
       });
     });
   });
@@ -121,7 +119,6 @@ module('Unit | Instance Initializer | session', function () {
         assert.notOk(session);
         this.instance.destroy();
         this.application.destroy();
-        sinon.restore();
       });
     });
 
@@ -157,7 +154,6 @@ module('Unit | Instance Initializer | session', function () {
         assert.notOk(session);
         this.instance.destroy();
         this.application.destroy();
-        sinon.restore();
       });
     });
 
@@ -193,7 +189,6 @@ module('Unit | Instance Initializer | session', function () {
         assert.notOk(session);
         this.instance.destroy();
         this.application.destroy();
-        sinon.restore();
       });
     });
   });

--- a/mon-pix/tests/unit/metrics-adapters/plausible-adapter-test.js
+++ b/mon-pix/tests/unit/metrics-adapters/plausible-adapter-test.js
@@ -16,6 +16,8 @@ module('Unit | MetricsAdapter | plausible-adapter', function (hooks) {
   });
 
   hooks.afterEach(function () {
+    // stubs must be restored before uninstall, which deletes the stubbed `window.plausible`
+    sinon.restore();
     this.adapter.uninstall();
   });
 

--- a/mon-pix/tests/unit/routes/authentication/login-gar-test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-gar-test.js
@@ -7,10 +7,6 @@ import sinon from 'sinon';
 module('Unit | Routes | authentication | login-gar', function (hooks) {
   setupTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#beforeModel', function () {
     module('when a token is set as an hash of an url', function () {
       test('should authenticate the user', async function (assert) {

--- a/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
@@ -12,10 +12,6 @@ module('Unit | Route | login-oidc', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#beforeModel', function () {
     module('when receives error from identity provider', function () {
       test('it throws an error', function (assert) {

--- a/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
@@ -27,10 +27,6 @@ module('Unit | Route | Entry Point', function (hooks) {
     route.currentUser = { user: {} };
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#beforeModel', function () {
     test('should invalidate session when a user is connected and anonymous', async function (assert) {
       //given

--- a/mon-pix/tests/unit/routes/campaigns/existing-participation-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/existing-participation-test.js
@@ -21,10 +21,6 @@ module('Unit | Route | ExistingParticipation', function (hooks) {
     route.store = { queryRecord: sinon.stub() };
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#beforeModel', function () {
     test('should call session requireAuthenticationAndApprovedTermsOfService with transition', async function (assert) {
       //given

--- a/mon-pix/tests/unit/services/authentication-test.js
+++ b/mon-pix/tests/unit/services/authentication-test.js
@@ -14,10 +14,6 @@ module('Unit | Services | authentication', function (hooks) {
     sinon.stub(authenticationService.router, 'replaceWith');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#handleAnonymousAuthentication', function () {
     module('when there is no session', function () {
       module('when the route is available for an anonymous user', function () {

--- a/mon-pix/tests/unit/services/current-domain-test.js
+++ b/mon-pix/tests/unit/services/current-domain-test.js
@@ -6,10 +6,6 @@ import sinon from 'sinon';
 module('Unit | Service | currentDomain', function (hooks) {
   setupTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#getExtension', function () {
     module('when location is FR TLD', function () {
       test(`returns fr`, function (assert) {

--- a/mon-pix/tests/unit/services/file-saver-test.js
+++ b/mon-pix/tests/unit/services/file-saver-test.js
@@ -45,10 +45,6 @@ module('Unit | Service | file-saver', function (hooks) {
         });
       });
 
-      hooks.afterEach(function () {
-        sinon.restore();
-      });
-
       test('should override the HTTP method', async function (assert) {
         // given
         const expectedMethod = 'PATCH';

--- a/mon-pix/tests/unit/services/focused-certification-challenge-warning-manager-test.js
+++ b/mon-pix/tests/unit/services/focused-certification-challenge-warning-manager-test.js
@@ -11,10 +11,6 @@ module('Unit | Service | focused-certification-challenge-warning-manager', funct
     getItemStub = sinon.stub(window.localStorage, 'getItem');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#setToConfirmed', function () {
     test('should set to true', function (assert) {
       // given

--- a/mon-pix/tests/unit/services/request-manager-test.js
+++ b/mon-pix/tests/unit/services/request-manager-test.js
@@ -25,10 +25,6 @@ module('Unit | Service | request-manager', function (hooks) {
     sinon.stub(localeService, 'acceptLanguageHeader').value('fr');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('request()', function () {
     test('it requests successfully with default headers', async function (assert) {
       // given

--- a/mon-pix/tests/unit/utils/location-test.js
+++ b/mon-pix/tests/unit/utils/location-test.js
@@ -2,11 +2,7 @@ import Location from 'mon-pix/utils/location';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Utility | location', function (hooks) {
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
+module('Unit | Utility | location', function () {
   module('#getHref', function () {
     test('should return the full URL', function (assert) {
       // given

--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -17,15 +17,7 @@ module('Acceptance | Certifications page', function (hooks) {
     await authenticateSession(user.id);
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
-  module('When user arrives on certifications page', function (hooks) {
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
+  module('When user arrives on certifications page', function () {
     test('should display certification banner when it is time to', async function (assert) {
       sinon.useFakeTimers({ now: new Date('2001-04-01T10:42:00Z'), shouldAdvanceTime: true });
 

--- a/orga/tests/integration/components/analysis/analysis-header-test.gjs
+++ b/orga/tests/integration/components/analysis/analysis-header-test.gjs
@@ -10,10 +10,6 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | analysis-header', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('for campaign or global analysis', function () {
     test('it should navigate the competences view', async function (assert) {
       // given

--- a/orga/tests/integration/components/banner/certification-test.gjs
+++ b/orga/tests/integration/components/banner/certification-test.gjs
@@ -14,10 +14,6 @@ module('Integration | Component | Banner::Certification', function (hooks) {
       sinon.useFakeTimers({ now: new Date('2001-04-01T10:42:00Z') });
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     module('when prescriber’s organization is of type SCO that manages students', function () {
       class CurrentUserStub extends Service {
         organization = { isSco: true };

--- a/orga/tests/integration/components/campaign/charts/campaign-badge-acquisition-test.gjs
+++ b/orga/tests/integration/components/campaign/charts/campaign-badge-acquisition-test.gjs
@@ -14,10 +14,6 @@ module('Integration | Component | Campaign::Charts::BadgeAcquisitionCards', func
     adapter = store.adapterFor('campaign-stats');
   });
 
-  hooks.afterEach(async function () {
-    sinon.restore();
-  });
-
   module('When the campaign has badges acquired', function (hooks) {
     hooks.beforeEach(async function () {
       sinon.stub(adapter, 'getBadgeAcquisitions').resolves({

--- a/orga/tests/integration/components/campaign/charts/result-distribution-test.gjs
+++ b/orga/tests/integration/components/campaign/charts/result-distribution-test.gjs
@@ -16,10 +16,6 @@ module('Integration | Component | Campaign::Charts::ResultDistribution', functio
     adapter = store.adapterFor('campaign-stats');
   });
 
-  hooks.afterEach(async function () {
-    sinon.restore();
-  });
-
   module('when the campaign has no stages', function (hooks) {
     hooks.beforeEach(async function () {
       dataFetcher = sinon.stub(adapter, 'getParticipationsByMasteryRate');

--- a/orga/tests/integration/components/sco-organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/sco-organization-participant/list-test.gjs
@@ -1136,10 +1136,6 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.certificability = [];
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     test('displays action bar', async function (assert) {
       // given
       const students = [

--- a/orga/tests/integration/components/tube/list-test.gjs
+++ b/orga/tests/integration/components/tube/list-test.gjs
@@ -126,10 +126,6 @@ module('Integration | Component | tube:list', function (hooks) {
     ];
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('it should display frameworks title', async function (assert) {
     // given
     const frameworks = allFrameworks.slice();

--- a/orga/tests/test-helper.js
+++ b/orga/tests/test-helper.js
@@ -6,6 +6,7 @@ import Application from 'pix-orga/app';
 import config from 'pix-orga/config/environment';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
+import sinon from 'sinon';
 
 export async function start(options) {
   // Set default browser locale
@@ -16,6 +17,11 @@ export async function start(options) {
   // Reset all cookies before each test to avoid side-effects
   QUnit.hooks.beforeEach(function () {
     clearAllCookies();
+  });
+
+  // Restore all sinon stubs after each test to avoid side-effects
+  QUnit.hooks.afterEach(function () {
+    sinon.restore();
   });
 
   setApplication(Application.create(config.APP));

--- a/orga/tests/unit/adapters/user-orga-setting-test.js
+++ b/orga/tests/unit/adapters/user-orga-setting-test.js
@@ -14,10 +14,6 @@ module('Unit | Adapters | user-orga-setting', function (hooks) {
     adapter.set('ajax', ajaxStub);
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#urlForUpdateRecord', function () {
     test('it should build update url from user id', async function (assert) {
       // when

--- a/orga/tests/unit/authenticators/oidc-test.js
+++ b/orga/tests/unit/authenticators/oidc-test.js
@@ -57,10 +57,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
       oidcIdentityProvidersService.set('store', storeStub);
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     test('retrieves an access token with authentication key', async function (assert) {
       // given
       const authenticator = this.owner.lookup('authenticator:oidc');
@@ -194,7 +190,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
 
           // then
           assert.strictEqual(authenticator.session.routeAfterInvalidation, redirectLogoutUrl);
-          sinon.restore();
         });
       });
 
@@ -227,7 +222,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
             '/connexion?error=USER_HAS_NO_ORGANIZATION_MEMBERSHIP',
           );
           sinon.assert.notCalled(window.fetch);
-          sinon.restore();
         });
       });
     });

--- a/orga/tests/unit/routes/application-test.js
+++ b/orga/tests/unit/routes/application-test.js
@@ -14,9 +14,6 @@ module('Unit | Route | application', function (hooks) {
     sinon.stub(this.route.locale, 'setBestLocale').resolves();
     sinon.stub(this.route.localeLoader, 'load').resolves();
   });
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
   module('model', function () {
     test('does not fetch sco organization banner', async function (assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/activity-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/activity-test.js
@@ -11,10 +11,6 @@ module('Unit | Route | authenticated/campaigns/campaign/activity', function (hoo
     store = this.owner.lookup('service:store');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('model', function () {
     test('should fetch data', async function (assert) {
       //given

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
@@ -11,10 +11,6 @@ module('Unit | Route | authenticated/campaigns/campaign/analysis', function (hoo
     currentUser = this.owner.lookup('service:current-user');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('beforeModel', function () {
     module('When places limit is reached', function () {
       test('should redirect on main campaign page', function (assert) {

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
@@ -83,11 +83,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
     });
   });
 
-  module('beforeModel', function (hooks) {
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
+  module('beforeModel', function () {
     module('When places limit is reached', function () {
       test('should redirect to main campaign page', function (assert) {
         //given

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
@@ -99,11 +99,7 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
     });
   });
 
-  module('beforeModel', function (hooks) {
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
+  module('beforeModel', function () {
     module('When places limit is reached', function () {
       test('should redirect to main campaign page', function (assert) {
         //given

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/settings-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/settings-test.js
@@ -11,11 +11,7 @@ module('Unit | Route | authenticated/campaigns/campaign/settings', function (hoo
   });
 
   module('beforeModel', function () {
-    module('When campaign is from combined course', function (hooks) {
-      hooks.afterEach(function () {
-        sinon.restore();
-      });
-
+    module('When campaign is from combined course', function () {
       test('should redirect on main campaign page', function (assert) {
         //given
         const campaignId = Symbol('CampaignId');
@@ -41,11 +37,7 @@ module('Unit | Route | authenticated/campaigns/campaign/settings', function (hoo
       });
     });
 
-    module('When campaign is not from combined course', function (hooks) {
-      hooks.afterEach(function () {
-        sinon.restore();
-      });
-
+    module('When campaign is not from combined course', function () {
       test('should not redirect on main campaign page', function (assert) {
         //given
         const campaignId = Symbol('CampaignId');

--- a/orga/tests/unit/routes/authenticated/campaigns/combined-courses-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/combined-courses-test.js
@@ -15,10 +15,6 @@ module('Unit | Route | authenticated/campaigns/combined-courses', function (hook
     currentUser = this.owner.lookup('service:current-user');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('model', function () {
     test('should query combined-courses with organizationId and pagination params', async function (assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/campaigns/new-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new-test.js
@@ -747,10 +747,6 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
       route = this.owner.lookup('route:authenticated/campaigns/new');
     });
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     module('When places limit is reached', function () {
       test('should redirect to main campaign page', function (assert) {
         //given

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment-test.js
@@ -5,11 +5,7 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/campaigns/{campaignId}/evaluation/{campaignParticipationId}', function (hooks) {
   setupTest(hooks);
 
-  module('Before model', function (hooks) {
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
+  module('Before model', function () {
     module('When places limit is reached', function () {
       test('should redirect on main campaign page', function (assert) {
         //given

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
@@ -7,10 +7,6 @@ module(
   function (hooks) {
     setupTest(hooks);
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     module('before model', function () {
       module('When places limit is reached', function () {
         test('should redirect on main campaign page', function (assert) {

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/results-test.js
@@ -7,10 +7,6 @@ module(
   function (hooks) {
     setupTest(hooks);
 
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
     module('Before model', function () {
       module('When places limit is reached', function () {
         test('should redirect on main campaign page', function (assert) {

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-profile-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-profile-test.js
@@ -5,11 +5,7 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/campaigns/{campaignId}/profils/{campaignParticipationId}', function (hooks) {
   setupTest(hooks);
 
-  module('Before model', function (hooks) {
-    hooks.afterEach(function () {
-      sinon.restore();
-    });
-
+  module('Before model', function () {
     module('When places limit is reached', function () {
       test('should redirect on main campaign page', function (assert) {
         //given

--- a/orga/tests/unit/routes/authenticated/catalogue-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue-test.js
@@ -5,10 +5,6 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/catalogue', function (hooks) {
   setupTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('beforeModel', function () {
     test("it should redirect to index page if user can't access campaign page", async function (assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/catalogue/index-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue/index-test.js
@@ -5,10 +5,6 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/catalogue/index', function (hooks) {
   setupTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('beforeModel', function () {
     test('it should redirect to catalogue all list page', async function (assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/catalogue/list-test.js
+++ b/orga/tests/unit/routes/authenticated/catalogue/list-test.js
@@ -5,10 +5,6 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/catalogue/list', function (hooks) {
   setupTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('beforeModel', function () {
     ['all', 'targetProfile', 'blueprint'].forEach((type) => {
       test(`it should not redirect if param type=${type}`, async function (assert) {

--- a/orga/tests/unit/routes/authenticated/combined-course-test.js
+++ b/orga/tests/unit/routes/authenticated/combined-course-test.js
@@ -4,10 +4,6 @@ import sinon from 'sinon';
 
 module('Unit | Route | authenticated/combined-course', function (hooks) {
   setupTest(hooks);
-
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
   module('beforeModel', function () {
     test('user is redirected to index when he has no access', async function (assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/combined-course/participation-detail-test.js
+++ b/orga/tests/unit/routes/authenticated/combined-course/participation-detail-test.js
@@ -5,10 +5,6 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/combined-course', function (hooks) {
   setupTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('beforeModel', function () {
     test('user is redirected to index when he has no access', async function (assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/combined-course/participations-test.js
+++ b/orga/tests/unit/routes/authenticated/combined-course/participations-test.js
@@ -15,10 +15,6 @@ module('Unit | Route | authenticated/combined-course-participations', function (
     };
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('model', function () {
     test('fetch model for combined course', async function (assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/organization-participants/list-test.js
@@ -33,9 +33,6 @@ module('Unit | Route | authenticated/organization-participants/list', function (
     pageNumber: pageNumberSymbol,
     pageSize: pageSizeSymbol,
   };
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/organization-participants/list');
     store = this.owner.lookup('service:store');

--- a/orga/tests/unit/routes/authenticated/preselect-target-profile-test.js
+++ b/orga/tests/unit/routes/authenticated/preselect-target-profile-test.js
@@ -5,10 +5,6 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/preselect-target-profile', function (hooks) {
   setupTest(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('model', function () {
     test('fetch a frameworks', async function (assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/sco-organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/sco-organization-participants/list-test.js
@@ -29,10 +29,6 @@ module('Unit | Route | authenticated/sco-organization-participants/list', functi
     divisionSort: divisionSortSymbol,
   };
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/sco-organization-participants/list');
     store = this.owner.lookup('service:store');

--- a/orga/tests/unit/routes/authenticated/sup-organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/sup-organization-participants/list-test.js
@@ -27,10 +27,6 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
     lastnameSort: lastnameSortSymbol,
   };
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/sup-organization-participants/list');
     store = this.owner.lookup('service:store');

--- a/orga/tests/unit/routes/authentication/oidc/flow-test.js
+++ b/orga/tests/unit/routes/authentication/oidc/flow-test.js
@@ -10,10 +10,6 @@ module('Unit | Route | Authentication | OIDC | flow', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#model', function (hooks) {
     hooks.beforeEach(function () {
       stubOidcIdentityProvidersService(this.owner, {

--- a/orga/tests/unit/services/current-domain-test.js
+++ b/orga/tests/unit/services/current-domain-test.js
@@ -5,10 +5,6 @@ import sinon from 'sinon';
 
 module('Unit | Service | currentDomain', function (hooks) {
   setupTest(hooks);
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('#getExtension', function () {
     module('when location is FR TLD', function () {
       test(`returns fr`, function (assert) {

--- a/orga/tests/unit/services/locale-loader-test.js
+++ b/orga/tests/unit/services/locale-loader-test.js
@@ -19,9 +19,6 @@ module('Unit | Services | locale-loader', function (hooks) {
     sinon.stub(intlService, 'addTranslations');
     sinon.stub(dayjs, 'locale');
   });
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
   test('loads daysjs language file from locale', async function (assert) {
     // when
     await localeLoaderService.load('de-AT');

--- a/orga/tests/unit/services/pix-metrics-test.js
+++ b/orga/tests/unit/services/pix-metrics-test.js
@@ -17,10 +17,6 @@ module('Unit | Service | PixMetrics', function (hooks) {
     sinon.stub(metricsService, 'trackEvent');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('trackPage', function () {
     test('it should redact id from url', function (assert) {
       // given

--- a/orga/tests/unit/services/request-manager-test.js
+++ b/orga/tests/unit/services/request-manager-test.js
@@ -25,10 +25,6 @@ module('Unit | Service | request-manager', function (hooks) {
     sinon.stub(localeService, 'acceptLanguageHeader').value('fr');
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('request()', function () {
     test('it requests successfully with default headers', async function (assert) {
       // given

--- a/orga/tests/unit/utils/location-test.js
+++ b/orga/tests/unit/utils/location-test.js
@@ -2,11 +2,7 @@ import Location from 'pix-orga/utils/location';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Utility | location', function (hooks) {
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
+module('Unit | Utility | location', function () {
   module('#getHref', function () {
     test('should return the full URL', function (assert) {
       // given


### PR DESCRIPTION
## ☀️ Problème

Contrairement aux tests de l'API, dans les tests frontends, on ne fait pas `sinon.restore()` entre chaque test.

Or certains tests font des stubs avec `sinon` qui ne sont jamais restaurés ce qui peut avoir des effets de bord sur les autres tests.

## ⛱️ Proposition

Pour chaque frontend (mon-pix, admin, orga, certif et junior) : 
- Dans le fichier `test-helper.js`, ajouter un hook `afterEach` qui fait `sinon.restore()`
- Supprimer les `sinon.restore()` inutiles dans les tests.

## 🧴 Remarques

Pas d'impact sur les performances.

## 🏊 Pour tester

La CI est verte.
