### PR TITLE
[FEATURE] Ajouter le score dans le simulateur SmartRandom️™️

### DIFF
--- a/admin/app/components/smart-random-simulator/tubes-viewer.gjs
+++ b/admin/app/components/smart-random-simulator/tubes-viewer.gjs
@@ -88,6 +88,19 @@ export default class TubesViewer extends Component {
     return skillReward.reward.toFixed(1);
   }
 
+  get competenceHeaderColumnCount() {
+    return this.levels.length + 1;
+  }
+
+  get hasCompetenceGrouping() {
+    return this.args.tubesByCompetence.some((competence) => competence.id);
+  }
+
+  @action
+  getCompetenceLabel(competence) {
+    return competence.index ? `${competence.index} ${competence.name}` : competence.name;
+  }
+
   @action
   toggleShowSkillsRewards() {
     this.showSkillsRewards = !this.showSkillsRewards;
@@ -194,22 +207,36 @@ export default class TubesViewer extends Component {
           </tr>
         </thead>
 
-        <tbody>
-          {{#each @tubes as |tube|}}
-            <tr>
-              <th class="tubes-viewer__table__name">{{tube.name}}</th>
-              {{#each this.levels as |level|}}
-                <td aria-label="{{tube.name}}{{level}}">
-                  <span class="tubes-viewer__table__skill {{this.getSkillStatus tube level}}">
-                    {{#if this.showSkillsRewards}}
-                      {{this.getSkillReward tube level}}
-                    {{/if}}
-                  </span>
-                </td>
-              {{/each}}
-            </tr>
-          {{/each}}
-        </tbody>
+        {{#each @tubesByCompetence as |competence|}}
+          <tbody class="tubes-viewer__table__competence">
+            {{#if this.hasCompetenceGrouping}}
+              <tr class="tubes-viewer__table__competence__row">
+                <th
+                  class="tubes-viewer__table__competence__name {{competence.areaColor}}"
+                  colspan={{this.competenceHeaderColumnCount}}
+                  scope="colgroup"
+                >
+                  {{this.getCompetenceLabel competence}}
+                </th>
+              </tr>
+            {{/if}}
+
+            {{#each competence.tubes as |tube|}}
+              <tr>
+                <th class="tubes-viewer__table__name">{{tube.name}}</th>
+                {{#each this.levels as |level|}}
+                  <td aria-label="{{tube.name}}{{level}}">
+                    <span class="tubes-viewer__table__skill {{this.getSkillStatus tube level}}">
+                      {{#if this.showSkillsRewards}}
+                        {{this.getSkillReward tube level}}
+                      {{/if}}
+                    </span>
+                  </td>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tbody>
+        {{/each}}
 
       </table>
 

--- a/admin/app/components/smart-random-simulator/tubes-viewer.gjs
+++ b/admin/app/components/smart-random-simulator/tubes-viewer.gjs
@@ -155,6 +155,8 @@ export default class TubesViewer extends Component {
 
       <p>Niveau prédit de l'utilisateur: {{if this.predictedLevel this.predictedLevel "N/A"}}</p>
 
+      <p>Score de l'utilisateur: {{@pixScore}} pix</p>
+
       <p>
         <PixCheckbox {{on "change" this.toggleShowSkillsRewards}} checked={{this.showSkillsRewards}}>
           <:label>Afficher la lucrativité des acquis</:label>

--- a/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
+++ b/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
@@ -27,6 +27,7 @@ export default class SmartRandomSimulator extends Controller {
   @tracked assessmentComplete = false;
   @tracked smartRandomLog = null;
   @tracked displayedStepIndex = 0;
+  @tracked pixScore = 0;
 
   @action
   async updateParametersValue(key, value) {
@@ -54,6 +55,7 @@ export default class SmartRandomSimulator extends Controller {
     this.knowledgeElements = [];
     this.returnedChallenges = [];
     this.assessmentComplete = false;
+    this.pixScore = 0;
     return await this.requestNextChallenge();
   }
 
@@ -149,6 +151,7 @@ export default class SmartRandomSimulator extends Controller {
       case 200: {
         const responseBody = await apiResponse.json();
         this.smartRandomLog = responseBody.smartRandomLog;
+        this.pixScore = responseBody.pixScore;
         this.displayedStepIndex = this.smartRandomLog.steps.length - 1;
         if (!responseBody.challenge) {
           this.assessmentComplete = true;
@@ -197,10 +200,11 @@ export default class SmartRandomSimulator extends Controller {
     const currentSkillTested = this.currentChallenge.skill;
     const currentSkillTubeName = this.getTubeNameFromSkillName(currentSkillTested.name);
     const currentChallengeSkillDifficulty = this.currentChallenge.skill.difficulty;
-    const inferredSkills =
+    const inferredSkills = (
       newAnswer.result === ANSWER_STATUSES.OK
         ? this.getLowerLevelSkillsFromSameTube(currentSkillTubeName, currentChallengeSkillDifficulty)
-        : this.getHigherLevelSkillsFromSameTube(currentSkillTubeName, currentChallengeSkillDifficulty);
+        : this.getHigherLevelSkillsFromSameTube(currentSkillTubeName, currentChallengeSkillDifficulty)
+    ).filter((skill) => !this.hasKnowledgeElementForSkill(skill));
 
     const inferredNewKnowledgeElements = inferredSkills.map((skill) => ({
       source: KNOWLEDGE_ELEMENTS_SOURCES.INFERRED,
@@ -213,6 +217,10 @@ export default class SmartRandomSimulator extends Controller {
     }));
 
     this.knowledgeElements = [...this.knowledgeElements, directNewKnowledgeElement, ...inferredNewKnowledgeElements];
+  }
+
+  hasKnowledgeElementForSkill(skill) {
+    return this.knowledgeElements.some((knowledgeElement) => knowledgeElement.skillId === skill.id);
   }
 
   getLowerLevelSkillsFromSameTube(currentSkillTubeName, currentChallengeSkillDifficulty) {

--- a/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
+++ b/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
@@ -10,12 +10,15 @@ const ANSWER_STATUSES = { OK: 'ok', KO: 'ko' };
 const KNOWLEDGE_ELEMENTS_STATUSES = { VALIDATED: 'validated', INVALIDATED: 'invalidated' };
 const KNOWLEDGE_ELEMENTS_SOURCES = { DIRECT: 'direct', INFERRED: 'inferred' };
 
+const UNKNOWN_COMPETENCE = { id: null, index: null, name: 'Hors compétence', areaColor: null };
+
 export default class SmartRandomSimulator extends Controller {
   @service session;
   @service pixToast;
 
   // Simulator parameters
   @tracked skills = [];
+  @tracked competences = [];
   @tracked answers = [];
   @tracked challenges = [];
   @tracked knowledgeElements = [];
@@ -78,6 +81,7 @@ export default class SmartRandomSimulator extends Controller {
       const responseBody = await apiResponse.json();
       this.skills = responseBody.skills;
       this.challenges = responseBody.challenges;
+      this.competences = responseBody.competences ?? [];
       this.pixToast.sendSuccessNotification({
         message: `Données chargées: ${this.skills.length} compétences et ${this.challenges.length} challenges`,
       });
@@ -114,6 +118,31 @@ export default class SmartRandomSimulator extends Controller {
       accumulator[accumulatorIndex].skills.push(skill);
       return accumulator;
     }, []);
+  }
+
+  get tubesByCompetence() {
+    const competenceById = new Map(this.competences.map((competence) => [competence.id, competence]));
+
+    const groupedTubes = this.skillsByTube.reduce((accumulator, tube) => {
+      const competenceId = tube.skills.find((skill) => skill.competenceId)?.competenceId;
+      const competence = competenceById.get(competenceId) ?? UNKNOWN_COMPETENCE;
+
+      const group = accumulator.get(competence.id);
+      if (group) {
+        group.tubes.push(tube);
+        return accumulator;
+      }
+
+      accumulator.set(competence.id, { ...competence, tubes: [tube] });
+      return accumulator;
+    }, new Map());
+
+    return [...groupedTubes.values()]
+      .map((competence) => ({
+        ...competence,
+        tubes: competence.tubes.toSorted((tube, otherTube) => tube.name.localeCompare(otherTube.name)),
+      }))
+      .toSorted(byCompetenceIndex);
   }
 
   get numberOfSkillsStillAvailable() {
@@ -242,4 +271,11 @@ export default class SmartRandomSimulator extends Controller {
   getTubeNameFromSkillName(skillName) {
     return skillName.slice(0, -1);
   }
+}
+
+// Les compétences sans index (celles des acquis saisis à la main) sont reléguées en fin de tableau
+function byCompetenceIndex(competence, otherCompetence) {
+  if (!competence.index) return 1;
+  if (!otherCompetence.index) return -1;
+  return competence.index.localeCompare(otherCompetence.index, undefined, { numeric: true });
 }

--- a/admin/app/styles/components/smart-random-simulator/tubes-viewer.scss
+++ b/admin/app/styles/components/smart-random-simulator/tubes-viewer.scss
@@ -77,6 +77,49 @@
 
   }
 
+  th.tubes-viewer__table__competence__name {
+    position: relative;
+    padding-left: var(--pix-spacing-4x);
+    color: var(--pix-neutral-800);
+    font-size: 0.875rem;
+    background: var(--pix-neutral-20);
+
+    &::before {
+      position: absolute;
+      top: 8px;
+      left: 5px;
+      width: 4px;
+      height: calc(100% - 16px);
+      background-color: var(--pix-primary-700);
+      border-radius: 2px;
+      content: '';
+    }
+
+    &.jaffa::before {
+      background-color: var(--pix-information-light);
+    }
+
+    &.emerald::before {
+      background-color: var(--pix-content-light);
+    }
+
+    &.cerulean::before {
+      background-color: var(--pix-communication-light);
+    }
+
+    &.wild-strawberry::before {
+      background-color: var(--pix-security-light);
+    }
+
+    &.butterfly-bush::before {
+      background-color: var(--pix-environment-light);
+    }
+  }
+
+  tr.tubes-viewer__table__competence__row {
+    height: 32px;
+  }
+
   &__captions {
     margin-top: var(--pix-spacing-3x);
     caption-side: bottom;

--- a/admin/app/templates/authenticated/smart-random-simulator/get-next-challenge.gjs
+++ b/admin/app/templates/authenticated/smart-random-simulator/get-next-challenge.gjs
@@ -45,6 +45,7 @@ import TubesViewer from 'pix-admin/components/smart-random-simulator/tubes-viewe
               @smartRandomLog={{@controller.smartRandomLog}}
               @totalNumberOfSkills={{@controller.skills.length}}
               @numberOfSkillsStillAvailable={{@controller.numberOfSkillsStillAvailable}}
+              @pixScore={{@controller.pixScore}}
               @displayedStepIndex={{@controller.displayedStepIndex}}
               @selectDisplayedStepIndex={{@controller.selectDisplayedStepIndex}}
             />
@@ -67,6 +68,7 @@ import TubesViewer from 'pix-admin/components/smart-random-simulator/tubes-viewe
               @smartRandomLog={{@controller.smartRandomLog}}
               @totalNumberOfSkills={{@controller.skills.length}}
               @numberOfSkillsStillAvailable={{@controller.numberOfSkillsStillAvailable}}
+              @pixScore={{@controller.pixScore}}
               @displayedStepIndex={{@controller.displayedStepIndex}}
               @selectDisplayedStepIndex={{@controller.selectDisplayedStepIndex}}
             />

--- a/admin/app/templates/authenticated/smart-random-simulator/get-next-challenge.gjs
+++ b/admin/app/templates/authenticated/smart-random-simulator/get-next-challenge.gjs
@@ -39,7 +39,7 @@ import TubesViewer from 'pix-admin/components/smart-random-simulator/tubes-viewe
             <Reset @reset={{@controller.reset}} />
 
             <TubesViewer
-              @tubes={{@controller.skillsByTube}}
+              @tubesByCompetence={{@controller.tubesByCompetence}}
               @currentSkillId={{@controller.currentChallenge.skill.id}}
               @knowledgeElements={{@controller.knowledgeElements}}
               @smartRandomLog={{@controller.smartRandomLog}}
@@ -62,7 +62,7 @@ import TubesViewer from 'pix-admin/components/smart-random-simulator/tubes-viewe
             />
 
             <TubesViewer
-              @tubes={{@controller.skillsByTube}}
+              @tubesByCompetence={{@controller.tubesByCompetence}}
               @currentSkillId={{@controller.currentChallenge.skill.id}}
               @knowledgeElements={{@controller.knowledgeElements}}
               @smartRandomLog={{@controller.smartRandomLog}}

--- a/admin/tests/integration/components/smart-random-simulator/tubes-viewer-test.gjs
+++ b/admin/tests/integration/components/smart-random-simulator/tubes-viewer-test.gjs
@@ -8,6 +8,7 @@ module('Integration | Component | SmartRandomSimulator::TubesViewer', function (
 
   let screen;
   const numberOfSkillsStillAvailable = 11;
+  const pixScore = 24;
   const numberOfSkillsFromKe = 2;
   const totalNumberOfSkills = numberOfSkillsStillAvailable + numberOfSkillsFromKe;
   const tubes = [
@@ -320,6 +321,7 @@ module('Integration | Component | SmartRandomSimulator::TubesViewer', function (
           @totalNumberOfSkills={{totalNumberOfSkills}}
           @selectDisplayedStepIndex={{selectDisplayedStepIndex}}
           @numberOfSkillsStillAvailable={{numberOfSkillsStillAvailable}}
+          @pixScore={{pixScore}}
         />
       </template>,
     );
@@ -337,6 +339,10 @@ module('Integration | Component | SmartRandomSimulator::TubesViewer', function (
 
   test('should display the predicted level', async function (assert) {
     assert.dom(screen.getByText("Niveau prédit de l'utilisateur: 2")).exists();
+  });
+
+  test('should display the user pix score', async function (assert) {
+    assert.dom(screen.getByText("Score de l'utilisateur: 24 pix")).exists();
   });
 
   test('should display all translated steps', async function (assert) {

--- a/admin/tests/integration/components/smart-random-simulator/tubes-viewer-test.gjs
+++ b/admin/tests/integration/components/smart-random-simulator/tubes-viewer-test.gjs
@@ -309,11 +309,28 @@ module('Integration | Component | SmartRandomSimulator::TubesViewer', function (
     },
   ];
 
+  const tubesByCompetence = [
+    {
+      id: 'competenceId1',
+      index: '1.1',
+      name: 'Mener une recherche et une veille d’information',
+      areaColor: 'jaffa',
+      tubes: tubes.slice(0, 2),
+    },
+    {
+      id: 'competenceId2',
+      index: '2.4',
+      name: 'S’insérer dans le monde numérique',
+      areaColor: 'emerald',
+      tubes: tubes.slice(2),
+    },
+  ];
+
   hooks.beforeEach(async function () {
     screen = await render(
       <template>
         <TubesViewer
-          @tubes={{tubes}}
+          @tubesByCompetence={{tubesByCompetence}}
           @currentSkillId={{currentSkillId}}
           @knowledgeElements={{knowledgeElements}}
           @smartRandomLog={{smartRandomLog}}
@@ -343,6 +360,45 @@ module('Integration | Component | SmartRandomSimulator::TubesViewer', function (
 
   test('should display the user pix score', async function (assert) {
     assert.dom(screen.getByText("Score de l'utilisateur: 24 pix")).exists();
+  });
+
+  test('should group the tubes under a competence header carrying the area colour', async function (assert) {
+    const firstCompetenceHeader = screen.getByRole('columnheader', {
+      name: '1.1 Mener une recherche et une veille d’information',
+    });
+    const secondCompetenceHeader = screen.getByRole('columnheader', {
+      name: '2.4 S’insérer dans le monde numérique',
+    });
+
+    assert.dom(firstCompetenceHeader).hasClass('jaffa');
+    assert.dom(secondCompetenceHeader).hasClass('emerald');
+    assert.strictEqual(firstCompetenceHeader.getAttribute('colspan'), '9');
+  });
+
+  test('should not display competence headers when no skill carries a competence', async function (assert) {
+    // given
+    const tubesWithoutCompetence = [{ id: null, index: null, name: 'Hors compétence', areaColor: null, tubes }];
+
+    // when
+    const screenWithoutCompetence = await render(
+      <template>
+        <TubesViewer
+          @tubesByCompetence={{tubesWithoutCompetence}}
+          @currentSkillId={{currentSkillId}}
+          @knowledgeElements={{knowledgeElements}}
+          @smartRandomLog={{smartRandomLog}}
+          @displayedStepIndex={{displayedStepIndex}}
+          @totalNumberOfSkills={{totalNumberOfSkills}}
+          @selectDisplayedStepIndex={{selectDisplayedStepIndex}}
+          @numberOfSkillsStillAvailable={{numberOfSkillsStillAvailable}}
+          @pixScore={{pixScore}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.strictEqual(screenWithoutCompetence.queryByText('Hors compétence'), null);
+    assert.dom(screenWithoutCompetence.getByRole('cell', { name: '@outilsRS1' })).exists();
   });
 
   test('should display all translated steps', async function (assert) {

--- a/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
+++ b/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
@@ -31,6 +31,20 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
   };
 
   const getCampaignParamsApiResponseBody = {
+    competences: [
+      {
+        id: 'recsvLz0W2ShyfD63',
+        index: '1.1',
+        name: 'Mener une recherche et une veille d’information',
+        areaColor: 'jaffa',
+      },
+      {
+        id: 'recFpYXCKcyhLI3Nu',
+        index: '2.4',
+        name: 'S’insérer dans le monde numérique',
+        areaColor: 'emerald',
+      },
+    ],
     skills: [
       {
         id: 'rec1al9C9yGMQwK6S',
@@ -130,6 +144,83 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
           ],
         },
       ]);
+    });
+  });
+
+  module('#tubesByCompetence', function () {
+    test('it should group tubes by competence, ordered by competence index then tube name', function (assert) {
+      // given
+      controller.competences = [
+        { id: 'competenceId1', index: '1.1', name: 'Mener une recherche', areaColor: 'jaffa' },
+        { id: 'competenceId21', index: '21.1', name: 'Pix+Édu - Communiquer', areaColor: null },
+      ];
+      controller.skills = [
+        { id: 'skill1', name: '@zebre2', difficulty: 2, competenceId: 'competenceId21' },
+        { id: 'skill2', name: '@requete2', difficulty: 2, competenceId: 'competenceId1' },
+        { id: 'skill3', name: '@abricot1', difficulty: 1, competenceId: 'competenceId21' },
+        { id: 'skill4', name: '@requete3', difficulty: 3, competenceId: 'competenceId1' },
+      ];
+
+      // when
+      const tubesByCompetence = controller.tubesByCompetence;
+
+      // then
+      assert.deepEqual(tubesByCompetence, [
+        {
+          id: 'competenceId1',
+          index: '1.1',
+          name: 'Mener une recherche',
+          areaColor: 'jaffa',
+          tubes: [
+            {
+              name: '@requete',
+              skills: [
+                { id: 'skill2', name: '@requete2', difficulty: 2, competenceId: 'competenceId1' },
+                { id: 'skill4', name: '@requete3', difficulty: 3, competenceId: 'competenceId1' },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'competenceId21',
+          index: '21.1',
+          name: 'Pix+Édu - Communiquer',
+          areaColor: null,
+          tubes: [
+            {
+              name: '@abricot',
+              skills: [{ id: 'skill3', name: '@abricot1', difficulty: 1, competenceId: 'competenceId21' }],
+            },
+            {
+              name: '@zebre',
+              skills: [{ id: 'skill1', name: '@zebre2', difficulty: 2, competenceId: 'competenceId21' }],
+            },
+          ],
+        },
+      ]);
+    });
+
+    test('it should gather tubes of unknown competences in a trailing group', function (assert) {
+      // given
+      controller.competences = [{ id: 'competenceId1', index: '1.1', name: 'Mener une recherche', areaColor: 'jaffa' }];
+      controller.skills = [
+        { id: 'skill1', name: '@requete2', difficulty: 2 },
+        { id: 'skill2', name: '@outilsEval1', difficulty: 1, competenceId: 'competenceId1' },
+      ];
+
+      // when
+      const tubesByCompetence = controller.tubesByCompetence;
+
+      // then
+      assert.strictEqual(tubesByCompetence.length, 2);
+      assert.strictEqual(tubesByCompetence[0].name, 'Mener une recherche');
+      assert.deepEqual(tubesByCompetence[1], {
+        id: null,
+        index: null,
+        name: 'Hors compétence',
+        areaColor: null,
+        tubes: [{ name: '@requete', skills: [{ id: 'skill1', name: '@requete2', difficulty: 2 }] }],
+      });
     });
   });
 
@@ -246,6 +337,7 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
         await controller.loadCampaignParams(1);
         assert.deepEqual(controller.challenges, getCampaignParamsApiResponseBody.challenges);
         assert.deepEqual(controller.skills, getCampaignParamsApiResponseBody.skills);
+        assert.deepEqual(controller.competences, getCampaignParamsApiResponseBody.competences);
       });
       test('it should call success notification service function', async function (assert) {
         // given

--- a/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
+++ b/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
@@ -21,11 +21,13 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
   const getNextChallengeApiResponseBody = {
     challenge: returnedChallenge,
     smartRandomLog: { predictedLevel: 8, steps: [] },
+    pixScore: 12,
   };
 
   const getAssessmentCompleteApiResponseBody = {
     challenge: null,
     smartRandomLog: { predictedLevel: 8, steps: [] },
+    pixScore: 12,
   };
 
   const getCampaignParamsApiResponseBody = {
@@ -184,6 +186,18 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
         assert.ok(controller);
         assert.true(controller.assessmentComplete);
       });
+
+      test('it should store the pix score returned by the API', async function (assert) {
+        // given
+        const apiResponse = new Response(JSON.stringify(getAssessmentCompleteApiResponseBody), { status: 200 });
+        fetchStub.resolves(apiResponse);
+
+        // when
+        await controller.requestNextChallenge();
+
+        // then
+        assert.strictEqual(controller.pixScore, 12);
+      });
     });
 
     module('when api answer is not 200', function () {
@@ -310,6 +324,7 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
         },
       ];
       controller.assessmentComplete = true;
+      controller.pixScore = 12;
       controller.requestNextChallenge = sinon.stub().resolves();
 
       // when
@@ -320,6 +335,7 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
       assert.deepEqual(controller.knowledgeElements, []);
       assert.deepEqual(controller.returnedChallenges, []);
       assert.false(controller.assessmentComplete);
+      assert.strictEqual(controller.pixScore, 0);
       assert.ok(controller.requestNextChallenge.calledOnce);
     });
   });
@@ -502,6 +518,45 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
         },
       ]);
     });
+
+    test('it should not infer knowledge elements on skills already assessed', async function (assert) {
+      // given
+      controller.skills = [
+        { id: 'skill1', name: '@outilsEval1', difficulty: 1 },
+        { id: 'skill2', name: '@outilsEval2', difficulty: 2 },
+        { id: 'skill3', name: '@outilsEval3', difficulty: 3 },
+      ];
+      controller.returnedChallenges = [
+        {
+          id: 'challenge1',
+          locales: ['fr', 'fr-fr'],
+          skill: { id: 'skill1', name: '@outilsEval1', difficulty: 1 },
+          focused: false,
+        },
+      ];
+      controller.requestNextChallenge = sinon.stub().resolves();
+      controller.knowledgeElements = [
+        { source: 'direct', status: 'invalidated', answerId: 111111, skillId: 'skill2' },
+        { source: 'inferred', status: 'invalidated', answerId: 111111, skillId: 'skill3' },
+      ];
+      controller.answers = [];
+      controller.assessmentComplete = false;
+
+      // when
+      await controller.failCurrentChallenge();
+
+      // then
+      assert.deepEqual(controller.knowledgeElements, [
+        { source: 'direct', status: 'invalidated', answerId: 111111, skillId: 'skill2' },
+        { source: 'inferred', status: 'invalidated', answerId: 111111, skillId: 'skill3' },
+        {
+          source: 'direct',
+          status: 'invalidated',
+          answerId: controller.answers[0].id,
+          skillId: 'skill1',
+        },
+      ]);
+    });
   });
 
   module('#succeedCurrentChallenge', function () {
@@ -627,6 +682,45 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
           status: 'validated',
           answerId: controller.answers[0].id,
           skillId: 'skill1',
+        },
+      ]);
+    });
+
+    test('it should not infer knowledge elements on skills already assessed', async function (assert) {
+      // given
+      controller.skills = [
+        { id: 'skill1', name: '@outilsEval1', difficulty: 1 },
+        { id: 'skill2', name: '@outilsEval2', difficulty: 2 },
+        { id: 'skill3', name: '@outilsEval3', difficulty: 3 },
+      ];
+      controller.returnedChallenges = [
+        {
+          id: 'challenge3',
+          locales: ['fr', 'fr-fr'],
+          skill: { id: 'skill3', name: '@outilsEval3', difficulty: 3 },
+          focused: false,
+        },
+      ];
+      controller.requestNextChallenge = sinon.stub().resolves();
+      controller.knowledgeElements = [
+        { source: 'direct', status: 'validated', answerId: 111111, skillId: 'skill2' },
+        { source: 'inferred', status: 'validated', answerId: 111111, skillId: 'skill1' },
+      ];
+      controller.answers = [];
+      controller.assessmentComplete = false;
+
+      // when
+      await controller.succeedCurrentChallenge();
+
+      // then
+      assert.deepEqual(controller.knowledgeElements, [
+        { source: 'direct', status: 'validated', answerId: 111111, skillId: 'skill2' },
+        { source: 'inferred', status: 'validated', answerId: 111111, skillId: 'skill1' },
+        {
+          source: 'direct',
+          status: 'validated',
+          answerId: controller.answers[0].id,
+          skillId: 'skill3',
         },
       ]);
     });

--- a/api/src/evaluation/domain/models/SimulationParameters.js
+++ b/api/src/evaluation/domain/models/SimulationParameters.js
@@ -1,3 +1,6 @@
+import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
+import { calculatePixScore } from '../services/scoring/scoring-service.js';
+
 class SimulationParameters {
   /**
    * @param {KnowledgeElement[]} knowledgeElements
@@ -14,6 +17,24 @@ class SimulationParameters {
     this.challenges = challenges;
     this.locale = locale;
     this.assessmentId = assessmentId;
+  }
+
+  /**
+   * Score de l'utilisateur simulé, calculé comme dans mon-pix : chaque acquis validé rapporte
+   * sa pixValue, le total étant plafonné par compétence.
+   * @returns {number}
+   */
+  get pixScore() {
+    const skillsById = new Map(this.skills.map((skill) => [skill.id, skill]));
+
+    const validatedKnowledgeElements = this.knowledgeElements
+      .filter((knowledgeElement) => knowledgeElement.isValidated && skillsById.has(knowledgeElement.skillId))
+      .map((knowledgeElement) => {
+        const { pixValue, competenceId } = skillsById.get(knowledgeElement.skillId);
+        return new KnowledgeElement({ ...knowledgeElement, earnedPix: pixValue ?? 0, competenceId });
+      });
+
+    return calculatePixScore(validatedKnowledgeElements);
   }
 }
 

--- a/api/src/evaluation/domain/usecases/get-campaign-parameters-for-simulator.js
+++ b/api/src/evaluation/domain/usecases/get-campaign-parameters-for-simulator.js
@@ -3,6 +3,8 @@ const getCampaignParametersForSimulator = async function ({
   locale,
   campaignRepository,
   challengeRepository,
+  competenceRepository,
+  areaRepository,
 }) {
   const campaign = await campaignRepository.get(campaignId);
   const skills = await campaignRepository.findSkills({ campaignId: campaign.id });
@@ -24,7 +26,23 @@ const getCampaignParametersForSimulator = async function ({
       responsive: challenge.responsive,
     };
   });
-  return { skills, challenges: sanitizedChallenges };
+  const competences = await findCompetencesOfSkills({ skills, locale, competenceRepository, areaRepository });
+  return { skills, challenges: sanitizedChallenges, competences };
+};
+
+const findCompetencesOfSkills = async ({ skills, locale, competenceRepository, areaRepository }) => {
+  const competenceIds = [...new Set(skills.map(({ competenceId }) => competenceId).filter(Boolean))];
+  const competences = await competenceRepository.findByRecordIds({ competenceIds, locale });
+
+  const areaIds = [...new Set(competences.map(({ areaId }) => areaId).filter(Boolean))];
+  const areas = await areaRepository.findByRecordIds({ areaIds, locale });
+  const areaColorById = new Map(areas.map(({ id, color }) => [id, color]));
+
+  return competences
+    .map(({ id, index, name, areaId }) => ({ id, index, name, areaColor: areaColorById.get(areaId) ?? null }))
+    .sort((competence, otherCompetence) =>
+      competence.index.localeCompare(otherCompetence.index, undefined, { numeric: true }),
+    );
 };
 
 export { getCampaignParametersForSimulator };

--- a/api/src/evaluation/domain/usecases/get-next-challenge-for-simulator.js
+++ b/api/src/evaluation/domain/usecases/get-next-challenge-for-simulator.js
@@ -5,7 +5,7 @@ import { getSmartRandomLog, logStep } from '../services/smart-random-log-service
  * @param {simulationParameters: SimulationParameters} simulationParameters
  * @param pickChallengeService
  * @param smartRandomService
- * @returns {Promise<{challenge: Challenge | null, smartRandomLog: SmartRandomLog}}
+ * @returns {Promise<{challenge: Challenge | null, smartRandomLog: SmartRandomLog, pixScore: number}}
  */
 const getNextChallengeForSimulator = function ({ simulationParameters, pickChallengeService, smartRandomService }) {
   const { possibleSkillsForNextChallenge, hasAssessmentEnded } = smartRandomService.getPossibleSkillsForNextChallenge({
@@ -23,6 +23,7 @@ const getNextChallengeForSimulator = function ({ simulationParameters, pickChall
     return {
       challenge: null,
       smartRandomLog: getSmartRandomLog(),
+      pixScore: simulationParameters.pixScore,
     };
   }
 
@@ -34,7 +35,7 @@ const getNextChallengeForSimulator = function ({ simulationParameters, pickChall
 
   logStep(STEPS_NAMES.RANDOM_PICK, [challenge.skill]);
 
-  return { challenge, smartRandomLog: getSmartRandomLog() };
+  return { challenge, smartRandomLog: getSmartRandomLog(), pixScore: simulationParameters.pixScore };
 };
 
 export { getNextChallengeForSimulator };

--- a/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
@@ -201,6 +201,30 @@ describe('Acceptance | API | Smart Random Simulator', function () {
           expect(JSON.parse(response.payload).smartRandomLog).to.exist;
         });
       });
+
+      context('when the user has validated some skills', function () {
+        it('should return the pix score earned by the simulated user', async function () {
+          // given
+          const payload = buildPayload();
+          payload.data.attributes.skills[0].pixValue = 2.6;
+          payload.data.attributes.skills[0].competenceId = 'competenceId';
+          payload.data.attributes.knowledgeElements[0].skillId = 'recoaijndozia123';
+
+          const options = {
+            method: 'POST',
+            url: '/api/admin/smart-random-simulator/get-next-challenge',
+            headers: generateAuthenticatedUserRequestHeaders({ userId }),
+            payload,
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(JSON.parse(response.payload).pixScore).to.equal(2);
+        });
+      });
     });
   });
 });

--- a/api/tests/evaluation/integration/domain/usecases/get-campaign-parameters-for-simulator_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-campaign-parameters-for-simulator_test.js
@@ -62,7 +62,63 @@ describe('Integration | Domain | UseCases | get-campaign-parameters-for-simulato
           }),
         ],
         challenges: [],
+        competences: [],
       });
+    });
+
+    it('should return the competences covered by the campaign skills, ordered by index', async function () {
+      // given
+      const campaignId = 100001;
+      databaseBuilder.factory.learningContent.buildArea({ id: 'areaId1', color: 'jaffa' });
+      databaseBuilder.factory.learningContent.buildArea({ id: 'areaId2', color: 'emerald' });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'competenceId21',
+        index: '21.1',
+        name_i18n: { fr: 'Pix+Édu - Communiquer' },
+        areaId: 'areaId1',
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'competenceId2',
+        index: '2.4',
+        name_i18n: { fr: 'S’insérer dans le monde numérique' },
+        areaId: 'areaId2',
+      });
+      databaseBuilder.factory.learningContent.buildSkill({
+        id: 'skillIdPixEdu',
+        status: 'actif',
+        competenceId: 'competenceId21',
+      });
+      databaseBuilder.factory.learningContent.buildSkill({
+        id: 'skillIdPix',
+        status: 'actif',
+        competenceId: 'competenceId2',
+      });
+      databaseBuilder.factory.buildCampaign({ id: campaignId });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillIdPixEdu' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillIdPix' });
+      await databaseBuilder.commit();
+
+      // when
+      const { competences } = await evaluationUsecases.getCampaignParametersForSimulator({
+        campaignId,
+        locale: 'fr',
+      });
+
+      // then
+      expect(competences).to.deep.equal([
+        {
+          id: 'competenceId2',
+          index: '2.4',
+          name: 'S’insérer dans le monde numérique',
+          areaColor: 'emerald',
+        },
+        {
+          id: 'competenceId21',
+          index: '21.1',
+          name: 'Pix+Édu - Communiquer',
+          areaColor: 'jaffa',
+        },
+      ]);
     });
   });
 });

--- a/api/tests/evaluation/unit/domain/models/SimulationParameters_test.js
+++ b/api/tests/evaluation/unit/domain/models/SimulationParameters_test.js
@@ -1,0 +1,141 @@
+import { SimulationParameters } from '../../../../../src/evaluation/domain/models/SimulationParameters.js';
+import { MAX_REACHABLE_PIX_BY_COMPETENCE } from '../../../../../src/shared/constants.js';
+import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { Skill } from '../../../../../src/shared/domain/models/Skill.js';
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Evaluation | Domain | Models | SimulationParameters', function () {
+  describe('#pixScore', function () {
+    it('returns 0 when no knowledge element has been created', function () {
+      // given
+      const simulationParameters = new SimulationParameters({
+        knowledgeElements: [],
+        skills: [domainBuilder.buildSkill({ id: 'skillId', pixValue: 4, competenceId: 'competenceId' })],
+      });
+
+      // when
+      const pixScore = simulationParameters.pixScore;
+
+      // then
+      expect(pixScore).to.equal(0);
+    });
+
+    it('sums the pix value of the skills validated by the user', function () {
+      // given
+      const skills = [
+        domainBuilder.buildSkill({ id: 'skill1', pixValue: 2.5, competenceId: 'competence1' }),
+        domainBuilder.buildSkill({ id: 'skill2', pixValue: 3.7, competenceId: 'competence1' }),
+      ];
+      const simulationParameters = new SimulationParameters({
+        knowledgeElements: [
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill1',
+            status: KnowledgeElement.StatusType.VALIDATED,
+            earnedPix: 0,
+            competenceId: null,
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill2',
+            status: KnowledgeElement.StatusType.VALIDATED,
+            earnedPix: 0,
+            competenceId: null,
+          }),
+        ],
+        skills,
+      });
+
+      // when
+      const pixScore = simulationParameters.pixScore;
+
+      // then
+      expect(pixScore).to.equal(6);
+    });
+
+    it('ignores invalidated knowledge elements', function () {
+      // given
+      const simulationParameters = new SimulationParameters({
+        knowledgeElements: [
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill1',
+            status: KnowledgeElement.StatusType.VALIDATED,
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill2',
+            status: KnowledgeElement.StatusType.INVALIDATED,
+          }),
+        ],
+        skills: [
+          domainBuilder.buildSkill({ id: 'skill1', pixValue: 4, competenceId: 'competence1' }),
+          domainBuilder.buildSkill({ id: 'skill2', pixValue: 4, competenceId: 'competence1' }),
+        ],
+      });
+
+      // when
+      const pixScore = simulationParameters.pixScore;
+
+      // then
+      expect(pixScore).to.equal(4);
+    });
+
+    it('ignores knowledge elements which are not related to a simulated skill', function () {
+      // given
+      const simulationParameters = new SimulationParameters({
+        knowledgeElements: [
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'unknownSkill',
+            status: KnowledgeElement.StatusType.VALIDATED,
+          }),
+        ],
+        skills: [domainBuilder.buildSkill({ id: 'skill1', pixValue: 4, competenceId: 'competence1' })],
+      });
+
+      // when
+      const pixScore = simulationParameters.pixScore;
+
+      // then
+      expect(pixScore).to.equal(0);
+    });
+
+    it('caps the score of each competence', function () {
+      // given
+      const skills = Array.from({ length: 20 }, (_, index) =>
+        domainBuilder.buildSkill({ id: `skill${index}`, pixValue: 4, competenceId: 'competence1' }),
+      );
+      const simulationParameters = new SimulationParameters({
+        knowledgeElements: skills.map((skill) =>
+          domainBuilder.buildKnowledgeElement({
+            skillId: skill.id,
+            status: KnowledgeElement.StatusType.VALIDATED,
+          }),
+        ),
+        skills,
+      });
+
+      // when
+      const pixScore = simulationParameters.pixScore;
+
+      // then
+      expect(pixScore).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
+    });
+
+    it('defaults the pix value of a skill without pixValue to 0', function () {
+      // given
+      const simulationParameters = new SimulationParameters({
+        knowledgeElements: [
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill1',
+            status: KnowledgeElement.StatusType.VALIDATED,
+          }),
+        ],
+        skills: [new Skill({ id: 'skill1' })],
+      });
+
+      // when
+      const pixScore = simulationParameters.pixScore;
+
+      // then
+      expect(pixScore).to.equal(0);
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/usecases/get-campaign-parameters-for-simulator_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-campaign-parameters-for-simulator_test.js
@@ -8,6 +8,8 @@ describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
   describe('#getCampaignParametersForSimulator', function () {
     let campaignRepository;
     let challengeRepository;
+    let competenceRepository;
+    let areaRepository;
 
     beforeEach(function () {
       campaignRepository = {
@@ -17,6 +19,14 @@ describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
 
       challengeRepository = {
         findOperativeChallengeDtosBySkillsAndLocales: sinon.stub(),
+      };
+
+      competenceRepository = {
+        findByRecordIds: sinon.stub().resolves([]),
+      };
+
+      areaRepository = {
+        findByRecordIds: sinon.stub().resolves([]),
       };
     });
 
@@ -73,6 +83,8 @@ describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
         locale: 'fr',
         campaignRepository,
         challengeRepository,
+        competenceRepository,
+        areaRepository,
       });
 
       // then
@@ -107,7 +119,95 @@ describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
             responsive: 'Tablette',
           },
         ],
+        competences: [],
       });
+    });
+
+    it('should return the competences covered by the campaign skills, ordered by index and coloured by area', async function () {
+      // given
+      const skills = [
+        domainBuilder.buildSkill({ id: 'skillId1', competenceId: 'competenceId21' }),
+        domainBuilder.buildSkill({ id: 'skillId2', competenceId: 'competenceId2' }),
+        domainBuilder.buildSkill({ id: 'skillId3', competenceId: 'competenceId2' }),
+      ];
+      campaignRepository.get.withArgs(12).resolves({ id: 12 });
+      campaignRepository.findSkills.withArgs({ campaignId: 12 }).resolves(skills);
+      challengeRepository.findOperativeChallengeDtosBySkillsAndLocales.resolves([]);
+
+      competenceRepository.findByRecordIds
+        .withArgs({ competenceIds: ['competenceId21', 'competenceId2'], locale: 'fr' })
+        .resolves([
+          domainBuilder.buildCompetence({
+            id: 'competenceId21',
+            index: '21.1',
+            name: 'Pix+Édu - Communiquer',
+            areaId: 'areaId21',
+          }),
+          domainBuilder.buildCompetence({
+            id: 'competenceId2',
+            index: '2.4',
+            name: "S'insérer dans le monde numérique",
+            areaId: 'areaId2',
+          }),
+        ]);
+
+      areaRepository.findByRecordIds
+        .withArgs({ areaIds: ['areaId21', 'areaId2'], locale: 'fr' })
+        .resolves([
+          domainBuilder.buildArea({ id: 'areaId2', color: 'emerald' }),
+          domainBuilder.buildArea({ id: 'areaId21', color: null }),
+        ]);
+
+      // when
+      const { competences } = await getCampaignParametersForSimulator({
+        campaignId: 12,
+        locale: 'fr',
+        campaignRepository,
+        challengeRepository,
+        competenceRepository,
+        areaRepository,
+      });
+
+      // then
+      expect(competences).to.deep.equal([
+        {
+          id: 'competenceId2',
+          index: '2.4',
+          name: "S'insérer dans le monde numérique",
+          areaColor: 'emerald',
+        },
+        {
+          id: 'competenceId21',
+          index: '21.1',
+          name: 'Pix+Édu - Communiquer',
+          areaColor: null,
+        },
+      ]);
+    });
+
+    it('should ignore skills without competence', async function () {
+      // given
+      const skills = [domainBuilder.buildSkill({ id: 'skillId1', competenceId: null })];
+      campaignRepository.get.withArgs(12).resolves({ id: 12 });
+      campaignRepository.findSkills.withArgs({ campaignId: 12 }).resolves(skills);
+      challengeRepository.findOperativeChallengeDtosBySkillsAndLocales.resolves([]);
+
+      // when
+      const { competences } = await getCampaignParametersForSimulator({
+        campaignId: 12,
+        locale: 'fr',
+        campaignRepository,
+        challengeRepository,
+        competenceRepository,
+        areaRepository,
+      });
+
+      // then
+      expect(competenceRepository.findByRecordIds).to.have.been.calledWithExactly({
+        competenceIds: [],
+        locale: 'fr',
+      });
+      expect(competences).to.deep.equal([]);
     });
   });
 });

--- a/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-simulator_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-simulator_test.js
@@ -20,7 +20,7 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
     });
 
     context('when smartRandomService hasAssessmentEnded property is true', function () {
-      it('should only return smartRandom details and call only smartRandomService', function () {
+      it('should only return smartRandom details and the user pix score, and call only smartRandomService', function () {
         // given
         smartRandomService.getPossibleSkillsForNextChallenge.returns({
           hasAssessmentEnded: true,
@@ -28,9 +28,10 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
         });
 
         // when
-        const { challenge } = getNextChallengeForSimulator({
+        const { challenge, pixScore } = getNextChallengeForSimulator({
           simulationParameters: {
             answers: [],
+            pixScore: 12,
           },
           pickChallengeService,
           smartRandomService,
@@ -40,6 +41,7 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
         expect(smartRandomService.getPossibleSkillsForNextChallenge).to.have.been.calledOnce;
         expect(pickChallengeService.pickChallenge).to.not.have.been.called;
         expect(challenge).to.be.null;
+        expect(pixScore).to.equal(12);
       });
     });
 
@@ -53,6 +55,7 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
           assessmentId: Symbol('assessmentId'),
           locale: Symbol('locale'),
           answers: [],
+          pixScore: 12,
         };
 
         smartRandomService.getPossibleSkillsForNextChallenge.returns({
@@ -79,6 +82,7 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
         });
 
         expect(result.challenge).to.equal(pickChallengeServiceResult);
+        expect(result.pixScore).to.equal(12);
       });
     });
   });


### PR DESCRIPTION
## ☀️ Problème

On aimerait avoir de la visibilité sur l'évolution du score d'un utilisateur lors du passage d'une campagne 

## ⛱️ Proposition

On calcule le score cote API et on le retourne au front.

## 🧴 Remarques

J'ai aussi trié les acquis par competence pour avoir un peu plus de visibilité. 

## 🏊 Pour tester

https://admin-pr17239.review.pix.fr/smart-random-simulator/get-next-challenge 

=> campagne 6000
=> Démarrer la simulation

- le score de l'utilisateur doit s'afficher
- les acquis doivent être rangés par compétence.