### PR TITLE
[TECH] Ajouter la validation de payload de la route d'update de certification-courses

### DIFF
--- a/admin/app/serializers/certification.js
+++ b/admin/app/serializers/certification.js
@@ -8,7 +8,6 @@ export default class Certification extends ApplicationSerializer {
       this.serializeAttribute(snapshot, data, 'lastName', 'last-name');
       this.serializeAttribute(snapshot, data, 'birthplace', 'birthplace');
       this.serializeAttribute(snapshot, data, 'birthdate', 'birthdate');
-      this.serializeAttribute(snapshot, data, 'isPublished', 'is-published');
       this.serializeAttribute(snapshot, data, 'sex', 'sex');
       this.serializeAttribute(snapshot, data, 'birthCountry', 'birth-country');
       this.serializeAttribute(snapshot, data, 'birthPostalCode', 'birth-postal-code');

--- a/api/src/certification/session-management/application/certification-course-route.js
+++ b/api/src/certification/session-management/application/certification-course-route.js
@@ -15,6 +15,22 @@ const register = async function (server) {
           params: Joi.object({
             certificationCourseId: identifiersType.certificationCourseId,
           }),
+          payload: Joi.object({
+            data: {
+              type: Joi.string(),
+              id: Joi.number().integer(),
+              attributes: {
+                'first-name': Joi.string().allow(null),
+                'last-name': Joi.string().allow(null),
+                birthdate: Joi.string().allow(null),
+                birthplace: Joi.string().allow(null, ''),
+                sex: Joi.string().allow(null, ''),
+                'birth-country': Joi.string().allow(null, ''),
+                'birth-insee-code': Joi.string().allow(null, ''),
+                'birth-postal-code': Joi.string().allow(null, ''),
+              },
+            },
+          }),
         },
         handler: certificationCourseController.update,
         pre: [

--- a/api/src/certification/session-management/infrastructure/serializers/certification-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/certification-serializer.js
@@ -16,7 +16,6 @@ export function serializeFromCertificationCourse(certificationCourse) {
       'birthplace',
       'birthdate',
       'sex',
-      'externalId',
       'birthINSEECode',
       'birthPostalCode',
       'birthCountry',

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -93,7 +93,6 @@ describe('Certification | Session Management | Acceptance | Application | Routes
                 'last-name': 'The all mighty',
                 birthplace: null,
                 birthdate: '1989-10-24',
-                'external-id': 'xenoverse2',
                 sex: 'M',
                 'birth-country': 'FRANCE',
                 'birth-insee-code': '01091',

--- a/api/tests/certification/session-management/unit/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-course-route_test.js
@@ -9,18 +9,99 @@ import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 
 describe('Certification | Session Management | Unit | Application | Routes | Certification Course', function () {
   describe('PATCH /api/admin/certification-courses/{certificationCourseId}', function () {
-    it('should exist', async function () {
+    let validPayload;
+
+    beforeEach(function () {
+      validPayload = {
+        data: {
+          type: 'certifications',
+          id: 1234,
+          attributes: {
+            'first-name': 'Freezer',
+            'last-name': 'The all mighty',
+            birthdate: '1989-10-24',
+            birthplace: null,
+            sex: 'M',
+            'birth-country': 'FRANCE',
+            'birth-insee-code': '01091',
+            'birth-postal-code': null,
+          },
+        },
+      };
+    });
+
+    it('return bad request if an identity attribute is not a string', async function () {
       // given
+      const invalidPayload = structuredClone(validPayload);
+      invalidPayload.data.attributes.birthdate = {};
       sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationCourseController, 'update').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/certification-courses/1234');
+      const response = await httpTestServer.request('PATCH', '/api/admin/certification-courses/1234', invalidPayload);
 
       // then
-      expect(response.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(400);
+      expect(JSON.stringify(response.payload)).to.includes('data.attributes.birthdate');
+      expect(JSON.stringify(response.payload)).to.includes('must be a string');
+    });
+
+    for (const attribute of ['first-name', 'last-name', 'birthdate']) {
+      it(`return bad request if ${attribute} is an empty string`, async function () {
+        // given
+        const invalidPayload = structuredClone(validPayload);
+        invalidPayload.data.attributes[attribute] = '';
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(certificationCourseController, 'update').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', '/api/admin/certification-courses/1234', invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        expect(JSON.stringify(response.payload)).to.includes(`data.attributes.${attribute}`);
+        expect(JSON.stringify(response.payload)).to.includes('is not allowed to be empty');
+      });
+    }
+
+    it('return bad request if the payload id is not a number', async function () {
+      // given
+      const invalidPayload = structuredClone(validPayload);
+      invalidPayload.data.id = 'coucou';
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(certificationCourseController, 'update').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/admin/certification-courses/1234', invalidPayload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(JSON.stringify(response.payload)).to.includes('data.id');
+      expect(JSON.stringify(response.payload)).to.includes('must be a number');
+    });
+
+    it('return bad request if extra unexpected attributes are added to the payload', async function () {
+      // given
+      const invalidPayload = structuredClone(validPayload);
+      invalidPayload.data.attributes.coucou = 'cava';
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(certificationCourseController, 'update').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/admin/certification-courses/1234', invalidPayload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(JSON.stringify(response.payload)).to.includes('data.attributes.coucou');
+      expect(JSON.stringify(response.payload)).to.includes('is not allowed');
     });
 
     it('should return a forbidden access if user has METIER role', async function () {
@@ -43,7 +124,7 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/certification-courses/1234');
+      const response = await httpTestServer.request('PATCH', '/api/admin/certification-courses/1234', validPayload);
 
       // then
       expect(response.statusCode).to.equal(403);

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/certification-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/certification-serializer_test.js
@@ -168,7 +168,6 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', function () {
           birthplace: 'Namek',
           birthdate: '1989-10-24',
           sex: 'M',
-          'external-id': 'xenoverse2',
           'birth-insee-code': '99100',
           'birth-postal-code': '75001',
           'birth-country': 'FRANCE',


### PR DESCRIPTION
## ☀️ Problème

La route `PATCH /api/admin/certification-courses/{certificationCourseId}` n'avait pas de validation de payload.

## ⛱️ Proposition

Ajouter les règles Joi de la payload de cette route.

## 🏊 Pour tester

Sur [PixAdmin en RA](https://admin-pr17149.review.pix.fr/), modifier les infos d'un candidat d'une session avec des certif-courses