### PR TITLE
[TECH] Logger les erreurs de validation de création d’utilisateur (PIX-23998)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -38,22 +38,22 @@ const createUser = async function ({
   userValidator,
   passwordValidator,
 }) {
-  await _assertValidData({
-    password,
-    user,
-    userRepository,
-    userValidator,
-    passwordValidator,
-  });
-
-  const userHasValidatedPixTermsOfService = user.cgu === true;
-  if (userHasValidatedPixTermsOfService) {
-    user.lastTermsOfServiceValidatedAt = new Date();
-  }
-
-  const hashedPassword = await cryptoService.hashPassword(password);
-
   const { savedUser, token } = await DomainTransaction.execute(async () => {
+    await _assertValidData({
+      password,
+      user,
+      userRepository,
+      userValidator,
+      passwordValidator,
+    });
+
+    const userHasValidatedPixTermsOfService = user.cgu === true;
+    if (userHasValidatedPixTermsOfService) {
+      user.lastTermsOfServiceValidatedAt = new Date();
+    }
+
+    const hashedPassword = await cryptoService.hashPassword(password);
+
     const savedUser = await userService.createUserWithPassword({
       user,
       locale,

--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -1,7 +1,10 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
+import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
 import { createAccountCreationEmail } from '../emails/create-account-creation.email.js';
 import { InvalidOrAlreadyUsedEmailError } from '../errors.js';
+
+const logger = child('iam:create-user', { event: SCOPES.IAM });
 
 /**
  * @param {Object} params
@@ -154,6 +157,9 @@ async function _assertValidData({ password, user, userRepository, userValidator,
 
   if (validationErrors.some((error) => error instanceof Error)) {
     const relevantErrors = validationErrors.filter((error) => error instanceof Error);
+    for (const error of relevantErrors) {
+      logger.warn(error, 'user creation validation error');
+    }
     throw EntityValidationError.fromMultipleEntityValidationErrors(relevantErrors);
   }
 }


### PR DESCRIPTION
## ☀️ Problème

On manque d’informations sur les erreurs HTTP 422 de la route de création d’utilisateur.

## ⛱️ Proposition

Ajouter des logs de niveau WARN pour les erreurs de validation (celles correspondant au statut 422) lors de la création d’un utilisateur.

## 🧴 Remarques

:warning: Les logs de validation peuvent être très nombreux et il faudra réévaluer la pertinence de leur présence.

## 🏊 Pour tester

Essayer de créer un utilisateur avec des problèmes de validation :
 - email déjà utilisé
 - nom ou prénom très long