### PR TITLE
[TECH] Ne plus utiliser PixBackgroundHeader dans la page de code session (PIX-23928).

### DIFF
--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -1,3 +1,4 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixCode from '@1024pix/pix-ui/components/pix-code';
@@ -180,7 +181,7 @@ export default class CertificationStarter extends Component {
   }
 
   <template>
-    <section class="certification-starter">
+    <PixBlock @shadow="heavy">
       <h1 class="certification-start-page__title">{{t "pages.certification-start.first-title"}}</h1>
 
       {{#if @model.certificationCandidate.isRegisteredToDoubleCertification}}
@@ -282,6 +283,6 @@ export default class CertificationStarter extends Component {
             }}</a>.
         </p>
       </div>
-    </section>
+    </PixBlock>
   </template>
 }

--- a/mon-pix/app/components/certifications/start.gjs
+++ b/mon-pix/app/components/certifications/start.gjs
@@ -1,17 +1,10 @@
-import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-
 import CertificationStarter from '../certification-starter';
 import CompanionBlocker from '../companion/blocker';
 
 <template>
   <CompanionBlocker>
-    <main class="main" role="main">
-      <PixBackgroundHeader id="main" class="certification-start-page__header">
-        <PixBlock @shadow="heavy" class="certification-start-page__block">
-          <CertificationStarter @model={{@model}} />
-        </PixBlock>
-      </PixBackgroundHeader>
+    <main class="certification-start-page" role="main">
+      <CertificationStarter @model={{@model}} />
     </main>
   </CompanionBlocker>
 </template>

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -1,4 +1,14 @@
+@use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
+
+.certification-join-page__block {
+  margin: var(--pix-spacing-3x) 0;
+  padding: var(--pix-spacing-4x) var(--pix-spacing-4x) var(--pix-spacing-12x) var(--pix-spacing-4x);
+
+  @include breakpoints.device-is('tablet') {
+    margin: var(--pix-spacing-6x) 0;
+  }
+}
 
 .certification-joiner {
   margin: var(--pix-spacing-8x) 0;

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -1,43 +1,35 @@
-/* stylelint-disable declaration-colon-newline-after */
-/* stylelint-disable function-parentheses-newline-inside */
-/* stylelint-disable no-descending-specificity */
 @use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 @use 'pix-design-tokens/fonts';
-@use 'pix-design-tokens/colors';
-
-.certification-starter {
-  @include breakpoints.device-is('desktop') {
-    padding: 50px 70px 40px;
-  }
-}
 
 .certification-start-page {
-  &__header .pix-background-header__background {
-    background: colors.$pix-primary-certif-gradient;
+  display: grid;
+  align-items: center;
+  max-width: 880px;
+  min-height: 100%;
+  margin: 0 auto;
+  padding-block: var(--pix-spacing-8x);
+
+  @include breakpoints.device-is('mobile') {
+    margin: var(--pix-spacing-4x);
   }
 
-  &__block {
-    margin: var(--pix-spacing-3x) 0;
-    padding: var(--pix-spacing-4x) var(--pix-spacing-4x) var(--pix-spacing-12x) var(--pix-spacing-4x);
-
-    @include breakpoints.device-is('tablet') {
-      margin: var(--pix-spacing-6x) 0;
-    }
-  }
+  @include breakpoints.device-is('tablet') {
+    margin-top: calc(var(--pix-app-layout-top) * -1);
+ }
 
   &__information {
+    @extend %pix-body-s;
+
     margin-top: var(--pix-spacing-3x);
     text-align: center;
-
-    @extend %pix-body-s;
   }
 
   &__title {
-    margin-bottom: var(--pix-spacing-6x);
-    text-align: center;
-
     @extend %pix-title-m;
+
+    margin-block: var(--pix-spacing-6x);
+    text-align: center;
 
     @include breakpoints.device-is('tablet') {
       margin-bottom: var(--pix-spacing-10x);
@@ -63,12 +55,12 @@
     &-items {
       &__eligible,
       &__non-eligible {
+        @extend %pix-body-s;
+
         display: flex;
         gap: var(--pix-spacing-1x);
         align-items: center;
         font-weight: 500;
-
-        @extend %pix-body-s;
       }
 
       &__eligible-icon {
@@ -90,11 +82,11 @@
 }
 
 .certification-start-page__cgu {
-  margin: var(--pix-spacing-2x) var(--pix-spacing-10x);
+  @extend %pix-body-xs;
+
+  margin-block: var(--pix-spacing-2x) var(--pix-spacing-6x);
   line-height: 18px;
   text-align: justify;
-
-  @extend %pix-body-xs;
 }
 
 .certification-start__form {
@@ -121,7 +113,7 @@
 }
 
 .certification-start-form__code {
-  padding-top: var(--pix-spacing-6x);
+  padding-top: var(--pix-spacing-4x);
 
   .label {
     margin-bottom: var(--pix-spacing-3x);

--- a/mon-pix/app/styles/components/llm/preview.scss
+++ b/mon-pix/app/styles/components/llm/preview.scss
@@ -1,3 +1,9 @@
+@use 'pix-design-tokens/colors';
+
+.llm-preview__header .pix-background-header__background {
+  background: colors.$pix-primary-certif-gradient;
+}
+
 .llm-preview__iframe {
   width: 100%;
   height: 600px;

--- a/mon-pix/app/templates/authenticated/certifications/join.gjs
+++ b/mon-pix/app/templates/authenticated/certifications/join.gjs
@@ -10,7 +10,7 @@ import CertificationNotCertifiable from 'mon-pix/components/certification-not-ce
 
   <main id="main" class="global-page-container" role="main">
     {{#if @controller.model.isCertifiable}}
-      <PixBlock class="certification-start-page__block">
+      <PixBlock class="certification-join-page__block">
         <CertificationBanners
           @certificationEligibility={{@controller.model}}
           @fullName={{@controller.currentUser.user.fullName}}

--- a/mon-pix/app/templates/llm/preview.gjs
+++ b/mon-pix/app/templates/llm/preview.gjs
@@ -31,7 +31,7 @@ export default class LLMPreviewComponent extends Component {
     {{pageTitle (t "pages.llm-preview.title")}}
 
     <main class="main" role="main">
-      <PixBackgroundHeader id="main" class="certification-start-page__header">
+      <PixBackgroundHeader id="main" class="llm-preview__header">
         <PageTitle>
           <:title>{{t "pages.llm-preview.title"}}</:title>
         </PageTitle>


### PR DESCRIPTION
## ☀️ Problème

On ne veut plus utiliser le composant `PixBackgroundHeader` de PixUI, il est déprécié.

## ⛱️ Proposition

Modifier le style pour ne plus utiliser le composant dans `start.gjs`.

On en profite pour centrer le contenu dans la page, en dehors du format mobile.

## 🧴 Remarques

Pour ne pas avoir trop d'effets de bords, on remet les styles partagés au niveau de la page de réconciliation (`join.gjs`).

## 🏊 Pour tester

Vérifier que le style des pages de réconciliation et code de session est bon !