### PR TITLE
[FEATURE] Afficher des boutons permettant d'afficher les contenus formatifs par 3 sur la page de résultat sur Pix App (PIX-22793).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -25,6 +25,10 @@ export default class Trainings extends Component {
     };
   });
 
+  get isNavigationVisible() {
+    return this.args.trainings.length > TRAININGS_PER_PAGE;
+  }
+
   get cards() {
     return this.list.children;
   }
@@ -75,23 +79,29 @@ export default class Trainings extends Component {
             }}</p>
         </div>
 
-        <div class="results-recommendation-engine-training__navigation">
-          <PixIconButton
-            @ariaLabel={{t "pages.skill-review.recommended-engine.trainings.previous-button-aria-label"}}
-            @iconName="chevronLeft"
-            @isDisabled={{this.isPreviousButtonDisabled}}
-            @triggerAction={{this.scrollToPreviousTrainings}}
-          />
-          <PixIconButton
-            @ariaLabel={{t "pages.skill-review.recommended-engine.trainings.next-button-aria-label"}}
-            @iconName="chevronRight"
-            @isDisabled={{this.isNextButtonDisabled}}
-            @triggerAction={{this.scrollToNextTrainings}}
-          />
-        </div>
+        {{#if this.isNavigationVisible}}
+          <div class="results-recommendation-engine-training__navigation">
+            <PixIconButton
+              @ariaLabel={{t "pages.skill-review.recommended-engine.trainings.previous-button-aria-label"}}
+              @iconName="chevronLeft"
+              @isDisabled={{this.isPreviousButtonDisabled}}
+              @triggerAction={{this.scrollToPreviousTrainings}}
+            />
+            <PixIconButton
+              @ariaLabel={{t "pages.skill-review.recommended-engine.trainings.next-button-aria-label"}}
+              @iconName="chevronRight"
+              @isDisabled={{this.isNextButtonDisabled}}
+              @triggerAction={{this.scrollToNextTrainings}}
+            />
+          </div>
+        {{/if}}
       </div>
 
-      <ul class="results-recommendation-engine-training__list" {{this.registerList}}>
+      <ul
+        class="results-recommendation-engine-training__list
+          {{if this.isNavigationVisible 'results-recommendation-engine-training__list--locked'}}"
+        {{this.registerList}}
+      >
         {{#each @trainings as |training|}}
           <li class="results-recommendation-engine-training-list__item"><TrainingCard
               @training={{training}}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -66,6 +66,13 @@ export default class Trainings extends Component {
     });
   }
 
+  slideAriaLabel = (index) => {
+    return this.intl.t('pages.skill-review.recommended-engine.trainings.slide-aria-label', {
+      position: index + 1,
+      total: this.args.trainings.length,
+    });
+  };
+
   get scrollBehavior() {
     return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth';
   }
@@ -118,6 +125,7 @@ export default class Trainings extends Component {
       tabindex="-1"
      class="results-recommendation-engine-training"
       aria-labelledby={{this.titleId}}
+      aria-roledescription={{t "pages.skill-review.recommended-engine.trainings.carousel-roledescription"}}
       {{onIntersect @onFullyVisible threshold=1}}
     >
       <div class="results-recommendation-engine-training__header">
@@ -154,13 +162,19 @@ export default class Trainings extends Component {
           {{if this.isNavigationVisible 'results-recommendation-engine-training__list--locked'}}"
         {{this.registerList}}
       >
-        {{#each @trainings as |training|}}
-          <li class="results-recommendation-engine-training-list__item"><TrainingCard
-              @training={{training}}
-              @onCardClick={{@onCardClick}}
-              @onModalButtonClick={{@onModalButtonClick}}
-              @onModalAccordionClick={{@onModalAccordionClick}}
-            /></li>
+        {{#each @trainings as |training index|}}
+          <li class="results-recommendation-engine-training-list__item">
+            <div
+              role="group"
+              aria-roledescription={{t "pages.skill-review.recommended-engine.trainings.slide-roledescription"}}
+              aria-label={{this.slideAriaLabel index}}
+            ><TrainingCard
+                @training={{training}}
+                @onCardClick={{@onCardClick}}
+                @onModalButtonClick={{@onModalButtonClick}}
+                @onModalAccordionClick={{@onModalAccordionClick}}
+              /></div>
+          </li>
         {{/each}}
         {{#if this.isNavigationVisible}}
           <li

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -2,6 +2,7 @@ import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -17,6 +18,7 @@ export default class Trainings extends Component {
   @service intl;
 
   @tracked currentPageFirstCardIndex = 0;
+  @tracked spacerWidth = null;
 
   titleId = `results-recommendation-engine-training-title-${guidFor(this)}`;
 
@@ -24,6 +26,7 @@ export default class Trainings extends Component {
 
   registerList = modifier((element) => {
     this.list = element;
+    this.updateSpacerWidth();
     window.addEventListener('resize', this.resyncScrollPosition);
 
     return () => {
@@ -37,6 +40,10 @@ export default class Trainings extends Component {
 
   get cards() {
     return this.list.children;
+  }
+
+  get spacerStyle() {
+    return this.spacerWidth === null ? null : htmlSafe(`width: ${this.spacerWidth}px`);
   }
 
   get isPreviousButtonDisabled() {
@@ -75,6 +82,7 @@ export default class Trainings extends Component {
 
   @action
   resyncScrollPosition() {
+    this.updateSpacerWidth();
     this.goToCardIndex(this.currentPageFirstCardIndex, 'instant');
   }
 
@@ -82,6 +90,26 @@ export default class Trainings extends Component {
     this.currentPageFirstCardIndex = index;
     const targetCard = this.cards[index];
     this.list.scrollTo({ left: targetCard.offsetLeft, behavior });
+  }
+
+  // The list can show more than TRAININGS_PER_PAGE cards at once (a peek of
+  // the next card is visible by design). The trailing spacer must cover that
+  // extra peeked width, otherwise the browser clamps scrollTo() short of the
+  // last card's offsetLeft and a previous card re-appears on the left.
+  //
+  // Only needed while scrolling is JS-driven (list--locked sets
+  // overflow-x: hidden at the desktop breakpoint, see trainings.scss). Below
+  // that breakpoint, scrolling is native and this spacer stays at its CSS
+  // default. Reading the computed overflow-x instead of duplicating the
+  // breakpoint value keeps the SCSS as the single source of truth.
+  updateSpacerWidth() {
+    if (!this.isNavigationVisible || getComputedStyle(this.list).overflowX !== 'hidden') {
+      this.spacerWidth = null;
+      return;
+    }
+
+    const [firstCard] = this.cards;
+    this.spacerWidth = Math.max(0, this.list.clientWidth - firstCard.offsetWidth);
   }
 
   <template>
@@ -134,6 +162,13 @@ export default class Trainings extends Component {
               @onModalAccordionClick={{@onModalAccordionClick}}
             /></li>
         {{/each}}
+        {{#if this.isNavigationVisible}}
+          <li
+            class="results-recommendation-engine-training__list-spacer"
+            aria-hidden="true"
+            style={{this.spacerStyle}}
+          ></li>
+        {{/if}}
       </ul>
     </section>
   </template>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -41,6 +41,10 @@ export default class Trainings extends Component {
     return this.currentPageFirstCardIndex + TRAININGS_PER_PAGE >= this.args.trainings.length;
   }
 
+  get scrollBehavior() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth';
+  }
+
   @action
   scrollToPreviousTrainings() {
     this.goToCardIndex(Math.max(this.currentPageFirstCardIndex - TRAININGS_PER_PAGE, 0));
@@ -56,7 +60,7 @@ export default class Trainings extends Component {
     this.goToCardIndex(this.currentPageFirstCardIndex, 'instant');
   }
 
-  goToCardIndex(index, behavior = 'smooth') {
+  goToCardIndex(index, behavior = this.scrollBehavior) {
     this.currentPageFirstCardIndex = index;
     const targetCard = this.cards[index];
     this.list.scrollTo({ left: targetCard.offsetLeft, behavior });

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -1,5 +1,7 @@
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -12,7 +14,11 @@ export const TRAININGS_LIST_ID = 'results-recommendation-engine-training-list';
 const TRAININGS_PER_PAGE = 3;
 
 export default class Trainings extends Component {
+  @service intl;
+
   @tracked currentPageFirstCardIndex = 0;
+
+  titleId = `results-recommendation-engine-training-title-${guidFor(this)}`;
 
   list = null;
 
@@ -39,6 +45,18 @@ export default class Trainings extends Component {
 
   get isNextButtonDisabled() {
     return this.currentPageFirstCardIndex + TRAININGS_PER_PAGE >= this.args.trainings.length;
+  }
+
+  get paginationAnnouncement() {
+    const total = this.args.trainings.length;
+    const from = this.currentPageFirstCardIndex + 1;
+    const to = Math.min(this.currentPageFirstCardIndex + TRAININGS_PER_PAGE, total);
+
+    return this.intl.t('pages.skill-review.recommended-engine.trainings.pagination-announcement', {
+      from,
+      to,
+      total,
+    });
   }
 
   get scrollBehavior() {
@@ -68,14 +86,15 @@ export default class Trainings extends Component {
 
   <template>
     <section
-      id={{TRAININGS_LIST_ID}}
+     id={{TRAININGS_LIST_ID}}
       tabindex="-1"
-      class="results-recommendation-engine-training"
+     class="results-recommendation-engine-training"
+      aria-labelledby={{this.titleId}}
       {{onIntersect @onFullyVisible threshold=1}}
     >
       <div class="results-recommendation-engine-training__header">
         <div>
-          <h2 class="results-recommendation-engine-training__title">{{t
+          <h2 id={{this.titleId}} class="results-recommendation-engine-training__title">{{t
               "pages.skill-review.recommended-engine.trainings.title"
             }}</h2>
           <p class="results-recommendation-engine-training__description">{{t
@@ -98,6 +117,7 @@ export default class Trainings extends Component {
               @triggerAction={{this.scrollToNextTrainings}}
             />
           </div>
+          <p class="sr-only" aria-live="polite">{{this.paginationAnnouncement}}</p>
         {{/if}}
       </div>
 

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -1,33 +1,106 @@
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { modifier } from 'ember-modifier';
 import onIntersect from 'mon-pix/modifiers/on-intersect';
 
 import TrainingCard from './training/card';
 
 export const TRAININGS_LIST_ID = 'results-recommendation-engine-training-list';
+const TRAININGS_PER_PAGE = 3;
 
-<template>
-  <section
-    id={{TRAININGS_LIST_ID}}
-    class="results-recommendation-engine-training"
-    tabindex="-1"
-    {{onIntersect @onFullyVisible threshold=1}}
-  >
-    <h2 class="results-recommendation-engine-training__title">{{t
-        "pages.skill-review.recommended-engine.trainings.title"
-      }}</h2>
-    <p class="results-recommendation-engine-training__description">{{t
-        "pages.skill-review.recommended-engine.trainings.description"
-      }}</p>
+export default class Trainings extends Component {
+  @tracked currentPageFirstCardIndex = 0;
 
-    <ul class="results-recommendation-engine-training__list">
-      {{#each @trainings as |training|}}
-        <li><TrainingCard
-            @training={{training}}
-            @onCardClick={{@onCardClick}}
-            @onModalButtonClick={{@onModalButtonClick}}
-            @onModalAccordionClick={{@onModalAccordionClick}}
-          /></li>
-      {{/each}}
-    </ul>
-  </section>
-</template>
+  list = null;
+
+  registerList = modifier((element) => {
+    this.list = element;
+    window.addEventListener('resize', this.resyncScrollPosition);
+
+    return () => {
+      window.removeEventListener('resize', this.resyncScrollPosition);
+    };
+  });
+
+  get cards() {
+    return this.list.children;
+  }
+
+  get isPreviousButtonDisabled() {
+    return this.currentPageFirstCardIndex === 0;
+  }
+
+  get isNextButtonDisabled() {
+    return this.currentPageFirstCardIndex + TRAININGS_PER_PAGE >= this.args.trainings.length;
+  }
+
+  @action
+  scrollToPreviousTrainings() {
+    this.goToCardIndex(Math.max(this.currentPageFirstCardIndex - TRAININGS_PER_PAGE, 0));
+  }
+
+  @action
+  scrollToNextTrainings() {
+    this.goToCardIndex(Math.min(this.currentPageFirstCardIndex + TRAININGS_PER_PAGE, this.args.trainings.length - 1));
+  }
+
+  @action
+  resyncScrollPosition() {
+    this.goToCardIndex(this.currentPageFirstCardIndex, 'instant');
+  }
+
+  goToCardIndex(index, behavior = 'smooth') {
+    this.currentPageFirstCardIndex = index;
+    const targetCard = this.cards[index];
+    this.list.scrollTo({ left: targetCard.offsetLeft, behavior });
+  }
+
+  <template>
+    <section
+      id={{TRAININGS_LIST_ID}}
+      tabindex="-1"
+      class="results-recommendation-engine-training"
+      {{onIntersect @onFullyVisible threshold=1}}
+    >
+      <div class="results-recommendation-engine-training__header">
+        <div>
+          <h2 class="results-recommendation-engine-training__title">{{t
+              "pages.skill-review.recommended-engine.trainings.title"
+            }}</h2>
+          <p class="results-recommendation-engine-training__description">{{t
+              "pages.skill-review.recommended-engine.trainings.description"
+            }}</p>
+        </div>
+
+        <div class="results-recommendation-engine-training__navigation">
+          <PixIconButton
+            @ariaLabel={{t "pages.skill-review.recommended-engine.trainings.previous-button-aria-label"}}
+            @iconName="chevronLeft"
+            @isDisabled={{this.isPreviousButtonDisabled}}
+            @triggerAction={{this.scrollToPreviousTrainings}}
+          />
+          <PixIconButton
+            @ariaLabel={{t "pages.skill-review.recommended-engine.trainings.next-button-aria-label"}}
+            @iconName="chevronRight"
+            @isDisabled={{this.isNextButtonDisabled}}
+            @triggerAction={{this.scrollToNextTrainings}}
+          />
+        </div>
+      </div>
+
+      <ul class="results-recommendation-engine-training__list" {{this.registerList}}>
+        {{#each @trainings as |training|}}
+          <li class="results-recommendation-engine-training-list__item"><TrainingCard
+              @training={{training}}
+              @onCardClick={{@onCardClick}}
+              @onModalButtonClick={{@onModalButtonClick}}
+              @onModalAccordionClick={{@onModalAccordionClick}}
+            /></li>
+        {{/each}}
+      </ul>
+    </section>
+  </template>
+}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -27,14 +27,16 @@ export default class Trainings extends Component {
   registerList = modifier((element) => {
     this.list = element;
     this.updateSpacerWidth();
-    window.addEventListener('resize', this.resyncScrollPosition);
+
+    const resizeObserver = new ResizeObserver(this.resyncScrollPosition);
+    resizeObserver.observe(element, { box: 'content-box' });
 
     return () => {
-      window.removeEventListener('resize', this.resyncScrollPosition);
+      resizeObserver.disconnect();
     };
   });
 
-  get isNavigationVisible() {
+  get areNavigationButtonsVisible() {
     return this.args.trainings.length > TRAININGS_PER_PAGE;
   }
 
@@ -66,12 +68,13 @@ export default class Trainings extends Component {
     });
   }
 
-  slideAriaLabel = (index) => {
+  @action
+  slideAriaLabel(index) {
     return this.intl.t('pages.skill-review.recommended-engine.trainings.slide-aria-label', {
       position: index + 1,
       total: this.args.trainings.length,
     });
-  };
+  }
 
   get scrollBehavior() {
     return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth';
@@ -89,6 +92,8 @@ export default class Trainings extends Component {
 
   @action
   resyncScrollPosition() {
+    if (!this.areNavigationButtonsVisible) return;
+
     this.updateSpacerWidth();
     this.goToCardIndex(this.currentPageFirstCardIndex, 'instant');
   }
@@ -104,13 +109,13 @@ export default class Trainings extends Component {
   // extra peeked width, otherwise the browser clamps scrollTo() short of the
   // last card's offsetLeft and a previous card re-appears on the left.
   //
-  // Only needed while scrolling is JS-driven (list--locked sets
+  // Only needed while scrolling is JS-driven (list--hidden sets
   // overflow-x: hidden at the desktop breakpoint, see trainings.scss). Below
   // that breakpoint, scrolling is native and this spacer stays at its CSS
   // default. Reading the computed overflow-x instead of duplicating the
   // breakpoint value keeps the SCSS as the single source of truth.
   updateSpacerWidth() {
-    if (!this.isNavigationVisible || getComputedStyle(this.list).overflowX !== 'hidden') {
+    if (!this.areNavigationButtonsVisible || getComputedStyle(this.list).overflowX !== 'hidden') {
       this.spacerWidth = null;
       return;
     }
@@ -121,9 +126,9 @@ export default class Trainings extends Component {
 
   <template>
     <section
-     id={{TRAININGS_LIST_ID}}
+      id={{TRAININGS_LIST_ID}}
       tabindex="-1"
-     class="results-recommendation-engine-training"
+      class="results-recommendation-engine-training"
       aria-labelledby={{this.titleId}}
       aria-roledescription={{t "pages.skill-review.recommended-engine.trainings.carousel-roledescription"}}
       {{onIntersect @onFullyVisible threshold=1}}
@@ -138,7 +143,7 @@ export default class Trainings extends Component {
             }}</p>
         </div>
 
-        {{#if this.isNavigationVisible}}
+        {{#if this.areNavigationButtonsVisible}}
           <div class="results-recommendation-engine-training__navigation">
             <PixIconButton
               @ariaLabel={{t "pages.skill-review.recommended-engine.trainings.previous-button-aria-label"}}
@@ -159,7 +164,7 @@ export default class Trainings extends Component {
 
       <ul
         class="results-recommendation-engine-training__list
-          {{if this.isNavigationVisible 'results-recommendation-engine-training__list--locked'}}"
+          {{if this.areNavigationButtonsVisible 'results-recommendation-engine-training__list--hidden'}}"
         {{this.registerList}}
       >
         {{#each @trainings as |training index|}}
@@ -176,7 +181,7 @@ export default class Trainings extends Component {
               /></div>
           </li>
         {{/each}}
-        {{#if this.isNavigationVisible}}
+        {{#if this.areNavigationButtonsVisible}}
           <li
             class="results-recommendation-engine-training__list-spacer"
             aria-hidden="true"

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -39,16 +39,9 @@
   &__list {
     display: flex;
     margin-top: var(--pix-spacing-4x);
-    overflow-x: auto;
     overflow-y: hidden;
-    scrollbar-width: none;
-    scroll-behavior: smooth;
 
-    @media (prefers-reduced-motion: reduce) {
-      scroll-behavior: auto;
-    }
-
-    &--locked {
+    &--hidden {
       @include breakpoints.device-is('desktop') {
         overflow-x: hidden;
       }

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -43,6 +43,12 @@
     overflow-y: hidden;
     scrollbar-width: none;
     scroll-behavior: smooth;
+
+    &--locked {
+      @include breakpoints.device-is('desktop') {
+        overflow-x: hidden;
+      }
+    }
   }
 }
 

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -53,6 +53,17 @@
         overflow-x: hidden;
       }
     }
+
+    // Width is set inline by the component at desktop breakpoints (see
+    // updateSpacerWidth in trainings.gjs), which reserves enough trailing
+    // space so an incomplete last page can still reach the left edge
+    // instead of being clamped back to a scroll position that re-reveals a
+    // previous card. This default only applies below the desktop breakpoint,
+    // where scrolling is native (no navigation buttons, no inline style).
+    &-spacer {
+      flex-shrink: 0;
+      width: 1px;
+    }
   }
 }
 

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -44,6 +44,10 @@
     scrollbar-width: none;
     scroll-behavior: smooth;
 
+    @media (prefers-reduced-motion: reduce) {
+      scroll-behavior: auto;
+    }
+
     &--locked {
       @include breakpoints.device-is('desktop') {
         overflow-x: hidden;

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -3,14 +3,21 @@
 @use 'pix-design-tokens/breakpoints';
 
 .results-recommendation-engine-training {
+  position: relative;
+
   &:focus-visible {
     outline: var(--pix-neutral-900) solid 2px;
   }
 
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: var(--pix-spacing-10x);
+  }
+
   &__title {
     @extend %pix-title-s;
-
-    margin-top: var(--pix-spacing-10x);
   }
 
   &__description {
@@ -20,14 +27,28 @@
     color: var(--pix-neutral-500);
   }
 
+  &__navigation {
+    display: none;
+
+    @include breakpoints.device-is('desktop') {
+      display: flex;
+      gap: var(--pix-spacing-2x);
+    }
+  }
+
   &__list {
     display: flex;
-    gap: var(--pix-spacing-8x);
     margin-top: var(--pix-spacing-4x);
-    padding: 3px 5px 7px;
-    overflow-y: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
     scrollbar-width: none;
     scroll-behavior: smooth;
+  }
+}
+
+.results-recommendation-engine-training-list {
+  &__item {
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
   }
 }
 
@@ -37,6 +58,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   gap: var(--pix-spacing-4x);
   justify-content: space-between;
   width: 20.6rem;

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -94,7 +94,7 @@ module(
           const trainings = screen.getByRole('heading', {
             name: t('pages.skill-review.recommended-engine.trainings.title'),
             level: 2,
-          }).parentElement;
+          }).parentElement.parentElement.parentElement;
           assert.strictEqual(document.activeElement, trainings);
         });
       });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -95,46 +95,86 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
   });
 
   module('carousel navigation', function () {
-    test('it renders the navigation buttons with the previous button disabled', async function (assert) {
+    test('it does not render navigation buttons when there are 3 trainings or less', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const trainings = createManyTrainings(store, 10);
+      const trainings = createManyTrainings(store, 3);
 
       // when
       const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
 
       // then
-      const previousButton = screen.getByRole('button', {
-        name: t('pages.skill-review.recommended-engine.trainings.previous-button-aria-label'),
-      });
-      const nextButton = screen.getByRole('button', {
-        name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
-      });
-      assert.dom(previousButton).hasAttribute('aria-disabled', 'true');
-      assert.dom(nextButton).doesNotHaveAttribute('aria-disabled');
+      assert
+        .dom(
+          screen.queryByRole('button', {
+            name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+          }),
+        )
+        .doesNotExist();
+      assert
+        .dom(
+          screen.queryByRole('button', {
+            name: t('pages.skill-review.recommended-engine.trainings.previous-button-aria-label'),
+          }),
+        )
+        .doesNotExist();
     });
 
-    module('when clicking the next button', function () {
-      test('it scrolls the list forward and enables the previous button', async function (assert) {
+    module('when there are more than 3 trainings', function () {
+      test('it renders the navigation buttons with the previous button disabled', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const trainings = createManyTrainings(store, 10);
-        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
-        const nextButton = screen.getByRole('button', {
-          name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
-        });
 
         // when
-        await click(nextButton);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
 
         // then
-        const lists = screen.getAllByRole('list');
-        assert.notStrictEqual(lists[0].scrollLeft, 0);
         const previousButton = screen.getByRole('button', {
           name: t('pages.skill-review.recommended-engine.trainings.previous-button-aria-label'),
         });
-        assert.dom(previousButton).doesNotHaveAttribute('aria-disabled');
+        const nextButton = screen.getByRole('button', {
+          name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+        });
+        assert.dom(previousButton).hasAttribute('aria-disabled', 'true');
+        assert.dom(nextButton).doesNotHaveAttribute('aria-disabled');
+      });
+
+      test('it locks manual scrolling on the list', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const trainings = createManyTrainings(store, 10);
+
+        // when
+        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+
+        // then
+        const lists = screen.getAllByRole('list');
+        assert.dom(lists[0]).hasClass('results-recommendation-engine-training__list--locked');
+      });
+
+      module('when clicking the next button', function () {
+        test('it scrolls the list forward and enables the previous button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const trainings = createManyTrainings(store, 10);
+          const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+          const nextButton = screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+          });
+
+          // when
+          await click(nextButton);
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+
+          // then
+          const lists = screen.getAllByRole('list');
+          assert.notStrictEqual(lists[0].scrollLeft, 0);
+          const previousButton = screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.trainings.previous-button-aria-label'),
+          });
+          assert.dom(previousButton).doesNotHaveAttribute('aria-disabled');
+        });
       });
     });
   });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -99,12 +99,43 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
     const trainings = [];
 
     // when
-    await render(<template><Trainings @trainings={{trainings}} /></template>);
+    const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
 
     // then
-    const heading = document.querySelector('.results-recommendation-engine-training__title');
-    const region = document.querySelector('.results-recommendation-engine-training');
-    assert.strictEqual(region.getAttribute('aria-labelledby'), heading.id);
+    assert
+      .dom(screen.getByRole('region', { name: t('pages.skill-review.recommended-engine.trainings.title') }))
+      .exists();
+  });
+
+  test('it exposes the section as a carousel, and each card as a labelled slide', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const trainings = createManyTrainings(store, 2);
+
+    // when
+    const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+
+    // then
+    const region = screen.getByRole('region', { name: t('pages.skill-review.recommended-engine.trainings.title') });
+    assert.strictEqual(
+      region.getAttribute('aria-roledescription'),
+      t('pages.skill-review.recommended-engine.trainings.carousel-roledescription'),
+    );
+
+    const slides = screen.getAllByRole('group');
+    assert.strictEqual(slides.length, 2);
+    assert.strictEqual(
+      slides[0].getAttribute('aria-roledescription'),
+      t('pages.skill-review.recommended-engine.trainings.slide-roledescription'),
+    );
+    assert.strictEqual(
+      slides[0].getAttribute('aria-label'),
+      t('pages.skill-review.recommended-engine.trainings.slide-aria-label', { position: 1, total: 2 }),
+    );
+    assert.strictEqual(
+      slides[1].getAttribute('aria-label'),
+      t('pages.skill-review.recommended-engine.trainings.slide-aria-label', { position: 2, total: 2 }),
+    );
   });
 
   module('carousel navigation', function () {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -94,6 +94,19 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
     });
   });
 
+  test('it exposes the section as a region labelled by its title', async function (assert) {
+    // given
+    const trainings = [];
+
+    // when
+    await render(<template><Trainings @trainings={{trainings}} /></template>);
+
+    // then
+    const heading = document.querySelector('.results-recommendation-engine-training__title');
+    const region = document.querySelector('.results-recommendation-engine-training');
+    assert.strictEqual(region.getAttribute('aria-labelledby'), heading.id);
+  });
+
   module('carousel navigation', function () {
     test('it does not render navigation buttons when there are 3 trainings or less', async function (assert) {
       // given
@@ -175,6 +188,46 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
           });
           assert.dom(previousButton).doesNotHaveAttribute('aria-disabled');
         });
+      });
+
+      test('it announces the visible page to assistive technologies', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const trainings = createManyTrainings(store, 10);
+        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+        const nextButton = screen.getByRole('button', {
+          name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+        });
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              t('pages.skill-review.recommended-engine.trainings.pagination-announcement', {
+                from: 1,
+                to: 3,
+                total: 10,
+              }),
+            ),
+          )
+          .exists();
+
+        // when
+        await click(nextButton);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              t('pages.skill-review.recommended-engine.trainings.pagination-announcement', {
+                from: 4,
+                to: 6,
+                total: 10,
+              }),
+            ),
+          )
+          .exists();
       });
     });
   });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -229,6 +229,48 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
           )
           .exists();
       });
+
+      test('it partially displays the upcoming card - clicking the button displays it in full and hides the previous cards', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const trainings = createManyTrainings(store, 7);
+        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+        const nextButton = screen.getByRole('button', {
+          name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+        });
+
+        // clicks to the intermediate page (cards 3, 4, 5 + a peek of card 6)
+        await click(nextButton);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // then card 6 straddles the list's right edge, not fully shown
+        const lists = screen.getAllByRole('list');
+        const cards = lists[0].children;
+        const listRect = lists[0].getBoundingClientRect();
+        const peekingLastCardRect = cards[6].getBoundingClientRect();
+
+        assert.true(peekingLastCardRect.left < listRect.right);
+        assert.true(peekingLastCardRect.right > listRect.right);
+
+        assert.dom(nextButton).doesNotHaveAttribute('aria-disabled');
+
+        // clicks to the final page
+        await click(nextButton);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // then card 6 is fully shown, alone, and card 5 is fully hidden
+        const roundingTolerance = 1;
+        const previousCardRect = cards[5].getBoundingClientRect();
+        const lastCardRect = cards[6].getBoundingClientRect();
+
+        assert.true(previousCardRect.right <= listRect.left + roundingTolerance);
+        assert.true(lastCardRect.right <= listRect.right + roundingTolerance);
+
+        const nextButtonOnFinalPage = screen.getByRole('button', {
+          name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+        });
+        assert.dom(nextButtonOnFinalPage).hasAttribute('aria-disabled', 'true');
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { click, waitUntil } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import Trainings from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/trainings';
 import { module, test } from 'qunit';
@@ -194,7 +194,7 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
 
         // then
         const lists = screen.getAllByRole('list');
-        assert.dom(lists[0]).hasClass('results-recommendation-engine-training__list--locked');
+        assert.dom(lists[0]).hasClass('results-recommendation-engine-training__list--hidden');
       });
 
       module('when clicking the next button', function () {
@@ -209,10 +209,10 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
 
           // when
           await click(nextButton);
-          await new Promise((resolve) => setTimeout(resolve, 1000));
+          const lists = screen.getAllByRole('list');
+          await waitUntil(() => lists[0].scrollLeft !== 0);
 
           // then
-          const lists = screen.getAllByRole('list');
           assert.notStrictEqual(lists[0].scrollLeft, 0);
           const previousButton = screen.getByRole('button', {
             name: t('pages.skill-review.recommended-engine.trainings.previous-button-aria-label'),
@@ -245,7 +245,6 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
 
         // when
         await click(nextButton);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
 
         // then
         assert
@@ -272,12 +271,15 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
 
         // clicks to the intermediate page (cards 3, 4, 5 + a peek of card 6)
         await click(nextButton);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-
-        // then card 6 straddles the list's right edge, not fully shown
         const lists = screen.getAllByRole('list');
         const cards = lists[0].children;
         const listRect = lists[0].getBoundingClientRect();
+        await waitUntil(() => {
+          const rect = cards[6].getBoundingClientRect();
+          return rect.left < listRect.right && rect.right > listRect.right;
+        });
+
+        // then card 6 straddles the list's right edge, not fully shown
         const peekingLastCardRect = cards[6].getBoundingClientRect();
 
         assert.true(peekingLastCardRect.left < listRect.right);
@@ -286,11 +288,15 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         assert.dom(nextButton).doesNotHaveAttribute('aria-disabled');
 
         // clicks to the final page
+        const roundingTolerance = 1;
         await click(nextButton);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await waitUntil(
+          () =>
+            cards[5].getBoundingClientRect().right <= listRect.left + roundingTolerance &&
+            cards[6].getBoundingClientRect().right <= listRect.right + roundingTolerance,
+        );
 
         // then card 6 is fully shown, alone, and card 5 is fully hidden
-        const roundingTolerance = 1;
         const previousCardRect = cards[5].getBoundingClientRect();
         const lastCardRect = cards[6].getBoundingClientRect();
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -1,10 +1,21 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import Trainings from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/trainings';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
+function createManyTrainings(store, count) {
+  return Array.from({ length: count }, (_, index) =>
+    store.createRecord('training', {
+      title: `Training ${index}`,
+      link: 'https://exemple.net/',
+      duration: { days: 2 },
+    }),
+  );
+}
 
 module('Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | Trainings', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -80,6 +91,51 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
 
       // then
       assert.strictEqual(observerOptions?.threshold, 1);
+    });
+  });
+
+  module('carousel navigation', function () {
+    test('it renders the navigation buttons with the previous button disabled', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const trainings = createManyTrainings(store, 10);
+
+      // when
+      const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+
+      // then
+      const previousButton = screen.getByRole('button', {
+        name: t('pages.skill-review.recommended-engine.trainings.previous-button-aria-label'),
+      });
+      const nextButton = screen.getByRole('button', {
+        name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+      });
+      assert.dom(previousButton).hasAttribute('aria-disabled', 'true');
+      assert.dom(nextButton).doesNotHaveAttribute('aria-disabled');
+    });
+
+    module('when clicking the next button', function () {
+      test('it scrolls the list forward and enables the previous button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const trainings = createManyTrainings(store, 10);
+        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+        const nextButton = screen.getByRole('button', {
+          name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+        });
+
+        // when
+        await click(nextButton);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // then
+        const lists = screen.getAllByRole('list');
+        assert.notStrictEqual(lists[0].scrollLeft, 0);
+        const previousButton = screen.getByRole('button', {
+          name: t('pages.skill-review.recommended-engine.trainings.previous-button-aria-label'),
+        });
+        assert.dom(previousButton).doesNotHaveAttribute('aria-disabled');
+      });
     });
   });
 });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2337,6 +2337,7 @@
         "trainings": {
           "description": "Die unten aufgeführten Lösungen werden dir basierend auf deinem Niveau empfohlen.",
           "next-button-aria-label": "Nächste Weiterbildungen anzeigen",
+          "pagination-announcement": "Weiterbildungen {from} bis {to} von {total} angezeigt",
           "previous-button-aria-label": "Vorherige Weiterbildungen anzeigen",
           "title": "Gehen Sie noch einen Schritt weiter – ganz in Ihrem eigenen Tempo."
         }

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2336,6 +2336,8 @@
         },
         "trainings": {
           "description": "Die unten aufgeführten Lösungen werden dir basierend auf deinem Niveau empfohlen.",
+          "next-button-aria-label": "Nächste Weiterbildungen anzeigen",
+          "previous-button-aria-label": "Vorherige Weiterbildungen anzeigen",
           "title": "Gehen Sie noch einen Schritt weiter – ganz in Ihrem eigenen Tempo."
         }
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2335,10 +2335,13 @@
           }
         },
         "trainings": {
+          "carousel-roledescription": "carousel",
           "description": "The solutions listed below are recommended to you based on your level.",
           "next-button-aria-label": "See next trainings",
           "pagination-announcement": "Showing trainings {from} to {to} of {total}",
           "previous-button-aria-label": "See previous trainings",
+          "slide-aria-label": "{position} of {total}",
+          "slide-roledescription": "slide",
           "title": "Go further, at your own pace."
         }
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2336,6 +2336,8 @@
         },
         "trainings": {
           "description": "The solutions listed below are recommended to you based on your level.",
+          "next-button-aria-label": "See next trainings",
+          "previous-button-aria-label": "See previous trainings",
           "title": "Go further, at your own pace."
         }
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2337,6 +2337,7 @@
         "trainings": {
           "description": "The solutions listed below are recommended to you based on your level.",
           "next-button-aria-label": "See next trainings",
+          "pagination-announcement": "Showing trainings {from} to {to} of {total}",
           "previous-button-aria-label": "See previous trainings",
           "title": "Go further, at your own pace."
         }

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2335,10 +2335,13 @@
           }
         },
         "trainings": {
+          "carousel-roledescription": "carrusel",
           "description": "Las soluciones que se muestran a continuación se te recomiendan en función de tu nivel.",
           "next-button-aria-label": "Ver las formaciones siguientes",
           "pagination-announcement": "Mostrando formaciones {from} a {to} de {total}",
           "previous-button-aria-label": "Ver las formaciones anteriores",
+          "slide-aria-label": "{position} de {total}",
+          "slide-roledescription": "diapositiva",
           "title": "Ve más allá, a tu propio ritmo."
         }
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2337,6 +2337,7 @@
         "trainings": {
           "description": "Las soluciones que se muestran a continuación se te recomiendan en función de tu nivel.",
           "next-button-aria-label": "Ver las formaciones siguientes",
+          "pagination-announcement": "Mostrando formaciones {from} a {to} de {total}",
           "previous-button-aria-label": "Ver las formaciones anteriores",
           "title": "Ve más allá, a tu propio ritmo."
         }

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2336,6 +2336,8 @@
         },
         "trainings": {
           "description": "Las soluciones que se muestran a continuación se te recomiendan en función de tu nivel.",
+          "next-button-aria-label": "Ver las formaciones siguientes",
+          "previous-button-aria-label": "Ver las formaciones anteriores",
           "title": "Ve más allá, a tu propio ritmo."
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2336,6 +2336,8 @@
         },
         "trainings": {
           "description": "Les solutions listées ci-dessous vous sont recommandées en fonction de votre niveau.",
+          "next-button-aria-label": "Voir les formations suivantes",
+          "previous-button-aria-label": "Voir les formations précédentes",
           "title": "Allez plus loin, à votre rythme."
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2335,10 +2335,13 @@
           }
         },
         "trainings": {
+          "carousel-roledescription": "carrousel",
           "description": "Les solutions listées ci-dessous vous sont recommandées en fonction de votre niveau.",
           "next-button-aria-label": "Voir les formations suivantes",
           "pagination-announcement": "Formations {from} à {to} sur {total} affichées",
           "previous-button-aria-label": "Voir les formations précédentes",
+          "slide-aria-label": "{position} sur {total}",
+          "slide-roledescription": "diapositive",
           "title": "Allez plus loin, à votre rythme."
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2337,6 +2337,7 @@
         "trainings": {
           "description": "Les solutions listées ci-dessous vous sont recommandées en fonction de votre niveau.",
           "next-button-aria-label": "Voir les formations suivantes",
+          "pagination-announcement": "Formations {from} à {to} sur {total} affichées",
           "previous-button-aria-label": "Voir les formations précédentes",
           "title": "Allez plus loin, à votre rythme."
         }

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2336,6 +2336,8 @@
         },
         "trainings": {
           "description": "Le soluzioni elencate qui sotto ti vengono consigliate in base al tuo livello.",
+          "next-button-aria-label": "Vedi le formazioni successive",
+          "previous-button-aria-label": "Vedi le formazioni precedenti",
           "title": "Andate oltre, al vostro ritmo."
         }
       },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2337,6 +2337,7 @@
         "trainings": {
           "description": "Le soluzioni elencate qui sotto ti vengono consigliate in base al tuo livello.",
           "next-button-aria-label": "Vedi le formazioni successive",
+          "pagination-announcement": "Formazioni da {from} a {to} su {total} visualizzate",
           "previous-button-aria-label": "Vedi le formazioni precedenti",
           "title": "Andate oltre, al vostro ritmo."
         }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2335,10 +2335,13 @@
           }
         },
         "trainings": {
+          "carousel-roledescription": "carrousel",
           "description": "De onderstaande oplossingen worden je aanbevolen op basis van je niveau.",
           "next-button-aria-label": "Volgende opleidingen bekijken",
           "pagination-announcement": "Opleidingen {from} tot {to} van {total} weergegeven",
           "previous-button-aria-label": "Vorige opleidingen bekijken",
+          "slide-aria-label": "{position} van {total}",
+          "slide-roledescription": "dia",
           "title": "Ga verder, op je eigen tempo."
         }
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2337,6 +2337,7 @@
         "trainings": {
           "description": "De onderstaande oplossingen worden je aanbevolen op basis van je niveau.",
           "next-button-aria-label": "Volgende opleidingen bekijken",
+          "pagination-announcement": "Opleidingen {from} tot {to} van {total} weergegeven",
           "previous-button-aria-label": "Vorige opleidingen bekijken",
           "title": "Ga verder, op je eigen tempo."
         }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2336,6 +2336,8 @@
         },
         "trainings": {
           "description": "De onderstaande oplossingen worden je aanbevolen op basis van je niveau.",
+          "next-button-aria-label": "Volgende opleidingen bekijken",
+          "previous-button-aria-label": "Vorige opleidingen bekijken",
           "title": "Ga verder, op je eigen tempo."
         }
       },


### PR DESCRIPTION
## ☀️ Problème

Actuellement, sur la page de résultats de fin de campagne d'évaluation du moteur de reco en desktop : 
- si 3 contenus formatifs recommandés, on voit les 3
- Si plus de 3 contenus formatifs, on peut voir la 4ème mais en grande partie occultée.
  - Il faut scroller sur les cartes pour voir le reste

En vue desktop, il faudrait ajouter des boutons permettant de scroller dans les contenus formatifs dès lors qu’il y en a plus de 3.

## ⛱️ Proposition

Au clic sur le bouton, les 3 premiers contenus formatifs sont remplacés par les contenus formatifs suivants.

- si on n’a recommandé que 4 contenus formatifs, l’utilisateur verra alors uniquement le 4ème contenu formatif qui était en partie occulté jusqu’ici.
- Si on en a recommandé 5, l’utilisateur verra les 4ème et 5ème contenus formatifs

Un effet de slide permet de faire la transition.

## 🧴 Remarques

Pas de boutons pour les tablettes et mobile.

---

- Pas encore dev le bouton PixIconButton en variant secondary
- Pas mis ce carrousel en tant que composant Pix UI (même si usage futur ailleurs - pas assez sec pour le faire)

> [!IMPORTANT]
>  **Pas traité le comportement au clavier => il faudra le gérer dans une autre PR**

## 🏊 Pour tester

- maude-hulix@example.net / pix123
- Ici il y a 2 contenus recommandés, on peut voir que les boutons ne s'affichent pas.
- dave-comp@example.net / pix123
- https://app-pr17192.review.pix.fr/campagnes/EDUMULTIP/evaluation/resultats
- Ici il y a 8 contenus recommandés, les boutons s'affichent
  - Le bouton pour aller en arrière est désactivés, en revanche, celui pour avancer est disponible
  - cliquer dessus
  - voir que la 7ème apparaît à moitié comme la 4ème
  - cliquer pour avancer
  - constater que seule la 8ème carte s'affiche 
  - le bouton pour avancer est désormais désactivé mais pas celui pour revenir en arrière
  - cliquer pour revenir en arrière et voir les 3 précédentes
  - on ne peut plus scroller dedans 

Vous pouvez jouer avec le nombre de contenus formatifs en appliquant une locale `Francophone (fr)` sur Admin https://admin-pr17192.review.pix.fr/trainings/list
En effet, sur pix.fr, seuls les contenus `Franco-français (fr-fr)` apparaissent 

Passer en tablette et mobile et voir que les boutons n’apparaissent pas, on reste sur le comportement d'avant.
