### PR TITLE
[BUGFIX] Réparer la modification d'un schéma de parcours (PIX-23905)

### DIFF
--- a/admin/app/models/reward-requirement.js
+++ b/admin/app/models/reward-requirement.js
@@ -1,4 +1,4 @@
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, hasMany } from '@warp-drive/legacy/model';
 
 export default class RewardRequirement extends Model {
   @attr() cappedTubesThreshold;


### PR DESCRIPTION
## ☀️ Problème

Lors de la création d’un schéma de parcours combiné dans pix Admin avec des reward requirements, on peut afficher le détail (malgré une erreur en console), mais on ne peut pas le modifier

## ⛱️ Proposition

Remplacement de l'import `@ember-data/model` par `@warp-drive/legacy/model` dans le modèle `reward-requirement`.

## 🧴 Remarques

Nous avons essayé de rédiger un test sans réussir à le faire échouer dans les conditions de reproduction du bug sans succès, donc nous n'avons pas ajouté de test sur ce comportement.

Aucun autre import `@ember-data/model` n'a été retrouvé dans la code-base.

## 🏊 Pour tester

1. Créer un schéma de parcours avec une attestation et des pré-requis.
2. Ouvrir le schéma de parcours créer
3. Le modifier avec succès.