### PR TITLE
[TECH] Supprime l'utilisation de `dayjs` dans l'utilitaire de date dans `shared`

### DIFF
--- a/api/src/certification/enrolment/infrastructure/candidates-import/candidates-import-transformation-structures.js
+++ b/api/src/certification/enrolment/infrastructure/candidates-import/candidates-import-transformation-structures.js
@@ -34,7 +34,7 @@ const _getTransformationsStruct = (translate) => [
     header: translate('candidate-list-template.headers.birth-date'),
     property: 'birthdate',
     transformFn: (cellVal) => {
-      return convertDateValue({ dateString: cellVal, inputFormat: 'DD/MM/YYYY', outputFormat: 'YYYY-MM-DD' });
+      return convertDateValue({ dateString: cellVal, inputFormat: 'DD/MM/YYYY' });
     },
   },
   {

--- a/api/src/certification/enrolment/infrastructure/serializers/csv/sessions-csv-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/csv/sessions-csv-serializer.js
@@ -87,7 +87,6 @@ function _getDataFromColumnNames({ expectedHeadersKeys, headers, line }) {
         convertDateValue({
           dateString: currentValue,
           inputFormat: 'DD/MM/YYYY',
-          outputFormat: 'YYYY-MM-DD',
         }) ?? currentValue;
     } else if (key === 'extraTimePercentage') {
       data[key] = currentValue || null;

--- a/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
+++ b/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
@@ -133,8 +133,6 @@ class ImportOrganizationLearnerSet {
         return convertDateValue({
           dateString: attribute,
           inputFormat: dateFormat.config.validate.format,
-          alternativeInputFormat: dateFormat.config.validate.format,
-          outputFormat: 'YYYY-MM-DD',
         });
       }
     }

--- a/api/src/prescription/learner-management/infrastructure/serializers/csv/parsers/shared-csv-parser.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/csv/parsers/shared-csv-parser.js
@@ -164,12 +164,16 @@ class SharedCsvParser {
   }
 
   _buildDateAttribute(dateString) {
-    const convertedDate = convertDateValue({
+    let convertedDate = convertDateValue({
       dateString,
       inputFormat: 'DD/MM/YYYY',
-      alternativeInputFormat: 'DD/MM/YY',
-      outputFormat: 'YYYY-MM-DD',
     });
+    if (convertedDate === null) {
+      convertedDate = convertDateValue({
+        dateString,
+        inputFormat: 'DD/MM/YY',
+      });
+    }
     return convertedDate || dateString;
   }
 

--- a/api/src/shared/infrastructure/utils/date-utils.js
+++ b/api/src/shared/infrastructure/utils/date-utils.js
@@ -1,43 +1,71 @@
-import dayjs from 'dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat.js';
-
-dayjs.extend(customParseFormat, {
-  parseTwoDigitYear: (yearString) => {
-    const year = parseInt(yearString);
-    const currentYear = new Date().getFullYear();
-    return 2000 + year < currentYear ? 2000 + year : 1900 + year;
-  },
-});
-
-function isValidDate(dateValue, format) {
-  return dayjs(dateValue, format, true).isValid() || dateValue instanceof Date;
+export function isValidDate(dateValue, format) {
+  return convertDateValue({ dateString: dateValue, inputFormat: format }) !== null;
 }
 
-function convertDateValue({ dateString, inputFormat, alternativeInputFormat = null, outputFormat }) {
-  const isDateInstance = dateString instanceof Date;
-
-  if (isDateInstance) {
-    return formatDate([dateString], outputFormat);
+export function convertDateValue({ dateString, inputFormat }) {
+  const dateObject = toDateObject({ dateString, inputFormat });
+  if (dateObject === null) {
+    return null;
   }
-
-  if (isValidDate(dateString, inputFormat)) {
-    return formatDate([dateString, inputFormat, true], outputFormat);
-  } else if (alternativeInputFormat && isValidDate(dateString, alternativeInputFormat)) {
-    return formatDate([dateString, alternativeInputFormat, true], outputFormat);
-  }
-
-  return null;
+  return toIsoDateString(dateObject);
 }
 
-function formatDate(params, outputFormat) {
-  return dayjs(...params).format(outputFormat);
+function toDateObject({ dateString, inputFormat }) {
+  if (dateString instanceof Date) {
+    return Number.isNaN(dateString.getTime()) ? null : dateString;
+  }
+
+  if (typeof dateString !== 'string' || typeof inputFormat !== 'string') {
+    return null;
+  }
+
+  if (!formatIsMatching(dateString, inputFormat)) {
+    return null;
+  }
+
+  const year = expandTwoDigitYear(extractDatePart(dateString, inputFormat, 'Y'));
+  const month = parseInt(extractDatePart(dateString, inputFormat, 'M')) - 1;
+  const dayOfMonth = parseInt(extractDatePart(dateString, inputFormat, 'D'));
+
+  const dateObject = new Date(year, month, dayOfMonth);
+  if (month !== dateObject.getMonth() || dayOfMonth !== dateObject.getDate()) {
+    return null;
+  }
+  return dateObject;
+}
+
+function formatIsMatching(dateString, inputFormat) {
+  return dateString.replace(/[0-9]/g, ' ') === inputFormat.replace(/(D|M|Y)/g, ' ');
+}
+
+function extractDatePart(dateString, inputFormat, formatToken) {
+  const formatCharacters = inputFormat.split('');
+  return dateString
+    .split('')
+    .filter((_, index) => formatCharacters[index] === formatToken)
+    .join('');
+}
+
+function expandTwoDigitYear(year) {
+  if (year.length !== 2) {
+    return year;
+  }
+  const currentTwoDigitYear = new Date().getFullYear().toString().slice(-2);
+  return year < currentTwoDigitYear ? `20${year}` : `19${year}`;
+}
+
+function toIsoDateString(date) {
+  const year = String(date.getFullYear()).padStart(4, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const dayOfMonth = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${dayOfMonth}`;
 }
 
 /**
  * @param {Date} date
  * @returns {Date} a new Date object
  */
-function anonymizeGeneralizeDate(date) {
+export function anonymizeGeneralizeDate(date) {
   if (!date) return null;
 
   const newDate = new Date(date);
@@ -45,5 +73,3 @@ function anonymizeGeneralizeDate(date) {
   newDate.setUTCHours(0, 0, 0, 0);
   return newDate;
 }
-
-export { anonymizeGeneralizeDate, convertDateValue, isValidDate };

--- a/api/tests/shared/unit/infrastructure/utils/date-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/date-utils_test.js
@@ -15,6 +15,10 @@ describe('Unit | Utils | date-utils', function () {
       it('should accept a date object', function () {
         expect(isValidDate(new Date(), 'YYYY-MM-DD')).to.be.true;
       });
+
+      it('should accept even with french format', function () {
+        expect(isValidDate('23/12/2022', 'DD/MM/YYYY')).to.be.true;
+      });
     });
 
     describe('Invalid cases', function () {
@@ -53,98 +57,98 @@ describe('Unit | Utils | date-utils', function () {
       it('should NOT accept a undefined value', function () {
         expect(isValidDate(undefined, 'YYYY-MM-DD')).to.be.false;
       });
+
+      it('should NOT accept an invalid date object', function () {
+        expect(isValidDate(new Date(NaN), 'YYYY-MM-DD')).to.be.false;
+      });
+
+      it('should NOT accept a plain object', function () {
+        expect(isValidDate({}, 'YYYY-MM-DD')).to.be.false;
+      });
+
+      it('should NOT accept an array', function () {
+        expect(isValidDate([], 'YYYY-MM-DD')).to.be.false;
+      });
+
+      it('should NOT accept a number', function () {
+        expect(isValidDate(123, 'YYYY-MM-DD')).to.be.false;
+      });
+
+      it('should NOT accept a boolean', function () {
+        expect(isValidDate(true, 'YYYY-MM-DD')).to.be.false;
+      });
     });
   });
 
   describe('#convertDateValue', function () {
-    context('when alternativeInputFormat does not exist', function () {
-      context('when dateValue does not match inputFormat', function () {
-        it('should return null', function () {
-          expect(convertDateValue({ dateString: '1980-05-05', inputFormat: 'DD/MM/YYYY', outputFormat: 'YYYY-MM-DD' }))
-            .to.be.null;
-        });
-      });
-
-      context('when dateValue matches inputFormat', function () {
-        it('should return converted date', function () {
-          expect(
-            convertDateValue({ dateString: '05/05/1980', inputFormat: 'DD/MM/YYYY', outputFormat: 'YYYY-MM-DD' }),
-          ).to.equal('1980-05-05');
-        });
+    context('when dateValue does not match inputFormat', function () {
+      it('should return null', function () {
+        expect(convertDateValue({ dateString: '1980-05-05', inputFormat: 'DD/MM/YYYY' })).to.be.null;
       });
     });
 
-    context('when alternativeInputFormat exists', function () {
-      context('when dateValue does not match nor inputFormat, nor alternativeInputFormat', function () {
-        it('should return null', function () {
-          expect(
-            convertDateValue({
-              dateString: '1980-05-05',
-              inputFormat: 'DD/MM/YYYY',
-              alternativeInputFormat: 'DD/MM/YY',
-              outputFormat: 'YYYY-MM-DD',
-            }),
-          ).to.be.null;
-        });
+    context('when dateValue matches inputFormat', function () {
+      it('should return converted date', function () {
+        expect(convertDateValue({ dateString: '05/05/1980', inputFormat: 'DD/MM/YYYY' })).to.equal('1980-05-05');
+      });
+    });
+
+    context('when dateValue is Date Object', function () {
+      it('should return converted date', function () {
+        expect(
+          convertDateValue({
+            dateString: new Date('1980-05-05'),
+            inputFormat: 'DD/MM/YYYY',
+          }),
+        ).to.equal('1980-05-05');
+      });
+    });
+
+    context('when dateValue matches alternativeInputFormat with 2 digits year', function () {
+      it('should return converted date with year 2000 if input year < the current year', function () {
+        const currentYear = new Date().getFullYear();
+        const currentTwoDigitYear = currentYear - 2000;
+        const inputDate = '05/05/' + (currentTwoDigitYear - 1);
+        const expectedDate = currentYear - 1 + '-05-05';
+        expect(
+          convertDateValue({
+            dateString: inputDate,
+            inputFormat: 'DD/MM/YY',
+          }),
+        ).to.equal(expectedDate);
       });
 
-      context('when dateValue matches inputFormat', function () {
-        it('should return converted date', function () {
-          expect(
-            convertDateValue({
-              dateString: '05/05/1980',
-              inputFormat: 'DD/MM/YYYY',
-              alternativeInputFormat: 'DD/MM/YY',
-              outputFormat: 'YYYY-MM-DD',
-            }),
-          ).to.equal('1980-05-05');
-        });
+      it('should return converted date with year 1900 if input year >= the current year', function () {
+        const currentYear = new Date().getFullYear();
+        const currentTwoDigitYear = currentYear - 2000;
+        const inputDate = '05/05/' + currentTwoDigitYear;
+        const expectedDate = 1900 + currentTwoDigitYear + '-05-05';
+        expect(
+          convertDateValue({
+            dateString: inputDate,
+            inputFormat: 'DD/MM/YY',
+          }),
+        ).to.equal(expectedDate);
       });
+    });
 
-      context('when dateValue is Date Object', function () {
-        it('should return converted date', function () {
-          expect(
-            convertDateValue({
-              dateString: new Date('1980-05-05'),
-              inputFormat: 'DD/MM/YYYY',
-              alternativeInputFormat: 'DD/MM/YY',
-              outputFormat: 'YYYY-MM-DD',
-            }),
-          ).to.equal('1980-05-05');
-        });
+    context('when inputFormat is missing', function () {
+      it('should return null instead of throwing', function () {
+        expect(convertDateValue({ dateString: '05/05/1980' })).to.be.null;
       });
+    });
 
-      context('when dateValue matches alternativeInputFormat with 2 digits year', function () {
-        it('should return converted date with year 2000 if input year < the current year', function () {
-          const currentYear = new Date().getFullYear();
-          const currentTwoDigitYear = currentYear - 2000;
-          const inputDate = '05/05/' + (currentTwoDigitYear - 1);
-          const expectedDate = currentYear - 1 + '-05-05';
-          expect(
-            convertDateValue({
-              dateString: inputDate,
-              inputFormat: 'DD/MM/YYYY',
-              alternativeInputFormat: 'DD/MM/YY',
-              outputFormat: 'YYYY-MM-DD',
-            }),
-          ).to.equal(expectedDate);
-        });
-
-        it('should return converted date with year 1900 if input year >= the current year', function () {
-          const currentYear = new Date().getFullYear();
-          const currentTwoDigitYear = currentYear - 2000;
-          const inputDate = '05/05/' + currentTwoDigitYear;
-          const expectedDate = 1900 + currentTwoDigitYear + '-05-05';
-          expect(
-            convertDateValue({
-              dateString: inputDate,
-              inputFormat: 'DD/MM/YYYY',
-              alternativeInputFormat: 'DD/MM/YY',
-              outputFormat: 'YYYY-MM-DD',
-            }),
-          ).to.equal(expectedDate);
-        });
+    context('when dateValue is neither a string nor a valid Date', function () {
+      it('should return null instead of throwing', function () {
+        expect(convertDateValue({ dateString: {}, inputFormat: 'DD/MM/YYYY' })).to.be.null;
+        expect(convertDateValue({ dateString: [], inputFormat: 'DD/MM/YYYY' })).to.be.null;
+        expect(convertDateValue({ dateString: 42, inputFormat: 'DD/MM/YYYY' })).to.be.null;
+        expect(convertDateValue({ dateString: new Date(NaN), inputFormat: 'DD/MM/YYYY' })).to.be.null;
       });
+    });
+
+    it('returns null for inexisting date', function () {
+      expect(convertDateValue({ dateString: '2008-02-31', inputFormat: 'YYYY-MM-DD' })).to.be.null;
     });
   });
 


### PR DESCRIPTION
## ☀️ Problème

Nous utilisons une bibliothèque pour faciliter le parsing de date dans un utilitaire.
Les bibliothèques nous expose à des risques

## ⛱️ Proposition

Remplacer l'utilisation de DayJS par du JavaScript natif

## 🧴 Remarques

Le paramètre de format de sortie était toujours le même, je me suis donc permis de supprimer le paramètre et de figé le format de sortie.

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
