### PR TITLE
[BUGFIX] Erreur 500 lors d'une réconciliation déjà effectuée avec la même adresse email (PIX-23921).

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
+++ b/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
@@ -61,6 +61,12 @@ export async function registerCandidateParticipation({
     return candidate;
   }
 
+  if (session.hasReconciledCandidateTo({ userId })) {
+    throw new UserAlreadyLinkedToCandidateInSessionError(
+      'The user is already linked to a candidate with different personal info in the given session',
+    );
+  }
+
   await checkAroundCertificationCenter({
     centerRepository,
     userRepository,

--- a/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
+++ b/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
@@ -64,6 +64,7 @@ export async function registerCandidateParticipation({
   if (session.hasReconciledCandidateTo({ userId })) {
     throw new UserAlreadyLinkedToCandidateInSessionError(
       'The user is already linked to a candidate with different personal info in the given session',
+      'USER_ALREADY_LINKED_TO_CANDIDATE_IN_SESSION',
     );
   }
 

--- a/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
+++ b/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
@@ -6,6 +6,7 @@ import {
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   MatchingReconciledStudentNotFoundError,
+  UnexpectedUserAccountError,
   UserAlreadyLinkedToCandidateInSessionError,
 } from '../../../../shared/domain/errors.js';
 import { CenterHabilitationError } from '../../../shared/domain/errors.js';
@@ -64,7 +65,6 @@ export async function registerCandidateParticipation({
   if (session.hasReconciledCandidateTo({ userId })) {
     throw new UserAlreadyLinkedToCandidateInSessionError(
       'The user is already linked to a candidate with different personal info in the given session',
-      'USER_ALREADY_LINKED_TO_CANDIDATE_IN_SESSION',
     );
   }
 
@@ -101,7 +101,7 @@ async function checkAndGetCandidateFromSession({
   });
 
   if (candidate.userId && candidate.userId !== userId) {
-    throw new UserAlreadyLinkedToCandidateInSessionError();
+    throw new UnexpectedUserAccountError({});
   }
 
   return candidate;

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -451,8 +451,8 @@ class UserAlreadyExistsWithAuthenticationMethodError extends DomainError {
 }
 
 class UserAlreadyLinkedToCandidateInSessionError extends DomainError {
-  constructor(message = 'Cet utilisateur est déjà lié à un candidat de certification au sein de cette session.') {
-    super(message);
+  constructor(message = 'Cet utilisateur est déjà lié à un candidat de certification au sein de cette session.', code) {
+    super(message, code);
   }
 }
 

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -451,8 +451,9 @@ class UserAlreadyExistsWithAuthenticationMethodError extends DomainError {
 }
 
 class UserAlreadyLinkedToCandidateInSessionError extends DomainError {
-  constructor(message = 'Cet utilisateur est déjà lié à un candidat de certification au sein de cette session.', code) {
-    super(message, code);
+  constructor(message = 'Cet utilisateur est déjà lié à un candidat de certification au sein de cette session.') {
+    super(message);
+    this.code = 'USER_ALREADY_LINKED_TO_CANDIDATE_IN_SESSION';
   }
 }
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -10,6 +10,7 @@ import {
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   MatchingReconciledStudentNotFoundError,
+  UnexpectedUserAccountError,
   UserAlreadyLinkedToCandidateInSessionError,
 } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -111,7 +112,7 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
     expect(error).to.be.instanceOf(SessionExpiredError);
   });
 
-  it('throws UserAlreadyLinkedToCandidateInSessionError when given user is already reconciled to an other candidate than matching', async function () {
+  it('throws UnexpectedUserAccountError when the matching candidate is already reconciled to an other user', async function () {
     const sessionAuthorization = domainBuilder.certification.enrolment
       .sessionAuthorizationBuilder()
       .withParameters({ id: sessionId })
@@ -131,23 +132,10 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
       .withParameters({
         sessionId,
       });
-    const alreadyReconciledCandidateBuilder = domainBuilder.certification.enrolment
-      .candidateBuilder()
-      .asReconciled({
-        userId: 123,
-      })
-      .withIdentity({
-        firstName: 'Tony',
-        lastName: 'Stark',
-        birthdate: '1994-07-18',
-      })
-      .withParameters({
-        sessionId,
-      });
     const session = domainBuilder.certification.enrolment
       .sessionEnrolmentBuilder()
       .withParameters({ id: sessionId })
-      .addCandidatesBuilders([matchingCandidateBuilder, alreadyReconciledCandidateBuilder])
+      .addCandidatesBuilders([matchingCandidateBuilder])
       .build();
     sessionRepository.get.resolves(session);
 
@@ -160,7 +148,9 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
       ...dependencies,
     });
 
-    expect(error).to.be.instanceOf(UserAlreadyLinkedToCandidateInSessionError);
+    expect(error).to.be.instanceOf(UnexpectedUserAccountError);
+    expect(error.code).to.equal('UNEXPECTED_USER_ACCOUNT');
+    expect(candidateRepository.update).to.not.have.been.called;
   });
 
   it('throws UserAlreadyLinkedToCandidateInSessionError when given user is already reconciled to an other candidate of the session', async function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -163,6 +163,56 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
     expect(error).to.be.instanceOf(UserAlreadyLinkedToCandidateInSessionError);
   });
 
+  it('throws UserAlreadyLinkedToCandidateInSessionError when given user is already reconciled to an other candidate of the session', async function () {
+    const sessionAuthorization = domainBuilder.certification.enrolment
+      .sessionAuthorizationBuilder()
+      .withParameters({ id: sessionId })
+      .build();
+    sessionAuthorizationAdapter.find.resolves(sessionAuthorization);
+
+    const matchingCandidateBuilder = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .withIdentity({
+        firstName: 'Brice',
+        lastName: 'Wine',
+        birthdate: '2000-03-23',
+      })
+      .withParameters({
+        sessionId,
+      });
+    const candidateAlreadyReconciledToUserBuilder = domainBuilder.certification.enrolment
+      .candidateBuilder()
+      .asReconciled({
+        userId: 123,
+      })
+      .withIdentity({
+        firstName: 'Tony',
+        lastName: 'Stark',
+        birthdate: '1994-07-18',
+      })
+      .withParameters({
+        sessionId,
+      });
+    const session = domainBuilder.certification.enrolment
+      .sessionEnrolmentBuilder()
+      .withParameters({ id: sessionId })
+      .addCandidatesBuilders([matchingCandidateBuilder, candidateAlreadyReconciledToUserBuilder])
+      .build();
+    sessionRepository.get.resolves(session);
+
+    const error = await catchErr(registerCandidateParticipation)({
+      firstName: 'Brice',
+      lastName: 'Wine',
+      birthdate: '2000-03-23',
+      userId: 123,
+      sessionId,
+      ...dependencies,
+    });
+
+    expect(error).to.be.instanceOf(UserAlreadyLinkedToCandidateInSessionError);
+    expect(candidateRepository.update).to.not.have.been.called;
+  });
+
   it('throws CertificationCandidateByPersonalInfoNotFoundError when given user personnal infos not matching', async function () {
     const userId = domainBuilder.certification.enrolment.buildUser().id;
     const sessionAuthorization = domainBuilder.certification.enrolment

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -210,6 +210,7 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
     });
 
     expect(error).to.be.instanceOf(UserAlreadyLinkedToCandidateInSessionError);
+    expect(error.code).to.equal('USER_ALREADY_LINKED_TO_CANDIDATE_IN_SESSION');
     expect(candidateRepository.update).to.not.have.been.called;
   });
 

--- a/mon-pix/app/components/certification-joiner.gjs
+++ b/mon-pix/app/components/certification-joiner.gjs
@@ -328,6 +328,14 @@ const ERROR_HANDLERS = [
     },
   },
   {
+    match: (error) => error.status === '403' && error.code === 'USER_ALREADY_LINKED_TO_CANDIDATE_IN_SESSION',
+    handle(component) {
+      component.errorMessage = component.intl.t(
+        'pages.certification-joiner.error-messages.account-already-linked-to-another-candidate',
+      );
+    },
+  },
+  {
     match: (error) => error.status === '409' && error.code === 'SESSION_EXPIRED_ERROR',
     handle(component) {
       component.errorMessage = component.intl.t('pages.certification-joiner.error-messages.session-not-joinable');

--- a/mon-pix/tests/integration/components/certification-joiner-test.gjs
+++ b/mon-pix/tests/integration/components/certification-joiner-test.gjs
@@ -178,6 +178,38 @@ module('Integration | Component | certification-joiner', function (hooks) {
       );
     });
 
+    test('should display an error message when the account is already linked to another candidate of the session', async function (assert) {
+      // given
+      const onStepChange = sinon.stub();
+      const screen = await render(<template><CertificationJoiner @onStepChange={{onStepChange}} /></template>);
+
+      await _fillInputsToJoinSession({ screen, t });
+
+      const store = this.owner.lookup('service:store');
+      const saveStub = sinon.stub();
+      saveStub.withArgs({ adapterOptions: { joinSession: true, sessionId: '123456' } }).throws({
+        errors: [
+          {
+            status: '403',
+            code: 'USER_ALREADY_LINKED_TO_CANDIDATE_IN_SESSION',
+          },
+        ],
+      });
+      const createRecordMock = sinon.mock();
+      createRecordMock.returns({ save: saveStub, deleteRecord: function () {} });
+      store.createRecord = createRecordMock;
+
+      // when
+      await click(screen.getByRole('button', { name: t('pages.certification-joiner.form.actions.submit') }));
+
+      // then
+      assert.ok(
+        screen.getByText(
+          "Le compte avec lequel vous êtes connecté(e) est déjà rattaché à un(e) autre candidat(e) de cette session. Vérifiez que vous êtes connecté(e) à votre propre compte Pix ou demandez de l'aide au surveillant.",
+        ),
+      );
+    });
+
     test('should display an error message on candidate not found', async function (assert) {
       // given
       const onStepChange = sinon.stub();

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -882,6 +882,7 @@
         "message": "Bravo {fullName}, dein Pix-Profil kann zertifiziert werden."
       },
       "error-messages": {
+        "account-already-linked-to-another-candidate": "Das Konto, mit dem du angemeldet bist, ist bereits mit einem/einer anderen Kandidaten/Kandidatin dieser Testung verknüpft. Vergewissere dich, dass du mit deinem eigenen Pix-Konto angemeldet bist, oder bitte die Aufsichtsperson um Hilfe.",
         "generic": {
           "check-personal-info": "Überprüfe bei der Aufsichtsperson, ob deine persönlichen Informationen mit dem Anmeldungsblatt übereinstimmen.",
           "check-session-number": "Überprüfe die Sitzungsnummer.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -882,6 +882,7 @@
         "message": "Well done, {fullName}, your Pix profile can now be certified."
       },
       "error-messages": {
+        "account-already-linked-to-another-candidate": "The account you are logged in with is already linked to another candidate in this session. Please check that you are logged into your own Pix account or ask the invigilator for help.",
         "generic": {
           "check-personal-info": "Check with the invigilator that your personal information matches the sign-in sheet.",
           "check-session-number": "Check the session number.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -882,6 +882,7 @@
         "message": "Enhorabuena {fullName}, tu perfil Pix se puede certificar."
       },
       "error-messages": {
+        "account-already-linked-to-another-candidate": "La cuenta con la que te has conectado ya está vinculada a otro candidato de esta sesión. Comprueba que te has conectado con tu propia cuenta Pix o pide ayuda al supervisor.",
         "generic": {
           "check-personal-info": "Comprueba con el supervisor que tus datos personales coinciden con los de la hoja de registro.",
           "check-session-number": "Comprueba el número de sesión.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -882,6 +882,7 @@
         "message": "Bravo {fullName}, votre profil Pix est certifiable."
       },
       "error-messages": {
+        "account-already-linked-to-another-candidate": "Le compte avec lequel vous êtes connecté(e) est déjà rattaché à un(e) autre candidat(e) de cette session. Vérifiez que vous êtes connecté(e) à votre propre compte Pix ou demandez de l'aide au surveillant.",
         "generic": {
           "check-personal-info": "Vérifiez auprès du surveillant la correspondance de vos informations personnelles avec la feuille d'émargement.",
           "check-session-number": "Vérifiez le numéro de session.",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -882,6 +882,7 @@
         "message": "Congratulazioni {fullName}, il tuo profilo Pix è certificabile."
       },
       "error-messages": {
+        "account-already-linked-to-another-candidate": "L'account con cui hai effettuato l'accesso è già collegato a un altro candidato di questa sessione. Verifica di aver effettuato l'accesso con il tuo account Pix o chiedi aiuto al tuo sorvegliante.",
         "generic": {
           "check-personal-info": "Verificare con il sorvegliante che i propri dati personali corrispondano a quelli riportati sul foglio di registrazione.",
           "check-session-number": "Controlla il numero della sessione.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -882,6 +882,7 @@
         "message": "Gefeliciteerd {fullName}, je Pix-profiel is certificeerbaar."
       },
       "error-messages": {
+        "account-already-linked-to-another-candidate": "Het account waarmee u bent ingelogd, is al gekoppeld aan een andere kandidaat van deze sessie. Controleer of u bent ingelogd met uw eigen Pix-account of vraag de toezichthouder om hulp.",
         "generic": {
           "check-personal-info": "Controleer bij de toezichthouder of je persoonlijke gegevens overeenkomen met die op het inschrijfformulier.",
           "check-session-number": "Controleer het sessienummer.",


### PR DESCRIPTION
## ☀️ Problème

Dans le cas où un candidat essaie de se réconcilier avec l’adresse email d’un autre candidat s'étant déjà réconcilié, une erreur 500 apparait.
Cela n'était pas le cas auparavant et une régression est apparue.
(Suppression dans [ce commit](https://github.com/1024pix/pix/pull/17009/changes/df46ae74ef12746b2e8e77623bca155298b5f726))

## ⛱️ Proposition

On remet le check

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- Se réconcilier à un test de certification avec un candidat
- Tenter de se réconcilier avec la même adresse et les identifiants d'un autre candidat
