### PR TITLE
[TECH] Corriger les ids dupliquées sur les modules (PIX-23720)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -356,7 +356,7 @@
                 "instruction": "Répondez aux questions suivantes en cliquant sur la bonne réponse.",
                 "cards": [
                   {
-                    "id": "e222b060-7c18-4ee2-afe2-2ae27c28946a",
+                    "id": "add627db-b054-4422-8dde-f2b496099dfc",
                     "text": "Les boules de pétanques sont creuses ?",
                     "image": {
                       "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
@@ -367,21 +367,21 @@
                     "solution": "A"
                   },
                   {
-                    "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
+                    "id": "286a3f8e-4385-4d26-96e0-8294c99b263e",
                     "text": "Les chiens ne transpirent pas.",
                     "proposalA": "Vrai",
                     "proposalB": "Faux",
                     "solution": "B"
                   },
                   {
-                    "id": "04bab312-160d-41b1-a5c9-017d563aef3a",
+                    "id": "4a281987-66f6-43b3-8d1b-587260cebc64",
                     "text": "Quel est l'organe qui rougit ?",
                     "proposalA": "L'estomac",
                     "proposalB": "Le coeur",
                     "solution": "A"
                   },
                   {
-                    "id": "1d1c33e3-e27d-4161-bfcc-529ea1aa573f",
+                    "id": "7046cad6-fa09-4a3f-b1a7-907aa56245fc",
                     "text": "Les dauphins sont des poissons.",
                     "image": {
                       "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
@@ -392,14 +392,14 @@
                     "solution": "B"
                   },
                   {
-                    "id": "4420c9f6-ae21-4401-a16c-41296d898a66",
+                    "id": "eb88ae72-b216-4f7c-b21f-417e6959b9fa",
                     "text": "La Terre est plus proche du Soleil que Mars.",
                     "proposalA": "Vrai",
                     "proposalB": "Faux",
                     "solution": "B"
                   },
                   {
-                    "id": "52d99648-5904-4a66-9fb8-476ba4da9465",
+                    "id": "50cbda62-a903-4e6e-9735-6446411c2d08",
                     "text": "L’eau bout à 100°C au niveau de la mer.",
                     "proposalA": "Vrai",
                     "proposalB": "Faux",

--- a/api/tests/devcomp/unit/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/devcomp/unit/infrastructure/repositories/module-repository_test.js
@@ -349,7 +349,7 @@ describe('Unit | DevComp | Repositories | ModuleRepository', function () {
                       if (ids.includes(component.element.id)) {
                         duplicateIds.add(component.element.id);
                       }
-                      if (component.element.type === 'flashcards') {
+                      if (component.element.type === 'flashcards' || component.element.type === 'qab') {
                         for (const card of component.element.cards) {
                           if (ids.includes(card.id)) {
                             duplicateIds.add(card.id);
@@ -365,7 +365,7 @@ describe('Unit | DevComp | Repositories | ModuleRepository', function () {
                           if (ids.includes(element.id)) {
                             duplicateIds.add(element.id);
                           }
-                          if (element.type === 'flashcards') {
+                          if (element.type === 'flashcards' || element.type === 'qab') {
                             for (const card of element.cards) {
                               if (ids.includes(card.id)) {
                                 duplicateIds.add(card.id);


### PR DESCRIPTION
## ☀️ Problème

Il y a actuellement des ids dupliquées dans les modules existants.
Cela concerne les éléments `qab` car on ne vérifie pas les ids dans les cartes.

## ⛱️ Proposition

- Mettre à jour le test de duplication d'ids pour vérifier les cartes des éléments `qab`.
- Corriger les ids dupliquées

## 🧴 Remarques

RAS

## 🏊 Pour tester

- Tests au vert ✅ 
