### PR TITLE
[FEATURE] Mettre à dispo le nom du domaine de la compétence via Maddo (PIX-23762)

### DIFF
--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -98,6 +98,7 @@ const register = async function (server) {
                       .items(
                         Joi.object({
                           competenceId: Joi.string().description('ID de la compétence auquel appartient le sujet'),
+                          areaName: Joi.string().description('Nom du domaine auquel appartient la compétence'),
                           id: Joi.string().description('ID du sujet'),
                           maxLevel: Joi.number().description('Niveau maximum atteignable dans cette campagne'),
                           reachedLevel: Joi.number().description('Niveau obtenu dans cette campagne'),

--- a/api/src/maddo/domain/models/TubeCoverage.js
+++ b/api/src/maddo/domain/models/TubeCoverage.js
@@ -1,7 +1,8 @@
 export class TubeCoverage {
-  constructor({ id, competenceId, maxLevel, reachedLevel, practicalDescription, practicalTitle }) {
+  constructor({ id, competenceId, areaName, maxLevel, reachedLevel, practicalDescription, practicalTitle }) {
     this.id = id;
     this.competenceId = competenceId;
+    this.areaName = areaName;
     this.maxLevel = maxLevel;
     this.reachedLevel = reachedLevel;
     this.practicalDescription = practicalDescription;

--- a/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
@@ -88,6 +88,7 @@ class TubeCoverage {
    * @typedef {Object} TubeCoverageArgs
    * @property {string} id
    * @property {string} competenceId
+   * @property {string} areaName
    * @property {string} title
    * @property {string} description
    * @property {number} maxLevel
@@ -98,9 +99,10 @@ class TubeCoverage {
    * @param {TubeCoverageArgs} args
    */
 
-  constructor({ id, competenceId, title, description, maxLevel, reachedLevel }) {
+  constructor({ id, competenceId, areaName, title, description, maxLevel, reachedLevel }) {
     this.id = id;
     this.competenceId = competenceId;
+    this.areaName = areaName;
     this.practicalTitle = title;
     this.practicalDescription = description;
     this.maxLevel = maxLevel;

--- a/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
+++ b/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
@@ -10,9 +10,11 @@ class CampaignResultLevelsPerTubesAndCompetences {
     this.learningContent = learningContent;
 
     this.#tubesWithLevels = learningContent.tubes.map((tube) => {
+      const competence = this.learningContent.competences.find((competence) => competence.id === tube.competenceId);
       return new TubeResultForKnowledgeElementSnapshots({
         tube,
-        competence: this.learningContent.competences.find((competence) => competence.id === tube.competenceId),
+        competence,
+        area: this.learningContent.findAreaOfCompetence(competence),
       });
     });
 

--- a/api/src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js
+++ b/api/src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js
@@ -6,6 +6,7 @@ class TubeResultForKnowledgeElementSnapshots {
   id;
   competenceId;
   competenceName;
+  areaName;
   title;
   description;
   maxLevel = 0;
@@ -13,12 +14,13 @@ class TubeResultForKnowledgeElementSnapshots {
   #sum = 0;
   #count = 0;
 
-  constructor({ tube, competence } = {}) {
+  constructor({ tube, competence, area } = {}) {
     this.#tube = tube;
     this.#competence = competence;
     this.id = tube.id;
     this.competenceId = competence.id;
     this.competenceName = competence.name;
+    this.areaName = area?.name;
     this.title = tube.practicalTitle;
     this.description = tube.practicalDescription;
     this.maxLevel = tube.maxLevel;

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
@@ -105,6 +105,7 @@ export class Badge {
  * @property {string} id
  * @property {string} competenceId
  * @property {string} competenceName
+ * @property {string} [areaName]
  * @property {string} title
  * @property {string} description
  * @property {number} maxLevel
@@ -117,15 +118,17 @@ export class TubeCoverage {
    * @param {string} args.id
    * @param {string} args.competenceId
    * @param {string} args.competenceName
+   * @param {string} [args.areaName]
    * @param {string} args.title
    * @param {string} args.description
    * @param {number} args.maxLevel
    * @param {number} args.reachedLevel
    */
-  constructor({ id, competenceId, competenceName, title, description, maxLevel, reachedLevel }) {
+  constructor({ id, competenceId, competenceName, areaName, title, description, maxLevel, reachedLevel }) {
     this.id = id;
     this.competenceId = competenceId;
     this.competenceName = competenceName;
+    this.areaName = areaName;
     this.title = title;
     this.description = description;
     this.maxLevel = maxLevel;

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -141,6 +141,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
               domainBuilder.maddo.buildTubeCoverage({
                 id: tube.id,
                 competenceId,
+                areaName: 'name Domaine A',
                 maxLevel: 2,
                 reachedLevel: 1,
                 practicalDescription: tube.practicalDescription_i18n['fr'],
@@ -357,6 +358,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
               domainBuilder.maddo.buildTubeCoverage({
                 id: tube.id,
                 competenceId,
+                areaName: 'name Domaine A',
                 maxLevel: 2,
                 reachedLevel: 2,
                 practicalDescription: tube.practicalDescription_i18n['fr'],
@@ -548,6 +550,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
               domainBuilder.maddo.buildTubeCoverage({
                 id: tube.id,
                 competenceId,
+                areaName: 'name Domaine A',
                 maxLevel: 2,
                 reachedLevel: 2,
                 practicalDescription: tube.practicalDescription_i18n['fr'],

--- a/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
@@ -199,6 +199,7 @@ describe('Integration | Application | campaign-api', function () {
           tubes: [
             {
               competenceId: 'competenceIdA',
+              areaName: 'name Domaine A',
               id: 'tubeIdA',
               maxLevel: 2,
               reachedLevel: 1,

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
@@ -81,6 +81,7 @@ describe('Integration | UseCase | find-paginated-filtered-organization-campaigns
           id: 'tubeIdA',
           competenceId: 'competenceIdA',
           competenceName: 'name FR Compétence A',
+          areaName: undefined,
           title: 'practicalTitle FR Tube A',
           description: 'practicalDescription FR Tube A',
           maxLevel: 2,

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
@@ -31,8 +31,8 @@ describe('Integration | UseCase | get-campaign-participations', function () {
     it('should return all participations for given campaign', async function () {
       // given
       const frameworkId = learningContent.buildFramework().id;
-      const areaId = learningContent.buildArea({ frameworkId }).id;
-      const competence = learningContent.buildCompetence({ areaId });
+      const area = learningContent.buildArea({ frameworkId });
+      const competence = learningContent.buildCompetence({ areaId: area.id });
       const tube = learningContent.buildTube({ competenceId: competence.id });
       const skillId = learningContent.buildSkill({
         id: 'recSkillId1',
@@ -171,6 +171,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
               id: tube.id,
               competenceId: competence.id,
               competenceName: competence.name_i18n[FRENCH_SPOKEN],
+              areaName: area.name,
               maxLevel: 2,
               reachedLevel: 1,
               description: tube.practicalDescription_i18n[FRENCH_SPOKEN],
@@ -218,8 +219,8 @@ describe('Integration | UseCase | get-campaign-participations', function () {
     it('should return all participations with tubes computed from knowledge element snapshots', async function () {
       // given
       const frameworkId = learningContent.buildFramework().id;
-      const areaId = learningContent.buildArea({ frameworkId }).id;
-      const competence = learningContent.buildCompetence({ areaId });
+      const area = learningContent.buildArea({ frameworkId });
+      const competence = learningContent.buildCompetence({ areaId: area.id });
       const tube = learningContent.buildTube({ competenceId: competence.id });
       const skill = learningContent.buildSkill({
         tubeId: tube.id,
@@ -308,6 +309,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
               id: tube.id,
               competenceId: competence.id,
               competenceName: competence.name_i18n[FRENCH_SPOKEN],
+              areaName: area.name,
               title: tube.practicalTitle_i18n[FRENCH_SPOKEN],
               description: tube.practicalDescription_i18n[FRENCH_SPOKEN],
               maxLevel: 1,
@@ -330,6 +332,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
               id: tube.id,
               competenceId: competence.id,
               competenceName: competence.name_i18n[FRENCH_SPOKEN],
+              areaName: area.name,
               title: tube.practicalTitle_i18n[FRENCH_SPOKEN],
               description: tube.practicalDescription_i18n[FRENCH_SPOKEN],
               maxLevel: 1,

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
@@ -60,7 +60,7 @@ describe('Unit | Domain | Models | CampaignResultLevelsPerTubesAndCompetences', 
         description: 'description compétence 2',
       });
 
-      const area = domainBuilder.buildArea({ id: 'recArea1', frameworkId: framework.id });
+      const area = domainBuilder.buildArea({ id: 'recArea1', frameworkId: framework.id, name: 'domaine 1' });
       const thematic1 = domainBuilder.buildThematic({
         id: 'thematic1',
         competenceId: 'competence1',
@@ -119,6 +119,7 @@ describe('Unit | Domain | Models | CampaignResultLevelsPerTubesAndCompetences', 
           id: 'tube1',
           competenceId: 'competence1',
           competenceName: 'compétence 1',
+          areaName: 'domaine 1',
           title: 'tube 1',
           description: 'tube 1 description',
           maxLevel: 2,
@@ -128,6 +129,7 @@ describe('Unit | Domain | Models | CampaignResultLevelsPerTubesAndCompetences', 
           id: 'tube2',
           competenceId: 'competence2',
           competenceName: 'compétence 2',
+          areaName: 'domaine 1',
           title: 'tube 2',
           description: 'tube 2 description',
           maxLevel: 4,

--- a/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
@@ -4,7 +4,7 @@ import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', function () {
-  let competence, tube, knowledgeElementSnapshots;
+  let competence, area, tube, knowledgeElementSnapshots;
 
   describe('Constructor', function () {
     beforeEach(function () {
@@ -47,6 +47,11 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         description: 'description compétence 1',
       });
 
+      area = domainBuilder.buildArea({
+        id: 'recArea1',
+        name: 'domaine 1',
+      });
+
       const user1ke1 = domainBuilder.buildKnowledgeElement({
         status: KnowledgeElement.StatusType.VALIDATED,
         skillId: 'recSkillWeb1',
@@ -82,6 +87,7 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         const tubeResult = new TubeResultForKnowledgeElementSnapshots({
           tube,
           competence,
+          area,
         });
 
         tubeResult.addKnowledgeElementSnapshots(knowledgeElementSnapshots);
@@ -94,6 +100,7 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         // mean level = user1 (level 1: ok, level 2: ko), user2: (level 1: ok)
         expect(tubeResult.meanLevel).equal(1);
         expect(tubeResult.competenceName).equal(competence.name);
+        expect(tubeResult.areaName).equal(area.name);
       });
     });
 
@@ -103,6 +110,7 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         const tubeResult = new TubeResultForKnowledgeElementSnapshots({
           tube,
           competence,
+          area,
         });
 
         //then
@@ -113,6 +121,7 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         expect(tubeResult.maxLevel).equal(2);
         expect(tubeResult.meanLevel).equal(0);
         expect(tubeResult.competenceName).equal(competence.name);
+        expect(tubeResult.areaName).equal(area.name);
       });
     });
   });

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignReport_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignReport_test.js
@@ -51,6 +51,7 @@ describe('Unit | Domain | Models | CampaignReport', function () {
       // then
       expect(campaignReport.tubes).to.deep.equal([
         {
+          areaName: undefined,
           competenceId: 'competence1',
           competenceName: 'compétence 1',
           description: 'tube 1 description',

--- a/api/tests/tooling/domain-builder/factory/maddo/build-tube-coverage.js
+++ b/api/tests/tooling/domain-builder/factory/maddo/build-tube-coverage.js
@@ -3,6 +3,7 @@ import { TubeCoverage } from '../../../../../src/maddo/domain/models/TubeCoverag
 export function buildTubeCoverage({
   id,
   competenceId,
+  areaName,
   maxLevel,
   reachedLevel,
   practicalDescription,
@@ -11,6 +12,7 @@ export function buildTubeCoverage({
   return new TubeCoverage({
     id,
     competenceId,
+    areaName,
     maxLevel,
     reachedLevel,
     practicalDescription,


### PR DESCRIPTION
## ☀️ Problème

Un partenaire a besoin de données supplémentaires : le domaine auquel appartient les compétences des tubes contenus dans les participations

## ⛱️ Proposition

Mettre à dispo la donnée du nom du domaine lié aux compétences validées ou non (`areaName`) au niveau des tubes dans les participations

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

- lancer Maddo
- récupérer les données de participations et vérifier que le `areaName` est bien présent

```
API_URL="http://localhost:3000/api"
CAMPAIGN_ID=6000
ORGA_ID=1005

# Get AUTH SECRET

# SECRET=$(scalingo --app pix-api-review-pr17250 env-get 'AUTH_SECRET')
SECRET=the-password-must-be-at-least-32-characters-long
EXPIRY=$(($(date +%s) + 36000))  # 10 hours from now

# JWT Header
HEADER='{"alg":"HS256","typ":"JWT"}'
HEADER_B64=$(echo -n "$HEADER" | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# JWT Payload
PAYLOAD="{\"client_id\":\"poleEmploi\",\"source\":\"pix-client\",\"scope\":\"campaigns men-dashboard meta replication\",\"exp\":$EXPIRY}"
PAYLOAD_B64=$(echo -n "$PAYLOAD" | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# JWT Signature
SIGNATURE_B64=$(echo -n "${HEADER_B64}.${PAYLOAD_B64}" | openssl dgst -sha256 -hmac "$SECRET" -binary | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# Complete JWT token
TOKEN="${HEADER_B64}.${PAYLOAD_B64}.${SIGNATURE_B64}"

echo $TOKEN

curl -X GET "${API_URL}/campaigns/${CAMPAIGN_ID}/participations" \
  -H "Authorization: Bearer ${TOKEN}" \
  -H "Cookie: locale=fr" \
  -H "Content-Type: application/json" | jq
```