### PR TITLE
[FEATURE] Ajouter le feature toggle newPixCertifLegalDocumentsVersioning (PIX-22440)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -130,4 +130,11 @@ export default {
     defaultValue: false,
     tags: ['backend', 'pix-api'],
   },
+  newPixCertifLegalDocumentsVersioning: {
+    type: 'boolean',
+    description: 'Enable new Pix Certif legal documents versioning for pix',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: false },
+    tags: ['team-acces', 'pix-api', 'backend'],
+  },
 };


### PR DESCRIPTION
## ☀️ Problème
Nous avons besoin d'un feature toggle pour pouvoir mettre en place le nouveau système de lecture et écriture des acceptations de CGU sur Pix Certif.

## ⛱️ Proposition
Ajouter le feature toggle dans l'API.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
En local, exécuter la commande npm run toggles -- --key=newPixCertifLegalDocumentsVersioning --value=true
Vérifier, avec la commande npm run toggles --list que le feature toggle est bien passé à true.
