### PR TITLE
[FEATURE] Modifier l'API legalDocuments pour lire les CGU de Pix Certif avec et sans feature toggle

### DIFF
--- a/api/src/legal-documents/domain/models/LegalDocumentStatus.js
+++ b/api/src/legal-documents/domain/models/LegalDocumentStatus.js
@@ -51,6 +51,17 @@ export class LegalDocumentStatus {
     });
   }
 
+  static buildForLegacyPixCertifTos({ pixCertifTermsOfServiceAccepted, lastPixCertifTermsOfServiceValidatedAt }) {
+    if (!pixCertifTermsOfServiceAccepted) {
+      return new LegalDocumentStatus({ status: STATUS.REQUESTED, acceptedAt: null, documentPath: null });
+    }
+    return new LegalDocumentStatus({
+      status: STATUS.ACCEPTED,
+      acceptedAt: lastPixCertifTermsOfServiceValidatedAt,
+      documentPath: null,
+    });
+  }
+
   static notApplicable() {
     return new LegalDocumentStatus({
       status: STATUS.NOT_APPLICABLE,

--- a/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
@@ -14,7 +14,7 @@ import { LegalDocumentType } from '../models/LegalDocumentType.js';
  * @throws {Error} If no legal document version is found for the type and service.
  */
 
-const { PIX_APP } = LegalDocumentService.VALUES;
+const { PIX_APP, PIX_CERTIF } = LegalDocumentService.VALUES;
 const { TOS } = LegalDocumentType.VALUES;
 
 const getLegalDocumentStatusByUserId = async ({
@@ -31,7 +31,11 @@ const getLegalDocumentStatusByUserId = async ({
   LegalDocumentType.assert(type);
 
   const isPixAppTos = service === PIX_APP && type === TOS;
+  const isPixCertifTos = service === PIX_CERTIF && type === TOS;
   const isNewVersioningEnabled = await featureToggles.get('newPixAppLegalDocumentsVersioning');
+  const isNewPixCertifLegalDocumentsVersioningEnabled = await featureToggles.get(
+    'newPixCertifLegalDocumentsVersioning',
+  );
 
   if (!isNewVersioningEnabled && isPixAppTos) {
     const user = await userRepository.getPixAppLegacyCguByUserId(userId);
@@ -40,6 +44,13 @@ const getLegalDocumentStatusByUserId = async ({
       mustValidateTermsOfService: user.mustValidateTermsOfService,
       lastTermsOfServiceValidatedAt: user.lastTermsOfServiceValidatedAt,
     });
+
+    return legalDocumentStatus;
+  }
+
+  if (!isNewPixCertifLegalDocumentsVersioningEnabled && isPixCertifTos) {
+    const user = await userRepository.getPixCertifLegacyTosByUserId(userId);
+    const legalDocumentStatus = LegalDocumentStatus.buildForLegacyPixCertifTos(user);
 
     return legalDocumentStatus;
   }

--- a/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
@@ -17,7 +17,10 @@ import { LegalDocumentType } from '../models/LegalDocumentType.js';
 const { PIX_APP, PIX_CERTIF } = LegalDocumentService.VALUES;
 const { TOS } = LegalDocumentType.VALUES;
 
-const getLegalDocumentStatusByUserId = async ({
+const isNewPixAppLegalDocumentsVersioning = featureToggles.use('newPixAppLegalDocumentsVersioning');
+const isNewPixCertifLegalDocumentsVersioningEnabled = featureToggles.use('newPixCertifLegalDocumentsVersioning');
+
+export async function getLegalDocumentStatusByUserId({
   userId,
   service,
   type,
@@ -26,33 +29,20 @@ const getLegalDocumentStatusByUserId = async ({
   userScoRepository,
   userAcceptanceRepository,
   logger,
-}) => {
+}) {
   LegalDocumentService.assert(service);
   LegalDocumentType.assert(type);
 
   const isPixAppTos = service === PIX_APP && type === TOS;
-  const isPixCertifTos = service === PIX_CERTIF && type === TOS;
-  const isNewVersioningEnabled = await featureToggles.get('newPixAppLegalDocumentsVersioning');
-  const isNewPixCertifLegalDocumentsVersioningEnabled = await featureToggles.get(
-    'newPixCertifLegalDocumentsVersioning',
-  );
-
-  if (!isNewVersioningEnabled && isPixAppTos) {
+  if (isPixAppTos && !isNewPixAppLegalDocumentsVersioning.value) {
     const user = await userRepository.getPixAppLegacyCguByUserId(userId);
-    const legalDocumentStatus = LegalDocumentStatus.buildForLegacyPixAppCgu({
-      cgu: user.cgu,
-      mustValidateTermsOfService: user.mustValidateTermsOfService,
-      lastTermsOfServiceValidatedAt: user.lastTermsOfServiceValidatedAt,
-    });
-
-    return legalDocumentStatus;
+    return LegalDocumentStatus.buildForLegacyPixAppCgu(user);
   }
 
-  if (!isNewPixCertifLegalDocumentsVersioningEnabled && isPixCertifTos) {
+  const isPixCertifTos = service === PIX_CERTIF && type === TOS;
+  if (isPixCertifTos && !isNewPixCertifLegalDocumentsVersioningEnabled.value) {
     const user = await userRepository.getPixCertifLegacyTosByUserId(userId);
-    const legalDocumentStatus = LegalDocumentStatus.buildForLegacyPixCertifTos(user);
-
-    return legalDocumentStatus;
+    return LegalDocumentStatus.buildForLegacyPixCertifTos(user);
   }
 
   const lastLegalDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ service, type });
@@ -80,6 +70,4 @@ const getLegalDocumentStatusByUserId = async ({
   }
 
   return legalDocumentStatus;
-};
-
-export { getLegalDocumentStatusByUserId };
+}

--- a/api/src/legal-documents/infrastructure/repositories/user.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user.repository.js
@@ -6,7 +6,7 @@ export async function isAnonymous(userId) {
   const user = await knexConnection('users').select('isAnonymous').where({ id: userId }).first();
   if (!user) throw new UserNotFoundError();
   return user.isAnonymous;
-};
+}
 
 export async function getPixAppLegacyCguByUserId(userId) {
   const knexConnection = DomainTransaction.getConnection();
@@ -16,7 +16,7 @@ export async function getPixAppLegacyCguByUserId(userId) {
     .first();
   if (!user) throw new UserNotFoundError();
   return user;
-};
+}
 
 export async function getPixCertifLegacyTosByUserId(userId) {
   const knexConnection = DomainTransaction.getConnection();
@@ -26,7 +26,7 @@ export async function getPixCertifLegacyTosByUserId(userId) {
     .first();
   if (!user) throw new UserNotFoundError();
   return user;
-};
+}
 
 export async function acceptLegacyPixAppTermsOfService(id) {
   const knexConn = DomainTransaction.getConnection();

--- a/api/src/legal-documents/infrastructure/repositories/user.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user.repository.js
@@ -1,14 +1,14 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserNotFoundError } from '../../../shared/domain/errors.js';
 
-const isAnonymous = async (userId) => {
+export async function isAnonymous(userId) {
   const knexConnection = DomainTransaction.getConnection();
   const user = await knexConnection('users').select('isAnonymous').where({ id: userId }).first();
   if (!user) throw new UserNotFoundError();
   return user.isAnonymous;
 };
 
-const getPixAppLegacyCguByUserId = async (userId) => {
+export async function getPixAppLegacyCguByUserId(userId) {
   const knexConnection = DomainTransaction.getConnection();
   const user = await knexConnection('users')
     .select('cgu', 'mustValidateTermsOfService', 'lastTermsOfServiceValidatedAt')
@@ -18,7 +18,7 @@ const getPixAppLegacyCguByUserId = async (userId) => {
   return user;
 };
 
-const getPixCertifLegacyTosByUserId = async (userId) => {
+export async function getPixCertifLegacyTosByUserId(userId) {
   const knexConnection = DomainTransaction.getConnection();
   const user = await knexConnection('users')
     .select('pixCertifTermsOfServiceAccepted', 'lastPixCertifTermsOfServiceValidatedAt')
@@ -28,7 +28,7 @@ const getPixCertifLegacyTosByUserId = async (userId) => {
   return user;
 };
 
-const acceptLegacyPixAppTermsOfService = async function (id) {
+export async function acceptLegacyPixAppTermsOfService(id) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('users').where({ id }).update({
     lastTermsOfServiceValidatedAt: new Date(),
@@ -36,6 +36,4 @@ const acceptLegacyPixAppTermsOfService = async function (id) {
     updatedAt: new Date(),
     cgu: true,
   });
-};
-
-export { acceptLegacyPixAppTermsOfService, getPixAppLegacyCguByUserId, getPixCertifLegacyTosByUserId, isAnonymous };
+}

--- a/api/src/legal-documents/infrastructure/repositories/user.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user.repository.js
@@ -18,6 +18,16 @@ const getPixAppLegacyCguByUserId = async (userId) => {
   return user;
 };
 
+const getPixCertifLegacyTosByUserId = async (userId) => {
+  const knexConnection = DomainTransaction.getConnection();
+  const user = await knexConnection('users')
+    .select('pixCertifTermsOfServiceAccepted', 'lastPixCertifTermsOfServiceValidatedAt')
+    .where({ id: userId })
+    .first();
+  if (!user) throw new UserNotFoundError();
+  return user;
+};
+
 const acceptLegacyPixAppTermsOfService = async function (id) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('users').where({ id }).update({
@@ -28,4 +38,4 @@ const acceptLegacyPixAppTermsOfService = async function (id) {
   });
 };
 
-export { acceptLegacyPixAppTermsOfService, getPixAppLegacyCguByUserId, isAnonymous };
+export { acceptLegacyPixAppTermsOfService, getPixAppLegacyCguByUserId, getPixCertifLegacyTosByUserId, isAnonymous };

--- a/api/tests/legal-documents/integration/domain/usecases/get-legal-document-status-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/get-legal-document-status-by-user-id.usecase.test.js
@@ -6,7 +6,7 @@ import { featureToggles } from '../../../../../src/shared/infrastructure/feature
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 
-const { PIX_APP, PIX_ORGA } = LegalDocumentService.VALUES;
+const { PIX_APP, PIX_ORGA, PIX_CERTIF } = LegalDocumentService.VALUES;
 const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Legal documents | Domain | Use case | get-legal-document-status-by-user-id', function () {
@@ -327,6 +327,58 @@ describe('Integration | Legal documents | Domain | Use case | get-legal-document
           // then
           expect(result).to.be.an.instanceOf(LegalDocumentStatus);
           expect(result.status).to.equal(STATUS.NOT_APPLICABLE);
+        });
+      });
+    });
+  });
+
+  context('when service is pix-certif', function () {
+    context('when feature toggle is disabled', function () {
+      beforeEach(async function () {
+        await featureToggles.set('newPixCertifLegalDocumentsVersioning', false);
+      });
+
+      context('when pixCertifTermsOfServiceAccepted=true', function () {
+        it('returns accepted status', async function () {
+          // given
+          const acceptedAt = new Date('2024-06-01');
+          const user = databaseBuilder.factory.buildUser({
+            pixCertifTermsOfServiceAccepted: true,
+            lastPixCertifTermsOfServiceValidatedAt: acceptedAt,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_CERTIF,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result).to.deep.equal({ status: STATUS.ACCEPTED, acceptedAt, documentPath: null });
+        });
+      });
+
+      context('when pixCertifTermsOfServiceAccepted=false', function () {
+        it('returns requested status', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser({
+            pixCertifTermsOfServiceAccepted: false,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await usecases.getLegalDocumentStatusByUserId({
+            userId: user.id,
+            service: PIX_CERTIF,
+            type: TOS,
+          });
+
+          // then
+          expect(result).to.be.an.instanceOf(LegalDocumentStatus);
+          expect(result).to.deep.equal({ status: STATUS.REQUESTED, acceptedAt: null, documentPath: null });
         });
       });
     });


### PR DESCRIPTION
## ☀️ Problème

Dans le cadre de la nouvelle gestion du versioning des CGU pour Pix App, nous avons besoin d’utiliser l'API permettant de récupérer les informations de CGU d’un utilisateur. 

Cette API doit prendre en charge la lecture de ces données selon le nouveau modèle (legal document) mais aussi selon l’ancien (table users) en fonction du feature toggle.

## ⛱️ Proposition

CAS 1 : Si le feature toggle newPixCertifLegalDocumentsVersioning est désactivé et service=pix-app et type=TOS.

On doit utiliser l’ancien système des CGU (table users) pour faire la correspondance avec le nouveau système (legal document), selon les règles suivantes :
Si pixCertifTermsOfServiceAccepted=false, alors status=requested
Si pixCertifTermsOfServiceAccepted=true, alors status=requested


CAS 2 : Si le feature toggle newPixAppLegalDocumentsVersioning est activé.
Le code actuel gère déjà ce cas, pas de modification induite par cette PR

## 🧴 Remarques

RAS

## 🏊 Pour tester

Pas de changement attendu en production, l'api interne getLegalDocumentStatusByUserId n'est pas encore appelée par la route `GET /api/certification-point-of-contacts/me`
