### PR TITLE
[BUGFIX] Empêcher un candidat sur .org d'accéder à un test Pix+ (PIX-23917).

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
+++ b/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
@@ -9,7 +9,7 @@ import {
   UserAlreadyLinkedToCandidateInSessionError,
 } from '../../../../shared/domain/errors.js';
 import { CenterHabilitationError } from '../../../shared/domain/errors.js';
-import { SessionExpiredError } from '../errors.js';
+import { SessionExpiredError, WrongDomainExtensionForPixPlusError } from '../errors.js';
 
 /**
  * Candidate entry to a certification is a multi step process
@@ -19,6 +19,7 @@ import { SessionExpiredError } from '../errors.js';
  * @param {string} params.firstName
  * @param {string} params.lastName
  * @param {Date} params.birthdate
+ * @param {boolean} params.isFrenchDomainExtension
  * @param {Function} params.normalizeStringFnc
  * @returns {Promise<Candidate>}
  */
@@ -28,6 +29,7 @@ export async function registerCandidateParticipation({
   firstName,
   lastName,
   birthdate,
+  isFrenchDomainExtension,
   normalizeStringFnc,
   candidateRepository,
   centerRepository,
@@ -68,6 +70,8 @@ export async function registerCandidateParticipation({
     candidate,
     userId,
   });
+
+  checkFrenchDomainForPixPlus({ candidate, isFrenchDomainExtension });
 
   await checkIfUserIsCertifiable({ placementProfileService, userId });
 
@@ -143,6 +147,17 @@ async function checkAroundCertificationCenter({ centerRepository, userRepository
     if (!user.has({ organizationLearnerId: candidate.organizationLearnerId })) {
       throw new MatchingReconciledStudentNotFoundError();
     }
+  }
+}
+
+/**
+ * @param {object} params
+ * @param {Candidate} params.candidate
+ * @param {boolean} params.isFrenchDomainExtension
+ */
+function checkFrenchDomainForPixPlus({ candidate, isFrenchDomainExtension }) {
+  if (!candidate.hasCoreScopeSubscription() && !isFrenchDomainExtension) {
+    throw new WrongDomainExtensionForPixPlusError();
   }
 }
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { SessionExpiredError } from '../../../../../../src/certification/enrolment/domain/errors.js';
+import {
+  SessionExpiredError,
+  WrongDomainExtensionForPixPlusError,
+} from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { registerCandidateParticipation } from '../../../../../../src/certification/enrolment/domain/usecases/register-candidate-participation.js';
 import { CenterHabilitationError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
@@ -346,6 +349,112 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
     });
 
     expect(error).to.be.instanceOf(CenterHabilitationError);
+  });
+
+  it('throws WrongDomainExtensionForPixPlusError when candidate subscribed to a pixplus certif and is not on the french domain', async function () {
+    const firstName = 'Brice';
+    const lastName = 'Wine';
+    const birthdate = '2000-03-23';
+    const user = domainBuilder.certification.enrolment.buildUser();
+
+    const sessionAuthorization = domainBuilder.certification.enrolment
+      .sessionAuthorizationBuilder()
+      .withParameters({ id: sessionId })
+      .build();
+    sessionAuthorizationAdapter.find.resolves(sessionAuthorization);
+
+    const candidateBuilder = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .withIdentity({
+        firstName,
+        lastName,
+        birthdate,
+      })
+      .withSubscription(Frameworks.DROIT)
+      .withParameters({
+        sessionId,
+      });
+    const session = domainBuilder.certification.enrolment
+      .sessionEnrolmentBuilder()
+      .withParameters({ id: sessionId })
+      .addCandidatesBuilders([candidateBuilder])
+      .build();
+    sessionRepository.get.resolves(session);
+    const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
+    const certificationCenter = domainBuilder.certification.enrolment.buildCenter({
+      habilitations: [{ key: Frameworks.DROIT }],
+      matchingOrganization: organization,
+    });
+    centerRepository.getById.resolves(certificationCenter);
+    userRepository.get.resolves(user);
+
+    const error = await catchErr(registerCandidateParticipation)({
+      firstName,
+      birthdate,
+      lastName,
+      userId: user.id,
+      sessionId,
+      isFrenchDomainExtension: false,
+      ...dependencies,
+    });
+
+    expect(error).to.be.instanceOf(WrongDomainExtensionForPixPlusError);
+    sinon.assert.notCalled(candidateRepository.update);
+    sinon.assert.notCalled(eventAdapter.onCandidateReconciled);
+  });
+
+  it('reconciles a candidate subscribed to a pixplus certif when on the french domain', async function () {
+    const firstName = 'Brice';
+    const lastName = 'Wine';
+    const birthdate = '2000-03-23';
+    const user = domainBuilder.certification.enrolment.buildUser();
+
+    const sessionAuthorization = domainBuilder.certification.enrolment
+      .sessionAuthorizationBuilder()
+      .withParameters({ id: sessionId })
+      .build();
+    sessionAuthorizationAdapter.find.resolves(sessionAuthorization);
+
+    const candidateBuilder = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .withIdentity({
+        firstName,
+        lastName,
+        birthdate,
+      })
+      .withSubscription(Frameworks.DROIT)
+      .withParameters({
+        sessionId,
+      });
+    const session = domainBuilder.certification.enrolment
+      .sessionEnrolmentBuilder()
+      .withParameters({ id: sessionId })
+      .addCandidatesBuilders([candidateBuilder])
+      .build();
+    sessionRepository.get.resolves(session);
+    const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
+    const certificationCenter = domainBuilder.certification.enrolment.buildCenter({
+      habilitations: [{ key: Frameworks.DROIT }],
+      matchingOrganization: organization,
+    });
+    const placementProfile = domainBuilder.buildPlacementProfile.buildCertifiable({ userId: user.id });
+    centerRepository.getById.resolves(certificationCenter);
+    userRepository.get.resolves(user);
+    placementProfileService.getPlacementProfile.resolves(placementProfile);
+
+    const reconciledCandidate = await registerCandidateParticipation({
+      firstName,
+      birthdate,
+      lastName,
+      userId: user.id,
+      sessionId,
+      isFrenchDomainExtension: true,
+      ...dependencies,
+    });
+
+    expect(reconciledCandidate).to.deep.equal(
+      candidateBuilder.asReconciled({ at: new Date(), userId: user.id }).build(),
+    );
   });
 
   it('throws MatchingReconciledStudentNotFoundError when center is managing student and candidate orgaLearnerId doesnt match user orgaLearnerIds', async function () {


### PR DESCRIPTION
## ☀️ Problème

Une régression permettant à un candidat d'accéder à un test Pix+ (uniquement disponible en français) sur le domaine `.org` a été trouvée (modification faite dans : #17053 )

## ⛱️ Proposition

Ré-ajouter le check du domaine

## 🧴 Remarques

Je manque d'infos sur pourquoi ce check a été signalé comme étant `irrelevant here` dans la PR d'origine. 🤔 

## 🏊 Pour tester

- Inscrire un candidat en Pix+
- Essayer de rentrer en certification sur le domaine `.org`
- Constater que cela n'est plus possible