### PR TITLE
[FEATURE] Afficher le statut des attestations "obtenue" uniquement si le parcours combiné est terminé (PIX-23974)

### DIFF
--- a/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseReward.js
+++ b/api/src/quest/domain/models/combined-course-participations/aggregates/CombinedCourseReward.js
@@ -19,9 +19,6 @@ export class CombinedCourseReward {
   }
 
   #computeStatus({ combinedCourseDetails }) {
-    if (this.data.obtainedAt) {
-      return CombinedCourseRewardStatuses.OBTAINED;
-    }
     if (combinedCourseDetails.status === CombinedCourseStatuses.NOT_STARTED) {
       return CombinedCourseRewardStatuses.NOT_STARTED;
     }
@@ -29,6 +26,9 @@ export class CombinedCourseReward {
       return CombinedCourseRewardStatuses.STARTED;
     }
     if (combinedCourseDetails.status === CombinedCourseStatuses.COMPLETED) {
+      if (this.data.obtainedAt) {
+        return CombinedCourseRewardStatuses.OBTAINED;
+      }
       return CombinedCourseRewardStatuses.NOT_OBTAINED;
     }
   }

--- a/api/tests/quest/integration/domain/services/combined-course-details-service_test.js
+++ b/api/tests/quest/integration/domain/services/combined-course-details-service_test.js
@@ -368,7 +368,7 @@ describe('Integration | Quest | Domain | Services | CombinedCourseDetailsService
       databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypeCombinedCourse({
         combinedCourseId,
         organizationLearnerId,
-        status: OrganizationLearnerParticipationStatuses.STARTED,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
       });
       databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypeCombinedCourse({
         combinedCourseId,

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
@@ -103,7 +103,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
         nbModulesCompleted: 0,
         nbCampaigns: 1,
         nbCampaignsCompleted: 0,
-        rewardStatus: CombinedCourseRewardStatuses.OBTAINED,
+        rewardStatus: CombinedCourseRewardStatuses.STARTED,
       },
       {
         id: participation2.id,

--- a/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseReward_test.js
+++ b/api/tests/quest/unit/domain/models/combined-course-participation/CombinedCourseReward_test.js
@@ -72,7 +72,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseReward', function () {
       expect(combinedCourseReward.status).equal(CombinedCourseRewardStatuses.NOT_STARTED);
     });
 
-    it('should have status obtained when combined course is not started and reward is obtained', function () {
+    it('should have status not started when combined course is not started and reward is obtained', function () {
       // given
       const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
         name,
@@ -89,7 +89,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseReward', function () {
       const combinedCourseReward = new CombinedCourseReward({ combinedCourseDetails, reward: attestationDetails });
 
       // then
-      expect(combinedCourseReward.status).equal(CombinedCourseRewardStatuses.OBTAINED);
+      expect(combinedCourseReward.status).equal(CombinedCourseRewardStatuses.NOT_STARTED);
     });
 
     it('should have status started when combined course is started and reward is not obtained', function () {
@@ -122,7 +122,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseReward', function () {
       expect(combinedCourseReward.status).equal(CombinedCourseRewardStatuses.STARTED);
     });
 
-    it('should have status obtained when combined course is started and reward is obtained', function () {
+    it('should have status started when combined course is started and reward is obtained', function () {
       // given
       const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
         name,
@@ -149,7 +149,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseReward', function () {
       const combinedCourseReward = new CombinedCourseReward({ combinedCourseDetails, reward: attestationDetails });
 
       // then
-      expect(combinedCourseReward.status).equal(CombinedCourseRewardStatuses.OBTAINED);
+      expect(combinedCourseReward.status).equal(CombinedCourseRewardStatuses.STARTED);
     });
 
     it('should have status obtained when combined course is completed and reward is obtained', function () {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -73,7 +73,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
           type: 'combined-course-rewards',
           id: '456',
           attributes: {
-            status: CombinedCourseRewardStatuses.OBTAINED,
+            status: CombinedCourseRewardStatuses.NOT_STARTED,
             type: REWARD_TYPES.ATTESTATION,
             'requirements-description': 'Description of reward requirements',
             label: 'rewardLabel',


### PR DESCRIPTION
## ☀️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lorsqu'un prescrit passe un parcours en ayant déjà obtenu l'attestation que délivre ce parcours, on lui afficche l'attestation comme obtenue. On veut finalement l'afficher "en cours" pour ce cas.

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Modification de la condition pour que le statut "obtenue" ne soit affiché que pour les parcours combinés terminés.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
- Sur PixAdmin, créer 2 parcours combinés pour le même schéma.
- Sur PixApp, passer le 1er parcours combiné et obtenir l'attestation : on doit avoir le statut "en cours" puis "obtenue".
- Puis aller sur le 2nd parcours : on ne doit pas voir l'attestation comme "obtenue" initialement, elle doit être "en cours". Finir le parcours -> l'attestation doit passer à "obtenue"
