### PR TITLE
[TECH] Sortir les erreurs jetées dans les repositories de `certification/evaluation` (PIX-24022).

### DIFF
--- a/api/src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js
@@ -6,6 +6,7 @@
  * @typedef {import('../index.js').ComplementaryCertificationBadgesRepository} ComplementaryCertificationBadgesRepository
  */
 
+import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
 import { AnswerCollectionForScoring } from '../../../../shared/domain/models/AnswerCollectionForScoring.js';
 import { ComplementaryCertificationCourseResult } from '../../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { ComplementaryCertificationKeys } from '../../../../shared/domain/models/ComplementaryCertificationKeys.js';
@@ -21,6 +22,7 @@ import { ComplementaryCertificationScoringWithoutComplementaryReferential } from
  * @param {ComplementaryCertificationCourseResultRepository} params.complementaryCertificationCourseResultRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {ComplementaryCertificationBadgesRepository} params.complementaryCertificationBadgesRepository
+ * @throws {CertificationCandidateNotFoundError}
  */
 export async function scoreComplementaryCertificationV2({
   certificationCourseId,
@@ -47,6 +49,10 @@ export async function scoreComplementaryCertificationV2({
   const candidate = await candidateRepository.findByAssessmentId({
     assessmentId: assessmentResult.assessmentId,
   });
+
+  if (!candidate) {
+    throw new CertificationCandidateNotFoundError();
+  }
 
   const complementaryCertificationKey =
     candidate.subscriptionFramework !== SCOPES.CORE ? candidate.subscriptionFramework : undefined;

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
@@ -10,6 +10,7 @@
  */
 
 import CertificationCancelled from '../../../../../../src/shared/domain/events/CertificationCancelled.js';
+import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
 import { AnswerCollectionForScoring } from '../../../../shared/domain/models/AnswerCollectionForScoring.js';
 import { CompetenceMark } from '../../../../shared/domain/models/CompetenceMark.js';
 import { ReproducibilityRate } from '../../../../shared/domain/models/ReproducibilityRate.js';
@@ -82,6 +83,7 @@ export async function handleV2CertificationScoring({
  * @param {CertificationAssessment} params.certificationAssessment
  * @param {ScoringService} params.scoringService
  * @param {CandidateRepository} params.candidateRepository
+ * @throws {CertificationCandidateNotFoundError}
  */
 export async function calculateCertificationAssessmentScore({
   certificationAssessment,
@@ -93,6 +95,10 @@ export async function calculateCertificationAssessmentScore({
   const candidate = await candidateRepository.findByAssessmentId({
     assessmentId: certificationAssessment.id,
   });
+
+  if (!candidate) {
+    throw new CertificationCandidateNotFoundError();
+  }
 
   const testedCompetences = await _getTestedCompetences({
     userId: certificationAssessment.userId,

--- a/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
@@ -10,7 +10,7 @@
  * @typedef {import('../../../../shared/domain/models/Assessment.js').Assessment} Assessment
  */
 
-import { AssessmentEndedError } from '../../../../shared/domain/errors.js';
+import { AssessmentEndedError, NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationChallenge } from '../../../shared/domain/models/CertificationChallenge.js';
 import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js';
 
@@ -26,6 +26,8 @@ import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js'
  * @param {PickChallengeService} params.pickChallengeService
  *
  * @returns {Promise<string>} next challenge id
+ * @throws {NotFoundError}
+ * @throws {AssessmentEndedError}
  */
 export async function getNextChallenge({
   assessmentId,
@@ -38,6 +40,10 @@ export async function getNextChallenge({
   pickChallengeService,
 }) {
   const assessmentSheet = await assessmentSheetRepository.getByAssessmentId(assessmentId);
+
+  if (!assessmentSheet) {
+    throw new NotFoundError(`No AssessmentSheet found for assessmentId ${assessmentId}`);
+  }
 
   const validatedLiveAlertChallengeIds = await _getValidatedLiveAlertChallengeIds({
     assessmentId: assessmentSheet.assessmentId,

--- a/api/src/certification/evaluation/domain/usecases/rescore-v2-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/rescore-v2-certification.js
@@ -6,7 +6,7 @@
  * @typedef {import('./index.js').SessionRepository} SessionRepository
  * @typedef {import('./index.js').Services} Services
  */
-import { NotFinalizedSessionError } from '../../../../shared/domain/errors.js';
+import { NotFinalizedSessionError, NotFoundError } from '../../../../shared/domain/errors.js';
 import CertificationCancelled from '../../../../shared/domain/events/CertificationCancelled.js';
 import { CertificationCourseUnrejected } from '../../../../shared/domain/events/CertificationCourseUnrejected.js';
 import CertificationUncancelled from '../../../../shared/domain/events/CertificationUncancelled.js';
@@ -77,11 +77,16 @@ export async function rescoreV2Certification({
  * @param {SessionRepository} params.sessionRepository
  *
  * @returns {Promise<void>}
+ * @throws {NotFoundError}
  * @throws {NotFinalizedSessionError}
  * @throws {SessionAlreadyPublishedError}
  */
 async function _verifySessionIsPublishable({ certificationCourseId, sessionRepository }) {
   const session = await sessionRepository.getByCertificationCourseId({ certificationCourseId });
+
+  if (!session) {
+    throw new NotFoundError(`Session does not exist for certificationCourseId ${certificationCourseId}`);
+  }
 
   if (!session.isFinalized) {
     throw new NotFinalizedSessionError();

--- a/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
@@ -133,6 +133,7 @@ export async function scoreV3Certification({
  * @param {SessionRepository} params.sessionRepository
  *
  * @returns {Promise<void>}
+ * @throws {NotFoundError}
  * @throws {NotFinalizedSessionError}
  * @throws {SessionAlreadyPublishedError}
  */
@@ -143,6 +144,10 @@ async function _verifyCertificationIsScorable({
   sessionRepository,
 }) {
   const session = await sessionRepository.getByCertificationCourseId({ certificationCourseId });
+
+  if (!session) {
+    throw new NotFoundError('Session does not exist');
+  }
 
   if (session.isPublished) {
     throw new SessionAlreadyPublishedError();

--- a/api/src/certification/evaluation/domain/usecases/simulate-capacity-from-score.js
+++ b/api/src/certification/evaluation/domain/usecases/simulate-capacity-from-score.js
@@ -1,10 +1,18 @@
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CapacitySimulator } from '../models/CapacitySimulator.js';
 
+/**
+ * @throws {NotFoundError}
+ */
 export async function simulateCapacityFromScore({ score, date, scoringConfigurationRepository }) {
   const v3CertificationScoring = await scoringConfigurationRepository.getLatestByDateAndLocale({
     locale: 'fr-fr',
     date,
   });
+
+  if (!v3CertificationScoring) {
+    throw new NotFoundError(`No certification scoring configuration found for date ${date.toISOString()}`);
+  }
 
   const certificationScoringIntervals = v3CertificationScoring.intervals;
   const maxReachableLevel = v3CertificationScoring.maxReachableLevel;

--- a/api/src/certification/evaluation/domain/usecases/simulate-score-from-capacity.js
+++ b/api/src/certification/evaluation/domain/usecases/simulate-score-from-capacity.js
@@ -1,10 +1,18 @@
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ScoringSimulator } from '../models/ScoringSimulator.js';
 
+/**
+ * @throws {NotFoundError}
+ */
 export async function simulateScoreFromCapacity({ capacity, date, scoringConfigurationRepository }) {
   const v3CertificationScoring = await scoringConfigurationRepository.getLatestByDateAndLocale({
     locale: 'fr-fr',
     date,
   });
+
+  if (!v3CertificationScoring) {
+    throw new NotFoundError(`No certification scoring configuration found for date ${date.toISOString()}`);
+  }
 
   const certificationScoringIntervals = v3CertificationScoring.intervals;
   const maxReachableLevel = v3CertificationScoring.maxReachableLevel;

--- a/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
@@ -1,5 +1,4 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as answerRepository from '../../../../shared/infrastructure/repositories/answer-repository.js';
 import { AssessmentSheet } from '../../domain/models/AssessmentSheet.js';
 
@@ -16,12 +15,17 @@ export async function findByCertificationCourseId(certificationCourseId) {
   });
 }
 
+/**
+ * @param {number} assessmentId
+ * @returns {Promise<AssessmentSheet|null>} the assessment sheet, or null when no assessment matches
+ */
 export async function getByAssessmentId(assessmentId) {
   const data = await baseQuery().where('assessments.id', '=', assessmentId).first();
 
   if (!data) {
-    throw new NotFoundError();
+    return null;
   }
+
   const answers = await answerRepository.findByAssessment(data.assessmentId);
 
   answers.sort((a, b) => a.createdAt - b.createdAt);

--- a/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
@@ -16,7 +16,6 @@ const VALIDATED_STATUS = 'validé';
  */
 export async function findActiveFlashCompatible({ locale, version }) {
   const knexConn = DomainTransaction.getConnection();
-  _assertLocaleIsDefined(locale);
   const cacheKey = `findActiveFlashCompatible({ versionId: ${version?.id}, locale: ${locale} })`;
 
   const calibrations = await knexConn
@@ -110,12 +109,6 @@ export async function getAllCalibratedChallenges({ version }) {
 
 function _byId(challenge1, challenge2) {
   return challenge1.id < challenge2.id ? -1 : 1;
-}
-
-function _assertLocaleIsDefined(locale) {
-  if (!locale) {
-    throw new Error('Locale shall be defined');
-  }
 }
 
 async function loadCalibratedSkillsMap(lcmsChallengeDtos) {

--- a/api/src/certification/evaluation/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/candidate-repository.js
@@ -26,8 +26,7 @@ import { Candidate } from '../../domain/models/Candidate.js';
  * @function
  * @param {object} params
  * @param {number} params.assessmentId
- * @returns {Promise<Candidate>}
- * @throws {CertificationCandidateNotFoundError}
+ * @returns {Promise<Candidate|null>} the candidate, or null when no candidate matches
  */
 export async function findByAssessmentId({ assessmentId }) {
   const knexConn = DomainTransaction.getConnection();
@@ -56,7 +55,7 @@ export async function findByAssessmentId({ assessmentId }) {
     .first();
 
   if (!result) {
-    throw new CertificationCandidateNotFoundError();
+    return null;
   }
 
   return _toDomain(result);

--- a/api/src/certification/evaluation/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/candidate-repository.js
@@ -1,6 +1,5 @@
 // @ts-check
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CertificationCandidateNotFoundError } from '../../../shared/domain/errors.js';
 import { Candidate } from '../../domain/models/Candidate.js';
 
 /**
@@ -66,8 +65,7 @@ export async function findByAssessmentId({ assessmentId }) {
  * @param {object} params
  * @param {number} params.userId
  * @param {number} params.sessionId
- * @returns {Promise<Candidate>}
- * @throws {CertificationCandidateNotFoundError}
+ * @returns {Promise<Candidate|null>} the candidate, or null when no candidate matches
  */
 export async function findByUserIdAndSessionId({ userId, sessionId }) {
   const knexConn = DomainTransaction.getConnection();
@@ -94,7 +92,7 @@ export async function findByUserIdAndSessionId({ userId, sessionId }) {
     .first();
 
   if (!result) {
-    throw new CertificationCandidateNotFoundError();
+    return null;
   }
 
   return _toDomain(result);

--- a/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
@@ -1,10 +1,16 @@
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as versionApi from '../../../configuration/application/api/version-api.js';
 import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 import { V3CertificationScoring } from '../../domain/models/V3CertificationScoring.js';
 
+/**
+ * @param {object} params
+ * @param {string} params.locale
+ * @param {Date} params.date
+ * @returns {Promise<V3CertificationScoring|null>} the scoring configuration, or null when no fully
+ * configured certification version applies at that date
+ */
 export async function getLatestByDateAndLocale({ locale, date }) {
   const certificationVersion = await versionApi.getByFrameworkAndDate({ date, framework: Frameworks.CORE });
 
@@ -14,7 +20,7 @@ export async function getLatestByDateAndLocale({ locale, date }) {
     !certificationVersion.globalScoringConfiguration ||
     !certificationVersion.minimumAnswersRequiredToValidateACertification
   ) {
-    throw new NotFoundError(`No certification scoring configuration found for date ${date.toISOString()}`);
+    return null;
   }
 
   const allAreas = await areaRepository.list();

--- a/api/src/certification/evaluation/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/session-repository.js
@@ -1,7 +1,11 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Session } from '../../domain/models/Session.js';
 
+/**
+ * @param {object} params
+ * @param {number} params.certificationCourseId
+ * @returns {Promise<Session|null>} the session, or null when no certification course matches
+ */
 export async function getByCertificationCourseId({ certificationCourseId }) {
   const knexConn = DomainTransaction.getConnection();
   const sessionDTO = await knexConn('sessions')
@@ -15,7 +19,7 @@ export async function getByCertificationCourseId({ certificationCourseId }) {
     .first();
 
   if (!sessionDTO) {
-    throw new NotFoundError('Certification course does not exist');
+    return null;
   }
 
   return _toDomain(sessionDTO);

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
@@ -1,11 +1,9 @@
 import * as assessmentSheetRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Certification | Evaluation | Infrastructure | Repositories | AssessmentSheetRepository', function () {
   let certificationCourseId, assessmentId, userId, versionId, answer1;
@@ -152,15 +150,15 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
     });
 
     context('when the assessment does not exist', function () {
-      it('returns a not found error', async function () {
+      it('returns null', async function () {
         // given
         const unknownAssessmentId = 123;
 
         // when
-        const error = await catchErr(assessmentSheetRepository.getByAssessmentId)(unknownAssessmentId);
+        const assessmentSheet = await assessmentSheetRepository.getByAssessmentId(unknownAssessmentId);
 
         // then
-        expect(error).to.be.instanceOf(NotFoundError);
+        expect(assessmentSheet).to.be.null;
       });
     });
   });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
@@ -555,20 +555,6 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       expect(flashCompatibleChallenges[0].discriminant).to.equal(certificationFrameworksChallenge.discriminant);
     });
 
-    context('when locale is not defined', function () {
-      it('should throw an Error', async function () {
-        // given
-        databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
-        await databaseBuilder.commit();
-
-        // when
-        const err = await catchErr(calibratedChallengeRepository.findActiveFlashCompatible)({});
-
-        // then
-        expect(err.message).to.equal('Locale shall be defined');
-      });
-    });
-
     context('when locale is defined', function () {
       context('when no active flash compatible challenges found', function () {
         it('should return an empty array', async function () {

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/candidate-repository_test.js
@@ -154,7 +154,7 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
     });
 
     describe('when certification candidate is not found', function () {
-      it('should throw a certification candidate not found error', async function () {
+      it('should return null', async function () {
         // given
         const session = databaseBuilder.factory.buildSession();
         const user = databaseBuilder.factory.buildUser();
@@ -179,12 +179,12 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
         await databaseBuilder.commit();
 
         // when
-        const error = await catchErr(candidateRepository.findByAssessmentId)({
+        const candidate = await candidateRepository.findByAssessmentId({
           assessmentId: 4659,
         });
 
         // then
-        expect(error).to.be.an.instanceOf(CertificationCandidateNotFoundError);
+        expect(candidate).to.be.null;
       });
     });
 

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/candidate-repository_test.js
@@ -1,11 +1,9 @@
 import * as candidateRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/candidate-repository.js';
-import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/shared/domain/errors.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Evaluation | Integration | Repository | candidate', function () {
   describe('#findByAssessmentId', function () {
@@ -293,7 +291,7 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
     });
 
     context('when certification candidate is not found', function () {
-      it('should throw a certification candidate not found error', async function () {
+      it('should return null', async function () {
         // given
         const session = databaseBuilder.factory.buildSession();
         const user = databaseBuilder.factory.buildUser();
@@ -310,13 +308,13 @@ describe('Certification | Evaluation | Integration | Repository | candidate', fu
         await databaseBuilder.commit();
 
         // when
-        const error = await catchErr(candidateRepository.findByUserIdAndSessionId)({
+        const candidate = await candidateRepository.findByUserIdAndSessionId({
           sessionId: session.id + 1,
           userId: user.id,
         });
 
         // then
-        expect(error).to.be.an.instanceOf(CertificationCandidateNotFoundError);
+        expect(candidate).to.be.null;
       });
     });
   });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
@@ -5,11 +5,9 @@ import {
 } from '../../../../../../src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { PIX_ORIGIN } from '../../../../../../src/shared/constants.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Evaluation | Integration | Repositories | scoring-configuration-repository', function () {
   describe('#getLatestByDateAndLocale', function () {
@@ -76,28 +74,28 @@ describe('Certification | Evaluation | Integration | Repositories | scoring-conf
     });
 
     describe('when the date is before the scoring configurations', function () {
-      it('should throw a NotFoundError', async function () {
+      it('should return null', async function () {
         // given
         const date = new Date('2018-06-01T08:00:00Z');
 
         // when
-        const error = await catchErr(getLatestByDateAndLocale)({ locale: 'fr-fr', date });
+        const result = await getLatestByDateAndLocale({ locale: 'fr-fr', date });
 
-        expect(error).to.be.instanceOf(NotFoundError);
-        expect(error.message).to.equal(`No certification scoring configuration found for date ${date.toISOString()}`);
+        // then
+        expect(result).to.be.null;
       });
     });
 
     describe('when the configuration is missing a scoring value', function () {
-      it('should throw a NotFoundError', async function () {
+      it('should return null', async function () {
         // given
         const date = new Date('2019-04-12T08:00:00Z');
 
         // when
-        const error = await catchErr(getLatestByDateAndLocale)({ locale: 'fr-fr', date });
+        const result = await getLatestByDateAndLocale({ locale: 'fr-fr', date });
 
-        expect(error).to.be.instanceOf(NotFoundError);
-        expect(error.message).to.equal(`No certification scoring configuration found for date ${date.toISOString()}`);
+        // then
+        expect(result).to.be.null;
       });
     });
 

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/session-repository_test.js
@@ -1,9 +1,7 @@
 import * as sessionRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/session-repository.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Evaluation | Integration | Infrastructure | Repositories | Session', function () {
   describe('#getByCertificationCourseId', function () {
@@ -34,14 +32,14 @@ describe('Certification | Evaluation | Integration | Infrastructure | Repositori
     });
 
     context('when the certification does not exist', function () {
-      it('should throw a not found error', async function () {
+      it('should return null', async function () {
         // given, when
-        const error = await catchErr(sessionRepository.getByCertificationCourseId)({
+        const session = await sessionRepository.getByCertificationCourseId({
           certificationCourseId: 123,
         });
 
         // then
-        expect(error).to.be.an.instanceof(NotFoundError);
+        expect(session).to.be.null;
       });
     });
   });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/score-complementary-certification-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/score-complementary-certification-v2_test.js
@@ -2,11 +2,13 @@ import range from 'lodash/range.js';
 import sinon from 'sinon';
 
 import { scoreComplementaryCertificationV2 } from '../../../../../../../src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js';
+import { CertificationCandidateNotFoundError } from '../../../../../../../src/certification/shared/domain/errors.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { Frameworks } from '../../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { status as assessmentResultStatuses } from '../../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { expect } from '../../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Evaluation | Unit | Domain | Services | Scoring Complementary Certification V2', function () {
   const certificationAssessmentRepository = {};
@@ -39,6 +41,34 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
     complementaryCertificationBadgesRepository.getAllWithSameTargetProfile = sinon.stub();
     complementaryCertificationRepository.get = sinon.stub();
     candidateRepository.findByAssessmentId = sinon.stub();
+  });
+
+  context('when the candidate is not found', function () {
+    it('should throw a CertificationCandidateNotFoundError', async function () {
+      // given
+      const certificationCourseId = 123;
+      const complementaryCertificationScoringCriteria =
+        domainBuilder.certification.evaluation.buildComplementaryCertificationScoringCriteria();
+      const assessmentResult = domainBuilder.buildAssessmentResult();
+
+      certificationCourseRepository.get
+        .withArgs({ id: certificationCourseId })
+        .resolves(domainBuilder.buildCertificationCourse());
+      assessmentResultRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId })
+        .resolves(assessmentResult);
+      candidateRepository.findByAssessmentId.withArgs({ assessmentId: assessmentResult.assessmentId }).resolves(null);
+
+      // when
+      const error = await catchErr(scoreComplementaryCertificationV2)({
+        certificationCourseId,
+        complementaryCertificationScoringCriteria,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(CertificationCandidateNotFoundError);
+    });
   });
 
   context('when there is a complementary referential', function () {

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -10,6 +10,7 @@ import {
 } from '../../../../../../../src/certification/evaluation/domain/services/scoring/scoring-v2.js';
 import { CertificationAssessment } from '../../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { ABORT_REASONS } from '../../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
+import { CertificationCandidateNotFoundError } from '../../../../../../../src/certification/shared/domain/errors.js';
 import { AutoJuryCommentKeys } from '../../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import * as scoringService from '../../../../../../../src/evaluation/domain/services/scoring/scoring-service.js';
 import CertificationCancelled from '../../../../../../../src/shared/domain/events/CertificationCancelled.js';
@@ -936,6 +937,26 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
         competenceWithMarks_3_3,
         competenceWithMarks_4_4,
       ];
+    });
+
+    context('When the candidate is not found', function () {
+      it('should throw a CertificationCandidateNotFoundError', async function () {
+        // given
+        const certificationAssessment = { id: 1 };
+        candidateRepository.findByAssessmentId.withArgs({ assessmentId: certificationAssessment.id }).resolves(null);
+
+        // when
+        const error = await catchErr(calculateCertificationAssessmentScore)({
+          certificationAssessment,
+          areaRepository,
+          placementProfileService: { getPlacementProfile: sinon.stub() },
+          scoringService,
+          candidateRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(CertificationCandidateNotFoundError);
+      });
     });
 
     context('When at least one challenge have more than one answer ', function () {

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -7,7 +7,7 @@ import {
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
-import { AssessmentEndedError } from '../../../../../../src/shared/domain/errors.js';
+import { AssessmentEndedError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -76,6 +76,31 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
       versionApi.getById.withArgs({ id: version.id }).resolves(version);
 
       assessmentSheetRepository.getByAssessmentId.withArgs(assessmentId).resolves(assessmentSheet);
+    });
+
+    context('when the assessment sheet does not exist', function () {
+      it('should throw a NotFoundError', async function () {
+        // given
+        const unknownAssessmentId = 999;
+        assessmentSheetRepository.getByAssessmentId.withArgs(unknownAssessmentId).resolves(null);
+
+        // when
+        const error = await catchErr(getNextChallenge)({
+          assessmentId: unknownAssessmentId,
+          assessmentSheetRepository,
+          certificationChallengeLiveAlertRepository,
+          sessionManagementCertificationChallengeRepository,
+          calibratedChallengeRepository,
+          versionApi,
+          flashAlgorithmService,
+          pickChallengeService,
+        });
+
+        // then
+        expect(error).to.deepEqualInstance(
+          new NotFoundError(`No AssessmentSheet found for assessmentId ${unknownAssessmentId}`),
+        );
+      });
     });
 
     context('when there are challenges left to answer', function () {

--- a/api/tests/certification/evaluation/unit/domain/usecases/rescore-v2-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/rescore-v2-certification_test.js
@@ -15,6 +15,27 @@ import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Certification | Evaluation | UseCases | rescore-v2-certification', function () {
   describe('session is not in a publishable state', function () {
+    it('should not rescore when the session does not exist', async function () {
+      // given
+      const certificationCourseId = 123;
+      const sessionRepository = { getByCertificationCourseId: sinon.stub().resolves(null) };
+      const services = { handleV2CertificationScoring: sinon.stub() };
+
+      const event = new CertificationCourseRejected({
+        certificationCourseId,
+      });
+
+      // when
+      await catchErr(rescoreV2Certification)({
+        event,
+        sessionRepository,
+        services,
+      });
+
+      // then
+      expect(services.handleV2CertificationScoring).to.not.have.been.called;
+    });
+
     it('should reject to do a rescoring is session is still in progress', async function () {
       // given
       const certificationCourseId = 123;

--- a/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
@@ -30,6 +30,17 @@ describe('Unit | Certification | Evaluation | Domain | UseCase | Score V3 Certif
     });
   });
 
+  context('when session does not exist', function () {
+    it('should throw a NotFoundError', async function () {
+      const dependencies = createDependencies({
+        sessionRepository: { getByCertificationCourseId: sinon.stub().resolves(null) },
+      });
+
+      const error = await catchErr(scoreV3Certification)(dependencies);
+      expect(error).to.deepEqualInstance(new NotFoundError('Session does not exist'));
+    });
+  });
+
   context('when candidate is not scorable', function () {
     context('when session is already published', function () {
       it('should throw a SessionAlreadyPublishedError', async function () {

--- a/api/tests/certification/evaluation/unit/domain/usecases/simulate-capacity-from-score_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/simulate-capacity-from-score_test.js
@@ -1,8 +1,10 @@
 import sinon from 'sinon';
 
 import { simulateCapacityFromScore } from '../../../../../../src/certification/evaluation/domain/usecases/simulate-capacity-from-score.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Evaluation | Unit | Domain | Usecase | simulate-capacity-from-score', function () {
   let scoringConfigurationRepository;
@@ -11,6 +13,26 @@ describe('Certification | Evaluation | Unit | Domain | Usecase | simulate-capaci
     scoringConfigurationRepository = {
       getLatestByDateAndLocale: sinon.stub(),
     };
+  });
+
+  context('when there is no scoring configuration for that date', function () {
+    it('should throw a NotFoundError', async function () {
+      // given
+      const date = new Date();
+      scoringConfigurationRepository.getLatestByDateAndLocale.withArgs({ date, locale: 'fr-fr' }).resolves(null);
+
+      // when
+      const error = await catchErr(simulateCapacityFromScore)({
+        score: 767,
+        date,
+        scoringConfigurationRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(
+        new NotFoundError(`No certification scoring configuration found for date ${date.toISOString()}`),
+      );
+    });
   });
 
   it('should return a capacity', async function () {

--- a/api/tests/certification/evaluation/unit/domain/usecases/simulate-score-from-capacity_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/simulate-score-from-capacity_test.js
@@ -1,8 +1,10 @@
 import sinon from 'sinon';
 
 import { simulateScoreFromCapacity } from '../../../../../../src/certification/evaluation/domain/usecases/simulate-score-from-capacity.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Evaluation | Unit | Domain | Usecase | simulate-score-from-capacity', function () {
   let scoringConfigurationRepository;
@@ -11,6 +13,26 @@ describe('Certification | Evaluation | Unit | Domain | Usecase | simulate-score-
     scoringConfigurationRepository = {
       getLatestByDateAndLocale: sinon.stub(),
     };
+  });
+
+  context('when there is no scoring configuration for that date', function () {
+    it('should throw a NotFoundError', async function () {
+      // given
+      const date = new Date();
+      scoringConfigurationRepository.getLatestByDateAndLocale.withArgs({ date, locale: 'fr-fr' }).resolves(null);
+
+      // when
+      const error = await catchErr(simulateScoreFromCapacity)({
+        capacity: 2,
+        date,
+        scoringConfigurationRepository,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(
+        new NotFoundError(`No certification scoring configuration found for date ${date.toISOString()}`),
+      );
+    });
   });
 
   it('should return a score', async function () {

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-evaluation-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-evaluation-repository_test.js
@@ -8,7 +8,8 @@ describe('Integration | Repository | certification-evaluation-repository', funct
   describe('#rescoreV2Certification', function () {
     it('should trigger a rescoring', async function () {
       // given
-      const certificationCancelledEvent = new CertificationCancelled({ certificationCourseId: 444, juryId: 555 });
+      const certificationCourseId = 444;
+      const certificationCancelledEvent = new CertificationCancelled({ certificationCourseId, juryId: 555 });
 
       // when
       const error = await catchErr(repositories.certificationEvaluationRepository.rescoreV2Certification)({
@@ -16,7 +17,9 @@ describe('Integration | Repository | certification-evaluation-repository', funct
       });
 
       // then
-      expect(error).to.deepEqualInstance(new NotFoundError('Certification course does not exist'));
+      expect(error).to.deepEqualInstance(
+        new NotFoundError(`Session does not exist for certificationCourseId ${certificationCourseId}`),
+      );
     });
   });
 


### PR DESCRIPTION
## ☀️ Problème                                                                                                                                                                                                 
                                                                                                                                                                                                                 
Plusieurs repositories du sous-contexte `certification/evaluation` lèvent des erreurs du lorsqu'ils ne trouvent pas de ligne en base.                                                                                                                                                                   
L'infrastructure porte ainsi une décision métier alors que son seul rôle devrait être de ce qu'elle a trouvé, ou non.
  
Dans la continuité de #17144, qui traitait `certification/enrolment`.                                                                                                                                          
                                                                                                                                                                                                                 ## ⛱️ Proposition                                                                                                                                                                                              
                                                                                                                                                                                                                 Les repositories renvoient désormais `null` au lieu de lever une erreur, et la décision remonte d'un cran :                                                                                                                                                                                            
                                                                                                                                                                                                                 
**Repositories (`evaluation/infrastructure`)**                                                                                                                                                                 
                                                                                                                                                                                                                 
| Repository | Méthode | Avant | Après |                                                                                                                                                                       
| --- | --- | --- | --- |                                                                                                                                                                                      
| `session-repository` | `getByCertificationCourseId` | `throw NotFoundError` | `return null` |                                                                                                                
| `assessment-sheet-repository` | `getByAssessmentId` | `throw NotFoundError` | `return null` |                                                                                                                
| `candidate-repository` | `findByAssessmentId` | `throw CertificationCandidateNotFoundError` | `return null` |                                                                                                
| `candidate-repository` | `findByUserIdAndSessionId` | `throw CertificationCandidateNotFoundError` | `return null` |                                                                                          
| `scoring-configuration-repository` | `getLatestByDateAndLocale` | `throw NotFoundError` | `return null` |                                                                                                    
| `calibrated-challenge-repository` | `findActiveFlashCompatible` | `throw Error('Locale shall be defined')` | supprimé (code mort) |                                                                          
                                                                                                                                                                                                                 
  **Où la décision est remontée (`evaluation/domain`)**
  
| Méthode | Décision remontée vers |                                                                                                                                                                           
| --- | --- |                                                                                                                                                                                                  
| `sessionRepository.getByCertificationCourseId` | `rescore-v2-certification`, `score-v3-certification` |                                                                                                      
| `assessmentSheetRepository.getByAssessmentId` | `get-next-challenge` |                                                                                                                                       
| `candidateRepository.findByAssessmentId` | `scoring-v2`, `score-complementary-certification-v2` |                                                                                                            
| `scoringConfigurationRepository.getLatestByDateAndLocale` | `simulate-capacity-from-score`, `simulate-score-from-capacity` |                                                                                 
| `candidateRepository.findByUserIdAndSessionId` | aucune, voir remarques |                                                                                                                                    
                                                                                                                                                                                                                 
  ## 🧴 Remarques                                                                                                                                                                                                
                                                                                                                                                                                                                 
- Le refacto porte uniquement sur `certification/evaluation`.                                                                                                                                                  
- **Aucun changement de comportement HTTP.** Contrairement à la PR `enrolment`, aucun contrôleur renvoie de statut brut : toutes les erreurs restent des `DomainError` levées depuis un usecase ou un service, donc le corps de réponse JSON:API est préservé à l'identique.                                                                                                                                    
- `candidateRepository.findByUserIdAndSessionId` : **aucune garde ajoutée** chez l'appelant.`start-or-resume-certification` lève déjà `UnexpectedUserAccountError` quand `candidateAuthorizationAdapter.find` renvoie `null`, et cet adapter interroge `certification-candidates` sur exactement le même couple `userId` / `sessionId`. Le candidat est donc garanti d'exister à ce point. Même raisonnement que sur `candidate-repository.update` dans la PR `enrolment`.                                                                                                                                                                                              
- `_assertLocaleIsDefined` est supprimée plutôt que déplacée : ses deux appelants sont déjà gardés en amont — validation Joi sur `scenario-simulator-route` d'un côté, `_validateUserLocale` à l'écriture de `certification-courses.lang` de l'autre.                                                                                                                                                                  
- **Non traité volontairement** : les 3 `NotFoundError` restantes de `calibrated-challenge-repository` (`getMany`, `getAllCalibratedChallenges`). Ce ne sont pas des lookups infructueux mais des incohérences entre deux sources de données, déjà tracées par `logger.error`. Pour `getAllCalibratedChallenges` la remontée est même structurellement impossible : l'appelant ne passe qu'un `version` et ne dispose d'aucun ensemble de référence pour détecter l'anomalie.                                                                                                                        
- L'assertion jumelle de `shared/infrastructure/repositories/challenge-repository.js:133` n'est pas touchée : elle sert d'autres appelants, hors périmètre.
    
    ## 🏊 Pour tester                                                                                                                                                                                              
                                                                                                                                                                                                                 
 - Tests verts.                                                                                                                                                                                                 
 - Non-régression sur les erreurs levées dans le sous-contexte `evaluation` :                                                                                                                                   
 - épreuve suivante sur un assessment inexistant → `404`                                                                                                                                                      
 - simulation de score ou de capacité (`POST /api/admin/simulate-score-or-capacity`) à une date sans configuration de scoring, ou dont la configuration est incomplète → `404`                                                                                                                                  
 - démarrage / reprise d'une certification pour un utilisateur non inscrit à la session → inchangé                                                                                                            
 - scoring V3 d'une certification dont la session est absente → job en échec sur `NotFoundError`                                                                                                              
 - rescoring V2 (neutralisation, annulation, jury) d'une certification dont la session est → `NotFoundError`                                                                                                                                                                                            
 - scoring V2 core et complémentaire d'un assessment sans candidat →`CertificationCandidateNotFoundError`                                                                                                                                                                      
 - simulateur de scénario flash (`POST /api/scenario-simulator`) → inchangé, la locale reste validée par la route