### PR TITLE
[BUGFIX] Corriger la réinitialisation d'un embed sur les modules (PIX-23201)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/31_StructurerTexte_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/31_StructurerTexte_NOV.json
@@ -289,7 +289,7 @@
                 "id": "ccc324a5-a1d3-4cfa-abe9-5a33baee133a",
                 "type": "text",
                 "tag": " ",
-                "content": "<p>Mina veut commencer à recopier le début de son discours.</p><p><strong>Dans le logiciel de traitement de texte ci-dessous, écrivez de début de la phrase suivante&nbsp;:</strong></p>"
+                "content": "<p>Mina veut commencer à recopier le début de son discours.</p><p><strong>Dans le logiciel de traitement de texte ci-dessous, écrivez le début de la phrase suivante&nbsp;:</strong></p>"
               }
             },
             {

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -56,8 +56,23 @@ export default class ModulixEmbed extends ModuleElement {
 
   @action
   resetEmbed() {
-    this.iframe.setAttribute('src', this.args.embed.url);
-    this.iframe.focus();
+    const tmpSrc = this.iframe.src;
+
+    const loadListener = () => {
+      const isFirstOnLoad = this.iframe.src === 'about:blank';
+      if (isFirstOnLoad) {
+        // First onload: when we reset the iframe
+        this.iframe.setAttribute('src', tmpSrc);
+      } else {
+        // Second onload: when we re-assign the iframe's src to its original value
+        this.iframe.focus();
+        this.iframe.removeEventListener('load', loadListener);
+      }
+    };
+
+    this.iframe.addEventListener('load', loadListener);
+
+    this.iframe.setAttribute('src', 'about:blank');
 
     this.passageEvents.record({
       type: 'EMBED_RETRIED',

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -534,7 +534,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
       // given
       const embed = {
         id: 'id',
-        title: 'title',
+        title: 'embed title',
         isCompletionRequired: false,
         url: 'https://example.org',
         height: 800,
@@ -544,6 +544,9 @@ module('Integration | Component | Module | Embed', function (hooks) {
       // when
       await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
       await clickByName(t('pages.modulix.buttons.interactive-element.reset.ariaLabel'));
+
+      // WORKAROUND: waiting for load event to finished
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
       const iframe = screen.getByTitle(embed.title);


### PR DESCRIPTION
## ☀️ Problème

La réinitialisation d'un embed dans un module ne fonctionne pas tout le temps. Cela ne marche pas lorsque l'url du simulateur comporte un `#` ([source](https://stackoverflow.com/questions/86428/what-s-the-best-way-to-reload-refresh-an-iframe#comment45503349_4062084)).

## ⛱️ Proposition

Changer l'implémentation en :
- utilisant une autre d'url d'une page rapide à charger.
- remettant l'url du simulateur en cours.

On réutilise la solution faite côté junior sur cette PR : https://github.com/1024pix/pix/pull/10784.

## 🧴 Remarques

RAS

## 🏊 Pour tester
- Aller sur le module [Prendre en main un traitement de texte](https://app-pr17170.review.pix.fr/modules/8baec56e/prendre-en-main-traitement-texte/passage)
- Vérifier que la réinitialisation des simulateurs fonctionne bien : 
  - Au niveau de la 2ème activité
  <img width="833" height="508" alt="Capture d’écran 2026-08-19 à 17 02 21" src="https://github.com/user-attachments/assets/01497036-6ed9-496a-b02a-1bb8e1fc8fe7" />
  - Au niveau de la 3ème activité 
  <img width="826" height="593" alt="Capture d’écran 2026-08-19 à 17 03 23" src="https://github.com/user-attachments/assets/1a624749-80ec-447f-a8c4-65221c83c38b" />
  - Au niveau du stepper horizontal
  - <img width="806" height="506" alt="Capture d’écran 2026-08-19 à 17 04 15" src="https://github.com/user-attachments/assets/a398504e-ee8e-41d4-98c5-d482ac7f6ee3" />
 
