### PR TITLE
[FEATURE] Add Proxy on Pix Admin

### DIFF
--- a/admin/.buildpacks
+++ b/admin/.buildpacks
@@ -1,2 +1,3 @@
 https://github.com/Scalingo/nodejs-buildpack
 https://github.com/Scalingo/nginx-buildpack
+https://github.com/1024pix/oauth2-proxy-buildpack

--- a/admin/Procfile
+++ b/admin/Procfile
@@ -1,0 +1,1 @@
+web: /app/bin/start_with_oauth2_proxy.sh exec /app/bin/run

--- a/admin/sample.env
+++ b/admin/sample.env
@@ -54,3 +54,10 @@
 # type: String
 # default: <empty>
 # USER_DASHBOARD_URL=https://metabase.pix.fr/dashboard/xxx/?id=
+
+# Disables completely the oauth2 proxy
+#
+# presence: optional
+# type: boolean
+# default: false
+OAUTH2_PROXY_DISABLE=true


### PR DESCRIPTION
## ☀️ Problème

J'aimerais réduire l'exposition

## ⛱️ Proposition

Ajout du buildpack Oauth2 Proxy

[Documentation sur Miro](https://miro.com/app/board/uXjVKQVbMBA=/?moveToWidget=3458764681692288498&cot=14)

## 🧴 Remarques

* Ajout du buildpack oauth2-proxy par dessus le builpack nginx, car il faut toujours un nginx configurable avec le fichier servers.conf.erb pour faire le routage et la config du front
* la variable `OAUTH2_PROXY_DISABLE` permet de désactiver le proxy sur les RA et integration
* ajout d'une variable `OAUTH2_PROXY_TRUSTED_PROXY_IPS` pour garantir la sécurité des headers `X-Forwarded-*`

## 🏊 Pour tester

Cf. review app
