### PR TITLE
[TECH] Internaliser les traductions pour la Pagination des applications (PIX-REFACTO).

### DIFF
--- a/orga/app/components/attestations/list.gjs
+++ b/orga/app/components/attestations/list.gjs
@@ -1,5 +1,4 @@
 import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
@@ -8,11 +7,11 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { formatDate, t } from 'ember-intl';
 import MultiSelectFilter from 'pix-orga/components/ui/multi-select-filter';
+import Pagination from 'pix-orga/components/ui/pagination';
 import ENV from 'pix-orga/config/environment';
 
 export default class AttestationList extends Component {
   @service intl;
-  @service locale;
 
   debounceTime = ENV.pagination.debounce;
 
@@ -115,6 +114,6 @@ export default class AttestationList extends Component {
       </:columns>
     </PixTable>
 
-    <PixPagination @pagination={{@participantStatuses.meta}} @locale={{this.locale.currentLanguage}} />
+    <Pagination @pagination={{@participantStatuses.meta}} />
   </template>
 }

--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -1,5 +1,4 @@
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { array, fn } from '@ember/helper';
@@ -10,6 +9,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { or } from 'ember-truth-helpers';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 import ParticipationStatus from '../../ui/participation-status';
 import ParticipationFilters from '../filter/participation-filters';
@@ -169,7 +169,7 @@ export default class ParticipantsList extends Component {
     {{/unless}}
 
     {{#if @participations}}
-      <PixPagination @pagination={{@participations.meta}} @locale={{this.locale.currentLanguage}} />
+      <Pagination @pagination={{@participations.meta}} />
     {{/if}}
 
     <DeleteParticipationModal

--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -1,6 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn, uniqueId } from '@ember/helper';
@@ -13,6 +12,7 @@ import { tracked } from '@glimmer/tracking';
 import { formatDate, t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 import ActivityType from 'pix-orga/components/activity-type';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 import InElement from '../in-element';
 import SelectableList from '../selectable-list';
@@ -235,7 +235,7 @@ const Filters = <template>
 
 const PixPaginationControl = <template>
   <InElement @destinationId={{@destinationId}} @waitForElement={{true}}>
-    <PixPagination @pagination={{@pagination}} @onChange={{@onChange}} @locale={{@locale}} />
+    <Pagination @pagination={{@pagination}} @onChange={{@onChange}} />
   </InElement>
 </template>;
 

--- a/orga/app/components/campaign/results/assessment-list.gjs
+++ b/orga/app/components/campaign/results/assessment-list.gjs
@@ -1,11 +1,10 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { array, fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
+import Pagination from 'pix-orga/components/ui/pagination';
 
-import getService from '../../../helpers/get-service.js';
 import MasteryPercentageDisplay from '../../ui/mastery-percentage-display';
 import CampaignBadges from '../badges';
 import CampaignParticipationFilters from '../filter/participation-filters';
@@ -134,9 +133,7 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
     {{/unless}}
 
     {{#if @participations}}
-      {{#let (getService "service:locale") as |locale|}}
-        <PixPagination @pagination={{@participations.meta}} @locale={{locale.currentLanguage}} />
-      {{/let}}
+      <Pagination @pagination={{@participations.meta}} />
     {{/if}}
   </section>
 </template>

--- a/orga/app/components/campaign/results/profile-list.gjs
+++ b/orga/app/components/campaign/results/profile-list.gjs
@@ -1,4 +1,3 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
@@ -6,7 +5,7 @@ import { array, fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { formatDate, t } from 'ember-intl';
 import { gt } from 'ember-truth-helpers';
-import getService from 'pix-orga/helpers/get-service';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 import CampaignParticipationFilters from '../filter/participation-filters';
 import EvolutionHeader from './evolution-header';
@@ -151,9 +150,7 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
     {{/unless}}
 
     {{#if (gt @profiles.length 0)}}
-      {{#let (getService "service:locale") as |locale|}}
-        <PixPagination @pagination={{@profiles.meta}} @locale={{locale.currentLanguage}} />
-      {{/let}}
+      <Pagination @pagination={{@profiles.meta}} />
     {{/if}}
   </section>
 </template>

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -1,7 +1,6 @@
 import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
@@ -13,6 +12,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import EmptyState from 'pix-orga/components/campaign/empty-state';
+import Pagination from 'pix-orga/components/ui/pagination';
 import ParticipationStatus from 'pix-orga/components/ui/participation-status';
 import ENV from 'pix-orga/config/environment';
 import { COMBINED_COURSE_PARTICIPATION_STATUSES } from 'pix-orga/models/combined-course-participation.js';
@@ -231,7 +231,7 @@ export default class CombinedCourse extends Component {
         </:columns>
       </PixTable>
       {{#if @participations.meta}}
-        <PixPagination @pagination={{@participations.meta}} @locale={{this.locale.currentLanguage}} />
+        <Pagination @pagination={{@participations.meta}} />
       {{/if}}
     {{else}}
       <EmptyState />

--- a/orga/app/components/mission/activity-table.gjs
+++ b/orga/app/components/mission/activity-table.gjs
@@ -1,9 +1,8 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { t } from 'ember-intl';
-import getService from 'pix-orga/helpers/get-service';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 function statusColor(status) {
   return {
@@ -48,9 +47,7 @@ function statusColor(status) {
       </:columns>
     </PixTable>
 
-    {{#let (getService "service:locale") as |locale|}}
-      <PixPagination @pagination={{@missionLearners.meta}} @locale={{locale.currentLanguage}} />
-    {{/let}}
+    <Pagination @pagination={{@missionLearners.meta}} />
 
   {{else}}
     <div class="table__empty content-text">

--- a/orga/app/components/mission/result-table.gjs
+++ b/orga/app/components/mission/result-table.gjs
@@ -1,11 +1,10 @@
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { t } from 'ember-intl';
-import getService from 'pix-orga/helpers/get-service';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 function indexNumber(index) {
   return { number: index + 1 };
@@ -104,9 +103,7 @@ function getMissionResultColor(result) {
       </:columns>
     </PixTable>
 
-    {{#let (getService "service:locale") as |locale|}}
-      <PixPagination @pagination={{@missionLearners.meta}} @locale={{locale.currentLanguage}} />
-    {{/let}}
+    <Pagination @pagination={{@missionLearners.meta}} />
   {{else}}
     <div class="table__empty content-text">
       {{t "pages.missions.mission.table.result.no-data"}}

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -1,7 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
@@ -14,6 +13,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { formatDate, t } from 'ember-intl';
 import { eq, not } from 'ember-truth-helpers';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 import { getColumnName } from '../../helpers/import-format.js';
 import CertificabilityCell from '../certificability/cell';
@@ -486,7 +486,7 @@ const ActionBar = <template>
 
 const PixPaginationControl = <template>
   <InElement @destinationId={{@destinationId}} @waitForElement={{true}}>
-    <PixPagination @pagination={{@pagination}} @onChange={{@onChange}} @locale={{@locale}} />
+    <Pagination @pagination={{@pagination}} @onChange={{@onChange}} />
   </InElement>
 </template>;
 

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -1,4 +1,3 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import { fn, uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
@@ -7,6 +6,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq, not } from 'ember-truth-helpers';
+import Pagination from 'pix-orga/components/ui/pagination';
 import ENV from 'pix-orga/config/environment';
 
 import { CONNECTION_TYPES } from '../../helpers/connection-types';
@@ -333,7 +333,7 @@ const Filters = <template>
 
 const PixPaginationControl = <template>
   <InElement @destinationId={{@destinationId}} @waitForElement={{true}}>
-    <PixPagination @pagination={{@pagination}} @onChange={{@onChange}} @locale={{@locale}} />
+    <Pagination @pagination={{@pagination}} @onChange={{@onChange}} />
   </InElement>
 </template>;
 

--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -1,6 +1,5 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
@@ -8,6 +7,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 import PageTitle from '../ui/page-title';
 import CoverRateGauge from './cover-rate-gauge';
@@ -165,7 +165,7 @@ export default class Statistics extends Component {
         </:columns>
       </PixTable>
 
-      <PixPagination @pagination={{this.pagination}} @locale={{this.locale.currentLanguage}} />
+      <Pagination @pagination={{this.pagination}} />
     {{else}}
       <PixBlock class="empty-state" @variant="orga">
         <div class="empty-state__text">

--- a/orga/app/components/sup-organization-participant/list.gjs
+++ b/orga/app/components/sup-organization-participant/list.gjs
@@ -1,4 +1,3 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import { fn, get, uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
@@ -7,6 +6,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq, not } from 'ember-truth-helpers';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 import ImportInformationBanner from '../import-information-banner';
 import InElement from '../in-element';
@@ -240,7 +240,7 @@ const Filters = <template>
 
 const PixPaginationControl = <template>
   <InElement @destinationId={{@destinationId}} @waitForElement={{true}}>
-    <PixPagination @pagination={{@pagination}} @onChange={{@onChange}} @locale={{@locale}} />
+    <Pagination @pagination={{@pagination}} @onChange={{@onChange}} />
   </InElement>
 </template>;
 

--- a/orga/app/components/team/members-list.gjs
+++ b/orga/app/components/team/members-list.gjs
@@ -1,9 +1,9 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 import MembersListItem from './members-list-item';
 
@@ -47,7 +47,7 @@ export default class MembersList extends Component {
     {{/unless}}
 
     {{#if @members}}
-      <PixPagination @pagination={{@members.meta}} @locale={{this.locale.currentLanguage}} />
+      <Pagination @pagination={{@members.meta}} />
     {{/if}}
   </template>
 }

--- a/orga/app/components/ui/pagination.gjs
+++ b/orga/app/components/ui/pagination.gjs
@@ -1,36 +1,51 @@
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
-import { t } from 'ember-intl';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 
-function firstItemPosition(pagination) {
-  if (!pagination) return 0;
+export default class Pagination extends Component {
+  @service intl;
 
-  const { page, pageSize } = pagination;
-  return (page - 1) * pageSize + 1;
+  get firstItemPosition() {
+    if (!this.args.pagination) return 0;
+
+    const { page, pageSize } = this.args.pagination;
+    return (page - 1) * pageSize + 1;
+  }
+
+  get lastItemPosition() {
+    if (!this.args.pagination) return 0;
+    const { rowCount, pageSize } = this.args.pagination;
+
+    return Math.min(rowCount, this.firstItemPosition + pageSize - 1);
+  }
+
+  get texts() {
+    if (!this.args.pagination) return {};
+
+    return {
+      title: this.intl.t('common.pagination.title'),
+      pageSize: this.intl.t('common.pagination.pageSize'),
+      pageElementCount: this.intl.t('common.pagination.pageElementCount', {
+        totalPage: this.args.pagination.pageCount,
+        total: this.args.pagination.rowCount,
+        start: this.firstItemPosition,
+        end: this.lastItemPosition,
+      }),
+      pageNumber: this.intl.t('common.pagination.pageNumber', {
+        current: this.args.pagination.page,
+        total: this.args.pagination.pageCount,
+      }),
+      previousPage: this.intl.t('common.pagination.previousPage'),
+      nextPage: this.intl.t('common.pagination.nextPage'),
+    };
+  }
+
+  <template>
+    <PixPagination
+      @pagination={{@pagination}}
+      @onChange={{@onChange}}
+      @texts={{this.texts}}
+      @pageOptions={{@pageOptions}}
+    />
+  </template>
 }
-
-function lastItemPosition(pagination) {
-  if (!pagination) return 0;
-  const { rowCount, pageSize } = pagination;
-
-  return Math.min(rowCount, firstItemPosition(pagination) + pageSize - 1);
-}
-
-<template>
-  <PixPagination
-    @pagination={{@pagination}}
-    @onChange={{@onChange}}
-    @beforeResultsPerPageLabel={{t "common.pagination.beforeResultsPerPageLabel"}}
-    @selectPageSizeLabel={{t "common.pagination.selectPageSizeLabel"}}
-    @singlePageElementCountLabel={{t "common.pagination.singlePageElementCountLabel" total=@pagination.rowCount}}
-    @multiplePageElementCountLabel={{t
-      "common.pagination.multiplePageElementCountLabel"
-      total=@pagination.rowCount
-      start=(firstItemPosition @pagination)
-      end=(lastItemPosition @pagination)
-    }}
-    @pageNumberLabel={{t "common.pagination.pageNumberLabel" current=@pagination.page total=@pagination.pageCount}}
-    @previousPageLabel={{t "common.pagination.previousPageLabel"}}
-    @nextPageLabel={{t "common.pagination.nextPageLabel"}}
-    @pageOptions={{@pageOptions}}
-  />
-</template>

--- a/orga/app/components/ui/pagination.gjs
+++ b/orga/app/components/ui/pagination.gjs
@@ -1,0 +1,36 @@
+import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import { t } from 'ember-intl';
+
+function firstItemPosition(pagination) {
+  if (!pagination) return 0;
+
+  const { page, pageSize } = pagination;
+  return (page - 1) * pageSize + 1;
+}
+
+function lastItemPosition(pagination) {
+  if (!pagination) return 0;
+  const { rowCount, pageSize } = pagination;
+
+  return Math.min(rowCount, firstItemPosition(pagination) + pageSize - 1);
+}
+
+<template>
+  <PixPagination
+    @pagination={{@pagination}}
+    @onChange={{@onChange}}
+    @beforeResultsPerPageLabel={{t "common.pagination.beforeResultsPerPageLabel"}}
+    @selectPageSizeLabel={{t "common.pagination.selectPageSizeLabel"}}
+    @singlePageElementCountLabel={{t "common.pagination.singlePageElementCountLabel" total=@pagination.rowCount}}
+    @multiplePageElementCountLabel={{t
+      "common.pagination.multiplePageElementCountLabel"
+      total=@pagination.rowCount
+      start=(firstItemPosition @pagination)
+      end=(lastItemPosition @pagination)
+    }}
+    @pageNumberLabel={{t "common.pagination.pageNumberLabel" current=@pagination.page total=@pagination.pageCount}}
+    @previousPageLabel={{t "common.pagination.previousPageLabel"}}
+    @nextPageLabel={{t "common.pagination.nextPageLabel"}}
+    @pageOptions={{@pageOptions}}
+  />
+</template>

--- a/orga/app/templates/authenticated/campaigns/combined-courses.gjs
+++ b/orga/app/templates/authenticated/campaigns/combined-courses.gjs
@@ -1,8 +1,8 @@
-import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
 import ListHeader from 'pix-orga/components/campaign/list-header';
 import CombinedCourseList from 'pix-orga/components/combined-course/list';
+import Pagination from 'pix-orga/components/ui/pagination';
 
 <template>
   {{pageTitle (t "pages.campaign.tab.combined-courses")}}
@@ -10,6 +10,6 @@ import CombinedCourseList from 'pix-orga/components/combined-course/list';
   <article>
     <ListHeader />
     <CombinedCourseList @combinedCourses={{@model.combinedCourses}} />
-    <PixPagination @pagination={{@model.combinedCourses.meta}} />
+    <Pagination @pagination={{@model.combinedCourses.meta}} />
   </article>
 </template>

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.44",
         "@1024pix/eslint-plugin": "^3.0.4",
-        "@1024pix/pix-ui": "61.4.0",
+        "@1024pix/pix-ui": "^63.0.0",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.28.6",
         "@babel/plugin-proposal-decorators": "^7.29.7",
@@ -269,8 +269,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "62.3.0",
-      "resolved": "git+ssh://git@github.com/1024pix/pix-ui.git#06b41950e518e1d992005fdd386e104270759560",
+      "version": "63.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-63.0.0.tgz",
+      "integrity": "sha512-FC1PRgTF6CmczE6lvFmpTpYg98pDe2aCxScIrgTvZS+sg3+Gfg3wxLJgmVhPCnDP8Ke2Fi0IRpDhHpR7XCrc9A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -269,9 +269,8 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "61.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-61.4.0.tgz",
-      "integrity": "sha512-bI1K/gPnO3fItIIJaC+ywuJxqsufCXvSueB0YILEosaLbK8mH8EjGcj7cDKqd2uILUMx5RkznY6F8j1elHluJw==",
+      "version": "62.3.0",
+      "resolved": "git+ssh://git@github.com/1024pix/pix-ui.git#06b41950e518e1d992005fdd386e104270759560",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/orga/package.json
+++ b/orga/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.44",
     "@1024pix/eslint-plugin": "^3.0.4",
-    "@1024pix/pix-ui": "61.4.0",
+    "@1024pix/pix-ui": "^63.0.0",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.28.6",
     "@babel/plugin-proposal-decorators": "^7.29.7",

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -236,8 +236,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
         }),
       );
 
-      const dialog = await screen.findByRole('dialog');
-      await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+      const dialog = await screen.findAllByRole('dialog');
+      await click(within(dialog[1]).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
 
       await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
 
@@ -292,8 +292,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
             name: t('pages.catalogue.modal.open-modal', { name: expectedTargetProfileName }),
           }),
         );
-        const dialog = await screen.findByRole('dialog');
-        await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+        const dialog = await screen.findAllByRole('dialog');
+        await click(within(dialog[1]).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
 
         await fillByLabel('Nom de la campagne *', 'Ma Campagne');
 
@@ -351,8 +351,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
             name: t('pages.catalogue.modal.open-modal', { name: expectedTargetProfileName }),
           }),
         );
-        const dialog = await screen.findByRole('dialog');
-        await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+        const dialog = await screen.findAllByRole('dialog');
+        await click(within(dialog[1]).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
 
         await fillByLabel('Nom de la campagne *', 'Ma Campagne');
 
@@ -387,8 +387,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
             name: t('pages.catalogue.modal.open-modal', { name: targetProfileName }),
           }),
         );
-        const dialog = await screen.findByRole('dialog');
-        await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+        const dialog = await screen.findAllByRole('dialog');
+        await click(within(dialog[1]).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
 
         await fillByLabel('Nom de la campagne *', 'Ma Campagne');
 
@@ -420,8 +420,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
             name: t('pages.catalogue.modal.open-modal', { name: expectedTargetProfileName }),
           }),
         );
-        const dialog = await screen.findByRole('dialog');
-        await click(within(dialog).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
+        const dialog = await screen.findAllByRole('dialog');
+        await click(within(dialog[1]).getByRole('link', { name: t('pages.catalogue.modal.select-course') }));
 
         await fillByLabel('Nom de la campagne *', 'Ma Campagne');
         const externalIdentifier = screen

--- a/orga/tests/acceptance/catalogue-test.js
+++ b/orga/tests/acceptance/catalogue-test.js
@@ -57,8 +57,8 @@ module('Acceptance | Catalogue page', function (hooks) {
     const screen = await visit(`/catalogue`);
     // then
     await click(screen.getByRole('link', { name: t('pages.catalogue.modal.open-modal', { name: course1.name }) }));
-    const dialog = await screen.findByRole('dialog');
-    assert.ok(within(dialog).getByRole('heading', { name: course1.name }));
+    const dialog = await screen.findAllByRole('dialog');
+    assert.ok(within(dialog[1]).getByRole('heading', { name: course1.name }));
   });
 
   test('it should display combined course blueprint course dialog when clicking on a card', async function (assert) {
@@ -66,8 +66,9 @@ module('Acceptance | Catalogue page', function (hooks) {
     const screen = await visit(`/catalogue`);
     // then
     await click(screen.getByRole('link', { name: t('pages.catalogue.modal.open-modal', { name: course2.name }) }));
-    const dialog = await screen.findByRole('dialog');
-    assert.ok(within(dialog).getByRole('heading', { name: course2.name }));
+
+    const dialog = await screen.findAllByRole('dialog');
+    assert.ok(within(dialog[1]).getByRole('heading', { name: course2.name }));
   });
 
   test('it should reset filter when changing tabs', async function (assert) {

--- a/orga/tests/integration/components/campaign/activity/participants-list-test.gjs
+++ b/orga/tests/integration/components/campaign/activity/participants-list-test.gjs
@@ -55,39 +55,6 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
     assert.ok(screen.getAllByText(t('components.participation-status.STARTED')));
   });
 
-  test('it should display pagination in correct language', async function (assert) {
-    class CurrentUserStub extends Service {
-      isAdminInOrganization = true;
-    }
-    const locale = this.owner.lookup('service:locale');
-    locale.setCurrentLocale('en');
-
-    this.owner.register('service:current-user', CurrentUserStub);
-
-    const campaign = { externalIdLabel: 'id', type: 'ASSESSMENT' };
-
-    const participations = [
-      {
-        firstName: 'Joe',
-        lastName: 'La frite',
-        status: 'STARTED',
-        participantExternalId: 'patate',
-      },
-    ];
-
-    const screen = await render(
-      <template>
-        <ParticipantsList
-          @campaign={{campaign}}
-          @participations={{participations}}
-          @onClickParticipant={{noop}}
-          @onFilter={{noop}}
-        />
-      </template>,
-    );
-    assert.ok(screen.getByLabelText('items', { exact: false }));
-  });
-
   test('it should link to the last shared or current campaign participation details', async function (assert) {
     class CurrentUserStub extends Service {
       isAdminInOrganization = true;

--- a/orga/tests/integration/components/campaign/list-test.gjs
+++ b/orga/tests/integration/components/campaign/list-test.gjs
@@ -146,38 +146,6 @@ module('Integration | Component | Campaign::List', function (hooks) {
       assert.ok(screen.queryByText('campagne 2'));
     });
 
-    test('it should display pagination in correct language', async function (assert) {
-      const locale = this.owner.lookup('service:locale');
-      locale.setCurrentLocale('en');
-      // given
-      const store = this.owner.lookup('service:store');
-
-      const campaign1 = store.createRecord('campaign', {
-        id: '1',
-        name: 'campagne 1',
-        code: 'AAAAAA111',
-        type: 'PROFILES_COLLECTION',
-      });
-      const campaign2 = store.createRecord('campaign', {
-        id: '2',
-        name: 'campagne 2',
-        code: 'BBBBBB222',
-        type: 'ASSESSMENT',
-      });
-      const campaigns = [campaign1, campaign2];
-      campaigns.meta = {
-        rowCount: 2,
-      };
-
-      // when
-      const screen = await render(
-        <template><List @campaigns={{campaigns}} @onFilter={{noop}} @onClickCampaign={{noop}} /></template>,
-      );
-
-      // then
-      assert.ok(screen.getByLabelText('items', { exact: false }));
-    });
-
     test('it should display a link to access campaign detail', async function (assert) {
       // given
       this.owner.setupRouter();

--- a/orga/tests/integration/components/campaign/results/profile-list-test.gjs
+++ b/orga/tests/integration/components/campaign/results/profile-list-test.gjs
@@ -445,43 +445,6 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       // then
       assert.ok(screen.getByRole('link', { href: '/campagnes/1/profils/7' }));
     });
-
-    test('it should display pagination in correct language', async function (assert) {
-      const locale = this.owner.lookup('service:locale');
-      locale.setCurrentLocale('en');
-
-      this.owner.setupRouter();
-      const campaign = store.createRecord('campaign', {
-        id: '1',
-        name: 'campagne 1',
-        code: 'AAAAAA111',
-        participationsCount: 1,
-      });
-      const profiles = [
-        {
-          id: 7,
-          lastName: 'Todori',
-          firstName: 'Shoto',
-        },
-      ];
-
-      // when
-      const screen = await render(
-        <template>
-          <ProfileList
-            @campaign={{campaign}}
-            @profiles={{profiles}}
-            @onClickParticipant={{noop}}
-            @onFilter={{noop}}
-            @selectedDivisions={{divisions}}
-            @selectedGroups={{groups}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.ok(screen.getByLabelText('items', { exact: false }));
-    });
   });
 
   module('when there is no profile', function () {

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -376,24 +376,6 @@ module('Integration | Component | combined-course/participations', function (hoo
   });
 
   module('pagination', function () {
-    test('it should display pagination in correct language', async function (assert) {
-      // when
-      const locale = this.owner.lookup('service:locale');
-      locale.setCurrentLocale('en');
-      const screen = await render(
-        <template>
-          <CombinedCourseParticipations
-            @hasCampaigns={{true}}
-            @hasModules={{true}}
-            @participations={{participations}}
-            @onFilter={{onFilter}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.ok(screen.getByLabelText(/items/));
-    });
     test('should display pagination', async function (assert) {
       //when
       const screen = await render(

--- a/orga/tests/integration/components/organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/organization-participant/list-test.gjs
@@ -149,41 +149,7 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
       });
     });
   });
-  module('pagination', function () {
-    test('it should display pagination in correct language', async function (assert) {
-      // given
-      const locale = this.owner.lookup('service:locale');
-      locale.setCurrentLocale('en');
-      const participants = [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-          id: 34,
-        },
-        {
-          lastName: "L'asticot",
-          firstName: 'Gogo',
-          id: 56,
-        },
-      ];
 
-      // when
-      const screen = await render(
-        <template>
-          <List
-            @participants={{participants}}
-            @triggerFiltering={{noop}}
-            @onClickLearner={{noop}}
-            @fullName={{fullNameFilter}}
-            @certificabilityFilter={{certificabilityFilter}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.ok(screen.getByLabelText('items', { exact: false }));
-    });
-  });
   module('row', function () {
     test('it should display a list of participants', async function (assert) {
       // given

--- a/orga/tests/integration/components/sco-organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/sco-organization-participant/list-test.gjs
@@ -130,42 +130,6 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     assert.strictEqual(screen.getAllByRole('row').length, 3);
   });
 
-  test('it should display pagination in correct language', async function (assert) {
-    // given
-    const locale = this.owner.lookup('service:locale');
-    locale.setCurrentLocale('en');
-
-    const students = [
-      { lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') },
-      { lastName: "L'asticot", firstName: 'Gogo', birthdate: new Date('2010-05-10') },
-    ];
-    const divisions = [];
-    const connectionTypes = [];
-    const certificability = [];
-    const search = null;
-    const noop = this.noop;
-
-    // when
-    const screen = await render(
-      <template>
-        <ScoOrganizationParticipantList
-          @students={{students}}
-          @onFilter={{noop}}
-          @searchFilter={{search}}
-          @divisionsFilter={{divisions}}
-          @connectionTypeFilter={{connectionTypes}}
-          @certificabilityFilter={{certificability}}
-          @onClickLearner={{noop}}
-          @onResetFilter={{noop}}
-          @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
-        />
-      </template>,
-    );
-
-    // then
-    assert.ok(screen.getByLabelText('items', { exact: false }));
-  });
-
   test('it should display a link to access student detail', async function (assert) {
     // given
     const students = [

--- a/orga/tests/integration/components/sup-organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/sup-organization-participant/list-test.gjs
@@ -105,40 +105,6 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     assert.strictEqual(screen.getAllByRole('row').length, 3);
   });
 
-  test('it should display pagination in correct language', async function (assert) {
-    // given
-    const locale = this.owner.lookup('service:locale');
-    locale.setCurrentLocale('en');
-
-    const students = [
-      { lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') },
-      { lastName: "L'asticot", firstName: 'Gogo', birthdate: new Date('2010-05-10') },
-    ];
-    const certificabilityFilter = [];
-    const groupFilter = [];
-    const searchFilter = null;
-    const studentNumberFilter = null;
-    const noop = this.noop;
-
-    // when
-    const screen = await render(
-      <template>
-        <SupOrganizationParticipantList
-          @students={{students}}
-          @onFilter={{noop}}
-          @onClickLearner={{noop}}
-          @searchFilter={{searchFilter}}
-          @groupsFilter={{groupFilter}}
-          @studentNumberFilter={{studentNumberFilter}}
-          @certificabilityFilter={{certificabilityFilter}}
-        />
-      </template>,
-    );
-
-    // then
-    assert.ok(screen.getByLabelText('items', { exact: false }));
-  });
-
   test('it should display a link to access student detail', async function (assert) {
     // given
     const students = [

--- a/orga/tests/unit/metrics-adapters/plausible-adapter-test.js
+++ b/orga/tests/unit/metrics-adapters/plausible-adapter-test.js
@@ -16,6 +16,7 @@ module('Unit | MetricsAdapter | plausible-adapter', function (hooks) {
   });
 
   hooks.afterEach(function () {
+    sinon.restore(); // must restore before uninstall, which deletes window.plausible
     this.adapter.uninstall();
   });
 

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -262,6 +262,14 @@
     "notification": {
       "close": "Benachrichtigung schließen"
     },
+    "pagination": {
+      "nextPage": "Zur nächsten Seite wechseln",
+      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 Elemente} =1 {1 Element} other {{total, number} Elemente}}} other {{start, number}-{end, number} von  {total, plural, =0 {0 Elemente} =1 {1 Element} other {{total, number} Elemente}}}}",
+      "pageNumber": "Seite  {current, number} / {total, number}",
+      "pageSize": "Anzahl der Elemente pro Seite",
+      "previousPage": "Zur vorherigen Seite wechseln",
+      "title": "Siehe"
+    },
     "result": {
       "accessibility-description": "Ergebnis erhalten = {percentage, number, ::percent}, d. h. die Stufe {stage} auf {totalStage}.",
       "percentage": "{value, number, ::percent}",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -262,6 +262,15 @@
     "notification": {
       "close": "Close the notification"
     },
+    "pagination": {
+      "beforeResultsPerPageLabel": "See",
+      "multiplePageElementCountLabel": "{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}",
+      "nextPageLabel": "Go to next page",
+      "pageNumberLabel": "Page {current, number} / {total, number}",
+      "previousPageLabel": "Go to previous page",
+      "selectPageSizeLabel": "Select the number of items by page",
+      "singlePageElementCountLabel": "{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}"
+    },
     "result": {
       "accessibility-description": "Results obtained = {percentage, number, ::percent},that is success rate {stage} of {totalStage}",
       "percentage": "{value, number, ::percent}",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -263,13 +263,12 @@
       "close": "Close the notification"
     },
     "pagination": {
-      "beforeResultsPerPageLabel": "See",
-      "multiplePageElementCountLabel": "{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}",
-      "nextPageLabel": "Go to next page",
-      "pageNumberLabel": "Page {current, number} / {total, number}",
-      "previousPageLabel": "Go to previous page",
-      "selectPageSizeLabel": "Select the number of items by page",
-      "singlePageElementCountLabel": "{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}"
+      "nextPage": "Go to next page",
+      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}} other {{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}}}",
+      "pageNumber": "Page {current, number} / {total, number}",
+      "pageSize": "Select the number of items by page",
+      "previousPage": "Go to previous page",
+      "title": "See"
     },
     "result": {
       "accessibility-description": "Results obtained = {percentage, number, ::percent},that is success rate {stage} of {totalStage}",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -262,6 +262,15 @@
     "notification": {
       "close": "Cerrar la notificación"
     },
+    "pagination": {
+      "beforeResultsPerPageLabel": "Ver",
+      "multiplePageElementCountLabel": "{start, number}-{end, number} de {total, plural, =0 {0 elemento} =1 {1 elemento} other {{total, number} elementos}}",
+      "nextPageLabel": "Ir a la página siguiente",
+      "pageNumberLabel": "Página {current, number} / {total, number}",
+      "previousPageLabel": "Ir a la página anterior",
+      "selectPageSizeLabel": "Número de elementos que se mostrarán por página",
+      "singlePageElementCountLabel": "{total, plural, =0 {0 elemento} =1 {1 elemento} other {{total, number} elementos}}"
+    },
     "result": {
       "accessibility-description": "Resultado obtenido = {percentage, number, ::percent}, es decir, el rodamiento {stage} sobre {totalStage}.",
       "percentage": "{value, number, ::percent}",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -263,13 +263,12 @@
       "close": "Cerrar la notificación"
     },
     "pagination": {
-      "beforeResultsPerPageLabel": "Ver",
-      "multiplePageElementCountLabel": "{start, number}-{end, number} de {total, plural, =0 {0 elemento} =1 {1 elemento} other {{total, number} elementos}}",
-      "nextPageLabel": "Ir a la página siguiente",
-      "pageNumberLabel": "Página {current, number} / {total, number}",
-      "previousPageLabel": "Ir a la página anterior",
-      "selectPageSizeLabel": "Número de elementos que se mostrarán por página",
-      "singlePageElementCountLabel": "{total, plural, =0 {0 elemento} =1 {1 elemento} other {{total, number} elementos}}"
+      "nextPage": "Ir a la página siguiente",
+      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 elemento} =1 {1 elemento} other {{total, number} elementos}}} other {{start, number}-{end, number} sur {total, plural, =0 {0 elemento} =1 {1 elemento} other {{total, number} elementos}}}}",
+      "pageNumber": "Página {current, number} / {total, number}",
+      "pageSize": "Número de elementos que se mostrarán por página",
+      "previousPage": "Ir a la página anterior",
+      "title": "Ver"
     },
     "result": {
       "accessibility-description": "Resultado obtenido = {percentage, number, ::percent}, es decir, el rodamiento {stage} sobre {totalStage}.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -262,6 +262,15 @@
     "notification": {
       "close": "Fermer la notification"
     },
+    "pagination": {
+      "beforeResultsPerPageLabel": "Voir",
+      "multiplePageElementCountLabel": "{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}",
+      "nextPageLabel": "Aller à la page suivante",
+      "pageNumberLabel": "Page {current, number} / {total, number}",
+      "previousPageLabel": "Aller à la page précédente",
+      "selectPageSizeLabel": "Nombre d'élément à afficher par page",
+      "singlePageElementCountLabel": "{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}"
+    },
     "result": {
       "accessibility-description": "Résultat obtenu = {percentage, number, ::percent}, soit le palier {stage} sur {totalStage}",
       "percentage": "{value, number, ::percent}",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -263,13 +263,12 @@
       "close": "Fermer la notification"
     },
     "pagination": {
-      "beforeResultsPerPageLabel": "Voir",
-      "multiplePageElementCountLabel": "{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}",
-      "nextPageLabel": "Aller à la page suivante",
-      "pageNumberLabel": "Page {current, number} / {total, number}",
-      "previousPageLabel": "Aller à la page précédente",
-      "selectPageSizeLabel": "Nombre d'élément à afficher par page",
-      "singlePageElementCountLabel": "{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}"
+      "nextPage": "Aller à la page suivante",
+      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}} other {{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}}}",
+      "pageNumber": "Page {current, number} / {total, number}",
+      "pageSize": "Nombre d'élément à afficher par page",
+      "previousPage": "Aller à la page précédente",
+      "title": "Voir"
     },
     "result": {
       "accessibility-description": "Résultat obtenu = {percentage, number, ::percent}, soit le palier {stage} sur {totalStage}",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -262,6 +262,14 @@
     "notification": {
       "close": "Chiudi la notifica"
     },
+    "pagination": {
+      "nextPage": "Vai alla pagina successiva",
+      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 elementi} =1 {1 elemento} other {{total, number} elementi}}} other {{start, number}-{end, number} su {total, plural, =0 {0 elementi} =1 {1 elemento} other {{total, number} elementi}}}}",
+      "pageNumber": "Pagina {current, number} / {total, number}",
+      "pageSize": "Numero di elementi da visualizzare per pagina",
+      "previousPage": "Vai alla pagina precedente",
+      "title": "Vedi"
+    },
     "result": {
       "accessibility-description": "Risultato ottenuto = {percentage, number, ::percent}, cioè il cuscinetto {stage} su {totalStage}.",
       "percentage": "{value, number, ::percent}",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -262,6 +262,15 @@
     "notification": {
       "close": "Melding sluiten"
     },
+    "pagination": {
+      "beforeResultsPerPageLabel": "Zie",
+      "multiplePageElementCountLabel": "{start, number}-{end, number} van {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}",
+      "nextPageLabel": "Ga naar volgende pagina",
+      "pageNumberLabel": "Pagina {current, number} / {total, number}",
+      "previousPageLabel": "Ga naar vorige pagina",
+      "selectPageSizeLabel": "Selecteer het aantal items per pagina",
+      "singlePageElementCountLabel": "{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}"
+    },
     "result": {
       "accessibility-description": "Verkregen resultaat = {percentage, number, ::percent}, ofwel de succesratio {stage} op {totalStage}",
       "percentage": "{value, number, ::percent}",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -263,13 +263,12 @@
       "close": "Melding sluiten"
     },
     "pagination": {
-      "beforeResultsPerPageLabel": "Zie",
-      "multiplePageElementCountLabel": "{start, number}-{end, number} van {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}",
-      "nextPageLabel": "Ga naar volgende pagina",
-      "pageNumberLabel": "Pagina {current, number} / {total, number}",
-      "previousPageLabel": "Ga naar vorige pagina",
-      "selectPageSizeLabel": "Selecteer het aantal items per pagina",
-      "singlePageElementCountLabel": "{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}"
+      "nextPage": "Ga naar volgende pagina",
+      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}} other {{start, number}-{end, number} sur {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}}}",
+      "pageNumber": "Pagina {current, number} / {total, number}",
+      "pageSize": "Selecteer het aantal items per pagina",
+      "previousPage": "Ga naar volgende pagina",
+      "title": "Zie"
     },
     "result": {
       "accessibility-description": "Verkregen resultaat = {percentage, number, ::percent}, ofwel de succesratio {stage} op {totalStage}",


### PR DESCRIPTION
## ☀️ Problème

Actuellement certaines traduction sont faites dans PixUI. ce qui est dommage car nous ne synchronisons pas les langues disponible sur le design system et les applicatif. 

De plus ce n'est pas au design system de porter de la traduction. 

## ⛱️ Proposition

Ajouter la traduction de la pagination dans les APP

de.json
```
"pagination": {
      "nextPage": "Zur nächsten Seite wechseln",
      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 Elemente} =1 {1 Element} other {{total, number} Elemente}}} other {{start, number}-{end, number} von  {total, plural, =0 {0 Elemente} =1 {1 Element} other {{total, number} Elemente}}}}",
      "pageNumber": "Seite  {current, number} / {total, number}",
      "pageSize": "Anzahl der Elemente pro Seite",
      "previousPage": "Zur vorherigen Seite wechseln",
      "title": "Siehe"
    },
```

en.json
```
"pagination": {
      "nextPage": "Go to next page",
      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}} other {{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}}}",
      "pageNumber": "Page {current, number} / {total, number}",
      "pageSize": "Select the number of items by page",
      "previousPage": "Go to previous page",
      "title": "See"
    },
```

es.json
```
"pagination": {
      "nextPage": "Ir a la página siguiente",
      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 elemento} =1 {1 elemento} other {{total, number} elementos}}} other {{start, number}-{end, number} sur {total, plural, =0 {0 elemento} =1 {1 elemento} other {{total, number} elementos}}}}",
      "pageNumber": "Página {current, number} / {total, number}",
      "pageSize": "Número de elementos que se mostrarán por página",
      "previousPage": "Ir a la página anterior",
      "title": "Ver"
    },
```

fr.json
```
"pagination": {
      "nextPage": "Aller à la page suivante",
      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}} other {{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}}}",
      "pageNumber": "Page {current, number} / {total, number}",
      "pageSize": "Nombre d'élément à afficher par page",
      "previousPage": "Aller à la page précédente",
      "title": "Voir"
    },
```

it.json
```
"pagination": {
      "nextPage": "Vai alla pagina successiva",
      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 elementi} =1 {1 elemento} other {{total, number} elementi}}} other {{start, number}-{end, number} su {total, plural, =0 {0 elementi} =1 {1 elemento} other {{total, number} elementi}}}}",
      "pageNumber": "Pagina {current, number} / {total, number}",
      "pageSize": "Numero di elementi da visualizzare per pagina",
      "previousPage": "Vai alla pagina precedente",
      "title": "Vedi"
    },
```

nl.json
```
  "pagination": {
      "nextPage": "Ga naar volgende pagina",
      "pageElementCount": "{totalPage, plural, =1 {{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}} other {{start, number}-{end, number} sur {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}}}",
      "pageNumber": "Pagina {current, number} / {total, number}",
      "pageSize": "Selecteer het aantal items per pagina",
      "previousPage": "Ga naar volgende pagina",
      "title": "Zie"
    },
```

## 🧴 Remarques

Ajout d'un wrapper pour éviter de recoder x fois le même comportement. Peut être que le start end de la page devrait être porté par l'API et non par un calcul du front. 

Implémentation de 🤡  [ça](https://github.com/1024pix/pix-ui/pull/1028) 🤡 

## 🏊 Pour tester

Faire un tour de PixOrga et vérifier que les paginations se comportent correctement. 