### PR TITLE
[BUGFIX] Ne pas créer de course item pour les CappedTubes (PIX-23995)

### DIFF
--- a/api/src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/combined-course-blueprints/entities/CombinedCourseBlueprint.js
@@ -182,25 +182,30 @@ export class CombinedCourseBlueprint {
   }
 
   generateItems({ targetProfiles, modules, recommendableModules }) {
-    this.items = this.quest.successRequirements.map((requirement) => {
-      if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
-        const targetProfile = targetProfiles.find(
-          (targetProfile) => targetProfile.id === parseInt(requirement.data.targetProfileId.data),
-        );
-        return new CampaignCombinedCourseBlueprintItem({ id: targetProfile.id, name: targetProfile.name });
-      }
-      if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
-        const module = modules.find((module) => module.id === requirement.data.moduleId.data);
-        const recommendableModule = recommendableModules.find(({ moduleId }) => moduleId === module.id);
+    this.items = this.quest.successRequirements
+      .filter(
+        ({ requirement_type }) =>
+          requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS || requirement_type === TYPES.OBJECT.PASSAGES,
+      )
+      .map((requirement) => {
+        if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
+          const targetProfile = targetProfiles.find(
+            (targetProfile) => targetProfile.id === parseInt(requirement.data.targetProfileId.data),
+          );
+          return new CampaignCombinedCourseBlueprintItem({ id: targetProfile.id, name: targetProfile.name });
+        }
+        if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
+          const module = modules.find((module) => module.id === requirement.data.moduleId.data);
+          const recommendableModule = recommendableModules.find(({ moduleId }) => moduleId === module.id);
 
-        return new ModuleCombinedCourseBlueprintItem({
-          id: module.id,
-          name: module.title,
-          duration: module.duration,
-          image: module.image,
-          isRecommendable: Boolean(recommendableModule),
-        });
-      }
-    });
+          return new ModuleCombinedCourseBlueprintItem({
+            id: module.id,
+            name: module.title,
+            duration: module.duration,
+            image: module.image,
+            isRecommendable: Boolean(recommendableModule),
+          });
+        }
+      });
   }
 }

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -567,5 +567,73 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         }),
       ]);
     });
+
+    it('should not generate items from capped tubes requirements', function () {
+      // given
+      const targetProfileId = 1;
+      const moduleId = 'step1-module1';
+
+      values.quest = new Quest({
+        rewardId: null,
+        rewardType: null,
+        eligibilityRequirements: [],
+        successRequirements: [
+          {
+            requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+            data: { cappedTubes: [{ tubeId: 'tubeA', level: 1 }], threshold: 100 },
+          },
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            targetProfileId: targetProfileId,
+          }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: moduleId,
+          }),
+        ],
+      });
+      const targetProfiles = [
+        {
+          id: targetProfileId,
+          name: 'Step1 Diag1',
+        },
+      ];
+      const modules = [
+        {
+          id: 'step1-module1',
+          title: 'Module 1',
+          image: 'illustration.svg',
+          duration: 5,
+        },
+      ];
+      const recommendableModules = [
+        {
+          moduleId: 'step1-module2',
+          targetProfileIds: [targetProfileId],
+        },
+      ];
+
+      // when
+      const combinedCourseBlueprint = new CombinedCourseBlueprint(values);
+      combinedCourseBlueprint.generateItems({
+        targetProfiles,
+        modules,
+        recommendableModules,
+      });
+
+      // then
+      expect(combinedCourseBlueprint.items).to.have.lengthOf(2);
+      expect(combinedCourseBlueprint.items).deep.equal([
+        new CampaignCombinedCourseBlueprintItem({
+          id: targetProfileId,
+          name: 'Step1 Diag1',
+        }),
+        new ModuleCombinedCourseBlueprintItem({
+          id: moduleId,
+          name: 'Module 1',
+          duration: 5,
+          image: 'illustration.svg',
+          isRecommendable: false,
+        }),
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## ☀️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Souci repéré dans le catalogue : on ne peut pas sélectionner des parcours qui ont des critères de succès de type "sujets cappés".

On observe une erreur en console, et que le endpoint renvoie certains items `null`.

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
La méthode `generateItems` de `CombinedCourseBlueprint` ne traite pas les success requirements de type "capped tubes", donc on map un objet undefined dans ce cas.

A priori, on ne devrait pas mapper les capped_tubes_requirements en tant que course items : les filtrer en entrée pour le garder que les campagnes et les modules.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- Dans PixAdmin, créer un schéma, avec des PCs et modules, et avec une attestation correspondant à des critères de sujet cappés
- Rattacher le schéma créé à l'orga 1000 (sco siecle)
- Dans PixOrga, se mettre sur SCO SIECLE et créer une campagne. Sélectionner le parcours qu'on vient de créer. Il doit s'ouvrir sans problème, et contenir les PCs et modules sélectionnés
