### PR TITLE
[FEATURE] Permettre de déplier / replier tous les accordéons à la création ou consultation d'un PC (PIX-23862)

### DIFF
--- a/admin/app/components/combined-course-blueprints/capped-tubes/area.gjs
+++ b/admin/app/components/combined-course-blueprints/capped-tubes/area.gjs
@@ -1,17 +1,16 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
-
+import ExpandableAccordion from '../../common/expandable-accordion';
 import Competence from './competence';
 
 <template>
   <div class="area-border-container">
     <div class="area-border {{@color}}"></div>
-    <PixAccordions class="{{@color}} list-competences">
+    <ExpandableAccordion class="{{@color}} list-competences" @expansion={{@expansion}}>
       <:title>{{@title}}</:title>
       <:content>
         {{#each @competences as |competence|}}
-          <Competence @title={{competence.name}} @thematics={{competence.thematics}} />
+          <Competence @title={{competence.name}} @thematics={{competence.thematics}} @expansion={{@expansion}} />
         {{/each}}
       </:content>
-    </PixAccordions>
+    </ExpandableAccordion>
   </div>
 </template>

--- a/admin/app/components/combined-course-blueprints/capped-tubes/competence.gjs
+++ b/admin/app/components/combined-course-blueprints/capped-tubes/competence.gjs
@@ -1,14 +1,14 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 
+import ExpandableAccordion from '../../common/expandable-accordion';
 import Header from '../../table/header';
 import Thematic from './thematic';
 import Tube from './tube';
 
 <template>
   <div class="competence-container">
-    <PixAccordions>
+    <ExpandableAccordion @expansion={{@expansion}}>
       <:title>{{@title}}</:title>
       <:content>
         <div class="panel">
@@ -46,6 +46,6 @@ import Tube from './tube';
           </table>
         </div>
       </:content>
-    </PixAccordions>
+    </ExpandableAccordion>
   </div>
 </template>

--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -10,6 +10,7 @@ import DownloadCombinedCourseBlueprint from 'pix-admin/components/combined-cours
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 
 import RequirementTag from '../common/combined-courses/requirement-tag';
+import ExpandableAccordions from '../common/expandable-accordions';
 import SafeMarkdownToHtml from '../safe-markdown-to-html';
 import Area from './capped-tubes/area';
 
@@ -136,9 +137,18 @@ export default class Details extends Component {
                         {{rewardRequirement.cappedTubesThreshold}}%
                       </p>
                       {{#if rewardRequirement.areas.length}}
-                        {{#each rewardRequirement.areas as |area|}}
-                          <Area @title={{area.title}} @color={{area.color}} @competences={{area.competences}} />
-                        {{/each}}
+                        <ExpandableAccordions>
+                          <:default as |expansion|>
+                            {{#each rewardRequirement.areas as |area|}}
+                              <Area
+                                @title={{area.title}}
+                                @color={{area.color}}
+                                @competences={{area.competences}}
+                                @expansion={{expansion}}
+                              />
+                            {{/each}}
+                          </:default>
+                        </ExpandableAccordions>
                       {{/if}}
                     </div>
                   </div>

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -554,6 +554,7 @@ const RewardRequirementsSection = <template>
             @onNameChange={{fn @onCappedTubesNameChange criterion}}
             @onTubesSelectionChange={{fn @onCappedTubesSelectionChange criterion}}
             @remove={{fn @removeCappedTubeCriterion index}}
+            @displayExpandAllButtons={{true}}
           />
         {{/each}}
         <br />

--- a/admin/app/components/common/expandable-accordion.gjs
+++ b/admin/app/components/common/expandable-accordion.gjs
@@ -1,0 +1,24 @@
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+export default class ExpandableAccordion extends Component {
+  accordionId = guidFor(this);
+
+  get isExpanded() {
+    return this.args.expansion?.isExpanded(this.accordionId);
+  }
+
+  @action
+  onToggle(isExpanded) {
+    this.args.expansion?.setExpansion(this.accordionId, isExpanded);
+  }
+
+  <template>
+    <PixAccordions @isExpanded={{this.isExpanded}} @onToggle={{this.onToggle}} ...attributes>
+      <:title>{{yield to="title"}}</:title>
+      <:content>{{yield to="content"}}</:content>
+    </PixAccordions>
+  </template>
+}

--- a/admin/app/components/common/expandable-accordion.gjs
+++ b/admin/app/components/common/expandable-accordion.gjs
@@ -6,6 +6,16 @@ import Component from '@glimmer/component';
 export default class ExpandableAccordion extends Component {
   accordionId = guidFor(this);
 
+  constructor(...args) {
+    super(...args);
+    this.args.expansion?.registerAccordion(this.accordionId);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.args.expansion?.unregisterAccordion(this.accordionId);
+  }
+
   get isExpanded() {
     return this.args.expansion?.isExpanded(this.accordionId);
   }

--- a/admin/app/components/common/expandable-accordions.gjs
+++ b/admin/app/components/common/expandable-accordions.gjs
@@ -1,0 +1,56 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { hash } from '@ember/helper';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class ExpandableAccordions extends Component {
+  @tracked isExpandedByDefault = false;
+  @tracked expansionByAccordionId = new Map();
+
+  get displayToolbar() {
+    return this.args.displayToolbar ?? true;
+  }
+
+  @action
+  isExpanded(accordionId) {
+    return this.expansionByAccordionId.get(accordionId) ?? this.isExpandedByDefault;
+  }
+
+  @action
+  setExpansion(accordionId, isExpanded) {
+    this.expansionByAccordionId = new Map(this.expansionByAccordionId).set(accordionId, isExpanded);
+  }
+
+  @action
+  expandAll() {
+    this.setDefaultExpansion(true);
+  }
+
+  @action
+  collapseAll() {
+    this.setDefaultExpansion(false);
+  }
+
+  setDefaultExpansion(isExpandedByDefault) {
+    this.isExpandedByDefault = isExpandedByDefault;
+    this.expansionByAccordionId = new Map();
+  }
+
+  <template>
+    <div class="expandable-accordions">
+      {{#if this.displayToolbar}}
+        <div class="expandable-accordions__toolbar">
+          <PixButton @variant="tertiary" @size="small" @triggerAction={{this.expandAll}}>
+            Tout déplier
+          </PixButton>
+          <PixButton @variant="tertiary" @size="small" @triggerAction={{this.collapseAll}}>
+            Tout replier
+          </PixButton>
+        </div>
+      {{/if}}
+
+      {{yield (hash isExpanded=this.isExpanded setExpansion=this.setExpansion)}}
+    </div>
+  </template>
+}

--- a/admin/app/components/common/expandable-accordions.gjs
+++ b/admin/app/components/common/expandable-accordions.gjs
@@ -3,18 +3,34 @@ import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { runTask } from 'ember-lifeline';
+
+const ACCORDIONS_PER_WAVE = 3;
+const DELAY_BETWEEN_WAVES_MS = 0;
 
 export default class ExpandableAccordions extends Component {
-  @tracked isExpandedByDefault = false;
   @tracked expansionByAccordionId = new Map();
+
+  accordionIds = new Set();
+  expansionGeneration = 0;
 
   get displayToolbar() {
     return this.args.displayToolbar ?? true;
   }
 
   @action
+  registerAccordion(accordionId) {
+    this.accordionIds.add(accordionId);
+  }
+
+  @action
+  unregisterAccordion(accordionId) {
+    this.accordionIds.delete(accordionId);
+  }
+
+  @action
   isExpanded(accordionId) {
-    return this.expansionByAccordionId.get(accordionId) ?? this.isExpandedByDefault;
+    return this.expansionByAccordionId.get(accordionId) ?? false;
   }
 
   @action
@@ -24,17 +40,25 @@ export default class ExpandableAccordions extends Component {
 
   @action
   expandAll() {
-    this.setDefaultExpansion(true);
+    this.expansionGeneration += 1;
+    this.expandNextWave(this.expansionGeneration);
   }
 
   @action
   collapseAll() {
-    this.setDefaultExpansion(false);
+    this.expansionGeneration += 1;
+    this.expansionByAccordionId = new Map();
   }
 
-  setDefaultExpansion(isExpandedByDefault) {
-    this.isExpandedByDefault = isExpandedByDefault;
-    this.expansionByAccordionId = new Map();
+  expandNextWave(generation) {
+    if (generation !== this.expansionGeneration) return;
+
+    const collapsedAccordionIds = [...this.accordionIds].filter((accordionId) => !this.isExpanded(accordionId));
+    if (collapsedAccordionIds.length === 0) return;
+
+    collapsedAccordionIds.slice(0, ACCORDIONS_PER_WAVE).forEach((accordionId) => this.setExpansion(accordionId, true));
+
+    runTask(this, () => this.expandNextWave(generation), DELAY_BETWEEN_WAVES_MS);
   }
 
   <template>
@@ -50,7 +74,14 @@ export default class ExpandableAccordions extends Component {
         </div>
       {{/if}}
 
-      {{yield (hash isExpanded=this.isExpanded setExpansion=this.setExpansion)}}
+      {{yield
+        (hash
+          isExpanded=this.isExpanded
+          setExpansion=this.setExpansion
+          registerAccordion=this.registerAccordion
+          unregisterAccordion=this.unregisterAccordion
+        )
+      }}
     </div>
   </template>
 }

--- a/admin/app/components/common/tubes-details/area.gjs
+++ b/admin/app/components/common/tubes-details/area.gjs
@@ -1,22 +1,22 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
-
+import ExpandableAccordion from '../expandable-accordion';
 import Competence from '../tubes-details/competence';
 
 <template>
   <div class="area-border-container">
     <div class="area-border {{@color}}"></div>
-    <PixAccordions class="{{@color}} list-competences">
+    <ExpandableAccordion class="{{@color}} list-competences" @expansion={{@expansion}}>
       <:title>{{@title}}</:title>
       <:content>
         {{#each @competences as |competence|}}
           <Competence
             @title={{competence.title}}
             @thematics={{competence.thematics}}
+            @expansion={{@expansion}}
             @displayDeviceCompatibility={{@displayDeviceCompatibility}}
             @displaySkillDifficultyAvailability={{@displaySkillDifficultyAvailability}}
           />
         {{/each}}
       </:content>
-    </PixAccordions>
+    </ExpandableAccordion>
   </div>
 </template>

--- a/admin/app/components/common/tubes-details/competence.gjs
+++ b/admin/app/components/common/tubes-details/competence.gjs
@@ -1,13 +1,13 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import { eq } from 'ember-truth-helpers';
 
 import Header from '../../table/header';
+import ExpandableAccordion from '../expandable-accordion';
 import Thematic from '../tubes-details/thematic';
 import Tube from '../tubes-details/tube';
 
 <template>
   <div class="competence-container">
-    <PixAccordions>
+    <ExpandableAccordion @expansion={{@expansion}}>
       <:title>{{@title}}</:title>
       <:content>
         <div class="panel">
@@ -56,6 +56,6 @@ import Tube from '../tubes-details/tube';
           </table>
         </div>
       </:content>
-    </PixAccordions>
+    </ExpandableAccordion>
   </div>
 </template>

--- a/admin/app/components/common/tubes-selection.gjs
+++ b/admin/app/components/common/tubes-selection.gjs
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import Card from '../card';
+import ExpandableAccordions from './expandable-accordions';
 import Areas from './tubes-selection/areas';
 
 const MAX_TUBE_LEVEL = 8;
@@ -262,17 +263,22 @@ export default class TubesSelection extends Component {
       {{#if this.hasNoFrameworksSelected}}
         Aucun référentiel de sélectionné
       {{else}}
-        <Areas
-          @areas={{this.areas}}
-          @setLevelTube={{this.setLevelTube}}
-          @selectedTubeIds={{this.selectedTubeIds}}
-          @checkTube={{this.checkTube}}
-          @uncheckTube={{this.uncheckTube}}
-          @tubeLevels={{this.tubeLevels}}
-          @displayDeviceCompatibility={{@displayDeviceCompatibility}}
-          @displaySkillDifficultyAvailability={{@displaySkillDifficultyAvailability}}
-          @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
-        />
+        <ExpandableAccordions>
+          <:default as |expansion|>
+            <Areas
+              @areas={{this.areas}}
+              @expansion={{expansion}}
+              @setLevelTube={{this.setLevelTube}}
+              @selectedTubeIds={{this.selectedTubeIds}}
+              @checkTube={{this.checkTube}}
+              @uncheckTube={{this.uncheckTube}}
+              @tubeLevels={{this.tubeLevels}}
+              @displayDeviceCompatibility={{@displayDeviceCompatibility}}
+              @displaySkillDifficultyAvailability={{@displaySkillDifficultyAvailability}}
+              @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
+            />
+          </:default>
+        </ExpandableAccordions>
       {{/if}}
     </div>
   </template>

--- a/admin/app/components/common/tubes-selection/areas.gjs
+++ b/admin/app/components/common/tubes-selection/areas.gjs
@@ -1,17 +1,17 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
-
+import ExpandableAccordion from '../expandable-accordion';
 import Competence from './competence';
 
 <template>
   {{#each @areas as |area|}}
     <div class="area-border-container">
       <div class="area-border {{area.color}}"></div>
-      <PixAccordions class="{{area.color}} list-competences">
+      <ExpandableAccordion class="{{area.color}} list-competences" @expansion={{@expansion}}>
         <:title>{{area.code}} · {{area.title}}</:title>
         <:content>
           {{#each area.sortedCompetences as |competence|}}
             <Competence
               @competence={{competence}}
+              @expansion={{@expansion}}
               @setLevelTube={{@setLevelTube}}
               @selectedTubeIds={{@selectedTubeIds}}
               @checkTube={{@checkTube}}
@@ -23,7 +23,7 @@ import Competence from './competence';
             />
           {{/each}}
         </:content>
-      </PixAccordions>
+      </ExpandableAccordion>
     </div>
   {{/each}}
 </template>

--- a/admin/app/components/common/tubes-selection/competence.gjs
+++ b/admin/app/components/common/tubes-selection/competence.gjs
@@ -1,4 +1,3 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -6,6 +5,7 @@ import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
 
 import Header from '../../table/header';
+import ExpandableAccordion from '../expandable-accordion';
 import Thematic from './thematic';
 import Tube from './tube';
 
@@ -47,7 +47,7 @@ export default class Competence extends Component {
 
   <template>
     <div class="competence-container">
-      <PixAccordions>
+      <ExpandableAccordion @expansion={{@expansion}}>
         <:title>{{@competence.index}} {{@competence.name}}</:title>
         <:content>
           <div class="panel">
@@ -111,7 +111,7 @@ export default class Competence extends Component {
             </table>
           </div>
         </:content>
-      </PixAccordions>
+      </ExpandableAccordion>
     </div>
   </template>
 }

--- a/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
+++ b/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
@@ -8,6 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import sortBy from 'lodash/sortBy';
 
+import ExpandableAccordions from '../../common/expandable-accordions';
 import Areas from '../../common/tubes-selection/areas';
 
 export default class CappedTubesCriterion extends Component {
@@ -24,6 +25,10 @@ export default class CappedTubesCriterion extends Component {
 
   get displaySkillDifficultySelection() {
     return this.args.displaySkillDifficultySelection ?? true;
+  }
+
+  get displayExpandAllButtons() {
+    return Boolean(this.args.displayExpandAllButtons);
   }
 
   get areas() {
@@ -109,16 +114,21 @@ export default class CappedTubesCriterion extends Component {
         >
           <:label>Taux de réussite requis</:label>
         </PixInput>
-        <Areas
-          @areas={{this.areas}}
-          @selectedTubeIds={{this.selectedTubeIds}}
-          @tubeLevels={{this.tubeLevels}}
-          @checkTube={{this.checkTube}}
-          @uncheckTube={{this.uncheckTube}}
-          @setLevelTube={{this.setLevelTube}}
-          @displayDeviceCompatibility={{true}}
-          @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
-        />
+        <ExpandableAccordions @displayToolbar={{this.displayExpandAllButtons}}>
+          <:default as |expansion|>
+            <Areas
+              @areas={{this.areas}}
+              @expansion={{expansion}}
+              @selectedTubeIds={{this.selectedTubeIds}}
+              @tubeLevels={{this.tubeLevels}}
+              @checkTube={{this.checkTube}}
+              @uncheckTube={{this.uncheckTube}}
+              @setLevelTube={{this.setLevelTube}}
+              @displayDeviceCompatibility={{true}}
+              @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
+            />
+          </:default>
+        </ExpandableAccordions>
       </main>
     </article>
   </template>

--- a/admin/app/components/target-profiles/badge-form/criteria.gjs
+++ b/admin/app/components/target-profiles/badge-form/criteria.gjs
@@ -113,6 +113,7 @@ export default class Criteria extends Component {
             @onNameChange={{fn this.onCappedTubesNameChange criterion}}
             @onTubesSelectionChange={{fn this.onCappedTubesSelectionChange criterion}}
             @remove={{fn this.removeCappedTubeCriterion index}}
+            @displayExpandAllButtons={{true}}
           />
         {{/each}}
         <PixButton

--- a/admin/app/components/target-profiles/details.gjs
+++ b/admin/app/components/target-profiles/details.gjs
@@ -1,21 +1,29 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 
+import ExpandableAccordions from '../common/expandable-accordions';
 import Area from '../common/tubes-details/area';
 
 <template>
   <PixBlock @variant="admin">
-    {{#each @areas as |area|}}
-      <Area
-        @title={{area.title}}
-        @color={{area.color}}
-        @competences={{area.competences}}
-        @displayDeviceCompatibility={{true}}
-        @displaySkillDifficultyAvailability={{true}}
-      />
+    {{#if @areas.length}}
+      <ExpandableAccordions>
+        <:default as |expansion|>
+          {{#each @areas as |area|}}
+            <Area
+              @title={{area.title}}
+              @color={{area.color}}
+              @competences={{area.competences}}
+              @expansion={{expansion}}
+              @displayDeviceCompatibility={{true}}
+              @displaySkillDifficultyAvailability={{true}}
+            />
+          {{/each}}
+        </:default>
+      </ExpandableAccordions>
     {{else}}
       <section class="page-section">
         <div class="table__empty">Profil cible vide.</div>
       </section>
-    {{/each}}
+    {{/if}}
   </PixBlock>
 </template>

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -51,6 +51,7 @@
 @use 'components/certification/candidate-edit-modal' as *;
 @use 'components/certification/certification-status-select' as *;
 @use 'components/certified-profile' as *;
+@use 'components/common/expandable-accordions' as *;
 @use 'components/common/tick-or-cross' as *;
 @use 'components/common/tubes-selection' as *;
 @use 'components/certification-frameworks/attach-badges/header' as *;

--- a/admin/app/styles/components/common/expandable-accordions.scss
+++ b/admin/app/styles/components/common/expandable-accordions.scss
@@ -1,0 +1,7 @@
+.expandable-accordions__toolbar {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: var(--pix-spacing-2x);
+}

--- a/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import Details from 'pix-admin/components/combined-course-blueprints/details';
 import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
@@ -129,6 +129,37 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
     const expectedThreshold = t('components.combined-course-blueprints.reward-requirements.threshold') + ': 50%';
     assert.ok(await screen.queryByText(expectedThreshold));
     assert.ok(await screen.queryByText('Area Test Title'));
+  });
+
+  test('should display every competence of a reward requirement on expand all', async function (assert) {
+    //given
+    const combinedCourseBlueprint = {
+      id: 123,
+      internalName: 'Modèle de parcours apprenant',
+      createdAt: new Date('2025-12-25'),
+      name: 'Parcours apprenant',
+      content: [],
+      rewardRequirements: [
+        {
+          name: 'requirements group name',
+          cappedTubesThreshold: 50,
+          areas: [
+            {
+              title: 'Area Test Title',
+              competences: [{ name: 'Competence Test Name', thematics: [] }],
+            },
+          ],
+        },
+      ],
+    };
+    const screen = await render(<template><Details @model={{combinedCourseBlueprint}} /></template>);
+    assert.dom(screen.queryByText('Competence Test Name')).doesNotExist();
+
+    //when
+    await clickByName('Tout déplier');
+
+    //then
+    assert.dom(screen.getByText('Competence Test Name')).isVisible();
   });
 
   test('should display default reward requirements group name if not provided', async function (assert) {

--- a/admin/tests/integration/components/common/expandable-accordions-test.gjs
+++ b/admin/tests/integration/components/common/expandable-accordions-test.gjs
@@ -1,0 +1,192 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import ExpandableAccordion from 'pix-admin/components/common/expandable-accordion';
+import ExpandableAccordions from 'pix-admin/components/common/expandable-accordions';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+const DOMAINE = 'Domaine 1';
+const AUTRE_DOMAINE = 'Domaine 2';
+const COMPETENCE = 'Compétence 1.1';
+const SUJETS = 'Sujets de la compétence 1.1';
+
+async function renderNestedAccordions() {
+  return render(
+    <template>
+      <ExpandableAccordions>
+        <:default as |expansion|>
+          <ExpandableAccordion @expansion={{expansion}}>
+            <:title>{{DOMAINE}}</:title>
+            <:content>
+              <ExpandableAccordion @expansion={{expansion}}>
+                <:title>{{COMPETENCE}}</:title>
+                <:content><p>{{SUJETS}}</p></:content>
+              </ExpandableAccordion>
+            </:content>
+          </ExpandableAccordion>
+
+          <ExpandableAccordion @expansion={{expansion}}>
+            <:title>{{AUTRE_DOMAINE}}</:title>
+            <:content><p>Contenu du domaine 2</p></:content>
+          </ExpandableAccordion>
+        </:default>
+      </ExpandableAccordions>
+    </template>,
+  );
+}
+
+function isExpanded(screen, name) {
+  return screen.getByRole('button', { name, hidden: true }).getAttribute('aria-expanded') === 'true';
+}
+
+module('Integration | Component | Common::ExpandableAccordions', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display the expand and collapse buttons', async function (assert) {
+    // when
+    const screen = await renderNestedAccordions();
+
+    // then
+    assert.dom(screen.getByRole('button', { name: 'Tout déplier' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Tout replier' })).exists();
+  });
+
+  test('it should render every accordion collapsed by default', async function (assert) {
+    // when
+    const screen = await renderNestedAccordions();
+
+    // then
+    assert.false(isExpanded(screen, DOMAINE));
+    assert.false(isExpanded(screen, AUTRE_DOMAINE));
+    assert.dom(screen.queryByText(SUJETS)).doesNotExist();
+  });
+
+  test('it should expand every accordion, nested ones included, on expand all', async function (assert) {
+    // given
+    const screen = await renderNestedAccordions();
+
+    // when
+    await clickByName('Tout déplier');
+
+    // then
+    assert.true(isExpanded(screen, DOMAINE));
+    assert.true(isExpanded(screen, AUTRE_DOMAINE));
+    assert.true(isExpanded(screen, COMPETENCE));
+    assert.dom(screen.getByText(SUJETS)).isVisible();
+  });
+
+  test('it should collapse every accordion on collapse all', async function (assert) {
+    // given
+    const screen = await renderNestedAccordions();
+    await clickByName('Tout déplier');
+
+    // when
+    await clickByName('Tout replier');
+
+    // then
+    assert.false(isExpanded(screen, DOMAINE));
+    assert.false(isExpanded(screen, AUTRE_DOMAINE));
+    assert.dom(screen.queryByText(SUJETS)).isNotVisible();
+  });
+
+  test('it should only toggle the clicked accordion', async function (assert) {
+    // given
+    const screen = await renderNestedAccordions();
+
+    // when
+    await clickByName(DOMAINE);
+
+    // then
+    assert.true(isExpanded(screen, DOMAINE));
+    assert.false(isExpanded(screen, AUTRE_DOMAINE));
+  });
+
+  test('it should expand everything again after a manual collapse', async function (assert) {
+    // given
+    const screen = await renderNestedAccordions();
+    await clickByName('Tout déplier');
+    await clickByName(DOMAINE);
+    assert.false(isExpanded(screen, DOMAINE));
+
+    // when
+    await clickByName('Tout déplier');
+
+    // then
+    assert.true(isExpanded(screen, DOMAINE));
+    assert.true(isExpanded(screen, AUTRE_DOMAINE));
+    assert.true(isExpanded(screen, COMPETENCE));
+  });
+
+  test('it should collapse everything after a manual collapse', async function (assert) {
+    // given
+    const screen = await renderNestedAccordions();
+    await clickByName('Tout déplier');
+    await clickByName(DOMAINE);
+
+    // when
+    await clickByName('Tout replier');
+
+    // then
+    assert.false(isExpanded(screen, DOMAINE));
+    assert.false(isExpanded(screen, AUTRE_DOMAINE));
+    assert.false(isExpanded(screen, COMPETENCE));
+  });
+
+  module('when the toolbar is hidden', function () {
+    test('it should not display the buttons but keep the accordions usable', async function (assert) {
+      // given
+      const screen = await render(
+        <template>
+          <ExpandableAccordions @displayToolbar={{false}}>
+            <:default as |expansion|>
+              <ExpandableAccordion @expansion={{expansion}}>
+                <:title>{{DOMAINE}}</:title>
+                <:content><p>{{SUJETS}}</p></:content>
+              </ExpandableAccordion>
+            </:default>
+          </ExpandableAccordions>
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Tout déplier' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Tout replier' })).doesNotExist();
+
+      // when
+      await clickByName(DOMAINE);
+
+      // then
+      assert.true(isExpanded(screen, DOMAINE));
+      assert.dom(screen.getByText(SUJETS)).isVisible();
+    });
+  });
+
+  module('when used without an expansion', function () {
+    test('it should let the accordion handle its own state', async function (assert) {
+      // given
+      const screen = await render(
+        <template>
+          <ExpandableAccordion>
+            <:title>{{DOMAINE}}</:title>
+            <:content><p>{{SUJETS}}</p></:content>
+          </ExpandableAccordion>
+        </template>,
+      );
+      assert.dom(screen.queryByText(SUJETS)).doesNotExist();
+
+      // when
+      await clickByName(DOMAINE);
+
+      // then
+      assert.true(isExpanded(screen, DOMAINE));
+      assert.dom(screen.getByText(SUJETS)).isVisible();
+
+      // when
+      await clickByName(DOMAINE);
+
+      // then
+      assert.false(isExpanded(screen, DOMAINE));
+      assert.dom(screen.getByText(SUJETS)).isNotVisible();
+    });
+  });
+});

--- a/admin/tests/integration/components/common/tubes-selection-test.gjs
+++ b/admin/tests/integration/components/common/tubes-selection-test.gjs
@@ -38,6 +38,27 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
     assert.dom(screen.getByText('@tubeName3 : Tube 3')).exists();
   });
 
+  test('it should display a list of tubes without clicking on each accordion on expand all', async function (assert) {
+    // when
+    await clickByName('Tout déplier');
+
+    // then
+    assert.dom(screen.getByText('@tubeName1 : Tube 1')).isVisible();
+    assert.dom(screen.getByText('@tubeName2 : Tube 2')).isVisible();
+    assert.dom(screen.getByText('@tubeName3 : Tube 3')).isVisible();
+  });
+
+  test('it should hide the tubes on collapse all', async function (assert) {
+    // given
+    await clickByName('Tout déplier');
+
+    // when
+    await clickByName('Tout replier');
+
+    // then
+    assert.dom(screen.getByText('@tubeName1 : Tube 1')).isNotVisible();
+  });
+
   test('it should check the tubes if selected', async function (assert) {
     // when
     await clickByName('1 · Titre domaine');

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/details-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/details-test.gjs
@@ -90,6 +90,33 @@ module('Integration | Component | routes/authenticated/target-profiles/target-pr
       assert.dom(screen.queryByText('Titre Area 2')).exists();
     });
 
+    test('it should display every competence and thematic on expand all', async function (assert) {
+      // given
+      const screen = await render(<template><Details @areas={{areas}} /></template>);
+
+      // when
+      await clickByName('Tout déplier');
+
+      // then
+      assert.dom(screen.getByText('Titre Competence 1 Area 1')).isVisible();
+      assert.dom(screen.getByText('Titre Competence 2 Area 2')).isVisible();
+      assert.dom(screen.getByText('Nom Thematic 1 Competence 1 Area 1')).isVisible();
+      assert.dom(screen.getByText('Nom Thematic 2 Competence 2 Area 2')).isVisible();
+    });
+
+    test('it should hide every competence on collapse all', async function (assert) {
+      // given
+      const screen = await render(<template><Details @areas={{areas}} /></template>);
+      await clickByName('Tout déplier');
+
+      // when
+      await clickByName('Tout replier');
+
+      // then
+      assert.dom(screen.getByText('Titre Competence 1 Area 1')).isNotVisible();
+      assert.dom(screen.getByText('Titre Competence 2 Area 2')).isNotVisible();
+    });
+
     test('it should display competences when clicking on area', async function (assert) {
       const screen = await render(<template><Details @areas={{areas}} /></template>);
 

--- a/admin/tests/integration/components/target-profiles/badge-form-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badge-form-test.gjs
@@ -113,6 +113,16 @@ module('Integration | Component | BadgeForm', function (hooks) {
       assert.dom(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' })).exists();
     });
 
+    test('it should display the expand and collapse buttons', async function (assert) {
+      // when
+      const screen = await render(<template><BadgeForm @targetProfile={{targetProfile}} /></template>);
+      await click(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' }));
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Tout déplier' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Tout replier' })).exists();
+    });
+
     test('it should add a new criteria on click', async function (assert) {
       // when
       const screen = await render(<template><BadgeForm @targetProfile={{targetProfile}} /></template>);

--- a/admin/tests/integration/components/target-profiles/badge-form/capped-tubes-criterion-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badge-form/capped-tubes-criterion-test.gjs
@@ -1,0 +1,54 @@
+import { render } from '@1024pix/ember-testing-library';
+import CappedTubesCriterion from 'pix-admin/components/target-profiles/badge-form/capped-tubes-criterion';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | TargetProfiles::BadgeForm::CappedTubesCriterion', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const areas = [];
+  const noop = sinon.stub();
+
+  test('it should not display the expand and collapse buttons by default', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <CappedTubesCriterion
+          @id="criterion"
+          @areas={{areas}}
+          @onTubesSelectionChange={{noop}}
+          @onNameChange={{noop}}
+          @onThresholdChange={{noop}}
+          @remove={{noop}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.queryByRole('button', { name: 'Tout déplier' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Tout replier' })).doesNotExist();
+  });
+
+  test('it should display the expand and collapse buttons when asked to', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <CappedTubesCriterion
+          @id="criterion"
+          @areas={{areas}}
+          @onTubesSelectionChange={{noop}}
+          @onNameChange={{noop}}
+          @onThresholdChange={{noop}}
+          @remove={{noop}}
+          @displayExpandAllButtons={{true}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('button', { name: 'Tout déplier' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Tout replier' })).exists();
+  });
+});


### PR DESCRIPTION
## ☀️ Problème

Lorsque l'on veut créer / modifier / consulter un PC, on doit ouvrir à la main tous les accordéons.
C'est chiant.

## ⛱️ Proposition

Ajouter 2 ButtonLinks qui permettent de déplier ou replier tous les accordéons : 
- à la création d'un target-profile
- à la consultation d'un target-profile
- à l'ajout d'un critère d'obtention d'un badge sur un target-profile
- à l'ajout d'un critère d'obtention de l'attestation sur un blueprint 
- ajout de critères sur les CF 

## 🧴 Remarques


## 🏊 Pour tester

- se connecter sur pix admin avec le compte super admin
- consulter un profil cible, cliquer sur "tout déplier" puis "tout replier"
- "tout déplier" puis refermer à la main certains sujets, puis cliquer sur "tout déplier"
- "tout déplier" puis refermer à la main certains sujets, puis cliquer sur "tout replier"

Vérifier que c'est bien ok aux autres endroits où le composant est utilisé :
- créer un PC 
- ajouter un badge 
- ajouter un déclencheur à un CF 
- Créer un schéma avec une attestation et un critère d'obtention 