### PR TITLE
[BUGFIX] Un message d'erreur apparait lorsqu'on entre un nombre decimal dans un champ input number (PIX-23692).

### DIFF
--- a/mon-pix/app/components/challenge-item/challenge-item-qroc.gjs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qroc.gjs
@@ -86,6 +86,7 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
                     @id="qroc_input"
                     name={{block.randomName}}
                     type="number"
+                    step="any"
                     min="0"
                     data-test="challenge-response-proposal-selector"
                     placeholder={{block.placeholder}}


### PR DESCRIPTION
## ☀️ Problème

Lors du passage d'une épreuve, un message d'erreur apparait lorsqu'on entre un nombre decimal dans un champ input number et qu'on veut valider  l'epreuve en appuyant sur entré directement depuis l'input number

## ⛱️ Proposition

Ajouter l'attribut `step="any"` ce qui permet de supprimer se message d'erreur tout en gardant l'incrémentation par un pour l'input.

## 🧴 Remarques

Je n'ai pas réussit a écrire de test pour reproduire le bug 

## 🏊 Pour tester

se rendre sur la preview d'une épreuve QROC de type number. Entrer un nombre décimal dans l'input et papyer sur la touche `entrer` => L'épreuve se valide
