### PR TITLE
[TECH] Ne plus utiliser PixBackgroundHeader dans la page de téléchargement de résultat de session (PIX-23926).

### DIFF
--- a/mon-pix/app/components/download-session-results.gjs
+++ b/mon-pix/app/components/download-session-results.gjs
@@ -1,4 +1,3 @@
-import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
@@ -40,25 +39,29 @@ export default class DownloadSessionResults extends Component {
   }
 
   <template>
-    <PixBackgroundHeader id="main">
-      <PixBlock class="download-session-results">
-        <form class="download-session-results__form" autocomplete="off">
+    <PixBlock class="download-session-results">
+      <form class="download-session-results__form" autocomplete="off">
 
-          <h1 class="form__title">
-            {{t "pages.download-session-results.title"}}
-          </h1>
+        <h1 class="form__title">
+          {{t "pages.download-session-results.title"}}
+        </h1>
 
-          <PixButton @type="submit" @triggerAction={{this.downloadSessionResults}} @size="large" class="form__actions">
-            {{t "pages.download-session-results.button.label"}}
-          </PixButton>
+        <PixButton
+          @type="submit"
+          @triggerAction={{this.downloadSessionResults}}
+          @size="large"
+          @iconBefore="download"
+          class="form__actions"
+        >
+          {{t "pages.download-session-results.button.label"}}
+        </PixButton>
 
-          {{#if this.errorMessage}}
-            <PixNotificationAlert @type="error" class="form__error">
-              {{this.errorMessage}}
-            </PixNotificationAlert>
-          {{/if}}
-        </form>
-      </PixBlock>
-    </PixBackgroundHeader>
+        {{#if this.errorMessage}}
+          <PixNotificationAlert @type="error" class="form__error">
+            {{this.errorMessage}}
+          </PixNotificationAlert>
+        {{/if}}
+      </form>
+    </PixBlock>
   </template>
 }

--- a/mon-pix/app/styles/pages/_download-session-results.scss
+++ b/mon-pix/app/styles/pages/_download-session-results.scss
@@ -1,32 +1,24 @@
-@use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 
 .download-session-results {
   max-width: max-content;
-  margin: 0 auto 32px;
-  padding: 48px 24px;
+  margin: var(--pix-spacing-12x) auto var(--pix-spacing-8x);
+  padding: var(--pix-spacing-10x) 4vw;
+}
 
-  @include breakpoints.device-is('tablet') {
-    padding: 48px 60px;
+.download-session-results__form {
+  .form__title {
+    @extend %pix-title-m;
+
+    margin-bottom: var(--pix-spacing-4x);
+    text-align: center;
   }
 
-  &__form {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  .form__actions {
+    margin: var(--pix-spacing-8x) auto 0;
+  }
 
-    .form__title {
-      @extend %pix-title-m;
-
-      margin-bottom: var(--pix-spacing-4x);
-    }
-
-    .form__actions {
-      margin-top: var(--pix-spacing-6x);
-    }
-
-    .form__error {
-      margin-top: var(--pix-spacing-4x);
-    }
+  .form__error {
+    margin-top: var(--pix-spacing-4x);
   }
 }


### PR DESCRIPTION
## ☀️ Problème

On ne veut plus utiliser ce composant déprécié de PixUI.

## ⛱️ Proposition

Modifier le style pour ne plus utiliser le composant dans `download-session-results.gjs`.

## 🏊 Pour tester

Évaluer la [page modifiée en RA](https://app-pr17174.review.pix.org/resultats-session?locale=fr#eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2lkIjo3NDA5LCJzY29wZSI6ImNlcnRpZmljYXRpb25SZXN1bHRzTGluayIsImlhdCI6MTc4NzIxNjkwOSwiZXhwIjoxNzg5ODA4OTA5fQ.WqEgIJ8u3RZ7_fMdihDPRmIL2HcW9Fv9bhZ7qqSgaOc).
