### PR TITLE
[TECH] POC - Utiliser @1024pix/nebulix-ember sur Admin et Orga

### DIFF
--- a/admin/app/components/actions-on-users-role-in-organization.gjs
+++ b/admin/app/components/actions-on-users-role-in-organization.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixIcon, PixModal, PixSelect, PixTableColumn } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/access/anonymize-gar-import.gjs
+++ b/admin/app/components/administration/access/anonymize-gar-import.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/access/oidc-providers-import.gjs
+++ b/admin/app/components/administration/access/oidc-providers-import.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/block-layout.gjs
+++ b/admin/app/components/administration/block-layout.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 
 <template>
   <PixBlock class="page-section" @shadow="light" ...attributes>

--- a/admin/app/components/administration/campaigns/campaigns-import.gjs
+++ b/admin/app/components/administration/campaigns/campaigns-import.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/campaigns/swap-campaign-codes.gjs
+++ b/admin/app/components/administration/campaigns/swap-campaign-codes.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/administration/campaigns/update-campaign-code.gjs
+++ b/admin/app/components/administration/campaigns/update-campaign-code.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/administration/certification/date-editor.gjs
+++ b/admin/app/components/administration/certification/date-editor.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
+++ b/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixButtonUpload, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/common/add-organization-features-in-batch.gjs
+++ b/admin/app/components/administration/common/add-organization-features-in-batch.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/common/create-attestations.gjs
+++ b/admin/app/components/administration/common/create-attestations.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixButtonUpload, PixInput, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/administration/common/create-combined-courses.gjs
+++ b/admin/app/components/administration/common/create-combined-courses.gjs
@@ -1,5 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButtonUpload, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/common/learning-content.gjs
+++ b/admin/app/components/administration/common/learning-content.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/common/upsert-quests-in-batch.gjs
+++ b/admin/app/components/administration/common/upsert-quests-in-batch.gjs
@@ -1,6 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButtonLink, PixButtonUpload, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/common/user-quest-checker.gjs
+++ b/admin/app/components/administration/common/user-quest-checker.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButton, PixInput, PixTag } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/administration/deployment/certification-centers-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/certification-centers-batch-archive.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/deployment/new-tag.gjs
+++ b/admin/app/components/administration/deployment/new-tag.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/administration/deployment/organization-tags-import.gjs
+++ b/admin/app/components/administration/deployment/organization-tags-import.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/deployment/organizations-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/organizations-batch-archive.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/deployment/organizations-import.gjs
+++ b/admin/app/components/administration/deployment/organizations-import.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';

--- a/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
+++ b/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/download-template.gjs
+++ b/admin/app/components/administration/download-template.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixButton, PixIcon } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/administration/nav.gjs
+++ b/admin/app/components/administration/nav.gjs
@@ -1,4 +1,4 @@
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/administration/organizations/update-organization-import-format.gjs
+++ b/admin/app/components/administration/organizations/update-organization-import-format.gjs
@@ -1,4 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButtonUpload } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/announcements/edit-form.gjs
+++ b/admin/app/components/announcements/edit-form.gjs
@@ -1,6 +1,4 @@
-import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTextArea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixBannerAlert, PixButton, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -54,14 +52,14 @@ export default class AnnouncementsEditForm extends Component {
     </PixBannerAlert>
     {{#each this.locales as |locale|}}
       <div class="announcements-edit-form">
-        <PixTextArea
+        <PixTextarea
           @id="announcement-content-{{locale}}"
           rows="6"
           value={{get this.content locale}}
           {{on "input" (fn this.updateContent locale)}}
         >
           <:label>{{locale}}</:label>
-        </PixTextArea>
+        </PixTextarea>
       </div>
     {{/each}}
     <PixButton @triggerAction={{this.save}} @isLoading={{this.isSaving}}>

--- a/admin/app/components/autonomous-courses/breadcrumb.gjs
+++ b/admin/app/components/autonomous-courses/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/autonomous-courses/details.gjs
+++ b/admin/app/components/autonomous-courses/details.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/autonomous-courses/index.gjs
+++ b/admin/app/components/autonomous-courses/index.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/autonomous-courses/list/index.gjs
+++ b/admin/app/components/autonomous-courses/list/index.gjs
@@ -1,6 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixFilterBanner, PixInput, PixTable } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/autonomous-courses/list/item.gjs
+++ b/admin/app/components/autonomous-courses/list/item.gjs
@@ -1,5 +1,4 @@
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixTableColumn, PixTag } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 import formatDate from 'ember-intl/helpers/format-date';

--- a/admin/app/components/autonomous-courses/new/index.gjs
+++ b/admin/app/components/autonomous-courses/new/index.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/autonomous-courses/new/technical-informations.gjs
+++ b/admin/app/components/autonomous-courses/new/technical-informations.gjs
@@ -1,5 +1,4 @@
-import PixFilterableAndSearchableSelect from '@1024pix/pix-ui/components/pix-filterable-and-searchable-select';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixFilterableAndSearchableSelect, PixInput } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { t } from 'ember-intl';

--- a/admin/app/components/autonomous-courses/new/user-informations.gjs
+++ b/admin/app/components/autonomous-courses/new/user-informations.gjs
@@ -1,5 +1,4 @@
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixInput, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { t } from 'ember-intl';

--- a/admin/app/components/autonomous-courses/update-autonomous-course-form.gjs
+++ b/admin/app/components/autonomous-courses/update-autonomous-course-form.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixInput, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/autonomous-courses/view-autonomous-course.gjs
+++ b/admin/app/components/autonomous-courses/view-autonomous-course.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixCheckbox, PixInput, PixTag, PixTextarea } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/badges/campaign-criterion.gjs
+++ b/admin/app/components/badges/campaign-criterion.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixButton, PixInput, PixModal, PixTooltip } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/campaigns/breadcrumb.gjs
+++ b/admin/app/components/campaigns/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class Breadcrumb extends Component {

--- a/admin/app/components/campaigns/details.gjs
+++ b/admin/app/components/campaigns/details.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButton, PixTag } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/campaigns/participation-row.gjs
+++ b/admin/app/components/campaigns/participation-row.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixIcon, PixInput, PixTableColumn } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';

--- a/admin/app/components/campaigns/participations-section.gjs
+++ b/admin/app/components/campaigns/participations-section.gjs
@@ -1,5 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixPagination, PixTable } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/campaigns/type.gjs
+++ b/admin/app/components/campaigns/type.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/campaigns/update.gjs
+++ b/admin/app/components/campaigns/update.gjs
@@ -1,9 +1,4 @@
-import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixBannerAlert, PixButton, PixCheckbox, PixInput, PixRadioButton, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/candidates/timeline.gjs
+++ b/admin/app/components/candidates/timeline.gjs
@@ -1,6 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixBlock, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { concat } from '@ember/helper';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/admin/app/components/certification-centers/attached-organizations.gjs
+++ b/admin/app/components/certification-centers/attached-organizations.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/certification-centers/breadcrumb.gjs
+++ b/admin/app/components/certification-centers/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/certification-centers/creation-form.gjs
+++ b/admin/app/components/certification-centers/creation-form.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixCheckbox, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';

--- a/admin/app/components/certification-centers/get.gjs
+++ b/admin/app/components/certification-centers/get.gjs
@@ -1,6 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixButtonLink, PixNotificationAlert, PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import CopyableId from 'pix-admin/components/ui/copyable-id';

--- a/admin/app/components/certification-centers/habilitation-tag.gjs
+++ b/admin/app/components/certification-centers/habilitation-tag.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class HabilitationTag extends Component {

--- a/admin/app/components/certification-centers/information-edit.gjs
+++ b/admin/app/components/certification-centers/information-edit.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixCheckbox, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';

--- a/admin/app/components/certification-centers/information-view.gjs
+++ b/admin/app/components/certification-centers/information-view.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/certification-centers/invitations-action.gjs
+++ b/admin/app/components/certification-centers/invitations-action.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/certification-centers/invitations.gjs
+++ b/admin/app/components/certification-centers/invitations.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -1,9 +1,11 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import {
+  PixFilterBanner,
+  PixInput,
+  PixPagination,
+  PixSegmentedControl,
+  PixTable,
+  PixTableColumn,
+} from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/certification-centers/membership-item-actions.gjs
+++ b/admin/app/components/certification-centers/membership-item-actions.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/certification-centers/membership-item-role.gjs
+++ b/admin/app/components/certification-centers/membership-item-role.gjs
@@ -1,4 +1,4 @@
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixSelect } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/admin/app/components/certification-centers/membership-item.gjs
+++ b/admin/app/components/certification-centers/membership-item.gjs
@@ -1,4 +1,4 @@
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/certification-centers/memberships-section.gjs
+++ b/admin/app/components/certification-centers/memberships-section.gjs
@@ -1,4 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixTable } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 import MembershipItem from './membership-item';

--- a/admin/app/components/certification-frameworks/attach-badges/badges/content-header.gjs
+++ b/admin/app/components/certification-frameworks/attach-badges/badges/content-header.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 
 <template>
   <span class="attach-badges-header__content">

--- a/admin/app/components/certification-frameworks/attach-badges/badges/list.gjs
+++ b/admin/app/components/certification-frameworks/attach-badges/badges/list.gjs
@@ -1,8 +1,4 @@
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixInput, PixNotificationAlert, PixTable, PixTableColumn, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/certification-frameworks/attach-badges/index.gjs
+++ b/admin/app/components/certification-frameworks/attach-badges/index.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixButton, PixCheckbox, PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/certification-frameworks/attach-badges/target-profile-selector/searchbar.gjs
+++ b/admin/app/components/certification-frameworks/attach-badges/target-profile-selector/searchbar.gjs
@@ -1,6 +1,6 @@
-import onEnterAction from '@1024pix/pix-ui/addon/modifiers/on-enter-action';
-import onSpaceAction from '@1024pix/pix-ui/addon/modifiers/on-space-action';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import { PixSearchInput } from '@1024pix/nebulix-ember';
+import onEnterAction from '@1024pix/nebulix-ember/modifiers/on-enter-action';
+import onSpaceAction from '@1024pix/nebulix-ember/modifiers/on-space-action';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/certification-frameworks/attach-badges/target-profile-selector/selected-target-profile.gjs
+++ b/admin/app/components/certification-frameworks/attach-badges/target-profile-selector/selected-target-profile.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 
 <template>

--- a/admin/app/components/certification-frameworks/certification-framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/framework-history.gjs
@@ -1,10 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButton, PixIcon, PixIconButton, PixModal, PixTable, PixTableColumn, PixTag } from '@1024pix/nebulix-ember';
 import { concat, fn, get } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/certification-frameworks/certification-framework/header.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/header.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixButtonLink, PixTooltip } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/admin/app/components/certification-frameworks/certification-framework/modal/certification-version-detail-modal.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/modal/certification-version-detail-modal.gjs
@@ -1,7 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixBlock, PixIcon, PixModal, PixTag } from '@1024pix/nebulix-ember';
 import { concat, get } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/certification-frameworks/certification-framework/modal/framework-content-details.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/modal/framework-content-details.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import sortBy from 'lodash/sortBy';

--- a/admin/app/components/certification-frameworks/certification-framework/modal/version-comment.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/modal/version-comment.gjs
@@ -1,6 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixBlock, PixButton, PixTextarea } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/certification-frameworks/certification-framework/target-profile/badges-list.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/target-profile/badges-list.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { array } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';

--- a/admin/app/components/certification-frameworks/certification-framework/target-profile/history.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/target-profile/history.gjs
@@ -1,8 +1,4 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixAccordions, PixIcon, PixIconButton, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/certification-frameworks/certification-framework/target-profile/information.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/target-profile/information.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-form.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixButtonLink, PixIconButton, PixInput } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-create-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-create-form.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButton, PixButtonLink } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-edit-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-edit-form.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixButtonLink, PixCheckbox, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { trackedObject } from '@ember/reactive/collections';

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixButtonLink, PixInput } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/certification-frameworks/list.gjs
+++ b/admin/app/components/certification-frameworks/list.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/admin/app/components/certifications/candidate-edit-modal.gjs
+++ b/admin/app/components/certifications/candidate-edit-modal.gjs
@@ -6,11 +6,7 @@ const FRANCE_INSEE_CODE = '99100';
 const INSEE_CODE_OPTION = 'insee';
 const POSTAL_CODE_OPTION = 'postal';
 
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixInput, PixModal, PixRadioButton, PixSelect } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';

--- a/admin/app/components/certifications/certification/comments.gjs
+++ b/admin/app/components/certifications/certification/comments.gjs
@@ -1,6 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixBlock, PixButton, PixTextarea } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -1,11 +1,13 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import {
+  PixButton,
+  PixIcon,
+  PixIconButton,
+  PixModal,
+  PixTable,
+  PixTableColumn,
+  PixTag,
+  PixTooltip,
+} from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 

--- a/admin/app/components/certifications/certification/informations/candidate.gjs
+++ b/admin/app/components/certifications/certification/informations/candidate.gjs
@@ -1,5 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixBlock, PixButton } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButton, PixButtonLink } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/certifications/certification/informations/issue-reports.gjs
+++ b/admin/app/components/certifications/certification/informations/issue-reports.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 import CertificationIssueReport from './issue-reports/issue-report';

--- a/admin/app/components/certifications/certification/informations/issue-reports/issue-report.gjs
+++ b/admin/app/components/certifications/certification/informations/issue-reports/issue-report.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixButton, PixIcon } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/certifications/certification/informations/issue-reports/resolve-issue-report-modal.gjs
+++ b/admin/app/components/certifications/certification/informations/issue-reports/resolve-issue-report-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixModal, PixTextarea } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v2-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v2-results.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixIconButton, PixSelect } from '@1024pix/nebulix-ember';
 
 <template>
   <div class="certification-information-pix-edu">

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixButton, PixIconButton, PixSelect, PixTooltip } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/certifications/certification/informations/state.gjs
+++ b/admin/app/components/certifications/certification/informations/state.gjs
@@ -1,5 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixBlock, PixTag } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 

--- a/admin/app/components/certifications/certified-profile.gjs
+++ b/admin/app/components/certifications/certified-profile.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { concat } from '@ember/helper';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/components/certifications/competence-list.gjs
+++ b/admin/app/components/certifications/competence-list.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/certifications/search-form.gjs
+++ b/admin/app/components/certifications/search-form.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/combined-course-blueprints/capped-tubes/area.gjs
+++ b/admin/app/components/combined-course-blueprints/capped-tubes/area.gjs
@@ -1,4 +1,4 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import { PixAccordions } from '@1024pix/nebulix-ember';
 
 import Competence from './competence';
 

--- a/admin/app/components/combined-course-blueprints/capped-tubes/competence.gjs
+++ b/admin/app/components/combined-course-blueprints/capped-tubes/competence.gjs
@@ -1,4 +1,4 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import { PixAccordions } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 

--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -1,5 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixBreadcrumb, PixButtonLink } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/admin/app/components/combined-course-blueprints/download-combined-course-blueprint.gjs
+++ b/admin/app/components/combined-course-blueprints/download-combined-course-blueprint.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -1,11 +1,13 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import {
+  PixButton,
+  PixIconButton,
+  PixInput,
+  PixRadioButton,
+  PixTable,
+  PixTableColumn,
+  PixTag,
+  PixTextarea,
+} from '@1024pix/nebulix-ember';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/combined-course-blueprints/list-summary-items.gjs
+++ b/admin/app/components/combined-course-blueprints/list-summary-items.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/combined-course-blueprints/select-attestation.gjs
+++ b/admin/app/components/combined-course-blueprints/select-attestation.gjs
@@ -1,4 +1,4 @@
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixSelect } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -1,4 +1,4 @@
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixTag } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';

--- a/admin/app/components/common/tick-or-cross.gjs
+++ b/admin/app/components/common/tick-or-cross.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class TickOrCross extends Component {

--- a/admin/app/components/common/tubes-details/area.gjs
+++ b/admin/app/components/common/tubes-details/area.gjs
@@ -1,4 +1,4 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import { PixAccordions } from '@1024pix/nebulix-ember';
 
 import Competence from '../tubes-details/competence';
 

--- a/admin/app/components/common/tubes-details/competence.gjs
+++ b/admin/app/components/common/tubes-details/competence.gjs
@@ -1,4 +1,4 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import { PixAccordions } from '@1024pix/nebulix-ember';
 import { eq } from 'ember-truth-helpers';
 
 import Header from '../../table/header';

--- a/admin/app/components/common/tubes-details/tube.gjs
+++ b/admin/app/components/common/tubes-details/tube.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/admin/app/components/common/tubes-selection.gjs
+++ b/admin/app/components/common/tubes-selection.gjs
@@ -1,6 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButtonUpload, PixMultiSelect, PixTag } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/common/tubes-selection/areas.gjs
+++ b/admin/app/components/common/tubes-selection/areas.gjs
@@ -1,4 +1,4 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import { PixAccordions } from '@1024pix/nebulix-ember';
 
 import Competence from './competence';
 

--- a/admin/app/components/common/tubes-selection/competence.gjs
+++ b/admin/app/components/common/tubes-selection/competence.gjs
@@ -1,5 +1,4 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import { PixAccordions, PixCheckbox } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/common/tubes-selection/thematic.gjs
+++ b/admin/app/components/common/tubes-selection/thematic.gjs
@@ -1,4 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import { PixCheckbox } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/common/tubes-selection/tube.gjs
+++ b/admin/app/components/common/tubes-selection/tube.gjs
@@ -1,7 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixCheckbox, PixIcon, PixSelect, PixTooltip } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/confirm-popup.gjs
+++ b/admin/app/components/confirm-popup.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/layout/menu-bar/entry.gjs
+++ b/admin/app/components/layout/menu-bar/entry.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 
 <template>

--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -1,5 +1,4 @@
-import PixNavigation from '@1024pix/pix-ui/components/pix-navigation';
-import PixNavigationButton from '@1024pix/pix-ui/components/pix-navigation-button';
+import { PixNavigation, PixNavigationButton } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixInput, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/networks/breadcrumb.gjs
+++ b/admin/app/components/networks/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/networks/creation-form.gjs
+++ b/admin/app/components/networks/creation-form.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/networks/edit-form.gjs
+++ b/admin/app/components/networks/edit-form.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/networks/list-items.gjs
+++ b/admin/app/components/networks/list-items.gjs
@@ -1,8 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixFilterBanner, PixInput, PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';

--- a/admin/app/components/networks/title-view.gjs
+++ b/admin/app/components/networks/title-view.gjs
@@ -1,5 +1,4 @@
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIconButton, PixTooltip } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import CopyableId from 'pix-admin/components/ui/copyable-id';
 

--- a/admin/app/components/organization-learners/filter-banner.gjs
+++ b/admin/app/components/organization-learners/filter-banner.gjs
@@ -1,6 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
+import { PixFilterBanner, PixInput, PixSegmentedControl } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/organization-learners/list-table.gjs
+++ b/admin/app/components/organization-learners/list-table.gjs
@@ -1,7 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixIcon, PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';

--- a/admin/app/components/organizations/all-tags.gjs
+++ b/admin/app/components/organizations/all-tags.gjs
@@ -1,5 +1,4 @@
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixSearchInput, PixTag } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/organizations/archiving-confirmation-modal.gjs
+++ b/admin/app/components/organizations/archiving-confirmation-modal.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/organizations/attach-organizations-form.gjs
+++ b/admin/app/components/organizations/attach-organizations-form.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/organizations/attached-certification-center.gjs
+++ b/admin/app/components/organizations/attached-certification-center.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixButtonLink, PixModal, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/organizations/attached-certification-centers/attach-certification-center-form.gjs
+++ b/admin/app/components/organizations/attached-certification-centers/attach-certification-center-form.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/components/organizations/breadcrumb.gjs
+++ b/admin/app/components/organizations/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/organizations/campaigns-section.gjs
+++ b/admin/app/components/organizations/campaigns-section.gjs
@@ -1,6 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import formatDate from 'ember-intl/helpers/format-date';
 import { or } from 'ember-truth-helpers';

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';

--- a/admin/app/components/organizations/features-section.gjs
+++ b/admin/app/components/organizations/features-section.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixCheckbox, PixModal, PixMultiSelect, PixSelect } from '@1024pix/nebulix-ember';
 import { concat, fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButtonLink, PixTag } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/admin/app/components/organizations/invitations-action.gjs
+++ b/admin/app/components/organizations/invitations-action.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/organizations/invitations.gjs
+++ b/admin/app/components/organizations/invitations.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -1,12 +1,14 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import {
+  PixButton,
+  PixFilterBanner,
+  PixInput,
+  PixModal,
+  PixPagination,
+  PixSegmentedControl,
+  PixSelect,
+  PixTable,
+  PixTableColumn,
+} from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/organizations/member-item.gjs
+++ b/admin/app/components/organizations/member-item.gjs
@@ -1,4 +1,4 @@
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/organizations/network/actions-section.gjs
+++ b/admin/app/components/organizations/network/actions-section.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { hash } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/organizations/network/attach-child-form.gjs
+++ b/admin/app/components/organizations/network/attach-child-form.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/organizations/network/list-item.gjs
+++ b/admin/app/components/organizations/network/list-item.gjs
@@ -1,4 +1,4 @@
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/organizations/network/list.gjs
+++ b/admin/app/components/organizations/network/list.gjs
@@ -1,4 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixTable } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 import ListItem from './list-item';

--- a/admin/app/components/organizations/places-lot-creation-form.gjs
+++ b/admin/app/components/organizations/places-lot-creation-form.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixButtonLink, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/organizations/places.gjs
+++ b/admin/app/components/organizations/places.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/organizations/places/list.gjs
+++ b/admin/app/components/organizations/places/list.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButton, PixTable, PixTableColumn, PixTag } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/organizations/places/statistics.gjs
+++ b/admin/app/components/organizations/places/statistics.gjs
@@ -1,4 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixIndicatorCard } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/organizations/statistics.gjs
+++ b/admin/app/components/organizations/statistics.gjs
@@ -1,8 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixIndicatorCard, PixTable, PixTableColumn, PixTooltip } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 const shouldDisplayStatistics = (statistics) => {

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixInput, PixModal, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/organizations/team-actions-section.gjs
+++ b/admin/app/components/organizations/team-actions-section.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/organizations/team-section.gjs
+++ b/admin/app/components/organizations/team-section.gjs
@@ -1,8 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixFilterBanner, PixInput, PixPagination, PixSelect, PixTable } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/quests/form.gjs
+++ b/admin/app/components/quests/form.gjs
@@ -1,9 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixBlock, PixButton, PixButtonLink, PixInput, PixSegmentedControl, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/quests/requirements/form.gjs
+++ b/admin/app/components/quests/requirements/form.gjs
@@ -1,6 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixBlock, PixButtonLink, PixSelect } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/quests/requirements/object/form-field.gjs
+++ b/admin/app/components/quests/requirements/object/form-field.gjs
@@ -1,6 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixCheckbox, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/quests/requirements/object/form.gjs
+++ b/admin/app/components/quests/requirements/object/form.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { PixButton, PixInput, PixRadioButton } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/quests/snippets/list.gjs
+++ b/admin/app/components/quests/snippets/list.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/sessions/breadcrumb.gjs
+++ b/admin/app/components/sessions/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class Breadcrumb extends Component {

--- a/admin/app/components/sessions/certifications/header.gjs
+++ b/admin/app/components/sessions/certifications/header.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixButton, PixTag, PixTooltip } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/sessions/certifications/list.gjs
+++ b/admin/app/components/sessions/certifications/list.gjs
@@ -1,6 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/sessions/filter-banner.gjs
+++ b/admin/app/components/sessions/filter-banner.gjs
@@ -1,6 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixFilterBanner, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/admin/app/components/sessions/jury-comment.gjs
+++ b/admin/app/components/sessions/jury-comment.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixTextarea } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/sessions/list-items.gjs
+++ b/admin/app/components/sessions/list-items.gjs
@@ -1,11 +1,13 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import {
+  PixButton,
+  PixCheckbox,
+  PixIcon,
+  PixPagination,
+  PixTable,
+  PixTableColumn,
+  PixTag,
+  PixTooltip,
+} from '@1024pix/nebulix-ember';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/sessions/session-informations.gjs
+++ b/admin/app/components/sessions/session-informations.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixButton, PixTooltip } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 import formatDate from 'ember-intl/helpers/format-date';

--- a/admin/app/components/sessions/session/session-candidates.gjs
+++ b/admin/app/components/sessions/session/session-candidates.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';

--- a/admin/app/components/smart-random-simulator/current-challenge.gjs
+++ b/admin/app/components/smart-random-simulator/current-challenge.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButton, PixTag } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/smart-random-simulator/reset.gjs
+++ b/admin/app/components/smart-random-simulator/reset.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 
 import Card from '../card';
 

--- a/admin/app/components/smart-random-simulator/smart-random-params.gjs
+++ b/admin/app/components/smart-random-simulator/smart-random-params.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixInput, PixSelect, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/smart-random-simulator/start.gjs
+++ b/admin/app/components/smart-random-simulator/start.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 <template>
   <section class="start">
     <PixButton @variant="primary" @triggerAction={{@startAssessment}}>

--- a/admin/app/components/smart-random-simulator/tubes-viewer.gjs
+++ b/admin/app/components/smart-random-simulator/tubes-viewer.gjs
@@ -1,6 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixCheckbox, PixTag, PixTooltip } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/stages/breadcrumb.gjs
+++ b/admin/app/components/stages/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class Breadcrumb extends Component {

--- a/admin/app/components/stages/stage-level-select.gjs
+++ b/admin/app/components/stages/stage-level-select.gjs
@@ -1,4 +1,4 @@
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixSelect } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class StageLevelSelect extends Component {

--- a/admin/app/components/stages/update-stage.gjs
+++ b/admin/app/components/stages/update-stage.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixInput, PixTextarea } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/stages/view-stage.gjs
+++ b/admin/app/components/stages/view-stage.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/target-profiles/badge-form.gjs
+++ b/admin/app/components/target-profiles/badge-form.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixButtonLink, PixCheckbox, PixInput, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/target-profiles/badge-form/campaign-criterion.gjs
+++ b/admin/app/components/target-profiles/badge-form/campaign-criterion.gjs
@@ -1,4 +1,4 @@
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
+++ b/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/target-profiles/badge-form/criteria.gjs
+++ b/admin/app/components/target-profiles/badge-form/criteria.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixCheckbox, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/target-profiles/badges.gjs
+++ b/admin/app/components/target-profiles/badges.gjs
@@ -1,10 +1,12 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import {
+  PixButton,
+  PixButtonLink,
+  PixIcon,
+  PixTable,
+  PixTableColumn,
+  PixTag,
+  PixTooltip,
+} from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/target-profiles/breadcrumb.gjs
+++ b/admin/app/components/target-profiles/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/target-profiles/category.gjs
+++ b/admin/app/components/target-profiles/category.gjs
@@ -1,4 +1,4 @@
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixTag } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 import { categories } from '../../models/target-profile';

--- a/admin/app/components/target-profiles/details.gjs
+++ b/admin/app/components/target-profiles/details.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 
 import Area from '../common/tubes-details/area';
 

--- a/admin/app/components/target-profiles/edit-target-profile-form.gjs
+++ b/admin/app/components/target-profiles/edit-target-profile-form.gjs
@@ -1,9 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixCheckbox, PixInput, PixNotificationAlert, PixSelect, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/target-profiles/insights.gjs
+++ b/admin/app/components/target-profiles/insights.gjs
@@ -1,5 +1,4 @@
-import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixBannerAlert, PixButtonLink } from '@1024pix/nebulix-ember';
 
 import Badges from './badges';
 import Stages from './stages';

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -1,9 +1,11 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import {
+  PixFilterBanner,
+  PixInput,
+  PixMultiSelect,
+  PixPagination,
+  PixTable,
+  PixTableColumn,
+} from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/target-profiles/modal/copy.gjs
+++ b/admin/app/components/target-profiles/modal/copy.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/target-profiles/pdf-parameters-modal.gjs
+++ b/admin/app/components/target-profiles/pdf-parameters-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixModal, PixSelect } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/target-profiles/stages.gjs
+++ b/admin/app/components/target-profiles/stages.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixButton, PixRadioButton, PixTooltip } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/target-profiles/stages/new-stage.gjs
+++ b/admin/app/components/target-profiles/stages/new-stage.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/target-profiles/stages/stage.gjs
+++ b/admin/app/components/target-profiles/stages/stage.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixButtonLink, PixModal } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixButton, PixButtonLink, PixModal, PixTabs } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/team/add-member.gjs
+++ b/admin/app/components/team/add-member.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/team/list.gjs
+++ b/admin/app/components/team/list.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixSelect, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { concat, fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/to-be-published-sessions/list-items.gjs
+++ b/admin/app/components/to-be-published-sessions/list-items.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/tools/campaigns.gjs
+++ b/admin/app/components/tools/campaigns.gjs
@@ -1,5 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButtonUpload, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/tools/certification/scoring-simulator.gjs
+++ b/admin/app/components/tools/certification/scoring-simulator.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixInput, PixNotificationAlert, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/tools/junior.gjs
+++ b/admin/app/components/tools/junior.gjs
@@ -1,5 +1,4 @@
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButtonUpload, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/components/trainings/breadcrumb.gjs
+++ b/admin/app/components/trainings/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class Breadcrumb extends Component {

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -1,10 +1,12 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTextArea from '@1024pix/pix-ui/components/pix-textarea';
+import {
+  PixButton,
+  PixCheckbox,
+  PixInput,
+  PixMultiSelect,
+  PixSegmentedControl,
+  PixSelect,
+  PixTextarea,
+} from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -340,15 +342,15 @@ export default class CreateOrUpdateTrainingForm extends Component {
             <:viewA>{{t "common.words.no"}}</:viewA>
             <:viewB>{{t "common.words.yes"}}</:viewB>
           </PixSegmentedControl>
-          <PixTextArea
+          <PixTextarea
             @id="trainingDescription"
             rows="4"
             value={{this.form.description}}
             {{on "change" (fn this.updateForm "description")}}
           >
             <:label>{{t "pages.trainings.training.form.recommendation-engine.description.label"}}</:label>
-          </PixTextArea>
-          <PixTextArea
+          </PixTextarea>
+          <PixTextarea
             @id="trainingObjectives"
             @subLabel={{t "pages.trainings.training.form.recommendation-engine.objectives.sub-label"}}
             rows="6"
@@ -356,15 +358,15 @@ export default class CreateOrUpdateTrainingForm extends Component {
             {{on "change" (fn this.updateForm "objectives")}}
           >
             <:label>{{t "pages.trainings.training.form.recommendation-engine.objectives.label"}}</:label>
-          </PixTextArea>
-          <PixTextArea
+          </PixTextarea>
+          <PixTextarea
             @id="trainingProgram"
             rows="6"
             value={{this.form.program}}
             {{on "change" (fn this.updateForm "program")}}
           >
             <:label>{{t "pages.trainings.training.form.recommendation-engine.program.label"}}</:label>
-          </PixTextArea>
+          </PixTextarea>
         </Card>
       </section>
       <section class="admin-form__actions">

--- a/admin/app/components/trainings/create-training-triggers.gjs
+++ b/admin/app/components/trainings/create-training-triggers.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButtonLink, PixTag } from '@1024pix/nebulix-ember';
 import { hash } from '@ember/helper';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/trainings/delete-training-trigger.gjs
+++ b/admin/app/components/trainings/delete-training-trigger.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/trainings/duplicate-training.gjs
+++ b/admin/app/components/trainings/duplicate-training.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/components/trainings/edit-trigger-threshold.gjs
+++ b/admin/app/components/trainings/edit-trigger-threshold.gjs
@@ -1,4 +1,4 @@
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixInput } from '@1024pix/nebulix-ember';
 
 import Card from '../card';
 import TubesSelection from '../common/tubes-selection';

--- a/admin/app/components/trainings/list-summary-items.gjs
+++ b/admin/app/components/trainings/list-summary-items.gjs
@@ -1,8 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixFilterBanner, PixInput, PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';

--- a/admin/app/components/trainings/state-tag.gjs
+++ b/admin/app/components/trainings/state-tag.gjs
@@ -1,4 +1,4 @@
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixTag } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class StateTag extends Component {

--- a/admin/app/components/ui/copy-button.gjs
+++ b/admin/app/components/ui/copy-button.gjs
@@ -1,5 +1,4 @@
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIconButton, PixTooltip } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/ui/deletion-modal.gjs
+++ b/admin/app/components/ui/deletion-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixCheckbox, PixModal } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/admin/app/components/users/breadcrumb.gjs
+++ b/admin/app/components/users/breadcrumb.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 export default class Breadcrumb extends Component {

--- a/admin/app/components/users/campaign-participations.gjs
+++ b/admin/app/components/users/campaign-participations.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/users/certification-centers/membership-item-actions.gjs
+++ b/admin/app/components/users/certification-centers/membership-item-actions.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/users/certification-centers/membership-item-role.gjs
+++ b/admin/app/components/users/certification-centers/membership-item-role.gjs
@@ -1,4 +1,4 @@
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixSelect } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 <template>
   {{#if @isEditionMode}}

--- a/admin/app/components/users/certification-centers/membership-item.gjs
+++ b/admin/app/components/users/certification-centers/membership-item.gjs
@@ -1,4 +1,4 @@
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/components/users/certification-centers/memberships.gjs
+++ b/admin/app/components/users/certification-centers/memberships.gjs
@@ -1,4 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixTable } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/users/filter-banner.gjs
+++ b/admin/app/components/users/filter-banner.gjs
@@ -1,6 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixFilterBanner, PixInput, PixSelect } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/users/list-items.gjs
+++ b/admin/app/components/users/list-items.gjs
@@ -1,6 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/users/user-certification-courses.gjs
+++ b/admin/app/components/users/user-certification-courses.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.gjs
+++ b/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixInput, PixModal } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixButton, PixIcon } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
+++ b/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixIcon, PixIconButton, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';

--- a/admin/app/components/users/user-detail-personal-information/reassign-gar-authentication-method-modal.gjs
+++ b/admin/app/components/users/user-detail-personal-information/reassign-gar-authentication-method-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixInput, PixModal } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/users/user-detail-personal-information/reassign-oidc-authentication-method-modal.gjs
+++ b/admin/app/components/users/user-detail-personal-information/reassign-oidc-authentication-method-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixInput, PixModal } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { t } from 'ember-intl';

--- a/admin/app/components/users/user-organization-memberships.gjs
+++ b/admin/app/components/users/user-organization-memberships.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -1,9 +1,11 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import {
+  PixButton,
+  PixButtonLink,
+  PixInput,
+  PixNotificationAlert,
+  PixSelect,
+  PixTooltip,
+} from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/admin/app/components/users/user-profile.gjs
+++ b/admin/app/components/users/user-profile.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/admin/app/components/with-required-action-sessions/list-items.gjs
+++ b/admin/app/components/with-required-action-sessions/list-items.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -1,3 +1,6 @@
+/* design system */
+@use 'nebulix-styles' as *;
+
 /* global */
 @use 'globals/a11y' as *;
 @use 'globals/global' as *;

--- a/admin/app/templates/authenticated.gjs
+++ b/admin/app/templates/authenticated.gjs
@@ -1,5 +1,4 @@
-import PixAppLayout from '@1024pix/pix-ui/components/pix-app-layout';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixAppLayout, PixToastContainer } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import Sidebar from 'pix-admin/components/layout/sidebar';
 <template>

--- a/admin/app/templates/authenticated/certification-centers/get/team.gjs
+++ b/admin/app/templates/authenticated/certification-centers/get/team.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import MembershipsSection from 'pix-admin/components/certification-centers/memberships-section';
 <template>

--- a/admin/app/templates/authenticated/certification-centers/list.gjs
+++ b/admin/app/templates/authenticated/certification-centers/list.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import ListItems from 'pix-admin/components/certification-centers/list-items';

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/index.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/index.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import Framework from 'pix-admin/components/certification-frameworks/certification-framework/framework';

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';

--- a/admin/app/templates/authenticated/combined-course-blueprints/edit.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/edit.gjs
@@ -1,4 +1,4 @@
-import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { PixBreadcrumb } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import pageTitle from 'ember-page-title/helpers/page-title';

--- a/admin/app/templates/authenticated/combined-course-blueprints/list.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/list.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import ListItems from 'pix-admin/components/networks/list-items';

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -1,5 +1,4 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixNotificationAlert, PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import Breadcrumb from 'pix-admin/components/organizations/breadcrumb';

--- a/admin/app/templates/authenticated/organizations/list.gjs
+++ b/admin/app/templates/authenticated/organizations/list.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import ListItems from 'pix-admin/components/organizations/list-items';

--- a/admin/app/templates/authenticated/sessions/certification.gjs
+++ b/admin/app/templates/authenticated/sessions/certification.gjs
@@ -1,4 +1,4 @@
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';

--- a/admin/app/templates/authenticated/sessions/certification/neutralization.gjs
+++ b/admin/app/templates/authenticated/sessions/certification/neutralization.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';

--- a/admin/app/templates/authenticated/sessions/list.gjs
+++ b/admin/app/templates/authenticated/sessions/list.gjs
@@ -1,4 +1,4 @@
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixTabs } from '@1024pix/nebulix-ember';
 import { hash } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';

--- a/admin/app/templates/authenticated/sessions/list/to-be-published.gjs
+++ b/admin/app/templates/authenticated/sessions/list/to-be-published.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import ConfirmPopup from 'pix-admin/components/confirm-popup';

--- a/admin/app/templates/authenticated/sessions/list/with-required-action.gjs
+++ b/admin/app/templates/authenticated/sessions/list/with-required-action.gjs
@@ -1,4 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import { PixCheckbox } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';

--- a/admin/app/templates/authenticated/sessions/session.gjs
+++ b/admin/app/templates/authenticated/sessions/session.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixButton, PixInput, PixTabs } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
 import pageTitle from 'ember-page-title/helpers/page-title';

--- a/admin/app/templates/authenticated/target-profiles/list.gjs
+++ b/admin/app/templates/authenticated/target-profiles/list.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import ListSummaryItems from 'pix-admin/components/target-profiles/list-summary-items';
 <template>

--- a/admin/app/templates/authenticated/tools.gjs
+++ b/admin/app/templates/authenticated/tools.gjs
@@ -1,4 +1,4 @@
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';

--- a/admin/app/templates/authenticated/trainings/list.gjs
+++ b/admin/app/templates/authenticated/trainings/list.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixButtonLink, PixIcon } from '@1024pix/nebulix-ember';
 import ListSummaryItems from 'pix-admin/components/trainings/list-summary-items';
 <template>
   <header>

--- a/admin/app/templates/authenticated/trainings/new.gjs
+++ b/admin/app/templates/authenticated/trainings/new.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import Breadcrumb from 'pix-admin/components/trainings/breadcrumb';
 import CreateOrUpdateTrainingForm from 'pix-admin/components/trainings/create-or-update-training-form';

--- a/admin/app/templates/authenticated/trainings/training.gjs
+++ b/admin/app/templates/authenticated/trainings/training.gjs
@@ -1,6 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixBlock, PixButtonLink, PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';

--- a/admin/app/templates/authenticated/trainings/training/details.gjs
+++ b/admin/app/templates/authenticated/trainings/training/details.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.gjs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixInput, PixModal, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';

--- a/admin/app/templates/authenticated/trainings/training/triggers/edit.gjs
+++ b/admin/app/templates/authenticated/trainings/training/triggers/edit.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import EditTriggerThreshold from 'pix-admin/components/trainings/edit-trigger-threshold';
 <template>

--- a/admin/app/templates/authenticated/users/get.gjs
+++ b/admin/app/templates/authenticated/users/get.gjs
@@ -1,4 +1,4 @@
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';

--- a/admin/ember-cli-build.js
+++ b/admin/ember-cli-build.js
@@ -11,7 +11,7 @@ const sourceMapConfig = {
 module.exports = async function (defaults) {
   const app = new EmberApp(defaults, {
     sassOptions: {
-      includePaths: ['node_modules/@1024pix/pix-ui/addon/styles', 'app/components'],
+      includePaths: ['node_modules/@1024pix/nebulix-ember/dist/styles', 'app/components'],
     },
     'ember-simple-auth': {
       useSessionSetupMethod: true,

--- a/admin/maintenance_page.html
+++ b/admin/maintenance_page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="no-js" lang="fr">
   <head>
     <meta charset="utf-8" />
@@ -14,7 +14,7 @@
 
       @font-face {
         font-family: 'Roboto';
-        src: url('/@1024pix/pix-ui/fonts/Roboto/Roboto-Medium.ttf');
+        src: url('/@1024pix/nebulix-ember/fonts/Roboto/Roboto-Medium.ttf');
         font-weight: 500;
         font-style: normal;
       }

--- a/admin/maintenance_scheduled.html
+++ b/admin/maintenance_scheduled.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="no-js" lang="fr">
   <head>
     <meta charset="utf-8" />
@@ -14,7 +14,7 @@
 
       @font-face {
         font-family: 'Roboto';
-        src: url('/@1024pix/pix-ui/fonts/Roboto/Roboto-Medium.ttf');
+        src: url('/@1024pix/nebulix-ember/fonts/Roboto/Roboto-Medium.ttf');
         font-weight: 500;
         font-style: normal;
       }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.41",
         "@1024pix/eslint-plugin": "^2.1.21",
-        "@1024pix/nebulix-ember": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
+        "@1024pix/nebulix-ember": "^0.1.1",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.28.5",
         "@ember-intl/v1-compat": "^1.0.0",
@@ -209,7 +209,8 @@
     },
     "node_modules/@1024pix/nebulix-ember": {
       "version": "0.1.1",
-      "resolved": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@1024pix/nebulix-ember/-/nebulix-ember-0.1.1.tgz",
+      "integrity": "sha512-bHx6tB4zm2a0pTXU+XIp2NerbEYv4ETqdSu5QauLlh347zD4/Y18Nw9klmjG4aRxTDF3jyy/WMufKvzaAeJJ+A==",
       "dev": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -226,17 +227,6 @@
       "peerDependencies": {
         "@glimmer/component": ">= 2.0.0",
         "ember-source": ">= 6.0.0"
-      }
-    },
-    "node_modules/@1024pix/nebulix-ember/node_modules/tracked-toolbox": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-3.0.0.tgz",
-      "integrity": "sha512-9Q5SH+0jevfB07oL2bsjxIDv0jQ2A6IgminkvnMMzGLc2EqCFm/yKuqNeUFvN3n+TOAQk+PZcePtIaxIo/1now==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.10.0",
-        "decorator-transforms": "^2.3.0"
       }
     },
     "node_modules/@1024pix/stylelint-config": {
@@ -29331,6 +29321,17 @@
         "@embroider/addon-shim": "^1.10.2",
         "decorator-transforms": "^2.0.0",
         "ember-tracked-storage-polyfill": "^1.0.0"
+      }
+    },
+    "node_modules/tracked-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-3.0.0.tgz",
+      "integrity": "sha512-9Q5SH+0jevfB07oL2bsjxIDv0jQ2A6IgminkvnMMzGLc2EqCFm/yKuqNeUFvN3n+TOAQk+PZcePtIaxIo/1now==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.10.0",
+        "decorator-transforms": "^2.3.0"
       }
     },
     "node_modules/tree-sync": {

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.41",
         "@1024pix/eslint-plugin": "^2.1.21",
-        "@1024pix/pix-ui": "^61.4.1",
+        "@1024pix/nebulix-ember": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.28.5",
         "@ember-intl/v1-compat": "^1.0.0",
@@ -35,6 +35,7 @@
         "ember-cli-babel": "^8.2.0",
         "ember-cli-dependency-checker": "^3.3.3",
         "ember-cli-deprecation-workflow": "^4.0.1",
+        "ember-cli-htmlbars": "^6.3.0",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-sass": "^11.0.1",
         "ember-cookies": "^1.3.0",
@@ -206,31 +207,36 @@
         "eslint": ">=9.17.0"
       }
     },
-    "node_modules/@1024pix/pix-ui": {
-      "version": "61.4.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-61.4.1.tgz",
-      "integrity": "sha512-uccyjJdMMg/2Zl+cmq/NSYNVGdr64wA9mQZxTQTCAB8MuSPNhhdijS9PLmXMj0nR72ftbbdrpbme8g3wVqomOA==",
+    "node_modules/@1024pix/nebulix-ember": {
+      "version": "0.1.1",
+      "resolved": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.9",
+        "@formatjs/intl": "^4.1.19",
+        "decorator-transforms": "^2.2.2",
+        "ember-click-outside": "^6.1.1",
+        "ember-lifeline": "^7.1.0",
+        "ember-modifier": "^4.3.0",
+        "ember-popperjs": "^3.0.0",
+        "ember-truth-helpers": "^5.0.0",
+        "tracked-toolbox": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@glimmer/component": ">= 2.0.0",
+        "ember-source": ">= 6.0.0"
+      }
+    },
+    "node_modules/@1024pix/nebulix-ember/node_modules/tracked-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-3.0.0.tgz",
+      "integrity": "sha512-9Q5SH+0jevfB07oL2bsjxIDv0jQ2A6IgminkvnMMzGLc2EqCFm/yKuqNeUFvN3n+TOAQk+PZcePtIaxIo/1now==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@formatjs/intl": "^4.0.0",
-        "check-engine": "^1.14.0",
-        "ember-auto-import": "^2.7.4",
-        "ember-cli-babel": "^8.2.0",
-        "ember-cli-htmlbars": "^6.3.0",
-        "ember-cli-sass": "^11.0.1",
-        "ember-click-outside": "^6.1.1",
-        "ember-lifeline": "^7.0.0",
-        "ember-modifier": "^4.2.0",
-        "ember-popperjs": "^3.0.0",
-        "ember-template-imports": "^4.3.0",
-        "ember-truth-helpers": "^5.0.0",
-        "tracked-toolbox": "^2.2.0"
-      },
-      "engines": {
-        "node": "^20 || ^22 || ^24"
+        "@embroider/addon-shim": "^1.10.0",
+        "decorator-transforms": "^2.3.0"
       }
     },
     "node_modules/@1024pix/stylelint-config": {
@@ -4902,25 +4908,15 @@
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.2.tgz",
-      "integrity": "sha512-V60fNY/X/7zqmRffr7qPwscGmVGYDmlKF069mSQ2a/7fE22q602NtIfOQY8vzRA63Gr/O/U6vjRVBHMabrnA9A==",
+      "version": "4.1.19",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.19.tgz",
+      "integrity": "sha512-bZMROATl+rzfL8wsDZ53i8XWHx5e6rVr8QlGT5GDvHImEUro4WE9pxUd2dobzmI3CtD+zkt/wkEdqcb+3CK8Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "intl-messageformat": "11.1.2",
-        "tslib": "^2.8.1"
-      },
-      "peerDependencies": {
-        "typescript": "^5.6.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17",
+        "intl-messageformat": "11.2.14"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
@@ -4933,62 +4929,29 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.1.tgz",
-      "integrity": "sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/intl-localematcher": "0.8.1",
-        "decimal.js": "^10.6.0",
-        "tslib": "^2.8.1"
-      }
-    },
     "node_modules/@formatjs/intl/node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
-      "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
+      "license": "MIT"
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.1.tgz",
-      "integrity": "sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/icu-skeleton-parser": "2.1.1",
-        "tslib": "^2.8.1"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.1.tgz",
-      "integrity": "sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
-      "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "tslib": "^2.8.1"
-      }
+      "license": "MIT"
     },
     "node_modules/@glimmer/component": {
       "version": "2.0.0",
@@ -7757,16 +7720,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -8513,13 +8466,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
       "integrity": "sha512-kXQ19Xhoghiyw66CUiGypnuRpWlbHAzY/+NyvqTEdTfhfQGH1/dbEMYiXju7fYKIFePpzp/y9dsu5Cu/PkmawQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10216,82 +10162,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "node_modules/check-engine": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/check-engine/-/check-engine-1.14.0.tgz",
-      "integrity": "sha512-CZZ3UmZKMer4O63yNWit5KLm7FoO69shcdPbkP8Dj4N728jqI7d8YyAigOgKnajVBA7TtaL7BuaMRDXcoYJKxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "3.7.2",
-        "colors": "1.4.0",
-        "command-line-usage": "6.1.3",
-        "jsonfile": "6.1.0",
-        "semver": "7.5.4",
-        "yargs": "17.7.1"
-      },
-      "bin": {
-        "check-engine": "bin/check-engine.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/check-engine/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/check-engine/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/check-engine/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/check-engine/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -10596,16 +10466,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -10617,100 +10477,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
-      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/commander": {
@@ -11750,16 +11516,6 @@
         "node": ">= 12.*"
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -12315,625 +12071,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cache-primitive-polyfill/-/ember-cache-primitive-polyfill-1.0.1.tgz",
-      "integrity": "sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1",
-        "ember-cli-version-checker": "^5.1.1",
-        "ember-compatibility-helpers": "^1.2.1",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
-      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/@babel/runtime": {
-      "version": "7.12.18",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/async-disk-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
-      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "2.1.0",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.5.3",
-        "rsvp": "^3.0.18",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/async-disk-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/async-disk-cache/node_modules/rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "0.12.* || 4.* || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/babel-plugin-module-resolver": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-babel-config": "^1.1.0",
-        "glob": "^7.1.2",
-        "pkg-up": "^2.0.0",
-        "reselect": "^3.0.1",
-        "resolve": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-babel-transpiler": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
-      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/polyfill": "^7.11.5",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "broccoli-persistent-filter": "^2.2.1",
-        "clone": "^2.1.2",
-        "hash-for-dep": "^1.4.7",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.9",
-        "json-stable-stringify": "^1.0.1",
-        "rsvp": "^4.8.4",
-        "workerpool": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-funnel/node_modules/fs-tree-diff": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-funnel/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-merge-trees": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-plugin": "^1.3.0",
-        "merge-trees": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-persistent-filter": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-disk-cache": "^1.2.1",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^1.0.0",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "mkdirp": "^0.5.1",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.7.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^1.3.3",
-        "walk-sync": "^1.0.0"
-      },
-      "engines": {
-        "node": "6.* || >= 8.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-persistent-filter/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^1.1.1"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-plugin/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-source": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
-      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel": {
-      "version": "7.26.11",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
-      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/helper-compilation-targets": "^7.12.0",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
-        "@babel/plugin-proposal-decorators": "^7.13.5",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
-        "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-runtime": "^7.13.9",
-        "@babel/plugin-transform-typescript": "^7.13.0",
-        "@babel/polyfill": "^7.11.5",
-        "@babel/preset-env": "^7.16.5",
-        "@babel/runtime": "7.12.18",
-        "amd-name-resolver": "^1.3.1",
-        "babel-plugin-debug-macros": "^0.3.4",
-        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
-        "babel-plugin-module-resolver": "^3.2.0",
-        "broccoli-babel-transpiler": "^7.8.0",
-        "broccoli-debug": "^0.6.4",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-source": "^2.1.2",
-        "calculate-cache-key-for-tree": "^2.0.0",
-        "clone": "^2.1.2",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^4.1.0",
-        "ensure-posix-path": "^1.0.2",
-        "fixturify-project": "^1.10.0",
-        "resolve-package-path": "^3.1.0",
-        "rimraf": "^3.0.1",
-        "semver": "^5.5.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
-      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-package-path": "^2.0.0",
-        "semver": "^6.3.0",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
-      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.13.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/find-babel-config": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
-      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^1.0.2",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/istextorbinary": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binaryextensions": "1 || 2",
-        "editions": "^1.1.1",
-        "textextensions": "1 || 2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/reselect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/resolve-package-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/sync-disk-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
-      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/sync-disk-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/walk-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/walk-sync/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/workerpool": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
-      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.3.4",
-        "object-assign": "4.1.1",
-        "rsvp": "^4.8.4"
       }
     },
     "node_modules/ember-cli": {
@@ -13894,9 +13031,9 @@
       }
     },
     "node_modules/ember-cli-htmlbars/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -14951,49 +14088,6 @@
         "ember-modifier": "^3.2.7 || ^4.0.0"
       }
     },
-    "node_modules/ember-compatibility-helpers": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.7.tgz",
-      "integrity": "sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-debug-macros": "^0.2.0",
-        "ember-cli-version-checker": "^5.1.1",
-        "find-up": "^5.0.0",
-        "fs-extra": "^9.1.0",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-compatibility-helpers/node_modules/babel-plugin-debug-macros": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-      "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-beta.42"
-      }
-    },
-    "node_modules/ember-compatibility-helpers/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/ember-cookies": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.4.1.tgz",
@@ -15491,9 +14585,9 @@
       }
     },
     "node_modules/ember-lifeline": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ember-lifeline/-/ember-lifeline-7.0.0.tgz",
-      "integrity": "sha512-2l51NzgH5vjN972zgbs+32rnXnnEFKB7qsSpJF+lBI4V5TG6DMy4SfowC72ZEuAtS58OVfwITbOO+RnM21EdpA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ember-lifeline/-/ember-lifeline-7.1.0.tgz",
+      "integrity": "sha512-hd3r0jwZLgXNn3l2YSX6wVnD1KD5h+WUG6P/xo4rJXFboy7nOwix38fZt9SbuO66QVZSkdqMeUqW6Z/NPWa9kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16191,16 +15285,14 @@
       }
     },
     "node_modules/ember-modifier": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.2.2.tgz",
-      "integrity": "sha512-pPYBAGyczX0hedGWQFQOEiL9s45KS9efKxJxUQkMLjQyh+1Uef1mcmAGsdw2KmvNupITkE/nXxmVO1kZ9tt3ag==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.3.0.tgz",
+      "integrity": "sha512-O0rirSLQbGg0VJ/NqoQ4uN1bh2iAekZC/Ykma+FkjCM2ofrO38u+d8n3+AK6uVWeMJmogGX2KL+Is5fofoInJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
-        "decorator-transforms": "^2.0.0",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0"
+        "decorator-transforms": "^2.0.0"
       }
     },
     "node_modules/ember-page-title": {
@@ -16994,9 +16086,9 @@
       }
     },
     "node_modules/ember-template-imports/node_modules/content-tag": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-4.1.0.tgz",
-      "integrity": "sha512-On6gUuvI1l5MScHO+Xbwjeq1Pk9H6HOipDWkzqGGUGmKpq6K5TRmQuCl1LGSHbdIo2l+lSsgLKrLgCl5kKYA+A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-4.2.0.tgz",
+      "integrity": "sha512-f/o+F3qSa4gg23I7RWy6cMDxP2nPo99YWusxw2bjne7ZC6Acqqf4uB/+87AekOq1ehTocHH7b7nMd2X4S3NHVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -21340,74 +20432,39 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.1.2.tgz",
-      "integrity": "sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==",
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.14.tgz",
+      "integrity": "sha512-9f2VD1HFuxUvMw0RxsaP8WmMns6JRTnsNB/zghTFrp11ZktiXWwVDeZBPQchBKEmo+Gx/ZhxI7Qht7YglFD4PA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.1.tgz",
-      "integrity": "sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/intl-localematcher": "0.8.1",
-        "decimal.js": "^10.6.0",
-        "tslib": "^2.8.1"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
-      "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
+      "license": "MIT"
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.1.tgz",
-      "integrity": "sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/icu-skeleton-parser": "2.1.1",
-        "tslib": "^2.8.1"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.1.tgz",
-      "integrity": "sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
-      "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "tslib": "^2.8.1"
-      }
+      "license": "MIT"
     },
     "node_modules/invert-kv": {
       "version": "3.0.1",
@@ -26451,16 +25508,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -29315,22 +28362,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/table-layout": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
-      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/table/node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -30302,18 +29333,6 @@
         "ember-tracked-storage-polyfill": "^1.0.0"
       }
     },
-    "node_modules/tracked-toolbox": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-2.2.0.tgz",
-      "integrity": "sha512-YknotXj74U0nCqBk9nh1Uv1IWTnVOgt8sXIecNkyEq4oFOU70niQUlozO4E3kMKx7ae/rNlOtoF+1ALcHYzCrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.10.0",
-        "decorator-transforms": "^2.3.0",
-        "ember-cache-primitive-polyfill": "^1.0.0"
-      }
-    },
     "node_modules/tree-sync": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-2.1.0.tgz",
@@ -30583,16 +29602,6 @@
       "integrity": "sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",
@@ -31549,20 +30558,6 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
-      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/workerpool": {
       "version": "10.0.2",

--- a/admin/package.json
+++ b/admin/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.41",
     "@1024pix/eslint-plugin": "^2.1.21",
-    "@1024pix/pix-ui": "^61.4.1",
+    "@1024pix/nebulix-ember": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.28.5",
     "@ember-intl/v1-compat": "^1.0.0",
@@ -67,6 +67,7 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.3",
     "ember-cli-deprecation-workflow": "^4.0.1",
+    "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cookies": "^1.3.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.41",
     "@1024pix/eslint-plugin": "^2.1.21",
-    "@1024pix/nebulix-ember": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
+    "@1024pix/nebulix-ember": "^0.1.1",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.28.5",
     "@ember-intl/v1-compat": "^1.0.0",

--- a/admin/tests/integration/components/administration/access/anonymize-gar-import-test.gjs
+++ b/admin/tests/integration/components/administration/access/anonymize-gar-import-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';

--- a/admin/tests/integration/components/administration/access/oidc-providers-import-test.gjs
+++ b/admin/tests/integration/components/administration/access/oidc-providers-import-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import OidcProvidersImport from 'pix-admin/components/administration/access/oidc-providers-import';

--- a/admin/tests/integration/components/administration/certification/sco-blocked-access-dates_test.gjs
+++ b/admin/tests/integration/components/administration/certification/sco-blocked-access-dates_test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ScoBlockedAccessDates from 'pix-admin/components/administration/certification/sco-blocked-access-dates';

--- a/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
+++ b/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';

--- a/admin/tests/integration/components/administration/common/add-organization-features-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/common/add-organization-features-in-batch-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';

--- a/admin/tests/integration/components/administration/common/create-attestations-test.gjs
+++ b/admin/tests/integration/components/administration/common/create-attestations-test.gjs
@@ -1,5 +1,5 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import { click, triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CreateAttestations from 'pix-admin/components/administration/common/create-attestations';

--- a/admin/tests/integration/components/administration/common/create-combined-courses-test.gjs
+++ b/admin/tests/integration/components/administration/common/create-combined-courses-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';

--- a/admin/tests/integration/components/administration/common/upsert-quests-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/common/upsert-quests-in-batch-test.gjs
@@ -1,5 +1,5 @@
 import { getDefaultNormalizer, render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';

--- a/admin/tests/integration/components/administration/deployment/certification-centers-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/certification-centers-batch-archive-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CertificationCentersBatchArchive from 'pix-admin/components/administration/deployment/certification-centers-batch-archive';

--- a/admin/tests/integration/components/administration/deployment/organization-tags-import_test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organization-tags-import_test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import OrganizationTagsImport from 'pix-admin/components/administration/deployment/organization-tags-import';

--- a/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import OrganizationsBatchArchive from 'pix-admin/components/administration/deployment/organizations-batch-archive';

--- a/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixToastContainer } from '@1024pix/nebulix-ember';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';

--- a/orga/app/components/activity-type.gjs
+++ b/orga/app/components/activity-type.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/orga/app/components/analysis/analysis-header.gjs
+++ b/orga/app/components/analysis/analysis-header.gjs
@@ -1,5 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
+import { PixBlock, PixSegmentedControl } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/analysis/analysis-per-competence.gjs
+++ b/orga/app/components/analysis/analysis-per-competence.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/orga/app/components/analysis/analysis-per-tube.gjs
+++ b/orga/app/components/analysis/analysis-per-tube.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import CoverRateGauge from 'pix-orga/components/statistics/cover-rate-gauge';

--- a/orga/app/components/analysis/global-positioning.gjs
+++ b/orga/app/components/analysis/global-positioning.gjs
@@ -1,5 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixGauge from '@1024pix/pix-ui/components/pix-gauge';
+import { PixBlock, PixGauge } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixMultiSelect, PixSelect } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/attestations/list.gjs
+++ b/orga/app/components/attestations/list.gjs
@@ -1,9 +1,11 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import {
+  PixFilterBanner,
+  PixPagination,
+  PixSearchInput,
+  PixTable,
+  PixTableColumn,
+  PixTag,
+} from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { formatDate, t } from 'ember-intl';

--- a/orga/app/components/authentication/authentication-identity-providers.gjs
+++ b/orga/app/components/authentication/authentication-identity-providers.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/authentication/join-request-form.gjs
+++ b/orga/app/components/authentication/join-request-form.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixButton, PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/authentication/login-form.gjs
+++ b/orga/app/components/authentication/login-form.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixInputPassword from '@1024pix/pix-ui/components/pix-input-password';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixInput, PixInputPassword, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/authentication/new-password-input/index.gjs
+++ b/orga/app/components/authentication/new-password-input/index.gjs
@@ -1,4 +1,4 @@
-import PixInputPassword from '@1024pix/pix-ui/components/pix-input-password';
+import { PixInputPassword } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/authentication/new-password-input/password-rule.gjs
+++ b/orga/app/components/authentication/new-password-input/password-rule.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 
 const RULE_STYLES = {

--- a/orga/app/components/authentication/oidc-association-confirmation.gjs
+++ b/orga/app/components/authentication/oidc-association-confirmation.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixIcon, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/authentication/oidc-provider-selector.gjs
+++ b/orga/app/components/authentication/oidc-provider-selector.gjs
@@ -1,4 +1,4 @@
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixSelect } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/authentication/oidc-signup-form.gjs
+++ b/orga/app/components/authentication/oidc-signup-form.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixCheckbox, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/authentication/signup-form/cgu-checkbox.gjs
+++ b/orga/app/components/authentication/signup-form/cgu-checkbox.gjs
@@ -1,4 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import { PixCheckbox } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/authentication/signup-form/index.gjs
+++ b/orga/app/components/authentication/signup-form/index.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixInput, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/authentication/sso-selection-form.gjs
+++ b/orga/app/components/authentication/sso-selection-form.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/banner/certification.gjs
+++ b/orga/app/components/banner/certification.gjs
@@ -1,4 +1,4 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/banner/communication.gjs
+++ b/orga/app/components/banner/communication.gjs
@@ -1,4 +1,4 @@
-import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
+import { PixBannerAlert } from '@1024pix/nebulix-ember';
 import { htmlSafe } from '@ember/template';
 import ENV from 'pix-orga/config/environment';
 

--- a/orga/app/components/banner/information-banners.gjs
+++ b/orga/app/components/banner/information-banners.gjs
@@ -1,4 +1,4 @@
-import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
+import { PixBannerAlert } from '@1024pix/nebulix-ember';
 
 import textWithMultipleLang from '../../helpers/text-with-multiple-lang.js';
 

--- a/orga/app/components/banner/maximum-places-exceeded.gjs
+++ b/orga/app/components/banner/maximum-places-exceeded.gjs
@@ -1,4 +1,4 @@
-import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
+import { PixBannerAlert } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/banner/mission-banner.gjs
+++ b/orga/app/components/banner/mission-banner.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixIcon, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import CopyPasteButton from 'pix-orga/components/copy-paste-button';

--- a/orga/app/components/banner/sco-banner.gjs
+++ b/orga/app/components/banner/sco-banner.gjs
@@ -1,4 +1,4 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixNotificationAlert } from '@1024pix/nebulix-ember';
 import SafeMarkdownToHtml from 'pix-orga/components/safe-markdown-to-html';
 
 <template>

--- a/orga/app/components/banner/survey.gjs
+++ b/orga/app/components/banner/survey.gjs
@@ -1,4 +1,4 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/campaign/activity/delete-participation-modal.gjs
+++ b/orga/app/components/campaign/activity/delete-participation-modal.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 function deleteParticipationModalWarning(type, status) {

--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -1,7 +1,4 @@
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixIconButton, PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { array, fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/orga/app/components/campaign/badges.gjs
+++ b/orga/app/components/campaign/badges.gjs
@@ -1,4 +1,4 @@
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixTooltip } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 const isAcquired = (badge, acquiredBadges = []) => {

--- a/orga/app/components/campaign/cards/participants-count.gjs
+++ b/orga/app/components/campaign/cards/participants-count.gjs
@@ -1,4 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixIndicatorCard } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/campaign/cards/result-average.gjs
+++ b/orga/app/components/campaign/cards/result-average.gjs
@@ -1,4 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixIndicatorCard } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/campaign/cards/shared-count.gjs
+++ b/orga/app/components/campaign/cards/shared-count.gjs
@@ -1,4 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixIndicatorCard } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/campaign/cards/stage-average.gjs
+++ b/orga/app/components/campaign/cards/stage-average.gjs
@@ -1,5 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
-import PixStars from '@1024pix/pix-ui/components/pix-stars';
+import { PixIndicatorCard, PixStars } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/campaign/charts/campaign-badge-acquisitions.gjs
+++ b/orga/app/components/campaign/charts/campaign-badge-acquisitions.gjs
@@ -1,4 +1,4 @@
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixTooltip } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/campaign/charts/participants-by-stage.gjs
+++ b/orga/app/components/campaign/charts/participants-by-stage.gjs
@@ -1,5 +1,4 @@
-import PixStars from '@1024pix/pix-ui/components/pix-stars';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixStars, PixTooltip } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';

--- a/orga/app/components/campaign/create-form-catalogue.gjs
+++ b/orga/app/components/campaign/create-form-catalogue.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -1,9 +1,11 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixFilterableAndSearchableSelect from '@1024pix/pix-ui/components/pix-filterable-and-searchable-select';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import {
+  PixButton,
+  PixFilterableAndSearchableSelect,
+  PixInput,
+  PixRadioButton,
+  PixSelect,
+  PixTextarea,
+} from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/orga/app/components/campaign/create-form/assessment-goal-customization.gjs
+++ b/orga/app/components/campaign/create-form/assessment-goal-customization.gjs
@@ -1,4 +1,4 @@
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/campaign/create-form/assessment-goal-settings.gjs
+++ b/orga/app/components/campaign/create-form/assessment-goal-settings.gjs
@@ -1,4 +1,4 @@
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { PixRadioButton } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/orga/app/components/campaign/create-form/campaign-goals.gjs
+++ b/orga/app/components/campaign/create-form/campaign-goals.gjs
@@ -1,4 +1,4 @@
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { PixRadioButton } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/campaign/create-form/campaign-name.gjs
+++ b/orga/app/components/campaign/create-form/campaign-name.gjs
@@ -1,4 +1,4 @@
-import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { PixInput } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/campaign/create-form/campaign-owner.gjs
+++ b/orga/app/components/campaign/create-form/campaign-owner.gjs
@@ -1,4 +1,4 @@
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixSelect } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/campaign/create-form/course-selection.gjs
+++ b/orga/app/components/campaign/create-form/course-selection.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import { or } from 'ember-truth-helpers';
 

--- a/orga/app/components/campaign/create-form/external-id.gjs
+++ b/orga/app/components/campaign/create-form/external-id.gjs
@@ -1,5 +1,4 @@
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { PixInput, PixRadioButton } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/orga/app/components/campaign/create-form/landing-page-text.gjs
+++ b/orga/app/components/campaign/create-form/landing-page-text.gjs
@@ -1,4 +1,4 @@
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixTextarea } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/campaign/create-form/multiple-sendings.gjs
+++ b/orga/app/components/campaign/create-form/multiple-sendings.gjs
@@ -1,4 +1,4 @@
-import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import { PixRadioButton } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/orga/app/components/campaign/empty-state.gjs
+++ b/orga/app/components/campaign/empty-state.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/campaign/filter/campaign-filters.gjs
+++ b/orga/app/components/campaign/filter/campaign-filters.gjs
@@ -1,6 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
-import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
+import { PixFilterBanner, PixSearchInput, PixSegmentedControl } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -1,8 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixStars from '@1024pix/pix-ui/components/pix-stars';
+import { PixFilterBanner, PixMultiSelect, PixSearchInput, PixSelect, PixStars } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/campaign/header/archived-banner.gjs
+++ b/orga/app/components/campaign/header/archived-banner.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixButton, PixIcon } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixButton, PixTabs } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';

--- a/orga/app/components/campaign/list-header.gjs
+++ b/orga/app/components/campaign/list-header.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixButtonLink, PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixCheckbox, PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn, uniqueId } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/orga/app/components/campaign/no-campaign-panel.gjs
+++ b/orga/app/components/campaign/no-campaign-panel.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/campaign/results/assessment-list.gjs
+++ b/orga/app/components/campaign/results/assessment-list.gjs
@@ -1,6 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixPagination, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { array, fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';

--- a/orga/app/components/campaign/results/participation-evolution-icon.gjs
+++ b/orga/app/components/campaign/results/participation-evolution-icon.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 const EVOLUTION_INFOS = {

--- a/orga/app/components/campaign/results/profile-list.gjs
+++ b/orga/app/components/campaign/results/profile-list.gjs
@@ -1,7 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixPagination, PixTable, PixTableColumn, PixTag } from '@1024pix/nebulix-ember';
 import { array, fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { formatDate, t } from 'ember-intl';

--- a/orga/app/components/campaign/settings/target-profile-tooltip.gjs
+++ b/orga/app/components/campaign/settings/target-profile-tooltip.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 import TargetProfileDetails from '../target-profile-details';

--- a/orga/app/components/campaign/settings/view.gjs
+++ b/orga/app/components/campaign/settings/view.gjs
@@ -1,8 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixBlock, PixButton, PixButtonLink, PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/campaign/target-profile-details.gjs
+++ b/orga/app/components/campaign/target-profile-details.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/orga/app/components/campaign/update-form.gjs
+++ b/orga/app/components/campaign/update-form.gjs
@@ -1,8 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixIcon, PixInput, PixSelect, PixTextarea } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -1,5 +1,4 @@
-import PixCard from '@1024pix/pix-ui/components/pix-card';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixCard, PixTag } from '@1024pix/nebulix-ember';
 import { concat, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';

--- a/orga/app/components/catalogue/course-modal.gjs
+++ b/orga/app/components/catalogue/course-modal.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixOverlay from '@1024pix/pix-ui/components/pix-overlay';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixButton, PixButtonLink, PixOverlay, PixTag } from '@1024pix/nebulix-ember';
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/orga/app/components/catalogue/course-modal/combined-course-blueprint-item.gjs
+++ b/orga/app/components/catalogue/course-modal/combined-course-blueprint-item.gjs
@@ -1,5 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixBlock, PixIcon } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/catalogue/course-modal/target-profile-content.gjs
+++ b/orga/app/components/catalogue/course-modal/target-profile-content.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -1,8 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixFilterBanner, PixMultiSelect, PixSearchInput, PixSelect, PixTabs } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/orga/app/components/certificability/tooltip.gjs
+++ b/orga/app/components/certificability/tooltip.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/combined-course/header.gjs
+++ b/orga/app/components/combined-course/header.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixButtonLink, PixIndicatorCard } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/combined-course/list.gjs
+++ b/orga/app/components/combined-course/list.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/orga/app/components/combined-course/participation-detail.gjs
+++ b/orga/app/components/combined-course/participation-detail.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -1,11 +1,13 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import {
+  PixFilterBanner,
+  PixIcon,
+  PixMultiSelect,
+  PixPagination,
+  PixSearchInput,
+  PixTable,
+  PixTableColumn,
+  PixTooltip,
+} from '@1024pix/nebulix-ember';
 import { uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';

--- a/orga/app/components/copy-paste-button.gjs
+++ b/orga/app/components/copy-paste-button.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/dropdown/icon-trigger.gjs
+++ b/orga/app/components/dropdown/icon-trigger.gjs
@@ -1,4 +1,4 @@
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import { PixIconButton } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/import-information-banner.gjs
+++ b/orga/app/components/import-information-banner.gjs
@@ -1,4 +1,4 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/import/banner.gjs
+++ b/orga/app/components/import/banner.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixIcon, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/orga/app/components/import/download-import-template-link.gjs
+++ b/orga/app/components/import/download-import-template-link.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/import/replace-students-modal.gjs
+++ b/orga/app/components/import/replace-students-modal.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixButtonUpload, PixCheckbox, PixModal } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/import/replace-sup.gjs
+++ b/orga/app/components/import/replace-sup.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/index/action-cards-list-item.gjs
+++ b/orga/app/components/index/action-cards-list-item.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 
 <template>
   <PixBlock class="action-cards-list-item" @variant="orga">

--- a/orga/app/components/index/classic.gjs
+++ b/orga/app/components/index/classic.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/orga/app/components/index/missions.gjs
+++ b/orga/app/components/index/missions.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButton, PixButtonLink } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/index/organization-information.gjs
+++ b/orga/app/components/index/organization-information.gjs
@@ -1,4 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixIndicatorCard } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 <template>
   <section>

--- a/orga/app/components/index/participation-statistics.gjs
+++ b/orga/app/components/index/participation-statistics.gjs
@@ -1,4 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixIndicatorCard } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/orga/app/components/layout/organization-places-or-credit-info.gjs
+++ b/orga/app/components/layout/organization-places-or-credit-info.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/layout/school-session-management.gjs
+++ b/orga/app/components/layout/school-session-management.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixButton, PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/layout/sidebar.gjs
+++ b/orga/app/components/layout/sidebar.gjs
@@ -1,6 +1,4 @@
-import PixNavigation from '@1024pix/pix-ui/components/pix-navigation';
-import PixNavigationButton from '@1024pix/pix-ui/components/pix-navigation-button';
-import PixNavigationSeparator from '@1024pix/pix-ui/components/pix-navigation-separator';
+import { PixNavigation, PixNavigationButton, PixNavigationSeparator } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/layout/user-logged-menu.gjs
+++ b/orga/app/components/layout/user-logged-menu.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixStructureSwitcher from '@1024pix/pix-ui/components/pix-structure-switcher';
+import { PixButtonLink, PixStructureSwitcher } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/locale-switcher.gjs
+++ b/orga/app/components/locale-switcher.gjs
@@ -2,7 +2,7 @@
 // If you need a change, as much as possible modify the original file
 // and propagate the changes in the copies in all the fronts
 
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixSelect } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/mission/activity-table.gjs
+++ b/orga/app/components/mission/activity-table.gjs
@@ -1,7 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixPagination, PixTable, PixTableColumn, PixTag } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import getService from 'pix-orga/helpers/get-service';
 

--- a/orga/app/components/mission/details.gjs
+++ b/orga/app/components/mission/details.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixButtonLink, PixIcon } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/mission/navigation.gjs
+++ b/orga/app/components/mission/navigation.gjs
@@ -1,4 +1,4 @@
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 

--- a/orga/app/components/mission/result-table.gjs
+++ b/orga/app/components/mission/result-table.gjs
@@ -1,9 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixPagination, PixTable, PixTableColumn, PixTag, PixTooltip } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import getService from 'pix-orga/helpers/get-service';
 

--- a/orga/app/components/organization-learner/activity.gjs
+++ b/orga/app/components/organization-learner/activity.gjs
@@ -1,4 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixIndicatorCard } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';

--- a/orga/app/components/organization-learner/activity/empty-state.gjs
+++ b/orga/app/components/organization-learner/activity/empty-state.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 const capitalize = (text = '') => text.charAt(0).toUpperCase() + text.slice(1);

--- a/orga/app/components/organization-learner/activity/participation-list.gjs
+++ b/orga/app/components/organization-learner/activity/participation-list.gjs
@@ -1,4 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixTable } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/organization-learner/activity/participation-row.gjs
+++ b/orga/app/components/organization-learner/activity/participation-row.gjs
@@ -1,4 +1,4 @@
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTableColumn } from '@1024pix/nebulix-ember';
 import { array } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';

--- a/orga/app/components/organization-participant/header.gjs
+++ b/orga/app/components/organization-participant/header.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/organization-participant/learner-filters.gjs
+++ b/orga/app/components/organization-participant/learner-filters.gjs
@@ -1,5 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import { PixFilterBanner, PixSearchInput } from '@1024pix/nebulix-ember';
 import { get } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -1,10 +1,12 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import {
+  PixButton,
+  PixCheckbox,
+  PixIcon,
+  PixPagination,
+  PixTable,
+  PixTableColumn,
+  PixTooltip,
+} from '@1024pix/nebulix-ember';
 import { fn, uniqueId } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action, get } from '@ember/object';

--- a/orga/app/components/organization-participant/no-participant-panel.gjs
+++ b/orga/app/components/organization-participant/no-participant-panel.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/participant/assessment/header.gjs
+++ b/orga/app/components/participant/assessment/header.gjs
@@ -1,7 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixProgressBar from '@1024pix/pix-ui/components/pix-progress-bar';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixBlock, PixIcon, PixProgressBar, PixSelect } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/participant/assessment/results.gjs
+++ b/orga/app/components/participant/assessment/results.gjs
@@ -1,6 +1,4 @@
-import PixProgressBar from '@1024pix/pix-ui/components/pix-progress-bar';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixProgressBar, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 import EmptyState from '../../ui/empty-state';

--- a/orga/app/components/participant/assessment/tabs.gjs
+++ b/orga/app/components/participant/assessment/tabs.gjs
@@ -1,4 +1,4 @@
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixTabs } from '@1024pix/nebulix-ember';
 import { array } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';

--- a/orga/app/components/participant/profile/header.gjs
+++ b/orga/app/components/participant/profile/header.gjs
@@ -1,6 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixBlock, PixIcon, PixTag } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { formatDate, t } from 'ember-intl';

--- a/orga/app/components/participant/profile/table.gjs
+++ b/orga/app/components/participant/profile/table.gjs
@@ -1,5 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/places/capacity-alert.gjs
+++ b/orga/app/components/places/capacity-alert.gjs
@@ -1,4 +1,4 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixNotificationAlert } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import { gt } from 'ember-truth-helpers';
 

--- a/orga/app/components/places/place-info.gjs
+++ b/orga/app/components/places/place-info.gjs
@@ -1,5 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixBlock, PixIcon } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/places/places-lot-alert.gjs
+++ b/orga/app/components/places/places-lot-alert.gjs
@@ -1,4 +1,4 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixNotificationAlert } from '@1024pix/nebulix-ember';
 import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 import { STATUSES } from 'pix-orga/models/organization-places-lot.js';

--- a/orga/app/components/places/places-lot-table.gjs
+++ b/orga/app/components/places/places-lot-table.gjs
@@ -1,6 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixTable, PixTableColumn, PixTag } from '@1024pix/nebulix-ember';
 import { formatDate, t } from 'ember-intl';
 import { eq, gt } from 'ember-truth-helpers';
 

--- a/orga/app/components/places/statistics.gjs
+++ b/orga/app/components/places/statistics.gjs
@@ -1,4 +1,4 @@
-import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { PixIndicatorCard } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/sco-organization-participant/generate-username-password-modal.gjs
+++ b/orga/app/components/sco-organization-participant/generate-username-password-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixModal, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';

--- a/orga/app/components/sco-organization-participant/header-actions.gjs
+++ b/orga/app/components/sco-organization-participant/header-actions.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/sco-organization-participant/list-action-bar.gjs
+++ b/orga/app/components/sco-organization-participant/list-action-bar.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 import ActionBar from '../ui/action-bar';

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -1,5 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixPagination, PixTable } from '@1024pix/nebulix-ember';
 import { fn, uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/sco-organization-participant/manage-authentication-method-modal.gjs
+++ b/orga/app/components/sco-organization-participant/manage-authentication-method-modal.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixIcon, PixInput, PixModal } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/sco-organization-participant/reset-password-modal.gjs
+++ b/orga/app/components/sco-organization-participant/reset-password-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButton, PixModal, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';

--- a/orga/app/components/sco-organization-participant/sco-learner-filters.gjs
+++ b/orga/app/components/sco-organization-participant/sco-learner-filters.gjs
@@ -1,5 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import { PixFilterBanner, PixSearchInput } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -1,5 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixCheckbox, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';

--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -1,9 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixBlock, PixButton, PixPagination, PixSelect, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/statistics/tag-level.gjs
+++ b/orga/app/components/statistics/tag-level.gjs
@@ -1,4 +1,4 @@
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixTag } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/orga/app/components/sup-organization-participant/action-bar.gjs
+++ b/orga/app/components/sup-organization-participant/action-bar.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 import ActionBar from '../ui/action-bar';

--- a/orga/app/components/sup-organization-participant/header-actions.gjs
+++ b/orga/app/components/sup-organization-participant/header-actions.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/sup-organization-participant/list.gjs
+++ b/orga/app/components/sup-organization-participant/list.gjs
@@ -1,5 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixPagination, PixTable } from '@1024pix/nebulix-ember';
 import { fn, get, uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/sup-organization-participant/modal/edit-student-number-modal.gjs
+++ b/orga/app/components/sup-organization-participant/modal/edit-student-number-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixInput, PixModal } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/sup-organization-participant/sup-learner-filters.gjs
+++ b/orga/app/components/sup-organization-participant/sup-learner-filters.gjs
@@ -1,5 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import { PixFilterBanner, PixSearchInput } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/sup-organization-participant/table-row.gjs
+++ b/orga/app/components/sup-organization-participant/table-row.gjs
@@ -1,5 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixCheckbox, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';

--- a/orga/app/components/table/header-sort.gjs
+++ b/orga/app/components/table/header-sort.gjs
@@ -1,4 +1,4 @@
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import { PixIconButton } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 

--- a/orga/app/components/team/invitations-list-item.gjs
+++ b/orga/app/components/team/invitations-list-item.gjs
@@ -1,6 +1,4 @@
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIconButton, PixTableColumn, PixTooltip } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/team/invitations-list.gjs
+++ b/orga/app/components/team/invitations-list.gjs
@@ -1,4 +1,4 @@
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixTable } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/team/invite-form.gjs
+++ b/orga/app/components/team/invite-form.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
+import { PixButton, PixModal, PixTextarea } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/team/leave-organization-modal.gjs
+++ b/orga/app/components/team/leave-organization-modal.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/team/members-list-item.gjs
+++ b/orga/app/components/team/members-list-item.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButton, PixIconButton, PixSelect, PixTableColumn } from '@1024pix/nebulix-ember';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/team/members-list.gjs
+++ b/orga/app/components/team/members-list.gjs
@@ -1,5 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { PixPagination, PixTable } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/team/remove-member-modal.gjs
+++ b/orga/app/components/team/remove-member-modal.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixModal } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/terms-of-service/acceptation.gjs
+++ b/orga/app/components/terms-of-service/acceptation.gjs
@@ -1,7 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixBlock, PixButton, PixButtonLink, PixIcon } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';

--- a/orga/app/components/tube/list.gjs
+++ b/orga/app/components/tube/list.gjs
@@ -1,6 +1,4 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixAccordions, PixButton, PixButtonLink } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/tube/thematic.gjs
+++ b/orga/app/components/tube/thematic.gjs
@@ -1,4 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import { PixCheckbox } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/tube/tube.gjs
+++ b/orga/app/components/tube/tube.gjs
@@ -1,7 +1,4 @@
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixCheckbox, PixIcon, PixSelect, PixTooltip } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/ui/chart-card.gjs
+++ b/orga/app/components/ui/chart-card.gjs
@@ -1,6 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixBlock, PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 <template>

--- a/orga/app/components/ui/chevron.gjs
+++ b/orga/app/components/ui/chevron.gjs
@@ -1,4 +1,4 @@
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import { PixIconButton } from '@1024pix/nebulix-ember';
 <template>
   <PixIconButton
     aria-label={{@ariaLabel}}

--- a/orga/app/components/ui/deletion-modal.gjs
+++ b/orga/app/components/ui/deletion-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixCheckbox, PixModal } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';

--- a/orga/app/components/ui/divisions-filter.gjs
+++ b/orga/app/components/ui/divisions-filter.gjs
@@ -1,4 +1,4 @@
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import { PixMultiSelect } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/ui/edit-participant-name-modal.gjs
+++ b/orga/app/components/ui/edit-participant-name-modal.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { PixButton, PixInput, PixModal } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/orga/app/components/ui/empty-state.gjs
+++ b/orga/app/components/ui/empty-state.gjs
@@ -1,4 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { PixBlock } from '@1024pix/nebulix-ember';
 
 <template>
   <PixBlock class="empty-state" @variant="orga">

--- a/orga/app/components/ui/explanation-card.gjs
+++ b/orga/app/components/ui/explanation-card.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 
 <template>
   <div class="explanation-card" ...attributes>

--- a/orga/app/components/ui/groups-filter.gjs
+++ b/orga/app/components/ui/groups-filter.gjs
@@ -1,4 +1,4 @@
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import { PixMultiSelect } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/ui/is-certifiable.gjs
+++ b/orga/app/components/ui/is-certifiable.gjs
@@ -1,4 +1,4 @@
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixTag } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 

--- a/orga/app/components/ui/last-participation-date-tooltip.gjs
+++ b/orga/app/components/ui/last-participation-date-tooltip.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { concat } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/ui/mastery-percentage-display.gjs
+++ b/orga/app/components/ui/mastery-percentage-display.gjs
@@ -1,6 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixStars from '@1024pix/pix-ui/components/pix-stars';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixStars, PixTooltip } from '@1024pix/nebulix-ember';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/orga/app/components/ui/multi-select-filter.gjs
+++ b/orga/app/components/ui/multi-select-filter.gjs
@@ -1,4 +1,4 @@
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import { PixMultiSelect } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/components/ui/participation-status.gjs
+++ b/orga/app/components/ui/participation-status.gjs
@@ -1,4 +1,4 @@
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { PixTag } from '@1024pix/nebulix-ember';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/orga/app/components/ui/search-input.gjs
+++ b/orga/app/components/ui/search-input.gjs
@@ -1,4 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixIcon } from '@1024pix/nebulix-ember';
 
 <template>
   {{! template-lint-disable require-input-label }}

--- a/orga/app/components/ui/select-filter.gjs
+++ b/orga/app/components/ui/select-filter.gjs
@@ -1,4 +1,4 @@
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixSelect } from '@1024pix/nebulix-ember';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 

--- a/orga/app/components/ui/tooltip-with-icon.gjs
+++ b/orga/app/components/ui/tooltip-with-icon.gjs
@@ -1,5 +1,4 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { PixIcon, PixTooltip } from '@1024pix/nebulix-ember';
 import { uniqueId } from '@ember/helper';
 
 const tooltipId = uniqueId();

--- a/orga/app/components/upload-button.gjs
+++ b/orga/app/components/upload-button.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { PixButton, PixButtonUpload } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 
 function fileTypes(supportedFormats, separator) {

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -1,4 +1,5 @@
 @charset "utf-8";
+@use 'nebulix-styles' as *;
 @use 'pix-design-tokens/breakpoints';
 
 // global

--- a/orga/app/templates/application.gjs
+++ b/orga/app/templates/application.gjs
@@ -1,5 +1,4 @@
-import PixAppLayout from '@1024pix/pix-ui/components/pix-app-layout';
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { PixAppLayout, PixToastContainer } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import Communication from 'pix-orga/components/banner/communication';

--- a/orga/app/templates/authenticated/campaigns/combined-courses.gjs
+++ b/orga/app/templates/authenticated/campaigns/combined-courses.gjs
@@ -1,4 +1,4 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import { PixPagination } from '@1024pix/nebulix-ember';
 import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
 import ListHeader from 'pix-orga/components/campaign/list-header';

--- a/orga/app/templates/authenticated/certifications.gjs
+++ b/orga/app/templates/authenticated/certifications.gjs
@@ -1,7 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { PixButton, PixIcon, PixNotificationAlert, PixSelect } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/orga/app/templates/authenticated/import-organization-participants.gjs
+++ b/orga/app/templates/authenticated/import-organization-participants.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import Import from 'pix-orga/components/import/index';

--- a/orga/app/templates/authenticated/missions/list.gjs
+++ b/orga/app/templates/authenticated/missions/list.gjs
@@ -1,6 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTable from '@1024pix/pix-ui/components/pix-table';
-import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { PixButtonLink, PixTable, PixTableColumn } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import eq from 'ember-truth-helpers/helpers/eq';

--- a/orga/app/templates/authenticated/missions/mission/activities.gjs
+++ b/orga/app/templates/authenticated/missions/mission/activities.gjs
@@ -1,6 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import { PixFilterBanner, PixMultiSelect, PixSearchInput } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import ActivityTable from 'pix-orga/components/mission/activity-table';
 import DivisionsFilter from 'pix-orga/components/ui/divisions-filter';

--- a/orga/app/templates/authenticated/missions/mission/results.gjs
+++ b/orga/app/templates/authenticated/missions/mission/results.gjs
@@ -1,6 +1,4 @@
-import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import { PixFilterBanner, PixMultiSelect, PixSearchInput } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import ResultTable from 'pix-orga/components/mission/result-table';
 import DivisionsFilter from 'pix-orga/components/ui/divisions-filter';

--- a/orga/app/templates/authenticated/team/list.gjs
+++ b/orga/app/templates/authenticated/team/list.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
+import { PixButtonLink, PixTabs } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';

--- a/orga/app/templates/authenticated/team/new.gjs
+++ b/orga/app/templates/authenticated/team/new.gjs
@@ -1,4 +1,4 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixNotificationAlert } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import InviteForm from 'pix-orga/components/team/invite-form';

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -1,5 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButton, PixButtonLink } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import LoginForm from 'pix-orga/components/authentication/login-form';

--- a/orga/app/templates/authentication/oidc/signup.gjs
+++ b/orga/app/templates/authentication/oidc/signup.gjs
@@ -1,5 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { PixButtonLink, PixNotificationAlert } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import OidcSignupForm from 'pix-orga/components/authentication/oidc-signup-form';

--- a/orga/app/templates/authentication/sso-selection.gjs
+++ b/orga/app/templates/authentication/sso-selection.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { PixButton } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import SsoSelectionForm from 'pix-orga/components/authentication/sso-selection-form';

--- a/orga/app/templates/join-request.gjs
+++ b/orga/app/templates/join-request.gjs
@@ -1,5 +1,4 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { PixBlock, PixIcon } from '@1024pix/nebulix-ember';
 import { LinkTo } from '@ember/routing';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import JoinRequestForm from 'pix-orga/components/authentication/join-request-form';

--- a/orga/app/templates/join/index.gjs
+++ b/orga/app/templates/join/index.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AuthenticationIdentityProviders from 'pix-orga/components/authentication/authentication-identity-providers';

--- a/orga/app/templates/join/signup.gjs
+++ b/orga/app/templates/join/signup.gjs
@@ -1,4 +1,4 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { PixButtonLink } from '@1024pix/nebulix-ember';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AuthenticationIdentityProviders from 'pix-orga/components/authentication/authentication-identity-providers';

--- a/orga/maintenance_page.html
+++ b/orga/maintenance_page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="no-js" lang="fr">
   <head>
     <meta charset="utf-8" />
@@ -14,7 +14,7 @@
 
       @font-face {
         font-family: 'Roboto';
-        src: url('/@1024pix/pix-ui/fonts/Roboto/Roboto-Medium.ttf');
+        src: url('/@1024pix/nebulix-ember/fonts/Roboto/Roboto-Medium.ttf');
         font-weight: 500;
         font-style: normal;
       }

--- a/orga/maintenance_scheduled.html
+++ b/orga/maintenance_scheduled.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="no-js" lang="fr">
   <head>
     <meta charset="utf-8" />
@@ -14,7 +14,7 @@
 
       @font-face {
         font-family: 'Roboto';
-        src: url('/@1024pix/pix-ui/fonts/Roboto/Roboto-Medium.ttf');
+        src: url('/@1024pix/nebulix-ember/fonts/Roboto/Roboto-Medium.ttf');
         font-weight: 500;
         font-style: normal;
       }

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.41",
         "@1024pix/eslint-plugin": "^2.1.21",
-        "@1024pix/pix-ui": "61.4.0",
+        "@1024pix/nebulix-ember": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.28.6",
         "@babel/plugin-proposal-decorators": "^7.27.1",
@@ -78,8 +78,6 @@
         "npm-run-all2": "^9.0.0",
         "p-queue": "^9.0.0",
         "patternomaly": "^1.3.2",
-        "postcss": "^8.5.10",
-        "postcss-url": "^10.1.3",
         "prettier": "^3.8.1",
         "prettier-plugin-ember-template-tag": "^2.1.3",
         "qunit": "^2.23.1",
@@ -133,110 +131,37 @@
         "eslint": ">=9.17.0"
       }
     },
-    "node_modules/@1024pix/pix-ui": {
-      "version": "61.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-61.4.0.tgz",
-      "integrity": "sha512-bI1K/gPnO3fItIIJaC+ywuJxqsufCXvSueB0YILEosaLbK8mH8EjGcj7cDKqd2uILUMx5RkznY6F8j1elHluJw==",
+    "node_modules/@1024pix/nebulix-ember": {
+      "version": "0.1.1",
+      "resolved": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
+      "integrity": "sha512-KZUujpjcJOlCS7+qKia+izEkGNdHA169klSlNOB1Zcwx94OhB8f71SRKVWZ5AFAuAEI8RUY+Q1sBPKp3C0AqTQ==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
+      "license": "AGPL-3.0",
       "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@formatjs/intl": "^4.0.0",
-        "check-engine": "^1.14.0",
-        "ember-auto-import": "^2.7.4",
-        "ember-cli-babel": "^8.2.0",
-        "ember-cli-htmlbars": "^6.3.0",
-        "ember-cli-sass": "^11.0.1",
+        "@embroider/addon-shim": "^1.8.9",
+        "@formatjs/intl": "^4.1.19",
+        "decorator-transforms": "^2.2.2",
         "ember-click-outside": "^6.1.1",
-        "ember-lifeline": "^7.0.0",
-        "ember-modifier": "^4.2.0",
+        "ember-lifeline": "^7.1.0",
+        "ember-modifier": "^4.3.0",
         "ember-popperjs": "^3.0.0",
-        "ember-template-imports": "^4.3.0",
         "ember-truth-helpers": "^5.0.0",
-        "tracked-toolbox": "^2.2.0"
+        "tracked-toolbox": "^3.0.0"
       },
-      "engines": {
-        "node": "^20 || ^22 || ^24"
+      "peerDependencies": {
+        "@glimmer/component": ">= 2.0.0",
+        "ember-source": ">= 6.0.0"
       }
     },
-    "node_modules/@1024pix/pix-ui/node_modules/babel-import-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.1.tgz",
-      "integrity": "sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/babel-plugin-ember-template-compilation": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.4.1.tgz",
-      "integrity": "sha512-n+ktQ3JeyWrpRutSyPn2PsHeH+A94SVm+iUoogzf9VUqpP47FfWem24gpQXhn+p6+x5/BpuFJXMLXWt7ZoYAKA==",
+    "node_modules/@1024pix/nebulix-ember/node_modules/tracked-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-3.0.0.tgz",
+      "integrity": "sha512-9Q5SH+0jevfB07oL2bsjxIDv0jQ2A6IgminkvnMMzGLc2EqCFm/yKuqNeUFvN3n+TOAQk+PZcePtIaxIo/1now==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/syntax": ">= 0.94.9",
-        "babel-import-util": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-htmlbars": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.3.0.tgz",
-      "integrity": "sha512-N9Y80oZfcfWLsqickMfRd9YByVcTGyhYRnYQ2XVPVrp6jyUyOeRWmEAPh7ERSXpp8Ws4hr/JB9QVQrn/yZa+Ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-ember-template-compilation": "^2.0.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.3.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "js-string-escape": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+        "@embroider/addon-shim": "^1.10.0",
+        "decorator-transforms": "^2.3.0"
       }
     },
     "node_modules/@1024pix/stylelint-config": {
@@ -4293,82 +4218,40 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@formatjs/bigdecimal": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/bigdecimal/-/bigdecimal-0.2.0.tgz",
-      "integrity": "sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.2.0.tgz",
-      "integrity": "sha512-dHnqHgBo6GXYGRsepaE1wmsC2etaivOWd5VaJstZd+HI2zR3DCUjbDVZRtoPGkkXZmyHvBwrdEUuqfvzhF/DtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/bigdecimal": "0.2.0",
-        "@formatjs/fast-memoize": "3.1.1",
-        "@formatjs/intl-localematcher": "0.8.2"
-      }
-    },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.1.tgz",
-      "integrity": "sha512-CbNbf+tlJn1baRnPkNePnBqTLxGliG6DDgNa/UtV66abwIjwsliPMOt0172tzxABYzSuxZBZfcp//qI8AvBWPg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.3.tgz",
-      "integrity": "sha512-HJWZ9S6JWey6iY5+YXE3Kd0ofWU1sC2KTTp56e1168g/xxWvVvr8k9G4fexIgwYV9wbtjY7kGYK5FjoWB3B2OQ==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0",
-        "@formatjs/icu-skeleton-parser": "2.1.3"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.3.tgz",
-      "integrity": "sha512-9mFp8TJ166ZM2pcjKwsBWXrDnOJGT7vMEScVgLygUODPOsE8S6f/FHoacvrlHK1B4dYZk8vSCNruyPU64AfgJQ==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@formatjs/intl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.4.tgz",
-      "integrity": "sha512-y5aZ5p5zO74mZPdQMe9gq8SR1P6rlPQkaYOVFHyRzWrViif4sRKIQX01GYbKJvaGanupVVX+0WoKJqLVsP+X3Q==",
+      "version": "4.1.19",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.19.tgz",
+      "integrity": "sha512-bZMROATl+rzfL8wsDZ53i8XWHx5e6rVr8QlGT5GDvHImEUro4WE9pxUd2dobzmI3CtD+zkt/wkEdqcb+3CK8Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0",
-        "@formatjs/fast-memoize": "3.1.1",
-        "@formatjs/icu-messageformat-parser": "3.5.3",
-        "intl-messageformat": "11.2.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.6.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.2.tgz",
-      "integrity": "sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "3.1.1"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17",
+        "intl-messageformat": "11.2.14"
       }
     },
     "node_modules/@glimmer/compiler": {
@@ -7450,16 +7333,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -8251,13 +8124,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
       "integrity": "sha512-kXQ19Xhoghiyw66CUiGypnuRpWlbHAzY/+NyvqTEdTfhfQGH1/dbEMYiXju7fYKIFePpzp/y9dsu5Cu/PkmawQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9054,31 +8920,6 @@
       "license": "MIT",
       "engines": {
         "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/broccoli-sass-source-maps": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-4.3.0.tgz",
-      "integrity": "sha512-t/YEueiFAOboCERQsH6J9RmifEDkqkoFjIB6owIeilpSbhJbNXj0FfzWcXnG/ahKYByHE4g3H7agHr2mtlJdDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-caching-writer": "^3.0.3",
-        "include-path-searcher": "^0.1.0",
-        "rsvp": "^4.8.5"
-      },
-      "engines": {
-        "node": ">=10.24.1"
-      }
-    },
-    "node_modules/broccoli-sass-source-maps/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "6.* || >= 7.*"
       }
     },
     "node_modules/broccoli-slow-trees": {
@@ -10118,82 +9959,6 @@
         "dayjs": "^1.9.7"
       }
     },
-    "node_modules/check-engine": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/check-engine/-/check-engine-1.14.0.tgz",
-      "integrity": "sha512-CZZ3UmZKMer4O63yNWit5KLm7FoO69shcdPbkP8Dj4N728jqI7d8YyAigOgKnajVBA7TtaL7BuaMRDXcoYJKxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "3.7.2",
-        "colors": "1.4.0",
-        "command-line-usage": "6.1.3",
-        "jsonfile": "6.1.0",
-        "semver": "7.5.4",
-        "yargs": "17.7.1"
-      },
-      "bin": {
-        "check-engine": "bin/check-engine.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/check-engine/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/check-engine/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/check-engine/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/check-engine/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -10388,21 +10153,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -10519,16 +10269,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -10540,100 +10280,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
-      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/commander": {
@@ -11609,13 +11255,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cuint": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -11802,16 +11441,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.*"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -12398,637 +12027,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/ember-cache-primitive-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cache-primitive-polyfill/-/ember-cache-primitive-polyfill-1.0.1.tgz",
-      "integrity": "sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1",
-        "ember-cli-version-checker": "^5.1.1",
-        "ember-compatibility-helpers": "^1.2.1",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
-      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/@babel/runtime": {
-      "version": "7.12.18",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/async-disk-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
-      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "2.1.0",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.5.3",
-        "rsvp": "^3.0.18",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/async-disk-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/async-disk-cache/node_modules/rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "0.12.* || 4.* || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/babel-plugin-module-resolver": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-babel-config": "^1.1.0",
-        "glob": "^7.1.2",
-        "pkg-up": "^2.0.0",
-        "reselect": "^3.0.1",
-        "resolve": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-babel-transpiler": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
-      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/polyfill": "^7.11.5",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "broccoli-persistent-filter": "^2.2.1",
-        "clone": "^2.1.2",
-        "hash-for-dep": "^1.4.7",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.9",
-        "json-stable-stringify": "^1.0.1",
-        "rsvp": "^4.8.4",
-        "workerpool": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-funnel/node_modules/fs-tree-diff": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-funnel/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-merge-trees": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-plugin": "^1.3.0",
-        "merge-trees": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-persistent-filter": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-disk-cache": "^1.2.1",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^1.0.0",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "mkdirp": "^0.5.1",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.7.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^1.3.3",
-        "walk-sync": "^1.0.0"
-      },
-      "engines": {
-        "node": "6.* || >= 8.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^1.1.1"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-plugin/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/broccoli-source": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
-      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel": {
-      "version": "7.26.11",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
-      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/helper-compilation-targets": "^7.12.0",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
-        "@babel/plugin-proposal-decorators": "^7.13.5",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
-        "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-runtime": "^7.13.9",
-        "@babel/plugin-transform-typescript": "^7.13.0",
-        "@babel/polyfill": "^7.11.5",
-        "@babel/preset-env": "^7.16.5",
-        "@babel/runtime": "7.12.18",
-        "amd-name-resolver": "^1.3.1",
-        "babel-plugin-debug-macros": "^0.3.4",
-        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
-        "babel-plugin-module-resolver": "^3.2.0",
-        "broccoli-babel-transpiler": "^7.8.0",
-        "broccoli-debug": "^0.6.4",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-source": "^2.1.2",
-        "calculate-cache-key-for-tree": "^2.0.0",
-        "clone": "^2.1.2",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^4.1.0",
-        "ensure-posix-path": "^1.0.2",
-        "fixturify-project": "^1.10.0",
-        "resolve-package-path": "^3.1.0",
-        "rimraf": "^3.0.1",
-        "semver": "^5.5.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
-      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-package-path": "^2.0.0",
-        "semver": "^6.3.0",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
-      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.13.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ember-cli-babel/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/find-babel-config": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
-      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^1.0.2",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/istextorbinary": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binaryextensions": "1 || 2",
-        "editions": "^1.1.1",
-        "textextensions": "1 || 2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/reselect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/resolve-package-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/sync-disk-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
-      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/sync-disk-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/walk-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
-      }
-    },
-    "node_modules/ember-cache-primitive-polyfill/node_modules/workerpool": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
-      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.3.4",
-        "object-assign": "4.1.1",
-        "rsvp": "^4.8.4"
-      }
-    },
     "node_modules/ember-cli": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-7.0.1.tgz",
@@ -13369,185 +12367,6 @@
       },
       "engines": {
         "node": "16.* || >= 18"
-      }
-    },
-    "node_modules/ember-cli-sass": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-11.0.1.tgz",
-      "integrity": "sha512-RMlFPMK4kaB+67seF/IIoY3EC4rRd+L58q+lyElrxB3FcQTgph/qmGwtqf9Up7m3SDbPiA7cccCOSmgReMgCXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-funnel": "^2.0.1",
-        "broccoli-merge-trees": "^3.0.1",
-        "broccoli-sass-source-maps": "^4.0.0",
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": ">= 10.*"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/broccoli-merge-trees": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-plugin": "^1.3.0",
-        "merge-trees": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/broccoli-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/fs-tree-diff": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-cli-sass/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-cli-sass/node_modules/walk-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
       }
     },
     "node_modules/ember-cli-string-utils": {
@@ -13994,49 +12813,6 @@
         "ember-modifier": "^3.2.7 || ^4.0.0"
       }
     },
-    "node_modules/ember-compatibility-helpers": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.7.tgz",
-      "integrity": "sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-debug-macros": "^0.2.0",
-        "ember-cli-version-checker": "^5.1.1",
-        "find-up": "^5.0.0",
-        "fs-extra": "^9.1.0",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-compatibility-helpers/node_modules/babel-plugin-debug-macros": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-      "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-beta.42"
-      }
-    },
-    "node_modules/ember-compatibility-helpers/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/ember-cookies": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.4.1.tgz",
@@ -14442,9 +13218,9 @@
       }
     },
     "node_modules/ember-lifeline": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ember-lifeline/-/ember-lifeline-7.0.0.tgz",
-      "integrity": "sha512-2l51NzgH5vjN972zgbs+32rnXnnEFKB7qsSpJF+lBI4V5TG6DMy4SfowC72ZEuAtS58OVfwITbOO+RnM21EdpA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ember-lifeline/-/ember-lifeline-7.1.0.tgz",
+      "integrity": "sha512-hd3r0jwZLgXNn3l2YSX6wVnD1KD5h+WUG6P/xo4rJXFboy7nOwix38fZt9SbuO66QVZSkdqMeUqW6Z/NPWa9kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15385,21 +14161,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/ember-template-imports": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-4.4.0.tgz",
-      "integrity": "sha512-HNOHabTEMbRluci1uScvh3ljMDo9E46dHHNcJAIf5yjOhIQ/zN4Y0DVDWrRfcbihlHvt4v/iF69G+8tffC1YkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-stew": "^3.0.0",
-        "content-tag": "^4.1.0",
-        "ember-cli-version-checker": "^5.1.2"
-      },
-      "engines": {
-        "node": "16.* || >= 18"
       }
     },
     "node_modules/ember-template-lint": {
@@ -19020,13 +17781,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/include-path-searcher": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/include-path-searcher/-/include-path-searcher-0.1.0.tgz",
-      "integrity": "sha512-KlpXnsZOrBGo4PPKqPFi3Ft6dcRyh8fTaqgzqDRi8jKAsngJEWWOxeFIWC8EfZtXKaZqlsNf9XRwcQ49DVgl/g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/indent-string": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
@@ -19130,15 +17884,14 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.0.tgz",
-      "integrity": "sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==",
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.14.tgz",
+      "integrity": "sha512-9f2VD1HFuxUvMw0RxsaP8WmMns6JRTnsNB/zghTFrp11ZktiXWwVDeZBPQchBKEmo+Gx/ZhxI7Qht7YglFD4PA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0",
-        "@formatjs/fast-memoize": "3.1.1",
-        "@formatjs/icu-messageformat-parser": "3.5.3"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17"
       }
     },
     "node_modules/invert-kv": {
@@ -23684,51 +22437,6 @@
         "postcss": ">=5.0.0"
       }
     },
-    "node_modules/postcss-url": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-10.1.3.tgz",
-      "integrity": "sha512-FUzyxfI5l2tKmXdYc6VTu3TWZsInayEKPbiyW+P6vmmIrrb4I6CGX0BFoewgYHLK+oIL5FECEK02REYRpBvUCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "make-dir": "~3.1.0",
-        "mime": "~2.5.2",
-        "minimatch": "~3.0.4",
-        "xxhashjs": "~0.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-url/node_modules/mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-url/node_modules/minimatch": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -24420,16 +23128,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -24659,16 +23357,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -27514,22 +26202,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/table-layout": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
-      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/table/node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -28082,18 +26754,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/tracked-toolbox": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-2.2.0.tgz",
-      "integrity": "sha512-YknotXj74U0nCqBk9nh1Uv1IWTnVOgt8sXIecNkyEq4oFOU70niQUlozO4E3kMKx7ae/rNlOtoF+1ALcHYzCrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.10.0",
-        "decorator-transforms": "^2.3.0",
-        "ember-cache-primitive-polyfill": "^1.0.0"
-      }
-    },
     "node_modules/tree-sync": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-2.1.0.tgz",
@@ -28345,16 +27005,6 @@
       "integrity": "sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",
@@ -29435,44 +28085,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
-      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/workerpool": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-10.0.2.tgz",
       "integrity": "sha512-8PCeZlCwu0+8hXruze1ahYNsY+M0LOCmbmySZ9BWWqWIXP9TAXa6FZCxACTDL/0j47pFcC4xW98Gr8nAC5oymg==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
     },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
@@ -29618,26 +28236,6 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/xxhashjs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
-      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cuint": "^0.2.2"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -29749,16 +28347,6 @@
       },
       "peerDependencies": {
         "yaml": "^2.3.0"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.41",
         "@1024pix/eslint-plugin": "^2.1.21",
-        "@1024pix/nebulix-ember": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
+        "@1024pix/nebulix-ember": "^0.1.1",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.28.6",
         "@babel/plugin-proposal-decorators": "^7.27.1",
@@ -133,8 +133,8 @@
     },
     "node_modules/@1024pix/nebulix-ember": {
       "version": "0.1.1",
-      "resolved": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
-      "integrity": "sha512-KZUujpjcJOlCS7+qKia+izEkGNdHA169klSlNOB1Zcwx94OhB8f71SRKVWZ5AFAuAEI8RUY+Q1sBPKp3C0AqTQ==",
+      "resolved": "https://registry.npmjs.org/@1024pix/nebulix-ember/-/nebulix-ember-0.1.1.tgz",
+      "integrity": "sha512-bHx6tB4zm2a0pTXU+XIp2NerbEYv4ETqdSu5QauLlh347zD4/Y18Nw9klmjG4aRxTDF3jyy/WMufKvzaAeJJ+A==",
       "dev": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -151,17 +151,6 @@
       "peerDependencies": {
         "@glimmer/component": ">= 2.0.0",
         "ember-source": ">= 6.0.0"
-      }
-    },
-    "node_modules/@1024pix/nebulix-ember/node_modules/tracked-toolbox": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-3.0.0.tgz",
-      "integrity": "sha512-9Q5SH+0jevfB07oL2bsjxIDv0jQ2A6IgminkvnMMzGLc2EqCFm/yKuqNeUFvN3n+TOAQk+PZcePtIaxIo/1now==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.10.0",
-        "decorator-transforms": "^2.3.0"
       }
     },
     "node_modules/@1024pix/stylelint-config": {
@@ -26752,6 +26741,17 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tracked-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-3.0.0.tgz",
+      "integrity": "sha512-9Q5SH+0jevfB07oL2bsjxIDv0jQ2A6IgminkvnMMzGLc2EqCFm/yKuqNeUFvN3n+TOAQk+PZcePtIaxIo/1now==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.10.0",
+        "decorator-transforms": "^2.3.0"
       }
     },
     "node_modules/tree-sync": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.41",
     "@1024pix/eslint-plugin": "^2.1.21",
-    "@1024pix/nebulix-ember": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
+    "@1024pix/nebulix-ember": "^0.1.1",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.28.6",
     "@babel/plugin-proposal-decorators": "^7.27.1",

--- a/orga/package.json
+++ b/orga/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.41",
     "@1024pix/eslint-plugin": "^2.1.21",
-    "@1024pix/pix-ui": "61.4.0",
+    "@1024pix/nebulix-ember": "file:../../pix-ui-libs/ember/nebulix/1024pix-nebulix-ember-0.1.1.tgz",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.28.6",
     "@babel/plugin-proposal-decorators": "^7.27.1",
@@ -108,8 +108,6 @@
     "npm-run-all2": "^9.0.0",
     "p-queue": "^9.0.0",
     "patternomaly": "^1.3.2",
-    "postcss": "^8.5.10",
-    "postcss-url": "^10.1.3",
     "prettier": "^3.8.1",
     "prettier-plugin-ember-template-tag": "^2.1.3",
     "qunit": "^2.23.1",

--- a/orga/tests/integration/components/selectable-list-test.gjs
+++ b/orga/tests/integration/components/selectable-list-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import { PixCheckbox } from '@1024pix/nebulix-ember';
 import { on } from '@ember/modifier';
 import { click } from '@ember/test-helpers';
 import { not } from 'ember-truth-helpers';

--- a/orga/vite.config.mjs
+++ b/orga/vite.config.mjs
@@ -3,8 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { loadTranslations } from '@ember-intl/vite';
 import { classicEmberSupport, ember, extensions } from '@embroider/vite';
 import { babel } from '@rollup/plugin-babel';
-import url from 'postcss-url';
-import sassEmbedded, { NodePackageImporter } from 'sass-embedded';
+import sassEmbedded from 'sass-embedded';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -20,39 +19,11 @@ export default defineConfig({
     sourcemap: true,
   },
   css: {
-    postcss: {
-      plugins: [
-        url({
-          url: (asset) => {
-            if (asset.url.startsWith('../@1024pix/')) {
-              // Pix UI static files are referenced by url starting with "../"
-              // but vite is bundling those files in root asset folder
-              // so we need to remove the "../" prefix
-              // ../@1024pix/pix-ui/fonts/Nunito/Nunito-Bold.woff2
-              return asset.url.replace('..', '');
-            }
-            return undefined;
-          },
-        }),
-      ],
-    },
     preprocessorOptions: {
       scss: {
         api: 'modern',
         implementation: sassEmbedded,
-        includePaths: ['app/styles'],
-        importers: [
-          new NodePackageImporter(),
-          // avoid error loading sass files from pix-ui addon
-          {
-            findFileUrl(url) {
-              if (url.startsWith('pix-design-token')) {
-                return new URL(`file://${process.cwd()}/node_modules/@1024pix/pix-ui/addon/styles/${url}`);
-              }
-              return null;
-            },
-          },
-        ],
+        loadPaths: ['app/styles', 'node_modules/@1024pix/nebulix-ember/dist/styles'],
       },
     },
   },


### PR DESCRIPTION
## ☀️ Problème

`@1024pix/pix-ui` est un addon v1

## ⛱️ Proposition

Expérimenter `@1024pix/nebulix-ember` qui est la version de `@1024pix/pix-ui` en addon v2.

Sur **Pix Admin (webpack)** et **Pix Orga (vite)** : 
1. Remplacer `@1024pix/pix-ui` par `@1024pix/nebulix-ember` et ajout de `"ember-cli-htmlbars": "^6.3.0"` (à cause de `ember-poppers`?) 
2. Configurer `@1024pix/nebulix-ember` dans `ember-cli-build.js` ou `vite.config.js`
3. Charger les styles de `@1024pix/nebulix-ember` dans `app.scss`
4. Modifier les imports des composants.

## 🧴 Remarques

**Expérimentation :** la dépendance est pour le moment une dépendance directe sur filesystem.
- Dans `pix-ui-libs/ember/nebulix`, faire `pnpm pack`.
- Puis dans Pix Admin et Pix Orga faire `npm install`.

**Attention :** `@1024pix/nebulix-ember@0.1.1` est construit sur la version de `@1024pix/pix-ui@62.0.0`
- Pix Admin avait `"@1024pix/pix-ui": "^61.4.1"`
- Pix Orga avait `"@1024pix/pix-ui": "^61.4.1"`

Il y a peut-être des composants qui ont changés entre les versions `61.4.1` et `62.0.0`

## 🏊 Pour tester

La CI doit passer et un tour complet du propriétaire.
