### PR TITLE
[TECH] Retirer PixBackgroundHeader de la page de fin de compétence sur Pix App (PIX-23924).

### DIFF
--- a/mon-pix/app/styles/pages/_competence-results.scss
+++ b/mon-pix/app/styles/pages/_competence-results.scss
@@ -2,6 +2,15 @@
 @use 'pix-design-tokens/typography';
 @use 'pix-design-tokens/fonts';
 
+.competence-results {
+  padding : 68px var(--pix-spacing-6x);
+
+  &__banner {
+    max-width: 980px;
+    margin: 0 auto;
+  }
+}
+
 .competence-results-panel-header {
   &__banner {
     display: flex;

--- a/mon-pix/app/templates/authenticated/competences/results.gjs
+++ b/mon-pix/app/templates/authenticated/competences/results.gjs
@@ -5,8 +5,8 @@ import ScorecardDetails from 'mon-pix/components/scorecard-details';
 <template>
   {{pageTitle (t "pages.competence-result.title")}}
 
-  <main id="main" role="main">
-    <PixBlock>
+  <main id="main" role="main" class="competence-results">
+    <PixBlock class="competence-results__banner">
       <div class="competence-results-panel__header">
         {{#if @model.scorecard.hasNotEarnedAnything}}
           <div class="competence-results-panel-header__banner competence-results-panel-header__banner--too-bad">

--- a/mon-pix/app/templates/authenticated/competences/results.gjs
+++ b/mon-pix/app/templates/authenticated/competences/results.gjs
@@ -1,4 +1,3 @@
-import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
@@ -7,64 +6,62 @@ import ScorecardDetails from 'mon-pix/components/scorecard-details';
   {{pageTitle (t "pages.competence-result.title")}}
 
   <main id="main" role="main">
-    <PixBackgroundHeader>
-      <PixBlock>
-        <div class="competence-results-panel__header">
-          {{#if @model.scorecard.hasNotEarnedAnything}}
-            <div class="competence-results-panel-header__banner competence-results-panel-header__banner--too-bad">
-              <p class="competence-results-panel-header__banner-result-comment">{{t
-                  "pages.competence-result.header.too-bad"
-                }}</p>
-              <div class="competence-results-banner__subtitle competence-results-banner__subtitle--small">
-                {{t "pages.competence-result.header.too-bad-subtitle"}}
+    <PixBlock>
+      <div class="competence-results-panel__header">
+        {{#if @model.scorecard.hasNotEarnedAnything}}
+          <div class="competence-results-panel-header__banner competence-results-panel-header__banner--too-bad">
+            <p class="competence-results-panel-header__banner-result-comment">{{t
+                "pages.competence-result.header.too-bad"
+              }}</p>
+            <div class="competence-results-banner__subtitle competence-results-banner__subtitle--small">
+              {{t "pages.competence-result.header.too-bad-subtitle"}}
+            </div>
+          </div>
+        {{else if @model.scorecard.hasNotReachedLevelOne}}
+          <div class="competence-results-panel-header__banner competence-results-panel-header__banner--not-bad">
+            <p class="competence-results-panel-header__banner-result-comment">{{t
+                "pages.competence-result.header.not-bad"
+              }}</p>
+            <div class="competence-results-banner__subtitle competence-results-banner__subtitle--left">
+              {{t "pages.competence-result.header.not-bad-subtitle"}}
+            </div>
+            <div class="competence-results-banner__text">
+              <div class="competence-results-banner-text__results">
+                <div class="competence-results-banner-text-results__label">{{t
+                    "pages.competence-result.header.you-have-earned"
+                  }}</div>
+                <div class="competence-results-banner-text-results__value">{{@model.scorecard.earnedPix}}
+                  {{t "common.pix"}}</div>
               </div>
             </div>
-          {{else if @model.scorecard.hasNotReachedLevelOne}}
-            <div class="competence-results-panel-header__banner competence-results-panel-header__banner--not-bad">
-              <p class="competence-results-panel-header__banner-result-comment">{{t
-                  "pages.competence-result.header.not-bad"
-                }}</p>
-              <div class="competence-results-banner__subtitle competence-results-banner__subtitle--left">
-                {{t "pages.competence-result.header.not-bad-subtitle"}}
+          </div>
+        {{else if @model.scorecard.hasReachedAtLeastLevelOne}}
+          <div class="competence-results-panel-header__banner competence-results-panel-header__banner--congrats">
+            <p class="competence-results-panel-header__banner-result-comment">{{t
+                "pages.competence-result.header.congratulations"
+              }}</p>
+            <div class="competence-results-banner__text competence-results-banner__text--spaced">
+              <div class="competence-results-banner-text__results competence-results-banner-text__results--spaced">
+                <div class="competence-results-banner-text-results__label">{{t
+                    "pages.competence-result.header.you-have-reached-level"
+                  }}</div>
+                <div class="competence-results-banner-text-results__value">{{t "common.level"}}
+                  {{@model.scorecard.level}}</div>
               </div>
-              <div class="competence-results-banner__text">
-                <div class="competence-results-banner-text__results">
-                  <div class="competence-results-banner-text-results__label">{{t
-                      "pages.competence-result.header.you-have-earned"
-                    }}</div>
-                  <div class="competence-results-banner-text-results__value">{{@model.scorecard.earnedPix}}
-                    {{t "common.pix"}}</div>
-                </div>
-              </div>
-            </div>
-          {{else if @model.scorecard.hasReachedAtLeastLevelOne}}
-            <div class="competence-results-panel-header__banner competence-results-panel-header__banner--congrats">
-              <p class="competence-results-panel-header__banner-result-comment">{{t
-                  "pages.competence-result.header.congratulations"
-                }}</p>
-              <div class="competence-results-banner__text competence-results-banner__text--spaced">
-                <div class="competence-results-banner-text__results competence-results-banner-text__results--spaced">
-                  <div class="competence-results-banner-text-results__label">{{t
-                      "pages.competence-result.header.you-have-reached-level"
-                    }}</div>
-                  <div class="competence-results-banner-text-results__value">{{t "common.level"}}
-                    {{@model.scorecard.level}}</div>
-                </div>
-                <div class="competence-results-banner-text__results competence-results-banner-text__results--spaced">
-                  <div class="competence-results-banner-text-results__label">{{t
-                      "pages.competence-result.header.you-have-earned"
-                    }}</div>
-                  <div class="competence-results-banner-text-results__value">{{@model.scorecard.earnedPix}}
-                    {{t "common.pix"}}</div>
-                </div>
+              <div class="competence-results-banner-text__results competence-results-banner-text__results--spaced">
+                <div class="competence-results-banner-text-results__label">{{t
+                    "pages.competence-result.header.you-have-earned"
+                  }}</div>
+                <div class="competence-results-banner-text-results__value">{{@model.scorecard.earnedPix}}
+                  {{t "common.pix"}}</div>
               </div>
             </div>
-          {{/if}}
-        </div>
-        {{#if @model.scorecard}}
-          <ScorecardDetails @scorecard={{@model.scorecard}} />
+          </div>
         {{/if}}
-      </PixBlock>
-    </PixBackgroundHeader>
+      </div>
+      {{#if @model.scorecard}}
+        <ScorecardDetails @scorecard={{@model.scorecard}} />
+      {{/if}}
+    </PixBlock>
   </main>
 </template>


### PR DESCRIPTION
## ☀️ Problème

PixBackgroundHeader est un composant Pix UI legacy que nous n'utilisons plus dans nos maquettes.

## ⛱️ Proposition

Le supprimer coté pas de competences sur Pix App.

<img width="1722" height="801" alt="Capture d’écran 2026-08-19 à 16 17 59" src="https://github.com/user-attachments/assets/256eea08-3450-47fc-b31a-0f2acf1fa360" />

## 🏊 Pour tester

Aller sur https://app-pr17173.review.pix.fr/competences/recsvLz0W2ShyfD63/resultats/156917


Comparer avec l'intégration pour voir que c'est comme avant (mais sans le **PixBackgroundHeader**) 
https://app.integration.pix.fr/competences/recsvLz0W2ShyfD63/resultats/156917