### PR TITLE
[BUGFIX] Ajout d'une erreur dans la réconciliation d'un candidat.

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
+++ b/api/src/certification/enrolment/domain/usecases/register-candidate-participation.js
@@ -49,6 +49,10 @@ export async function registerCandidateParticipation({
 
   const session = await sessionRepository.get({ id: sessionId });
 
+  if (!session) {
+    throw new NotFoundError(`Session ${sessionId} does not exist`);
+  }
+
   const candidate = await checkAndGetCandidateFromSession({
     userId,
     firstName,

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -121,6 +121,17 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
       // then
       expect(session).to.be.null;
     });
+
+    it('returns null when the session has no certification center', async function () {
+      databaseBuilder.factory.buildSession({ id: 789, certificationCenterId: null });
+      await databaseBuilder.commit();
+
+      // when
+      const session = await sessionRepository.get({ id: 789 });
+
+      // then
+      expect(session).to.be.null;
+    });
   });
 
   describe('#updateInfo', function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/register-candidate-participation_test.js
@@ -88,6 +88,28 @@ describe('Unit | Domain | Usecase | register-candidate-participation', function 
     expect(error).to.be.instanceOf(NotFoundError);
   });
 
+  it('throws NotFoundError when the session is joinable but could not be loaded', async function () {
+    const userId = 123;
+
+    const sessionAuthorization = domainBuilder.certification.enrolment
+      .sessionAuthorizationBuilder()
+      .withParameters({ id: sessionId })
+      .build();
+    sessionAuthorizationAdapter.find.resolves(sessionAuthorization);
+    sessionRepository.get.resolves(null);
+
+    const error = await catchErr(registerCandidateParticipation)({
+      firstName: 'Tony',
+      lastName: 'Stark',
+      birthdate: '1994-07-18',
+      userId,
+      sessionId,
+      ...dependencies,
+    });
+
+    expect(error).to.be.instanceOf(NotFoundError);
+  });
+
   it('throws SessionExpiredError when session has expired', async function () {
     const userId = 123;
     const sessionId = 456;


### PR DESCRIPTION
## ☀️ Problème

Des erreurs 500 sont levées car des des tentatives de réconciliation ont lieu sur des sessions n'ayant pas de certificationCenterId associés (sessions créées avant l'ajout de la colonne en BDD), renvoyant `null` qui n'est pas traité dans le usecase `register-candidate-participation`

## ⛱️ Proposition

On renvoie une erreur 404 au lieu de 500

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- Créer une session
- Retirer le certificationCenterId en BDD
- Essayer de réconcilier un candidat
- Vérifier que l'erreur est une 404