### PR TITLE
[BUGFIX] Corrige des comportements du formulaire d'édition d'une version (PIX-23909)

### DIFF
--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-edit-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-edit-form.gjs
@@ -4,10 +4,11 @@ import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { trackedObject } from '@ember/reactive/collections';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
 import Card from 'pix-admin/components/card';
 import formatDateToStandard from 'pix-admin/utils/date';
 
@@ -17,27 +18,39 @@ export default class CertificationVersionEditForm extends Component {
   @service intl;
   @service pixToast;
 
-  validationForm = trackedObject({
-    startDate: 'default',
-    assessmentDuration: 'default',
-    defaultProbabilityToPickChallenge: 'default',
-    variationPercent: 'default',
-    defaultCandidateCapacity: 'default',
-    maximumAssessmentLength: 'default',
-    minimumAnswersRequiredForValidation: 'default',
-    challengesBetweenSameCompetence: 'default',
-  });
+  @tracked _touchedFields = new Set();
 
   formatAssessmentDuration(assessmentDuration) {
-    if (assessmentDuration === null || assessmentDuration === undefined) {
-      return null;
-    }
-
+    if (assessmentDuration === null || assessmentDuration === undefined) return null;
     return `${String(Math.floor(assessmentDuration / 60)).padStart(2, '0')}:${String(assessmentDuration % 60).padStart(2, '0')}`;
   }
 
   formatStartDate(startDate) {
     return startDate ? formatDateToStandard(startDate) : null;
+  }
+
+  _isInvalid(value) {
+    return value === null || value === undefined || value === 'Invalid Date' || Number.isNaN(value);
+  }
+
+  @action
+  validationStatusFor(key, value) {
+    if (!this._touchedFields.has(key)) return 'default';
+    return this._isInvalid(value) ? 'error' : 'default';
+  }
+
+  get isFormValid() {
+    const v = this.args.draftVersion;
+    return [
+      this.formatStartDate(v?.startDate),
+      this.formatAssessmentDuration(v?.assessmentDuration),
+      v?.defaultProbabilityToPickChallenge,
+      v?.variationPercent,
+      v?.defaultCandidateCapacity,
+      v?.maximumAssessmentLength,
+      v?.minimumAnswersRequiredForValidation,
+      v?.challengesBetweenSameCompetence,
+    ].every((val) => !this._isInvalid(val));
   }
 
   @action
@@ -46,6 +59,14 @@ export default class CertificationVersionEditForm extends Component {
     return this.intl.t('components.certification-frameworks.certification-framework.versions.edit.sublabel', {
       value: activeVersionValue,
     });
+  }
+
+  @action
+  onBlur(event) {
+    const key = event.target.name;
+    if (key) {
+      this._touchedFields = new Set([...this._touchedFields, key]);
+    }
   }
 
   @action
@@ -65,33 +86,8 @@ export default class CertificationVersionEditForm extends Component {
   }
 
   @action
-  updateDefaultProbabilityToPickChallenge(event) {
-    this.args.draftVersion.defaultProbabilityToPickChallenge = Number(event.target.valueAsNumber);
-  }
-
-  @action
-  updateVariationPercent(event) {
-    this.args.draftVersion.variationPercent = Number(event.target.valueAsNumber);
-  }
-
-  @action
-  updateDefaultCandidateCapacity(event) {
-    this.args.draftVersion.defaultCandidateCapacity = Number(event.target.valueAsNumber);
-  }
-
-  @action
-  updateMaximumAssessmentLength(event) {
-    this.args.draftVersion.maximumAssessmentLength = Number(event.target.valueAsNumber);
-  }
-
-  @action
-  updateMinimumAnswersRequiredForValidation(event) {
-    this.args.draftVersion.minimumAnswersRequiredForValidation = Number(event.target.valueAsNumber);
-  }
-
-  @action
-  updateChallengesBetweenSameCompetence(event) {
-    this.args.draftVersion.challengesBetweenSameCompetence = Number(event.target.valueAsNumber);
+  updateNumberField(event) {
+    this.args.draftVersion[event.target.name] = event.target.valueAsNumber;
   }
 
   @action
@@ -104,31 +100,21 @@ export default class CertificationVersionEditForm extends Component {
     this.args.draftVersion.enablePassageByAllCompetences = !this.args.draftVersion.enablePassageByAllCompetences;
   }
 
-  get disableSubmit() {
-    const hasFormValidationError = Object.values(this.validationForm).some((state) => state === 'error');
-    return !this.args.draftVersion?.hasDirtyAttributes || hasFormValidationError;
+  async _persistVersion() {
+    if (!this.args.draftVersion.hasDirtyAttributes) return;
+    await this.args.draftVersion.save();
+    this.pixToast.sendSuccessNotification({
+      message: this.intl.t(
+        'components.certification-frameworks.certification-framework.versions.edit.success-notification',
+      ),
+    });
   }
 
   @action
-  validateInput(value, key) {
-    if (value === null || value === undefined || value === 'Invalid Date' || Number.isNaN(value)) {
-      this.validationForm[key] = 'error';
-    } else {
-      this.validationForm[key] = 'default';
-    }
-    return this.validationForm[key];
-  }
-
-  @action
-  async saveVersion(event) {
-    event.preventDefault();
+  async saveForLater() {
+    if (!this.isFormValid) return;
     try {
-      await this.args.draftVersion.save();
-      this.pixToast.sendSuccessNotification({
-        message: this.intl.t(
-          'components.certification-frameworks.certification-framework.versions.edit.success-notification',
-        ),
-      });
+      await this._persistVersion();
       await this.store.findRecord('certification-framework', this.args.activeVersion.scope);
       this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
     } catch (err) {
@@ -137,14 +123,24 @@ export default class CertificationVersionEditForm extends Component {
   }
 
   @action
-  async noop(event) {
-    event.preventDefault();
+  async saveAndNext() {
+    if (!this.isFormValid) return;
+    try {
+      await this._persistVersion();
+      this.router.transitionTo(
+        'authenticated.certification-frameworks.certification-framework.versions.version.calibration',
+        this.args.draftVersion.id,
+      );
+    } catch (err) {
+      this.pixToast.sendErrorNotification({ message: err.errors?.[0].detail });
+    }
   }
 
   <template>
-    <Card @title="Configuration de l’algorithme de déroulé du test">
-      <form id="version-edit-form" class="versions-edit__form" {{on "submit" this.saveVersion}}>
+    <Card @title={{t "components.certification-frameworks.certification-framework.versions.edit.title"}}>
+      <form class="versions-edit__form">
         <PixInput
+          name="startDate"
           type="date"
           required={{true}}
           @requiredLabel={{t "common.forms.mandatory"}}
@@ -153,13 +149,15 @@ export default class CertificationVersionEditForm extends Component {
           @errorMessage={{t
             "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
           }}
-          @validationStatus={{this.validateInput (this.formatStartDate @draftVersion.startDate) "startDate"}}
+          @validationStatus={{this.validationStatusFor "startDate" (this.formatStartDate @draftVersion.startDate)}}
           {{on "change" this.updateStartDate}}
+          {{on "focusout" this.onBlur}}
         >
           <:label>
             {{t "components.certification-frameworks.certification-framework.versions.edit.start-date-label"}}</:label>
         </PixInput>
         <PixInput
+          name="assessmentDuration"
           type="time"
           required={{true}}
           @requiredLabel={{t "common.forms.mandatory"}}
@@ -167,18 +165,20 @@ export default class CertificationVersionEditForm extends Component {
           @errorMessage={{t
             "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
           }}
-          @validationStatus={{this.validateInput
-            (this.formatAssessmentDuration @draftVersion.assessmentDuration)
+          @validationStatus={{this.validationStatusFor
             "assessmentDuration"
+            (this.formatAssessmentDuration @draftVersion.assessmentDuration)
           }}
           @value={{this.formatAssessmentDuration @draftVersion.assessmentDuration}}
           {{on "change" this.updateAssessmentDuration}}
+          {{on "focusout" this.onBlur}}
         >
           <:label>{{t
               "components.certification-frameworks.certification-framework.versions.edit.assessment-duration-label"
             }}</:label>
         </PixInput>
         <PixInput
+          name="defaultProbabilityToPickChallenge"
           type="number"
           required={{true}}
           @requiredLabel={{t "common.forms.mandatory"}}
@@ -186,12 +186,13 @@ export default class CertificationVersionEditForm extends Component {
           @errorMessage={{t
             "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
           }}
-          @validationStatus={{this.validateInput
-            @draftVersion.defaultProbabilityToPickChallenge
+          @validationStatus={{this.validationStatusFor
             "defaultProbabilityToPickChallenge"
+            @draftVersion.defaultProbabilityToPickChallenge
           }}
           @value={{@draftVersion.defaultProbabilityToPickChallenge}}
-          {{on "change" this.updateDefaultProbabilityToPickChallenge}}
+          {{on "change" this.updateNumberField}}
+          {{on "focusout" this.onBlur}}
         >
           <:label>{{t
               "components.certification-frameworks.certification-framework.versions.edit.default-probability-to-pick-challenge-label"
@@ -199,6 +200,7 @@ export default class CertificationVersionEditForm extends Component {
         </PixInput>
         <section>
           <PixInput
+            name="variationPercent"
             type="number"
             required={{true}}
             step="any"
@@ -207,15 +209,17 @@ export default class CertificationVersionEditForm extends Component {
             @errorMessage={{t
               "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
             }}
-            @validationStatus={{this.validateInput @draftVersion.variationPercent "variationPercent"}}
+            @validationStatus={{this.validationStatusFor "variationPercent" @draftVersion.variationPercent}}
             @value={{@draftVersion.variationPercent}}
-            {{on "change" this.updateVariationPercent}}
+            {{on "change" this.updateNumberField}}
+            {{on "focusout" this.onBlur}}
           >
             <:label>{{t
                 "components.certification-frameworks.certification-framework.versions.edit.variation-percent-label"
               }}</:label>
           </PixInput>
           <PixInput
+            name="defaultCandidateCapacity"
             type="number"
             required={{true}}
             @requiredLabel={{t "common.forms.mandatory"}}
@@ -223,18 +227,22 @@ export default class CertificationVersionEditForm extends Component {
             @errorMessage={{t
               "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
             }}
-            @validationStatus={{this.validateInput @draftVersion.defaultCandidateCapacity "defaultCandidateCapacity"}}
+            @validationStatus={{this.validationStatusFor
+              "defaultCandidateCapacity"
+              @draftVersion.defaultCandidateCapacity
+            }}
             @value={{@draftVersion.defaultCandidateCapacity}}
-            {{on "change" this.updateDefaultCandidateCapacity}}
+            {{on "change" this.updateNumberField}}
+            {{on "focusout" this.onBlur}}
           >
             <:label>{{t
                 "components.certification-frameworks.certification-framework.versions.edit.default-candidate-capacity-label"
               }}</:label>
           </PixInput>
-
         </section>
         <section>
           <PixInput
+            name="maximumAssessmentLength"
             type="number"
             required={{true}}
             @requiredLabel={{t "common.forms.mandatory"}}
@@ -242,15 +250,20 @@ export default class CertificationVersionEditForm extends Component {
             @errorMessage={{t
               "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
             }}
-            @validationStatus={{this.validateInput @draftVersion.maximumAssessmentLength "maximumAssessmentLength"}}
+            @validationStatus={{this.validationStatusFor
+              "maximumAssessmentLength"
+              @draftVersion.maximumAssessmentLength
+            }}
             @value={{@draftVersion.maximumAssessmentLength}}
-            {{on "change" this.updateMaximumAssessmentLength}}
+            {{on "change" this.updateNumberField}}
+            {{on "focusout" this.onBlur}}
           >
             <:label>{{t
                 "components.certification-frameworks.certification-framework.versions.edit.maximum-assessment-length-label"
               }}</:label>
           </PixInput>
           <PixInput
+            name="minimumAnswersRequiredForValidation"
             type="number"
             required={{true}}
             @requiredLabel={{t "common.forms.mandatory"}}
@@ -258,12 +271,13 @@ export default class CertificationVersionEditForm extends Component {
             @errorMessage={{t
               "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
             }}
-            @validationStatus={{this.validateInput
-              @draftVersion.minimumAnswersRequiredForValidation
+            @validationStatus={{this.validationStatusFor
               "minimumAnswersRequiredForValidation"
+              @draftVersion.minimumAnswersRequiredForValidation
             }}
             @value={{@draftVersion.minimumAnswersRequiredForValidation}}
-            {{on "change" this.updateMinimumAnswersRequiredForValidation}}
+            {{on "change" this.updateNumberField}}
+            {{on "focusout" this.onBlur}}
           >
             <:label>{{t
                 "components.certification-frameworks.certification-framework.versions.edit.minimum-answers-required-for-validation-label"
@@ -271,6 +285,7 @@ export default class CertificationVersionEditForm extends Component {
           </PixInput>
         </section>
         <PixInput
+          name="challengesBetweenSameCompetence"
           type="number"
           required={{true}}
           @requiredLabel={{t "common.forms.mandatory"}}
@@ -278,12 +293,13 @@ export default class CertificationVersionEditForm extends Component {
           @errorMessage={{t
             "components.certification-frameworks.certification-framework.versions.edit.validation-message-error"
           }}
-          @validationStatus={{this.validateInput
-            @draftVersion.challengesBetweenSameCompetence
+          @validationStatus={{this.validationStatusFor
             "challengesBetweenSameCompetence"
+            @draftVersion.challengesBetweenSameCompetence
           }}
           @value={{@draftVersion.challengesBetweenSameCompetence}}
-          {{on "change" this.updateChallengesBetweenSameCompetence}}
+          {{on "change" this.updateNumberField}}
+          {{on "focusout" this.onBlur}}
         >
           <:label>{{t
               "components.certification-frameworks.certification-framework.versions.edit.challenges-between-same-competence-label"
@@ -326,18 +342,15 @@ export default class CertificationVersionEditForm extends Component {
       </form>
     </Card>
     <section class="actions-container">
-      <PixButton @type="submit" form="version-edit-form" @isDisabled={{this.disableSubmit}} @variant="secondary">
+      <PixButton @isDisabled={{not this.isFormValid}} @variant="secondary" @triggerAction={{this.saveForLater}}>
         {{t "components.certification-frameworks.certification-framework.versions.edit.submit-button"}}
       </PixButton>
       <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
         {{t "common.actions.cancel"}}
       </PixButtonLink>
-      <PixButtonLink
-        @route="authenticated.certification-frameworks.certification-framework.versions.version.calibration"
-        @variant="primary"
-      >
+      <PixButton @isDisabled={{not this.isFormValid}} @variant="primary" @triggerAction={{this.saveAndNext}}>
         {{t "common.actions.next"}}
-      </PixButtonLink>
+      </PixButton>
     </section>
   </template>
 }

--- a/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-edit-form.scss
+++ b/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-edit-form.scss
@@ -20,6 +20,5 @@
 .actions-container {
   display: flex;
   gap: 1rem;
-  justify-content: flex-end;
   margin-top: 1rem;
 }

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/edit-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/edit-test.js
@@ -51,62 +51,14 @@ module('Acceptance | Certification Framework | item | Framework | edit', functio
   });
 
   module('when admin member has role "SUPER ADMIN"', function () {
-    module('when user edit and save the changes', function () {
-      test('should persist modifications on the version and be visible in details page', async function (assert) {
+    module('when user edit and save the changes for later', function () {
+      test('should persist modifications on the version and redirect to version list page', async function (assert) {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const screen = await visit(`/certification-frameworks/CORE`);
         await clickByName('Éditer la version 14');
 
-        await fillIn(
-          screen.getByLabelText(t(`${BASE_I18N_KEY}.start-date-label`), {
-            exact: false,
-          }),
-          '2026-01-01',
-        );
-        await fillIn(
-          screen.getByLabelText(t(`${BASE_I18N_KEY}.assessment-duration-label`), {
-            exact: false,
-          }),
-          '01:30',
-        );
-        await fillIn(
-          screen.getByLabelText(t(`${BASE_I18N_KEY}.default-probability-to-pick-challenge-label`), {
-            exact: false,
-          }),
-          '20',
-        );
-        await fillIn(
-          screen.getByLabelText(t(`${BASE_I18N_KEY}.variation-percent-label`), {
-            exact: false,
-          }),
-          '0.35',
-        );
-        await fillIn(
-          screen.getByLabelText(t(`${BASE_I18N_KEY}.default-candidate-capacity-label`), {
-            exact: false,
-          }),
-          '-2',
-        );
-        await fillIn(
-          screen.getByLabelText(t(`${BASE_I18N_KEY}.maximum-assessment-length-label`), {
-            exact: false,
-          }),
-          '22',
-        );
-        await fillIn(
-          screen.getByLabelText(t(`${BASE_I18N_KEY}.minimum-answers-required-for-validation-label`), {
-            exact: false,
-          }),
-          '11',
-        );
-        await fillIn(
-          screen.getByLabelText(t(`${BASE_I18N_KEY}.challenges-between-same-competence-label`), {
-            exact: false,
-          }),
-          '3',
-        );
-        await clickByName(new RegExp(t(`${BASE_I18N_KEY}.limit-to-one-question-per-tube-label`)));
-        await clickByName(new RegExp(t(`${BASE_I18N_KEY}.enable-passage-by-all-competences-label`)));
+        await correctlyFillOutForm(screen);
+
         await clickByName('Enregistrer pour plus tard');
 
         assert.dom(screen.getByText(t(`${BASE_I18N_KEY}.success-notification`))).exists();
@@ -170,12 +122,14 @@ module('Acceptance | Certification Framework | item | Framework | edit', functio
     });
 
     module('when trying to click on next button', function () {
-      test('redirects to calibration page', async function (assert) {
+      test('persist the information and redirects to calibration page', async function (assert) {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
-        await visit(`/certification-frameworks/CORE/versions/14/edit`);
+        const screen = await visit(`/certification-frameworks/CORE/versions/14/edit`);
+        await correctlyFillOutForm(screen);
         await clickByName('Suivant');
         assert.strictEqual(currentURL(), '/certification-frameworks/CORE/versions/14/calibration');
+        assert.dom(screen.getByText(t(`${BASE_I18N_KEY}.success-notification`))).exists();
       });
     });
   });
@@ -188,3 +142,58 @@ module('Acceptance | Certification Framework | item | Framework | edit', functio
     });
   });
 });
+
+async function correctlyFillOutForm(screen) {
+  const BASE_I18N_KEY = 'components.certification-frameworks.certification-framework.versions.edit';
+
+  await fillIn(
+    screen.getByLabelText(t(`${BASE_I18N_KEY}.start-date-label`), {
+      exact: false,
+    }),
+    '2026-01-01',
+  );
+  await fillIn(
+    screen.getByLabelText(t(`${BASE_I18N_KEY}.assessment-duration-label`), {
+      exact: false,
+    }),
+    '01:30',
+  );
+  await fillIn(
+    screen.getByLabelText(t(`${BASE_I18N_KEY}.default-probability-to-pick-challenge-label`), {
+      exact: false,
+    }),
+    '20',
+  );
+  await fillIn(
+    screen.getByLabelText(t(`${BASE_I18N_KEY}.variation-percent-label`), {
+      exact: false,
+    }),
+    '0.35',
+  );
+  await fillIn(
+    screen.getByLabelText(t(`${BASE_I18N_KEY}.default-candidate-capacity-label`), {
+      exact: false,
+    }),
+    '-2',
+  );
+  await fillIn(
+    screen.getByLabelText(t(`${BASE_I18N_KEY}.maximum-assessment-length-label`), {
+      exact: false,
+    }),
+    '22',
+  );
+  await fillIn(
+    screen.getByLabelText(t(`${BASE_I18N_KEY}.minimum-answers-required-for-validation-label`), {
+      exact: false,
+    }),
+    '11',
+  );
+  await fillIn(
+    screen.getByLabelText(t(`${BASE_I18N_KEY}.challenges-between-same-competence-label`), {
+      exact: false,
+    }),
+    '3',
+  );
+  await clickByName(new RegExp(t(`${BASE_I18N_KEY}.limit-to-one-question-per-tube-label`)));
+  await clickByName(new RegExp(t(`${BASE_I18N_KEY}.enable-passage-by-all-competences-label`)));
+}

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-edit-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-edit-form-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { triggerEvent } from '@ember/test-helpers';
 import CertificationVersionEditForm from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-edit-form';
 import { module, test } from 'qunit';
 
@@ -128,7 +129,7 @@ module(
         .isChecked();
     });
 
-    test('it should inform user when empty input is required', async function (assert) {
+    test('it should not show errors on load but disable buttons when a required field is empty', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const draftVersion = store.createRecord('certification-version', {
@@ -149,14 +150,16 @@ module(
 
       const screen = await render(<template><CertificationVersionEditForm @draftVersion={{draftVersion}} /></template>);
 
-      // then
+      // then: no error visible on initial render
       assert
         .dom(
-          screen.getByText(
+          screen.queryByText(
             t('components.certification-frameworks.certification-framework.versions.edit.validation-message-error'),
           ),
         )
-        .exists();
+        .doesNotExist();
+
+      // and both action buttons are disabled
       assert
         .dom(
           screen.getByRole('button', {
@@ -164,6 +167,23 @@ module(
           }),
         )
         .hasAttribute('aria-disabled');
+      assert.dom(screen.getByRole('button', { name: t('common.actions.next') })).hasAttribute('aria-disabled');
+
+      // when the user focuses then leaves the empty startDate field
+      const startDateInput = screen.getByLabelText(
+        t('components.certification-frameworks.certification-framework.versions.edit.start-date-label'),
+        { exact: false },
+      );
+      await triggerEvent(startDateInput, 'focusout');
+
+      // then the error message is shown
+      assert
+        .dom(
+          screen.getByText(
+            t('components.certification-frameworks.certification-framework.versions.edit.validation-message-error'),
+          ),
+        )
+        .exists();
     });
 
     module('when there is no activeVersion', function () {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -620,6 +620,7 @@
             "sublabel": "Value of the active version: {value}",
             "submit-button": "Save for later",
             "success-notification": "Changes to the version have been saved successfully.",
+            "title": "Configuration of the test's execution algorithm",
             "validation-message-error": "This field is mandatory",
             "variation-percent-label": "Ability progression cap:"
           },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -628,6 +628,7 @@
             "sublabel": "Valeur de la version active : {value}",
             "submit-button": "Enregistrer pour plus tard",
             "success-notification": "Les modifications sur la version ont été enregistrées avec succès.",
+            "title": "Configuration de l'algorithme de déroulé du test",
             "validation-message-error": "Ce champ doit être rempli",
             "variation-percent-label": "Capage de la progression de la capacité :"
           },


### PR DESCRIPTION
## ☀️ Problème

- Ne pas afficher les erreurs dès le chargement de la page
- Le bouton “Suivant” devrait déclencher un enregistrement
- Le bouton “Suivant” devrait être désactivé lorsque le formulaire est invalide
- Le bouton “Enregistrer pour plus tard” ne devrait pas fonctionner lorsqu’il est disable

## ⛱️ Proposition

Correction des bugs + condenser les handlers numériques en un seul, corrections mineures de traduction, css etc

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
aller à l'étape 2 de la création d'une version et tester les comportements du formulaire et des boutons (créer des erreurs dans les champs, enregistrer pour plus tard et revenir, suivant, quitter et revenir etc.. ). Constater que les erreurs sont correctement affichées, qu'on enregistre les infos et qu'on ne permet pas l'enregistrement d'un formulaire invalide.
