### PR TITLE
[FEATURE] Récupération de la config de score de calibration au lieu de la version (PIX-23958).

### DIFF
--- a/admin/app/adapters/calibration-scoring-configuration.js
+++ b/admin/app/adapters/calibration-scoring-configuration.js
@@ -2,8 +2,7 @@ import ApplicationAdapter from './application';
 
 export default class CalibrationScoringConfigurationAdapter extends ApplicationAdapter {
   urlForQueryRecord(query) {
-    const url = `${this.host}/${this.namespace}/certification-versions/${query.versionId}/calibrations/${query.calibrationId}/scoring-configuration`;
-    delete query.versionId;
+    const url = `${this.host}/${this.namespace}/calibrations/${query.calibrationId}/scoring-configuration`;
     delete query.calibrationId;
     return url;
   }

--- a/admin/app/adapters/calibration-scoring-configuration.js
+++ b/admin/app/adapters/calibration-scoring-configuration.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class CalibrationScoringConfigurationAdapter extends ApplicationAdapter {
+  urlForQueryRecord(query) {
+    const url = `${this.host}/${this.namespace}/certification-versions/${query.versionId}/calibrations/${query.calibrationId}/scoring-configuration`;
+    delete query.versionId;
+    delete query.calibrationId;
+    return url;
+  }
+}

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -28,7 +28,7 @@ export default class ScoringForm extends Component {
     super(...arguments);
 
     const { calibrationScoringConfiguration } = this.args;
-    this.calibrationBounds = calibrationScoringConfiguration?.isAvailable
+    this.calibrationBounds = calibrationScoringConfiguration?.hasProposal
       ? calibrationScoringConfiguration.globalScoringConfiguration.map(({ meshLevel, bounds }) => ({
           meshLevel,
           bounds: { min: bounds.min, max: bounds.max },
@@ -69,11 +69,10 @@ export default class ScoringForm extends Component {
         'components.certification-frameworks.certification-framework.versions.scoring.no-calibration-attached',
       );
     }
-    if (this.args.calibrationScoringConfiguration?.isAvailable) return null;
+    if (this.args.calibrationScoringConfiguration?.hasProposal) return null;
 
-    const availability = this.args.calibrationScoringConfiguration?.availability ?? 'PENDING';
     return this.intl.t(
-      `components.certification-frameworks.certification-framework.versions.scoring.calibration-proposal-${availability}`,
+      'components.certification-frameworks.certification-framework.versions.scoring.calibration-proposal-unavailable',
       { calibrationId },
     );
   }

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -12,18 +13,78 @@ import Card from 'pix-admin/components/card';
 export default class ScoringForm extends Component {
   @service pixToast;
   @service intl;
+
+  /**
+   * Bounds proposed by the calibration, copied once so that the rows keep their identity across
+   * renders while the admin edits them.
+   *
+   * They deliberately do NOT land on the draft version record before the form is submitted: routes
+   * sharing that record roll back its dirty attributes when they exit, which would wipe the values
+   * as soon as another version route is left.
+   */
+  calibrationBounds;
+
+  constructor() {
+    super(...arguments);
+
+    const { calibrationScoringConfiguration } = this.args;
+    this.calibrationBounds = calibrationScoringConfiguration?.isAvailable
+      ? calibrationScoringConfiguration.globalScoringConfiguration.map(({ meshLevel, bounds }) => ({
+          meshLevel,
+          bounds: { min: bounds.min, max: bounds.max },
+        }))
+      : [];
+  }
+
   get hasError() {
     return this.globalScoringConfiguration.some(({ bounds }) => bounds.max <= bounds.min);
   }
 
+  /**
+   * What the admin already saved on the draft always wins over the calibration proposal, otherwise
+   * their adjustments would be overwritten on every visit.
+   */
   get globalScoringConfiguration() {
-    return this.args.draftVersion.globalScoringConfiguration;
+    const savedConfiguration = this.args.draftVersion.globalScoringConfiguration;
+    return savedConfiguration?.length ? savedConfiguration : this.calibrationBounds;
+  }
+
+  /**
+   * The bounds in force on the active version, displayed as a reference next to the editable ones.
+   * They come from the API database, unlike the proposal which comes from the datamart.
+   */
+  get activeVersionConfiguration() {
+    return this.args.activeVersion?.globalScoringConfiguration ?? [];
+  }
+
+  /**
+   * The bounds proposed by the calibration already seed the form, so the only thing left to say is
+   * why they are missing when they are.
+   */
+  get calibrationProposalUnavailabilityMessage() {
+    const calibrationId = this.args.draftVersion.externalCalibrationId;
+
+    if (!calibrationId) {
+      return this.intl.t(
+        'components.certification-frameworks.certification-framework.versions.scoring.no-calibration-attached',
+      );
+    }
+    if (this.args.calibrationScoringConfiguration?.isAvailable) return null;
+
+    const availability = this.args.calibrationScoringConfiguration?.availability ?? 'PENDING';
+    return this.intl.t(
+      `components.certification-frameworks.certification-framework.versions.scoring.calibration-proposal-${availability}`,
+      { calibrationId },
+    );
   }
 
   @action
   async saveCapacityByMesh(event) {
     event.preventDefault();
     if (this.hasError) return;
+
+    // The displayed bounds may still be the untouched calibration ones: commit them to the record.
+    this.args.draftVersion.globalScoringConfiguration = this.globalScoringConfiguration;
 
     try {
       await this.args.draftVersion.save();
@@ -69,11 +130,23 @@ export default class ScoringForm extends Component {
     return this.globalScoringConfiguration.at(index).bounds.max > this.globalScoringConfiguration.at(index).bounds.min;
   }
 
+  @action
+  activeVersionBound(meshLevel, name) {
+    const bounds = this.activeVersionConfiguration.find((mesh) => mesh.meshLevel === meshLevel)?.bounds;
+    return bounds ? bounds[name] : '—';
+  }
+
   <template>
     <Card
       class="versions-scoring"
       @title={{t "components.certification-frameworks.certification-framework.versions.scoring.title"}}
     >
+      {{#if this.calibrationProposalUnavailabilityMessage}}
+        <PixNotificationAlert @type="warning" @withIcon={{true}}>
+          <p>{{this.calibrationProposalUnavailabilityMessage}}</p>
+        </PixNotificationAlert>
+      {{/if}}
+
       <form id="version-scoring-form" class="versions-scoring__form" {{on "submit" this.saveCapacityByMesh}}>
         {{#each this.globalScoringConfiguration as |mesh|}}
           <h3>{{t
@@ -92,7 +165,7 @@ export default class ScoringForm extends Component {
             >
               <:label>{{t
                   "components.certification-frameworks.certification-framework.versions.scoring.previous-version-capacity"
-                  previousVersionCapacity=mesh.bounds.min
+                  previousVersionCapacity=(this.activeVersionBound mesh.meshLevel "min")
                 }}</:label>
             </PixInput>
 
@@ -110,7 +183,7 @@ export default class ScoringForm extends Component {
             >
               <:label>{{t
                   "components.certification-frameworks.certification-framework.versions.scoring.previous-version-capacity"
-                  previousVersionCapacity=mesh.bounds.max
+                  previousVersionCapacity=(this.activeVersionBound mesh.meshLevel "max")
                 }}</:label>
             </PixInput>
           </section>

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -1,7 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -27,13 +26,12 @@ export default class ScoringForm extends Component {
   constructor() {
     super(...arguments);
 
-    const { calibrationScoringConfiguration } = this.args;
-    this.calibrationBounds = calibrationScoringConfiguration?.hasProposal
-      ? calibrationScoringConfiguration.globalScoringConfiguration.map(({ meshLevel, bounds }) => ({
-          meshLevel,
-          bounds: { min: bounds.min, max: bounds.max },
-        }))
-      : [];
+    this.calibrationBounds = this.args.calibrationScoringConfiguration.globalScoringConfiguration.map(
+      ({ meshLevel, bounds }) => ({
+        meshLevel,
+        bounds: { min: bounds.min, max: bounds.max },
+      }),
+    );
   }
 
   get hasError() {
@@ -55,26 +53,6 @@ export default class ScoringForm extends Component {
    */
   get activeVersionConfiguration() {
     return this.args.activeVersion?.globalScoringConfiguration ?? [];
-  }
-
-  /**
-   * The bounds proposed by the calibration already seed the form, so the only thing left to say is
-   * why they are missing when they are.
-   */
-  get calibrationProposalUnavailabilityMessage() {
-    const calibrationId = this.args.draftVersion.externalCalibrationId;
-
-    if (!calibrationId) {
-      return this.intl.t(
-        'components.certification-frameworks.certification-framework.versions.scoring.no-calibration-attached',
-      );
-    }
-    if (this.args.calibrationScoringConfiguration?.hasProposal) return null;
-
-    return this.intl.t(
-      'components.certification-frameworks.certification-framework.versions.scoring.calibration-proposal-unavailable',
-      { calibrationId },
-    );
   }
 
   @action
@@ -140,12 +118,6 @@ export default class ScoringForm extends Component {
       class="versions-scoring"
       @title={{t "components.certification-frameworks.certification-framework.versions.scoring.title"}}
     >
-      {{#if this.calibrationProposalUnavailabilityMessage}}
-        <PixNotificationAlert @type="warning" @withIcon={{true}}>
-          <p>{{this.calibrationProposalUnavailabilityMessage}}</p>
-        </PixNotificationAlert>
-      {{/if}}
-
       <form id="version-scoring-form" class="versions-scoring__form" {{on "submit" this.saveCapacityByMesh}}>
         {{#each this.globalScoringConfiguration as |mesh|}}
           <h3>{{t

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -13,44 +13,17 @@ export default class ScoringForm extends Component {
   @service pixToast;
   @service intl;
 
-  /**
-   * Bounds proposed by the calibration, copied once so that the rows keep their identity across
-   * renders while the admin edits them.
-   *
-   * They deliberately do NOT land on the draft version record before the form is submitted: routes
-   * sharing that record roll back its dirty attributes when they exit, which would wipe the values
-   * as soon as another version route is left.
-   */
-  calibrationBounds;
-
-  constructor() {
-    super(...arguments);
-
-    this.calibrationBounds = this.args.calibrationScoringConfiguration.globalScoringConfiguration.map(
-      ({ meshLevel, bounds }) => ({
-        meshLevel,
-        bounds: { min: bounds.min, max: bounds.max },
-      }),
-    );
-  }
-
   get hasError() {
     return this.globalScoringConfiguration.some(({ bounds }) => bounds.max <= bounds.min);
   }
 
-  /**
-   * What the admin already saved on the draft always wins over the calibration proposal, otherwise
-   * their adjustments would be overwritten on every visit.
-   */
   get globalScoringConfiguration() {
     const savedConfiguration = this.args.draftVersion.globalScoringConfiguration;
-    return savedConfiguration?.length ? savedConfiguration : this.calibrationBounds;
+    return savedConfiguration?.length
+      ? savedConfiguration
+      : this.args.calibrationScoringConfiguration.globalScoringConfiguration;
   }
 
-  /**
-   * The bounds in force on the active version, displayed as a reference next to the editable ones.
-   * They come from the API database, unlike the proposal which comes from the datamart.
-   */
   get activeVersionConfiguration() {
     return this.args.activeVersion?.globalScoringConfiguration ?? [];
   }
@@ -120,7 +93,9 @@ export default class ScoringForm extends Component {
     >
       <form id="version-scoring-form" class="versions-scoring__form" {{on "submit" this.saveCapacityByMesh}}>
         {{#each this.globalScoringConfiguration as |mesh|}}
-          <h3>{{t
+          <h3>
+
+            {{t
               "components.certification-frameworks.certification-framework.versions.scoring.level"
               index=mesh.meshLevel
             }}</h3>

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form.gjs
@@ -33,7 +33,6 @@ export default class ScoringForm extends Component {
     event.preventDefault();
     if (this.hasError) return;
 
-    // The displayed bounds may still be the untouched calibration ones: commit them to the record.
     this.args.draftVersion.globalScoringConfiguration = this.globalScoringConfiguration;
 
     try {

--- a/admin/app/models/calibration-scoring-configuration.js
+++ b/admin/app/models/calibration-scoring-configuration.js
@@ -3,12 +3,4 @@ import Model, { attr } from '@warp-drive/legacy/model';
 export default class CalibrationScoringConfiguration extends Model {
   @attr('number') calibrationId;
   @attr() globalScoringConfiguration;
-
-  /**
-   * The API only exposes the meshes of a validated set, so an empty configuration means Data has
-   * not delivered or not validated them yet — two cases the form has nothing to tell apart.
-   */
-  get hasProposal() {
-    return Boolean(this.globalScoringConfiguration?.length);
-  }
 }

--- a/admin/app/models/calibration-scoring-configuration.js
+++ b/admin/app/models/calibration-scoring-configuration.js
@@ -1,0 +1,17 @@
+import Model, { attr } from '@warp-drive/legacy/model';
+
+export const SCORING_MESH_AVAILABILITIES = {
+  AVAILABLE: 'AVAILABLE',
+  PENDING: 'PENDING',
+  NOT_VALIDATED: 'NOT_VALIDATED',
+};
+
+export default class CalibrationScoringConfiguration extends Model {
+  @attr('number') calibrationId;
+  @attr('string') availability;
+  @attr() globalScoringConfiguration;
+
+  get isAvailable() {
+    return this.availability === SCORING_MESH_AVAILABILITIES.AVAILABLE;
+  }
+}

--- a/admin/app/models/calibration-scoring-configuration.js
+++ b/admin/app/models/calibration-scoring-configuration.js
@@ -1,17 +1,14 @@
 import Model, { attr } from '@warp-drive/legacy/model';
 
-export const SCORING_MESH_AVAILABILITIES = {
-  AVAILABLE: 'AVAILABLE',
-  PENDING: 'PENDING',
-  NOT_VALIDATED: 'NOT_VALIDATED',
-};
-
 export default class CalibrationScoringConfiguration extends Model {
   @attr('number') calibrationId;
-  @attr('string') availability;
   @attr() globalScoringConfiguration;
 
-  get isAvailable() {
-    return this.availability === SCORING_MESH_AVAILABILITIES.AVAILABLE;
+  /**
+   * The API only exposes the meshes of a validated set, so an empty configuration means Data has
+   * not delivered or not validated them yet — two cases the form has nothing to tell apart.
+   */
+  get hasProposal() {
+    return Boolean(this.globalScoringConfiguration?.length);
   }
 }

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -30,7 +30,6 @@ export default class ScoringRoute extends Route {
 
     try {
       return await this.store.queryRecord('calibration-scoring-configuration', {
-        versionId: draftVersion.id,
         calibrationId: draftVersion.externalCalibrationId,
       });
     } catch {

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -38,7 +38,7 @@ export default class ScoringRoute extends Route {
   }
 
   afterModel(model) {
-    if (!model.draftVersion.isDraft) {
+    if (!model.draftVersion.isDraft || !model.calibrationScoringConfiguration?.globalScoringConfiguration?.length) {
       this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
     }
   }

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -20,11 +20,6 @@ export default class ScoringRoute extends Route {
     };
   }
 
-  /**
-   * The proposal lives in the datamart: it may not have been delivered yet, and a datamart outage
-   * must not take the whole page down. A failure is downgraded to "no proposal", a state the form
-   * already knows how to render.
-   */
   async loadCalibrationScoringConfiguration(draftVersion) {
     if (!draftVersion.externalCalibrationId) return null;
 

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -6,14 +6,36 @@ export default class ScoringRoute extends Route {
   @service router;
 
   async model() {
+    const { activeVersion } = this.modelFor('authenticated.certification-frameworks.certification-framework.versions');
+
     const { version_id: versionId } = this.paramsFor(
       'authenticated.certification-frameworks.certification-framework.versions.version',
     );
     const draftVersion = await this.store.findRecord('certification-version', versionId);
 
     return {
+      activeVersion,
       draftVersion,
+      calibrationScoringConfiguration: await this.loadCalibrationScoringConfiguration(draftVersion),
     };
+  }
+
+  /**
+   * The proposal lives in the datamart: it may not have been delivered yet, and a datamart outage
+   * must not take the whole page down. A failure is downgraded to "no proposal", a state the form
+   * already knows how to render.
+   */
+  async loadCalibrationScoringConfiguration(draftVersion) {
+    if (!draftVersion.externalCalibrationId) return null;
+
+    try {
+      return await this.store.queryRecord('calibration-scoring-configuration', {
+        versionId: draftVersion.id,
+        calibrationId: draftVersion.externalCalibrationId,
+      });
+    } catch {
+      return null;
+    }
   }
 
   afterModel(model) {

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
@@ -1,3 +1,9 @@
 import CertificationVersionScoringForm from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form';
 
-<template><CertificationVersionScoringForm @draftVersion={{@model.draftVersion}} /></template>
+<template>
+  <CertificationVersionScoringForm
+    @draftVersion={{@model.draftVersion}}
+    @activeVersion={{@model.activeVersion}}
+    @calibrationScoringConfiguration={{@model.calibrationScoringConfiguration}}
+  />
+</template>

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
@@ -48,6 +48,11 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     );
     server.create('certification-framework', { id: 'CORE', versionSummaries });
     server.create('certification-version', {
+      id: 13,
+      status: 'active',
+      globalScoringConfiguration: [{ bounds: { min: -4, max: 2 }, meshLevel: 0 }],
+    });
+    server.create('certification-version', {
       id: 14,
       status: 'draft',
       globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
@@ -75,6 +80,124 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
         assert
           .dom(
             screen.getByText(t('components.certification-frameworks.certification-framework.versions.scoring.title')),
+          )
+          .exists();
+      });
+    });
+
+    module('when the draft version has no calibration attached', function () {
+      test('tells the admin the bounds have to be filled in manually', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+
+        assert
+          .dom(
+            screen.getByText(
+              t('components.certification-frameworks.certification-framework.versions.scoring.no-calibration-attached'),
+            ),
+          )
+          .exists();
+      });
+    });
+
+    module('when the attached calibration carries a scoring configuration', function (hooks) {
+      hooks.beforeEach(function () {
+        server.db.certificationVersions.update('14', { externalCalibrationId: 1 });
+        server.get('/admin/certification-versions/:id/calibrations/:calibrationId/scoring-configuration', (schema) => {
+          return schema.create('calibration-scoring-configuration', {
+            id: '14_1',
+            calibrationId: 1,
+            availability: 'AVAILABLE',
+            globalScoringConfiguration: [
+              { bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 },
+              { bounds: { min: -1.4, max: 0.6 }, meshLevel: 1 },
+            ],
+          });
+        });
+      });
+
+      test('keeps the configuration already saved on the draft version', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+
+        assert.dom(screen.getByDisplayValue('8')).exists();
+        assert.dom(screen.queryByDisplayValue('-4.67')).doesNotExist();
+      });
+
+      module('when the draft version has no configuration saved yet', function (hooks) {
+        hooks.beforeEach(function () {
+          server.db.certificationVersions.update('14', { globalScoringConfiguration: [] });
+        });
+
+        test('fills the form with the calibration values on page load', async function (assert) {
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+          const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+
+          assert.dom(screen.getByDisplayValue('-4.67')).exists();
+          assert.dom(screen.getByDisplayValue('0.6')).exists();
+        });
+
+        test('fills the form even when the version is already in the store', async function (assert) {
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+          // the edit page loads the very same record, so reaching scoring from there hits the store cache
+          await visit(`/certification-frameworks/CORE/versions/14/edit`);
+          const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+
+          assert.dom(screen.getByDisplayValue('-4.67')).exists();
+          assert.dom(screen.getByDisplayValue('0.6')).exists();
+        });
+
+        test('persists the calibration bounds when submitting without editing them', async function (assert) {
+          let patchedAttributes;
+          server.patch('/admin/certification-versions/:id', (schema, request) => {
+            patchedAttributes = JSON.parse(request.requestBody).data.attributes;
+            return schema.certificationVersions.find(request.params.id);
+          });
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+          await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+          await clickByName(
+            t('components.certification-frameworks.certification-framework.versions.scoring.capacity-submit-button'),
+          );
+
+          assert.deepEqual(patchedAttributes['global-scoring-configuration'], [
+            { bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 },
+            { bounds: { min: -1.4, max: 0.6 }, meshLevel: 1 },
+          ]);
+        });
+      });
+    });
+
+    module('when the attached calibration has no scoring configuration yet', function (hooks) {
+      hooks.beforeEach(function () {
+        server.db.certificationVersions.update('14', { externalCalibrationId: 1 });
+        server.get('/admin/certification-versions/:id/calibrations/:calibrationId/scoring-configuration', (schema) => {
+          return schema.create('calibration-scoring-configuration', {
+            id: '14_1',
+            calibrationId: 1,
+            availability: 'PENDING',
+            globalScoringConfiguration: [],
+          });
+        });
+      });
+
+      test('tells the admin the bounds have not been delivered yet', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+
+        assert
+          .dom(
+            screen.getByText(
+              t(
+                'components.certification-frameworks.certification-framework.versions.scoring.calibration-proposal-PENDING',
+                { calibrationId: 1 },
+              ),
+            ),
           )
           .exists();
       });

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
@@ -104,9 +104,9 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     module('when the attached calibration carries a scoring configuration', function (hooks) {
       hooks.beforeEach(function () {
         server.db.certificationVersions.update('14', { externalCalibrationId: 1 });
-        server.get('/admin/certification-versions/:id/calibrations/:calibrationId/scoring-configuration', (schema) => {
+        server.get('/admin/calibrations/:calibrationId/scoring-configuration', (schema) => {
           return schema.create('calibration-scoring-configuration', {
-            id: '14_1',
+            id: '1',
             calibrationId: 1,
             availability: 'AVAILABLE',
             globalScoringConfiguration: [
@@ -175,9 +175,9 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     module('when the attached calibration has no scoring configuration yet', function (hooks) {
       hooks.beforeEach(function () {
         server.db.certificationVersions.update('14', { externalCalibrationId: 1 });
-        server.get('/admin/certification-versions/:id/calibrations/:calibrationId/scoring-configuration', (schema) => {
+        server.get('/admin/calibrations/:calibrationId/scoring-configuration', (schema) => {
           return schema.create('calibration-scoring-configuration', {
-            id: '14_1',
+            id: '1',
             calibrationId: 1,
             availability: 'PENDING',
             globalScoringConfiguration: [],

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
@@ -55,7 +55,16 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     server.create('certification-version', {
       id: 14,
       status: 'draft',
+      externalCalibrationId: 1,
       globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
+    });
+    server.create('calibration-scoring-configuration', {
+      id: '1',
+      calibrationId: 1,
+      globalScoringConfiguration: [
+        { bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 },
+        { bounds: { min: -1.4, max: 0.6 }, meshLevel: 1 },
+      ],
     });
   });
 
@@ -86,36 +95,17 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     });
 
     module('when the draft version has no calibration attached', function () {
-      test('tells the admin the bounds have to be filled in manually', async function (assert) {
+      test('redirects to the framework page', async function (assert) {
+        server.db.certificationVersions.update('14', { externalCalibrationId: null });
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
-        const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+        await visit(`/certification-frameworks/CORE/versions/14/scoring`);
 
-        assert
-          .dom(
-            screen.getByText(
-              t('components.certification-frameworks.certification-framework.versions.scoring.no-calibration-attached'),
-            ),
-          )
-          .exists();
+        assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
       });
     });
 
-    module('when the attached calibration carries a scoring configuration', function (hooks) {
-      hooks.beforeEach(function () {
-        server.db.certificationVersions.update('14', { externalCalibrationId: 1 });
-        server.get('/admin/calibrations/:calibrationId/scoring-configuration', (schema) => {
-          return schema.create('calibration-scoring-configuration', {
-            id: '1',
-            calibrationId: 1,
-            globalScoringConfiguration: [
-              { bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 },
-              { bounds: { min: -1.4, max: 0.6 }, meshLevel: 1 },
-            ],
-          });
-        });
-      });
-
+    module('when the attached calibration carries a scoring configuration', function () {
       test('keeps the configuration already saved on the draft version', async function (assert) {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
@@ -173,31 +163,15 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
 
     module('when the attached calibration has no scoring configuration yet', function (hooks) {
       hooks.beforeEach(function () {
-        server.db.certificationVersions.update('14', { externalCalibrationId: 1 });
-        server.get('/admin/calibrations/:calibrationId/scoring-configuration', (schema) => {
-          return schema.create('calibration-scoring-configuration', {
-            id: '1',
-            calibrationId: 1,
-            globalScoringConfiguration: [],
-          });
-        });
+        server.db.calibrationScoringConfigurations.update('1', { globalScoringConfiguration: [] });
       });
 
-      test('tells the admin the bounds have not been delivered yet', async function (assert) {
+      test('redirects to the framework page', async function (assert) {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
-        const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+        await visit(`/certification-frameworks/CORE/versions/14/scoring`);
 
-        assert
-          .dom(
-            screen.getByText(
-              t(
-                'components.certification-frameworks.certification-framework.versions.scoring.calibration-proposal-unavailable',
-                { calibrationId: 1 },
-              ),
-            ),
-          )
-          .exists();
+        assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
       });
     });
 

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
@@ -108,7 +108,6 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
           return schema.create('calibration-scoring-configuration', {
             id: '1',
             calibrationId: 1,
-            availability: 'AVAILABLE',
             globalScoringConfiguration: [
               { bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 },
               { bounds: { min: -1.4, max: 0.6 }, meshLevel: 1 },
@@ -179,7 +178,6 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
           return schema.create('calibration-scoring-configuration', {
             id: '1',
             calibrationId: 1,
-            availability: 'PENDING',
             globalScoringConfiguration: [],
           });
         });
@@ -194,7 +192,7 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
           .dom(
             screen.getByText(
               t(
-                'components.certification-frameworks.certification-framework.versions.scoring.calibration-proposal-PENDING',
+                'components.certification-frameworks.certification-framework.versions.scoring.calibration-proposal-unavailable',
                 { calibrationId: 1 },
               ),
             ),

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
@@ -156,7 +156,6 @@ module(
         const calibrationScoringConfiguration = store.createRecord('calibration-scoring-configuration', {
           id: '5',
           calibrationId: 5,
-          availability: 'AVAILABLE',
           globalScoringConfiguration: [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],
         });
 
@@ -188,7 +187,6 @@ module(
         const calibrationScoringConfiguration = store.createRecord('calibration-scoring-configuration', {
           id: '5',
           calibrationId: 5,
-          availability: 'AVAILABLE',
           globalScoringConfiguration: [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],
         });
 

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
@@ -26,6 +26,15 @@ function labelOf(input) {
   return input.labels[0];
 }
 
+// The route redirects away when the calibration proposes no bound, so the form always receives one.
+function createCalibrationProposal(store, globalScoringConfiguration) {
+  return store.createRecord('calibration-scoring-configuration', {
+    id: '5',
+    calibrationId: 5,
+    globalScoringConfiguration: globalScoringConfiguration ?? [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],
+  });
+}
+
 module(
   'Integration | Component | certification-frameworks/certification-framework/versions/certification-version-scoring-form',
   function (hooks) {
@@ -51,10 +60,16 @@ module(
             { bounds: { min: 8, max: 15 }, meshLevel: 1 },
           ],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // then
@@ -74,10 +89,16 @@ module(
             { bounds: { min: 8, max: 15 }, meshLevel: 1 },
           ],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // then
@@ -108,11 +129,16 @@ module(
             { bounds: { min: 9, max: 16 }, meshLevel: 1 },
           ],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
           <template>
-            <CertificationVersionScoringForm @draftVersion={{draftVersion}} @activeVersion={{activeVersion}} />
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @activeVersion={{activeVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
           </template>,
         );
 
@@ -133,10 +159,16 @@ module(
           status: 'draft',
           globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // then
@@ -153,11 +185,7 @@ module(
           externalCalibrationId: 5,
           globalScoringConfiguration: [],
         });
-        const calibrationScoringConfiguration = store.createRecord('calibration-scoring-configuration', {
-          id: '5',
-          calibrationId: 5,
-          globalScoringConfiguration: [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],
-        });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
@@ -184,11 +212,7 @@ module(
           externalCalibrationId: 5,
           globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
         });
-        const calibrationScoringConfiguration = store.createRecord('calibration-scoring-configuration', {
-          id: '5',
-          calibrationId: 5,
-          globalScoringConfiguration: [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],
-        });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
@@ -215,10 +239,16 @@ module(
           status: 'draft',
           globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // then
@@ -233,10 +263,16 @@ module(
           status: 'draft',
           globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // then
@@ -251,10 +287,16 @@ module(
           status: 'draft',
           globalScoringConfiguration: [{ bounds: { min: 3, max: 3 }, meshLevel: 0 }],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // then
@@ -271,10 +313,16 @@ module(
           status: 'draft',
           globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         // when
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // then
@@ -300,9 +348,15 @@ module(
             { bounds: { min: 8, max: 15 }, meshLevel: 1 },
           ],
         });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // when
@@ -323,9 +377,15 @@ module(
           globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
         });
         sinon.stub(draftVersion, 'save').resolves();
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // when
@@ -350,9 +410,15 @@ module(
           globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
         });
         sinon.stub(draftVersion, 'save').rejects({ errors: [{ detail: 'Erreur serveur' }] });
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // when
@@ -371,9 +437,15 @@ module(
           globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
         });
         sinon.stub(draftVersion, 'save').resolves();
+        const calibrationScoringConfiguration = createCalibrationProposal(store);
 
         const screen = await render(
-          <template><CertificationVersionScoringForm @draftVersion={{draftVersion}} /></template>,
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
         );
 
         // when

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
@@ -89,7 +89,7 @@ module(
         assert.dom(maxInputs[1]).hasValue('15');
       });
 
-      test('it labels each input with the capacity of the previous version', async function (assert) {
+      test('it labels each input with the capacity of the active version', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const draftVersion = store.createRecord('certification-version', {
@@ -100,6 +100,39 @@ module(
             { bounds: { min: 8, max: 15 }, meshLevel: 1 },
           ],
         });
+        const activeVersion = store.createRecord('certification-version', {
+          id: '2',
+          status: 'active',
+          globalScoringConfiguration: [
+            { bounds: { min: 2, max: 9 }, meshLevel: 0 },
+            { bounds: { min: 9, max: 16 }, meshLevel: 1 },
+          ],
+        });
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationVersionScoringForm @draftVersion={{draftVersion}} @activeVersion={{activeVersion}} />
+          </template>,
+        );
+
+        // then
+        const { min: minInputs, max: maxInputs } = getBoundsInputs(screen);
+
+        assert.dom(labelOf(minInputs[0])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 2 }));
+        assert.dom(labelOf(maxInputs[0])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 9 }));
+        assert.dom(labelOf(minInputs[1])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 9 }));
+        assert.dom(labelOf(maxInputs[1])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 16 }));
+      });
+
+      test('it falls back to a dash when there is no active version to compare with', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
+        });
 
         // when
         const screen = await render(
@@ -107,12 +140,71 @@ module(
         );
 
         // then
-        const { min: minInputs, max: maxInputs } = getBoundsInputs(screen);
+        const { min: minInputs } = getBoundsInputs(screen);
+        assert.dom(labelOf(minInputs[0])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: '—' }));
+      });
 
-        assert.dom(labelOf(minInputs[0])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 1 }));
-        assert.dom(labelOf(maxInputs[0])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 8 }));
-        assert.dom(labelOf(minInputs[1])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 8 }));
-        assert.dom(labelOf(maxInputs[1])).includesText(t(CAPACITY_LABEL, { previousVersionCapacity: 15 }));
+      test('it displays the bounds proposed by the calibration when the draft has none', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          externalCalibrationId: 5,
+          globalScoringConfiguration: [],
+        });
+        const calibrationScoringConfiguration = store.createRecord('calibration-scoring-configuration', {
+          id: '1_5',
+          calibrationId: 5,
+          availability: 'AVAILABLE',
+          globalScoringConfiguration: [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],
+        });
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
+        );
+
+        // then
+        const { min: minInputs, max: maxInputs } = getBoundsInputs(screen);
+        assert.dom(minInputs[0]).hasValue('-4.67');
+        assert.dom(maxInputs[0]).hasValue('-1.4');
+      });
+
+      test('it keeps the bounds saved on the draft over the ones proposed by the calibration', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const draftVersion = store.createRecord('certification-version', {
+          id: '1',
+          status: 'draft',
+          externalCalibrationId: 5,
+          globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
+        });
+        const calibrationScoringConfiguration = store.createRecord('calibration-scoring-configuration', {
+          id: '1_5',
+          calibrationId: 5,
+          availability: 'AVAILABLE',
+          globalScoringConfiguration: [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],
+        });
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationVersionScoringForm
+              @draftVersion={{draftVersion}}
+              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
+            />
+          </template>,
+        );
+
+        // then
+        const { min: minInputs } = getBoundsInputs(screen);
+        assert.dom(minInputs[0]).hasValue('1');
       });
     });
 

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
@@ -154,7 +154,7 @@ module(
           globalScoringConfiguration: [],
         });
         const calibrationScoringConfiguration = store.createRecord('calibration-scoring-configuration', {
-          id: '1_5',
+          id: '5',
           calibrationId: 5,
           availability: 'AVAILABLE',
           globalScoringConfiguration: [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],
@@ -186,7 +186,7 @@ module(
           globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
         });
         const calibrationScoringConfiguration = store.createRecord('calibration-scoring-configuration', {
-          id: '1_5',
+          id: '5',
           calibrationId: 5,
           availability: 'AVAILABLE',
           globalScoringConfiguration: [{ bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 }],

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-scoring-form-test.gjs
@@ -26,7 +26,6 @@ function labelOf(input) {
   return input.labels[0];
 }
 
-// The route redirects away when the calibration proposes no bound, so the form always receives one.
 function createCalibrationProposal(store, globalScoringConfiguration) {
   return store.createRecord('calibration-scoring-configuration', {
     id: '5',

--- a/admin/tests/mirage/models.js
+++ b/admin/tests/mirage/models.js
@@ -15,6 +15,7 @@ import autonomousCourseTargetProfile from './models/autonomous-course-target-pro
 import badge from './models/badge';
 import badgeCriterion from './models/badge-criterion';
 import calibrationReport from './models/calibration-report';
+import calibrationScoringConfiguration from './models/calibration-scoring-configuration';
 import campaign from './models/campaign';
 import campaignParticipation from './models/campaign-participation';
 import certification from './models/certification';
@@ -95,6 +96,7 @@ export default {
   campaign,
   campaignParticipation,
   calibrationReport,
+  calibrationScoringConfiguration,
   certification,
   certificationCandidate,
   certificationCandidateTimeline,

--- a/admin/tests/mirage/models/calibration-scoring-configuration.js
+++ b/admin/tests/mirage/models/calibration-scoring-configuration.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend();

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -127,7 +127,7 @@ export default function routes() {
     return schema.calibrationReports.first();
   });
 
-  this.get('/admin/certification-versions/:id/calibrations/:calibrationId/scoring-configuration', (schema) => {
+  this.get('/admin/calibrations/:calibrationId/scoring-configuration', (schema) => {
     return schema.calibrationScoringConfigurations.first();
   });
 

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -127,6 +127,10 @@ export default function routes() {
     return schema.calibrationReports.first();
   });
 
+  this.get('/admin/certification-versions/:id/calibrations/:calibrationId/scoring-configuration', (schema) => {
+    return schema.calibrationScoringConfigurations.first();
+  });
+
   this.get('/admin/certification-frameworks', (schema) => {
     return schema.certificationFrameworks.all();
   });

--- a/admin/tests/mirage/serializers.js
+++ b/admin/tests/mirage/serializers.js
@@ -5,6 +5,7 @@ import attachedCertificationCenter from './serializers/attached-certification-ce
 import autonomousCourseListItem from './serializers/autonomous-course-list-item';
 import badge from './serializers/badge';
 import calibrationReport from './serializers/calibration-report';
+import calibrationScoringConfiguration from './serializers/calibration-scoring-configuration';
 import campaign from './serializers/campaign';
 import campaignParticipation from './serializers/campaign-participation';
 import certification from './serializers/certification';
@@ -41,6 +42,7 @@ export default {
   campaign,
   campaignParticipation,
   calibrationReport,
+  calibrationScoringConfiguration,
   certificationCandidate,
   certificationCenter,
   certificationCenterMembership,

--- a/admin/tests/mirage/serializers/calibration-scoring-configuration.js
+++ b/admin/tests/mirage/serializers/calibration-scoring-configuration.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend();

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -587,6 +587,7 @@
             "label-for-CALIBRATION_STATUS": "Status",
             "label-for-COMPETENCE_SCORING_PRESENCE": "Validated competences scoring present",
             "label-for-MESH_SCORING_PRESENCE": "Validated mesh scoring present",
+            "label-for-SCORING_MESH_AVAILABILITY": "Bounds of capacity by mesh",
             "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Tubes in calibration only",
             "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Tubes in version only",
             "report-title": "Calibration report of ID {calibrationId} generated at",
@@ -632,9 +633,12 @@
           },
           "page-title": "Creation of a new version of the certification in {scope} framework",
           "scoring": {
+            "calibration-proposal-NOT_VALIDATED": "The bounds of capacity by mesh of calibration {calibrationId} exist but have not been validated by Data yet.",
+            "calibration-proposal-PENDING": "The bounds of capacity by mesh of calibration {calibrationId} have not been delivered by Data yet. They are not produced for every framework.",
             "cannot-be-lower-error": "The maximal capacity for a given level has to be strictly greater than its minimal capacity.",
             "capacity-submit-button": "Save capacities by mesh",
             "level": "Level {index}",
+            "no-calibration-attached": "No calibration is attached to this version: the bounds have to be filled in manually.",
             "previous-version-capacity": "Previous value: {previousVersionCapacity}",
             "success-notification": "The scoring has been successfully updated",
             "title": "Bounds of capacity by mesh"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -587,7 +587,6 @@
             "label-for-CALIBRATION_STATUS": "Status",
             "label-for-COMPETENCE_SCORING_PRESENCE": "Validated competences scoring present",
             "label-for-MESH_SCORING_PRESENCE": "Validated mesh scoring present",
-            "label-for-SCORING_MESH_AVAILABILITY": "Bounds of capacity by mesh",
             "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Tubes in calibration only",
             "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Tubes in version only",
             "report-title": "Calibration report of ID {calibrationId} generated at",
@@ -633,8 +632,7 @@
           },
           "page-title": "Creation of a new version of the certification in {scope} framework",
           "scoring": {
-            "calibration-proposal-NOT_VALIDATED": "The bounds of capacity by mesh of calibration {calibrationId} exist but have not been validated by Data yet.",
-            "calibration-proposal-PENDING": "The bounds of capacity by mesh of calibration {calibrationId} have not been delivered by Data yet. They are not produced for every framework.",
+            "calibration-proposal-unavailable": "No validated bounds are available for calibration {calibrationId}.",
             "cannot-be-lower-error": "The maximal capacity for a given level has to be strictly greater than its minimal capacity.",
             "capacity-submit-button": "Save capacities by mesh",
             "level": "Level {index}",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -632,11 +632,9 @@
           },
           "page-title": "Creation of a new version of the certification in {scope} framework",
           "scoring": {
-            "calibration-proposal-unavailable": "No validated bounds are available for calibration {calibrationId}.",
             "cannot-be-lower-error": "The maximal capacity for a given level has to be strictly greater than its minimal capacity.",
             "capacity-submit-button": "Save capacities by mesh",
             "level": "Level {index}",
-            "no-calibration-attached": "No calibration is attached to this version: the bounds have to be filled in manually.",
             "previous-version-capacity": "Previous value: {previousVersionCapacity}",
             "success-notification": "The scoring has been successfully updated",
             "title": "Bounds of capacity by mesh"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -595,7 +595,6 @@
             "label-for-CALIBRATION_STATUS": "Statut",
             "label-for-COMPETENCE_SCORING_PRESENCE": "Présence d'un scoring par compétences validé",
             "label-for-MESH_SCORING_PRESENCE": "Présence d'un scoring par maille validé",
-            "label-for-SCORING_MESH_AVAILABILITY": "Bornes de capacités par mailles",
             "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Sujet présents uniquement dans la calibration",
             "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Sujet présents uniquement dans la version",
             "report-title": "Rapport de la calibration d'ID {calibrationId} générée le",
@@ -642,8 +641,7 @@
           },
           "page-title": "Création d’une nouvelle version du référentiel de certification pour {scope}",
           "scoring": {
-            "calibration-proposal-NOT_VALIDATED": "Les bornes de capacités par mailles de la calibration {calibrationId} existent mais ne sont pas encore validées par Data.",
-            "calibration-proposal-PENDING": "Les bornes de capacités par mailles de la calibration {calibrationId} n'ont pas encore été livrées par Data. Elles ne sont pas produites pour tous les référentiels.",
+            "calibration-proposal-unavailable": "Aucune borne validée n'est disponible pour la calibration {calibrationId}.",
             "cannot-be-lower-error": "La capacité maximale d'un niveau doit être strictement supérieur à sa capacité minimale.",
             "capacity-submit-button": "Sauvegarder les capacités par mailles",
             "level": "Niveau {index}",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -641,11 +641,9 @@
           },
           "page-title": "Création d’une nouvelle version du référentiel de certification pour {scope}",
           "scoring": {
-            "calibration-proposal-unavailable": "Aucune borne validée n'est disponible pour la calibration {calibrationId}.",
             "cannot-be-lower-error": "La capacité maximale d'un niveau doit être strictement supérieur à sa capacité minimale.",
             "capacity-submit-button": "Sauvegarder les capacités par mailles",
             "level": "Niveau {index}",
-            "no-calibration-attached": "Aucune calibration n'est rattachée à cette version : les bornes doivent être saisies manuellement.",
             "previous-version-capacity": "Ancienne valeur : {previousVersionCapacity}",
             "success-notification": "Le scoring a bien été mis à jour",
             "title": "Bornes de capacités par mailles"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -595,9 +595,11 @@
             "label-for-CALIBRATION_STATUS": "Statut",
             "label-for-COMPETENCE_SCORING_PRESENCE": "Présence d'un scoring par compétences validé",
             "label-for-MESH_SCORING_PRESENCE": "Présence d'un scoring par maille validé",
+            "label-for-SCORING_MESH_AVAILABILITY": "Bornes de capacités par mailles",
             "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Sujet présents uniquement dans la calibration",
             "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Sujet présents uniquement dans la version",
             "report-title": "Rapport de la calibration d'ID {calibrationId} générée le",
+            "save-button-label": "Enregistrer l'ID {id} de calibration",
             "save-success-message": "L'ID de calibration a été enregistré.",
             "scopes": {
               "CORE": "Pix Cœur (transverse)",
@@ -640,9 +642,12 @@
           },
           "page-title": "Création d’une nouvelle version du référentiel de certification pour {scope}",
           "scoring": {
+            "calibration-proposal-NOT_VALIDATED": "Les bornes de capacités par mailles de la calibration {calibrationId} existent mais ne sont pas encore validées par Data.",
+            "calibration-proposal-PENDING": "Les bornes de capacités par mailles de la calibration {calibrationId} n'ont pas encore été livrées par Data. Elles ne sont pas produites pour tous les référentiels.",
             "cannot-be-lower-error": "La capacité maximale d'un niveau doit être strictement supérieur à sa capacité minimale.",
             "capacity-submit-button": "Sauvegarder les capacités par mailles",
             "level": "Niveau {index}",
+            "no-calibration-attached": "Aucune calibration n'est rattachée à cette version : les bornes doivent être saisies manuellement.",
             "previous-version-capacity": "Ancienne valeur : {previousVersionCapacity}",
             "success-notification": "Le scoring a bien été mis à jour",
             "title": "Bornes de capacités par mailles"

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -63,11 +63,8 @@ async function generateCalibrationReport(request, h) {
 }
 
 async function getCalibrationScoringConfiguration(request, h) {
-  const { certificationVersionId: versionId, calibrationId } = request.params;
-  const calibrationScoringConfiguration = await usecases.getCalibrationScoringConfiguration({
-    versionId,
-    calibrationId,
-  });
+  const { calibrationId } = request.params;
+  const calibrationScoringConfiguration = await usecases.getCalibrationScoringConfiguration({ calibrationId });
   return h.response(calibrationScoringConfigurationSerializer.serialize(calibrationScoringConfiguration)).code(200);
 }
 

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -4,6 +4,7 @@ const { Deserializer } = jsonapiSerializer;
 
 import { usecases } from '../domain/usecases/index.js';
 import * as calibrationReportSerializer from '../infrastructure/serializers/calibration-report-serializer.js';
+import * as calibrationScoringConfigurationSerializer from '../infrastructure/serializers/calibration-scoring-configuration-serializer.js';
 import { certificationInfoSerializer } from '../infrastructure/serializers/certification-info-serializer.js';
 import * as versionDetailsSerializer from '../infrastructure/serializers/version-details-serializer.js';
 
@@ -61,6 +62,15 @@ async function generateCalibrationReport(request, h) {
   return h.response(calibrationReportSerializer.serialize(report)).code(200);
 }
 
+async function getCalibrationScoringConfiguration(request, h) {
+  const { certificationVersionId: versionId, calibrationId } = request.params;
+  const calibrationScoringConfiguration = await usecases.getCalibrationScoringConfiguration({
+    versionId,
+    calibrationId,
+  });
+  return h.response(calibrationScoringConfigurationSerializer.serialize(calibrationScoringConfiguration)).code(200);
+}
+
 async function getInfo(request) {
   const framework = request.params.framework;
 
@@ -79,6 +89,7 @@ export const certificationVersionController = {
   updateComments,
   getInfo,
   generateCalibrationReport,
+  getCalibrationScoringConfiguration,
 };
 
 function deserialize(json) {

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -243,7 +243,7 @@ async function register(server) {
     },
     {
       method: 'GET',
-      path: '/api/admin/certification-versions/{certificationVersionId}/calibrations/{calibrationId}/scoring-configuration',
+      path: '/api/admin/calibrations/{calibrationId}/scoring-configuration',
       config: {
         pre: [
           {
@@ -257,7 +257,6 @@ async function register(server) {
         ],
         validate: {
           params: Joi.object({
-            certificationVersionId: identifiersType.certificationVersionId,
             calibrationId: identifiersType.calibrationId,
           }),
         },

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -241,6 +241,35 @@ async function register(server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/certification-versions/{certificationVersionId}/calibrations/{calibrationId}/scoring-configuration',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationVersionId: identifiersType.certificationVersionId,
+            calibrationId: identifiersType.calibrationId,
+          }),
+        },
+        handler: certificationVersionController.getCalibrationScoringConfiguration,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte au SUPER ADMIN',
+          "Elle permet d'obtenir la configuration de scoring globale proposée par une calibration, afin de pré-remplir le formulaire de scoring d'une version draft",
+          "Elle renvoie un état de disponibilité : la maille de scoring est livrée par Data après la calibration, et n'est pas livrée pour tous les référentiels",
+        ],
+      },
+    },
   ]);
 }
 

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -265,7 +265,6 @@ async function register(server) {
         notes: [
           'Cette route est restreinte au SUPER ADMIN',
           "Elle permet d'obtenir la configuration de scoring globale proposée par une calibration, afin de pré-remplir le formulaire de scoring d'une version draft",
-          "Elle renvoie un état de disponibilité : la maille de scoring est livrée par Data après la calibration, et n'est pas livrée pour tous les référentiels",
         ],
       },
     },

--- a/api/src/certification/configuration/domain/models/Calibration.js
+++ b/api/src/certification/configuration/domain/models/Calibration.js
@@ -18,7 +18,7 @@ export const CALIBRATION_SCOPES = Object.freeze({
 export class Calibration {
   /**
    * @param {object} params
-   * @param {Array<CalibrationScoringMesh>} [params.scoringMeshes] - empty until Data delivers a validated mesh set
+   * @param {Array<CalibrationScoringMesh>} [params.scoringMeshes]
    */
   constructor({ id, startedAt, status, scope, calibratedChallenges, scoringMeshes = [] }) {
     this.id = id;
@@ -69,12 +69,6 @@ export class CalibratedChallenge {
   }
 }
 
-/**
- * One mesh of the scoring mesh set curated by Data. Bounds are expressed in capacity.
- *
- * Data delivers the set asynchronously, after the calibration itself, and does not deliver it at all
- * for some scopes: a calibration carrying no mesh is a nominal state, not an error.
- */
 export class CalibrationScoringMesh {
   constructor({ mesh, minBoundCuratedValue, maxBoundCuratedValue }) {
     this.mesh = mesh;

--- a/api/src/certification/configuration/domain/models/Calibration.js
+++ b/api/src/certification/configuration/domain/models/Calibration.js
@@ -15,31 +15,18 @@ export const CALIBRATION_SCOPES = Object.freeze({
   PRO_SANTE: 'PRO_SANTE',
 });
 
-export const SCORING_MESH_AVAILABILITIES = Object.freeze({
-  AVAILABLE: 'AVAILABLE',
-  PENDING: 'PENDING',
-  NOT_VALIDATED: 'NOT_VALIDATED',
-});
-
 export class Calibration {
   /**
    * @param {object} params
-   * @param {CalibrationScoringMeshSet} [params.scoringMeshSet] - defaults to an empty, thus pending, set
+   * @param {Array<CalibrationScoringMesh>} [params.scoringMeshes] - empty until Data delivers a validated mesh set
    */
-  constructor({
-    id,
-    startedAt,
-    status,
-    scope,
-    calibratedChallenges,
-    scoringMeshSet = new CalibrationScoringMeshSet(),
-  }) {
+  constructor({ id, startedAt, status, scope, calibratedChallenges, scoringMeshes = [] }) {
     this.id = id;
     this.startedAt = startedAt;
     this.status = status;
     this.scope = scope;
     this.calibratedChallenges = calibratedChallenges;
-    this.scoringMeshSet = scoringMeshSet;
+    this.scoringMeshes = scoringMeshes;
   }
 
   get challengeCount() {
@@ -83,48 +70,16 @@ export class CalibratedChallenge {
 }
 
 /**
- * One mesh of a scoring mesh set, as curated by Data. Bounds are expressed in capacity.
+ * One mesh of the scoring mesh set curated by Data. Bounds are expressed in capacity.
+ *
+ * Data delivers the set asynchronously, after the calibration itself, and does not deliver it at all
+ * for some scopes: a calibration carrying no mesh is a nominal state, not an error.
  */
 export class CalibrationScoringMesh {
   constructor({ mesh, minBoundCuratedValue, maxBoundCuratedValue }) {
     this.mesh = mesh;
     this.minBoundCuratedValue = minBoundCuratedValue;
     this.maxBoundCuratedValue = maxBoundCuratedValue;
-  }
-}
-
-/**
- * The scoring mesh set attached to a calibration.
- *
- * Data delivers it asynchronously, after the calibration itself, and does not deliver it at all for
- * some scopes: an empty set is a nominal state, not an error.
- */
-export class CalibrationScoringMeshSet {
-  /**
-   * @param {object} [params]
-   * @param {typeof CALIBRATION_STATUSES[keyof typeof CALIBRATION_STATUSES]|null} [params.status] - null when Data has not delivered any set yet
-   * @param {Array<CalibrationScoringMesh>} [params.meshes]
-   */
-  constructor({ status = null, meshes = [] } = {}) {
-    this.status = status;
-    this.meshes = meshes;
-  }
-
-  /**
-   * @returns {typeof SCORING_MESH_AVAILABILITIES[keyof typeof SCORING_MESH_AVAILABILITIES]}
-   */
-  get availability() {
-    if (this.status === null || this.meshes.length === 0) {
-      return SCORING_MESH_AVAILABILITIES.PENDING;
-    }
-    if (this.status !== CALIBRATION_STATUSES.VALIDATED) {
-      return SCORING_MESH_AVAILABILITIES.NOT_VALIDATED;
-    }
-    return SCORING_MESH_AVAILABILITIES.AVAILABLE;
-  }
-
-  get isAvailable() {
-    return this.availability === SCORING_MESH_AVAILABILITIES.AVAILABLE;
   }
 }
 

--- a/api/src/certification/configuration/domain/models/Calibration.js
+++ b/api/src/certification/configuration/domain/models/Calibration.js
@@ -15,13 +15,31 @@ export const CALIBRATION_SCOPES = Object.freeze({
   PRO_SANTE: 'PRO_SANTE',
 });
 
+export const SCORING_MESH_AVAILABILITIES = Object.freeze({
+  AVAILABLE: 'AVAILABLE',
+  PENDING: 'PENDING',
+  NOT_VALIDATED: 'NOT_VALIDATED',
+});
+
 export class Calibration {
-  constructor({ id, startedAt, status, scope, calibratedChallenges }) {
+  /**
+   * @param {object} params
+   * @param {CalibrationScoringMeshSet} [params.scoringMeshSet] - defaults to an empty, thus pending, set
+   */
+  constructor({
+    id,
+    startedAt,
+    status,
+    scope,
+    calibratedChallenges,
+    scoringMeshSet = new CalibrationScoringMeshSet(),
+  }) {
     this.id = id;
     this.startedAt = startedAt;
     this.status = status;
     this.scope = scope;
     this.calibratedChallenges = calibratedChallenges;
+    this.scoringMeshSet = scoringMeshSet;
   }
 
   get challengeCount() {
@@ -61,6 +79,52 @@ export class CalibratedChallenge {
     this.tubeId = tubeId;
     this.alpha = alpha;
     this.delta = delta;
+  }
+}
+
+/**
+ * One mesh of a scoring mesh set, as curated by Data. Bounds are expressed in capacity.
+ */
+export class CalibrationScoringMesh {
+  constructor({ mesh, minBoundCuratedValue, maxBoundCuratedValue }) {
+    this.mesh = mesh;
+    this.minBoundCuratedValue = minBoundCuratedValue;
+    this.maxBoundCuratedValue = maxBoundCuratedValue;
+  }
+}
+
+/**
+ * The scoring mesh set attached to a calibration.
+ *
+ * Data delivers it asynchronously, after the calibration itself, and does not deliver it at all for
+ * some scopes: an empty set is a nominal state, not an error.
+ */
+export class CalibrationScoringMeshSet {
+  /**
+   * @param {object} [params]
+   * @param {typeof CALIBRATION_STATUSES[keyof typeof CALIBRATION_STATUSES]|null} [params.status] - null when Data has not delivered any set yet
+   * @param {Array<CalibrationScoringMesh>} [params.meshes]
+   */
+  constructor({ status = null, meshes = [] } = {}) {
+    this.status = status;
+    this.meshes = meshes;
+  }
+
+  /**
+   * @returns {typeof SCORING_MESH_AVAILABILITIES[keyof typeof SCORING_MESH_AVAILABILITIES]}
+   */
+  get availability() {
+    if (this.status === null || this.meshes.length === 0) {
+      return SCORING_MESH_AVAILABILITIES.PENDING;
+    }
+    if (this.status !== CALIBRATION_STATUSES.VALIDATED) {
+      return SCORING_MESH_AVAILABILITIES.NOT_VALIDATED;
+    }
+    return SCORING_MESH_AVAILABILITIES.AVAILABLE;
+  }
+
+  get isAvailable() {
+    return this.availability === SCORING_MESH_AVAILABILITIES.AVAILABLE;
   }
 }
 

--- a/api/src/certification/configuration/domain/models/CalibrationReport.js
+++ b/api/src/certification/configuration/domain/models/CalibrationReport.js
@@ -3,7 +3,7 @@
  * @typedef {import('./Calibration.js').CalibrationForReport} CalibrationForReport
  */
 import { SCOPES } from '../../../shared/domain/models/Scopes.js';
-import { CALIBRATION_STATUSES, fromCalibrationScope } from './Calibration.js';
+import { CALIBRATION_STATUSES, fromCalibrationScope, SCORING_MESH_AVAILABILITIES } from './Calibration.js';
 
 export class CalibrationReport {
   constructor({ versionId, calibrationId, generatedAt, reportLines }) {
@@ -32,6 +32,7 @@ export const REPORT_LABELS = Object.freeze({
   CALIBRATION_SCOPE: 'CALIBRATION_SCOPE',
   MESH_SCORING_PRESENCE: 'MESH_SCORING_PRESENCE',
   COMPETENCE_SCORING_PRESENCE: 'COMPETENCE_SCORING_PRESENCE',
+  SCORING_MESH_AVAILABILITY: 'SCORING_MESH_AVAILABILITY',
 });
 
 export const ALERT_LEVELS = Object.freeze({
@@ -55,6 +56,7 @@ export function buildReport({ version, calibration }) {
   computeReportForStatus(calibration, reportLines);
   computeReportForMeshScoring(version, calibration, reportLines);
   computeReportForCompetenceScoring(version, calibration, reportLines);
+  computeReportForScoringMeshAvailability(calibration, reportLines);
   return new CalibrationReport({
     versionId: version.id,
     calibrationId: calibration.id,
@@ -132,6 +134,25 @@ function computeReportForScope(version, calibration, reportLines) {
       content: adaptedCalibrationScope,
       alertLevel,
       additionalContent,
+    }),
+  );
+}
+
+function computeReportForScoringMeshAvailability(calibration, reportLines) {
+  const availability = calibration.scoringMeshSet.availability;
+  const additionalContentByAvailability = {
+    [SCORING_MESH_AVAILABILITIES.AVAILABLE]: null,
+    [SCORING_MESH_AVAILABILITIES.PENDING]:
+      "Les bornes de capacités par mailles de cette calibration n'ont pas encore été livrées",
+    [SCORING_MESH_AVAILABILITIES.NOT_VALIDATED]:
+      'Les bornes de capacités par mailles de cette calibration ne sont pas validées',
+  };
+  reportLines.push(
+    new CalibrationReportLine({
+      label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
+      content: availability,
+      alertLevel: availability === SCORING_MESH_AVAILABILITIES.AVAILABLE ? null : ALERT_LEVELS.LOW,
+      additionalContent: additionalContentByAvailability[availability],
     }),
   );
 }

--- a/api/src/certification/configuration/domain/models/CalibrationReport.js
+++ b/api/src/certification/configuration/domain/models/CalibrationReport.js
@@ -3,7 +3,7 @@
  * @typedef {import('./Calibration.js').CalibrationForReport} CalibrationForReport
  */
 import { SCOPES } from '../../../shared/domain/models/Scopes.js';
-import { CALIBRATION_STATUSES, fromCalibrationScope, SCORING_MESH_AVAILABILITIES } from './Calibration.js';
+import { CALIBRATION_STATUSES, fromCalibrationScope } from './Calibration.js';
 
 export class CalibrationReport {
   constructor({ versionId, calibrationId, generatedAt, reportLines }) {
@@ -32,7 +32,6 @@ export const REPORT_LABELS = Object.freeze({
   CALIBRATION_SCOPE: 'CALIBRATION_SCOPE',
   MESH_SCORING_PRESENCE: 'MESH_SCORING_PRESENCE',
   COMPETENCE_SCORING_PRESENCE: 'COMPETENCE_SCORING_PRESENCE',
-  SCORING_MESH_AVAILABILITY: 'SCORING_MESH_AVAILABILITY',
 });
 
 export const ALERT_LEVELS = Object.freeze({
@@ -56,7 +55,6 @@ export function buildReport({ version, calibration }) {
   computeReportForStatus(calibration, reportLines);
   computeReportForMeshScoring(version, calibration, reportLines);
   computeReportForCompetenceScoring(version, calibration, reportLines);
-  computeReportForScoringMeshAvailability(calibration, reportLines);
   return new CalibrationReport({
     versionId: version.id,
     calibrationId: calibration.id,
@@ -134,25 +132,6 @@ function computeReportForScope(version, calibration, reportLines) {
       content: adaptedCalibrationScope,
       alertLevel,
       additionalContent,
-    }),
-  );
-}
-
-function computeReportForScoringMeshAvailability(calibration, reportLines) {
-  const availability = calibration.scoringMeshSet.availability;
-  const additionalContentByAvailability = {
-    [SCORING_MESH_AVAILABILITIES.AVAILABLE]: null,
-    [SCORING_MESH_AVAILABILITIES.PENDING]:
-      "Les bornes de capacités par mailles de cette calibration n'ont pas encore été livrées",
-    [SCORING_MESH_AVAILABILITIES.NOT_VALIDATED]:
-      'Les bornes de capacités par mailles de cette calibration ne sont pas validées',
-  };
-  reportLines.push(
-    new CalibrationReportLine({
-      label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
-      content: availability,
-      alertLevel: availability === SCORING_MESH_AVAILABILITIES.AVAILABLE ? null : ALERT_LEVELS.LOW,
-      additionalContent: additionalContentByAvailability[availability],
     }),
   );
 }

--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -169,10 +169,10 @@ export class Version {
         limitToOneQuestionPerTube: version?.challengesConfiguration?.limitToOneQuestionPerTube ?? true,
         enablePassageByAllCompetences: version?.challengesConfiguration?.enablePassageByAllCompetences ?? true,
       }),
-      globalScoringConfiguration: version?.globalScoringConfiguration ?? [],
-      competencesScoringConfiguration: version?.competencesScoringConfiguration ?? [],
+      globalScoringConfiguration: [],
+      competencesScoringConfiguration: [],
       status: VERSION_STATUSES.DRAFT,
-      externalCalibrationId: version?.externalCalibrationId ?? null,
+      externalCalibrationId: null,
       comments: null,
       tubeIds,
     });

--- a/api/src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js
+++ b/api/src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js
@@ -1,0 +1,66 @@
+/**
+ * @typedef {import('../models/Calibration.js').Calibration} Calibration
+ * @typedef {import('../models/Calibration.js').CalibrationScoringMesh} CalibrationScoringMesh
+ */
+
+import { SCORING_MESH_AVAILABILITIES } from '../models/Calibration.js';
+
+/**
+ * The global scoring configuration a draft version could adopt, as proposed by a calibration.
+ *
+ * It is NOT an attribute of the version: it lives in the datamart, Data delivers it after the
+ * calibration itself and sometimes never delivers it at all. Nothing is persisted here, the
+ * configuration is only committed to the version when a super admin submits the scoring form.
+ */
+export class CalibrationScoringConfiguration {
+  /**
+   * @param {object} params
+   * @param {number} params.versionId
+   * @param {number} params.calibrationId
+   * @param {typeof SCORING_MESH_AVAILABILITIES[keyof typeof SCORING_MESH_AVAILABILITIES]} params.availability
+   * @param {Array<{meshLevel: number, bounds: {min: number, max: number}}>} params.globalScoringConfiguration - empty unless available
+   */
+  constructor({ versionId, calibrationId, availability, globalScoringConfiguration }) {
+    this.versionId = versionId;
+    this.calibrationId = calibrationId;
+    this.availability = availability;
+    this.globalScoringConfiguration = globalScoringConfiguration;
+  }
+
+  /**
+   * Translates the datamart vocabulary (mesh, curated bounds) into the one the API configuration
+   * speaks (mesh level, bounds).
+   *
+   * @param {object} params
+   * @param {number} params.versionId
+   * @param {Calibration} params.calibration
+   * @returns {CalibrationScoringConfiguration}
+   */
+  static fromCalibration({ versionId, calibration }) {
+    const { scoringMeshSet } = calibration;
+
+    return new CalibrationScoringConfiguration({
+      versionId,
+      calibrationId: calibration.id,
+      availability: scoringMeshSet.availability,
+      globalScoringConfiguration: scoringMeshSet.isAvailable ? scoringMeshSet.meshes.map(_toMeshLevelBounds) : [],
+    });
+  }
+
+  get isAvailable() {
+    return this.availability === SCORING_MESH_AVAILABILITIES.AVAILABLE;
+  }
+}
+
+/**
+ * @param {CalibrationScoringMesh} calibrationScoringMesh
+ */
+function _toMeshLevelBounds({ mesh, minBoundCuratedValue, maxBoundCuratedValue }) {
+  return {
+    meshLevel: mesh,
+    bounds: {
+      min: minBoundCuratedValue,
+      max: maxBoundCuratedValue,
+    },
+  };
+}

--- a/api/src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js
+++ b/api/src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js
@@ -3,18 +3,11 @@
  * @typedef {import('../models/Calibration.js').CalibrationScoringMesh} CalibrationScoringMesh
  */
 
-/**
- * The global scoring configuration a draft version could adopt, as proposed by a calibration.
- *
- * It is NOT an attribute of the version: it lives in the datamart, Data delivers it after the
- * calibration itself and sometimes never delivers it at all. Nothing is persisted here, the
- * configuration is only committed to the version when a super admin submits the scoring form.
- */
 export class CalibrationScoringConfiguration {
   /**
    * @param {object} params
    * @param {number} params.calibrationId
-   * @param {Array<{meshLevel: number, bounds: {min: number, max: number}}>} params.globalScoringConfiguration - empty when the calibration carries no validated mesh
+   * @param {Array<{meshLevel: number, bounds: {min: number, max: number}}>} params.globalScoringConfiguration
    */
   constructor({ calibrationId, globalScoringConfiguration }) {
     this.calibrationId = calibrationId;
@@ -22,9 +15,6 @@ export class CalibrationScoringConfiguration {
   }
 
   /**
-   * Translates the datamart vocabulary (mesh, curated bounds) into the one the API configuration
-   * speaks (mesh level, bounds).
-   *
    * @param {object} params
    * @param {Calibration} params.calibration
    * @returns {CalibrationScoringConfiguration}

--- a/api/src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js
+++ b/api/src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js
@@ -15,13 +15,11 @@ import { SCORING_MESH_AVAILABILITIES } from '../models/Calibration.js';
 export class CalibrationScoringConfiguration {
   /**
    * @param {object} params
-   * @param {number} params.versionId
    * @param {number} params.calibrationId
    * @param {typeof SCORING_MESH_AVAILABILITIES[keyof typeof SCORING_MESH_AVAILABILITIES]} params.availability
    * @param {Array<{meshLevel: number, bounds: {min: number, max: number}}>} params.globalScoringConfiguration - empty unless available
    */
-  constructor({ versionId, calibrationId, availability, globalScoringConfiguration }) {
-    this.versionId = versionId;
+  constructor({ calibrationId, availability, globalScoringConfiguration }) {
     this.calibrationId = calibrationId;
     this.availability = availability;
     this.globalScoringConfiguration = globalScoringConfiguration;
@@ -32,15 +30,13 @@ export class CalibrationScoringConfiguration {
    * speaks (mesh level, bounds).
    *
    * @param {object} params
-   * @param {number} params.versionId
    * @param {Calibration} params.calibration
    * @returns {CalibrationScoringConfiguration}
    */
-  static fromCalibration({ versionId, calibration }) {
+  static fromCalibration({ calibration }) {
     const { scoringMeshSet } = calibration;
 
     return new CalibrationScoringConfiguration({
-      versionId,
       calibrationId: calibration.id,
       availability: scoringMeshSet.availability,
       globalScoringConfiguration: scoringMeshSet.isAvailable ? scoringMeshSet.meshes.map(_toMeshLevelBounds) : [],

--- a/api/src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js
+++ b/api/src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js
@@ -3,8 +3,6 @@
  * @typedef {import('../models/Calibration.js').CalibrationScoringMesh} CalibrationScoringMesh
  */
 
-import { SCORING_MESH_AVAILABILITIES } from '../models/Calibration.js';
-
 /**
  * The global scoring configuration a draft version could adopt, as proposed by a calibration.
  *
@@ -16,12 +14,10 @@ export class CalibrationScoringConfiguration {
   /**
    * @param {object} params
    * @param {number} params.calibrationId
-   * @param {typeof SCORING_MESH_AVAILABILITIES[keyof typeof SCORING_MESH_AVAILABILITIES]} params.availability
-   * @param {Array<{meshLevel: number, bounds: {min: number, max: number}}>} params.globalScoringConfiguration - empty unless available
+   * @param {Array<{meshLevel: number, bounds: {min: number, max: number}}>} params.globalScoringConfiguration - empty when the calibration carries no validated mesh
    */
-  constructor({ calibrationId, availability, globalScoringConfiguration }) {
+  constructor({ calibrationId, globalScoringConfiguration }) {
     this.calibrationId = calibrationId;
-    this.availability = availability;
     this.globalScoringConfiguration = globalScoringConfiguration;
   }
 
@@ -34,17 +30,10 @@ export class CalibrationScoringConfiguration {
    * @returns {CalibrationScoringConfiguration}
    */
   static fromCalibration({ calibration }) {
-    const { scoringMeshSet } = calibration;
-
     return new CalibrationScoringConfiguration({
       calibrationId: calibration.id,
-      availability: scoringMeshSet.availability,
-      globalScoringConfiguration: scoringMeshSet.isAvailable ? scoringMeshSet.meshes.map(_toMeshLevelBounds) : [],
+      globalScoringConfiguration: calibration.scoringMeshes.map(_toMeshLevelBounds),
     });
-  }
-
-  get isAvailable() {
-    return this.availability === SCORING_MESH_AVAILABILITIES.AVAILABLE;
   }
 }
 

--- a/api/src/certification/configuration/domain/usecases/get-calibration-scoring-configuration.js
+++ b/api/src/certification/configuration/domain/usecases/get-calibration-scoring-configuration.js
@@ -1,0 +1,38 @@
+/**
+ * @typedef {import ('./index.js').VersionRepository} VersionRepository
+ * @typedef {import ('./index.js').CalibrationRepository} CalibrationRepository
+ */
+
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { CalibrationScoringConfiguration } from '../read-models/CalibrationScoringConfiguration.js';
+
+/**
+ * Returns the global scoring configuration proposed by a calibration, to seed the scoring form of a
+ * draft version. An unavailable configuration is a nominal answer, not an error: Data delivers the
+ * scoring meshes after the calibration itself, and never delivers them for some scopes.
+ *
+ * @param {object} params
+ * @param {number} params.versionId
+ * @param {number} params.calibrationId
+ * @param {VersionRepository} params.versionRepository
+ * @param {CalibrationRepository} params.calibrationRepository
+ * @returns {Promise<CalibrationScoringConfiguration>}
+ */
+export async function getCalibrationScoringConfiguration({
+  versionId,
+  calibrationId,
+  versionRepository,
+  calibrationRepository,
+}) {
+  const version = await versionRepository.getById({ id: versionId });
+  if (!version) {
+    throw new NotFoundError(`Cannot find version of id "${versionId}"`);
+  }
+
+  const calibration = await calibrationRepository.find(calibrationId);
+  if (!calibration) {
+    throw new NotFoundError(`Cannot find calibration of external id "${calibrationId}"`);
+  }
+
+  return CalibrationScoringConfiguration.fromCalibration({ versionId, calibration });
+}

--- a/api/src/certification/configuration/domain/usecases/get-calibration-scoring-configuration.js
+++ b/api/src/certification/configuration/domain/usecases/get-calibration-scoring-configuration.js
@@ -1,5 +1,4 @@
 /**
- * @typedef {import ('./index.js').VersionRepository} VersionRepository
  * @typedef {import ('./index.js').CalibrationRepository} CalibrationRepository
  */
 
@@ -12,27 +11,15 @@ import { CalibrationScoringConfiguration } from '../read-models/CalibrationScori
  * scoring meshes after the calibration itself, and never delivers them for some scopes.
  *
  * @param {object} params
- * @param {number} params.versionId
  * @param {number} params.calibrationId
- * @param {VersionRepository} params.versionRepository
  * @param {CalibrationRepository} params.calibrationRepository
  * @returns {Promise<CalibrationScoringConfiguration>}
  */
-export async function getCalibrationScoringConfiguration({
-  versionId,
-  calibrationId,
-  versionRepository,
-  calibrationRepository,
-}) {
-  const version = await versionRepository.getById({ id: versionId });
-  if (!version) {
-    throw new NotFoundError(`Cannot find version of id "${versionId}"`);
-  }
-
+export async function getCalibrationScoringConfiguration({ calibrationId, calibrationRepository }) {
   const calibration = await calibrationRepository.find(calibrationId);
   if (!calibration) {
     throw new NotFoundError(`Cannot find calibration of external id "${calibrationId}"`);
   }
 
-  return CalibrationScoringConfiguration.fromCalibration({ versionId, calibration });
+  return CalibrationScoringConfiguration.fromCalibration({ calibration });
 }

--- a/api/src/certification/configuration/domain/usecases/get-calibration-scoring-configuration.js
+++ b/api/src/certification/configuration/domain/usecases/get-calibration-scoring-configuration.js
@@ -6,10 +6,6 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CalibrationScoringConfiguration } from '../read-models/CalibrationScoringConfiguration.js';
 
 /**
- * Returns the global scoring configuration proposed by a calibration, to seed the scoring form of a
- * draft version. An unavailable configuration is a nominal answer, not an error: Data delivers the
- * scoring meshes after the calibration itself, and never delivers them for some scopes.
- *
  * @param {object} params
  * @param {number} params.calibrationId
  * @param {CalibrationRepository} params.calibrationRepository

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -19,6 +19,7 @@ import { deleteVersion } from './delete-version.js';
 import { exportScoWhitelist } from './export-sco-whitelist.js';
 import { findComplementaryCertifications } from './find-complementary-certifications.js';
 import { generateCalibrationReportCheck } from './generate-calibration-report-check.js';
+import { getCalibrationScoringConfiguration } from './get-calibration-scoring-configuration.js';
 import { getComplementaryCertificationForTargetProfileAttachmentRepository } from './get-complementary-certification-for-target-profile-attachment.js';
 import { getComplementaryCertificationTargetProfileHistory } from './get-complementary-certification-target-profile-history.js';
 import { getInfo } from './get-info.js';
@@ -70,6 +71,7 @@ const usecasesWithoutInjectedDependencies = {
   deleteVersion,
   exportScoWhitelist,
   findComplementaryCertifications,
+  getCalibrationScoringConfiguration,
   getComplementaryCertificationForTargetProfileAttachmentRepository,
   getComplementaryCertificationTargetProfileHistory,
   getInfo,

--- a/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
@@ -5,8 +5,8 @@ import {
   CalibratedChallenge,
   Calibration,
   CalibrationForReport,
+  CALIBRATION_STATUSES,
   CalibrationScoringMesh,
-  CalibrationScoringMeshSet,
 } from '../../domain/models/Calibration.js';
 
 export async function findForReport(calibrationId) {
@@ -104,12 +104,12 @@ export async function find(calibrationId) {
       );
     }
 
-    const scoringMeshSet = await _findScoringMeshSet(calibrationId);
+    const scoringMeshes = await _findScoringMeshes(calibrationId);
 
     return new Calibration({
       ...generalInfo,
       calibratedChallenges,
-      scoringMeshSet,
+      scoringMeshes,
     });
   } catch (err) {
     logger.error(
@@ -121,21 +121,21 @@ export async function find(calibrationId) {
 }
 
 /**
- * Data may not have delivered any scoring mesh set for this calibration, which is a nominal state:
- * an empty set is returned rather than null.
+ * Only a validated mesh set is worth exposing: a set Data has not delivered yet and one it has not
+ * validated yet are both answered with no mesh at all, which is a nominal state.
  *
  * @param {number} calibrationId
- * @returns {Promise<CalibrationScoringMeshSet>}
+ * @returns {Promise<Array<CalibrationScoringMesh>>}
  */
-async function _findScoringMeshSet(calibrationId) {
+async function _findScoringMeshes(calibrationId) {
   const meshSetData = await datamartKnex
-    .select({ id: 'id', status: 'status' })
+    .select({ id: 'id' })
     .from('data_scoring_meshes_all')
-    .where({ calibration_id: calibrationId })
+    .where({ calibration_id: calibrationId, status: CALIBRATION_STATUSES.VALIDATED })
     .orderBy('id', 'desc')
     .first();
 
-  if (!meshSetData) return new CalibrationScoringMeshSet();
+  if (!meshSetData) return [];
 
   const meshesData = await datamartKnex
     .select({
@@ -147,15 +147,12 @@ async function _findScoringMeshSet(calibrationId) {
     .where({ scoring_meshes_all_id: meshSetData.id })
     .orderBy('mesh', 'asc');
 
-  return new CalibrationScoringMeshSet({
-    status: meshSetData.status,
-    meshes: meshesData.map(
-      (meshData) =>
-        new CalibrationScoringMesh({
-          mesh: Number(meshData.mesh),
-          minBoundCuratedValue: Number(meshData.minBoundCuratedValue),
-          maxBoundCuratedValue: Number(meshData.maxBoundCuratedValue),
-        }),
-    ),
-  });
+  return meshesData.map(
+    (meshData) =>
+      new CalibrationScoringMesh({
+        mesh: Number(meshData.mesh),
+        minBoundCuratedValue: Number(meshData.minBoundCuratedValue),
+        maxBoundCuratedValue: Number(meshData.maxBoundCuratedValue),
+      }),
+  );
 }

--- a/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
@@ -121,9 +121,6 @@ export async function find(calibrationId) {
 }
 
 /**
- * Only a validated mesh set is worth exposing: a set Data has not delivered yet and one it has not
- * validated yet are both answered with no mesh at all, which is a nominal state.
- *
  * @param {number} calibrationId
  * @returns {Promise<Array<CalibrationScoringMesh>>}
  */

--- a/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
@@ -4,8 +4,8 @@ import { logger, SCOPES } from '../../../../shared/infrastructure/utils/logger.j
 import {
   CalibratedChallenge,
   Calibration,
-  CalibrationForReport,
   CALIBRATION_STATUSES,
+  CalibrationForReport,
   CalibrationScoringMesh,
 } from '../../domain/models/Calibration.js';
 

--- a/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/calibration-repository.js
@@ -1,7 +1,13 @@
 import { knex as datamartKnex } from '../../../../../datamart/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { logger, SCOPES } from '../../../../shared/infrastructure/utils/logger.js';
-import { CalibratedChallenge, Calibration, CalibrationForReport } from '../../domain/models/Calibration.js';
+import {
+  CalibratedChallenge,
+  Calibration,
+  CalibrationForReport,
+  CalibrationScoringMesh,
+  CalibrationScoringMeshSet,
+} from '../../domain/models/Calibration.js';
 
 export async function findForReport(calibrationId) {
   const knexConn = DomainTransaction.getConnection();
@@ -98,9 +104,12 @@ export async function find(calibrationId) {
       );
     }
 
+    const scoringMeshSet = await _findScoringMeshSet(calibrationId);
+
     return new Calibration({
       ...generalInfo,
       calibratedChallenges,
+      scoringMeshSet,
     });
   } catch (err) {
     logger.error(
@@ -109,4 +118,44 @@ export async function find(calibrationId) {
     );
     throw err;
   }
+}
+
+/**
+ * Data may not have delivered any scoring mesh set for this calibration, which is a nominal state:
+ * an empty set is returned rather than null.
+ *
+ * @param {number} calibrationId
+ * @returns {Promise<CalibrationScoringMeshSet>}
+ */
+async function _findScoringMeshSet(calibrationId) {
+  const meshSetData = await datamartKnex
+    .select({ id: 'id', status: 'status' })
+    .from('data_scoring_meshes_all')
+    .where({ calibration_id: calibrationId })
+    .orderBy('id', 'desc')
+    .first();
+
+  if (!meshSetData) return new CalibrationScoringMeshSet();
+
+  const meshesData = await datamartKnex
+    .select({
+      mesh: 'mesh',
+      minBoundCuratedValue: 'min_bound_curated_value',
+      maxBoundCuratedValue: 'max_bound_curated_value',
+    })
+    .from('data_scoring_meshes')
+    .where({ scoring_meshes_all_id: meshSetData.id })
+    .orderBy('mesh', 'asc');
+
+  return new CalibrationScoringMeshSet({
+    status: meshSetData.status,
+    meshes: meshesData.map(
+      (meshData) =>
+        new CalibrationScoringMesh({
+          mesh: Number(meshData.mesh),
+          minBoundCuratedValue: Number(meshData.minBoundCuratedValue),
+          maxBoundCuratedValue: Number(meshData.maxBoundCuratedValue),
+        }),
+    ),
+  });
 }

--- a/api/src/certification/configuration/infrastructure/serializers/calibration-scoring-configuration-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/calibration-scoring-configuration-serializer.js
@@ -1,0 +1,17 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+export function serialize(calibrationScoringConfiguration) {
+  return new Serializer('calibration-scoring-configurations', {
+    attributes: ['calibrationId', 'availability', 'globalScoringConfiguration'],
+    transform: (calibrationScoringConfiguration) => {
+      return {
+        id: `${calibrationScoringConfiguration.versionId}_${calibrationScoringConfiguration.calibrationId}`,
+        calibrationId: calibrationScoringConfiguration.calibrationId,
+        availability: calibrationScoringConfiguration.availability,
+        globalScoringConfiguration: calibrationScoringConfiguration.globalScoringConfiguration,
+      };
+    },
+  }).serialize(calibrationScoringConfiguration);
+}

--- a/api/src/certification/configuration/infrastructure/serializers/calibration-scoring-configuration-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/calibration-scoring-configuration-serializer.js
@@ -7,7 +7,7 @@ export function serialize(calibrationScoringConfiguration) {
     attributes: ['calibrationId', 'availability', 'globalScoringConfiguration'],
     transform: (calibrationScoringConfiguration) => {
       return {
-        id: `${calibrationScoringConfiguration.versionId}_${calibrationScoringConfiguration.calibrationId}`,
+        id: `${calibrationScoringConfiguration.calibrationId}`,
         calibrationId: calibrationScoringConfiguration.calibrationId,
         availability: calibrationScoringConfiguration.availability,
         globalScoringConfiguration: calibrationScoringConfiguration.globalScoringConfiguration,

--- a/api/src/certification/configuration/infrastructure/serializers/calibration-scoring-configuration-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/calibration-scoring-configuration-serializer.js
@@ -4,12 +4,11 @@ const { Serializer } = jsonapiSerializer;
 
 export function serialize(calibrationScoringConfiguration) {
   return new Serializer('calibration-scoring-configurations', {
-    attributes: ['calibrationId', 'availability', 'globalScoringConfiguration'],
+    attributes: ['calibrationId', 'globalScoringConfiguration'],
     transform: (calibrationScoringConfiguration) => {
       return {
         id: `${calibrationScoringConfiguration.calibrationId}`,
         calibrationId: calibrationScoringConfiguration.calibrationId,
-        availability: calibrationScoringConfiguration.availability,
         globalScoringConfiguration: calibrationScoringConfiguration.globalScoringConfiguration,
       };
     },

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import {
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
+  SCORING_MESH_AVAILABILITIES,
 } from '../../../../../src/certification/configuration/domain/models/Calibration.js';
 import {
   ALERT_LEVELS,
@@ -770,9 +771,131 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
               content: false,
               label: REPORT_LABELS.COMPETENCE_SCORING_PRESENCE,
             },
+            {
+              additionalContent:
+                "Les bornes de capacités par mailles de cette calibration n'ont pas encore été livrées",
+              alertLevel: ALERT_LEVELS.LOW,
+              content: SCORING_MESH_AVAILABILITIES.PENDING,
+              label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
+            },
           ],
         },
       });
+    });
+  });
+
+  describe('GET /api/admin/certification-versions/{certificationVersionId}/calibrations/{calibrationId}/scoring-configuration', function () {
+    beforeEach(function () {
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .withParameters({ id: 1, scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+        .insertToDB({ databaseBuilder });
+    });
+
+    it('returns the global scoring configuration proposed by the calibration', async function () {
+      // given
+      await domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+        .asValidated({ startedAt: new Date('2026-03-04') })
+        .withParameters({ id: 2 })
+        .withScoringMeshes([
+          { mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 },
+          { mesh: 1, minBoundCuratedValue: -1.4, maxBoundCuratedValue: 0.6 },
+        ])
+        .insertToDB({ datamartBuilder });
+
+      await databaseBuilder.commit();
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/certification-versions/1/calibrations/2/scoring-configuration`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal({
+        type: 'calibration-scoring-configurations',
+        id: '1_2',
+        attributes: {
+          'calibration-id': 2,
+          availability: SCORING_MESH_AVAILABILITIES.AVAILABLE,
+          'global-scoring-configuration': [
+            { meshLevel: 0, bounds: { min: -4.67, max: -1.4 } },
+            { meshLevel: 1, bounds: { min: -1.4, max: 0.6 } },
+          ],
+        },
+      });
+    });
+
+    it('returns a 200 with a pending availability when Data has not delivered the meshes', async function () {
+      // given
+      await domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+        .asValidated({ startedAt: new Date('2026-03-04') })
+        .withParameters({ id: 2 })
+        .insertToDB({ datamartBuilder });
+
+      await databaseBuilder.commit();
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/certification-versions/1/calibrations/2/scoring-configuration`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.attributes).to.deep.equal({
+        'calibration-id': 2,
+        availability: SCORING_MESH_AVAILABILITIES.PENDING,
+        'global-scoring-configuration': [],
+      });
+    });
+
+    it('returns a 404 when the calibration does not exist', async function () {
+      // given
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/certification-versions/1/calibrations/404/scoring-configuration`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+
+    it('returns a 403 when the user is not a super admin', async function () {
+      // given
+      const certifUser = databaseBuilder.factory.buildUser.withRole({ role: 'CERTIF' });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/certification-versions/1/calibrations/2/scoring-configuration`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: certifUser.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
     });
   });
 });

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 import {
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
-  SCORING_MESH_AVAILABILITIES,
 } from '../../../../../src/certification/configuration/domain/models/Calibration.js';
 import {
   ALERT_LEVELS,
@@ -771,13 +770,6 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
               content: false,
               label: REPORT_LABELS.COMPETENCE_SCORING_PRESENCE,
             },
-            {
-              additionalContent:
-                "Les bornes de capacités par mailles de cette calibration n'ont pas encore été livrées",
-              alertLevel: ALERT_LEVELS.LOW,
-              content: SCORING_MESH_AVAILABILITIES.PENDING,
-              label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
-            },
           ],
         },
       });
@@ -817,7 +809,6 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
         id: '2',
         attributes: {
           'calibration-id': 2,
-          availability: SCORING_MESH_AVAILABILITIES.AVAILABLE,
           'global-scoring-configuration': [
             { meshLevel: 0, bounds: { min: -4.67, max: -1.4 } },
             { meshLevel: 1, bounds: { min: -1.4, max: 0.6 } },
@@ -826,7 +817,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       });
     });
 
-    it('returns a 200 with a pending availability when Data has not delivered the meshes', async function () {
+    it('returns a 200 with an empty configuration when Data has not delivered the meshes', async function () {
       // given
       await domainBuilder.certification.configuration
         .calibrationBuilder()
@@ -851,7 +842,6 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.attributes).to.deep.equal({
         'calibration-id': 2,
-        availability: SCORING_MESH_AVAILABILITIES.PENDING,
         'global-scoring-configuration': [],
       });
     });

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -784,14 +784,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
     });
   });
 
-  describe('GET /api/admin/certification-versions/{certificationVersionId}/calibrations/{calibrationId}/scoring-configuration', function () {
-    beforeEach(function () {
-      domainBuilder.certification.configuration
-        .versionBuilder()
-        .withParameters({ id: 1, scope: SCOPES.CORE, tubeIds: ['tubeA'] })
-        .insertToDB({ databaseBuilder });
-    });
-
+  describe('GET /api/admin/calibrations/{calibrationId}/scoring-configuration', function () {
     it('returns the global scoring configuration proposed by the calibration', async function () {
       // given
       await domainBuilder.certification.configuration
@@ -810,7 +803,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       const options = {
         method: 'GET',
-        url: `/api/admin/certification-versions/1/calibrations/2/scoring-configuration`,
+        url: `/api/admin/calibrations/2/scoring-configuration`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
@@ -821,7 +814,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       expect(response.statusCode).to.equal(200);
       expect(response.result.data).to.deep.equal({
         type: 'calibration-scoring-configurations',
-        id: '1_2',
+        id: '2',
         attributes: {
           'calibration-id': 2,
           availability: SCORING_MESH_AVAILABILITIES.AVAILABLE,
@@ -847,7 +840,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       const options = {
         method: 'GET',
-        url: `/api/admin/certification-versions/1/calibrations/2/scoring-configuration`,
+        url: `/api/admin/calibrations/2/scoring-configuration`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
@@ -869,7 +862,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       const options = {
         method: 'GET',
-        url: `/api/admin/certification-versions/1/calibrations/404/scoring-configuration`,
+        url: `/api/admin/calibrations/404/scoring-configuration`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
@@ -887,7 +880,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       const options = {
         method: 'GET',
-        url: `/api/admin/certification-versions/1/calibrations/2/scoring-configuration`,
+        url: `/api/admin/calibrations/2/scoring-configuration`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: certifUser.id }),
       };
 

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/calibration-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/calibration-repository_test.js
@@ -4,7 +4,6 @@ import {
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
   CalibrationScoringMesh,
-  SCORING_MESH_AVAILABILITIES,
 } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import * as calibrationRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/calibration-repository.js';
 import { databaseBuilder, datamartBuilder } from '../../../../../tooling/databases.js';
@@ -134,8 +133,8 @@ describe('Certification | Configuration | Integration | Repository | calibration
       expect(calibration).to.be.instanceOf(expectedCalibration.constructor);
     });
 
-    context('scoring mesh set', function () {
-      it('returns a pending set when Data has not delivered any mesh set', async function () {
+    context('scoring meshes', function () {
+      it('returns no mesh when Data has not delivered any mesh set', async function () {
         // given
         await domainBuilder.certification.configuration
           .calibrationBuilder()
@@ -149,8 +148,7 @@ describe('Certification | Configuration | Integration | Repository | calibration
         const calibration = await calibrationRepository.find(113);
 
         // then
-        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
-        expect(calibration.scoringMeshSet.meshes).to.deep.equal([]);
+        expect(calibration.scoringMeshes).to.deep.equal([]);
       });
 
       it('returns the meshes ordered by mesh, with their curated bounds', async function () {
@@ -171,14 +169,13 @@ describe('Certification | Configuration | Integration | Repository | calibration
         const calibration = await calibrationRepository.find(113);
 
         // then
-        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.AVAILABLE);
-        expect(calibration.scoringMeshSet.meshes).to.deep.equal([
+        expect(calibration.scoringMeshes).to.deep.equal([
           new CalibrationScoringMesh({ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }),
           new CalibrationScoringMesh({ mesh: 1, minBoundCuratedValue: -1.4, maxBoundCuratedValue: 0.6 }),
         ]);
       });
 
-      it('carries the set own status, which is independent from the calibration one', async function () {
+      it('ignores a mesh set that is not validated, even on a validated calibration', async function () {
         // given
         await domainBuilder.certification.configuration
           .calibrationBuilder()
@@ -196,7 +193,7 @@ describe('Certification | Configuration | Integration | Repository | calibration
 
         // then
         expect(calibration.status).to.equal(CALIBRATION_STATUSES.VALIDATED);
-        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.NOT_VALIDATED);
+        expect(calibration.scoringMeshes).to.deep.equal([]);
       });
 
       it('does not pick the mesh set of another calibration', async function () {
@@ -219,7 +216,7 @@ describe('Certification | Configuration | Integration | Repository | calibration
         const calibration = await calibrationRepository.find(113);
 
         // then
-        expect(calibration.scoringMeshSet.meshes).to.deep.equal([]);
+        expect(calibration.scoringMeshes).to.deep.equal([]);
       });
     });
   });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/calibration-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/calibration-repository_test.js
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 
-import { CALIBRATION_SCOPES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import {
+  CALIBRATION_SCOPES,
+  CALIBRATION_STATUSES,
+  CalibrationScoringMesh,
+  SCORING_MESH_AVAILABILITIES,
+} from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import * as calibrationRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/calibration-repository.js';
 import { databaseBuilder, datamartBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -127,6 +132,95 @@ describe('Certification | Configuration | Integration | Repository | calibration
       // then
       expect(calibration).to.deep.equal(expectedCalibration);
       expect(calibration).to.be.instanceOf(expectedCalibration.constructor);
+    });
+
+    context('scoring mesh set', function () {
+      it('returns a pending set when Data has not delivered any mesh set', async function () {
+        // given
+        await domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .asValidated({ startedAt: new Date('2026-03-04') })
+          .withParameters({ id: 113 })
+          .insertToDB({ datamartBuilder });
+
+        await datamartBuilder.commit();
+
+        // when
+        const calibration = await calibrationRepository.find(113);
+
+        // then
+        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
+        expect(calibration.scoringMeshSet.meshes).to.deep.equal([]);
+      });
+
+      it('returns the meshes ordered by mesh, with their curated bounds', async function () {
+        // given
+        await domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .asValidated({ startedAt: new Date('2026-03-04') })
+          .withParameters({ id: 113 })
+          .withScoringMeshes([
+            { mesh: 1, minBoundCuratedValue: -1.4, maxBoundCuratedValue: 0.6 },
+            { mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 },
+          ])
+          .insertToDB({ datamartBuilder });
+
+        await datamartBuilder.commit();
+
+        // when
+        const calibration = await calibrationRepository.find(113);
+
+        // then
+        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.AVAILABLE);
+        expect(calibration.scoringMeshSet.meshes).to.deep.equal([
+          new CalibrationScoringMesh({ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }),
+          new CalibrationScoringMesh({ mesh: 1, minBoundCuratedValue: -1.4, maxBoundCuratedValue: 0.6 }),
+        ]);
+      });
+
+      it('carries the set own status, which is independent from the calibration one', async function () {
+        // given
+        await domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .asValidated({ startedAt: new Date('2026-03-04') })
+          .withParameters({ id: 113 })
+          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }], {
+            status: CALIBRATION_STATUSES.TO_VALIDATE,
+          })
+          .insertToDB({ datamartBuilder });
+
+        await datamartBuilder.commit();
+
+        // when
+        const calibration = await calibrationRepository.find(113);
+
+        // then
+        expect(calibration.status).to.equal(CALIBRATION_STATUSES.VALIDATED);
+        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.NOT_VALIDATED);
+      });
+
+      it('does not pick the mesh set of another calibration', async function () {
+        // given
+        await domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .asValidated({ startedAt: new Date('2026-03-04') })
+          .withParameters({ id: 113 })
+          .insertToDB({ datamartBuilder });
+        await domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .asValidated({ startedAt: new Date('2026-03-04') })
+          .withParameters({ id: 115 })
+          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
+          .insertToDB({ datamartBuilder });
+
+        await datamartBuilder.commit();
+
+        // when
+        const calibration = await calibrationRepository.find(113);
+
+        // then
+        expect(calibration.scoringMeshSet.meshes).to.deep.equal([]);
+      });
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import {
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
-  SCORING_MESH_AVAILABILITIES,
 } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import {
   ALERT_LEVELS,
@@ -352,79 +351,6 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
               alertLevel: ALERT_LEVELS.HIGH,
               label: REPORT_LABELS.CALIBRATION_STATUS,
               content: CALIBRATION_STATUSES.TO_VALIDATE,
-            },
-          ]);
-        });
-      });
-    });
-
-    context('computing info related to the scoring mesh set availability', function () {
-      let calibrationBuilder, version;
-      beforeEach(function () {
-        calibrationBuilder = domainBuilder.certification.configuration
-          .calibrationBuilder()
-          .onScope({ scope: CALIBRATION_SCOPES.COEUR })
-          .asValidated({ startedAt: new Date() })
-          .withCalibratredChallenges([{ tubeId: 'tubeA' }]);
-        version = domainBuilder.certification.configuration
-          .versionBuilder()
-          .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
-          .build();
-      });
-
-      context('when Data delivered a validated scoring mesh set', function () {
-        it('adds a dedicated report line with no alert level', function () {
-          const calibration = calibrationBuilder
-            .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
-            .build();
-
-          const report = buildReport({ version, calibration });
-
-          expect(report.reportLines).to.deep.include.members([
-            {
-              additionalContent: null,
-              alertLevel: null,
-              label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
-              content: SCORING_MESH_AVAILABILITIES.AVAILABLE,
-            },
-          ]);
-        });
-      });
-
-      context('when Data has not delivered any scoring mesh set', function () {
-        it('adds a dedicated report line with low alert level, since some scopes never get one', function () {
-          const calibration = calibrationBuilder.build();
-
-          const report = buildReport({ version, calibration });
-
-          expect(report.reportLines).to.deep.include.members([
-            {
-              additionalContent:
-                "Les bornes de capacités par mailles de cette calibration n'ont pas encore été livrées",
-              alertLevel: ALERT_LEVELS.LOW,
-              label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
-              content: SCORING_MESH_AVAILABILITIES.PENDING,
-            },
-          ]);
-        });
-      });
-
-      context('when the delivered scoring mesh set is not validated', function () {
-        it('adds a dedicated report line with low alert level', function () {
-          const calibration = calibrationBuilder
-            .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }], {
-              status: CALIBRATION_STATUSES.TO_VALIDATE,
-            })
-            .build();
-
-          const report = buildReport({ version, calibration });
-
-          expect(report.reportLines).to.deep.include.members([
-            {
-              additionalContent: 'Les bornes de capacités par mailles de cette calibration ne sont pas validées',
-              alertLevel: ALERT_LEVELS.LOW,
-              label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
-              content: SCORING_MESH_AVAILABILITIES.NOT_VALIDATED,
             },
           ]);
         });

--- a/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/CalibrationReport_test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import {
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
+  SCORING_MESH_AVAILABILITIES,
 } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import {
   ALERT_LEVELS,
@@ -351,6 +352,79 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration R
               alertLevel: ALERT_LEVELS.HIGH,
               label: REPORT_LABELS.CALIBRATION_STATUS,
               content: CALIBRATION_STATUSES.TO_VALIDATE,
+            },
+          ]);
+        });
+      });
+    });
+
+    context('computing info related to the scoring mesh set availability', function () {
+      let calibrationBuilder, version;
+      beforeEach(function () {
+        calibrationBuilder = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+          .asValidated({ startedAt: new Date() })
+          .withCalibratredChallenges([{ tubeId: 'tubeA' }]);
+        version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'] })
+          .build();
+      });
+
+      context('when Data delivered a validated scoring mesh set', function () {
+        it('adds a dedicated report line with no alert level', function () {
+          const calibration = calibrationBuilder
+            .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
+            .build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            {
+              additionalContent: null,
+              alertLevel: null,
+              label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
+              content: SCORING_MESH_AVAILABILITIES.AVAILABLE,
+            },
+          ]);
+        });
+      });
+
+      context('when Data has not delivered any scoring mesh set', function () {
+        it('adds a dedicated report line with low alert level, since some scopes never get one', function () {
+          const calibration = calibrationBuilder.build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            {
+              additionalContent:
+                "Les bornes de capacités par mailles de cette calibration n'ont pas encore été livrées",
+              alertLevel: ALERT_LEVELS.LOW,
+              label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
+              content: SCORING_MESH_AVAILABILITIES.PENDING,
+            },
+          ]);
+        });
+      });
+
+      context('when the delivered scoring mesh set is not validated', function () {
+        it('adds a dedicated report line with low alert level', function () {
+          const calibration = calibrationBuilder
+            .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }], {
+              status: CALIBRATION_STATUSES.TO_VALIDATE,
+            })
+            .build();
+
+          const report = buildReport({ version, calibration });
+
+          expect(report.reportLines).to.deep.include.members([
+            {
+              additionalContent: 'Les bornes de capacités par mailles de cette calibration ne sont pas validées',
+              alertLevel: ALERT_LEVELS.LOW,
+              label: REPORT_LABELS.SCORING_MESH_AVAILABILITY,
+              content: SCORING_MESH_AVAILABILITIES.NOT_VALIDATED,
             },
           ]);
         });

--- a/api/tests/certification/configuration/unit/domain/models/Calibration_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Calibration_test.js
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
 
+import {
+  CALIBRATION_STATUSES,
+  SCORING_MESH_AVAILABILITIES,
+} from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | Certification | Configuration | Domain | Models | Calibration', function () {
@@ -37,6 +41,58 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration',
         .build();
 
       expect(calibration.tubeIds).to.deep.equal(new Set(['tubeA', 'tubeB', 'tubeC']));
+    });
+  });
+
+  describe('#scoringMeshSet', function () {
+    describe('#availability', function () {
+      it('returns PENDING when Data has not delivered any scoring mesh set', function () {
+        const calibration = domainBuilder.certification.configuration.calibrationBuilder().build();
+
+        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
+        expect(calibration.scoringMeshSet.isAvailable).to.be.false;
+      });
+
+      it('returns PENDING when the delivered set holds no mesh', function () {
+        const calibration = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .withScoringMeshes([])
+          .build();
+
+        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
+      });
+
+      it('returns NOT_VALIDATED when the delivered set is not validated', function () {
+        const calibration = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }], {
+            status: CALIBRATION_STATUSES.TO_VALIDATE,
+          })
+          .build();
+
+        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.NOT_VALIDATED);
+        expect(calibration.scoringMeshSet.isAvailable).to.be.false;
+      });
+
+      it('returns AVAILABLE when the delivered set is validated and holds meshes', function () {
+        const calibration = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
+          .build();
+
+        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.AVAILABLE);
+        expect(calibration.scoringMeshSet.isAvailable).to.be.true;
+      });
+
+      it('does not depend on the calibration own status', function () {
+        const calibration = domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .asInvalidated()
+          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
+          .build();
+
+        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.AVAILABLE);
+      });
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/models/Calibration_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Calibration_test.js
@@ -1,9 +1,6 @@
 import { expect } from 'chai';
 
-import {
-  CALIBRATION_STATUSES,
-  SCORING_MESH_AVAILABILITIES,
-} from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import { CalibrationScoringMesh } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | Certification | Configuration | Domain | Models | Calibration', function () {
@@ -44,55 +41,32 @@ describe('Unit | Certification | Configuration | Domain | Models | Calibration',
     });
   });
 
-  describe('#scoringMeshSet', function () {
-    describe('#availability', function () {
-      it('returns PENDING when Data has not delivered any scoring mesh set', function () {
-        const calibration = domainBuilder.certification.configuration.calibrationBuilder().build();
+  describe('#scoringMeshes', function () {
+    it('is empty when Data has not delivered any scoring mesh', function () {
+      const calibration = domainBuilder.certification.configuration.calibrationBuilder().build();
 
-        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
-        expect(calibration.scoringMeshSet.isAvailable).to.be.false;
-      });
+      expect(calibration.scoringMeshes).to.deep.equal([]);
+    });
 
-      it('returns PENDING when the delivered set holds no mesh', function () {
-        const calibration = domainBuilder.certification.configuration
-          .calibrationBuilder()
-          .withScoringMeshes([])
-          .build();
+    it('carries the delivered meshes', function () {
+      const calibration = domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
+        .build();
 
-        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
-      });
+      expect(calibration.scoringMeshes).to.deep.equal([
+        new CalibrationScoringMesh({ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }),
+      ]);
+    });
 
-      it('returns NOT_VALIDATED when the delivered set is not validated', function () {
-        const calibration = domainBuilder.certification.configuration
-          .calibrationBuilder()
-          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }], {
-            status: CALIBRATION_STATUSES.TO_VALIDATE,
-          })
-          .build();
+    it('does not depend on the calibration own status', function () {
+      const calibration = domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .asInvalidated()
+        .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
+        .build();
 
-        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.NOT_VALIDATED);
-        expect(calibration.scoringMeshSet.isAvailable).to.be.false;
-      });
-
-      it('returns AVAILABLE when the delivered set is validated and holds meshes', function () {
-        const calibration = domainBuilder.certification.configuration
-          .calibrationBuilder()
-          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
-          .build();
-
-        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.AVAILABLE);
-        expect(calibration.scoringMeshSet.isAvailable).to.be.true;
-      });
-
-      it('does not depend on the calibration own status', function () {
-        const calibration = domainBuilder.certification.configuration
-          .calibrationBuilder()
-          .asInvalidated()
-          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
-          .build();
-
-        expect(calibration.scoringMeshSet.availability).to.equal(SCORING_MESH_AVAILABILITIES.AVAILABLE);
-      });
+      expect(calibration.scoringMeshes).to.have.lengthOf(1);
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/models/Version_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Version_test.js
@@ -132,6 +132,7 @@ describe('Certification | Configuration | Unit | Domain | Models | Version', fun
               minimumAnswersRequiredToValidateACertification: 11,
               globalScoringConfiguration: [{ bounds: { min: 1, max: 2 }, meshLevel: 0 }],
               competencesScoringConfiguration: ['some competencesScoringConfiguration'],
+              externalCalibrationId: 3,
               challengesConfiguration: {
                 maximumAssessmentLength: 11,
                 challengesBetweenSameCompetence: 11,
@@ -159,8 +160,9 @@ describe('Certification | Configuration | Unit | Domain | Models | Version', fun
                 tubeIds: ['rec456'],
                 assessmentDuration: 11,
                 minimumAnswersRequiredToValidateACertification: 11,
-                globalScoringConfiguration: [{ bounds: { min: 1, max: 2 }, meshLevel: 0 }],
-                competencesScoringConfiguration: ['some competencesScoringConfiguration'],
+                globalScoringConfiguration: [],
+                externalCalibrationId: null,
+                competencesScoringConfiguration: [],
                 challengesConfiguration: {
                   maximumAssessmentLength: 11,
                   challengesBetweenSameCompetence: 11,

--- a/api/tests/certification/configuration/unit/domain/read-models/CalibrationScoringConfiguration_test.js
+++ b/api/tests/certification/configuration/unit/domain/read-models/CalibrationScoringConfiguration_test.js
@@ -21,15 +21,11 @@ describe('Unit | Certification | Configuration | Domain | Read-models | Calibrat
         .build();
 
       // when
-      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({
-        versionId: 42,
-        calibration,
-      });
+      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({ calibration });
 
       // then
       expect(calibrationScoringConfiguration).to.deep.equal(
         new CalibrationScoringConfiguration({
-          versionId: 42,
           calibrationId: 113,
           availability: SCORING_MESH_AVAILABILITIES.AVAILABLE,
           globalScoringConfiguration: [
@@ -49,10 +45,7 @@ describe('Unit | Certification | Configuration | Domain | Read-models | Calibrat
         .build();
 
       // when
-      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({
-        versionId: 42,
-        calibration,
-      });
+      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({ calibration });
 
       // then
       expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
@@ -71,10 +64,7 @@ describe('Unit | Certification | Configuration | Domain | Read-models | Calibrat
         .build();
 
       // when
-      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({
-        versionId: 42,
-        calibration,
-      });
+      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({ calibration });
 
       // then
       expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.NOT_VALIDATED);

--- a/api/tests/certification/configuration/unit/domain/read-models/CalibrationScoringConfiguration_test.js
+++ b/api/tests/certification/configuration/unit/domain/read-models/CalibrationScoringConfiguration_test.js
@@ -1,9 +1,5 @@
 import { expect } from 'chai';
 
-import {
-  CALIBRATION_STATUSES,
-  SCORING_MESH_AVAILABILITIES,
-} from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import { CalibrationScoringConfiguration } from '../../../../../../src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -27,17 +23,15 @@ describe('Unit | Certification | Configuration | Domain | Read-models | Calibrat
       expect(calibrationScoringConfiguration).to.deep.equal(
         new CalibrationScoringConfiguration({
           calibrationId: 113,
-          availability: SCORING_MESH_AVAILABILITIES.AVAILABLE,
           globalScoringConfiguration: [
             { meshLevel: 0, bounds: { min: -4.67, max: -1.4 } },
             { meshLevel: 1, bounds: { min: -1.4, max: 0.6 } },
           ],
         }),
       );
-      expect(calibrationScoringConfiguration.isAvailable).to.be.true;
     });
 
-    it('returns an empty configuration when Data has not delivered the meshes yet', function () {
+    it('returns an empty configuration when the calibration carries no mesh', function () {
       // given
       const calibration = domainBuilder.certification.configuration
         .calibrationBuilder()
@@ -48,26 +42,6 @@ describe('Unit | Certification | Configuration | Domain | Read-models | Calibrat
       const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({ calibration });
 
       // then
-      expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
-      expect(calibrationScoringConfiguration.globalScoringConfiguration).to.deep.equal([]);
-      expect(calibrationScoringConfiguration.isAvailable).to.be.false;
-    });
-
-    it('does not expose the meshes of a set that is not validated', function () {
-      // given
-      const calibration = domainBuilder.certification.configuration
-        .calibrationBuilder()
-        .withParameters({ id: 113 })
-        .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }], {
-          status: CALIBRATION_STATUSES.TO_VALIDATE,
-        })
-        .build();
-
-      // when
-      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({ calibration });
-
-      // then
-      expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.NOT_VALIDATED);
       expect(calibrationScoringConfiguration.globalScoringConfiguration).to.deep.equal([]);
     });
   });

--- a/api/tests/certification/configuration/unit/domain/read-models/CalibrationScoringConfiguration_test.js
+++ b/api/tests/certification/configuration/unit/domain/read-models/CalibrationScoringConfiguration_test.js
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+
+import {
+  CALIBRATION_STATUSES,
+  SCORING_MESH_AVAILABILITIES,
+} from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import { CalibrationScoringConfiguration } from '../../../../../../src/certification/configuration/domain/read-models/CalibrationScoringConfiguration.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Certification | Configuration | Domain | Read-models | Calibration Scoring Configuration', function () {
+  describe('#fromCalibration', function () {
+    it('translates the datamart meshes into the API global scoring configuration', function () {
+      // given
+      const calibration = domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .withParameters({ id: 113 })
+        .withScoringMeshes([
+          { mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 },
+          { mesh: 1, minBoundCuratedValue: -1.4, maxBoundCuratedValue: 0.6 },
+        ])
+        .build();
+
+      // when
+      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({
+        versionId: 42,
+        calibration,
+      });
+
+      // then
+      expect(calibrationScoringConfiguration).to.deep.equal(
+        new CalibrationScoringConfiguration({
+          versionId: 42,
+          calibrationId: 113,
+          availability: SCORING_MESH_AVAILABILITIES.AVAILABLE,
+          globalScoringConfiguration: [
+            { meshLevel: 0, bounds: { min: -4.67, max: -1.4 } },
+            { meshLevel: 1, bounds: { min: -1.4, max: 0.6 } },
+          ],
+        }),
+      );
+      expect(calibrationScoringConfiguration.isAvailable).to.be.true;
+    });
+
+    it('returns an empty configuration when Data has not delivered the meshes yet', function () {
+      // given
+      const calibration = domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .withParameters({ id: 113 })
+        .build();
+
+      // when
+      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({
+        versionId: 42,
+        calibration,
+      });
+
+      // then
+      expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
+      expect(calibrationScoringConfiguration.globalScoringConfiguration).to.deep.equal([]);
+      expect(calibrationScoringConfiguration.isAvailable).to.be.false;
+    });
+
+    it('does not expose the meshes of a set that is not validated', function () {
+      // given
+      const calibration = domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .withParameters({ id: 113 })
+        .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }], {
+          status: CALIBRATION_STATUSES.TO_VALIDATE,
+        })
+        .build();
+
+      // when
+      const calibrationScoringConfiguration = CalibrationScoringConfiguration.fromCalibration({
+        versionId: 42,
+        calibration,
+      });
+
+      // then
+      expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.NOT_VALIDATED);
+      expect(calibrationScoringConfiguration.globalScoringConfiguration).to.deep.equal([]);
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/usecases/create-draft_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-draft_test.js
@@ -90,10 +90,8 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
               tubeIds,
               assessmentDuration: 111,
               minimumAnswersRequiredToValidateACertification: 222,
-              globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -1.4 } }],
-              competencesScoringConfiguration: [
-                { competence: '1.1', values: [{ bounds: { max: -2, min: -10 }, competenceLevel: 0 }] },
-              ],
+              globalScoringConfiguration: [],
+              competencesScoringConfiguration: [],
             })
             .build(),
         );

--- a/api/tests/certification/configuration/unit/domain/usecases/get-calibration-scoring-configuration_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-calibration-scoring-configuration_test.js
@@ -1,0 +1,99 @@
+import sinon from 'sinon';
+
+import { SCORING_MESH_AVAILABILITIES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
+import { getCalibrationScoringConfiguration } from '../../../../../../src/certification/configuration/domain/usecases/get-calibration-scoring-configuration.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
+
+describe('Certification | Configuration | Unit | UseCase | get-calibration-scoring-configuration', function () {
+  let versionRepository, calibrationRepository, draftVersion;
+
+  beforeEach(function () {
+    versionRepository = { getById: sinon.stub() };
+    calibrationRepository = { find: sinon.stub() };
+    draftVersion = domainBuilder.certification.configuration
+      .versionBuilder()
+      .asDraft({ startDate: null })
+      .withParameters({ id: 42 })
+      .build();
+  });
+
+  context('when version is not found', function () {
+    it('throws a NotFoundError', async function () {
+      versionRepository.getById.withArgs({ id: 42 }).resolves(null);
+
+      const err = await catchErr(getCalibrationScoringConfiguration)({
+        versionId: 42,
+        calibrationId: 113,
+        versionRepository,
+        calibrationRepository,
+      });
+
+      expect(err).to.be.instanceOf(NotFoundError);
+      expect(err.message).to.equal('Cannot find version of id "42"');
+    });
+  });
+
+  context('when calibration is not found', function () {
+    it('throws a NotFoundError', async function () {
+      versionRepository.getById.withArgs({ id: 42 }).resolves(draftVersion);
+      calibrationRepository.find.withArgs(113).resolves(null);
+
+      const err = await catchErr(getCalibrationScoringConfiguration)({
+        versionId: 42,
+        calibrationId: 113,
+        versionRepository,
+        calibrationRepository,
+      });
+
+      expect(err).to.be.instanceOf(NotFoundError);
+      expect(err.message).to.equal('Cannot find calibration of external id "113"');
+    });
+  });
+
+  context('when the calibration carries a validated scoring mesh set', function () {
+    it('returns the proposed global scoring configuration', async function () {
+      versionRepository.getById.withArgs({ id: 42 }).resolves(draftVersion);
+      calibrationRepository.find.withArgs(113).resolves(
+        domainBuilder.certification.configuration
+          .calibrationBuilder()
+          .withParameters({ id: 113 })
+          .withScoringMeshes([{ mesh: 0, minBoundCuratedValue: -4.67, maxBoundCuratedValue: -1.4 }])
+          .build(),
+      );
+
+      const calibrationScoringConfiguration = await getCalibrationScoringConfiguration({
+        versionId: 42,
+        calibrationId: 113,
+        versionRepository,
+        calibrationRepository,
+      });
+
+      expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.AVAILABLE);
+      expect(calibrationScoringConfiguration.globalScoringConfiguration).to.deep.equal([
+        { meshLevel: 0, bounds: { min: -4.67, max: -1.4 } },
+      ]);
+    });
+  });
+
+  context('when Data has not delivered the scoring mesh set', function () {
+    it('returns a pending configuration rather than throwing', async function () {
+      versionRepository.getById.withArgs({ id: 42 }).resolves(draftVersion);
+      calibrationRepository.find
+        .withArgs(113)
+        .resolves(domainBuilder.certification.configuration.calibrationBuilder().withParameters({ id: 113 }).build());
+
+      const calibrationScoringConfiguration = await getCalibrationScoringConfiguration({
+        versionId: 42,
+        calibrationId: 113,
+        versionRepository,
+        calibrationRepository,
+      });
+
+      expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
+      expect(calibrationScoringConfiguration.globalScoringConfiguration).to.deep.equal([]);
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/usecases/get-calibration-scoring-configuration_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-calibration-scoring-configuration_test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { SCORING_MESH_AVAILABILITIES } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 import { getCalibrationScoringConfiguration } from '../../../../../../src/certification/configuration/domain/usecases/get-calibration-scoring-configuration.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
@@ -28,7 +27,7 @@ describe('Certification | Configuration | Unit | UseCase | get-calibration-scori
     });
   });
 
-  context('when the calibration carries a validated scoring mesh set', function () {
+  context('when the calibration carries scoring meshes', function () {
     it('returns the proposed global scoring configuration', async function () {
       calibrationRepository.find.withArgs(113).resolves(
         domainBuilder.certification.configuration
@@ -43,15 +42,14 @@ describe('Certification | Configuration | Unit | UseCase | get-calibration-scori
         calibrationRepository,
       });
 
-      expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.AVAILABLE);
       expect(calibrationScoringConfiguration.globalScoringConfiguration).to.deep.equal([
         { meshLevel: 0, bounds: { min: -4.67, max: -1.4 } },
       ]);
     });
   });
 
-  context('when Data has not delivered the scoring mesh set', function () {
-    it('returns a pending configuration rather than throwing', async function () {
+  context('when the calibration carries no scoring mesh', function () {
+    it('returns an empty configuration rather than throwing', async function () {
       calibrationRepository.find
         .withArgs(113)
         .resolves(domainBuilder.certification.configuration.calibrationBuilder().withParameters({ id: 113 }).build());
@@ -61,7 +59,6 @@ describe('Certification | Configuration | Unit | UseCase | get-calibration-scori
         calibrationRepository,
       });
 
-      expect(calibrationScoringConfiguration.availability).to.equal(SCORING_MESH_AVAILABILITIES.PENDING);
       expect(calibrationScoringConfiguration.globalScoringConfiguration).to.deep.equal([]);
     });
   });

--- a/api/tests/certification/configuration/unit/domain/usecases/get-calibration-scoring-configuration_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-calibration-scoring-configuration_test.js
@@ -8,43 +8,18 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Unit | UseCase | get-calibration-scoring-configuration', function () {
-  let versionRepository, calibrationRepository, draftVersion;
+  let calibrationRepository;
 
   beforeEach(function () {
-    versionRepository = { getById: sinon.stub() };
     calibrationRepository = { find: sinon.stub() };
-    draftVersion = domainBuilder.certification.configuration
-      .versionBuilder()
-      .asDraft({ startDate: null })
-      .withParameters({ id: 42 })
-      .build();
-  });
-
-  context('when version is not found', function () {
-    it('throws a NotFoundError', async function () {
-      versionRepository.getById.withArgs({ id: 42 }).resolves(null);
-
-      const err = await catchErr(getCalibrationScoringConfiguration)({
-        versionId: 42,
-        calibrationId: 113,
-        versionRepository,
-        calibrationRepository,
-      });
-
-      expect(err).to.be.instanceOf(NotFoundError);
-      expect(err.message).to.equal('Cannot find version of id "42"');
-    });
   });
 
   context('when calibration is not found', function () {
     it('throws a NotFoundError', async function () {
-      versionRepository.getById.withArgs({ id: 42 }).resolves(draftVersion);
       calibrationRepository.find.withArgs(113).resolves(null);
 
       const err = await catchErr(getCalibrationScoringConfiguration)({
-        versionId: 42,
         calibrationId: 113,
-        versionRepository,
         calibrationRepository,
       });
 
@@ -55,7 +30,6 @@ describe('Certification | Configuration | Unit | UseCase | get-calibration-scori
 
   context('when the calibration carries a validated scoring mesh set', function () {
     it('returns the proposed global scoring configuration', async function () {
-      versionRepository.getById.withArgs({ id: 42 }).resolves(draftVersion);
       calibrationRepository.find.withArgs(113).resolves(
         domainBuilder.certification.configuration
           .calibrationBuilder()
@@ -65,9 +39,7 @@ describe('Certification | Configuration | Unit | UseCase | get-calibration-scori
       );
 
       const calibrationScoringConfiguration = await getCalibrationScoringConfiguration({
-        versionId: 42,
         calibrationId: 113,
-        versionRepository,
         calibrationRepository,
       });
 
@@ -80,15 +52,12 @@ describe('Certification | Configuration | Unit | UseCase | get-calibration-scori
 
   context('when Data has not delivered the scoring mesh set', function () {
     it('returns a pending configuration rather than throwing', async function () {
-      versionRepository.getById.withArgs({ id: 42 }).resolves(draftVersion);
       calibrationRepository.find
         .withArgs(113)
         .resolves(domainBuilder.certification.configuration.calibrationBuilder().withParameters({ id: 113 }).build());
 
       const calibrationScoringConfiguration = await getCalibrationScoringConfiguration({
-        versionId: 42,
         calibrationId: 113,
-        versionRepository,
         calibrationRepository,
       });
 

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
@@ -124,10 +124,7 @@ class CalibrationBuilder {
 
   /**
    * Attaches a scoring mesh set to the calibration. Without this call the calibration carries no set
-   * at all, which is the nominal state of a calibration whose meshes Data has not delivered yet.
-   *
-   * A set left in a non-validated status is persisted as such, but the built calibration carries no
-   * mesh: only a validated set reaches the domain.
+   * at all, which is the nominal state of a draft calibration.
    *
    * @param {ScoringMeshData[]} scoringMeshesData
    * @param {object} [params]
@@ -199,7 +196,6 @@ class CalibrationBuilder {
       (calibratedChallengeData) => new CalibratedChallenge(calibratedChallengeData),
     );
 
-    // Mirrors the repository, which only ever hands over the meshes of a validated set.
     const scoringMeshes =
       this.scoringMeshesStatus === CALIBRATION_STATUSES.VALIDATED
         ? (this.scoringMeshesData ?? []).map((scoringMeshData) => new CalibrationScoringMesh(scoringMeshData))

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
@@ -3,6 +3,8 @@ import {
   Calibration,
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
+  CalibrationScoringMesh,
+  CalibrationScoringMeshSet,
 } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 
 /**
@@ -11,6 +13,13 @@ import {
  * @property {number} delta
  * @property {string} challengeId
  * @property {string} tubeId
+ */
+
+/**
+ * @typedef {Object} ScoringMeshData
+ * @property {number} mesh
+ * @property {number} minBoundCuratedValue
+ * @property {number} maxBoundCuratedValue
  */
 
 /**
@@ -32,6 +41,8 @@ class CalibrationBuilder {
     this.status = CALIBRATION_STATUSES.VALIDATED;
     this.scope = CALIBRATION_SCOPES.COEUR;
     this.calibratedChallengesData = [];
+    this.scoringMeshesData = null;
+    this.scoringMeshesStatus = CALIBRATION_STATUSES.VALIDATED;
   }
 
   /**
@@ -113,6 +124,21 @@ class CalibrationBuilder {
   }
 
   /**
+   * Attaches a scoring mesh set to the calibration. Without this call the calibration carries no set
+   * at all, which is the nominal state of a calibration whose meshes Data has not delivered yet.
+   *
+   * @param {ScoringMeshData[]} scoringMeshesData
+   * @param {object} [params]
+   * @param {typeof CALIBRATION_STATUSES[keyof typeof CALIBRATION_STATUSES]} [params.status] - status of the SET, independent from the calibration one
+   * @returns {CalibrationBuilder}
+   */
+  withScoringMeshes(scoringMeshesData, { status = CALIBRATION_STATUSES.VALIDATED } = {}) {
+    this.scoringMeshesData = scoringMeshesData;
+    this.scoringMeshesStatus = status;
+    return this;
+  }
+
+  /**
    * Buffers the calibration row and any subsequent data into the DATAMART builder
    * then returns the built domain Calibration carrying the persisted id.
    * Call `datamartBuilder.commit()` afterwards to actually persist.
@@ -142,6 +168,22 @@ class CalibrationBuilder {
       });
     });
 
+    if (this.scoringMeshesData) {
+      const persistedScoringMeshesAll = datamartBuilder.factory.buildScoringMeshesAll({
+        calibrationId: persistedCalibration.id,
+        status: this.scoringMeshesStatus,
+      });
+
+      this.scoringMeshesData.forEach((scoringMeshData) => {
+        datamartBuilder.factory.buildScoringMesh({
+          scoringMeshesAllId: persistedScoringMeshesAll.id,
+          mesh: scoringMeshData.mesh,
+          minBoundCuratedValue: scoringMeshData.minBoundCuratedValue,
+          maxBoundCuratedValue: scoringMeshData.maxBoundCuratedValue,
+        });
+      });
+    }
+
     return calibration;
   }
 
@@ -155,12 +197,22 @@ class CalibrationBuilder {
       (calibratedChallengeData) => new CalibratedChallenge(calibratedChallengeData),
     );
 
+    const scoringMeshSet = new CalibrationScoringMeshSet(
+      this.scoringMeshesData
+        ? {
+            status: this.scoringMeshesStatus,
+            meshes: this.scoringMeshesData.map((scoringMeshData) => new CalibrationScoringMesh(scoringMeshData)),
+          }
+        : undefined,
+    );
+
     return new Calibration({
       id: this.id,
       startedAt: this.startedAt,
       status: this.status,
       scope: this.scope,
       calibratedChallenges,
+      scoringMeshSet,
     });
   }
 }

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-calibration.js
@@ -4,7 +4,6 @@ import {
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
   CalibrationScoringMesh,
-  CalibrationScoringMeshSet,
 } from '../../../../../../src/certification/configuration/domain/models/Calibration.js';
 
 /**
@@ -127,6 +126,9 @@ class CalibrationBuilder {
    * Attaches a scoring mesh set to the calibration. Without this call the calibration carries no set
    * at all, which is the nominal state of a calibration whose meshes Data has not delivered yet.
    *
+   * A set left in a non-validated status is persisted as such, but the built calibration carries no
+   * mesh: only a validated set reaches the domain.
+   *
    * @param {ScoringMeshData[]} scoringMeshesData
    * @param {object} [params]
    * @param {typeof CALIBRATION_STATUSES[keyof typeof CALIBRATION_STATUSES]} [params.status] - status of the SET, independent from the calibration one
@@ -197,14 +199,11 @@ class CalibrationBuilder {
       (calibratedChallengeData) => new CalibratedChallenge(calibratedChallengeData),
     );
 
-    const scoringMeshSet = new CalibrationScoringMeshSet(
-      this.scoringMeshesData
-        ? {
-            status: this.scoringMeshesStatus,
-            meshes: this.scoringMeshesData.map((scoringMeshData) => new CalibrationScoringMesh(scoringMeshData)),
-          }
-        : undefined,
-    );
+    // Mirrors the repository, which only ever hands over the meshes of a validated set.
+    const scoringMeshes =
+      this.scoringMeshesStatus === CALIBRATION_STATUSES.VALIDATED
+        ? (this.scoringMeshesData ?? []).map((scoringMeshData) => new CalibrationScoringMesh(scoringMeshData))
+        : [];
 
     return new Calibration({
       id: this.id,
@@ -212,7 +211,7 @@ class CalibrationBuilder {
       status: this.status,
       scope: this.scope,
       calibratedChallenges,
-      scoringMeshSet,
+      scoringMeshes,
     });
   }
 }


### PR DESCRIPTION
## ☀️ Problème

Dans la page dédiée à la configuration de score lors de la création d'une version, nous affichons les données de l'ancienne version. Celles-ci ne doivent servir que d'indicateurs de ce qui existait avant.

## ⛱️ Proposition

Nous nous basons désormais sur les valeurs de la configuration de score globale de la calibration associée au `externalCalibrationId` précédemment enregistré.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- Créer une nouvelle version de référentiel
- Aller jusqu'à la page de scoring
- Vérifier que les données de label correspondent à celles de l'ancienne version
- Vérifier que les valeurs dans les inputs correspondent à celles de la calibration
