### PR TITLE
[FEATURE] Gérer le message `terminate` des embeds dans Modulix (PIX-23911)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -21,6 +21,35 @@
       "type": "blank",
       "grains": [
         {
+          "id": "0115b2d7-83a4-4ee3-acff-7198f5172853",
+          "type": "discovery",
+          "title": "Embed Auto",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "54d93d01-03f5-4297-b89c-6ea57b444f54",
+                "type": "text",
+                "content": "<p>Embed Auto</p>",
+                "tag": " "
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8d7d05d6-3d48-4acc-b8d6-51042dc27bda",
+                "type": "embed",
+                "isCompletionRequired": true,
+                "title": "Embed Auto",
+                "url": "https://epreuves.pix.fr/fr/ui-kit/qcm-qcu-select/example-qcm.html",
+                "instruction": "<p>Sélectionnez un élément et validez votre choix, le bouton 'Continuer' va apparaître.</p><br>",
+                "solution": "",
+                "height": 0
+              }
+            }
+          ]
+        },
+        {
           "id": "b3ac67ab-9ff8-4a30-86b0-9fa8a2c57c1b",
           "type": "discovery",
           "title": "analyse-mails-phishing",

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -126,6 +126,7 @@ export default class ModulixEmbed extends ModuleElement {
       this.reportInfo = {
         answer: message.state,
         elementId: this.args.embed.id,
+        type: this.args.embed.type,
       };
 
       this.args.onAnswer({
@@ -150,6 +151,7 @@ export default class ModulixEmbed extends ModuleElement {
     this.reportInfo = {
       answer: message.answer,
       elementId: this.args.embed.id,
+      type: this.args.embed.type,
     };
 
     this.args.onAnswer({

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -121,6 +121,29 @@ export default class ModulixEmbed extends ModuleElement {
     }
 
     if (!this.args.embed.isCompletionRequired) return;
+
+    if (message.type === 'terminate') {
+      this.reportInfo = {
+        answer: message.state,
+        elementId: this.args.embed.id,
+      };
+
+      this.args.onAnswer({
+        userResponse: [message.state],
+        element: this.args.embed,
+      });
+
+      this.passageEvents.record({
+        type: 'EMBED_ANSWERED',
+        data: {
+          answer: message.state,
+          elementId: this.args.embed.id,
+          status: message.state === 'error' ? 'ko' : 'ok',
+        },
+      });
+      return;
+    }
+
     if (message.type) return;
     if (!message.answer) return;
 

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -529,6 +529,49 @@ module('Integration | Component | Module | Embed', function (hooks) {
     });
   });
 
+  module('when embed sends a terminate message', function () {
+    test('should call onAnswer with message state', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'Simulateur',
+        isCompletionRequired: true,
+        url: 'https://example.org',
+        height: 800,
+      };
+      const passageId = '5729837548';
+      const onAnswerStub = sinon.stub();
+      const screen = await render(
+        <template><ModulixEmbed @embed={{embed}} @passageId={{passageId}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+
+      // when
+      const iframe = screen.getByTitle('Simulateur');
+      const event = new MessageEvent('message', {
+        data: { type: 'terminate', from: 'pix', state: 'success' },
+        origin: 'https://epreuves.pix.fr',
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(event);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // then
+      sinon.assert.calledWith(onAnswerStub, {
+        userResponse: ['success'],
+        element: embed,
+      });
+      sinon.assert.calledWith(passageEventRecordStub, {
+        type: 'EMBED_ANSWERED',
+        data: {
+          answer: 'success',
+          elementId: embed.id,
+          status: 'ok',
+        },
+      });
+      assert.ok(true);
+    });
+  });
+
   module('when user clicks on reset button', function () {
     test('should focus on the iframe', async function (assert) {
       // given


### PR DESCRIPTION
## ☀️ Problème

Les embeds envoient un nouveau type de message `terminate`, qui n'est pas encore géré côté Modulix. Le bouton "Continuer" doit s'afficher à sa réception.

## ⛱️ Proposition

Gérer l'évènement, en gardant le code déjà existant pour la rétrocompatibilité.

## 🏊 Pour tester

- Se rendre sur le module [`demo-epreuves-components`](https://app-pr17160.review.pix.fr/modules/0aefd71f/demo-epreuves-components/passage).
- Constater que le bouton "Continuer" n'est pas visible.
- Cliquer sur le bouton "Commencer" et répondre au QCM.
- Constater que le bouton "Continuer" est désormais visible.