### PR TITLE
[TECH] Mise en place de l'event driven design

### DIFF
--- a/api/src/certification/evaluation/infrastructure/repositories/jobs/certification-completed-job-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/jobs/certification-completed-job-repository.js
@@ -1,8 +1,5 @@
-import {
-  JobPriority,
-  JobRepository,
-  JobRetry,
-} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobPriority, JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { CertificationCompletedJob } from '../../../domain/events/CertificationCompleted.js';
 class CertificationCompletedJobRepository extends JobRepository {
   constructor() {

--- a/api/src/learning-content/infrastructure/repositories/jobs/create-learning-content-release-job-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/jobs/create-learning-content-release-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { CreateLearningContentReleaseJob } from '../../../domain/models/CreateLearningReleaseJob.js';
 
 class CreateLearningContentReleaseJobRepository extends JobRepository {

--- a/api/src/learning-content/infrastructure/repositories/jobs/refresh-learning-content-job-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/jobs/refresh-learning-content-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { RefreshLearningContentJob } from '../../../domain/models/RefreshLearningContentJob.js';
 
 class RefreshLearningContentJobRepository extends JobRepository {

--- a/api/src/maddo/infrastructure/repositories/jobs/replication-job-repository.js
+++ b/api/src/maddo/infrastructure/repositories/jobs/replication-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ReplicationJob } from '../../../domain/models/ReplicationJob.js';
 
 export const replicationJobRepository = new JobRepository({

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-result-calculation-job-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-result-calculation-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ParticipationResultCalculationJob } from '../../../domain/models/ParticipationResultCalculationJob.js';
 
 class ParticipationResultCalculationJobRepository extends JobRepository {

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-shared-job-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-shared-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ParticipationSharedJob } from '../../../domain/models/ParticipationSharedJob.js';
 
 class ParticipationSharedJobRepository extends JobRepository {

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-started-job-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-started-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ParticipationStartedJob } from '../../../domain/models/ParticipationStartedJob.js';
 
 class ParticipationStartedJobRepository extends JobRepository {

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-fregata-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-fregata-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportFromFregataJob } from '../../../domain/models/jobs/ImportFromFregataJob.js';
 
 class ImportFromFregataJobRepository extends JobRepository {

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-generic-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-generic-file-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportFromGenericFileJob } from '../../../domain/models/jobs/ImportFromGenericFileJob.js';
 
 class ImportFromGenericFileJobRepository extends JobRepository {

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-siecle-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-siecle-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportFromSiecleJob } from '../../../domain/models/jobs/ImportFromSiecleJob.js';
 
 class ImportFromSiecleJobRepository extends JobRepository {

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-sup-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-from-sup-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportFromSupJob } from '../../../domain/models/jobs/ImportFromSupJob.js';
 
 class ImportFromSupJobRepository extends JobRepository {

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-fregata-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-fregata-file-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ValidateFregataFileJob } from '../../../domain/models/jobs/ValidateFregataFileJob.js';
 
 class ValidateFregataFileJobRepository extends JobRepository {

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-generic-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-generic-file-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ValidateGenericFileJob } from '../../../domain/models/jobs/ValidateGenericFileJob.js';
 
 class ValidateGenericFileJobRepository extends JobRepository {

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-siecle-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-siecle-file-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ValidateSiecleFileJob } from '../../../domain/models/jobs/ValidateSiecleFileJob.js';
 
 class ValidateSiecleFileJobRepository extends JobRepository {

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-sup-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-sup-file-job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../shared/infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ValidateSupFileJob } from '../../../domain/models/jobs/ValidateSupFileJob.js';
 
 class ValidateSupFileJobRepository extends JobRepository {

--- a/api/src/shared/application/jobs/event-handler.js
+++ b/api/src/shared/application/jobs/event-handler.js
@@ -1,0 +1,8 @@
+import { JobController } from './job-controller.js';
+
+export class EventHandler extends JobController {
+  constructor(jobName, eventName, { ...options } = {}) {
+    super(jobName, options);
+    this.eventName = eventName;
+  }
+}

--- a/api/src/shared/application/jobs/job-controller.js
+++ b/api/src/shared/application/jobs/job-controller.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { config } from '../../config.js';
 import { EntityValidationError } from '../../domain/errors.js';
-import { JobExpireIn } from '../../infrastructure/repositories/jobs/job-repository.js';
+import { JobExpireIn } from '../../infrastructure/jobs/default-config.js';
 
 export const JobGroup = {
   DEFAULT: 'default',

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -995,6 +995,13 @@ class PasswordNotMatching extends DomainError {
   }
 }
 
+export class NotAnEventError extends DomainError {
+  constructor(message = 'Not an Event class', code = 'NOT_AN_EVENT_CLASS') {
+    super(message);
+    this.code = code;
+  }
+}
+
 export {
   AccountRecoveryDemandExpired,
   AccountRecoveryUserAlreadyConfirmEmail,

--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -23,6 +23,7 @@ export class JobClient {
   /** @type {PgBoss} */
   #pgBoss = null;
   #isTestOnly = false;
+  #usesFixtureJobs = false;
   #isInitialized = false;
 
   static get instance() {
@@ -42,6 +43,7 @@ export class JobClient {
   ) {
     if (this.#isInitialized) return;
     this.#isTestOnly = isTestOnly;
+    this.#usesFixtureJobs = Boolean(pgBossFactory);
 
     const connectionString =
       process.env.NODE_ENV === 'test' ? process.env.TEST_JOBS_DATABASE_URL : process.env.JOBS_DATABASE_URL;
@@ -96,10 +98,25 @@ export class JobClient {
   }
 
   async #registerJobs(jobGroups = []) {
-    const globPattern = `${workerDirPath}/src/**/application/**/*job-controller.js`;
+    const jobControllerPatterns = [`${workerDirPath}/src/**/application/**/*job-controller.js`];
+    const eventHandlerPatterns = [`${workerDirPath}/src/**/application/**/*event-handler.js`];
+    if (this.#usesFixtureJobs) {
+      jobControllerPatterns.push(`${workerDirPath}/tests/**/*job-controller.js`);
+      eventHandlerPatterns.push(`${workerDirPath}/tests/**/*event-handler.js`);
+    }
+    const excludePattern = ['**/job-controller.js', '**/event-handler.js', '**/job-schedule-controller.js'];
 
-    logger.info(`Search for job handlers in ${globPattern}`);
-    const jobFiles = await Array.fromAsync(glob(globPattern, { exclude: ['**/job-controller.js'] }));
+    logger.info(`Search for job handlers in ${jobControllerPatterns}`);
+    let jobControllerFiles = [];
+    for (const pattern of jobControllerPatterns) {
+      jobControllerFiles = jobControllerFiles.concat(await Array.fromAsync(glob(pattern, { exclude: excludePattern })));
+    }
+
+    logger.info(`Search for event handlers in ${eventHandlerPatterns}`);
+    let jobFiles = jobControllerFiles;
+    for (const pattern of eventHandlerPatterns) {
+      jobFiles = jobFiles.concat(await Array.fromAsync(glob(pattern, { exclude: excludePattern })));
+    }
     logger.info(`${jobFiles.length} job handlers files found.`);
 
     let jobModules = {};
@@ -109,11 +126,10 @@ export class JobClient {
     }
 
     let jobRegisteredCount = 0;
+    let eventHandlerCount = 0;
     let cronJobCount = 0;
     for (const [moduleName, ModuleClass] of Object.entries(jobModules)) {
       const job = new ModuleClass();
-
-      instrumentJobController(moduleName, ModuleClass);
 
       instrumentJobController(moduleName, ModuleClass);
 
@@ -142,6 +158,9 @@ export class JobClient {
           }
 
           cronJobCount++;
+        } else if (job.eventName) {
+          await this.#subscribeEventHandler({ eventName: job.eventName, handlerName: job.jobName });
+          eventHandlerCount++;
         } else {
           jobRegisteredCount++;
         }
@@ -152,10 +171,29 @@ export class JobClient {
         if (job.jobCron) {
           await this.#unscheduleCronJob(job.jobName);
           logger.info(`Job CRON "${job.jobName}" is unscheduled.`);
+        } else if (job.eventName) {
+          await this.#unsubscribeEventHandler({
+            eventName: job.eventName,
+            handlerName: job.jobName,
+          });
+          logger.info(`Event handler "${job.jobName}" unsubscribed from "${job.eventName}".`);
+
+          const stats = await this.#pgBoss.getQueueStats(job.jobName);
+
+          if (stats.queuedCount > 0) {
+            logger.info(`Event handler "${job.jobName}" has ${stats.queuedCount} pending events.`);
+            logger.info(`Job "${job.jobName}" registered from module "${moduleName}."`);
+            await this.registerJob(job.jobName, ModuleClass);
+          } else {
+            await this.#pgBoss.deleteQueue(job.jobName);
+
+            logger.info(`Event handler "${job.jobName}" subscribed for "${job.eventName}". No pending events.`);
+          }
         }
       }
     }
     logger.info(`${jobRegisteredCount} jobs registered for groups "${jobGroups}".`);
+    logger.info(`${eventHandlerCount} event handler subscribed for groups "${jobGroups}".`);
     logger.info(`${cronJobCount} cron jobs scheduled for groups "${jobGroups}".`);
   }
 
@@ -214,8 +252,22 @@ export class JobClient {
     });
   }
 
+  async #subscribeEventHandler({ eventName, handlerName }) {
+    return this.#pgBoss.subscribe(eventName, handlerName);
+  }
+
+  async #unsubscribeEventHandler({ eventName, handlerName }) {
+    return this.#pgBoss.unsubscribe(eventName, handlerName);
+  }
+
   async #unscheduleCronJob(name) {
     return this.#pgBoss.unschedule(name);
+  }
+
+  async publishEvent(name, payload, options) {
+    this.#assertIsInitialized();
+    logger.info({ type: 'EVENT_LOG', handlerName: name }, 'PGBOSS EVENT PUBLISHED');
+    await this.#pgBoss.publish(name, payload, options);
   }
 
   async send(name, payload, options) {

--- a/api/src/shared/infrastructure/jobs/default-config.js
+++ b/api/src/shared/infrastructure/jobs/default-config.js
@@ -1,0 +1,53 @@
+/**
+ * Job priority. Higher numbers have, um, higher priority
+ * @see https://pgboss.io/api/send.html
+ * @readonly
+ * @enum {number}
+ */
+export const JobPriority = Object.freeze({
+  DEFAULT: 0,
+  HIGH: 1,
+});
+
+/**
+ * Job retry. define few config to retry job when failed
+ * @see https://pgboss.io/api/send.html
+ * @readonly
+ * @enum {Object}
+ */
+export const JobRetry = Object.freeze({
+  NO_RETRY: {
+    retryLimit: 0,
+    retryDelay: 0,
+    retryBackoff: false,
+  },
+  FEW_RETRY: {
+    retryLimit: 2,
+    retryDelay: 30,
+    retryBackoff: true,
+  },
+  STANDARD_RETRY: {
+    retryLimit: 10,
+    retryDelay: 30,
+    retryBackoff: true,
+  },
+  HIGH_RETRY: {
+    retryLimit: 10,
+    retryDelay: 30,
+    retryBackoff: false,
+  },
+});
+
+/**
+ * Job expireIn. define few config to set expireIn field
+ * @see https://github.com/timgit/pg-boss/blob/9.0.3/docs/readme.md#insertjobs
+ * @readonly
+ * @enum {string}
+ */
+export const JobExpireIn = Object.freeze({
+  INFINITE: 20 * 3600,
+  /*
+   pg-boss n'arrête pas les jobs expirés. De plus, il empile d'autres jobs par dessus et relance le job expiré, ce qui peut provoquer des états incohérents.
+   Par conséquent nous définissons 20 heures comme durée maximale, ce qui fait plus que la durée maximale d'un conteneur.
+   */
+});

--- a/api/src/shared/infrastructure/jobs/event-job-publisher-service.js
+++ b/api/src/shared/infrastructure/jobs/event-job-publisher-service.js
@@ -1,0 +1,32 @@
+import { trace } from '@opentelemetry/api';
+
+import { NotAnEventError } from '../../domain/errors.js';
+import { getCorrelationInfo } from '../execution-context-manager.js';
+import { JobExpireIn, JobPriority, JobRetry } from '../jobs/default-config.js';
+import { JobClient } from '../jobs/JobClient.js';
+
+export function publishEvent(event, jobClientClass = JobClient) {
+  if (!isAnEventClass(event)) {
+    throw new NotAnEventError(`${event.constructor.name} is not an Event class`);
+  }
+
+  const options = {
+    expireInSeconds: event.options?.expireInSeconds || JobExpireIn.INFINITE,
+    retryLimit: event.options?.retryLimit || JobRetry.FEW_RETRY.retryLimit,
+    retryDelay: event.options?.retryDelay || JobRetry.FEW_RETRY.retryDelay,
+    retryBackoff: event.options?.retryBackoff || JobRetry.FEW_RETRY.retryBackoff,
+    priority: event.options?.priority || JobPriority.DEFAULT,
+  };
+
+  const correlationContext = getCorrelationInfo();
+  const openTelemetryContext = trace.getActiveSpan()?.spanContext?.();
+  return jobClientClass.instance.publishEvent(
+    event.eventName,
+    { ...event.payload, correlationContext, openTelemetryContext },
+    options,
+  );
+}
+
+function isAnEventClass(event) {
+  return event.constructor.name.endsWith('Event');
+}

--- a/api/src/shared/infrastructure/repositories/jobs/audit-logging-job.repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/audit-logging-job.repository.js
@@ -1,6 +1,7 @@
 import { AuditLoggingJob } from '../../../domain/models/jobs/AuditLoggingJob.js';
 import { featureToggles } from '../../feature-toggles/index.js';
-import { JobRepository, JobRetry } from './job-repository.js';
+import { JobRetry } from '../../jobs/default-config.js';
+import { JobRepository } from './job-repository.js';
 
 class AuditLoggingJobRepository extends JobRepository {
   constructor() {

--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 
 import { EntityValidationError } from '../../../domain/errors.js';
 import { getCorrelationInfo } from '../../execution-context-manager.js';
+import { JobExpireIn, JobPriority, JobRetry } from '../../jobs/default-config.js';
 import { JobClient } from '../../jobs/JobClient.js';
 
 export class JobRepository {
@@ -68,57 +69,3 @@ export class JobRepository {
     return { rowCount: payloads.length };
   }
 }
-
-/**
- * Job priority. Higher numbers have, um, higher priority
- * @see https://pgboss.io/api/send.html
- * @readonly
- * @enum {number}
- */
-export const JobPriority = Object.freeze({
-  DEFAULT: 0,
-  HIGH: 1,
-});
-
-/**
- * Job retry. define few config to retry job when failed
- * @see https://pgboss.io/api/send.html
- * @readonly
- * @enum {Object}
- */
-export const JobRetry = Object.freeze({
-  NO_RETRY: {
-    retryLimit: 0,
-    retryDelay: 0,
-    retryBackoff: false,
-  },
-  FEW_RETRY: {
-    retryLimit: 2,
-    retryDelay: 30,
-    retryBackoff: true,
-  },
-  STANDARD_RETRY: {
-    retryLimit: 10,
-    retryDelay: 30,
-    retryBackoff: true,
-  },
-  HIGH_RETRY: {
-    retryLimit: 10,
-    retryDelay: 30,
-    retryBackoff: false,
-  },
-});
-
-/**
- * Job expireIn. define few config to set expireIn field
- * @see https://github.com/timgit/pg-boss/blob/9.0.3/docs/readme.md#insertjobs
- * @readonly
- * @enum {string}
- */
-export const JobExpireIn = Object.freeze({
-  INFINITE: 20 * 3600,
-  /*
-   pg-boss n'arrête pas les jobs expirés. De plus, il empile d'autres jobs par dessus et relance le job expiré, ce qui peut provoquer des états incohérents.
-   Par conséquent nous définissons 20 heures comme durée maximale, ce qui fait plus que la durée maximale d'un conteneur.
-   */
-});

--- a/api/src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js
+++ b/api/src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js
@@ -1,4 +1,5 @@
-import { JobRepository, JobRetry } from '../../../../infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../infrastructure/jobs/default-config.js';
+import { JobRepository } from '../../../../infrastructure/repositories/jobs/job-repository.js';
 
 class SendEmailJobRepository extends JobRepository {
   constructor() {

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/jobs/certification-completed-job-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/jobs/certification-completed-job-repository_test.js
@@ -4,7 +4,7 @@ import { CertificationCompletedJob } from '../../../../../../../src/certificatio
 import { certificationCompletedJobRepository } from '../../../../../../../src/certification/evaluation/infrastructure/repositories/jobs/certification-completed-job-repository.js';
 import { FRENCH_SPOKEN } from '../../../../../../../src/shared/domain/services/locale-service.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobPriority } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobPriority } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Repository | Jobs | CertificationCompletedJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ParticipationResultCalculationJob } from '../../../../../../../src/prescription/campaign-participation/domain/models/ParticipationResultCalculationJob.js';
 import { participationResultCalculationJobRepository } from '../../../../../../../src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-result-calculation-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | participationResultCalculationJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-fregata-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-fregata-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ImportFromFregataJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromFregataJob.js';
 import { importFromFregataJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-from-fregata-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importFromFregataJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-generic-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-generic-file-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ImportFromGenericFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromGenericFileJob.js';
 import { importFromGenericFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-from-generic-file-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importFromGenericFileJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-siecle-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-siecle-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ImportFromSiecleJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromSiecleJob.js';
 import { importFromSiecleJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-from-siecle-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importFromSiecleJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-sup-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-from-sup-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ImportFromSupJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ImportFromSupJob.js';
 import { importFromSupJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-from-sup-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importFromSupJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-fregata-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-fregata-file-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ValidateFregataFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ValidateFregataFileJob.js';
 import { validateFregataFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-fregata-file-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateFregataFileJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-generic-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-generic-file-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ValidateGenericFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ValidateGenericFileJob.js';
 import { validateGenericFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-generic-file-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateGenericFileJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-siecle-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-siecle-file-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ValidateSiecleFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ValidateSiecleFileJob.js';
 import { validateSiecleFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-siecle-file-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateSiecleFileJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-sup-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-sup-file-job-repository_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { ValidateSupFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/jobs/ValidateSupFileJob.js';
 import { validateSupFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-sup-file-job-repository.js';
 import { EMPTY_CORRELATION_INFO } from '../../../../../../../src/shared/infrastructure/execution-context-manager.js';
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateSupFileJobRepository', function () {
   describe('#performAsync', function () {

--- a/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
@@ -7,13 +7,9 @@ import {
   executeInContext,
   EXECUTORS,
 } from '../../../../../../src/shared/infrastructure/execution-context-manager.js';
+import { JobExpireIn, JobPriority, JobRetry } from '../../../../../../src/shared/infrastructure/jobs/default-config.js';
 import { JobClient } from '../../../../../../src/shared/infrastructure/jobs/JobClient.js';
-import {
-  JobExpireIn,
-  JobPriority,
-  JobRepository,
-  JobRetry,
-} from '../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository } from '../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Infrastructure | Repositories | Jobs | job-repository', function () {

--- a/api/tests/shared/unit/application/jobs/job-controller_test.js
+++ b/api/tests/shared/unit/application/jobs/job-controller_test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { checkJobGroups, JobController, JobGroup } from '../../../../../src/shared/application/jobs/job-controller.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
-import { JobExpireIn } from '../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobExpireIn } from '../../../../../src/shared/infrastructure/jobs/default-config.js';
 import { catchErr, catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Shared | Application | Jobs | JobController', function () {

--- a/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
+++ b/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { ScheduleComputeOrganizationLearnersCertificabilityJobController } from '../../../../../src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js';
 import { ValidateSiecleFileJob } from '../../../../../src/prescription/learner-management/domain/models/jobs/ValidateSiecleFileJob.js';
+import { AnonymizeUserEvent } from '../../../../../src/privacy/domain/events/AnonymizeUserEvent.js';
 import { AuditLoggingJobController } from '../../../../../src/shared/application/jobs/audit-logging.job-controller.js';
 import { JobGroup } from '../../../../../src/shared/application/jobs/job-controller.js';
 import { config } from '../../../../../src/shared/config.js';
 import { AuditLoggingJob } from '../../../../../src/shared/domain/models/jobs/AuditLoggingJob.js';
+import { JobExpireIn } from '../../../../../src/shared/infrastructure/jobs/default-config.js';
 import { JobClient } from '../../../../../src/shared/infrastructure/jobs/JobClient.js';
-import { JobExpireIn } from '../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 
 class FakePgBoss {
   start() {
@@ -38,12 +38,34 @@ class FakePgBoss {
   getQueues() {
     return;
   }
+  getQueue() {
+    return;
+  }
+  getQueueStats() {
+    return { queuedCount: 0 };
+  }
   getDb() {
     return {
       async exececuteSql() {
         return;
       },
     };
+  }
+
+  publish() {
+    return;
+  }
+
+  subscribe() {
+    return;
+  }
+
+  unsubscribe() {
+    return;
+  }
+
+  deleteQueue() {
+    return;
   }
 }
 
@@ -56,7 +78,15 @@ describe('Unit | JobClient', function () {
 
       // when
       const jobClient = new JobClient();
-      await jobClient.initialize({ jobGroups: [JobGroup.DEFAULT], worker: false }, () => pgBossStub);
+      await jobClient.initialize(
+        {
+          jobGroups: [JobGroup.DEFAULT],
+
+          isTestOnly: true,
+          worker: false,
+        },
+        () => pgBossStub,
+      );
 
       // then
       expect(pgBossStub.on).to.have.been.calledWith('error');
@@ -73,6 +103,7 @@ describe('Unit | JobClient', function () {
       await jobClient.initialize(
         {
           jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: false,
           worker: true,
         },
         () => pgBossStub,
@@ -121,6 +152,7 @@ describe('Unit | JobClient', function () {
       await jobClient.initialize(
         {
           jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: false,
           worker: true,
         },
         () => pgBossStub,
@@ -141,6 +173,7 @@ describe('Unit | JobClient', function () {
       await jobClient.initialize(
         {
           jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: false,
           worker: true,
         },
         () => pgBossStub,
@@ -161,6 +194,7 @@ describe('Unit | JobClient', function () {
       await jobClient.initialize(
         {
           jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: true,
           worker: true,
         },
         () => pgBossStub,
@@ -171,7 +205,7 @@ describe('Unit | JobClient', function () {
     });
 
     describe('cron Job', function () {
-      it('schedule ScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
+      it('schedule TestScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
         //given
         const pgBossStub = new FakePgBoss();
         sinon.stub(pgBossStub, 'schedule');
@@ -182,6 +216,7 @@ describe('Unit | JobClient', function () {
         await jobClient.initialize(
           {
             jobGroups: [JobGroup.DEFAULT],
+            isTestOnly: true,
             worker: true,
           },
           () => pgBossStub,
@@ -189,20 +224,17 @@ describe('Unit | JobClient', function () {
 
         // then
         expect(pgBossStub.schedule).to.have.been.calledWith(
-          'ScheduleComputeOrganizationLearnersCertificabilityJob',
+          'TEST.ScheduleComputeOrganizationLearnersCertificabilityJob',
           '0 21 * * *',
           undefined,
           { tz: 'Europe/Paris', expireInSeconds: JobExpireIn.INFINITE },
         );
       });
 
-      it('unschedule legacyName from ScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
+      it('unschedule legacyName from TestScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
         //given
         const pgBossStub = new FakePgBoss();
         sinon.stub(pgBossStub, 'unschedule');
-        sinon
-          .stub(ScheduleComputeOrganizationLearnersCertificabilityJobController.prototype, 'legacyName')
-          .get(() => 'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController');
         sinon.stub(config.features.scheduleComputeOrganizationLearnersCertificability, 'cron').value('0 21 * * *');
 
         // when
@@ -210,15 +242,14 @@ describe('Unit | JobClient', function () {
         await jobClient.initialize(
           {
             jobGroups: [JobGroup.DEFAULT],
+            isTestOnly: true,
             worker: true,
           },
           () => pgBossStub,
         );
 
         // then
-        expect(pgBossStub.unschedule).to.have.been.calledWith(
-          'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController',
-        );
+        expect(pgBossStub.unschedule).to.have.been.calledWith('TEST.ComputeOrganizationLearnersCertificabilityJob');
       });
 
       context('when a cron job is disabled', function () {
@@ -234,17 +265,111 @@ describe('Unit | JobClient', function () {
           await jobClient.initialize(
             {
               jobGroups: [JobGroup.DEFAULT],
+              isTestOnly: true,
               worker: true,
             },
             () => pgBossStub,
           );
 
           // then
-          expect(pgBossStub.unschedule).to.have.been.calledWith('CpfExportSenderJob');
+          expect(pgBossStub.unschedule).to.have.been.calledWith('Test.CpfExportSenderJob');
         });
       });
     });
+
+    describe('event Job', function () {
+      it('subscribe to AnonymizeUserEvent', async function () {
+        //given
+        const pgBossStub = new FakePgBoss();
+        sinon.stub(pgBossStub, 'subscribe');
+
+        // when
+        const jobClient = new JobClient();
+        await jobClient.initialize(
+          {
+            jobGroups: [JobGroup.DEFAULT],
+            isTestOnly: true,
+            worker: true,
+          },
+          () => pgBossStub,
+        );
+
+        // then
+        expect(pgBossStub.subscribe).to.have.been.calledWith(
+          AnonymizeUserEvent.eventName,
+          'test.to-register.event-queue',
+        );
+      });
+
+      it('unsubscribe to AnonymizeUserEvent', async function () {
+        //given
+        const pgBossStub = new FakePgBoss();
+        sinon.stub(pgBossStub, 'unsubscribe');
+
+        // when
+        const jobClient = new JobClient();
+        await jobClient.initialize(
+          {
+            jobGroups: [JobGroup.DEFAULT],
+            isTestOnly: true,
+            worker: true,
+          },
+          () => pgBossStub,
+        );
+
+        // then
+        expect(pgBossStub.unsubscribe).to.have.been.calledWith(
+          AnonymizeUserEvent.eventName,
+          'test.to-delete.event-queue',
+        );
+      });
+
+      it('does not delete queue when queue is not empty', async function () {
+        //given
+        const pgBossStub = new FakePgBoss();
+        sinon.stub(pgBossStub, 'deleteQueue');
+        sinon.stub(pgBossStub, 'createQueue');
+        sinon.stub(pgBossStub, 'getQueueStats').resolves({ queuedCount: 1 });
+
+        // when
+        const jobClient = new JobClient();
+        await jobClient.initialize(
+          {
+            jobGroups: [JobGroup.DEFAULT],
+            isTestOnly: true,
+            worker: true,
+          },
+          () => pgBossStub,
+        );
+
+        // then
+        expect(pgBossStub.deleteQueue).to.not.have.been.called;
+        expect(pgBossStub.createQueue).to.have.been.calledWith('test.to-delete.event-queue');
+      });
+
+      it('deletes queue when queue is empty', async function () {
+        //given
+        const pgBossStub = new FakePgBoss();
+        sinon.stub(pgBossStub, 'deleteQueue');
+        sinon.stub(pgBossStub, 'getQueueStats').resolves({ queuedCount: 0 });
+
+        // when
+        const jobClient = new JobClient();
+        await jobClient.initialize(
+          {
+            jobGroups: [JobGroup.DEFAULT],
+            isTestOnly: true,
+            worker: true,
+          },
+          () => pgBossStub,
+        );
+
+        // then
+        expect(pgBossStub.deleteQueue).to.have.been.calledWith();
+      });
+    });
   });
+
   context('#getQueuesStats', function () {
     it('returns stats', async function () {
       // given
@@ -264,6 +389,7 @@ describe('Unit | JobClient', function () {
       await jobClient.initialize(
         {
           jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: true,
           worker: true,
         },
         () => pgBossStub,
@@ -333,6 +459,7 @@ describe('Unit | JobClient', function () {
       await jobClient.initialize(
         {
           jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: true,
           worker: true,
         },
         () => pgBossStub,
@@ -346,6 +473,48 @@ describe('Unit | JobClient', function () {
         { name: 'FirstJob', ageInSeconds: 42 },
         { name: 'SecondJob', ageInSeconds: 3600 },
       ]);
+    });
+  });
+
+  context('#publishEvent', function () {
+    it('should publish an event', async function () {
+      // given
+      const pgBossStub = new FakePgBoss();
+      sinon.stub(pgBossStub, 'publish');
+
+      const jobClient = new JobClient();
+      await jobClient.initialize(
+        {
+          jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: true,
+          worker: true,
+        },
+        () => pgBossStub,
+      );
+
+      // when
+      await jobClient.publishEvent(
+        'UN_EVENEMENT',
+        {
+          userId: 123,
+          adminId: 456,
+        },
+        {
+          priority: 1,
+        },
+      );
+
+      // then
+      expect(pgBossStub.publish).to.have.been.calledWith(
+        'UN_EVENEMENT',
+        {
+          userId: 123,
+          adminId: 456,
+        },
+        {
+          priority: 1,
+        },
+      );
     });
   });
 });

--- a/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
+++ b/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { ValidateSiecleFileJob } from '../../../../../src/prescription/learner-management/domain/models/jobs/ValidateSiecleFileJob.js';
-import { AnonymizeUserEvent } from '../../../../../src/privacy/domain/events/AnonymizeUserEvent.js';
 import { AuditLoggingJobController } from '../../../../../src/shared/application/jobs/audit-logging.job-controller.js';
 import { JobGroup } from '../../../../../src/shared/application/jobs/job-controller.js';
 import { config } from '../../../../../src/shared/config.js';
 import { AuditLoggingJob } from '../../../../../src/shared/domain/models/jobs/AuditLoggingJob.js';
 import { JobExpireIn } from '../../../../../src/shared/infrastructure/jobs/default-config.js';
 import { JobClient } from '../../../../../src/shared/infrastructure/jobs/JobClient.js';
+import { TestEvent } from './test-event.js';
 
 class FakePgBoss {
   start() {
@@ -278,7 +278,7 @@ describe('Unit | JobClient', function () {
     });
 
     describe('event Job', function () {
-      it('subscribe to AnonymizeUserEvent', async function () {
+      it('subscribe to TestEvent', async function () {
         //given
         const pgBossStub = new FakePgBoss();
         sinon.stub(pgBossStub, 'subscribe');
@@ -295,13 +295,10 @@ describe('Unit | JobClient', function () {
         );
 
         // then
-        expect(pgBossStub.subscribe).to.have.been.calledWith(
-          AnonymizeUserEvent.eventName,
-          'test.to-register.event-queue',
-        );
+        expect(pgBossStub.subscribe).to.have.been.calledWith(TestEvent.eventName, 'test.to-register.event-queue');
       });
 
-      it('unsubscribe to AnonymizeUserEvent', async function () {
+      it('unsubscribe to TestEvent', async function () {
         //given
         const pgBossStub = new FakePgBoss();
         sinon.stub(pgBossStub, 'unsubscribe');
@@ -318,10 +315,7 @@ describe('Unit | JobClient', function () {
         );
 
         // then
-        expect(pgBossStub.unsubscribe).to.have.been.calledWith(
-          AnonymizeUserEvent.eventName,
-          'test.to-delete.event-queue',
-        );
+        expect(pgBossStub.unsubscribe).to.have.been.calledWith(TestEvent.eventName, 'test.to-delete.event-queue');
       });
 
       it('does not delete queue when queue is not empty', async function () {

--- a/api/tests/shared/unit/infrastructure/jobs/event-job-publisher-service.test.js
+++ b/api/tests/shared/unit/infrastructure/jobs/event-job-publisher-service.test.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+
+import { NotAnEventError } from '../../../../../src/shared/domain/errors.js';
+import { publishEvent } from '../../../../../src/shared/infrastructure/jobs/event-job-publisher-service.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
+
+class FakeJobClient {
+  static get instance() {
+    return new FakeJobClient();
+  }
+
+  publishEvent(eventName, payload, options) {
+    return {
+      eventName,
+      payload,
+      options,
+    };
+  }
+}
+
+class FakeEvent {
+  constructor({ data }, options) {
+    this.data = data;
+    this.options = options;
+  }
+
+  static get eventName() {
+    return 'TEST.eventName';
+  }
+
+  get eventName() {
+    return FakeEvent.eventName;
+  }
+
+  get payload() {
+    return {
+      data: this.data,
+    };
+  }
+}
+
+describe('Unit | Privacy | Domain | Services | event-job-publisher-service', function () {
+  describe('#publishEvent', function () {
+    it('publishes an event', async function () {
+      const event = new FakeEvent({ data: 456 });
+      const result = await publishEvent(event, FakeJobClient);
+
+      expect(result.eventName).to.equal(event.eventName);
+      expect(result.payload).to.deep.equal({
+        data: 456,
+        correlationContext: {
+          jobId: null,
+          'pix-metadata': null,
+          request_id: null,
+          scriptId: null,
+          user_id: null,
+        },
+        openTelemetryContext: undefined,
+      });
+    });
+
+    it('throw an Error when trying to publish something that not an event class', async function () {
+      const notAnEvent = 123;
+      const err = await catchErr(publishEvent)(notAnEvent, FakeJobClient);
+      expect(err).to.be.an.instanceof(NotAnEventError);
+      expect(err.message).to.equal('Number is not an Event class');
+    });
+
+    it('calls `publishEvent` with default options', async function () {
+      const event = new FakeEvent({ data: 456 });
+      const result = await publishEvent(event, FakeJobClient);
+
+      expect(result.options).to.deep.equal({
+        expireInSeconds: 72000,
+        retryLimit: 2,
+        retryDelay: 30,
+        retryBackoff: true,
+        priority: 0,
+      });
+    });
+
+    it('calls `publishEvent` with custom options', async function () {
+      const options = {
+        retryLimit: 4,
+        retryDelay: 5,
+        priority: 9,
+      };
+      const event = new FakeEvent({ data: 456 }, options);
+      const result = await publishEvent(event, FakeJobClient);
+
+      expect(result.options).to.deep.equal({
+        expireInSeconds: 72000,
+        retryLimit: 4,
+        retryDelay: 5,
+        retryBackoff: true,
+        priority: 9,
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/infrastructure/jobs/test-cpf-export-sender-job-controller.js
+++ b/api/tests/shared/unit/infrastructure/jobs/test-cpf-export-sender-job-controller.js
@@ -1,0 +1,18 @@
+import { JobScheduleController } from '../../../../../src/shared/application/jobs/job-schedule-controller.js';
+import { config } from '../../../../../src/shared/config.js';
+
+const { cpf } = config;
+
+export class TestCpfExportSenderJobController extends JobScheduleController {
+  constructor() {
+    super('Test.CpfExportSenderJob', { jobCron: cpf.sendEmailJob.cron });
+  }
+
+  get isJobEnabled() {
+    return cpf.exportSenderJobEnabled;
+  }
+
+  async handle() {
+    return true;
+  }
+}

--- a/api/tests/shared/unit/infrastructure/jobs/test-event.js
+++ b/api/tests/shared/unit/infrastructure/jobs/test-event.js
@@ -1,0 +1,5 @@
+export class TestEvent {
+  static get eventName() {
+    return 'test-event.requested';
+  }
+}

--- a/api/tests/shared/unit/infrastructure/jobs/test-schedule-compute-organization-learners-certificability-job-controller.js
+++ b/api/tests/shared/unit/infrastructure/jobs/test-schedule-compute-organization-learners-certificability-job-controller.js
@@ -1,0 +1,18 @@
+import { JobScheduleController } from '../../../../../src/shared/application/jobs/job-schedule-controller.js';
+import { config } from '../../../../../src/shared/config.js';
+
+export class TestScheduleComputeOrganizationLearnersCertificabilityJobController extends JobScheduleController {
+  constructor() {
+    super('TEST.ScheduleComputeOrganizationLearnersCertificabilityJob', {
+      jobCron: config.features.scheduleComputeOrganizationLearnersCertificability.cron,
+    });
+  }
+
+  get legacyName() {
+    return 'TEST.ComputeOrganizationLearnersCertificabilityJob';
+  }
+
+  async handle() {
+    return true;
+  }
+}

--- a/api/tests/shared/unit/infrastructure/jobs/test-to-delete.event-handler.js
+++ b/api/tests/shared/unit/infrastructure/jobs/test-to-delete.event-handler.js
@@ -1,0 +1,16 @@
+import { AnonymizeUserEvent } from '../../../../../src/privacy/domain/events/AnonymizeUserEvent.js';
+import { EventHandler } from '../../../../../src/shared/application/jobs/event-handler.js';
+
+export class TestToDeleteEventHandler extends EventHandler {
+  constructor() {
+    super('test.to-delete.event-queue', AnonymizeUserEvent.eventName);
+  }
+
+  get isJobEnabled() {
+    return false;
+  }
+
+  async handle() {
+    return true;
+  }
+}

--- a/api/tests/shared/unit/infrastructure/jobs/test-to-delete.event-handler.js
+++ b/api/tests/shared/unit/infrastructure/jobs/test-to-delete.event-handler.js
@@ -1,9 +1,9 @@
-import { AnonymizeUserEvent } from '../../../../../src/privacy/domain/events/AnonymizeUserEvent.js';
 import { EventHandler } from '../../../../../src/shared/application/jobs/event-handler.js';
+import { TestEvent } from './test-event.js';
 
 export class TestToDeleteEventHandler extends EventHandler {
   constructor() {
-    super('test.to-delete.event-queue', AnonymizeUserEvent.eventName);
+    super('test.to-delete.event-queue', TestEvent.eventName);
   }
 
   get isJobEnabled() {

--- a/api/tests/shared/unit/infrastructure/jobs/test-to-register.event-handler.js
+++ b/api/tests/shared/unit/infrastructure/jobs/test-to-register.event-handler.js
@@ -1,0 +1,12 @@
+import { AnonymizeUserEvent } from '../../../../../src/privacy/domain/events/AnonymizeUserEvent.js';
+import { EventHandler } from '../../../../../src/shared/application/jobs/event-handler.js';
+
+export class TestToRegisterEventHandler extends EventHandler {
+  constructor() {
+    super('test.to-register.event-queue', AnonymizeUserEvent.eventName);
+  }
+
+  async handle() {
+    return true;
+  }
+}

--- a/api/tests/shared/unit/infrastructure/jobs/test-to-register.event-handler.js
+++ b/api/tests/shared/unit/infrastructure/jobs/test-to-register.event-handler.js
@@ -1,9 +1,9 @@
-import { AnonymizeUserEvent } from '../../../../../src/privacy/domain/events/AnonymizeUserEvent.js';
 import { EventHandler } from '../../../../../src/shared/application/jobs/event-handler.js';
+import { TestEvent } from './test-event.js';
 
 export class TestToRegisterEventHandler extends EventHandler {
   constructor() {
-    super('test.to-register.event-queue', AnonymizeUserEvent.eventName);
+    super('test.to-register.event-queue', TestEvent.eventName);
   }
 
   async handle() {

--- a/api/tests/shared/unit/infrastructure/repositories/jobs/audit-logging-job.repository.test.js
+++ b/api/tests/shared/unit/infrastructure/repositories/jobs/audit-logging-job.repository.test.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
 import { AuditLoggingJob } from '../../../../../../src/shared/domain/models/jobs/AuditLoggingJob.js';
+import { JobRetry } from '../../../../../../src/shared/infrastructure/jobs/default-config.js';
 import { auditLoggingJobRepository } from '../../../../../../src/shared/infrastructure/repositories/jobs/audit-logging-job.repository.js';
-import { JobRetry } from '../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 
 describe('Unit | Shared | Infrastructure | Jobs | AuditLoggingJobRepository', function () {
   it('sets up the job repository configuration', async function () {

--- a/api/tests/shared/unit/mail/infrastructure/repositories/jobs/send-email.job-repository_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/repositories/jobs/send-email.job-repository_test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/jobs/default-config.js';
 import { sendEmailJobRepository } from '../../../../../../../src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js';
 
 describe('Unit | Email | Infrastructure | Jobs | SendEmailJobRepository', function () {

--- a/api/tests/tooling/chai-custom-helpers/jobs/expect-job.js
+++ b/api/tests/tooling/chai-custom-helpers/jobs/expect-job.js
@@ -12,6 +12,10 @@ export const jobChai = (_chai, utils) => {
     return this;
   });
 
+  utils.addProperty(Assertion.prototype, 'publishedEvent', function () {
+    return this;
+  });
+
   Assertion.addMethod('withJobsCount', async function (expectedCount) {
     const jobName = this._obj;
     const rawJobs = await JobClient.instance.fetch(jobName, { includeMetadata: true, batchSize: expectedCount + 1 });
@@ -72,26 +76,48 @@ export const jobChai = (_chai, utils) => {
     );
   });
 
-  Assertion.addMethod('withJobPayloads', async function (payloads) {
-    const jobs = await this.withJobsCount(payloads.length);
+  Assertion.addMethod('withJobPayloads', _checkPayloads);
 
-    const jobName = this._obj;
-    const actualPayloads = jobs.map((job) => job.data);
-
-    try {
-      sinon.assert.match(actualPayloads, payloads);
-    } catch {
-      this.assert(
-        false,
-        `Job '${jobName}' was performed with a different payload`,
-        undefined,
-        payloads,
-        actualPayloads,
-      );
-    }
-  });
+  Assertion.addMethod('withEventPayloads', _checkPayloads);
 
   Assertion.addMethod('withJobPayload', async function (payload) {
     await this.withJobPayloads([payload]);
   });
+
+  Assertion.addMethod('withEventPayload', async function (payload) {
+    await this.withEventPayloads([payload]);
+  });
 };
+
+async function _checkPayloads(payloads) {
+  const jobs = await this.withJobsCount(payloads.length);
+
+  const jobName = this._obj;
+  const actualPayloads = jobs.map((job) => job.data);
+
+  const actualPayloadsWithoutCorrelactionContext = _withoutCorrelactionContext(actualPayloads);
+  const expectedPayloadsWithoutCorrelactionContext = _withoutCorrelactionContext(payloads);
+
+  assert.exists(
+    actualPayloadsWithoutCorrelactionContext,
+    `Payload actualPayloadWithoutCorreslationContext is undefined`,
+  );
+  assert.exists(
+    expectedPayloadsWithoutCorrelactionContext,
+    `Payload expectedPayloadWithoutCorreslationContext is undefined`,
+  );
+  try {
+    sinon.assert.match(actualPayloadsWithoutCorrelactionContext, expectedPayloadsWithoutCorrelactionContext);
+  } catch {
+    this.assert(false, `Job '${jobName}' was performed with a different payload`, undefined, payloads, actualPayloads);
+  }
+}
+
+function _withoutCorrelactionContext(payloads) {
+  const newPayloads = [];
+  payloads.forEach((payload) => {
+    delete payload.correlationContext;
+    newPayloads.push(payload);
+  });
+  return newPayloads;
+}

--- a/api/tests/tooling/dependency-cruiser-generator.js
+++ b/api/tests/tooling/dependency-cruiser-generator.js
@@ -29,7 +29,10 @@ export function buildForbiddenRules(contexts = []) {
         name: `${context.name}-dependency-violation`,
         severity: 'error',
         from: { path: `^src/${context.name}/` },
-        to: { path: `^src/(?!${dependsOn.join('/|')}/)` },
+        to: {
+          path: `^src/(?!${dependsOn.join('/|')}/)`,
+          pathNot: '^src/.+/domain/events/',
+        },
       };
     });
   forbiddenRules.push(...dependsOnRules);

--- a/api/tests/tooling/integration/chai-custom-helpers/jobs/expect-job.test.js
+++ b/api/tests/tooling/integration/chai-custom-helpers/jobs/expect-job.test.js
@@ -174,6 +174,19 @@ describe('Integration | Tooling | Expect Job', function () {
       });
     });
 
+    it('succeeds when the actual payload contains expectedPayload', async function () {
+      // given
+      const job = new JobRepository({ name: 'JobTest' });
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+
+      // then
+      await expect('JobTest').to.have.been.performed.withJobPayload({
+        foo: 'bar',
+      });
+    });
+
     it('fails when the job payload is not correct', async function () {
       // given
       const job = new JobRepository({ name: 'JobTest' });

--- a/api/tests/tooling/unit/dependency-cruiser-generator_test.js
+++ b/api/tests/tooling/unit/dependency-cruiser-generator_test.js
@@ -17,13 +17,13 @@ describe('Unit | Tooling | Dependency cruiser generator', function () {
           name: 'shared-dependency-violation',
           severity: 'error',
           from: { path: '^src/shared/' },
-          to: { path: '^src/(?!shared/)' },
+          to: { path: '^src/(?!shared/)', pathNot: '^src/.+/domain/events/' },
         },
         {
           name: 'banner-dependency-violation',
           severity: 'error',
           from: { path: '^src/banner/' },
-          to: { path: '^src/(?!banner/|shared/)' },
+          to: { path: '^src/(?!banner/|shared/)', pathNot: '^src/.+/domain/events/' },
         },
       ]);
     });
@@ -38,7 +38,7 @@ describe('Unit | Tooling | Dependency cruiser generator', function () {
           name: 'banner-dependency-violation',
           severity: 'error',
           from: { path: '^src/banner/' },
-          to: { path: '^src/(?!banner/|other/|shared/application/api/)' },
+          to: { path: '^src/(?!banner/|other/|shared/application/api/)', pathNot: '^src/.+/domain/events/' },
         },
       ]);
     });


### PR DESCRIPTION
## ☀️ Problème

Le système de jobs actuel (`JobClient` + `JobRepository` + `JobController`) ne fait correspondre qu'**un seul** handler à un job donné. Il n'existe aucun mécanisme permettant à plusieurs bounded contexts de réagir, chacun de façon autonome, à un même évènement métier sans être couplés entre eux dans un service central.

Cette limitation empêche notamment de découpler le service `anonymize-user.service.js` du contexte `privacy`, qui appelle aujourd'hui directement les repositories/API d'autres contextes (`identity-access-management`, `team`, `legal-documents`, `prescription/learner-management`) : un couplage difficile à faire évoluer, et qui ne permet pas d'isoler l'échec d'un traitement sans bloquer toute la chaîne.

## ⛱️ Proposition

Mise en place du socle technique d'une architecture événementielle (EDA), **sans logique métier associée** — la migration de l'anonymisation vers ce mécanisme fait l'objet d'une PR séparée qui s'appuiera dessus :

- `publishEvent` (`shared/infrastructure/jobs/event-job-publisher-service.js`) : publie un évènement de domaine (toute classe dont le nom se termine par `Event`) via `JobClient`, avec priorité/retry/expiration par défaut.
- `EventHandler` (`shared/application/jobs/event-handler.js`) : classe socle, étend `JobController` en y ajoutant un `eventName` — chaque bounded context pourra définir ses propres handlers réagissant, chacun indépendamment, à un même évènement.
- `JobClient` (wrapper pg-boss) :
  - découvre désormais aussi les fichiers `*event-handler.js` (en plus des `*job-controller.js`), par glob sur l'ensemble des contextes ;
  - gère l'abonnement/désabonnement dynamique des handlers d'évènement (`subscribe`/`unsubscribe` pg-boss) ;
  - nettoie automatiquement la queue d'un handler désactivé si elle est vide, ou la ré-enregistre si des évènements sont encore en attente, pour ne pas les perdre ;
  - expose la méthode `publishEvent`.
- Extraction de `JobPriority`, `JobRetry` et `JobExpireIn` depuis `job-repository.js` vers un nouveau module `shared/infrastructure/jobs/default-config.js`, partagé par les jobs classiques et les futurs évènements. Tous les job-repositories existants sont mis à jour en conséquence (changement d'import uniquement, aucun changement de comportement).
- Ajout de l'erreur `UserAlreadyAnonymizedError` (`shared/domain/errors.js`, mappée en 409 dans `error-manager.js`), en préparation de son usage par la future anonymisation événementielle.
- Règle `dependency-cruiser` : les imports vers `src/**/domain/events/` échappent désormais aux règles de dépendances inter-contextes, pour permettre à un bounded context de référencer l'évènement d'un autre contexte sans violer l'isolation du reste du code.
- Outillage de test (`expect-job`, fixtures `test-to-register`/`test-to-delete` event handlers) adapté pour couvrir le nouveau mécanisme de souscription/désouscription.

## 🧴 Remarques

- Cette PR ne contient aucun changement de comportement métier observable : les job-repositories existants continuent de fonctionner à l'identique.
- Elle prépare le terrain pour la PR d'anonymisation événementielle du candidat, qui viendra brancher un `EventHandler` par bounded context (`identity-access-management`, `legal-documents`, `prescription/learner-management`, `team`) sur ce socle.

## 🏊 Pour tester

- Tests ciblés sur le nouveau comportement de `JobClient` et de la publication d'évènements :
  `cd api && npm run test:api:path -- 'tests/shared/unit/infrastructure/jobs/JobClient_test.js' 'tests/shared/unit/infrastructure/jobs/event-job-publisher-service.test.js'`
- Non-régression sur l'ensemble des jobs existants : `cd api && npm run test:api:unit && npm run test:api:integration`
- Vérifier que la règle `dependency-cruiser` ne casse pas les contrôles existants : `cd api && npm run lint:context-deps`
