### PR TITLE
[TECH] Ne plus utiliser PixBackgroundHeader dans les composants liés à l'authentification/réconciliation via SSO ou lors du passage d'une campagne

### DIFF
--- a/mon-pix/app/components/campaigns/invited/learner-reconciliation.gjs
+++ b/mon-pix/app/components/campaigns/invited/learner-reconciliation.gjs
@@ -1,4 +1,3 @@
-import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
@@ -111,7 +110,7 @@ export default class LearnerReconciliation extends Component {
   }
 
   <template>
-    <PixBackgroundHeader>
+    <div class="global-page-container learner-reconciliation-page">
       <PixBlock class="learner-reconciliation">
         <header class="learner-reconciliation__title-container" role="banner">
           <h1 class="learner-reconciliation__title">{{t
@@ -141,6 +140,6 @@ export default class LearnerReconciliation extends Component {
           <PixButton @type="submit" @isLoading={{@isLoading}}>{{t "common.actions.lets-go"}}</PixButton>
         </form>
       </PixBlock>
-    </PixBackgroundHeader>
+    </div>
   </template>
 }

--- a/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.gjs
+++ b/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.gjs
@@ -1,4 +1,3 @@
-import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
@@ -91,51 +90,49 @@ export default class FillInParticipantExternalId extends Component {
   }
 
   <template>
-    <main role="main">
-      <PixBackgroundHeader>
-        <PixBlock class="fill-in-participant-external-id">
-          <h1 class="fill-in-participant-external-id__title">{{t "pages.fill-in-participant-external-id.first-title"}}
-          </h1>
-          <p class="fill-in-participant-external-id__announcement">
-            {{t "pages.fill-in-participant-external-id.announcement"}}
-          </p>
+    <main role="main" class="global-page-container fill-in-participant-external-id-page">
+      <PixBlock class="fill-in-participant-external-id">
+        <h1 class="fill-in-participant-external-id__title">{{t "pages.fill-in-participant-external-id.first-title"}}
+        </h1>
+        <p class="fill-in-participant-external-id__announcement">
+          {{t "pages.fill-in-participant-external-id.announcement"}}
+        </p>
 
-          <form {{on "submit" this.submit}} class="fill-in-participant-external-id__form">
-            <PixInput
-              @id="external-id"
-              @value={{this.participantExternalId}}
-              @errorMessage={{this.errorMessage}}
-              @validationStatus={{if this.errorMessage "error"}}
-              @requiredLabel={{true}}
-              {{on "input" this.resetErrorMessage}}
-              {{on "change" this.updateParticipantExternalId}}
-              @subLabel={{this.idPixInputSubLabel}}
-              type={{this.idPixInputType}}
-              aria-autocomplete="none"
-            >
-              <:label>{{@campaign.externalIdLabel}}</:label>
-            </PixInput>
+        <form {{on "submit" this.submit}} class="fill-in-participant-external-id__form">
+          <PixInput
+            @id="external-id"
+            @value={{this.participantExternalId}}
+            @errorMessage={{this.errorMessage}}
+            @validationStatus={{if this.errorMessage "error"}}
+            @requiredLabel={{true}}
+            {{on "input" this.resetErrorMessage}}
+            {{on "change" this.updateParticipantExternalId}}
+            @subLabel={{this.idPixInputSubLabel}}
+            type={{this.idPixInputType}}
+            aria-autocomplete="none"
+          >
+            <:label>{{@campaign.externalIdLabel}}</:label>
+          </PixInput>
 
-            {{#if @campaign.externalIdHelpImageUrl}}
-              <img
-                class="fill-in-participant-external-id__help"
-                src={{@campaign.externalIdHelpImageUrl}}
-                alt={{@campaign.alternativeTextToExternalIdHelpImage}}
-              />
-            {{/if}}
+          {{#if @campaign.externalIdHelpImageUrl}}
+            <img
+              class="fill-in-participant-external-id__help"
+              src={{@campaign.externalIdHelpImageUrl}}
+              alt={{@campaign.alternativeTextToExternalIdHelpImage}}
+            />
+          {{/if}}
 
-            <div class="fill-in-participant-external-id__buttonbar">
-              <PixButton @variant="secondary" @triggerAction={{this.cancel}}>
-                {{t "pages.fill-in-participant-external-id.buttons.cancel"}}
-              </PixButton>
+          <div class="fill-in-participant-external-id__buttonbar">
+            <PixButton @variant="secondary" @triggerAction={{this.cancel}}>
+              {{t "pages.fill-in-participant-external-id.buttons.cancel"}}
+            </PixButton>
 
-              <PixButton @type="submit">
-                {{t "pages.fill-in-participant-external-id.buttons.continue"}}
-              </PixButton>
-            </div>
-          </form>
-        </PixBlock>
-      </PixBackgroundHeader>
+            <PixButton @type="submit">
+              {{t "pages.fill-in-participant-external-id.buttons.continue"}}
+            </PixButton>
+          </div>
+        </form>
+      </PixBlock>
     </main>
   </template>
 }

--- a/mon-pix/app/styles/components/authentication/_oidc-signup-or-login.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-signup-or-login.scss
@@ -1,6 +1,10 @@
 @use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 
+.oidc-signup-or-login-page {
+  padding-top: 68px;
+}
+
 .oidc-signup-or-login-form {
   display: flex;
   flex-direction: column;

--- a/mon-pix/app/styles/components/campaigns/invited/learner-reconciliation.scss
+++ b/mon-pix/app/styles/components/campaigns/invited/learner-reconciliation.scss
@@ -1,5 +1,9 @@
 @use 'pix-design-tokens/typography';
 
+.learner-reconciliation-page {
+  padding-top: 68px;
+}
+
 .learner-reconciliation {
   padding: var(--pix-spacing-10x);
 

--- a/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
+++ b/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
@@ -1,6 +1,10 @@
 @use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 
+.fill-in-participant-external-id-page {
+  padding-top: 68px;
+}
+
 .fill-in-participant-external-id {
   display: flex;
   flex-direction: column;

--- a/mon-pix/app/templates/authentication/oidc-signup-or-login.gjs
+++ b/mon-pix/app/templates/authentication/oidc-signup-or-login.gjs
@@ -1,4 +1,3 @@
-import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
@@ -9,7 +8,7 @@ import LocaleSwitcher from 'mon-pix/components/locale-switcher';
 <template>
   {{pageTitle (t "pages.oidc-signup-or-login.title")}}
 
-  <PixBackgroundHeader>
+  <div class="global-page-container oidc-signup-or-login-page">
     <PixBlock @shadow="light" class="oidc-signup-or-login-form">
       <a href={{@controller.showcase.url}} class="oidc-signup-or-login-form__logo">
         <img src="/images/pix-logo.svg" alt="{{@controller.showcase.linkText}}" />
@@ -40,5 +39,5 @@ import LocaleSwitcher from 'mon-pix/components/locale-switcher';
     {{#if @controller.isInternationalDomain}}
       <LocaleSwitcher />
     {{/if}}
-  </PixBackgroundHeader>
+  </div>
 </template>


### PR DESCRIPTION
## ☀️ Problème

Le composant PixBackgroundHeader est déprécié ; c'était un wrapper pour avoir le fond en dégradé, mais on ne s'en sert plus nulle part.

## ⛱️ Proposition

Dans ces  trois fichiers liés à l'authentification, ne plus utiliser le wrapper PixBackgroundHeader et conserver le PixBlock classique sans le fond avec le dégradé. 

## 🧴 Remarques

On utilise directement 68px pour la marge des blocs car il n'y a pas de variable css correspondant à cet espacement.

## 🏊 Pour tester

- mon-pix/app/templates/authentication/oidc-signup-or-login.gjs
Connectez-vous via SSO ; la page de la "double mire" doit être identique à celle-ci :
<img width="549" height="417" alt="oidc_signup_or_login" src="https://github.com/user-attachments/assets/1cc253c5-d2dc-40fa-9652-5193a2488df9" />


- mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.gjs
Connectez-vous avec les identifiants d'un utilisateur lambda (par exemple justin.compte@example.net)
Cliquez sur "J'ai un code" > PROASSMUL.
Vérifiez que la page du formulaire affiché est identique (contenu et style) à celui-ci : 
<img width="1145" height="533" alt="fill_in_participant_external_id" src="https://github.com/user-attachments/assets/88d3db9c-93f7-4e90-ae72-a72ff96e54fe" />

- mon-pix/app/components/campaigns/invited/learner-reconciliation.gjs
Toujours authentifié avec le compte précédents, cliquez sur "j'ai un code" > PROGENCOL.
Vérifiez que la page du formulaire affiché est identique (contenu et style) à celui-ci :
<img width="1446" height="713" alt="learner_reconciliation" src="https://github.com/user-attachments/assets/f4d5d1d0-9101-44e7-afa8-0635428dac0f" />

