### PR TITLE
[BUGFIX] Empêcher l'enregistrement de réponses sur une évaluation terminée

### DIFF
--- a/api/src/certification/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/certification/evaluation/application/http-error-mapper-configuration.js
@@ -9,6 +9,7 @@ import {
   CandidateNotAuthorizedToResumeCertificationTestError,
   CenterNotHabilitatedError,
   CertificationDurationExceededError,
+  CertificationTestEndedError,
   NextChallengeAlreadyComputingError,
   SessionNotJoinableError,
 } from '../domain/errors.js';
@@ -20,6 +21,10 @@ const evaluationDomainErrorMappingConfiguration = [
   },
   {
     name: CertificationDurationExceededError.name,
+    httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: CertificationTestEndedError.name,
     httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
   },
   {

--- a/api/src/certification/evaluation/domain/errors.js
+++ b/api/src/certification/evaluation/domain/errors.js
@@ -21,6 +21,15 @@ export class CertificationDurationExceededError extends DomainError {
   }
 }
 
+export class CertificationTestEndedError extends DomainError {
+  constructor(
+    message = 'The certification test has ended, it is no longer possible to answer.',
+    code = 'CERTIFICATION_TEST_ENDED',
+  ) {
+    super(message, code);
+  }
+}
+
 export class CandidateNotAuthorizedToJoinSessionError extends DomainError {
   constructor(
     message = 'Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.',

--- a/api/src/certification/evaluation/domain/models/AssessmentSheet.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSheet.js
@@ -7,6 +7,7 @@ import {
 } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { ABORT_REASONS } from '../../../shared/domain/constants/abort-reasons.js';
+import { CertificationDurationExceededError, CertificationTestEndedError } from '../errors.js';
 
 export const STATES = Assessment.states;
 export const STATES_OF_LAST_QUESTION = Assessment.statesOfLastQuestion;
@@ -96,6 +97,10 @@ export class AssessmentSheet {
     return this.state === STATES.ENDED_DUE_TO_FINALIZATION;
   }
 
+  hasBeenEndedDueToDurationExceeded() {
+    return this.state === STATES.ENDED_DUE_TO_DURATION_EXCEEDED;
+  }
+
   isChallengeAlreadyAnswered(challengeId) {
     return this.answers.some((answer) => answer.challengeId === challengeId);
   }
@@ -122,6 +127,12 @@ export class AssessmentSheet {
     }
     if (this.hasBeenEndedDueToFinalization()) {
       throw new CertificationEndedByFinalizationError();
+    }
+    if (this.hasBeenEndedDueToDurationExceeded()) {
+      throw new CertificationDurationExceededError();
+    }
+    if (!this.isStarted) {
+      throw new CertificationTestEndedError();
     }
     if (!this.isChallengeExpectedToBeAnswered(answer.challengeId)) {
       throw new ChallengeNotAskedError();

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -1,4 +1,5 @@
 import {
+  ConflictError,
   ForbiddenError,
   InternalServerError,
   PreconditionFailedError,
@@ -7,6 +8,7 @@ import {
   AcquiredBadgeForbiddenUpdateError,
   AlreadyRatedAssessmentError,
   AnswerEvaluationError,
+  AssessmentAlreadyEndedError,
   CompetenceResetError,
   ImproveCompetenceEvaluationForbiddenError,
 } from '../domain/errors.js';
@@ -34,6 +36,12 @@ const evaluationDomainErrorMappingConfiguration = [
     name: AnswerEvaluationError.name,
     httpErrorFn: (error) => {
       return new InternalServerError(error.message);
+    },
+  },
+  {
+    name: AssessmentAlreadyEndedError.name,
+    httpErrorFn: (error) => {
+      return new ConflictError(error.message, error.code);
     },
   },
   {

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -19,6 +19,12 @@ class AcquiredBadgeForbiddenUpdateError extends DomainError {
   }
 }
 
+class AssessmentAlreadyEndedError extends DomainError {
+  constructor(message = "L'évaluation est terminée, il n'est plus possible d'y répondre.") {
+    super(message, 'ASSESSMENT_ENDED');
+  }
+}
+
 class AnswerEvaluationError extends DomainError {
   constructor(challenge) {
     super(`Problème lors de l'évaluation de la réponse du challenge: "${challenge.id}"`, '', challenge);
@@ -48,6 +54,7 @@ export {
   AcquiredBadgeForbiddenUpdateError,
   AlreadyRatedAssessmentError,
   AnswerEvaluationError,
+  AssessmentAlreadyEndedError,
   CertificationBadgeForbiddenDeletionError,
   CompetenceResetError,
   ImproveCompetenceEvaluationForbiddenError,

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -2,6 +2,7 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ChallengeAlreadyAnsweredError, EmptyAnswerError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
+import { AssessmentAlreadyEndedError } from '../errors.js';
 
 export async function saveAndCorrectAnswerForCampaign({
   answer,
@@ -21,6 +22,9 @@ export async function saveAndCorrectAnswerForCampaign({
 }) {
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+  }
+  if (!assessment.isStarted()) {
+    throw new AssessmentAlreadyEndedError();
   }
   if (!assessment.isCampaignParticipationAvailable() || !assessment?.campaign.isAccessible) {
     throw new ForbiddenAccess('Campaign does not accept any answer.');

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -2,6 +2,7 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ChallengeAlreadyAnsweredError, EmptyAnswerError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
+import { AssessmentAlreadyEndedError } from '../errors.js';
 
 export async function saveAndCorrectAnswerForCompetenceEvaluation({
   answer,
@@ -21,6 +22,9 @@ export async function saveAndCorrectAnswerForCompetenceEvaluation({
 }) {
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+  }
+  if (!assessment.isStarted()) {
+    throw new AssessmentAlreadyEndedError();
   }
   if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
     throw new ChallengeAlreadyAnsweredError();

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
@@ -3,6 +3,7 @@ import {
   ChallengeNotAskedError,
   EmptyAnswerError,
 } from '../../../shared/domain/errors.js';
+import { AssessmentAlreadyEndedError } from '../errors.js';
 
 export async function saveAndCorrectAnswerForDemoAndPreview({
   answer,
@@ -12,6 +13,9 @@ export async function saveAndCorrectAnswerForDemoAndPreview({
   challengeRepository,
   correctionService,
 }) {
+  if (!assessment.isStarted()) {
+    throw new AssessmentAlreadyEndedError();
+  }
   if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
     throw new ChallengeAlreadyAnsweredError();
   }

--- a/api/tests/certification/evaluation/acceptance/answer-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/answer-route_test.js
@@ -1,3 +1,4 @@
+import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../tooling/databases.js';
 import { getServer } from '../../../tooling/server/shared-server.js';
@@ -74,7 +75,8 @@ async function _setupTestData(databaseBuilder, { competenceId, doesCandidateNeed
   });
 
   const assessment = databaseBuilder.factory.buildAssessment({
-    type: 'CERTIFICATION',
+    type: Assessment.types.CERTIFICATION,
+    state: Assessment.states.STARTED,
     userId,
     competenceId,
     certificationCourseId: certificationCourse.id,

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -1,5 +1,9 @@
 import sinon from 'sinon';
 
+import {
+  CertificationDurationExceededError,
+  CertificationTestEndedError,
+} from '../../../../../../src/certification/evaluation/domain/errors.js';
 import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import {
   CertificationEndedByFinalizationError,
@@ -156,6 +160,28 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
       });
   });
 
+  context('#hasBeenEndedDueToDurationExceeded', function () {
+    it(`returns true when state is ${STATES.ENDED_DUE_TO_DURATION_EXCEEDED}`, function () {
+      const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+        state: STATES.ENDED_DUE_TO_DURATION_EXCEEDED,
+      });
+
+      expect(assessmentSheet.hasBeenEndedDueToDurationExceeded()).to.be.true;
+    });
+
+    Object.values(STATES)
+      .filter((state) => state !== STATES.ENDED_DUE_TO_DURATION_EXCEEDED)
+      .forEach((state) => {
+        it(`return false when state is ${state}`, async function () {
+          const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+            state,
+          });
+
+          expect(assessmentSheet.hasBeenEndedDueToDurationExceeded()).to.be.false;
+        });
+      });
+  });
+
   context('#isChallengeAlreadyAnswered', function () {
     it('returns false when no answers yet', function () {
       const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
@@ -270,7 +296,10 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
       it('does not throw', function () {
         // given
         const answer = domainBuilder.buildAnswer();
-        const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({ userId: 123 });
+        const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+          userId: 123,
+          state: STATES.STARTED,
+        });
 
         // then
         expect(() =>
@@ -324,11 +353,46 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
       });
     });
 
+    context('when the assessment has been ended due to duration exceeded', function () {
+      it('should throw a CertificationDurationExceededError error', function () {
+        // given
+        const answer = domainBuilder.buildAnswer();
+        const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+          userId: 123,
+          state: STATES.ENDED_DUE_TO_DURATION_EXCEEDED,
+        });
+
+        // when
+        expect(() => assessmentSheet.checkIfCandidateCanAnswer({ answer, userId: assessmentSheet.userId })).to.throw(
+          CertificationDurationExceededError,
+        );
+      });
+    });
+
+    context('when the assessment is no longer in progress', function () {
+      [STATES.COMPLETED, STATES.ABORTED].forEach((state) => {
+        it(`should throw a CertificationTestEndedError error when state is ${state}`, function () {
+          // given
+          const answer = domainBuilder.buildAnswer();
+          const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+            userId: 123,
+            state,
+          });
+
+          // when
+          expect(() => assessmentSheet.checkIfCandidateCanAnswer({ answer, userId: assessmentSheet.userId })).to.throw(
+            CertificationTestEndedError,
+          );
+        });
+      });
+    });
+
     context('when the challenge is not expected to be answered', function () {
       it('should throw a ChallengeNotAskedError error', function () {
         // given
         const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
           userId: 123,
+          state: STATES.STARTED,
           lastChallengeId: 1,
         });
 
@@ -345,6 +409,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
         const answer = domainBuilder.buildAnswer();
         const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
           userId: 123,
+          state: STATES.STARTED,
           answers: [answer],
         });
 

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
@@ -3,6 +3,7 @@ import {
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { ENGLISH_SPOKEN, FRENCH_FRANCE } from '../../../../../src/shared/domain/services/locale-service.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect } from '../../../../test-helper.js';
@@ -32,7 +33,8 @@ describe('Acceptance | Controller | answer-controller-save', function () {
 
     beforeEach(async function () {
       const assessment = databaseBuilder.factory.buildAssessment({
-        type: 'COMPETENCE_EVALUATION',
+        type: Assessment.types.COMPETENCE_EVALUATION,
+        state: Assessment.states.STARTED,
         competenceId: competenceId,
       });
       insertedAssessmentId = assessment.id;
@@ -278,6 +280,50 @@ describe('Acceptance | Controller | answer-controller-save', function () {
 
           // then
           expect(response.statusCode).to.equal(201);
+        });
+      });
+    });
+
+    context('when the assessment is already ended', function () {
+      [
+        Assessment.states.COMPLETED,
+        Assessment.states.ABORTED,
+        Assessment.states.ENDED_BY_INVIGILATOR,
+        Assessment.states.ENDED_DUE_TO_FINALIZATION,
+        Assessment.states.ENDED_DUE_TO_DURATION_EXCEEDED,
+      ].forEach((state) => {
+        it(`should return a 409 HTTP status code and save nothing when the assessment is "${state}"`, async function () {
+          // given
+          const endedAssessment = databaseBuilder.factory.buildAssessment({
+            type: Assessment.types.COMPETENCE_EVALUATION,
+            state,
+            competenceId,
+            lastChallengeId: challengeId,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const response = await server.inject({
+            method: 'POST',
+            url: '/api/answers',
+            headers: generateAuthenticatedUserRequestHeaders({ userId: endedAssessment.userId }),
+            payload: {
+              data: {
+                type: 'answers',
+                attributes: { value: correctAnswer },
+                relationships: {
+                  assessment: { data: { type: 'assessments', id: endedAssessment.id } },
+                  challenge: { data: { type: 'challenges', id: challengeId } },
+                },
+              },
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0].code).to.equal('ASSESSMENT_ENDED');
+          const savedAnswers = await knex('answers').where({ assessmentId: endedAssessment.id });
+          expect(savedAnswers).to.be.empty;
         });
       });
     });

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -28,6 +28,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
         // campaignParticipationId are nullify when campaign is deleted
         campaignParticipationId: null,
         type: Assessment.types.CAMPAIGN,
+        state: Assessment.states.STARTED,
       });
       databaseBuilder.factory.learningContent.buildArea({
         id: 'monAreaId',
@@ -114,6 +115,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
         userId,
         campaignParticipationId: participation.id,
         type: Assessment.types.CAMPAIGN,
+        state: Assessment.states.STARTED,
       });
       databaseBuilder.factory.learningContent.buildArea({
         id: 'monAreaId',
@@ -206,6 +208,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
         userId,
         campaignParticipationId,
         type: Assessment.types.CAMPAIGN,
+        state: Assessment.states.STARTED,
       });
       databaseBuilder.factory.buildCompetenceEvaluation({
         userId,
@@ -334,6 +337,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
         userId,
         campaignParticipationId,
         type: Assessment.types.CAMPAIGN,
+        state: Assessment.states.STARTED,
       });
       databaseBuilder.factory.buildCompetenceEvaluation({
         userId,

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
@@ -23,6 +23,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for compe
       userId,
       competenceId,
       type: Assessment.types.COMPETENCE_EVALUATION,
+      state: Assessment.states.STARTED,
     });
     databaseBuilder.factory.buildCompetenceEvaluation({
       userId,

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import { AssessmentAlreadyEndedError } from '../../../../../src/evaluation/domain/errors.js';
 import * as correctionService from '../../../../../src/evaluation/domain/services/correction-service.js';
 import { saveAndCorrectAnswerForCampaign } from '../../../../../src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
@@ -77,6 +78,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       method: Assessment.methods.SMART_RANDOM,
       campaignParticipationId,
       answers: [],
+      state: Assessment.states.STARTED,
       campaign,
     });
     campaignRepository.getCampaignIdByCampaignParticipationId
@@ -127,6 +129,34 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
 
       // then
       return expect(result).to.be.rejectedWith(ForbiddenAccess);
+    });
+  });
+
+  context('when the assessment is already ended', function () {
+    [
+      Assessment.states.COMPLETED,
+      Assessment.states.ABORTED,
+      Assessment.states.ENDED_BY_INVIGILATOR,
+      Assessment.states.ENDED_DUE_TO_FINALIZATION,
+      Assessment.states.ENDED_DUE_TO_DURATION_EXCEEDED,
+    ].forEach((state) => {
+      it(`should fail because AssessmentAlreadyEndedError when the assessment is "${state}"`, async function () {
+        // given
+        assessment.state = state;
+
+        // when
+        const error = await catchErr(saveAndCorrectAnswerForCampaign)({
+          answer,
+          userId,
+          assessment,
+          locale,
+          ...dependencies,
+        });
+
+        // then
+        expect(error).to.be.an.instanceOf(AssessmentAlreadyEndedError);
+        expect(answerRepository.save).to.not.have.been.called;
+      });
     });
   });
 
@@ -183,6 +213,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.CAMPAIGN,
         answers: [],
+        state: Assessment.states.STARTED,
         campaign,
       });
 
@@ -222,6 +253,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         type: Assessment.types.CAMPAIGN,
         campaignParticipationId,
         answers: [],
+        state: Assessment.states.STARTED,
         campaign,
       });
       const answerSaved = domainBuilder.buildAnswer(emptyAnswer);
@@ -341,6 +373,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         method: Assessment.methods.SMART_RANDOM,
         campaignParticipationId,
         answers: [],
+        state: Assessment.states.STARTED,
         campaign,
       });
       answerSaved = domainBuilder.buildAnswer(answer);

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import { AssessmentAlreadyEndedError } from '../../../../../src/evaluation/domain/errors.js';
 import * as correctionService from '../../../../../src/evaluation/domain/services/correction-service.js';
 import { saveAndCorrectAnswerForCompetenceEvaluation } from '../../../../../src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
@@ -66,6 +67,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       lastQuestionDate: nowDate,
       type: Assessment.types.COMPETENCE_EVALUATION,
       answers: [],
+      state: Assessment.states.STARTED,
     });
     answer = domainBuilder.buildAnswer({ assessmentId: assessment.id, value: correctAnswerValue, challengeId });
     answer.id = undefined;
@@ -111,6 +113,34 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
 
       // then
       return expect(result).to.be.rejectedWith(ForbiddenAccess);
+    });
+  });
+
+  context('when the assessment is already ended', function () {
+    [
+      Assessment.states.COMPLETED,
+      Assessment.states.ABORTED,
+      Assessment.states.ENDED_BY_INVIGILATOR,
+      Assessment.states.ENDED_DUE_TO_FINALIZATION,
+      Assessment.states.ENDED_DUE_TO_DURATION_EXCEEDED,
+    ].forEach((state) => {
+      it(`should fail because AssessmentAlreadyEndedError when the assessment is "${state}"`, async function () {
+        // given
+        assessment.state = state;
+
+        // when
+        const error = await catchErr(saveAndCorrectAnswerForCompetenceEvaluation)({
+          answer,
+          userId,
+          assessment,
+          locale,
+          ...dependencies,
+        });
+
+        // then
+        expect(error).to.be.an.instanceOf(AssessmentAlreadyEndedError);
+        expect(answerRepository.save).to.not.have.been.called;
+      });
     });
   });
 
@@ -166,6 +196,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.COMPETENCE_EVALUATION,
         answers: [],
+        state: Assessment.states.STARTED,
       });
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves([]);
 
@@ -202,6 +233,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.COMPETENCE_EVALUATION,
         answers: [],
+        state: Assessment.states.STARTED,
       });
       const answerSaved = domainBuilder.buildAnswer(emptyAnswer);
       answerRepository.save.resolves(answerSaved);
@@ -359,6 +391,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         answers: [],
+        state: Assessment.states.STARTED,
       });
       answerSaved = domainBuilder.buildAnswer(answer);
       answerSaved.timeSpent = 5;

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-demo-and-preview_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-demo-and-preview_test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import { AssessmentAlreadyEndedError } from '../../../../../src/evaluation/domain/errors.js';
 import * as correctionService from '../../../../../src/evaluation/domain/services/correction-service.js';
 import { saveAndCorrectAnswerForDemoAndPreview } from '../../../../../src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
@@ -41,6 +42,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
       lastQuestionDate: nowDate,
       type: Assessment.types.DEMO,
       answers: [],
+      state: Assessment.states.STARTED,
     });
     answer = domainBuilder.buildAnswer({ assessmentId: assessment.id, value: correctAnswerValue, challengeId });
     answer.id = undefined;
@@ -58,6 +60,33 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
       challengeRepository,
       correctionService,
     };
+  });
+
+  context('when the assessment is already ended', function () {
+    [
+      Assessment.states.COMPLETED,
+      Assessment.states.ABORTED,
+      Assessment.states.ENDED_BY_INVIGILATOR,
+      Assessment.states.ENDED_DUE_TO_FINALIZATION,
+      Assessment.states.ENDED_DUE_TO_DURATION_EXCEEDED,
+    ].forEach((state) => {
+      it(`should fail because AssessmentAlreadyEndedError when the assessment is "${state}"`, async function () {
+        // given
+        assessment.state = state;
+
+        // when
+        const error = await catchErr(saveAndCorrectAnswerForDemoAndPreview)({
+          answer,
+          assessment,
+          locale,
+          ...dependencies,
+        });
+
+        // then
+        expect(error).to.be.an.instanceOf(AssessmentAlreadyEndedError);
+        expect(answerRepository.save).to.not.have.been.called;
+      });
+    });
   });
 
   context('when an answer for that challenge has already been provided', function () {
@@ -164,6 +193,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.DEMO,
         answers: [],
+        state: Assessment.states.STARTED,
       });
       answerSaved = domainBuilder.buildAnswer(answer);
       answerSaved.timeSpent = 5;
@@ -199,6 +229,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.CERTIFICATION,
         answers: [],
+        state: Assessment.states.STARTED,
       });
       answerSaved = domainBuilder.buildAnswer(focusedOutAnswer);
       answerRepository.save.resolves(answerSaved);
@@ -232,6 +263,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.DEMO,
         answers: [],
+        state: Assessment.states.STARTED,
       });
 
       // when
@@ -261,6 +293,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-d
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.DEMO,
         answers: [],
+        state: Assessment.states.STARTED,
       });
       const answerSaved = domainBuilder.buildAnswer(emptyAnswer);
       answerRepository.save.resolves(answerSaved);


### PR DESCRIPTION
## ☀️ Problème

Une réponse envoyée sur un assessment `completed` (ou `aborted`, `endedByInvigilator`…) est acceptée et persistée, knowledge-elements compris. 

## ⛱️ Proposition

Nouvelle erreur `AssessmentAlreadyEndedError`

## 🏊 Pour tester

Démarrer un parcours, laisser la question ouverte dans un onglet, terminer l'assessment, valider la réponse: 409 `ASSESSMENT_ENDED`, rien en base.
