### PR TITLE
[BUGFIX] Ne pas renvoyer les profils cibles obsolètes dans le catalogue (PIX-23956)

### DIFF
--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
@@ -74,6 +74,7 @@ const findSharedByOrganizationId = async (organizationId) =>
   DomainTransaction.getConnection()('target-profiles')
     .join('target-profile-shares', 'target-profiles.id', 'target-profile-shares.targetProfileId')
     .where('target-profile-shares.organizationId', organizationId)
+    .where('outdated', false)
     .select(
       'target-profiles.id',
       'target-profiles.name',

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -256,6 +256,20 @@ describe('Integration | Repository | Target-profile', function () {
       // then
       expect(result).to.deep.equal([]);
     });
+
+    it('does not return outdated target profiles', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile({ outdated: true }).id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await targetProfileRepository.findSharedByOrganizationId(organizationId);
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
   });
 
   describe('#findSkillsByIds', function () {


### PR DESCRIPTION
## ☀️ Problème
Le profils cibles obsolètes sont présents dans le catalogue

## ⛱️ Proposition
Ne pas renvoyer les profils cibles obsolètes dans le catalogue 
