### PR TITLE
[FEATURE] Ajouter un placeholder par défaut pour les blocs Select des QROCM (PIX-23818)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -44,6 +44,10 @@ function convertString(joiStringDescribedSchema) {
     jsonSchema.options = { infoText: joiStringDescribedSchema.flags['description'] };
   }
 
+  if (hasFlag(joiStringDescribedSchema.flags, 'default')) {
+    jsonSchema.default = joiStringDescribedSchema.flags['default'];
+  }
+
   const emailRule = findRule(rules, 'email');
   if (emailRule !== undefined) {
     jsonSchema.format = 'email';

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
@@ -373,7 +373,7 @@
                     "input": "0",
                     "type": "select",
                     "display": "inline",
-                    "placeholder": "",
+                    "placeholder": "- Sélectionner -",
                     "ariaLabel": "choisir le mot dans le menu déroulant",
                     "tolerances": [],
                     "options": [
@@ -400,7 +400,7 @@
                     "input": "1",
                     "type": "select",
                     "display": "inline",
-                    "placeholder": "",
+                    "placeholder": "- Sélectionner -",
                     "ariaLabel": "choisir le mot dans le menu déroulant",
                     "tolerances": [],
                     "options": [
@@ -427,7 +427,7 @@
                     "input": "2",
                     "type": "select",
                     "display": "inline",
-                    "placeholder": "",
+                    "placeholder": "- Sélectionner -",
                     "ariaLabel": "choisir le mot dans le menu déroulant",
                     "tolerances": [],
                     "options": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
@@ -67,6 +67,7 @@ const blockSelectSchema = Joi.object({
   placeholder: htmlNotAllowedSchema
     .allow('')
     .required()
+    .default('- Sélectionner -')
     .description("Texte de substitution qui s'affiche dans le champ lorsqu’aucune option n'est sélectionnée."),
   ariaLabel: htmlNotAllowedSchema
     .required()

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -26,6 +26,12 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       expect(jsonSchema).to.deep.equal({ type: 'string', format: null, options: null });
     });
 
+    it('should convert Joi.string.default to JSON Schema with default', function () {
+      const joiSchema = Joi.string().default('courgette');
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, default: 'courgette', options: null });
+    });
+
     it('should convert Joi.string.min to JSON Schema with minLength', function () {
       const joiSchema = Joi.string().min(8);
       const jsonSchema = convertJoiToJsonSchema(joiSchema);


### PR DESCRIPTION
## ☀️ Problème

On voudrait ajouter un placeholder par défaut sur les QROCM avec un bloc `select`.

## ⛱️ Proposition

Le faire en mettant '- Sélectionner -' dans le schéma Joi.

## 🧴 Remarques

- Les modules avec un QROCM qui ont un placeholder vide ont été mis à jour.
- le script `convertJoiToJsonSchema` a été mis à jour pouvoir géré les valeurs par défauts sur le type string. À voir s'il faut le faire aussi sur les autres types.

## 🏊 Pour tester
- Lancer Modulix Editor et Pix API en local
- Ajouter un bloc qrocm
- Constater que le placeholder a bien la valeur `- Sélectionner -`