### PR TITLE
[FEATURE] Ajout du paramètre `withArchived` à la route Maddo de récupération des campagnes d'une organisation (PIX-23973)

### DIFF
--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -6,11 +6,12 @@ export async function getOrganizations(request, h, dependencies = { findOrganiza
 }
 
 export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
-  const { page } = request.query;
+  const { page, withArchived } = request.query;
   const requestedOrganizationId = request.params.organizationId;
   const result = await dependencies.findCampaigns({
     organizationId: requestedOrganizationId,
     page,
+    withArchived,
   });
   return h.response(result).code(200);
 }

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -46,14 +46,17 @@ const register = async function (server) {
         auth: { access: { scope: 'campaigns' } },
         validate: {
           params: Joi.object({
-            organizationId: identifiersType.organizationId,
+            organizationId: identifiersType.organizationId.description("ID de l'organisation"),
           }),
           query: Joi.object({
-            withArchived: Joi.boolean().allow(null).optional(),
+            withArchived: Joi.boolean()
+              .allow(null)
+              .optional()
+              .description('Permet de récupérer les campagnes archivées en plus des campagnes non archivées.'),
             page: createPageQuerySchema({
               maxSize: 1000,
               defaultValue: { number: 1, size: 1000 },
-            }),
+            }).description('Pagination (numéro et taille de la page)'),
           }),
         },
         pre: [organizationPreHandler, isOrganizationInJurisdictionPreHandler],

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -49,6 +49,7 @@ const register = async function (server) {
             organizationId: identifiersType.organizationId,
           }),
           query: Joi.object({
+            withArchived: Joi.boolean().allow(null).optional(),
             page: createPageQuerySchema({
               maxSize: 1000,
               defaultValue: { number: 1, size: 1000 },

--- a/api/src/maddo/domain/usecases/find-campaigns.js
+++ b/api/src/maddo/domain/usecases/find-campaigns.js
@@ -1,3 +1,3 @@
-export async function findCampaigns({ organizationId, campaignRepository, page }) {
-  return campaignRepository.findByOrganizationId(organizationId, page);
+export async function findCampaigns({ organizationId, campaignRepository, page, withArchived }) {
+  return campaignRepository.findByOrganizationId({ organizationId, page, withArchived });
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -2,11 +2,11 @@ import * as campaignAPI from '../../../prescription/campaign/application/api/cam
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
-export async function findByOrganizationId(organizationId, page) {
+export async function findByOrganizationId({ organizationId, page, withArchived = false }) {
   const campaigns = await campaignAPI.findAllSummariesForOrganization({
     organizationId,
     withTargetProfileName: true,
-    withArchived: false,
+    withArchived,
     page,
   });
   return {

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -152,6 +152,86 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
       ]);
     });
 
+    context('with param withArchived true', function () {
+      it('returns all campaigns (archived or not, but not deleted) of organization in client jurisdiction with status 200', async function () {
+        // given
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const campaign1 = databaseBuilder.factory.buildCampaign({
+          organizationId: orgaInJurisdiction.id,
+          targetProfileId: targetProfile.id,
+        });
+        const campaign2 = databaseBuilder.factory.buildCampaign({
+          organizationId: orgaInJurisdiction.id,
+          targetProfileId: targetProfile.id,
+          archivedAt: new Date('2026-01-01'),
+        });
+        databaseBuilder.factory.buildCampaign({
+          organizationId: orgaInJurisdiction.id,
+          targetProfileId: targetProfile.id,
+          deletedAt: new Date('2026-01-01'),
+        });
+        const campaign3 = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.PROFILES_COLLECTION,
+          organizationId: orgaInJurisdiction.id,
+        });
+        databaseBuilder.factory.buildCampaign({
+          organizationId: orgaAlsoInJurisdiction.id,
+        });
+        databaseBuilder.factory.buildCampaign({ organizationId: orgaNotInJurisdiction.id });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/organizations/${orgaInJurisdiction.id}/campaigns?withArchived=true`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'campaigns'),
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.page).to.deep.equal({
+          number: 1,
+          size: 1000,
+          count: 1,
+        });
+        expect(response.result.campaigns).to.deep.equal([
+          new Campaign({
+            id: campaign1.id,
+            name: campaign1.name,
+            type: campaign1.type,
+            targetProfileName: targetProfile.name,
+            code: campaign1.code,
+            createdAt: campaign1.createdAt,
+            archivedAt: null,
+          }),
+          new Campaign({
+            id: campaign2.id,
+            name: campaign2.name,
+            type: campaign2.type,
+            targetProfileName: targetProfile.name,
+            code: campaign2.code,
+            createdAt: campaign2.createdAt,
+            archivedAt: campaign2.archivedAt,
+          }),
+          new Campaign({
+            id: campaign3.id,
+            name: campaign3.name,
+            type: campaign3.type,
+            targetProfileName: null,
+            code: campaign3.code,
+            createdAt: campaign3.createdAt,
+            archivedAt: null,
+            tubes: null,
+          }),
+        ]);
+      });
+    });
+
     context('pagination management', function () {
       it('returns the n first campaigns of organization in client jurisdiction with status 200', async function () {
         // given

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -83,12 +83,26 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
       await databaseBuilder.commit();
     });
 
-    it('returns the list of all campaigns belonging to organization in the client jurisdiction with an HTTP status code 200', async function () {
+    it('returns all campaigns (not archived, not deleted) of organization in client jurisdiction with status 200', async function () {
       // given
       const targetProfile = databaseBuilder.factory.buildTargetProfile();
-      const campaign1InJurisdiction = databaseBuilder.factory.buildCampaign({
+      const campaign1 = databaseBuilder.factory.buildCampaign({
         organizationId: orgaInJurisdiction.id,
         targetProfileId: targetProfile.id,
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: orgaInJurisdiction.id,
+        targetProfileId: targetProfile.id,
+        archivedAt: new Date('2026-01-01'),
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: orgaInJurisdiction.id,
+        targetProfileId: targetProfile.id,
+        deletedAt: new Date('2026-01-01'),
+      });
+      const campaign2 = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.PROFILES_COLLECTION,
+        organizationId: orgaInJurisdiction.id,
       });
       databaseBuilder.factory.buildCampaign({
         organizationId: orgaAlsoInJurisdiction.id,
@@ -117,56 +131,29 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
       });
       expect(response.result.campaigns).to.deep.equal([
         new Campaign({
-          id: campaign1InJurisdiction.id,
-          name: campaign1InJurisdiction.name,
-          type: campaign1InJurisdiction.type,
+          id: campaign1.id,
+          name: campaign1.name,
+          type: campaign1.type,
           targetProfileName: targetProfile.name,
-          code: campaign1InJurisdiction.code,
-          createdAt: campaign1InJurisdiction.createdAt,
-          archivedAt: campaign1InJurisdiction.archivedAt,
+          code: campaign1.code,
+          createdAt: campaign1.createdAt,
+          archivedAt: null,
+        }),
+        new Campaign({
+          id: campaign2.id,
+          name: campaign2.name,
+          type: campaign2.type,
+          targetProfileName: null,
+          code: campaign2.code,
+          createdAt: campaign2.createdAt,
+          archivedAt: null,
+          tubes: null,
         }),
       ]);
     });
 
-    context('when organization contains profile collection campaigns', function () {
-      it('returns the list of all campaigns belonging to organization in the client jurisdiction with an HTTP status code 200', async function () {
-        // given
-        const campaign1InJurisdiction = databaseBuilder.factory.buildCampaign({
-          type: CampaignTypes.PROFILES_COLLECTION,
-          organizationId: orgaInJurisdiction.id,
-        });
-        await databaseBuilder.commit();
-
-        const options = {
-          method: 'GET',
-          url: `/api/organizations/${orgaInJurisdiction.id}/campaigns`,
-          headers: {
-            authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'campaigns'),
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.campaigns).to.deep.equal([
-          new Campaign({
-            id: campaign1InJurisdiction.id,
-            name: campaign1InJurisdiction.name,
-            type: campaign1InJurisdiction.type,
-            targetProfileName: null,
-            code: campaign1InJurisdiction.code,
-            createdAt: campaign1InJurisdiction.createdAt,
-            archivedAt: campaign1InJurisdiction.archivedAt,
-            tubes: null,
-          }),
-        ]);
-      });
-    });
-
     context('pagination management', function () {
-      it('returns the list of n first campaigns belonging to organization in the client jurisdiction with an HTTP status code 200', async function () {
+      it('returns the n first campaigns of organization in client jurisdiction with status 200', async function () {
         // given
         const targetProfile = databaseBuilder.factory.buildTargetProfile();
         const campaign1InJurisdiction = databaseBuilder.factory.buildCampaign({

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
@@ -5,7 +5,7 @@ import { databaseBuilder } from '../../../../tooling/databases.js';
 
 describe('Maddo | Infrastructure | Repositories | Integration | campaign', function () {
   describe('#findByOrganizationId', function () {
-    it('lists campaigns belonging to organization with given id', async function () {
+    it('lists campaigns belonging to an organization without archived nor deleted campaigns', async function () {
       // given
       const organization = databaseBuilder.factory.buildOrganization();
       const { id: otherOrganizationId } = databaseBuilder.factory.buildOrganization();
@@ -37,7 +37,11 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
       await databaseBuilder.commit();
 
       // when
-      const { campaigns, page } = await findByOrganizationId(organization.id, { number: 1, size: 10 });
+      const { campaigns, page } = await findByOrganizationId({
+        organizationId: organization.id,
+        page: { number: 1, size: 10 },
+        withArchived: false,
+      });
 
       // then
       expect(page).to.deep.equal({
@@ -46,6 +50,81 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
         count: 1,
       });
       expect(campaigns).to.deep.equal([
+        new Campaign({
+          id: campaign2.id,
+          name: campaign2.name,
+          type: campaign2.type,
+          targetProfileName: targetProfile.name,
+          code: campaign2.code,
+          archivedAt: null,
+          createdAt: campaign2.createdAt,
+        }),
+        new Campaign({
+          id: campaign1.id,
+          name: campaign1.name,
+          type: campaign1.type,
+          targetProfileName: targetProfile.name,
+          code: campaign1.code,
+          createdAt: campaign1.createdAt,
+          archivedAt: null,
+        }),
+      ]);
+    });
+
+    it('lists campaigns belonging to an organization with archived campaigns but without deleted campaigns', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const { id: otherOrganizationId } = databaseBuilder.factory.buildOrganization();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const campaign1 = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+        createdAt: new Date('2026-01-01'),
+      });
+      const campaign2 = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+        createdAt: new Date('2026-01-02'),
+        archivedAt: new Date('2026-01-03'),
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+        createdAt: new Date('2026-01-02'),
+        deletedAt: new Date('2026-01-03'),
+      });
+      const campaign3 = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+        createdAt: new Date('2026-01-03'),
+      });
+      databaseBuilder.factory.buildCampaign({ organizationId: otherOrganizationId });
+
+      await databaseBuilder.commit();
+
+      // when
+      const { campaigns, page } = await findByOrganizationId({
+        organizationId: organization.id,
+        page: { number: 1, size: 10 },
+        withArchived: true,
+      });
+
+      // then
+      expect(page).to.deep.equal({
+        number: 1,
+        size: 10,
+        count: 1,
+      });
+      expect(campaigns).to.deep.equal([
+        new Campaign({
+          id: campaign3.id,
+          name: campaign3.name,
+          type: campaign3.type,
+          targetProfileName: targetProfile.name,
+          code: campaign3.code,
+          archivedAt: null,
+          createdAt: campaign3.createdAt,
+        }),
         new Campaign({
           id: campaign2.id,
           name: campaign2.name,
@@ -62,7 +141,7 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
           targetProfileName: targetProfile.name,
           code: campaign1.code,
           createdAt: campaign1.createdAt,
-          archivedAt: campaign1.archivedAt,
+          archivedAt: null,
         }),
       ]);
     });


### PR DESCRIPTION
## ☀️ Problème

France travail utilisait une route qui renvoyait toutes les campagnes d’une organisation, en incluant les campagnes archivées. (sans les campagnes supprimées)
Mais notre route maddo ne permet pas de renvoyer les campagnes archivées en plus de toutes celles non archivées. 

## ⛱️ Proposition

On ajoute un paramètre de route `withArchived` qui permet de spécifier pour un appel si on veut des campagnes archivées en plus des non archivées dans le retour de la route.

## 🧴 Remarques

Ptit coup de polish sur des tests

## 🏊 Pour tester

Tester un appel à la route sans withArchived pour vérifier qu’on ne renvoie pas les campagnes archivées
Tester un appel à la route avec withArchived pour vérifier qu’on renvoie les campagnes archivées en plus des autres
